### PR TITLE
separate out constant part of union eve

### DIFF
--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -751,45 +751,6 @@ union eve
         targ_ulong[8]   Vulong8;   // uint[8]
         targ_llong[4]   Vllong4;   // long[4]
         targ_ullong[4]  Vullong4;  // ulong[4]
-
-        struct                  // 48 bit 386 far pointer
-        {   targ_long   Voff;
-            targ_ushort Vseg;
-        }
-        struct
-        {
-            targ_size_t Voffset;// offset from symbol
-            Symbol *Vsym;       // pointer to symbol table
-            union
-            {
-                param_t* Vtal;  // template-argument-list for SCfunctempl,
-                                // used only to transmit it to cpp_overload()
-                LIST* Erd;      // OPvar: reaching definitions
-            }
-        }
-        struct
-        {
-            targ_size_t Voffset2;// member pointer offset
-            Classsym* Vsym2;    // struct tag
-            elem* ethis;        // OPrelconst: 'this' for member pointer
-        }
-        struct
-        {
-            targ_size_t Voffset3;// offset from string
-            char* Vstring;      // pointer to string (OPstring or OPasm)
-            size_t Vstrlen;     // length of string
-        }
-        struct
-        {
-            elem* E1;           // left child for unary & binary nodes
-            elem* E2;           // right child for binary nodes
-            Symbol* Edtor;      // OPctor: destructor
-        }
-        struct
-        {
-            elem* Eleft2;       // left child for OPddtor
-            void* Edecl;        // VarDeclaration being constructed
-        }                       // OPdctor,OPddtor
 }                               // variants for each type of elem
 
 // Symbols

--- a/compiler/src/dmd/backend/el.d
+++ b/compiler/src/dmd/backend/el.d
@@ -76,7 +76,50 @@ struct elem
                         // always 0 until CSE elimination is done
     eflags_t Eflags;
 
-    eve EV;             // variants for each type of elem
+    union
+    {
+        eve EV;                 // arithmetic constants
+
+        struct
+        {
+            elem* E1;           // left child for unary & binary nodes
+            elem* E2;           // right child for binary nodes
+            Symbol* Edtor;      // OPctor: destructor
+        }
+        struct
+        {
+            elem* Eleft2;       // left child for OPddtor
+            void* Edecl;        // VarDeclaration being constructed
+        }                       // OPdctor,OPddtor
+        struct                  // 48 bit 386 far pointer
+        {   targ_long   Voff;
+            targ_ushort Vseg;
+        }
+        struct
+        {
+            targ_size_t Voffset;// offset from symbol
+            Symbol *Vsym;       // pointer to symbol table
+            union
+            {
+                param_t* Vtal;  // template-argument-list for SCfunctempl,
+                                // used only to transmit it to cpp_overload()
+                LIST* Erd;      // OPvar: reaching definitions
+            }
+        }
+        struct
+        {
+            targ_size_t Voffset2;// member pointer offset
+            Classsym* Vsym2;    // struct tag
+            elem* ethis;        // OPrelconst: 'this' for member pointer
+        }
+        struct
+        {
+            targ_size_t Voffset3;// offset from string
+            char* Vstring;      // pointer to string (OPstring or OPasm)
+            size_t Vstrlen;     // length of string
+        }
+    }
+
     alias EV this;      // convenience so .EV. is not necessary
 
     union

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -391,7 +391,7 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
             {
                 elem *e = exp2_copytotemp(econd);
                 block_appendexp(mystate.switchBlock, e);
-                econd = e.EV.E2;
+                econd = e.E2;
             }
 
             if (numcases)
@@ -975,7 +975,7 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
                     {
                         // rewrite ebegin to use __cxa_begin_catch
                         Symbol *s2 = getRtlsym(RTLSYM.CXA_BEGIN_CATCH);
-                        ebegin.EV.Vsym = s2;
+                        ebegin.Vsym = s2;
                     }
                 }
                 else


### PR DESCRIPTION
The non-constant part of `eve` is not necessary to be there.