### PR TITLE
struct elem: add alias this to remove .EV. pt 4

### DIFF
--- a/compiler/src/dmd/backend/blockopt.d
+++ b/compiler/src/dmd/backend/blockopt.d
@@ -485,7 +485,7 @@ void block_appendexp(block *b,elem *e)
             {
                 ec.Ety = ty;
                 ec.ET = t;
-                pe = &(ec.EV.E2);
+                pe = &(ec.E2);
                 ec = *pe;
             }
             e = el_bin(OPcomma,ty,ec,e);
@@ -879,10 +879,10 @@ private void bropt()
             {
                 tym_t tym;
 
-                tym = n.EV.E1.Ety;
+                tym = n.E1.Ety;
                 *pn = el_selecte1(n);
                 (*pn).Ety = tym;
-                for (n = b.Belem; n.Eoper == OPcomma; n = n.EV.E2)
+                for (n = b.Belem; n.Eoper == OPcomma; n = n.E2)
                     n.Ety = tym;
                 b.Bsucc = list_reverse(b.Bsucc);
                 debug if (debugc) printf("CHANGE: if (!e)\n");
@@ -1461,9 +1461,9 @@ private void bl_enlist2(ref Barray!(elem*) elems, elem* e)
         elem_debug(e);
         if (e.Eoper == OPcomma)
         {
-            bl_enlist2(elems, e.EV.E1);
-            bl_enlist2(elems, e.EV.E2);
-            e.EV.E1 = e.EV.E2 = null;
+            bl_enlist2(elems, e.E1);
+            bl_enlist2(elems, e.E2);
+            e.E1 = e.E2 = null;
             el_free(e);
         }
         else
@@ -1481,9 +1481,9 @@ private list_t bl_enlist(elem *e)
         elem_debug(e);
         if (e.Eoper == OPcomma)
         {
-            list_t el2 = bl_enlist(e.EV.E1);
-            el = bl_enlist(e.EV.E2);
-            e.EV.E1 = e.EV.E2 = null;
+            list_t el2 = bl_enlist(e.E1);
+            el = bl_enlist(e.E2);
+            e.E1 = e.E2 = null;
             el_free(e);
 
             /* Append el2 list to el    */
@@ -1809,29 +1809,29 @@ private void brtailrecursion()
             {
                 e = *el_scancommas(&e);
                 if (e.Eoper == OPcond)
-                    return isCandidate(e.EV.E2.EV.E1) || isCandidate(e.EV.E2.EV.E2);
+                    return isCandidate(e.E2.E1) || isCandidate(e.E2.E2);
 
                 return OTcall(e.Eoper) &&
-                       e.EV.E1.Eoper == OPvar &&
-                       e.EV.E1.EV.Vsym == funcsym_p;
+                       e.E1.Eoper == OPvar &&
+                       e.E1.Vsym == funcsym_p;
             }
 
             if (e.Eoper == OPcond &&
-                (isCandidate(e.EV.E2.EV.E1) || isCandidate(e.EV.E2.EV.E2)))
+                (isCandidate(e.E2.E1) || isCandidate(e.E2.E2)))
             {
                 /* Split OPcond into a BCiftrue block and two return blocks
                  */
                 block* b1 = block_calloc();
                 block* b2 = block_calloc();
 
-                b1.Belem = e.EV.E2.EV.E1;
-                e.EV.E2.EV.E1 = null;
+                b1.Belem = e.E2.E1;
+                e.E2.E1 = null;
 
-                b2.Belem = e.EV.E2.EV.E2;
-                e.EV.E2.EV.E2 = null;
+                b2.Belem = e.E2.E2;
+                e.E2.E2 = null;
 
-                *pe = e.EV.E1;
-                e.EV.E1 = null;
+                *pe = e.E1;
+                e.E1 = null;
                 el_free(e);
 
                 if (b.BC == BCgoto)
@@ -1860,8 +1860,8 @@ private void brtailrecursion()
             }
 
             if (OTcall(e.Eoper) &&
-                e.EV.E1.Eoper == OPvar &&
-                e.EV.E1.EV.Vsym == funcsym_p)
+                e.E1.Eoper == OPvar &&
+                e.E1.Vsym == funcsym_p)
             {
                 //printf("before:\n");
                 //elem_print(*pe);
@@ -1873,7 +1873,7 @@ private void brtailrecursion()
                 {
                     int si = 0;
                     elem *e2 = null;
-                    *pe = assignparams(&e.EV.E2,&si,&e2);
+                    *pe = assignparams(&e.E2,&si,&e2);
                     *pe = el_combine(*pe,e2);
                 }
                 el_free(e);
@@ -1918,10 +1918,10 @@ private elem * assignparams(elem **pe,int *psi,elem **pe2)
     {
         elem *ea = null;
         elem *eb = null;
-        elem *e2 = assignparams(&e.EV.E2,psi,&eb);
-        elem *e1 = assignparams(&e.EV.E1,psi,&ea);
-        e.EV.E1 = null;
-        e.EV.E2 = null;
+        elem *e2 = assignparams(&e.E2,psi,&eb);
+        elem *e1 = assignparams(&e.E1,psi,&ea);
+        e.E1 = null;
+        e.E2 = null;
         e = el_combine(e1,e2);
         *pe2 = el_combine(eb,ea);
     }
@@ -1940,8 +1940,8 @@ private elem * assignparams(elem **pe,int *psi,elem **pe2)
             op = OPstreq;
             t = e.ET;
             elem *ex = e;
-            e = e.EV.E1;
-            ex.EV.E1 = null;
+            e = e.E1;
+            ex.E1 = null;
             el_free(ex);
         }
         elem *es = el_var(s);
@@ -1950,7 +1950,7 @@ private elem * assignparams(elem **pe,int *psi,elem **pe2)
         if (op == OPstreq)
             e.ET = t;
         *pe2 = el_bin(op,TYvoid,el_var(sp),el_copytree(es));
-        (*pe2).EV.E1.Ety = es.Ety;
+        (*pe2).E1.Ety = es.Ety;
         if (op == OPstreq)
             (*pe2).ET = t;
         *psi = ++si;
@@ -1983,33 +1983,33 @@ private void emptyloops()
             // Find einit
             elem *einit = *el_scancommas(&(bpred.Belem));
             if (einit.Eoper != OPeq ||
-                einit.EV.E2.Eoper != OPconst ||
-                einit.EV.E1.Eoper != OPvar)
+                einit.E2.Eoper != OPconst ||
+                einit.E1.Eoper != OPvar)
                 continue;
 
             // Look for ((i += 1) < limit)
             elem *erel = b.Belem;
             if (erel.Eoper != OPlt ||
-                erel.EV.E2.Eoper != OPconst ||
-                erel.EV.E1.Eoper != OPaddass)
+                erel.E2.Eoper != OPconst ||
+                erel.E1.Eoper != OPaddass)
                 continue;
 
-            elem *einc = erel.EV.E1;
-            if (einc.EV.E2.Eoper != OPconst ||
-                einc.EV.E1.Eoper != OPvar ||
-                !el_match(einc.EV.E1,einit.EV.E1))
+            elem *einc = erel.E1;
+            if (einc.E2.Eoper != OPconst ||
+                einc.E1.Eoper != OPvar ||
+                !el_match(einc.E1,einit.E1))
                 continue;
 
-            if (!tyintegral(einit.EV.E1.Ety) ||
-                el_tolong(einc.EV.E2) != 1 ||
-                el_tolong(einit.EV.E2) >= el_tolong(erel.EV.E2)
+            if (!tyintegral(einit.E1.Ety) ||
+                el_tolong(einc.E2) != 1 ||
+                el_tolong(einit.E2) >= el_tolong(erel.E2)
                )
                 continue;
 
              {
                 erel.Eoper = OPeq;
-                erel.Ety = erel.EV.E1.Ety;
-                erel.EV.E1 = el_selecte1(erel.EV.E1);
+                erel.Ety = erel.E1.Ety;
+                erel.E1 = el_selecte1(erel.E1);
                 b.BC = BCgoto;
                 list_subtract(&b.Bsucc,b);
                 list_subtract(&b.Bpred,b);
@@ -2063,8 +2063,8 @@ private int funcsideeffect_walk(elem *e)
         case OPcall:
         case OPucall:
             Symbol *s;
-            if (e.EV.E1.Eoper == OPvar &&
-                tyfunc((s = e.EV.E1.EV.Vsym).Stype.Tty) &&
+            if (e.E1.Eoper == OPvar &&
+                tyfunc((s = e.E1.Vsym).Stype.Tty) &&
                 ((s.Sfunc && s.Sfunc.Fflags3 & Fnosideeff) || s == funcsym_p)
                )
                 break;
@@ -2076,9 +2076,9 @@ private int funcsideeffect_walk(elem *e)
         default:
             assert(op < OPMAX);
             return OTsideff(op) ||
-                (OTunary(op) && funcsideeffect_walk(e.EV.E1)) ||
-                (OTbinary(op) && (funcsideeffect_walk(e.EV.E1) ||
-                                  funcsideeffect_walk(e.EV.E2)));
+                (OTunary(op) && funcsideeffect_walk(e.E1)) ||
+                (OTbinary(op) && (funcsideeffect_walk(e.E1) ||
+                                  funcsideeffect_walk(e.E2)));
     }
     return 0;
 
@@ -2096,12 +2096,12 @@ private int el_anyframeptr(elem *e)
     while (1)
     {
         if (OTunary(e.Eoper))
-            e = e.EV.E1;
+            e = e.E1;
         else if (OTbinary(e.Eoper))
         {
-            if (el_anyframeptr(e.EV.E2))
+            if (el_anyframeptr(e.E2))
                 return 1;
-            e = e.EV.E1;
+            e = e.E1;
         }
         else if (e.Eoper == OPframeptr)
             return 1;
@@ -2145,13 +2145,13 @@ private void blassertsplit()
             {
                 if (OTunary(e.Eoper))
                 {
-                    e = e.EV.E1;
+                    e = e.E1;
                     continue;
                 }
                 else if (OTbinary(e.Eoper))
                 {
-                    accumDctor(e.EV.E1);
-                    e = e.EV.E2;
+                    accumDctor(e.E1);
+                    e = e.E2;
                     continue;
                 }
                 else if (e.Eoper == OPdctor)
@@ -2166,28 +2166,28 @@ private void blassertsplit()
         foreach (i, e; earray)
         {
             if (!(dctor == 0 &&   // don't split block between a dctor..ddtor pair
-                e.Eoper == OPoror && e.EV.E2.Eoper == OPcall && e.EV.E2.EV.E1.Eoper == OPvar))
+                e.Eoper == OPoror && e.E2.Eoper == OPcall && e.E2.E1.Eoper == OPvar))
             {
                 accumDctor(e);
                 continue;
             }
-            Symbol *f = e.EV.E2.EV.E1.EV.Vsym;
+            Symbol *f = e.E2.E1.Vsym;
             if (!(f.Sflags & SFLexit))
             {
                 accumDctor(e);
                 continue;
             }
 
-            if (accumDctor(e.EV.E1))
+            if (accumDctor(e.E1))
             {
-                accumDctor(e.EV.E2);
+                accumDctor(e.E2);
                 continue;
             }
 
             // Create exit block
             block *bexit = block_calloc();
             bexit.BC = BCexit;
-            bexit.Belem = e.EV.E2;
+            bexit.Belem = e.E2;
 
             /* Append bexit to block list
              */
@@ -2202,9 +2202,9 @@ private void blassertsplit()
                 bx = bxn;
             }
 
-            earray[i] = e.EV.E1;
-            e.EV.E1 = null;
-            e.EV.E2 = null;
+            earray[i] = e.E1;
+            e.E1 = null;
+            e.E2 = null;
             el_free(e);
 
             /* Split b into two blocks, [b,b2]

--- a/compiler/src/dmd/backend/debugprint.d
+++ b/compiler/src/dmd/backend/debugprint.d
@@ -214,47 +214,47 @@ void WReqn(elem *e)
   {
         ferr(oper_str(e.Eoper));
         ferr(" ");
-        if (OTbinary(e.EV.E1.Eoper))
+        if (OTbinary(e.E1.Eoper))
         {       nest++;
                 ferr("(");
-                WReqn(e.EV.E1);
+                WReqn(e.E1);
                 ferr(")");
                 nest--;
         }
         else
-                WReqn(e.EV.E1);
+                WReqn(e.E1);
   }
   else if (e.Eoper == OPcomma && !nest)
-  {     WReqn(e.EV.E1);
+  {     WReqn(e.E1);
         printf(";\n\t");
-        WReqn(e.EV.E2);
+        WReqn(e.E2);
   }
   else if (OTbinary(e.Eoper))
   {
-        if (OTbinary(e.EV.E1.Eoper))
+        if (OTbinary(e.E1.Eoper))
         {       nest++;
                 ferr("(");
-                WReqn(e.EV.E1);
+                WReqn(e.E1);
                 ferr(")");
                 nest--;
         }
         else
-                WReqn(e.EV.E1);
+                WReqn(e.E1);
         ferr(" ");
         ferr(oper_str(e.Eoper));
         ferr(" ");
         if (e.Eoper == OPstreq)
             printf("%d", cast(int)type_size(e.ET));
         ferr(" ");
-        if (OTbinary(e.EV.E2.Eoper))
+        if (OTbinary(e.E2.Eoper))
         {       nest++;
                 ferr("(");
-                WReqn(e.EV.E2);
+                WReqn(e.E2);
                 ferr(")");
                 nest--;
         }
         else
-                WReqn(e.EV.E2);
+                WReqn(e.E2);
   }
   else
   {
@@ -267,22 +267,22 @@ void WReqn(elem *e)
                 goto case OPvar;
 
             case OPvar:
-                printf("%s",e.EV.Vsym.Sident.ptr);
-                if (e.EV.Vsym.Ssymnum != SYMIDX.max)
-                    printf("(%d)", cast(int) e.EV.Vsym.Ssymnum);
-                if (e.EV.Voffset != 0)
+                printf("%s",e.Vsym.Sident.ptr);
+                if (e.Vsym.Ssymnum != SYMIDX.max)
+                    printf("(%d)", cast(int) e.Vsym.Ssymnum);
+                if (e.Voffset != 0)
                 {
-                    if (e.EV.Voffset.sizeof == 8)
-                        printf(".x%llx", cast(ulong)e.EV.Voffset);
+                    if (e.Voffset.sizeof == 8)
+                        printf(".x%llx", cast(ulong)e.Voffset);
                     else
-                        printf(".%d",cast(int)e.EV.Voffset);
+                        printf(".%d",cast(int)e.Voffset);
                 }
                 break;
             case OPasm:
             case OPstring:
-                printf("\"%s\"",e.EV.Vstring);
-                if (e.EV.Voffset)
-                    printf("+%lld",cast(long)e.EV.Voffset);
+                printf("\"%s\"",e.Vstring);
+                if (e.Voffset)
+                    printf("+%lld",cast(long)e.Voffset);
                 break;
             case OPmark:
             case OPgot:

--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -622,9 +622,9 @@ again:
 debug
 {
     if (OTbinary(e.Eoper))
-        assert(e.EV.E1 && e.EV.E2);
+        assert(e.E1 && e.E2);
 //    else if (OTunary(e.Eoper))
-//      assert(e.EV.E1 && !e.EV.E2);
+//      assert(e.E1 && !e.E2);
 }
 
     switch (e.Eoper)
@@ -636,18 +636,18 @@ debug
         //if (!EOP(e)) printf("e.Eoper = x%x\n",e.Eoper);
 }
         if (OTbinary(e.Eoper))
-        {   outelem(e.EV.E1, addressOfParam);
-            e = e.EV.E2;
+        {   outelem(e.E1, addressOfParam);
+            e = e.E2;
         }
         else if (OTunary(e.Eoper))
         {
-            e = e.EV.E1;
+            e = e.E1;
         }
         else
             break;
         goto again;                     /* iterate instead of recurse   */
     case OPaddr:
-        e1 = e.EV.E1;
+        e1 = e.E1;
         if (e1.Eoper == OPvar)
         {   // Fold into an OPrelconst
             tym = e.Ety;
@@ -661,7 +661,7 @@ debug
 
     case OPrelconst:
     case OPvar:
-        s = e.EV.Vsym;
+        s = e.Vsym;
         assert(s);
         symbol_debug(s);
         switch (s.Sclass)
@@ -771,38 +771,38 @@ private void out_regcand_walk(elem *e, ref bool addressOfParam)
 
         if (OTbinary(e.Eoper))
         {   if (e.Eoper == OPstreq)
-            {   if (e.EV.E1.Eoper == OPvar)
+            {   if (e.E1.Eoper == OPvar)
                 {
-                    Symbol *s = e.EV.E1.EV.Vsym;
+                    Symbol *s = e.E1.Vsym;
                     s.Sflags &= ~(SFLunambig | GTregcand);
                 }
-                if (e.EV.E2.Eoper == OPvar)
+                if (e.E2.Eoper == OPvar)
                 {
-                    Symbol *s = e.EV.E2.EV.Vsym;
+                    Symbol *s = e.E2.Vsym;
                     s.Sflags &= ~(SFLunambig | GTregcand);
                 }
             }
-            out_regcand_walk(e.EV.E1, addressOfParam);
-            e = e.EV.E2;
+            out_regcand_walk(e.E1, addressOfParam);
+            e = e.E2;
         }
         else if (OTunary(e.Eoper))
         {
             // Don't put 'this' pointers in registers if we need
             // them for EH stack cleanup.
             if (e.Eoper == OPctor)
-            {   elem *e1 = e.EV.E1;
+            {   elem *e1 = e.E1;
 
                 if (e1.Eoper == OPadd)
-                    e1 = e1.EV.E1;
+                    e1 = e1.E1;
                 if (e1.Eoper == OPvar)
-                    e1.EV.Vsym.Sflags &= ~GTregcand;
+                    e1.Vsym.Sflags &= ~GTregcand;
             }
-            e = e.EV.E1;
+            e = e.E1;
         }
         else
         {   if (e.Eoper == OPrelconst)
             {
-                Symbol *s = e.EV.Vsym;
+                Symbol *s = e.Vsym;
                 assert(s);
                 symbol_debug(s);
                 switch (s.Sclass)
@@ -829,11 +829,11 @@ private void out_regcand_walk(elem *e, ref bool addressOfParam)
             }
             else if (e.Eoper == OPvar)
             {
-                if (e.EV.Voffset)
-                {   if (!(e.EV.Voffset == 1 && tybyte(e.Ety)) &&
-                        !(e.EV.Voffset == REGSIZE && tysize(e.Ety) == REGSIZE))
+                if (e.Voffset)
+                {   if (!(e.Voffset == 1 && tybyte(e.Ety)) &&
+                        !(e.Voffset == REGSIZE && tysize(e.Ety) == REGSIZE))
                     {
-                        e.EV.Vsym.Sflags &= ~GTregcand;
+                        e.Vsym.Sflags &= ~GTregcand;
                     }
                 }
             }

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -140,7 +140,7 @@ void el_term()
         while (nextfree)
         {
             elem *e;
-            e = nextfree.EV.E1;
+            e = nextfree.E1;
             mem_ffree(nextfree);
             nextfree = e;
         }
@@ -164,7 +164,7 @@ elem *el_calloc()
     if (nextfree)
     {
         e = nextfree;
-        nextfree = e.EV.E1;
+        nextfree = e.E1;
     }
     else
         e = cast(elem *) mem_fmalloc(elem.sizeof);
@@ -214,7 +214,7 @@ L1:
 
         case OPstring:
         case OPasm:
-            mem_free(e.EV.Vstring);
+            mem_free(e.Vstring);
             break;
 
         default:
@@ -222,10 +222,10 @@ L1:
             if (!OTleaf(op))
             {
                 if (OTbinary(op))
-                    el_free(e.EV.E2);
-                elem* en = e.EV.E1;
+                    el_free(e.E2);
+                elem* en = e.E1;
                 debug memset(e,0xFF,elem_size);
-                e.EV.E1 = nextfree;
+                e.E1 = nextfree;
                 nextfree = e;
 
                 version (STATS)
@@ -237,7 +237,7 @@ L1:
             break;
     }
     debug memset(e,0xFF,elem_size);
-    e.EV.E1 = nextfree;
+    e.E1 = nextfree;
     nextfree = e;
 
     version (STATS)
@@ -252,7 +252,7 @@ version (STATS)
         elem *e;
         int count;
 
-        for(e=nextfree;e;e=e.EV.E1)
+        for(e=nextfree;e;e=e.E1)
             count++;
         printf("Requests for elems %d\n",elcount);
         printf("Requests to free elems %d\n",elfreed);
@@ -362,7 +362,7 @@ elem *el_combines(void **args, int length)
 size_t el_opN(const elem *e, OPER op)
 {
     if (e.Eoper == op)
-        return el_opN(e.EV.E1, op) + el_opN(e.EV.E2, op);
+        return el_opN(e.E1, op) + el_opN(e.E2, op);
     else
         return 1;
 }
@@ -376,8 +376,8 @@ void el_opArray(elem ***parray, elem *e, OPER op)
 {
     if (e.Eoper == op)
     {
-        el_opArray(parray, e.EV.E1, op);
-        el_opArray(parray, e.EV.E2, op);
+        el_opArray(parray, e.E1, op);
+        el_opArray(parray, e.E2, op);
     }
     else
     {
@@ -391,10 +391,10 @@ void el_opFree(elem *e, OPER op)
 {
     if (e.Eoper == op)
     {
-        el_opFree(e.EV.E1, op);
-        el_opFree(e.EV.E2, op);
-        e.EV.E1 = null;
-        e.EV.E2 = null;
+        el_opFree(e.E1, op);
+        el_opFree(e.E2, op);
+        e.E1 = null;
+        e.E2 = null;
         el_free(e);
     }
 }
@@ -431,8 +431,8 @@ void el_paramArray(elem ***parray, elem *e)
 {
     if (e.Eoper == OPparam)
     {
-        el_paramArray(parray, e.EV.E1);
-        el_paramArray(parray, e.EV.E2);
+        el_paramArray(parray, e.E1);
+        el_paramArray(parray, e.E2);
         freenode(e);
     }
     else
@@ -500,10 +500,10 @@ elem * el_selecte1(elem *e)
     assert(!PARSER);
     elem_debug(e);
     assert(!OTleaf(e.Eoper));
-    e1 = e.EV.E1;
+    e1 = e.E1;
     elem_debug(e1);
-    if (e.EV.E2) elem_debug(e.EV.E2);
-    e.EV.E1 = null;                               // so e1 won't be freed
+    if (e.E2) elem_debug(e.E2);
+    e.E1 = null;                               // so e1 won't be freed
     if (configv.addlinenumbers)
     {
         if (e.Esrcpos.Slinnum)
@@ -529,11 +529,11 @@ elem * el_selecte2(elem *e)
     //printf("el_selecte2(%p)\n",e);
     elem_debug(e);
     assert(OTbinary(e.Eoper));
-    if (e.EV.E1)
-        elem_debug(e.EV.E1);
-    e2 = e.EV.E2;
+    if (e.E1)
+        elem_debug(e.E1);
+    e2 = e.E2;
     elem_debug(e2);
-    e.EV.E2 = null;                       // so e2 won't be freed
+    e.E2 = null;                       // so e2 won't be freed
     if (configv.addlinenumbers)
     {
         if (e.Esrcpos.Slinnum)
@@ -568,9 +568,9 @@ elem * el_copytree(elem *e)
     d.Ecount = 0;
     if (!OTleaf(e.Eoper))
     {
-        d.EV.E1 = el_copytree(e.EV.E1);
+        d.E1 = el_copytree(e.E1);
         if (OTbinary(e.Eoper))
-            d.EV.E2 = el_copytree(e.EV.E2);
+            d.E2 = el_copytree(e.E2);
     }
     else
     {
@@ -588,19 +588,19 @@ static if (0)
 
                     el_convstring(e);   // convert string to symbol
                     d.Eoper = OPrelconst;
-                    d.EV.Vsym = e.EV.Vsym;
+                    d.Vsym = e.Vsym;
                     break;
                 }
 }
 static if (0)
 {
             case OPrelconst:
-                e.EV.sm.ethis = null;
+                e.sm.ethis = null;
                 break;
 }
             case OPasm:
-                d.EV.Vstring = cast(char *) mem_malloc(d.EV.Vstrlen);
-                memcpy(d.EV.Vstring,e.EV.Vstring,e.EV.Vstrlen);
+                d.Vstring = cast(char *) mem_malloc(d.Vstrlen);
+                memcpy(d.Vstring,e.Vstring,e.Vstrlen);
                 break;
 
             default:
@@ -632,9 +632,9 @@ elem *exp2_copytotemp(elem *e)
     {
         eeq.Eoper = OPstreq;
         eeq.ET = e.ET;
-        eeq.EV.E1.ET = e.ET;
+        eeq.E1.ET = e.ET;
         er.ET = e.ET;
-        er.EV.E2.ET = e.ET;
+        er.E2.ET = e.ET;
     }
     return er;
 }
@@ -651,7 +651,7 @@ elem * el_same(ref elem* pe)
     if (e && el_sideeffect(e))
     {
         pe = exp2_copytotemp(e);       /* convert to ((tmp=e),tmp)     */
-        e = pe.EV.E2;                  /* point at tmp                 */
+        e = pe.E2;                  /* point at tmp                 */
     }
     return el_copytree(e);
 }
@@ -668,7 +668,7 @@ elem *el_copytotmp(ref elem* pe)
     if (e)
     {
         pe = exp2_copytotemp(e);
-        e = pe.EV.E2;
+        e = pe.E2;
     }
     return el_copytree(e);
 }
@@ -689,9 +689,9 @@ int el_appears(const(elem)* e, const Symbol *s)
         elem_debug(e);
         if (!OTleaf(e.Eoper))
         {
-            if (OTbinary(e.Eoper) && el_appears(e.EV.E2,s))
+            if (OTbinary(e.Eoper) && el_appears(e.E2,s))
                 return 1;
-            e = e.EV.E1;
+            e = e.E1;
         }
         else
         {
@@ -699,7 +699,7 @@ int el_appears(const(elem)* e, const Symbol *s)
             {
                 case OPvar:
                 case OPrelconst:
-                    if (e.EV.Vsym == s)
+                    if (e.Vsym == s)
                         return 1;
                     break;
 
@@ -731,21 +731,21 @@ Symbol *el_basesym(elem *e)
         switch (e.Eoper)
         {
             case OPvar:
-                s = e.EV.Vsym;
+                s = e.Vsym;
                 break;
 
             case OPcomma:
-                e = e.EV.E2;
+                e = e.E2;
                 continue;
 
             case OPind:
-                s = el_basesym(e.EV.E1);
+                s = el_basesym(e.E1);
                 break;
 
             case OPadd:
-                s = el_basesym(e.EV.E1);
+                s = el_basesym(e.E1);
                 if (!s)
-                    s = el_basesym(e.EV.E2);
+                    s = el_basesym(e.E2);
                 break;
         }
         break;
@@ -764,23 +764,23 @@ Symbol *el_basesym(elem *e)
 bool el_anydef(const elem *ed, const(elem)* e)
 {
     const edop = ed.Eoper;
-    const s = (edop == OPvar) ? ed.EV.Vsym : null;
+    const s = (edop == OPvar) ? ed.Vsym : null;
     while (1)
     {
         const op = e.Eoper;
         if (!OTleaf(op))
         {
-            auto e1 = e.EV.E1;
+            auto e1 = e.E1;
             if (OTdef(op))
             {
-                if (e1.Eoper == OPvar && e1.EV.Vsym == s)
+                if (e1.Eoper == OPvar && e1.Vsym == s)
                     return true;
 
                 // This doesn't cover all the cases
                 if (e1.Eoper == edop && el_match(e1,ed))
                     return true;
             }
-            if (OTbinary(op) && el_anydef(ed,e.EV.E2))
+            if (OTbinary(op) && el_anydef(ed,e.E2))
                 return true;
             e = e1;
         }
@@ -812,8 +812,8 @@ elem* el_bint(OPER op,type *t,elem *e1,elem *e2)
     elem_debug(e1);
     if (e2)
         elem_debug(e2);
-    e.EV.E1 = e1;
-    e.EV.E2 = e2;
+    e.E1 = e1;
+    e.E2 = e2;
     return e;
 }
 
@@ -831,8 +831,8 @@ static if (0)
     elem* e = el_calloc();
     e.Ety = ty;
     e.Eoper = cast(ubyte)op;
-    e.EV.E1 = e1;
-    e.EV.E2 = e2;
+    e.E1 = e1;
+    e.E2 = e2;
     if (op == OPcomma && tyaggregate(ty))
         e.ET = e2.ET;
     return e;
@@ -853,7 +853,7 @@ elem* el_unat(OPER op,type *t,elem *e1)
     elem_debug(e1);
     elem* e = el_calloc();
     e.Eoper = cast(ubyte)op;
-    e.EV.E1 = e1;
+    e.E1 = e1;
     if (t)
     {
         type_debug(t);
@@ -874,7 +874,7 @@ elem* el_una(OPER op,tym_t ty,elem *e1)
     elem* e = el_calloc();
     e.Ety = ty;
     e.Eoper = cast(ubyte)op;
-    e.EV.E1 = e1;
+    e.E1 = e1;
     return e;
 }
 
@@ -894,7 +894,7 @@ extern (C) elem * el_longt(type *t,targ_llong val)
         type_debug(t);
         e.ET.Tcount++;
     }
-    e.EV.Vllong = val;
+    e.Vllong = val;
     return e;
 }
 
@@ -909,17 +909,17 @@ elem * el_long(tym_t t,targ_llong val)
     {
         case TYfloat:
         case TYifloat:
-            e.EV.Vfloat = val;
+            e.Vfloat = val;
             break;
 
         case TYdouble:
         case TYidouble:
-            e.EV.Vdouble = val;
+            e.Vdouble = val;
             break;
 
         case TYldouble:
         case TYildouble:
-            e.EV.Vldouble = val;
+            e.Vldouble = val;
             break;
 
         case TYcfloat:
@@ -928,7 +928,7 @@ elem * el_long(tym_t t,targ_llong val)
             assert(0);
 
         default:
-            e.EV.Vllong = val;
+            e.Vllong = val;
             break;
     }
     return e;
@@ -964,7 +964,7 @@ elem* el_vectorConst(tym_t ty, ulong val)
         case TYuchar32:
             foreach (i; 0 .. sz)
             {
-                e.EV.Vuchar32[i] = cast(ubyte)val;
+                e.Vuchar32[i] = cast(ubyte)val;
             }
             break;
 
@@ -974,7 +974,7 @@ elem* el_vectorConst(tym_t ty, ulong val)
         case TYushort16:
             foreach (i; 0 .. sz / 2)
             {
-                e.EV.Vushort16[i] = cast(ushort)val;
+                e.Vushort16[i] = cast(ushort)val;
             }
             break;
 
@@ -984,7 +984,7 @@ elem* el_vectorConst(tym_t ty, ulong val)
         case TYulong8:
             foreach (i; 0 .. sz / 4)
             {
-                e.EV.Vulong8[i] = cast(uint)val;
+                e.Vulong8[i] = cast(uint)val;
             }
             break;
 
@@ -994,7 +994,7 @@ elem* el_vectorConst(tym_t ty, ulong val)
         case TYullong4:
             foreach (i; 0 .. sz / 8)
             {
-                e.EV.Vullong4[i] = val;
+                e.Vullong4[i] = val;
             }
             break;
 
@@ -1032,7 +1032,7 @@ bool el_funcsideeff(const elem *e)
 {
     const(Symbol)* s;
     if (e.Eoper == OPvar &&
-        tyfunc((s = e.EV.Vsym).Stype.Tty) &&
+        tyfunc((s = e.Vsym).Stype.Tty) &&
         ((s.Sfunc && s.Sfunc.Fflags3 & Fnosideeff) || s == funcsym_p)
        )
         return false;
@@ -1052,9 +1052,9 @@ bool el_sideeffect(const elem *e)
     elem_debug(e);
     return  typemask(e) & (mTYvolatile | mTYshared) ||
             OTsideff(op) ||
-            (OTunary(op) && el_sideeffect(e.EV.E1)) ||
-            (OTbinary(op) && (el_sideeffect(e.EV.E1) ||
-                                  el_sideeffect(e.EV.E2)));
+            (OTunary(op) && el_sideeffect(e.E1)) ||
+            (OTbinary(op) && (el_sideeffect(e.E1) ||
+                                  el_sideeffect(e.E2)));
 }
 
 /******************************
@@ -1075,7 +1075,7 @@ int el_depends(const(elem)* ea, const elem *eb)
     switch (ea.Eoper)
     {
         case OPbit:
-            ea = ea.EV.E1;
+            ea = ea.E1;
             goto L1;
 
         case OPvar:
@@ -1093,7 +1093,7 @@ int el_depends(const(elem)* ea, const elem *eb)
             goto Lnodep;
 
         case OPvar:
-            if (ea.Eoper == OPvar && ea.EV.Vsym != eb.EV.Vsym)
+            if (ea.Eoper == OPvar && ea.Vsym != eb.Vsym)
                 goto Lnodep;
             break;
 
@@ -1141,8 +1141,8 @@ bool el_returns(const(elem)* e)
         {
             case OPcall:
             case OPucall:
-                e = e.EV.E1;
-                if (e.Eoper == OPvar && e.EV.Vsym.Sflags & SFLexit)
+                e = e.E1;
+                if (e.Eoper == OPvar && e.Vsym.Sflags & SFLexit)
                     return false;
                 break;
 
@@ -1151,24 +1151,24 @@ bool el_returns(const(elem)* e)
 
             case OPandand:
             case OPoror:
-                e = e.EV.E1;
+                e = e.E1;
                 continue;
 
             case OPcolon:
             case OPcolon2:
-                return el_returns(e.EV.E1) || el_returns(e.EV.E2);
+                return el_returns(e.E1) || el_returns(e.E2);
 
             default:
                 if (OTbinary(e.Eoper))
                 {
-                    if (!el_returns(e.EV.E2))
+                    if (!el_returns(e.E2))
                         return false;
-                    e = e.EV.E1;
+                    e = e.E1;
                     continue;
                 }
                 if (OTunary(e.Eoper))
                 {
-                    e = e.EV.E1;
+                    e = e.E1;
                     continue;
                 }
                 break;
@@ -1188,7 +1188,7 @@ bool el_returns(const(elem)* e)
 elem **el_scancommas(elem **pe)
 {
     while ((*pe).Eoper == OPcomma)
-        pe = &(*pe).EV.E2;
+        pe = &(*pe).E2;
     return pe;
 }
 
@@ -1204,14 +1204,14 @@ int el_countCommas(const(elem)* e)
     {
         if (OTbinary(e.Eoper))
         {
-            ncommas += (e.Eoper == OPcomma) + el_countCommas(e.EV.E2);
+            ncommas += (e.Eoper == OPcomma) + el_countCommas(e.E2);
         }
         else if (OTunary(e.Eoper))
         {
         }
         else
             break;
-        e = e.EV.E1;
+        e = e.E1;
     }
     return ncommas;
 }
@@ -1245,15 +1245,15 @@ elem *el_convfloat(elem *e)
     {
         case TYfloat:
         case TYifloat:
-            p = &e.EV.Vfloat;
-            assert(sz == (e.EV.Vfloat).sizeof);
+            p = &e.Vfloat;
+            assert(sz == (e.Vfloat).sizeof);
             break;
 
         case TYdouble:
         case TYidouble:
         case TYdouble_alias:
-            p = &e.EV.Vdouble;
-            assert(sz == (e.EV.Vdouble).sizeof);
+            p = &e.Vdouble;
+            assert(sz == (e.Vdouble).sizeof);
             break;
 
         case TYldouble:
@@ -1263,24 +1263,24 @@ elem *el_convfloat(elem *e)
              */
             p = buffer.ptr;
             memset(buffer.ptr, 0, sz);                      // ensure padding is 0
-            memcpy(buffer.ptr, &e.EV.Vldouble, 10);
+            memcpy(buffer.ptr, &e.Vldouble, 10);
             break;
 
         case TYcfloat:
-            p = &e.EV.Vcfloat;
-            assert(sz == (e.EV.Vcfloat).sizeof);
+            p = &e.Vcfloat;
+            assert(sz == (e.Vcfloat).sizeof);
             break;
 
         case TYcdouble:
-            p = &e.EV.Vcdouble;
-            assert(sz == (e.EV.Vcdouble).sizeof);
+            p = &e.Vcdouble;
+            assert(sz == (e.Vcdouble).sizeof);
             break;
 
         case TYcldouble:
             p = buffer.ptr;
             memset(buffer.ptr, 0, sz);
-            memcpy(buffer.ptr, &e.EV.Vcldouble.re, 10);
-            memcpy(buffer.ptr + tysize(TYldouble), &e.EV.Vcldouble.im, 10);
+            memcpy(buffer.ptr, &e.Vcldouble.re, 10);
+            memcpy(buffer.ptr + tysize(TYldouble), &e.Vcldouble.im, 10);
             break;
 
         default:
@@ -1289,10 +1289,10 @@ elem *el_convfloat(elem *e)
 
     static if (0)
     {
-        printf("%gL+%gLi\n", cast(double)e.EV.Vcldouble.re, cast(double)e.EV.Vcldouble.im);
-        printf("el_convfloat() %g %g sz=%d\n", e.EV.Vcdouble.re, e.EV.Vcdouble.im, sz);
+        printf("%gL+%gLi\n", cast(double)e.Vcldouble.re, cast(double)e.Vcldouble.im);
+        printf("el_convfloat() %g %g sz=%d\n", e.Vcdouble.re, e.Vcdouble.im, sz);
         printf("el_convfloat(): sz = %d\n", sz);
-        ushort *p = cast(ushort *)&e.EV.Vcldouble;
+        ushort *p = cast(ushort *)&e.Vcldouble;
         for (int i = 0; i < sz/2; i++) printf("%04x ", p[i]);
         printf("\n");
     }
@@ -1360,9 +1360,9 @@ elem *el_convstring(elem *e)
     assert(!PARSER);
     elem_debug(e);
     assert(e.Eoper == OPstring);
-    p = e.EV.Vstring;
-    e.EV.Vstring = null;
-    size_t len = e.EV.Vstrlen;
+    p = e.Vstring;
+    e.Vstring = null;
+    size_t len = e.Vstrlen;
 
     // Handle strings that go into the code segment
     if (tybasic(e.Ety) == TYcptr ||
@@ -1425,12 +1425,12 @@ L1:
     // Refer e to the symbol generated
     elem *ex = el_ptr(s);
     ex.Ety = e.Ety;
-    if (e.EV.Voffset)
+    if (e.Voffset)
     {
         if (ex.Eoper == OPrelconst)
-             ex.EV.Voffset += e.EV.Voffset;
+             ex.Voffset += e.Voffset;
         else
-             ex = el_bin(OPadd, ex.Ety, ex, el_long(TYint, e.EV.Voffset));
+             ex = el_bin(OPadd, ex.Ety, ex, el_long(TYint, e.Voffset));
     }
     el_free(e);
     return ex;
@@ -1456,7 +1456,7 @@ void shrinkLongDoubleConstantIfPossible(elem *e)
          * Use 'volatile' to prevent optimizer from folding away the conversions,
          * and thereby missing the truncation in the conversion to double.
          */
-        auto v = e.EV.Vldouble;
+        auto v = e.Vldouble;
         double vDouble;
 
         version (CRuntime_Microsoft)
@@ -1472,7 +1472,7 @@ void shrinkLongDoubleConstantIfPossible(elem *e)
         if (v == vDouble)       // This will fail if compiler does NaN incorrectly!
         {
             // Yes, we can do it!
-            e.EV.Vdouble = vDouble;
+            e.Vdouble = vDouble;
             e.Ety = TYdouble;
         }
     }
@@ -1515,10 +1515,10 @@ elem *el_convert(elem *e)
              * in this case, we preserve the constant 2.
              */
             if (tyreal(e.Ety) &&       // don't bother with imaginary or complex
-                e.EV.E2.Eoper == OPconst && el_toldoubled(e.EV.E2) == 2.0L)
+                e.E2.Eoper == OPconst && el_toldoubled(e.E2) == 2.0L)
             {
-                e.EV.E1 = el_convert(e.EV.E1);
-                /* Don't call el_convert(e.EV.E2), we want it to stay as a constant
+                e.E1 = el_convert(e.E1);
+                /* Don't call el_convert(e.E2), we want it to stay as a constant
                  * which will be detected by code gen.
                  */
                 break;
@@ -1530,20 +1530,20 @@ elem *el_convert(elem *e)
         case OPmin:
             // For a*b,a+b,a-b,a/b, if a long double constant is involved, convert it to a double constant.
             if (tyreal(e.Ety))
-                 shrinkLongDoubleConstantIfPossible(e.EV.E1);
+                 shrinkLongDoubleConstantIfPossible(e.E1);
             if (tyreal(e.Ety))
-                shrinkLongDoubleConstantIfPossible(e.EV.E2);
+                shrinkLongDoubleConstantIfPossible(e.E2);
             goto default;
 
         default:
             if (OTbinary(op))
             {
-                e.EV.E1 = el_convert(e.EV.E1);
-                e.EV.E2 = el_convert(e.EV.E2);
+                e.E1 = el_convert(e.E1);
+                e.E2 = el_convert(e.E2);
             }
             else if (OTunary(op))
             {
-                e.EV.E1 = el_convert(e.EV.E1);
+                e.E1 = el_convert(e.E1);
             }
             break;
     }
@@ -1583,7 +1583,7 @@ elem *el_dctor(elem *e,void *decl)
     elem *ector = el_calloc();
     ector.Eoper = OPdctor;
     ector.Ety = TYvoid;
-    ector.EV.ed.Edecl = decl;
+    ector.ed.Edecl = decl;
     if (e)
         e = el_bin(OPinfo,e.Ety,ector,e);
     else
@@ -1613,8 +1613,8 @@ elem *el_ddtor(elem *e,void *decl)
     elem *edtor = el_calloc();
     edtor.Eoper = OPddtor;
     edtor.Ety = TYvoid;
-    edtor.EV.ed.Edecl = decl;
-    edtor.EV.ed.Eleft = e;
+    edtor.ed.Edecl = decl;
+    edtor.ed.Eleft = e;
     return edtor;
 }
 }
@@ -1657,7 +1657,7 @@ elem *el_ctor_dtor(elem *ec, elem *ed, out elem* pedtor)
         elem *ector = el_calloc();
         ector.Eoper = OPdctor;
         ector.Ety = TYvoid;
-//      ector.EV.ed.Edecl = decl;
+//      ector.ed.Edecl = decl;
 
         eve c = void;
         memset(&c, 0, c.sizeof);
@@ -1671,8 +1671,8 @@ elem *el_ctor_dtor(elem *ec, elem *ed, out elem* pedtor)
         elem *edtor = el_calloc();
         edtor.Eoper = OPddtor;
         edtor.Ety = TYvoid;
-//      edtor.EV.Edecl = decl;
-//      edtor.EV.E1 = e;
+//      edtor.Edecl = decl;
+//      edtor.E1 = e;
 
         c.Vint = 1;
         elem *e_flag_1 = el_bin(OPeq, TYvoid, el_var(sflag), el_const(TYbool, c));  // __flag = 1
@@ -1680,7 +1680,7 @@ elem *el_ctor_dtor(elem *ec, elem *ed, out elem* pedtor)
         elem *eu = el_bin(OPcall, TYvoid, el_var(getRtlsym(RTLSYM.UNWIND_RESUME)), el_var(seo));
         eu = el_bin(OPandand, TYvoid, el_una(OPnot, TYbool, el_var(sflag)), eu);
 
-        edtor.EV.E1 = el_combine(el_combine(e_eax, ed), eu);
+        edtor.E1 = el_combine(el_combine(e_eax, ed), eu);
 
         pedtor = el_combine(e_flag_1, edtor);
     }
@@ -1693,7 +1693,7 @@ elem *el_ctor_dtor(elem *ec, elem *ed, out elem* pedtor)
         elem *ector = el_calloc();
         ector.Eoper = OPdctor;
         ector.Ety = TYvoid;
-//      ector.EV.ed.Edecl = decl;
+//      ector.ed.Edecl = decl;
         if (ec)
             er = el_bin(OPinfo,ec.Ety,ector,ec);
         else
@@ -1709,8 +1709,8 @@ elem *el_ctor_dtor(elem *ec, elem *ed, out elem* pedtor)
         elem *edtor = el_calloc();
         edtor.Eoper = OPddtor;
         edtor.Ety = TYvoid;
-//      edtor.EV.Edecl = decl;
-        edtor.EV.E1 = ed;
+//      edtor.Edecl = decl;
+        edtor.E1 = ed;
         pedtor = edtor;
     }
 
@@ -1770,13 +1770,13 @@ elem ** el_parent(elem *e, return ref elem* pe)
     if (e == pe)
         return &pe; // not @safe
     else if (OTunary(pe.Eoper))
-        return el_parent(e, pe.EV.E1);
+        return el_parent(e, pe.E1);
     else if (OTbinary(pe.Eoper))
     {
-        elem** pe2 = el_parent(e, pe.EV.E1);
+        elem** pe2 = el_parent(e, pe.E1);
         if (pe2)
             return pe2;
-        return el_parent(e, pe.EV.E2);
+        return el_parent(e, pe.E2);
     }
     else
         return null;
@@ -1824,8 +1824,8 @@ L1:
     L2:
         if (PARSER)
         {
-            n1 = n1.EV.E1;
-            n2 = n2.EV.E1;
+            n1 = n1.E1;
+            n2 = n2.E1;
             assert(n1 && n2);
             goto L1;
         }
@@ -1835,17 +1835,17 @@ L1:
             {   if (/*n1.Enumbytes != n2.Enumbytes ||*/ n1.ET != n2.ET)
                     return false;
             }
-            n1 = n1.EV.E1;
-            n2 = n2.EV.E1;
+            n1 = n1.E1;
+            n2 = n2.E1;
             assert(n1 && n2);
             goto L1;
         }
         else
         {
-            if (n1.EV.E1 == n2.EV.E1)
+            if (n1.E1 == n2.E1)
                 goto ismatch;
-            n1 = n1.EV.E1;
-            n2 = n2.EV.E1;
+            n1 = n1.E1;
+            n2 = n2.E1;
             assert(n1 && n2);
             goto L1;
         }
@@ -1860,7 +1860,7 @@ L1:
                     return false;
             }
         }
-        if (el_matchx(n1.EV.E2, n2.EV.E2, gmatch2))
+        if (el_matchx(n1.E2, n2.E2, gmatch2))
         {
             goto L2;    // check left tree
         }
@@ -1881,7 +1881,7 @@ L1:
                     case TYushort:
                     case TYchar16:
                     case_short:
-                        if (n1.EV.Vshort != n2.EV.Vshort)
+                        if (n1.Vshort != n2.Vshort)
                             return false;
                         break;
 
@@ -1889,20 +1889,20 @@ L1:
                     case TYulong:
                     case TYdchar:
                     case_long:
-                        if (n1.EV.Vlong != n2.EV.Vlong)
+                        if (n1.Vlong != n2.Vlong)
                             return false;
                         break;
 
                     case TYllong:
                     case TYullong:
                     case_llong:
-                        if (n1.EV.Vllong != n2.EV.Vllong)
+                        if (n1.Vllong != n2.Vllong)
                             return false;
                         break;
 
                     case TYcent:
                     case TYucent:
-                        if (n1.EV.Vcent != n2.EV.Vcent)
+                        if (n1.Vcent != n2.Vcent)
                                 return false;
                         break;
 
@@ -1942,7 +1942,7 @@ L1:
                     case TYchar:
                     case TYuchar:
                     case TYschar:
-                        if (n1.EV.Vschar != n2.EV.Vschar)
+                        if (n1.Vschar != n2.Vschar)
                             return false;
                         break;
 
@@ -1962,20 +1962,20 @@ L1:
                          */
                     case TYfloat:
                     case TYifloat:
-                        if (memcmp(&n1.EV,&n2.EV,(n1.EV.Vfloat).sizeof))
+                        if (memcmp(&n1.EV,&n2.EV,(n1.Vfloat).sizeof))
                             return false;
                         break;
 
                     case TYdouble:
                     case TYdouble_alias:
                     case TYidouble:
-                        if (memcmp(&n1.EV,&n2.EV,(n1.EV.Vdouble).sizeof))
+                        if (memcmp(&n1.EV,&n2.EV,(n1.Vdouble).sizeof))
                             return false;
                         break;
 
                     case TYldouble:
                     case TYildouble:
-                        static if ((n1.EV.Vldouble).sizeof > 10)
+                        static if ((n1.Vldouble).sizeof > 10)
                         {
                             /* sizeof is 12, but actual size is 10 */
                             if (memcmp(&n1.EV,&n2.EV,10))
@@ -1983,18 +1983,18 @@ L1:
                         }
                         else
                         {
-                            if (memcmp(&n1.EV,&n2.EV,(n1.EV.Vldouble).sizeof))
+                            if (memcmp(&n1.EV,&n2.EV,(n1.Vldouble).sizeof))
                                 return false;
                         }
                         break;
 
                     case TYcfloat:
-                        if (memcmp(&n1.EV,&n2.EV,(n1.EV.Vcfloat).sizeof))
+                        if (memcmp(&n1.EV,&n2.EV,(n1.Vcfloat).sizeof))
                             return false;
                         break;
 
                     case TYcdouble:
-                        if (memcmp(&n1.EV,&n2.EV,(n1.EV.Vcdouble).sizeof))
+                        if (memcmp(&n1.EV,&n2.EV,(n1.Vcdouble).sizeof))
                             return false;
                         break;
 
@@ -2008,7 +2008,7 @@ L1:
                     case TYulong4:
                     case TYllong2:
                     case TYullong2:
-                        if (n1.EV.Vcent != n2.EV.Vcent)
+                        if (n1.Vcent != n2.Vcent)
                             return false;
                         break;
 
@@ -2027,16 +2027,16 @@ L1:
                         break;
 
                     case TYcldouble:
-                        static if ((n1.EV.Vldouble).sizeof > 10)
+                        static if ((n1.Vldouble).sizeof > 10)
                         {
                             /* sizeof is 12, but actual size of each part is 10 */
                             if (memcmp(&n1.EV,&n2.EV,10) ||
-                                memcmp(&n1.EV.Vldouble + 1, &n2.EV.Vldouble + 1, 10))
+                                memcmp(&n1.Vldouble + 1, &n2.Vldouble + 1, 10))
                                 return false;
                         }
                         else
                         {
-                            if (memcmp(&n1.EV,&n2.EV,(n1.EV.Vcldouble).sizeof))
+                            if (memcmp(&n1.EV,&n2.EV,(n1.Vcldouble).sizeof))
                                 return false;
                         }
                         break;
@@ -2051,21 +2051,21 @@ L1:
                 break;
             case OPrelconst:
             case OPvar:
-                symbol_debug(n1.EV.Vsym);
-                symbol_debug(n2.EV.Vsym);
-                if (n1.EV.Voffset != n2.EV.Voffset)
+                symbol_debug(n1.Vsym);
+                symbol_debug(n2.Vsym);
+                if (n1.Voffset != n2.Voffset)
                     return false;
-                if (n1.EV.Vsym != n2.EV.Vsym)
+                if (n1.Vsym != n2.Vsym)
                     return false;
                 break;
 
             case OPasm:
             case OPstring:
             {
-                const n = n2.EV.Vstrlen;
-                if (n1.EV.Vstrlen != n ||
-                    n1.EV.Voffset != n2.EV.Voffset ||
-                    memcmp(n1.EV.Vstring, n2.EV.Vstring, n))
+                const n = n2.Vstrlen;
+                if (n1.Vstrlen != n ||
+                    n1.Voffset != n2.Voffset ||
+                    memcmp(n1.Vstring, n2.Vstring, n))
                         return false;   /* check bytes in the string    */
                 break;
             }
@@ -2167,25 +2167,25 @@ targ_llong el_tolong(elem *e)
             goto case TYschar;
 
         case TYschar:
-            result = e.EV.Vschar;
+            result = e.Vschar;
             break;
 
         case TYuchar:
         case TYbool:
         Uchar:
-            result = e.EV.Vuchar;
+            result = e.Vuchar;
             break;
 
         case TYshort:
         Ishort:
-            result = e.EV.Vshort;
+            result = e.Vshort;
             break;
 
         case TYushort:
         case TYwchar_t:
         case TYchar16:
         Ushort:
-            result = e.EV.Vushort;
+            result = e.Vushort;
             break;
 
         case TYsptr:
@@ -2217,7 +2217,7 @@ targ_llong el_tolong(elem *e)
         case TYvptr:
         case TYvoid:                    /* some odd cases               */
         Ulong:
-            result = e.EV.Vulong;
+            result = e.Vulong;
             break;
 
         case TYint:
@@ -2227,13 +2227,13 @@ targ_llong el_tolong(elem *e)
 
         case TYlong:
         Ilong:
-            result = e.EV.Vlong;
+            result = e.Vlong;
             break;
 
         case TYllong:
         case TYullong:
         Ullong:
-            result = e.EV.Vullong;
+            result = e.Vullong;
             break;
 
         case TYdouble_alias:
@@ -2275,7 +2275,7 @@ bool el_allbits(const elem* e,int bit)
 {
     elem_debug(e);
     assert(e.Eoper == OPconst);
-    targ_llong value = e.EV.Vullong;
+    targ_llong value = e.Vullong;
     switch (tysize(e.Ety))
     {
         case 1: value = cast(byte) value;
@@ -2309,7 +2309,7 @@ bool el_signx32(const elem* e)
     assert(e.Eoper == OPconst);
     if (tysize(e.Ety) == 8)
     {
-        if (e.EV.Vullong != cast(int)e.EV.Vullong)
+        if (e.Vullong != cast(int)e.Vullong)
             return false;
     }
     return true;
@@ -2331,21 +2331,21 @@ longdouble_soft el_toldouble(elem *e)
     {
         case TYfloat:
         case TYifloat:
-            result = longdouble_soft(e.EV.Vfloat);
+            result = longdouble_soft(e.Vfloat);
             break;
 
         case TYdouble:
         case TYidouble:
         case TYdouble_alias:
-            result = longdouble_soft(e.EV.Vdouble);
+            result = longdouble_soft(e.Vdouble);
             break;
 
         case TYldouble:
         case TYildouble:
-            static if (is(typeof(e.EV.Vldouble) == real))
-                result = longdouble_soft(e.EV.Vldouble);
+            static if (is(typeof(e.Vldouble) == real))
+                result = longdouble_soft(e.Vldouble);
             else
-                result = longdouble_soft(cast(real)e.EV.Vldouble);
+                result = longdouble_soft(cast(real)e.Vldouble);
             break;
 
         default:
@@ -2366,18 +2366,18 @@ targ_ldouble el_toldouble(elem *e)
     {
         case TYfloat:
         case TYifloat:
-            result = e.EV.Vfloat;
+            result = e.Vfloat;
             break;
 
         case TYdouble:
         case TYidouble:
         case TYdouble_alias:
-            result = e.EV.Vdouble;
+            result = e.Vdouble;
             break;
 
         case TYldouble:
         case TYildouble:
-            result = e.EV.Vldouble;
+            result = e.Vldouble;
             break;
 
         default:
@@ -2403,12 +2403,12 @@ bool el_isdependent(elem* e)
         if (e.PEFflags & PEFdependent)
             return true;
         if (OTunary(e.Eoper))
-            e = e.EV.E1;
+            e = e.E1;
         else if (OTbinary(e.Eoper))
         {
-            if (el_isdependent(e.EV.E2))
+            if (el_isdependent(e.E2))
                 return true;
-            e = e.EV.E1;
+            e = e.E1;
         }
         else
             break;
@@ -2446,11 +2446,11 @@ void el_check(const(elem)* e)
     while (1)
     {
         if (OTunary(e.Eoper))
-            e = e.EV.E1;
+            e = e.E1;
         else if (OTbinary(e.Eoper))
         {
-            el_check(e.EV.E2);
-            e = e.EV.E1;
+            el_check(e.E2);
+            e = e.E1;
         }
         else
             break;
@@ -2508,38 +2508,38 @@ void elem_print(const elem* e, int nestlevel = 0)
     }
     if (OTunary(e.Eoper))
     {
-        if (e.EV.E2)
-            printf("%p %p\n",e.EV.E1,e.EV.E2);
+        if (e.E2)
+            printf("%p %p\n",e.E1,e.E2);
         else
-            printf("%p\n",e.EV.E1);
-        elem_print(e.EV.E1, nestlevel + 1);
+            printf("%p\n",e.E1);
+        elem_print(e.E1, nestlevel + 1);
     }
     else if (OTbinary(e.Eoper))
     {
         if (!PARSER && e.Eoper == OPstreq && e.ET)
                 printf("bytes=%d ", cast(int)type_size(e.ET));
-        printf("%p %p\n",e.EV.E1,e.EV.E2);
-        elem_print(e.EV.E1, nestlevel + 1);
-        elem_print(e.EV.E2, nestlevel + 1);
+        printf("%p %p\n",e.E1,e.E2);
+        elem_print(e.E1, nestlevel + 1);
+        elem_print(e.E2, nestlevel + 1);
     }
     else
     {
         switch (e.Eoper)
         {
             case OPrelconst:
-                printf(" %lld+&",cast(ulong)e.EV.Voffset);
-                printf(" %s",e.EV.Vsym.Sident.ptr);
+                printf(" %lld+&",cast(ulong)e.Voffset);
+                printf(" %s",e.Vsym.Sident.ptr);
                 break;
 
             case OPvar:
-                if (e.EV.Voffset)
-                    printf(" %lld+",cast(ulong)e.EV.Voffset);
-                printf(" %s",e.EV.Vsym.Sident.ptr);
+                if (e.Voffset)
+                    printf(" %lld+",cast(ulong)e.Voffset);
+                printf(" %s",e.Vsym.Sident.ptr);
                 break;
 
             case OPasm:
             case OPstring:
-                printf(" '%s',%lld",e.EV.Vstring,cast(ulong)e.EV.Voffset);
+                printf(" '%s',%lld",e.Vstring,cast(ulong)e.Voffset);
                 break;
 
             case OPconst:
@@ -2564,7 +2564,7 @@ case_tym:
         case TYchar:
         case TYschar:
         case TYuchar:
-            printf("%d ",e.EV.Vuchar);
+            printf("%d ",e.Vuchar);
             break;
 
         case TYsptr:
@@ -2603,7 +2603,7 @@ case_tym:
         case TYushort:
         case TYchar16:
         L3:
-            printf("%d ",e.EV.Vint);
+            printf("%d ",e.Vint);
             break;
 
         case TYlong:
@@ -2613,30 +2613,30 @@ case_tym:
         case TYvptr:
         case TYhptr:
         L1:
-            printf("%dL ",e.EV.Vlong);
+            printf("%dL ",e.Vlong);
             break;
 
         case TYllong:
         L2:
-            printf("%lldLL ",cast(ulong)e.EV.Vllong);
+            printf("%lldLL ",cast(ulong)e.Vllong);
             break;
 
         case TYullong:
-            printf("%lluLL ",cast(ulong)e.EV.Vullong);
+            printf("%lluLL ",cast(ulong)e.Vullong);
             break;
 
         case TYcent:
         case TYucent:
-            printf("%lluLL+%lluLL ", cast(ulong)e.EV.Vcent.hi, cast(ulong)e.EV.Vcent.lo);
+            printf("%lluLL+%lluLL ", cast(ulong)e.Vcent.hi, cast(ulong)e.Vcent.lo);
             break;
 
         case TYfloat:
-            printf("%gf ",cast(double)e.EV.Vfloat);
+            printf("%gf ",cast(double)e.Vfloat);
             break;
 
         case TYdouble:
         case TYdouble_alias:
-            printf("%g ",cast(double)e.EV.Vdouble);
+            printf("%g ",cast(double)e.Vdouble);
             break;
 
         case TYldouble:
@@ -2645,39 +2645,39 @@ case_tym:
             {
                 const buffer_len = 3 + 3 * (targ_ldouble).sizeof + 1;
                 char[buffer_len] buffer = void;
-                static if (is(typeof(e.EV.Vldouble) == real))
-                    ld_sprint(buffer.ptr, buffer_len, 'g', longdouble_soft(e.EV.Vldouble));
+                static if (is(typeof(e.Vldouble) == real))
+                    ld_sprint(buffer.ptr, buffer_len, 'g', longdouble_soft(e.Vldouble));
                 else
-                    ld_sprint(buffer.ptr, buffer_len, 'g', longdouble_soft(cast(real)e.EV.Vldouble));
+                    ld_sprint(buffer.ptr, buffer_len, 'g', longdouble_soft(cast(real)e.Vldouble));
                 printf("%s ", buffer.ptr);
             }
             else
-                printf("%Lg ", e.EV.Vldouble);
+                printf("%Lg ", e.Vldouble);
             break;
         }
 
         case TYifloat:
-            printf("%gfi ", cast(double)e.EV.Vfloat);
+            printf("%gfi ", cast(double)e.Vfloat);
             break;
 
         case TYidouble:
-            printf("%gi ", cast(double)e.EV.Vdouble);
+            printf("%gi ", cast(double)e.Vdouble);
             break;
 
         case TYildouble:
-            printf("%gLi ", cast(double)e.EV.Vldouble);
+            printf("%gLi ", cast(double)e.Vldouble);
             break;
 
         case TYcfloat:
-            printf("%gf+%gfi ", cast(double)e.EV.Vcfloat.re, cast(double)e.EV.Vcfloat.im);
+            printf("%gf+%gfi ", cast(double)e.Vcfloat.re, cast(double)e.Vcfloat.im);
             break;
 
         case TYcdouble:
-            printf("%g+%gi ", cast(double)e.EV.Vcdouble.re, cast(double)e.EV.Vcdouble.im);
+            printf("%g+%gi ", cast(double)e.Vcdouble.re, cast(double)e.Vcdouble.im);
             break;
 
         case TYcldouble:
-            printf("%gL+%gLi ", cast(double)e.EV.Vcldouble.re, cast(double)e.EV.Vcldouble.im);
+            printf("%gL+%gLi ", cast(double)e.Vcldouble.re, cast(double)e.Vcldouble.im);
             break;
 
         // SIMD 16 byte vector types        // D type
@@ -2691,7 +2691,7 @@ case_tym:
         case TYulong4:
         case TYllong2:
         case TYullong2:
-            printf("%llxLL+%llxLL ", cast(long)e.EV.Vcent.hi, cast(long)e.EV.Vcent.lo);
+            printf("%llxLL+%llxLL ", cast(long)e.Vcent.hi, cast(long)e.Vcent.lo);
             break;
 
         // SIMD 32 byte (256 bit) vector types
@@ -2706,7 +2706,7 @@ case_tym:
         case TYllong4:            // long[4]
         case TYullong4:           // ulong[4]
              printf("x%llx,x%llx,x%llx,x%llx ",
-                e.EV.Vullong4[3],e.EV.Vullong4[2],e.EV.Vullong4[1],e.EV.Vullong4[0]);
+                e.Vullong4[3],e.Vullong4[2],e.Vullong4[1],e.Vullong4[0]);
                 break;
 
         // SIMD 64 byte (512 bit) vector types
@@ -2757,9 +2757,9 @@ void el_hydrate(elem **pe)
     }
     if (!OTleaf(e.Eoper))
     {
-        el_hydrate(&e.EV.E1);
+        el_hydrate(&e.E1);
         if (OTbinary(e.Eoper))
-            el_hydrate(&e.EV.E2);
+            el_hydrate(&e.E2);
         else if (e.Eoper == OPctor)
         {
         }
@@ -2770,15 +2770,15 @@ void el_hydrate(elem **pe)
         {
             case OPstring:
             case OPasm:
-                ph_hydrate(cast(void**)&e.EV.Vstring);
+                ph_hydrate(cast(void**)&e.Vstring);
                 break;
 
             case OPrelconst:
                 //if (tybasic(e.ET.Tty) == TYmemptr)
-                    //el_hydrate(&e.EV.sm.ethis);
+                    //el_hydrate(&e.sm.ethis);
             case OPvar:
-                symbol_hydrate(&e.EV.Vsym);
-                symbol_debug(e.EV.Vsym);
+                symbol_hydrate(&e.Vsym);
+                symbol_debug(e.Vsym);
                 break;
 
             default:
@@ -2820,9 +2820,9 @@ void el_dehydrate(elem **pe)
         srcpos_dehydrate(&e.Esrcpos);
     if (!OTleaf(e.Eoper))
     {
-        el_dehydrate(&e.EV.E1);
+        el_dehydrate(&e.E1);
         if (OTbinary(e.Eoper))
-            el_dehydrate(&e.EV.E2);
+            el_dehydrate(&e.E2);
     }
     else
     {
@@ -2830,14 +2830,14 @@ void el_dehydrate(elem **pe)
         {
             case OPstring:
             case OPasm:
-                ph_dehydrate(&e.EV.Vstring);
+                ph_dehydrate(&e.Vstring);
                 break;
 
             case OPrelconst:
                 //if (tybasic(e.ET.Tty) == TYmemptr)
-                    //el_dehydrate(&e.EV.sm.ethis);
+                    //el_dehydrate(&e.sm.ethis);
             case OPvar:
-                symbol_dehydrate(&e.EV.Vsym);
+                symbol_dehydrate(&e.Vsym);
                 break;
 
             default:

--- a/compiler/src/dmd/backend/elpicpie.d
+++ b/compiler/src/dmd/backend/elpicpie.d
@@ -93,7 +93,7 @@ elem * el_var(Symbol *s)
     type_debug(s.Stype);
     e = el_calloc();
     e.Eoper = OPvar;
-    e.EV.Vsym = s;
+    e.Vsym = s;
     type_debug(s.Stype);
     e.Ety = s.ty();
     if (s.Stype.Tty & mTYthread)
@@ -141,7 +141,7 @@ else if (config.exe & EX_posix)
         if (I64)
             Obj.refGOTsym();
         elem *e1 = el_calloc();
-        e1.EV.Vsym = s;
+        e1.Vsym = s;
         if (s.Sclass == SC.global ||
             s.Sclass == SC.static_ ||
             s.Sclass == SC.locstat)
@@ -158,8 +158,8 @@ else if (config.exe & EX_posix)
         elem* e2 = el_una(OPind, TYsize, el_long(TYfgPtr, 0)); // I64: FS:[0000], I32: GS:[0000]
 
         e.Eoper = OPind;
-        e.EV.E1 = el_bin(OPadd,e1.Ety,e2,e1);
-        e.EV.E2 = null;
+        e.E1 = el_bin(OPadd,e1.Ety,e2,e1);
+        e.E2 = null;
 }
 else if (config.exe & EX_windos)
 {
@@ -192,7 +192,7 @@ else if (config.exe & EX_windos)
 
         e1 = el_calloc();
         e1.Eoper = OPrelconst;
-        e1.EV.Vsym = s;
+        e1.Vsym = s;
         e1.Ety = TYnptr;
 
         if (false && config.wflags & WFexe) // disabled to work with betterC/importC
@@ -209,8 +209,8 @@ else if (config.exe & EX_windos)
         e2 = el_una(OPind,TYsize_t,e2);
 
         e.Eoper = OPind;
-        e.EV.E1 = el_bin(OPadd,e1.Ety,e1,e2);
-        e.EV.E2 = null;
+        e.E1 = el_bin(OPadd,e1.Ety,e1,e2);
+        e.E2 = null;
 }
     }
     return e;
@@ -268,7 +268,7 @@ elem * el_ptr(Symbol *s)
         {
             elem* e = el_calloc();
             e.Eoper = OPvar;
-            e.EV.Vsym = s;
+            e.Vsym = s;
             if (I64)
                 e.Ety = typtr;
             else if (I32)
@@ -386,7 +386,7 @@ private elem *el_picvar_OSX(Symbol *s)
     type_debug(s.Stype);
     e = el_calloc();
     e.Eoper = OPvar;
-    e.EV.Vsym = s;
+    e.Vsym = s;
     e.Ety = s.ty();
 
     switch (s.Sclass)
@@ -502,7 +502,7 @@ static if (1)
 
                 elem *e2 = el_calloc();
                 e2.Eoper = OPvar;
-                e2.EV.Vsym = s;
+                e2.Vsym = s;
                 e2.Ety = s.ty();
                 e2.Eoper = OPrelconst;
                 e2.Ety = TYnptr;
@@ -537,7 +537,7 @@ private elem *el_picvar_posix(Symbol *s)
     type_debug(s.Stype);
     e = el_calloc();
     e.Eoper = OPvar;
-    e.EV.Vsym = s;
+    e.Vsym = s;
     e.Ety = s.ty();
 
     /* For 32 bit PIC:
@@ -757,7 +757,7 @@ private elem *el_pievar(Symbol *s)
     type_debug(s.Stype);
     auto e = el_calloc();
     e.Eoper = OPvar;
-    e.EV.Vsym = s;
+    e.Vsym = s;
     e.Ety = s.ty();
 
     if (I64)
@@ -840,7 +840,7 @@ private elem *el_pieptr(Symbol *s)
     type_debug(s.Stype);
     auto e = el_calloc();
     e.Eoper = OPrelconst;
-    e.EV.Vsym = s;
+    e.Vsym = s;
     e.Ety = TYnptr;
 
     elem* e0 = el_una(OPind, TYsize, el_long(TYfgPtr, 0)); // I64: FS:[0000], I32: GS:[0000]

--- a/compiler/src/dmd/backend/evalu8.d
+++ b/compiler/src/dmd/backend/evalu8.d
@@ -107,23 +107,23 @@ int boolres(elem *e)
                     break;
                 }
                 case TYcfloat:
-                    if (isnan(e.EV.Vcfloat.re) || isnan(e.EV.Vcfloat.im))
+                    if (isnan(e.Vcfloat.re) || isnan(e.Vcfloat.im))
                         b = 1;
                     else
-                        b = e.EV.Vcfloat.re != 0 || e.EV.Vcfloat.im != 0;
+                        b = e.Vcfloat.re != 0 || e.Vcfloat.im != 0;
                     break;
                 case TYcdouble:
                 case TYdouble2:
-                    if (isnan(e.EV.Vcdouble.re) || isnan(e.EV.Vcdouble.im))
+                    if (isnan(e.Vcdouble.re) || isnan(e.Vcdouble.im))
                         b = 1;
                     else
-                        b = e.EV.Vcdouble.re != 0 || e.EV.Vcdouble.im != 0;
+                        b = e.Vcdouble.re != 0 || e.Vcdouble.im != 0;
                     break;
                 case TYcldouble:
-                    if (isnan(e.EV.Vcldouble.re) || isnan(e.EV.Vcldouble.im))
+                    if (isnan(e.Vcldouble.re) || isnan(e.Vcldouble.im))
                         b = 1;
                     else
-                        b = e.EV.Vcldouble.re != 0 || e.EV.Vcldouble.im != 0;
+                        b = e.Vcldouble.re != 0 || e.Vcldouble.im != 0;
                     break;
 
                 case TYstruct:  // happens on syntax error of (struct x)0
@@ -144,12 +144,12 @@ int boolres(elem *e)
                 case TYulong4:
                 case TYllong2:
                 case TYullong2:
-                    b = e.EV.Vcent.lo || e.EV.Vcent.hi;
+                    b = e.Vcent.lo || e.Vcent.hi;
                     break;
 
                 case TYfloat4:
                 {   b = 0;
-                    foreach (f; e.EV.Vfloat4)
+                    foreach (f; e.Vfloat4)
                     {
                         if (f != 0)
                         {   b = 1;
@@ -168,13 +168,13 @@ int boolres(elem *e)
                 case TYllong4:
                 case TYullong4:
                     b = 0;
-                    foreach (elem; e.EV.Vulong8)
+                    foreach (elem; e.Vulong8)
                         b |= elem != 0;
                     break;
 
                 case TYfloat8:
                     b = 0;
-                    foreach (f; e.EV.Vfloat8)
+                    foreach (f; e.Vfloat8)
                     {
                         if (f != 0)
                         {   b = 1;
@@ -185,7 +185,7 @@ int boolres(elem *e)
 
                 case TYdouble4:
                     b = 0;
-                    foreach (f; e.EV.Vdouble4)
+                    foreach (f; e.Vdouble4)
                     {
                         if (f != 0)
                         {   b = 1;
@@ -220,7 +220,7 @@ int iftrue(elem *e)
         {
             case OPcomma:
             case OPinfo:
-                e = e.EV.E2;
+                e = e.E2;
                 break;
 
             case OPrelconst:
@@ -229,7 +229,7 @@ int iftrue(elem *e)
                 return boolres(e);
 
             case OPoror:
-                return tybasic(e.EV.E2.Ety) == TYnoreturn;
+                return tybasic(e.E2.Ety) == TYnoreturn;
 
             default:
                 return false;
@@ -252,14 +252,14 @@ int iffalse(elem *e)
         {
             case OPcomma:
             case OPinfo:
-                e = e.EV.E2;
+                e = e.E2;
                 break;
 
             case OPconst:
                 return !boolres(e);
 
             case OPandand:
-                return tybasic(e.EV.E2.Ety) == TYnoreturn;
+                return tybasic(e.E2.Ety) == TYnoreturn;
 
             default:
                 return false;
@@ -291,7 +291,7 @@ elem * evalu8(elem *e, goal_t goal)
     assert(e && !OTleaf(e.Eoper));
     op = e.Eoper;
     elem_debug(e);
-    e1 = e.EV.E1;
+    e1 = e.E1;
 
     //printf("evalu8(): "); elem_print(e);
     elem_debug(e1);
@@ -300,7 +300,7 @@ elem * evalu8(elem *e, goal_t goal)
         tym2 = 0;
         e2 = null;
         if (OTbinary(e.Eoper))
-        {   e2 = e.EV.E2;
+        {   e2 = e.E2;
             elem_debug(e2);
             if (e2.Eoper == OPconst && !tyvector(e2.Ety))
             {
@@ -343,7 +343,7 @@ static if (0)
   if (0 && e2)
   {
       debug printf("d1 = %Lg, d2 = %Lg, op = %d, OPne = %d, tym = x%lx\n",d1,d2,op,OPne,tym);
-      debug printf("tym1 = x%lx, tym2 = x%lx, e2 = %g\n",tym,tym2,e2.EV.Vdouble);
+      debug printf("tym1 = x%lx, tym2 = x%lx, e2 = %g\n",tym,tym2,e2.Vdouble);
 
       eve u;
       debug printf("d1 = x%16llx\n", (u.Vldouble = d1, u.Vullong));
@@ -359,15 +359,15 @@ static if (0)
                 switch (tym2)
                 {
                     case TYfloat:
-                        e.EV.Vfloat = e1.EV.Vfloat + e2.EV.Vfloat;
+                        e.Vfloat = e1.Vfloat + e2.Vfloat;
                         break;
                     case TYifloat:
-                        e.EV.Vcfloat.re = e1.EV.Vfloat;
-                        e.EV.Vcfloat.im = e2.EV.Vfloat;
+                        e.Vcfloat.re = e1.Vfloat;
+                        e.Vcfloat.im = e2.Vfloat;
                         break;
                     case TYcfloat:
-                        e.EV.Vcfloat.re = e1.EV.Vfloat + e2.EV.Vcfloat.re;
-                        e.EV.Vcfloat.im = 0            + e2.EV.Vcfloat.im;
+                        e.Vcfloat.re = e1.Vfloat + e2.Vcfloat.re;
+                        e.Vcfloat.im = 0            + e2.Vcfloat.im;
                         break;
                     default:
                         assert(0);
@@ -379,15 +379,15 @@ static if (0)
                 {
                     case TYdouble:
                     case TYdouble_alias:
-                            e.EV.Vdouble = e1.EV.Vdouble + e2.EV.Vdouble;
+                            e.Vdouble = e1.Vdouble + e2.Vdouble;
                         break;
                     case TYidouble:
-                        e.EV.Vcdouble.re = e1.EV.Vdouble;
-                        e.EV.Vcdouble.im = e2.EV.Vdouble;
+                        e.Vcdouble.re = e1.Vdouble;
+                        e.Vcdouble.im = e2.Vdouble;
                         break;
                     case TYcdouble:
-                        e.EV.Vcdouble.re = e1.EV.Vdouble + e2.EV.Vcdouble.re;
-                        e.EV.Vcdouble.im = 0             + e2.EV.Vcdouble.im;
+                        e.Vcdouble.re = e1.Vdouble + e2.Vcdouble.re;
+                        e.Vcdouble.im = 0             + e2.Vcdouble.im;
                         break;
                     default:
                         assert(0);
@@ -397,15 +397,15 @@ static if (0)
                 switch (tym2)
                 {
                     case TYldouble:
-                        e.EV.Vldouble = d1 + d2;
+                        e.Vldouble = d1 + d2;
                         break;
                     case TYildouble:
-                        e.EV.Vcldouble.re = d1;
-                        e.EV.Vcldouble.im = d2;
+                        e.Vcldouble.re = d1;
+                        e.Vcldouble.im = d2;
                         break;
                     case TYcldouble:
-                        e.EV.Vcldouble.re = d1 + e2.EV.Vcldouble.re;
-                        e.EV.Vcldouble.im = 0  + e2.EV.Vcldouble.im;
+                        e.Vcldouble.re = d1 + e2.Vcldouble.re;
+                        e.Vcldouble.im = 0  + e2.Vcldouble.im;
                         break;
                     default:
                         assert(0);
@@ -415,15 +415,15 @@ static if (0)
                 switch (tym2)
                 {
                     case TYfloat:
-                        e.EV.Vcfloat.re = e2.EV.Vfloat;
-                        e.EV.Vcfloat.im = e1.EV.Vfloat;
+                        e.Vcfloat.re = e2.Vfloat;
+                        e.Vcfloat.im = e1.Vfloat;
                         break;
                     case TYifloat:
-                        e.EV.Vfloat = e1.EV.Vfloat + e2.EV.Vfloat;
+                        e.Vfloat = e1.Vfloat + e2.Vfloat;
                         break;
                     case TYcfloat:
-                        e.EV.Vcfloat.re = 0            + e2.EV.Vcfloat.re;
-                        e.EV.Vcfloat.im = e1.EV.Vfloat + e2.EV.Vcfloat.im;
+                        e.Vcfloat.re = 0            + e2.Vcfloat.re;
+                        e.Vcfloat.im = e1.Vfloat + e2.Vcfloat.im;
                         break;
                     default:
                         assert(0);
@@ -433,15 +433,15 @@ static if (0)
                 switch (tym2)
                 {
                     case TYdouble:
-                        e.EV.Vcdouble.re = e2.EV.Vdouble;
-                        e.EV.Vcdouble.im = e1.EV.Vdouble;
+                        e.Vcdouble.re = e2.Vdouble;
+                        e.Vcdouble.im = e1.Vdouble;
                         break;
                     case TYidouble:
-                        e.EV.Vdouble = e1.EV.Vdouble + e2.EV.Vdouble;
+                        e.Vdouble = e1.Vdouble + e2.Vdouble;
                         break;
                     case TYcdouble:
-                        e.EV.Vcdouble.re = 0             + e2.EV.Vcdouble.re;
-                        e.EV.Vcdouble.im = e1.EV.Vdouble + e2.EV.Vcdouble.im;
+                        e.Vcdouble.re = 0             + e2.Vcdouble.re;
+                        e.Vcdouble.im = e1.Vdouble + e2.Vcdouble.im;
                         break;
                     default:
                         assert(0);
@@ -451,15 +451,15 @@ static if (0)
                 switch (tym2)
                 {
                     case TYldouble:
-                        e.EV.Vcldouble.re = d2;
-                        e.EV.Vcldouble.im = d1;
+                        e.Vcldouble.re = d2;
+                        e.Vcldouble.im = d1;
                         break;
                     case TYildouble:
-                        e.EV.Vldouble = d1 + d2;
+                        e.Vldouble = d1 + d2;
                         break;
                     case TYcldouble:
-                        e.EV.Vcldouble.re = 0  + e2.EV.Vcldouble.re;
-                        e.EV.Vcldouble.im = d1 + e2.EV.Vcldouble.im;
+                        e.Vcldouble.re = 0  + e2.Vcldouble.re;
+                        e.Vcldouble.im = d1 + e2.Vcldouble.im;
                         break;
                     default:
                         assert(0);
@@ -469,16 +469,16 @@ static if (0)
                 switch (tym2)
                 {
                     case TYfloat:
-                        e.EV.Vcfloat.re = e1.EV.Vcfloat.re + e2.EV.Vfloat;
-                        e.EV.Vcfloat.im = e1.EV.Vcfloat.im;
+                        e.Vcfloat.re = e1.Vcfloat.re + e2.Vfloat;
+                        e.Vcfloat.im = e1.Vcfloat.im;
                         break;
                     case TYifloat:
-                        e.EV.Vcfloat.re = e1.EV.Vcfloat.re;
-                        e.EV.Vcfloat.im = e1.EV.Vcfloat.im + e2.EV.Vfloat;
+                        e.Vcfloat.re = e1.Vcfloat.re;
+                        e.Vcfloat.im = e1.Vcfloat.im + e2.Vfloat;
                         break;
                     case TYcfloat:
-                        e.EV.Vcfloat.re = e1.EV.Vcfloat.re + e2.EV.Vcfloat.re;
-                        e.EV.Vcfloat.im = e1.EV.Vcfloat.im + e2.EV.Vcfloat.im;
+                        e.Vcfloat.re = e1.Vcfloat.re + e2.Vcfloat.re;
+                        e.Vcfloat.im = e1.Vcfloat.im + e2.Vcfloat.im;
                         break;
                     default:
                         assert(0);
@@ -488,16 +488,16 @@ static if (0)
                 switch (tym2)
                 {
                     case TYdouble:
-                        e.EV.Vcdouble.re = e1.EV.Vcdouble.re + e2.EV.Vdouble;
-                        e.EV.Vcdouble.im = e1.EV.Vcdouble.im;
+                        e.Vcdouble.re = e1.Vcdouble.re + e2.Vdouble;
+                        e.Vcdouble.im = e1.Vcdouble.im;
                         break;
                     case TYidouble:
-                        e.EV.Vcdouble.re = e1.EV.Vcdouble.re;
-                        e.EV.Vcdouble.im = e1.EV.Vcdouble.im + e2.EV.Vdouble;
+                        e.Vcdouble.re = e1.Vcdouble.re;
+                        e.Vcdouble.im = e1.Vcdouble.im + e2.Vdouble;
                         break;
                     case TYcdouble:
-                        e.EV.Vcdouble.re = e1.EV.Vcdouble.re + e2.EV.Vcdouble.re;
-                        e.EV.Vcdouble.im = e1.EV.Vcdouble.im + e2.EV.Vcdouble.im;
+                        e.Vcdouble.re = e1.Vcdouble.re + e2.Vcdouble.re;
+                        e.Vcdouble.im = e1.Vcdouble.im + e2.Vcdouble.im;
                         break;
                     default:
                         assert(0);
@@ -507,16 +507,16 @@ static if (0)
                 switch (tym2)
                 {
                     case TYldouble:
-                        e.EV.Vcldouble.re = e1.EV.Vcldouble.re + d2;
-                        e.EV.Vcldouble.im = e1.EV.Vcldouble.im;
+                        e.Vcldouble.re = e1.Vcldouble.re + d2;
+                        e.Vcldouble.im = e1.Vcldouble.im;
                         break;
                     case TYildouble:
-                        e.EV.Vcldouble.re = e1.EV.Vcldouble.re;
-                        e.EV.Vcldouble.im = e1.EV.Vcldouble.im + d2;
+                        e.Vcldouble.re = e1.Vcldouble.re;
+                        e.Vcldouble.im = e1.Vcldouble.im + d2;
                         break;
                     case TYcldouble:
-                        e.EV.Vcldouble.re = e1.EV.Vcldouble.re + e2.EV.Vcldouble.re;
-                        e.EV.Vcldouble.im = e1.EV.Vcldouble.im + e2.EV.Vcldouble.im;
+                        e.Vcldouble.re = e1.Vcldouble.re + e2.Vcldouble.re;
+                        e.Vcldouble.im = e1.Vcldouble.im + e2.Vcldouble.im;
                         break;
                     default:
                         assert(0);
@@ -525,24 +525,24 @@ static if (0)
 
             case TYcent:
             case TYucent:
-                e.EV.Vcent = dmd.common.int128.add(e1.EV.Vcent, e2.EV.Vcent);
+                e.Vcent = dmd.common.int128.add(e1.Vcent, e2.Vcent);
                 break;
 
             default:
                 if (_tysize[TYint] == 2)
                 {   if (tyfv(tym))
-                        e.EV.Vlong = cast(targ_long)((l1 & 0xFFFF0000) |
+                        e.Vlong = cast(targ_long)((l1 & 0xFFFF0000) |
                             cast(targ_ushort) (cast(targ_ushort) l1 + i2));
                     else if (tyfv(tym2))
-                        e.EV.Vlong = cast(targ_long)((l2 & 0xFFFF0000) |
+                        e.Vlong = cast(targ_long)((l2 & 0xFFFF0000) |
                             cast(targ_ushort) (i1 + cast(targ_ushort) l2));
                     else if (tyintegral(tym) || typtr(tym))
-                        e.EV.Vllong = l1 + l2;
+                        e.Vllong = l1 + l2;
                     else
                         assert(0);
                 }
                 else if (tyintegral(tym) || typtr(tym))
-                    e.EV.Vllong = l1 + l2;
+                    e.Vllong = l1 + l2;
                 else
                     assert(0);
                 break;
@@ -556,15 +556,15 @@ static if (0)
                 switch (tym2)
                 {
                     case TYfloat:
-                        e.EV.Vfloat = e1.EV.Vfloat - e2.EV.Vfloat;
+                        e.Vfloat = e1.Vfloat - e2.Vfloat;
                         break;
                     case TYifloat:
-                        e.EV.Vcfloat.re =  e1.EV.Vfloat;
-                        e.EV.Vcfloat.im = -e2.EV.Vfloat;
+                        e.Vcfloat.re =  e1.Vfloat;
+                        e.Vcfloat.im = -e2.Vfloat;
                         break;
                     case TYcfloat:
-                        e.EV.Vcfloat.re = e1.EV.Vfloat - e2.EV.Vcfloat.re;
-                        e.EV.Vcfloat.im = 0            - e2.EV.Vcfloat.im;
+                        e.Vcfloat.re = e1.Vfloat - e2.Vcfloat.re;
+                        e.Vcfloat.im = 0            - e2.Vcfloat.im;
                         break;
                     default:
                         assert(0);
@@ -576,15 +576,15 @@ static if (0)
                 {
                     case TYdouble:
                     case TYdouble_alias:
-                        e.EV.Vdouble = e1.EV.Vdouble - e2.EV.Vdouble;
+                        e.Vdouble = e1.Vdouble - e2.Vdouble;
                         break;
                     case TYidouble:
-                        e.EV.Vcdouble.re =  e1.EV.Vdouble;
-                        e.EV.Vcdouble.im = -e2.EV.Vdouble;
+                        e.Vcdouble.re =  e1.Vdouble;
+                        e.Vcdouble.im = -e2.Vdouble;
                         break;
                     case TYcdouble:
-                        e.EV.Vcdouble.re = e1.EV.Vdouble - e2.EV.Vcdouble.re;
-                        e.EV.Vcdouble.im = 0             - e2.EV.Vcdouble.im;
+                        e.Vcdouble.re = e1.Vdouble - e2.Vcdouble.re;
+                        e.Vcdouble.im = 0             - e2.Vcdouble.im;
                         break;
                     default:
                         assert(0);
@@ -594,15 +594,15 @@ static if (0)
                 switch (tym2)
                 {
                     case TYldouble:
-                        e.EV.Vldouble = d1 - d2;
+                        e.Vldouble = d1 - d2;
                         break;
                     case TYildouble:
-                        e.EV.Vcldouble.re =  d1;
-                        e.EV.Vcldouble.im = -d2;
+                        e.Vcldouble.re =  d1;
+                        e.Vcldouble.im = -d2;
                         break;
                     case TYcldouble:
-                        e.EV.Vcldouble.re = d1 - e2.EV.Vcldouble.re;
-                        e.EV.Vcldouble.im = 0  - e2.EV.Vcldouble.im;
+                        e.Vcldouble.re = d1 - e2.Vcldouble.re;
+                        e.Vcldouble.im = 0  - e2.Vcldouble.im;
                         break;
                     default:
                         assert(0);
@@ -612,15 +612,15 @@ static if (0)
                 switch (tym2)
                 {
                     case TYfloat:
-                        e.EV.Vcfloat.re = -e2.EV.Vfloat;
-                        e.EV.Vcfloat.im =  e1.EV.Vfloat;
+                        e.Vcfloat.re = -e2.Vfloat;
+                        e.Vcfloat.im =  e1.Vfloat;
                         break;
                     case TYifloat:
-                        e.EV.Vfloat = e1.EV.Vfloat - e2.EV.Vfloat;
+                        e.Vfloat = e1.Vfloat - e2.Vfloat;
                         break;
                     case TYcfloat:
-                        e.EV.Vcfloat.re = 0            - e2.EV.Vcfloat.re;
-                        e.EV.Vcfloat.im = e1.EV.Vfloat - e2.EV.Vcfloat.im;
+                        e.Vcfloat.re = 0            - e2.Vcfloat.re;
+                        e.Vcfloat.im = e1.Vfloat - e2.Vcfloat.im;
                         break;
                     default:
                         assert(0);
@@ -630,15 +630,15 @@ static if (0)
                 switch (tym2)
                 {
                     case TYdouble:
-                        e.EV.Vcdouble.re = -e2.EV.Vdouble;
-                        e.EV.Vcdouble.im =  e1.EV.Vdouble;
+                        e.Vcdouble.re = -e2.Vdouble;
+                        e.Vcdouble.im =  e1.Vdouble;
                         break;
                     case TYidouble:
-                        e.EV.Vdouble = e1.EV.Vdouble - e2.EV.Vdouble;
+                        e.Vdouble = e1.Vdouble - e2.Vdouble;
                         break;
                     case TYcdouble:
-                        e.EV.Vcdouble.re = 0             - e2.EV.Vcdouble.re;
-                        e.EV.Vcdouble.im = e1.EV.Vdouble - e2.EV.Vcdouble.im;
+                        e.Vcdouble.re = 0             - e2.Vcdouble.re;
+                        e.Vcdouble.im = e1.Vdouble - e2.Vcdouble.im;
                         break;
                     default:
                         assert(0);
@@ -648,15 +648,15 @@ static if (0)
                 switch (tym2)
                 {
                     case TYldouble:
-                        e.EV.Vcldouble.re = -d2;
-                        e.EV.Vcldouble.im =  d1;
+                        e.Vcldouble.re = -d2;
+                        e.Vcldouble.im =  d1;
                         break;
                     case TYildouble:
-                        e.EV.Vldouble = d1 - d2;
+                        e.Vldouble = d1 - d2;
                         break;
                     case TYcldouble:
-                        e.EV.Vcldouble.re = 0  - e2.EV.Vcldouble.re;
-                        e.EV.Vcldouble.im = d1 - e2.EV.Vcldouble.im;
+                        e.Vcldouble.re = 0  - e2.Vcldouble.re;
+                        e.Vcldouble.im = d1 - e2.Vcldouble.im;
                         break;
                     default:
                         assert(0);
@@ -666,16 +666,16 @@ static if (0)
                 switch (tym2)
                 {
                     case TYfloat:
-                        e.EV.Vcfloat.re = e1.EV.Vcfloat.re - e2.EV.Vfloat;
-                        e.EV.Vcfloat.im = e1.EV.Vcfloat.im;
+                        e.Vcfloat.re = e1.Vcfloat.re - e2.Vfloat;
+                        e.Vcfloat.im = e1.Vcfloat.im;
                         break;
                     case TYifloat:
-                        e.EV.Vcfloat.re = e1.EV.Vcfloat.re;
-                        e.EV.Vcfloat.im = e1.EV.Vcfloat.im - e2.EV.Vfloat;
+                        e.Vcfloat.re = e1.Vcfloat.re;
+                        e.Vcfloat.im = e1.Vcfloat.im - e2.Vfloat;
                         break;
                     case TYcfloat:
-                        e.EV.Vcfloat.re = e1.EV.Vcfloat.re - e2.EV.Vcfloat.re;
-                        e.EV.Vcfloat.im = e1.EV.Vcfloat.im - e2.EV.Vcfloat.im;
+                        e.Vcfloat.re = e1.Vcfloat.re - e2.Vcfloat.re;
+                        e.Vcfloat.im = e1.Vcfloat.im - e2.Vcfloat.im;
                         break;
                     default:
                         assert(0);
@@ -685,16 +685,16 @@ static if (0)
                 switch (tym2)
                 {
                     case TYdouble:
-                        e.EV.Vcdouble.re = e1.EV.Vcdouble.re - e2.EV.Vdouble;
-                        e.EV.Vcdouble.im = e1.EV.Vcdouble.im;
+                        e.Vcdouble.re = e1.Vcdouble.re - e2.Vdouble;
+                        e.Vcdouble.im = e1.Vcdouble.im;
                         break;
                     case TYidouble:
-                        e.EV.Vcdouble.re = e1.EV.Vcdouble.re;
-                        e.EV.Vcdouble.im = e1.EV.Vcdouble.im - e2.EV.Vdouble;
+                        e.Vcdouble.re = e1.Vcdouble.re;
+                        e.Vcdouble.im = e1.Vcdouble.im - e2.Vdouble;
                         break;
                     case TYcdouble:
-                        e.EV.Vcdouble.re = e1.EV.Vcdouble.re - e2.EV.Vcdouble.re;
-                        e.EV.Vcdouble.im = e1.EV.Vcdouble.im - e2.EV.Vcdouble.im;
+                        e.Vcdouble.re = e1.Vcdouble.re - e2.Vcdouble.re;
+                        e.Vcdouble.im = e1.Vcdouble.im - e2.Vcdouble.im;
                         break;
                     default:
                         assert(0);
@@ -704,16 +704,16 @@ static if (0)
                 switch (tym2)
                 {
                     case TYldouble:
-                        e.EV.Vcldouble.re = e1.EV.Vcldouble.re - d2;
-                        e.EV.Vcldouble.im = e1.EV.Vcldouble.im;
+                        e.Vcldouble.re = e1.Vcldouble.re - d2;
+                        e.Vcldouble.im = e1.Vcldouble.im;
                         break;
                     case TYildouble:
-                        e.EV.Vcldouble.re = e1.EV.Vcldouble.re;
-                        e.EV.Vcldouble.im = e1.EV.Vcldouble.im - d2;
+                        e.Vcldouble.re = e1.Vcldouble.re;
+                        e.Vcldouble.im = e1.Vcldouble.im - d2;
                         break;
                     case TYcldouble:
-                        e.EV.Vcldouble.re = e1.EV.Vcldouble.re - e2.EV.Vcldouble.re;
-                        e.EV.Vcldouble.im = e1.EV.Vcldouble.im - e2.EV.Vcldouble.im;
+                        e.Vcldouble.re = e1.Vcldouble.re - e2.Vcldouble.re;
+                        e.Vcldouble.im = e1.Vcldouble.im - e2.Vcldouble.im;
                         break;
                     default:
                         assert(0);
@@ -722,16 +722,16 @@ static if (0)
 
             case TYcent:
             case TYucent:
-                e.EV.Vcent = dmd.common.int128.sub(e1.EV.Vcent, e2.EV.Vcent);
+                e.Vcent = dmd.common.int128.sub(e1.Vcent, e2.Vcent);
                 break;
 
             default:
                 if (_tysize[TYint] == 2 &&
                     tyfv(tym) && _tysize[tym2] == 2)
-                    e.EV.Vllong = (l1 & 0xFFFF0000) |
+                    e.Vllong = (l1 & 0xFFFF0000) |
                         cast(targ_ushort) (cast(targ_ushort) l1 - i2);
                 else if (tyintegral(tym) || typtr(tym))
-                    e.EV.Vllong = l1 - l2;
+                    e.Vllong = l1 - l2;
                 else
                     assert(0);
                 break;
@@ -739,9 +739,9 @@ static if (0)
         break;
     case OPmul:
         if (tym == TYcent || tym == TYucent)
-            e.EV.Vcent = dmd.common.int128.mul(e1.EV.Vcent, e2.EV.Vcent);
+            e.Vcent = dmd.common.int128.mul(e1.Vcent, e2.Vcent);
         else if (tyintegral(tym) || typtr(tym))
-            e.EV.Vllong = l1 * l2;
+            e.Vllong = l1 * l2;
         else
         {   switch (tym)
             {
@@ -750,11 +750,11 @@ static if (0)
                     {
                         case TYfloat:
                         case TYifloat:
-                            e.EV.Vfloat = e1.EV.Vfloat * e2.EV.Vfloat;
+                            e.Vfloat = e1.Vfloat * e2.Vfloat;
                             break;
                         case TYcfloat:
-                            e.EV.Vcfloat.re = e1.EV.Vfloat * e2.EV.Vcfloat.re;
-                            e.EV.Vcfloat.im = e1.EV.Vfloat * e2.EV.Vcfloat.im;
+                            e.Vcfloat.re = e1.Vfloat * e2.Vcfloat.re;
+                            e.Vcfloat.im = e1.Vfloat * e2.Vcfloat.im;
                             break;
                         default:
                             assert(0);
@@ -767,11 +767,11 @@ static if (0)
                         case TYdouble:
                         case TYdouble_alias:
                         case TYidouble:
-                            e.EV.Vdouble = e1.EV.Vdouble * e2.EV.Vdouble;
+                            e.Vdouble = e1.Vdouble * e2.Vdouble;
                             break;
                         case TYcdouble:
-                            e.EV.Vcdouble.re = e1.EV.Vdouble * e2.EV.Vcdouble.re;
-                            e.EV.Vcdouble.im = e1.EV.Vdouble * e2.EV.Vcdouble.im;
+                            e.Vcdouble.re = e1.Vdouble * e2.Vcdouble.re;
+                            e.Vcdouble.im = e1.Vdouble * e2.Vcdouble.im;
                             break;
                         default:
                             assert(0);
@@ -782,11 +782,11 @@ static if (0)
                     {
                         case TYldouble:
                         case TYildouble:
-                            e.EV.Vldouble = d1 * d2;
+                            e.Vldouble = d1 * d2;
                             break;
                         case TYcldouble:
-                            e.EV.Vcldouble.re = d1 * e2.EV.Vcldouble.re;
-                            e.EV.Vcldouble.im = d1 * e2.EV.Vcldouble.im;
+                            e.Vcldouble.re = d1 * e2.Vcldouble.re;
+                            e.Vcldouble.im = d1 * e2.Vcldouble.im;
                             break;
                         default:
                             assert(0);
@@ -796,14 +796,14 @@ static if (0)
                     switch (tym2)
                     {
                         case TYfloat:
-                            e.EV.Vfloat = e1.EV.Vfloat * e2.EV.Vfloat;
+                            e.Vfloat = e1.Vfloat * e2.Vfloat;
                             break;
                         case TYifloat:
-                            e.EV.Vfloat = -e1.EV.Vfloat * e2.EV.Vfloat;
+                            e.Vfloat = -e1.Vfloat * e2.Vfloat;
                             break;
                         case TYcfloat:
-                            e.EV.Vcfloat.re = -e1.EV.Vfloat * e2.EV.Vcfloat.im;
-                            e.EV.Vcfloat.im =  e1.EV.Vfloat * e2.EV.Vcfloat.re;
+                            e.Vcfloat.re = -e1.Vfloat * e2.Vcfloat.im;
+                            e.Vcfloat.im =  e1.Vfloat * e2.Vcfloat.re;
                             break;
                         default:
                             assert(0);
@@ -813,14 +813,14 @@ static if (0)
                     switch (tym2)
                     {
                         case TYdouble:
-                            e.EV.Vdouble = e1.EV.Vdouble * e2.EV.Vdouble;
+                            e.Vdouble = e1.Vdouble * e2.Vdouble;
                             break;
                         case TYidouble:
-                            e.EV.Vdouble = -e1.EV.Vdouble * e2.EV.Vdouble;
+                            e.Vdouble = -e1.Vdouble * e2.Vdouble;
                             break;
                         case TYcdouble:
-                            e.EV.Vcdouble.re = -e1.EV.Vdouble * e2.EV.Vcdouble.im;
-                            e.EV.Vcdouble.im =  e1.EV.Vdouble * e2.EV.Vcdouble.re;
+                            e.Vcdouble.re = -e1.Vdouble * e2.Vcdouble.im;
+                            e.Vcdouble.im =  e1.Vdouble * e2.Vcdouble.re;
                             break;
                         default:
                             assert(0);
@@ -830,14 +830,14 @@ static if (0)
                     switch (tym2)
                     {
                         case TYldouble:
-                            e.EV.Vldouble = d1 * d2;
+                            e.Vldouble = d1 * d2;
                             break;
                         case TYildouble:
-                            e.EV.Vldouble = -d1 * d2;
+                            e.Vldouble = -d1 * d2;
                             break;
                         case TYcldouble:
-                            e.EV.Vcldouble.re = -d1 * e2.EV.Vcldouble.im;
-                            e.EV.Vcldouble.im =  d1 * e2.EV.Vcldouble.re;
+                            e.Vcldouble.re = -d1 * e2.Vcldouble.im;
+                            e.Vcldouble.im =  d1 * e2.Vcldouble.re;
                             break;
                         default:
                             assert(0);
@@ -847,15 +847,15 @@ static if (0)
                     switch (tym2)
                     {
                         case TYfloat:
-                            e.EV.Vcfloat.re = e1.EV.Vcfloat.re * e2.EV.Vfloat;
-                            e.EV.Vcfloat.im = e1.EV.Vcfloat.im * e2.EV.Vfloat;
+                            e.Vcfloat.re = e1.Vcfloat.re * e2.Vfloat;
+                            e.Vcfloat.im = e1.Vcfloat.im * e2.Vfloat;
                             break;
                         case TYifloat:
-                            e.EV.Vcfloat.re = -e1.EV.Vcfloat.im * e2.EV.Vfloat;
-                            e.EV.Vcfloat.im =  e1.EV.Vcfloat.re * e2.EV.Vfloat;
+                            e.Vcfloat.re = -e1.Vcfloat.im * e2.Vfloat;
+                            e.Vcfloat.im =  e1.Vcfloat.re * e2.Vfloat;
                             break;
                         case TYcfloat:
-                            e.EV.Vcfloat = Complex_f.mul(e1.EV.Vcfloat, e2.EV.Vcfloat);
+                            e.Vcfloat = Complex_f.mul(e1.Vcfloat, e2.Vcfloat);
                             break;
                         default:
                             assert(0);
@@ -865,15 +865,15 @@ static if (0)
                     switch (tym2)
                     {
                         case TYdouble:
-                            e.EV.Vcdouble.re = e1.EV.Vcdouble.re * e2.EV.Vdouble;
-                            e.EV.Vcdouble.im = e1.EV.Vcdouble.im * e2.EV.Vdouble;
+                            e.Vcdouble.re = e1.Vcdouble.re * e2.Vdouble;
+                            e.Vcdouble.im = e1.Vcdouble.im * e2.Vdouble;
                             break;
                         case TYidouble:
-                            e.EV.Vcdouble.re = -e1.EV.Vcdouble.im * e2.EV.Vdouble;
-                            e.EV.Vcdouble.im =  e1.EV.Vcdouble.re * e2.EV.Vdouble;
+                            e.Vcdouble.re = -e1.Vcdouble.im * e2.Vdouble;
+                            e.Vcdouble.im =  e1.Vcdouble.re * e2.Vdouble;
                             break;
                         case TYcdouble:
-                            e.EV.Vcdouble = Complex_d.mul(e1.EV.Vcdouble, e2.EV.Vcdouble);
+                            e.Vcdouble = Complex_d.mul(e1.Vcdouble, e2.Vcdouble);
                             break;
                         default:
                             assert(0);
@@ -883,15 +883,15 @@ static if (0)
                     switch (tym2)
                     {
                         case TYldouble:
-                            e.EV.Vcldouble.re = e1.EV.Vcldouble.re * d2;
-                            e.EV.Vcldouble.im = e1.EV.Vcldouble.im * d2;
+                            e.Vcldouble.re = e1.Vcldouble.re * d2;
+                            e.Vcldouble.im = e1.Vcldouble.im * d2;
                             break;
                         case TYildouble:
-                            e.EV.Vcldouble.re = -e1.EV.Vcldouble.im * d2;
-                            e.EV.Vcldouble.im =  e1.EV.Vcldouble.re * d2;
+                            e.Vcldouble.re = -e1.Vcldouble.im * d2;
+                            e.Vcldouble.im =  e1.Vcldouble.re * d2;
                             break;
                         case TYcldouble:
-                            e.EV.Vcldouble = Complex_ld.mul(e1.EV.Vcldouble, e2.EV.Vcldouble);
+                            e.Vcldouble = Complex_ld.mul(e1.Vcldouble, e2.Vcldouble);
                             break;
                         default:
                             assert(0);
@@ -913,12 +913,12 @@ static if (0)
         if (uns)
         {
             if (tym == TYucent)
-                e.EV.Vcent = dmd.common.int128.udiv(e1.EV.Vcent, e2.EV.Vcent);
+                e.Vcent = dmd.common.int128.udiv(e1.Vcent, e2.Vcent);
             else
-                e.EV.Vullong = (cast(targ_ullong) l1) / (cast(targ_ullong) l2);
+                e.Vullong = (cast(targ_ullong) l1) / (cast(targ_ullong) l2);
         }
         else if (tym == TYcent)
-            e.EV.Vcent = dmd.common.int128.div(e1.EV.Vcent, e2.EV.Vcent);
+            e.Vcent = dmd.common.int128.div(e1.Vcent, e2.Vcent);
         else
         {   switch (tym)
             {
@@ -926,15 +926,15 @@ static if (0)
                     switch (tym2)
                     {
                         case TYfloat:
-                            e.EV.Vfloat = e1.EV.Vfloat / e2.EV.Vfloat;
+                            e.Vfloat = e1.Vfloat / e2.Vfloat;
                             break;
                         case TYifloat:
-                            e.EV.Vfloat = -e1.EV.Vfloat / e2.EV.Vfloat;
+                            e.Vfloat = -e1.Vfloat / e2.Vfloat;
                             break;
                         case TYcfloat:
-                            e.EV.Vcfloat.re = cast(float)d1;
-                            e.EV.Vcfloat.im = 0;
-                            e.EV.Vcfloat = Complex_f.div(e.EV.Vcfloat, e2.EV.Vcfloat);
+                            e.Vcfloat.re = cast(float)d1;
+                            e.Vcfloat.im = 0;
+                            e.Vcfloat = Complex_f.div(e.Vcfloat, e2.Vcfloat);
                             break;
                         default:
                             assert(0);
@@ -946,19 +946,19 @@ static if (0)
                     {
                         case TYdouble:
                         case TYdouble_alias:
-                            e.EV.Vdouble = e1.EV.Vdouble / e2.EV.Vdouble;
+                            e.Vdouble = e1.Vdouble / e2.Vdouble;
                             break;
                         case TYldouble:
                             // cast is required because Vldouble is a soft type on windows
-                            e.EV.Vdouble = cast(double)(e1.EV.Vdouble / e2.EV.Vldouble);
+                            e.Vdouble = cast(double)(e1.Vdouble / e2.Vldouble);
                             break;
                         case TYidouble:
-                            e.EV.Vdouble = -e1.EV.Vdouble / e2.EV.Vdouble;
+                            e.Vdouble = -e1.Vdouble / e2.Vdouble;
                             break;
                         case TYcdouble:
-                            e.EV.Vcdouble.re = cast(double)d1;
-                            e.EV.Vcdouble.im = 0;
-                            e.EV.Vcdouble = Complex_d.div(e.EV.Vcdouble, e2.EV.Vcdouble);
+                            e.Vcdouble.re = cast(double)d1;
+                            e.Vcdouble.im = 0;
+                            e.Vcdouble = Complex_d.div(e.Vcdouble, e2.Vcdouble);
                             break;
                         default:
                             assert(0);
@@ -968,15 +968,15 @@ static if (0)
                     switch (tym2)
                     {
                         case TYldouble:
-                            e.EV.Vldouble = d1 / d2;
+                            e.Vldouble = d1 / d2;
                             break;
                         case TYildouble:
-                            e.EV.Vldouble = -d1 / d2;
+                            e.Vldouble = -d1 / d2;
                             break;
                         case TYcldouble:
-                            e.EV.Vcldouble.re = d1;
-                            e.EV.Vcldouble.im = 0;
-                            e.EV.Vcldouble = Complex_ld.div(e.EV.Vcldouble, e2.EV.Vcldouble);
+                            e.Vcldouble.re = d1;
+                            e.Vcldouble.im = 0;
+                            e.Vcldouble = Complex_ld.div(e.Vcldouble, e2.Vcldouble);
                             break;
                         default:
                             assert(0);
@@ -987,12 +987,12 @@ static if (0)
                     {
                         case TYfloat:
                         case TYifloat:
-                            e.EV.Vfloat = e1.EV.Vfloat / e2.EV.Vfloat;
+                            e.Vfloat = e1.Vfloat / e2.Vfloat;
                             break;
                         case TYcfloat:
-                            e.EV.Vcfloat.re = 0;
-                            e.EV.Vcfloat.im = e1.EV.Vfloat;
-                            e.EV.Vcfloat = Complex_f.div(e.EV.Vcfloat, e2.EV.Vcfloat);
+                            e.Vcfloat.re = 0;
+                            e.Vcfloat.im = e1.Vfloat;
+                            e.Vcfloat = Complex_f.div(e.Vcfloat, e2.Vcfloat);
                             break;
                         default:
                             assert(0);
@@ -1003,12 +1003,12 @@ static if (0)
                     {
                         case TYdouble:
                         case TYidouble:
-                            e.EV.Vdouble = e1.EV.Vdouble / e2.EV.Vdouble;
+                            e.Vdouble = e1.Vdouble / e2.Vdouble;
                             break;
                         case TYcdouble:
-                            e.EV.Vcdouble.re = 0;
-                            e.EV.Vcdouble.im = e1.EV.Vdouble;
-                            e.EV.Vcdouble = Complex_d.div(e.EV.Vcdouble, e2.EV.Vcdouble);
+                            e.Vcdouble.re = 0;
+                            e.Vcdouble.im = e1.Vdouble;
+                            e.Vcdouble = Complex_d.div(e.Vcdouble, e2.Vcdouble);
                             break;
                         default:
                             assert(0);
@@ -1019,12 +1019,12 @@ static if (0)
                     {
                         case TYldouble:
                         case TYildouble:
-                            e.EV.Vldouble = d1 / d2;
+                            e.Vldouble = d1 / d2;
                             break;
                         case TYcldouble:
-                            e.EV.Vcldouble.re = 0;
-                            e.EV.Vcldouble.im = d1;
-                            e.EV.Vcldouble = Complex_ld.div(e.EV.Vcldouble, e2.EV.Vcldouble);
+                            e.Vcldouble.re = 0;
+                            e.Vcldouble.im = d1;
+                            e.Vcldouble = Complex_ld.div(e.Vcldouble, e2.Vcldouble);
                             break;
                         default:
                             assert(0);
@@ -1034,15 +1034,15 @@ static if (0)
                     switch (tym2)
                     {
                         case TYfloat:
-                            e.EV.Vcfloat.re = e1.EV.Vcfloat.re / e2.EV.Vfloat;
-                            e.EV.Vcfloat.im = e1.EV.Vcfloat.im / e2.EV.Vfloat;
+                            e.Vcfloat.re = e1.Vcfloat.re / e2.Vfloat;
+                            e.Vcfloat.im = e1.Vcfloat.im / e2.Vfloat;
                             break;
                         case TYifloat:
-                            e.EV.Vcfloat.re =  e1.EV.Vcfloat.im / e2.EV.Vfloat;
-                            e.EV.Vcfloat.im = -e1.EV.Vcfloat.re / e2.EV.Vfloat;
+                            e.Vcfloat.re =  e1.Vcfloat.im / e2.Vfloat;
+                            e.Vcfloat.im = -e1.Vcfloat.re / e2.Vfloat;
                             break;
                         case TYcfloat:
-                            e.EV.Vcfloat = Complex_f.div(e1.EV.Vcfloat, e2.EV.Vcfloat);
+                            e.Vcfloat = Complex_f.div(e1.Vcfloat, e2.Vcfloat);
                             break;
                         default:
                             assert(0);
@@ -1052,15 +1052,15 @@ static if (0)
                     switch (tym2)
                     {
                         case TYdouble:
-                            e.EV.Vcdouble.re = e1.EV.Vcdouble.re / e2.EV.Vdouble;
-                            e.EV.Vcdouble.im = e1.EV.Vcdouble.im / e2.EV.Vdouble;
+                            e.Vcdouble.re = e1.Vcdouble.re / e2.Vdouble;
+                            e.Vcdouble.im = e1.Vcdouble.im / e2.Vdouble;
                             break;
                         case TYidouble:
-                            e.EV.Vcdouble.re =  e1.EV.Vcdouble.im / e2.EV.Vdouble;
-                            e.EV.Vcdouble.im = -e1.EV.Vcdouble.re / e2.EV.Vdouble;
+                            e.Vcdouble.re =  e1.Vcdouble.im / e2.Vdouble;
+                            e.Vcdouble.im = -e1.Vcdouble.re / e2.Vdouble;
                             break;
                         case TYcdouble:
-                            e.EV.Vcdouble = Complex_d.div(e1.EV.Vcdouble, e2.EV.Vcdouble);
+                            e.Vcdouble = Complex_d.div(e1.Vcdouble, e2.Vcdouble);
                             break;
                         default:
                             assert(0);
@@ -1070,22 +1070,22 @@ static if (0)
                     switch (tym2)
                     {
                         case TYldouble:
-                            e.EV.Vcldouble.re = e1.EV.Vcldouble.re / d2;
-                            e.EV.Vcldouble.im = e1.EV.Vcldouble.im / d2;
+                            e.Vcldouble.re = e1.Vcldouble.re / d2;
+                            e.Vcldouble.im = e1.Vcldouble.im / d2;
                             break;
                         case TYildouble:
-                            e.EV.Vcldouble.re =  e1.EV.Vcldouble.im / d2;
-                            e.EV.Vcldouble.im = -e1.EV.Vcldouble.re / d2;
+                            e.Vcldouble.re =  e1.Vcldouble.im / d2;
+                            e.Vcldouble.im = -e1.Vcldouble.re / d2;
                             break;
                         case TYcldouble:
-                            e.EV.Vcldouble = Complex_ld.div(e1.EV.Vcldouble, e2.EV.Vcldouble);
+                            e.Vcldouble = Complex_ld.div(e1.Vcldouble, e2.Vcldouble);
                             break;
                         default:
                             assert(0);
                     }
                     break;
                 default:
-                    e.EV.Vllong = l1 / l2;
+                    e.Vllong = l1 / l2;
                     break;
             }
         }
@@ -1107,12 +1107,12 @@ static if (0)
         if (uns)
         {
             if (tym == TYucent)
-                dmd.common.int128.udivmod(e1.EV.Vcent, e2.EV.Vcent, e.EV.Vcent);
+                dmd.common.int128.udivmod(e1.Vcent, e2.Vcent, e.Vcent);
             else
-                e.EV.Vullong = (cast(targ_ullong) l1) % (cast(targ_ullong) l2);
+                e.Vullong = (cast(targ_ullong) l1) % (cast(targ_ullong) l2);
         }
         else if (tym == TYcent)
-            dmd.common.int128.divmod(e1.EV.Vcent, e2.EV.Vcent, e.EV.Vcent);
+            dmd.common.int128.divmod(e1.Vcent, e2.Vcent, e.Vcent);
         else
         {
             // BUG: what do we do for imaginary, complex?
@@ -1120,23 +1120,23 @@ static if (0)
             {   case TYdouble:
                 case TYidouble:
                 case TYdouble_alias:
-                    e.EV.Vdouble = fmod(e1.EV.Vdouble,e2.EV.Vdouble);
+                    e.Vdouble = fmod(e1.Vdouble,e2.Vdouble);
                     break;
                 case TYfloat:
                 case TYifloat:
-                    e.EV.Vfloat = fmodf(e1.EV.Vfloat,e2.EV.Vfloat);
+                    e.Vfloat = fmodf(e1.Vfloat,e2.Vfloat);
                     break;
                 case TYldouble:
                 case TYildouble:
-                    e.EV.Vldouble = _modulo(d1, d2);
+                    e.Vldouble = _modulo(d1, d2);
                     break;
                 case TYcfloat:
                     switch (tym2)
                     {
                         case TYfloat:
                         case TYifloat:
-                            e.EV.Vcfloat.re = fmodf(e1.EV.Vcfloat.re, e2.EV.Vfloat);
-                            e.EV.Vcfloat.im = fmodf(e1.EV.Vcfloat.im, e2.EV.Vfloat);
+                            e.Vcfloat.re = fmodf(e1.Vcfloat.re, e2.Vfloat);
+                            e.Vcfloat.im = fmodf(e1.Vcfloat.im, e2.Vfloat);
                             break;
                         default:
                             assert(0);
@@ -1147,8 +1147,8 @@ static if (0)
                     {
                         case TYdouble:
                         case TYidouble:
-                            e.EV.Vcdouble.re = fmod(e1.EV.Vcdouble.re, e2.EV.Vdouble);
-                            e.EV.Vcdouble.im = fmod(e1.EV.Vcdouble.im, e2.EV.Vdouble);
+                            e.Vcdouble.re = fmod(e1.Vcdouble.re, e2.Vdouble);
+                            e.Vcdouble.im = fmod(e1.Vcdouble.im, e2.Vdouble);
                             break;
                         default:
                             assert(0);
@@ -1159,15 +1159,15 @@ static if (0)
                     {
                         case TYldouble:
                         case TYildouble:
-                            e.EV.Vcldouble.re = _modulo(e1.EV.Vcldouble.re, d2);
-                            e.EV.Vcldouble.im = _modulo(e1.EV.Vcldouble.im, d2);
+                            e.Vcldouble.re = _modulo(e1.Vcldouble.re, d2);
+                            e.Vcldouble.im = _modulo(e1.Vcldouble.im, d2);
                             break;
                         default:
                             assert(0);
                     }
                     break;
                 default:
-                    e.EV.Vllong = l1 % l2;
+                    e.Vllong = l1 % l2;
                     break;
             }
         }
@@ -1195,14 +1195,14 @@ static if (0)
         switch (tysize(tym))
         {
             case 2:
-                e.EV.Vllong = (rem << 16) | (quo & 0xFFFF);
+                e.Vllong = (rem << 16) | (quo & 0xFFFF);
                 break;
             case 4:
-                e.EV.Vllong = (rem << 32) | (quo & 0xFFFFFFFF);
+                e.Vllong = (rem << 32) | (quo & 0xFFFFFFFF);
                 break;
             case 8:
-                e.EV.Vcent.lo = quo;
-                e.EV.Vcent.hi = rem;
+                e.Vcent.lo = quo;
+                e.Vcent.hi = rem;
                 break;
             default:
                 assert(0);
@@ -1211,103 +1211,103 @@ static if (0)
     }
     case OPand:
         if (tym == TYcent || tym == TYucent)
-            e.EV.Vcent = dmd.common.int128.and(e1.EV.Vcent, e2.EV.Vcent);
+            e.Vcent = dmd.common.int128.and(e1.Vcent, e2.Vcent);
         else
-            e.EV.Vllong = l1 & l2;
+            e.Vllong = l1 & l2;
         break;
     case OPor:
         if (tym == TYcent || tym == TYucent)
-            e.EV.Vcent = dmd.common.int128.or(e1.EV.Vcent, e2.EV.Vcent);
+            e.Vcent = dmd.common.int128.or(e1.Vcent, e2.Vcent);
         else
-            e.EV.Vllong = l1 | l2;
+            e.Vllong = l1 | l2;
         break;
     case OPxor:
         if (tym == TYcent || tym == TYucent)
-            e.EV.Vcent = dmd.common.int128.xor(e1.EV.Vcent, e2.EV.Vcent);
+            e.Vcent = dmd.common.int128.xor(e1.Vcent, e2.Vcent);
         else
-            e.EV.Vllong = l1 ^ l2;
+            e.Vllong = l1 ^ l2;
         break;
     case OPnot:
-        e.EV.Vint = boolres(e1) ^ true;
+        e.Vint = boolres(e1) ^ true;
         break;
     case OPcom:
         if (tym == TYcent || tym == TYucent)
-            e.EV.Vcent = dmd.common.int128.com(e1.EV.Vcent);
+            e.Vcent = dmd.common.int128.com(e1.Vcent);
         else
-            e.EV.Vllong = ~l1;
+            e.Vllong = ~l1;
         break;
     case OPcomma:
         e.EV = e2.EV;
         break;
     case OPoror:
-        e.EV.Vint = boolres(e1) || boolres(e2);
+        e.Vint = boolres(e1) || boolres(e2);
         break;
     case OPandand:
-        e.EV.Vint = boolres(e1) && boolres(e2);
+        e.Vint = boolres(e1) && boolres(e2);
         break;
     case OPshl:
         if (tym == TYcent || tym == TYucent)
-            e.EV.Vcent = dmd.common.int128.shl(e1.EV.Vcent, i2);
+            e.Vcent = dmd.common.int128.shl(e1.Vcent, i2);
         else if (cast(targ_ullong) i2 < targ_ullong.sizeof * 8)
-            e.EV.Vllong = l1 << i2;
+            e.Vllong = l1 << i2;
         else
-            e.EV.Vllong = 0;
+            e.Vllong = 0;
         break;
     case OPshr:
         if (tym == TYcent || tym == TYucent)
         {
-            e.EV.Vcent = dmd.common.int128.shr(e1.EV.Vcent, i2);
+            e.Vcent = dmd.common.int128.shr(e1.Vcent, i2);
             break;
         }
         if (cast(targ_ullong) i2 > targ_ullong.sizeof * 8)
             i2 = targ_ullong.sizeof * 8;
         // Always unsigned
-        e.EV.Vullong = (cast(targ_ullong) l1) >> i2;
+        e.Vullong = (cast(targ_ullong) l1) >> i2;
         break;
 
     case OPbtst:
         if (cast(targ_ullong) i2 > targ_ullong.sizeof * 8)
             i2 = targ_ullong.sizeof * 8;
-        e.EV.Vullong = ((cast(targ_ullong) l1) >> i2) & 1;
+        e.Vullong = ((cast(targ_ullong) l1) >> i2) & 1;
         break;
 
     case OPashr:
         if (tym == TYcent || tym == TYucent)
         {
-            e.EV.Vcent = dmd.common.int128.sar(e1.EV.Vcent, i2);
+            e.Vcent = dmd.common.int128.sar(e1.Vcent, i2);
             break;
         }
         if (cast(targ_ullong) i2 > targ_ullong.sizeof * 8)
             i2 = targ_ullong.sizeof * 8;
         // Always signed
-        e.EV.Vllong = l1 >> i2;
+        e.Vllong = l1 >> i2;
         break;
 
     case OPpair:
         switch (tysize(e.Ety))
         {
             case 4:
-                e.EV.Vlong = (i2 << 16) | (i1 & 0xFFFF);
+                e.Vlong = (i2 << 16) | (i1 & 0xFFFF);
                 break;
             case 8:
                 if (tyfloating(tym))
                 {
-                    e.EV.Vcfloat.re = cast(float)d1;
-                    e.EV.Vcfloat.im = cast(float)d2;
+                    e.Vcfloat.re = cast(float)d1;
+                    e.Vcfloat.im = cast(float)d2;
                 }
                 else
-                    e.EV.Vllong = (l2 << 32) | (l1 & 0xFFFFFFFF);
+                    e.Vllong = (l2 << 32) | (l1 & 0xFFFFFFFF);
                 break;
             case 16:
                 if (tyfloating(tym))
                 {
-                    e.EV.Vcdouble.re = cast(double)d1;
-                    e.EV.Vcdouble.im = cast(double)d2;
+                    e.Vcdouble.re = cast(double)d1;
+                    e.Vcdouble.im = cast(double)d2;
                 }
                 else
                 {
-                    e.EV.Vcent.lo = l1;
-                    e.EV.Vcent.hi = l2;
+                    e.Vcent.lo = l1;
+                    e.Vcent.hi = l2;
                 }
                 break;
 
@@ -1317,8 +1317,8 @@ static if (0)
             default:
                 if (tyfloating(tym))
                 {
-                    e.EV.Vcldouble.re = d1;
-                    e.EV.Vcldouble.im = d2;
+                    e.Vcldouble.re = d1;
+                    e.Vcldouble.im = d2;
                 }
                 else
                 {
@@ -1333,35 +1333,35 @@ static if (0)
         switch (tysize(e.Ety))
         {
             case 4:
-                e.EV.Vlong = (i1 << 16) | (i2 & 0xFFFF);
+                e.Vlong = (i1 << 16) | (i2 & 0xFFFF);
                 break;
             case 8:
-                e.EV.Vllong = (l1 << 32) | (l2 & 0xFFFFFFFF);
+                e.Vllong = (l1 << 32) | (l2 & 0xFFFFFFFF);
                 if (tyfloating(tym))
                 {
-                    e.EV.Vcfloat.re = cast(float)d2;
-                    e.EV.Vcfloat.im = cast(float)d1;
+                    e.Vcfloat.re = cast(float)d2;
+                    e.Vcfloat.im = cast(float)d1;
                 }
                 else
-                    e.EV.Vllong = (l1 << 32) | (l2 & 0xFFFFFFFF);
+                    e.Vllong = (l1 << 32) | (l2 & 0xFFFFFFFF);
                 break;
             case 16:
                 if (tyfloating(tym))
                 {
-                    e.EV.Vcdouble.re = cast(double)d2;
-                    e.EV.Vcdouble.im = cast(double)d1;
+                    e.Vcdouble.re = cast(double)d2;
+                    e.Vcdouble.im = cast(double)d1;
                 }
                 else
                 {
-                    e.EV.Vcent.lo = l2;
-                    e.EV.Vcent.hi = l1;
+                    e.Vcent.lo = l2;
+                    e.Vcent.hi = l1;
                 }
                 break;
             default:
                 if (tyfloating(tym))
                 {
-                    e.EV.Vcldouble.re = d2;
-                    e.EV.Vcldouble.im = d1;
+                    e.Vcldouble.re = d2;
+                    e.Vcldouble.im = d1;
                 }
                 else
                 {
@@ -1373,41 +1373,41 @@ static if (0)
 
     case OPneg:
         // Avoid converting NANS to NAN
-        memcpy(&e.EV.Vcldouble,&e1.EV.Vcldouble,e.EV.Vcldouble.sizeof);
+        memcpy(&e.Vcldouble,&e1.Vcldouble,e.Vcldouble.sizeof);
         switch (tym)
         {   case TYdouble:
             case TYidouble:
             case TYdouble_alias:
-                e.EV.Vdouble = -e.EV.Vdouble;
+                e.Vdouble = -e.Vdouble;
                 break;
             case TYfloat:
             case TYifloat:
-                e.EV.Vfloat = -e.EV.Vfloat;
+                e.Vfloat = -e.Vfloat;
                 break;
             case TYldouble:
             case TYildouble:
-                e.EV.Vldouble = -e.EV.Vldouble;
+                e.Vldouble = -e.Vldouble;
                 break;
             case TYcfloat:
-                e.EV.Vcfloat.re = -e.EV.Vcfloat.re;
-                e.EV.Vcfloat.im = -e.EV.Vcfloat.im;
+                e.Vcfloat.re = -e.Vcfloat.re;
+                e.Vcfloat.im = -e.Vcfloat.im;
                 break;
             case TYcdouble:
-                e.EV.Vcdouble.re = -e.EV.Vcdouble.re;
-                e.EV.Vcdouble.im = -e.EV.Vcdouble.im;
+                e.Vcdouble.re = -e.Vcdouble.re;
+                e.Vcdouble.im = -e.Vcdouble.im;
                 break;
             case TYcldouble:
-                e.EV.Vcldouble.re = -e.EV.Vcldouble.re;
-                e.EV.Vcldouble.im = -e.EV.Vcldouble.im;
+                e.Vcldouble.re = -e.Vcldouble.re;
+                e.Vcldouble.im = -e.Vcldouble.im;
                 break;
 
             case TYcent:
             case TYucent:
-                e.EV.Vcent = dmd.common.int128.neg(e1.EV.Vcent);
+                e.Vcent = dmd.common.int128.neg(e1.Vcent);
                 break;
 
             default:
-                e.EV.Vllong = -l1;
+                e.Vllong = -l1;
                 break;
         }
         break;
@@ -1417,35 +1417,35 @@ static if (0)
             case TYdouble:
             case TYidouble:
             case TYdouble_alias:
-                e.EV.Vdouble = fabs(e1.EV.Vdouble);
+                e.Vdouble = fabs(e1.Vdouble);
                 break;
             case TYfloat:
             case TYifloat:
 version (DigitalMars)
-                e.EV.Vfloat = fabsf(e1.EV.Vfloat);
+                e.Vfloat = fabsf(e1.Vfloat);
 else
-                e.EV.Vfloat = fabs(e1.EV.Vfloat);
+                e.Vfloat = fabs(e1.Vfloat);
 
                 break;
             case TYldouble:
             case TYildouble:
-                e.EV.Vldouble = fabsl(d1);
+                e.Vldouble = fabsl(d1);
                 break;
             case TYcfloat:
-                e.EV.Vfloat = cast(float)Complex_f.abs(e1.EV.Vcfloat);
+                e.Vfloat = cast(float)Complex_f.abs(e1.Vcfloat);
                 break;
             case TYcdouble:
-                e.EV.Vdouble = cast(double)Complex_d.abs(e1.EV.Vcdouble);
+                e.Vdouble = cast(double)Complex_d.abs(e1.Vcdouble);
                 break;
             case TYcldouble:
-                e.EV.Vldouble = Complex_ld.abs(e1.EV.Vcldouble);
+                e.Vldouble = Complex_ld.abs(e1.Vcldouble);
                 break;
             case TYcent:
             case TYucent:
-                e.EV.Vcent = cast(long)e1.EV.Vcent.hi < 0 ? dmd.common.int128.neg(e1.EV.Vcent) : e1.EV.Vcent;
+                e.Vcent = cast(long)e1.Vcent.hi < 0 ? dmd.common.int128.neg(e1.Vcent) : e1.Vcent;
                 break;
             default:
-                e.EV.Vllong = l1 < 0 ? -l1 : l1;
+                e.Vllong = l1 < 0 ? -l1 : l1;
                 break;
         }
         break;
@@ -1461,7 +1461,7 @@ else
     case OPgt:
         if (!tyfloating(tym))
             goto Lnle;
-        e.EV.Vint = (op == OPngt) ^ (d1 > d2);
+        e.Vint = (op == OPngt) ^ (d1 > d2);
         break;
 
     case OPnle:
@@ -1472,7 +1472,7 @@ else
         if (uns)
         {
             if (tym == TYucent)
-                b = dmd.common.int128.ule(e1.EV.Vcent, e2.EV.Vcent);
+                b = dmd.common.int128.ule(e1.Vcent, e2.Vcent);
             else
                 b = cast(int)((cast(targ_ullong) l1) <= (cast(targ_ullong) l2));
         }
@@ -1481,11 +1481,11 @@ else
             if (tyfloating(tym))
                 b = cast(int)(!unordered(d1, d2) && d1 <= d2);
             else if (tym == TYcent)
-                b = dmd.common.int128.le(e1.EV.Vcent, e2.EV.Vcent);
+                b = dmd.common.int128.le(e1.Vcent, e2.Vcent);
             else
                 b = cast(int)(l1 <= l2);
         }
-        e.EV.Vint = (op != OPle) ^ b;
+        e.Vint = (op != OPle) ^ b;
         break;
     }
 
@@ -1493,7 +1493,7 @@ else
     case OPge:
         if (!tyfloating(tym))
             goto Lnlt;
-        e.EV.Vint = (op == OPnge) ^ (!unordered(d1, d2) && d1 >= d2);
+        e.Vint = (op == OPnge) ^ (!unordered(d1, d2) && d1 >= d2);
         break;
 
     case OPnlt:
@@ -1504,7 +1504,7 @@ else
         if (uns)
         {
             if (tym == TYucent)
-                b = dmd.common.int128.ult(e1.EV.Vcent, e2.EV.Vcent);
+                b = dmd.common.int128.ult(e1.Vcent, e2.Vcent);
             else
                 b = cast(int)((cast(targ_ullong) l1) < (cast(targ_ullong) l2));
         }
@@ -1513,11 +1513,11 @@ else
             if (tyfloating(tym))
                 b = cast(int)(!unordered(d1, d2) && d1 < d2);
             else if (tym == TYcent)
-                b = dmd.common.int128.lt(e1.EV.Vcent, e2.EV.Vcent);
+                b = dmd.common.int128.lt(e1.Vcent, e2.Vcent);
             else
                 b = cast(int)(l1 < l2);
         }
-        e.EV.Vint = (op != OPlt) ^ b;
+        e.Vint = (op != OPlt) ^ b;
         break;
     }
 
@@ -1530,157 +1530,157 @@ else
             switch (tybasic(tym))
             {
                 case TYcfloat:
-                    if (isnan(e1.EV.Vcfloat.re) || isnan(e1.EV.Vcfloat.im) ||
-                        isnan(e2.EV.Vcfloat.re) || isnan(e2.EV.Vcfloat.im))
+                    if (isnan(e1.Vcfloat.re) || isnan(e1.Vcfloat.im) ||
+                        isnan(e2.Vcfloat.re) || isnan(e2.Vcfloat.im))
                         b = 0;
                     else
-                        b = cast(int)((e1.EV.Vcfloat.re == e2.EV.Vcfloat.re) &&
-                                      (e1.EV.Vcfloat.im == e2.EV.Vcfloat.im));
+                        b = cast(int)((e1.Vcfloat.re == e2.Vcfloat.re) &&
+                                      (e1.Vcfloat.im == e2.Vcfloat.im));
                     break;
                 case TYcdouble:
-                    if (isnan(e1.EV.Vcdouble.re) || isnan(e1.EV.Vcdouble.im) ||
-                        isnan(e2.EV.Vcdouble.re) || isnan(e2.EV.Vcdouble.im))
+                    if (isnan(e1.Vcdouble.re) || isnan(e1.Vcdouble.im) ||
+                        isnan(e2.Vcdouble.re) || isnan(e2.Vcdouble.im))
                         b = 0;
                     else
-                        b = cast(int)((e1.EV.Vcdouble.re == e2.EV.Vcdouble.re) &&
-                                      (e1.EV.Vcdouble.im == e2.EV.Vcdouble.im));
+                        b = cast(int)((e1.Vcdouble.re == e2.Vcdouble.re) &&
+                                      (e1.Vcdouble.im == e2.Vcdouble.im));
                     break;
                 case TYcldouble:
-                    if (isnan(e1.EV.Vcldouble.re) || isnan(e1.EV.Vcldouble.im) ||
-                        isnan(e2.EV.Vcldouble.re) || isnan(e2.EV.Vcldouble.im))
+                    if (isnan(e1.Vcldouble.re) || isnan(e1.Vcldouble.im) ||
+                        isnan(e2.Vcldouble.re) || isnan(e2.Vcldouble.im))
                         b = 0;
                     else
-                        b = cast(int)((e1.EV.Vcldouble.re == e2.EV.Vcldouble.re) &&
-                                      (e1.EV.Vcldouble.im == e2.EV.Vcldouble.im));
+                        b = cast(int)((e1.Vcldouble.re == e2.Vcldouble.re) &&
+                                      (e1.Vcldouble.im == e2.Vcldouble.im));
                     break;
                 default:
                     b = cast(int)(d1 == d2);
                     break;
             }
-            //printf("%Lg + %Lgi, %Lg + %Lgi\n", e1.EV.Vcldouble.re, e1.EV.Vcldouble.im, e2.EV.Vcldouble.re, e2.EV.Vcldouble.im);
+            //printf("%Lg + %Lgi, %Lg + %Lgi\n", e1.Vcldouble.re, e1.Vcldouble.im, e2.Vcldouble.re, e2.Vcldouble.im);
         }
         else if (tym == TYcent || tym == TYucent)
-            b = cast(int)(e1.EV.Vcent == e2.EV.Vcent);
+            b = cast(int)(e1.Vcent == e2.Vcent);
         else
             b = cast(int)(l1 == l2);
-        e.EV.Vint = (op == OPne) ^ b;
+        e.Vint = (op == OPne) ^ b;
         break;
     }
 
     case OPord:
     case OPunord:
         // BUG: complex numbers
-        e.EV.Vint = (op == OPord) ^ (unordered(d1, d2)); // !<>=
+        e.Vint = (op == OPord) ^ (unordered(d1, d2)); // !<>=
         break;
 
     case OPnlg:
     case OPlg:
         // BUG: complex numbers
-        e.EV.Vint = (op == OPnlg) ^ (!unordered(d1, d2) && d1 != d2); // <>
+        e.Vint = (op == OPnlg) ^ (!unordered(d1, d2) && d1 != d2); // <>
         break;
 
     case OPnleg:
     case OPleg:
         // BUG: complex numbers
-        e.EV.Vint = (op == OPnleg) ^ (!unordered(d1, d2)); // <>=
+        e.Vint = (op == OPnleg) ^ (!unordered(d1, d2)); // <>=
         break;
 
     case OPnule:
     case OPule:
         // BUG: complex numbers
-        e.EV.Vint = (op == OPnule) ^ (unordered(d1, d2) || d1 <= d2); // !>
+        e.Vint = (op == OPnule) ^ (unordered(d1, d2) || d1 <= d2); // !>
         break;
 
     case OPnul:
     case OPul:
         // BUG: complex numbers
-        e.EV.Vint = (op == OPnul) ^ (unordered(d1, d2) || d1 < d2); // !>=
+        e.Vint = (op == OPnul) ^ (unordered(d1, d2) || d1 < d2); // !>=
         break;
 
     case OPnuge:
     case OPuge:
         // BUG: complex numbers
-        e.EV.Vint = (op == OPnuge) ^ (unordered(d1, d2) || d1 >= d2); // !<
+        e.Vint = (op == OPnuge) ^ (unordered(d1, d2) || d1 >= d2); // !<
         break;
 
     case OPnug:
     case OPug:
         // BUG: complex numbers
-        e.EV.Vint = (op == OPnug) ^ (unordered(d1, d2) || d1 > d2); // !<=
+        e.Vint = (op == OPnug) ^ (unordered(d1, d2) || d1 > d2); // !<=
         break;
 
     case OPnue:
     case OPue:
         // BUG: complex numbers
-        e.EV.Vint = (op == OPnue) ^ (unordered(d1, d2) || d1 == d2); // !<>
+        e.Vint = (op == OPnue) ^ (unordered(d1, d2) || d1 == d2); // !<>
         break;
 
     case OPs16_32:
-        e.EV.Vlong = cast(targ_short) i1;
+        e.Vlong = cast(targ_short) i1;
         break;
     case OPnp_fp:
     case OPu16_32:
-        e.EV.Vulong = cast(targ_ushort) i1;
+        e.Vulong = cast(targ_ushort) i1;
         break;
     case OPd_u32:
-        e.EV.Vulong = cast(targ_ulong)d1;
-        //printf("OPd_u32: dbl = %g, ulng = x%lx\n",d1,e.EV.Vulong);
+        e.Vulong = cast(targ_ulong)d1;
+        //printf("OPd_u32: dbl = %g, ulng = x%lx\n",d1,e.Vulong);
         break;
     case OPd_s32:
-        e.EV.Vlong = cast(targ_long)d1;
+        e.Vlong = cast(targ_long)d1;
         break;
     case OPu32_d:
-        e.EV.Vdouble = cast(uint) l1;
+        e.Vdouble = cast(uint) l1;
         break;
     case OPs32_d:
-        e.EV.Vdouble = cast(int) l1;
+        e.Vdouble = cast(int) l1;
         break;
     case OPd_s16:
-        e.EV.Vint = cast(targ_int)d1;
+        e.Vint = cast(targ_int)d1;
         break;
     case OPs16_d:
-        e.EV.Vdouble = cast(targ_short) i1;
+        e.Vdouble = cast(targ_short) i1;
         break;
     case OPd_u16:
-        e.EV.Vushort = cast(targ_ushort)d1;
+        e.Vushort = cast(targ_ushort)d1;
         break;
     case OPu16_d:
-        e.EV.Vdouble = cast(targ_ushort) i1;
+        e.Vdouble = cast(targ_ushort) i1;
         break;
     case OPd_s64:
-        e.EV.Vllong = cast(targ_llong)d1;
+        e.Vllong = cast(targ_llong)d1;
         break;
     case OPd_u64:
     case OPld_u64:
-        e.EV.Vullong = cast(targ_ullong)d1;
+        e.Vullong = cast(targ_ullong)d1;
         break;
     case OPs64_d:
-        e.EV.Vdouble = l1;
+        e.Vdouble = l1;
         break;
     case OPu64_d:
-        e.EV.Vdouble = cast(targ_ullong) l1;
+        e.Vdouble = cast(targ_ullong) l1;
         break;
     case OPd_f:
         assert((statusFE() & 0x3800) == 0);
-        e.EV.Vfloat = e1.EV.Vdouble;
+        e.Vfloat = e1.Vdouble;
         if (tycomplex(tym))
-            e.EV.Vcfloat.im = e1.EV.Vcdouble.im;
+            e.Vcfloat.im = e1.Vcdouble.im;
         assert((statusFE() & 0x3800) == 0);
         break;
     case OPf_d:
-        e.EV.Vdouble = e1.EV.Vfloat;
+        e.Vdouble = e1.Vfloat;
         if (tycomplex(tym))
-            e.EV.Vcdouble.im = e1.EV.Vcfloat.im;
+            e.Vcdouble.im = e1.Vcfloat.im;
         break;
     case OPd_ld:
-        e.EV.Vldouble = e1.EV.Vdouble;
+        e.Vldouble = e1.Vdouble;
         if (tycomplex(tym))
-            e.EV.Vcldouble.im = e1.EV.Vcdouble.im;
+            e.Vcldouble.im = e1.Vcdouble.im;
         break;
     case OPld_d:
-        e.EV.Vdouble = cast(double)e1.EV.Vldouble;
+        e.Vdouble = cast(double)e1.Vldouble;
         if (tycomplex(tym))
-            e.EV.Vcdouble.im = cast(double)e1.EV.Vcldouble.im;
+            e.Vcdouble.im = cast(double)e1.Vcldouble.im;
         break;
     case OPc_r:
         e.EV = e1.EV;
@@ -1689,92 +1689,92 @@ else
         switch (tym)
         {
             case TYcfloat:
-                e.EV.Vfloat = e1.EV.Vcfloat.im;
+                e.Vfloat = e1.Vcfloat.im;
                 break;
             case TYcdouble:
-                e.EV.Vdouble = e1.EV.Vcdouble.im;
+                e.Vdouble = e1.Vcdouble.im;
                 break;
             case TYcldouble:
-                e.EV.Vldouble = e1.EV.Vcldouble.im;
+                e.Vldouble = e1.Vcldouble.im;
                 break;
             default:
                 assert(0);
         }
         break;
     case OPs8_16:
-        e.EV.Vint = cast(targ_schar) i1;
+        e.Vint = cast(targ_schar) i1;
         break;
     case OPu8_16:
-        e.EV.Vint = i1 & 0xFF;
+        e.Vint = i1 & 0xFF;
         break;
     case OP16_8:
-        e.EV.Vint = i1;
+        e.Vint = i1;
         break;
     case OPbool:
-        e.EV.Vint = boolres(e1);
+        e.Vint = boolres(e1);
         break;
     case OP32_16:
     case OPoffset:
-        e.EV.Vint = cast(targ_int)l1;
+        e.Vint = cast(targ_int)l1;
         break;
 
     case OP64_32:
-        e.EV.Vlong = cast(targ_long)l1;
+        e.Vlong = cast(targ_long)l1;
         break;
     case OPs32_64:
-        e.EV.Vllong = cast(targ_long) l1;
+        e.Vllong = cast(targ_long) l1;
         break;
     case OPu32_64:
-        e.EV.Vllong = cast(targ_ulong) l1;
+        e.Vllong = cast(targ_ulong) l1;
         break;
 
     case OP128_64:
-        e.EV.Vllong = e1.EV.Vcent.lo;
+        e.Vllong = e1.Vcent.lo;
         break;
     case OPs64_128:
-        e.EV.Vcent.lo = e1.EV.Vllong;
-        e.EV.Vcent.hi = 0;
-        if (cast(targ_llong)e.EV.Vcent.lo < 0)
-            e.EV.Vcent.hi = ~cast(targ_ullong)0;
+        e.Vcent.lo = e1.Vllong;
+        e.Vcent.hi = 0;
+        if (cast(targ_llong)e.Vcent.lo < 0)
+            e.Vcent.hi = ~cast(targ_ullong)0;
         break;
     case OPu64_128:
-        e.EV.Vcent.lo = e1.EV.Vullong;
-        e.EV.Vcent.hi = 0;
+        e.Vcent.lo = e1.Vullong;
+        e.Vcent.hi = 0;
         break;
 
     case OPmsw:
         switch (tysize(tym))
         {
             case 4:
-                e.EV.Vllong = (l1 >> 16) & 0xFFFF;
+                e.Vllong = (l1 >> 16) & 0xFFFF;
                 break;
             case 8:
-                e.EV.Vllong = (l1 >> 32) & 0xFFFFFFFF;
+                e.Vllong = (l1 >> 32) & 0xFFFFFFFF;
                 break;
             case 16:
-                e.EV.Vllong = e1.EV.Vcent.hi;
+                e.Vllong = e1.Vcent.hi;
                 break;
             default:
                 assert(0);
         }
         break;
     case OPb_8:
-        e.EV.Vlong = i1 & 1;
+        e.Vlong = i1 & 1;
         break;
     case OPbswap:
         if (tysize(tym) == 2)
         {
-            e.EV.Vint = ((i1 >> 8) & 0x00FF) |
+            e.Vint = ((i1 >> 8) & 0x00FF) |
                         ((i1 << 8) & 0xFF00);
         }
         else if (tysize(tym) == 4)
-            e.EV.Vint = core.bitop.bswap(cast(uint) i1);
+            e.Vint = core.bitop.bswap(cast(uint) i1);
         else if (tysize(tym) == 8)
-            e.EV.Vllong = core.bitop.bswap(cast(ulong) l1);
+            e.Vllong = core.bitop.bswap(cast(ulong) l1);
         else
         {
-            e.EV.Vcent.hi = core.bitop.bswap(e1.EV.Vcent.lo);
-            e.EV.Vcent.lo = core.bitop.bswap(e1.EV.Vcent.hi);
+            e.Vcent.hi = core.bitop.bswap(e1.Vcent.lo);
+            e.Vcent.lo = core.bitop.bswap(e1.Vcent.hi);
         }
         break;
 
@@ -1789,7 +1789,7 @@ else
             case 8:     break;
             default:    assert(0);
         }
-        e.EV.Vllong = core.bitop.popcnt(cast(ulong) l1);
+        e.Vllong = core.bitop.popcnt(cast(ulong) l1);
         break;
     }
 
@@ -1802,22 +1802,22 @@ else
         {
             case 1:
                 n &= 7;
-                e.EV.Vuchar = cast(ubyte)((i1 << n) | ((i1 & 0xFF) >> (8 - n)));
+                e.Vuchar = cast(ubyte)((i1 << n) | ((i1 & 0xFF) >> (8 - n)));
                 break;
             case 2:
                 n &= 0xF;
-                e.EV.Vushort = cast(targ_ushort)((i1 << n) | ((i1 & 0xFFFF) >> (16 - n)));
+                e.Vushort = cast(targ_ushort)((i1 << n) | ((i1 & 0xFFFF) >> (16 - n)));
                 break;
             case 4:
                 n &= 0x1F;
-                e.EV.Vulong = cast(targ_ulong)((i1 << n) | ((i1 & 0xFFFFFFFF) >> (32 - n)));
+                e.Vulong = cast(targ_ulong)((i1 << n) | ((i1 & 0xFFFFFFFF) >> (32 - n)));
                 break;
             case 8:
                 n &= 0x3F;
-                e.EV.Vullong = cast(targ_ullong)((l1 << n) | ((l1 & 0xFFFFFFFFFFFFFFFFL) >> (64 - n)));
+                e.Vullong = cast(targ_ullong)((l1 << n) | ((l1 & 0xFFFFFFFFFFFFFFFFL) >> (64 - n)));
                 break;
             case 16:
-                e.EV.Vcent = dmd.common.int128.rol(e1.EV.Vcent, n);
+                e.Vcent = dmd.common.int128.rol(e1.Vcent, n);
                 break;
             default:
                 assert(0);
@@ -1836,7 +1836,7 @@ static if (0) // && MARS
         {
             error(e.Esrcpos.Sfilename, e.Esrcpos.Slinnum, e.Esrcpos.Scharnum,
                 "dereference of null pointer");
-            e.EV.E1.EV.Vlong = 4096;     // suppress redundant messages
+            e.E1.Vlong = 4096;     // suppress redundant messages
         }
 }
         return e;
@@ -1846,61 +1846,61 @@ static if (0) // && MARS
         {
             // 16 byte vectors
             case TYfloat4:
-                foreach (ref lhsElem; e.EV.Vfloat4)
-                    lhsElem = e1.EV.Vfloat;
+                foreach (ref lhsElem; e.Vfloat4)
+                    lhsElem = e1.Vfloat;
                 break;
             case TYdouble2:
-                foreach (ref lhsElem; e.EV.Vdouble2)
-                    lhsElem = e1.EV.Vdouble;
+                foreach (ref lhsElem; e.Vdouble2)
+                    lhsElem = e1.Vdouble;
                 break;
             case TYschar16:
             case TYuchar16:
-                foreach (ref lhsElem; e.EV.Vuchar16)
+                foreach (ref lhsElem; e.Vuchar16)
                     lhsElem = cast(targ_uchar)i1;
                 break;
             case TYshort8:
             case TYushort8:
-                foreach (ref lhsElem; e.EV.Vushort8)
+                foreach (ref lhsElem; e.Vushort8)
                     lhsElem = cast(targ_ushort)i1;
                 break;
             case TYlong4:
             case TYulong4:
-                foreach (ref lhsElem; e.EV.Vulong4)
+                foreach (ref lhsElem; e.Vulong4)
                     lhsElem = cast(targ_ulong)i1;
                 break;
             case TYllong2:
             case TYullong2:
-                foreach (ref lhsElem; e.EV.Vullong2)
+                foreach (ref lhsElem; e.Vullong2)
                     lhsElem = cast(targ_ullong)l1;
                 break;
 
             // 32 byte vectors
             case TYfloat8:
-                foreach (ref lhsElem; e.EV.Vfloat8)
-                    lhsElem = e1.EV.Vfloat;
+                foreach (ref lhsElem; e.Vfloat8)
+                    lhsElem = e1.Vfloat;
                 break;
             case TYdouble4:
-                foreach (ref lhsElem; e.EV.Vdouble4)
-                    lhsElem = e1.EV.Vdouble;
+                foreach (ref lhsElem; e.Vdouble4)
+                    lhsElem = e1.Vdouble;
                 break;
             case TYschar32:
             case TYuchar32:
-                foreach (ref lhsElem; e.EV.Vuchar32)
+                foreach (ref lhsElem; e.Vuchar32)
                     lhsElem = cast(targ_uchar)i1;
                 break;
             case TYshort16:
             case TYushort16:
-                foreach (ref lhsElem; e.EV.Vushort16)
+                foreach (ref lhsElem; e.Vushort16)
                     lhsElem = cast(targ_ushort)i1;
                 break;
             case TYlong8:
             case TYulong8:
-                foreach (ref lhsElem; e.EV.Vulong8)
+                foreach (ref lhsElem; e.Vulong8)
                     lhsElem = cast(targ_ulong)i1;
                 break;
             case TYllong4:
             case TYullong4:
-                foreach (ref lhsElem; e.EV.Vullong4)
+                foreach (ref lhsElem; e.Vullong4)
                     lhsElem = cast(targ_ullong)l1;
                 break;
 
@@ -1926,7 +1926,7 @@ static if (0) // && MARS
     {
     }
 
-  /*debug printf("result = x%lx\n",e.EV.Vlong);*/
+  /*debug printf("result = x%lx\n",e.Vlong);*/
   e.Eoper = OPconst;
   el_free(e1);
   if (e2)
@@ -1952,16 +1952,16 @@ extern (D) targ_ldouble el_toldoubled(elem *e)
     {
         case TYfloat:
         case TYifloat:
-            result = e.EV.Vfloat;
+            result = e.Vfloat;
             break;
         case TYdouble:
         case TYidouble:
         case TYdouble_alias:
-            result = e.EV.Vdouble;
+            result = e.Vdouble;
             break;
         case TYldouble:
         case TYildouble:
-            result = e.EV.Vldouble;
+            result = e.Vldouble;
             break;
         default:
             result = 0;

--- a/compiler/src/dmd/backend/inliner.d
+++ b/compiler/src/dmd/backend/inliner.d
@@ -203,9 +203,9 @@ bool canInlineExpression(elem* e)
                 /* Statics cannot be accessed from a different object file,
                  * so the reference will fail.
                  */
-                if (e.EV.Vsym.Sclass == SC.locstat || e.EV.Vsym.Sclass == SC.static_)
+                if (e.Vsym.Sclass == SC.locstat || e.Vsym.Sclass == SC.static_)
                 {
-                    if (log) printf("not inlining due to %s\n", e.EV.Vsym.Sident.ptr);
+                    if (log) printf("not inlining due to %s\n", e.Vsym.Sident.ptr);
                     return false;
                 }
             }
@@ -215,14 +215,14 @@ bool canInlineExpression(elem* e)
         }
         else if (OTunary(e.Eoper))
         {
-            e = e.EV.E1;
+            e = e.E1;
             continue;
         }
         else
         {
-            if (!canInlineExpression(e.EV.E1))
+            if (!canInlineExpression(e.E1))
                 return false;
-            e = e.EV.E2;
+            e = e.E2;
             continue;
         }
     }
@@ -243,15 +243,15 @@ elem* scanExpressionForInlines(elem *e)
     const op = e.Eoper;
     if (OTbinary(op))
     {
-        e.EV.E1 = scanExpressionForInlines(e.EV.E1);
-        e.EV.E2 = scanExpressionForInlines(e.EV.E2);
+        e.E1 = scanExpressionForInlines(e.E1);
+        e.E2 = scanExpressionForInlines(e.E2);
         if (op == OPcall)
             e = tryInliningCall(e);
     }
     else if (OTunary(op))
     {
         assert(op != OPstrctor);  // never happens in MARS
-        e.EV.E1 = scanExpressionForInlines(e.EV.E1);
+        e.E1 = scanExpressionForInlines(e.E1);
         if (op == OPucall)
         {
             e = tryInliningCall(e);
@@ -277,11 +277,11 @@ private elem* tryInliningCall(elem *e)
     //elem_debug(e);
     assert(e && (e.Eoper == OPcall || e.Eoper == OPucall));
 
-    if (e.EV.E1.Eoper != OPvar)
+    if (e.E1.Eoper != OPvar)
         return e;
 
     // This is an explicit function call (not through a pointer)
-    Symbol* sfunc = e.EV.E1.EV.Vsym;
+    Symbol* sfunc = e.E1.Vsym;
     if (log) printf("tryInliningCall: %s, class = %d\n", prettyident(sfunc),sfunc.Sclass);
 
     // sfunc may not be a function due to user's clever casting
@@ -416,7 +416,7 @@ private elem* inlineCall(elem *e,Symbol *sfunc)
      */
     if (e.Eoper == OPcall)
     {
-        elem* eargs = initializeParamsWithArgs(e.EV.E2, sistart, globsym.length);
+        elem* eargs = initializeParamsWithArgs(e.E2, sistart, globsym.length);
         ec = el_combine(eargs,ec);
     }
 
@@ -463,7 +463,7 @@ private elem* initializeParamsWithArgs(elem* eargs, SYMIDX sistart, SYMIDX siend
         elem* e = args[n - 1];
 
         if (e.Eoper == OPstrpar)
-            e = e.EV.E1;
+            e = e.E1;
 
         /* Look for and return next parameter Symbol
          */
@@ -493,10 +493,10 @@ private elem* initializeParamsWithArgs(elem* eargs, SYMIDX sistart, SYMIDX siend
         //elem_print(e);
         if (e.Eoper == OPstrctor)
         {
-            ecopy = el_combine(el_copytree(e.EV.E1), ecopy);     // skip the OPstrctor
+            ecopy = el_combine(el_copytree(e.E1), ecopy);     // skip the OPstrctor
             e = ecopy;
             //while (e.Eoper == OPcomma)
-            //    e = e.EV.E2;
+            //    e = e.E2;
             debug
             {
                 if (e.Eoper != OPcall && e.Eoper != OPcond)
@@ -525,17 +525,17 @@ private elem* initializeParamsWithArgs(elem* eargs, SYMIDX sistart, SYMIDX siend
             if (e.Eoper != OPvar)
             {
                 elem* ec = exp2_copytotemp(e);
-                e = ec.EV.E2;
-                ex = ec.EV.E1;
-                ec.EV.E1 = null;
-                ec.EV.E2 = null;
+                e = ec.E2;
+                ex = ec.E1;
+                ec.E1 = null;
+                ec.E2 = null;
                 el_free(ec);
-                e.EV.Vsym.Sfl = FLauto;
+                e.Vsym.Sfl = FLauto;
             }
             assert(e.Eoper == OPvar);
             elem* e2 = el_copytree(e);
-            e.EV.Voffset += 0;
-            e2.EV.Voffset += szs;
+            e.Voffset += 0;
+            e2.Voffset += szs;
             e.Ety = ty;
             e2.Ety = ty;
             elem* elo = el_bin(OPeq, ty, el_var(s), e);
@@ -617,20 +617,20 @@ private void adjustExpression(elem *e)
         if (!OTleaf(e.Eoper))
         {
             if (OTbinary(e.Eoper))
-                adjustExpression(e.EV.E2);
+                adjustExpression(e.E2);
             else
-                assert(!e.EV.E2);
-            e = e.EV.E1;
+                assert(!e.E2);
+            e = e.E1;
         }
         else
         {
             if (e.Eoper == OPvar || e.Eoper == OPrelconst)
             {
-                Symbol *s = e.EV.Vsym;
+                Symbol *s = e.Vsym;
 
                 if (s.Sflags & SFLreplace)
                 {
-                    e.EV.Vsym = globsym[s.Ssymnum];
+                    e.Vsym = globsym[s.Ssymnum];
                     //printf("  replacing %p %s\n", e, s.Sident.ptr);
                 }
             }


### PR DESCRIPTION
I should have thought of using `alias this` for this long ago.