### PR TITLE
rename ESCAPE to PSOP

### DIFF
--- a/compiler/src/dmd/backend/cgsched.d
+++ b/compiler/src/dmd/backend/cgsched.d
@@ -1466,8 +1466,8 @@ else
             c.Iflags |= CFpsw;
             break;
 
-        case ESCAPE:
-            if (c.Iop == (ESCAPE | ESCadjfpu))
+        case PSOP.root:
+            if (c.Iop == PSOP.adjfpu)
                 ci.fpuadjust = c.IEV1.Vint;
             break;
 
@@ -1890,7 +1890,7 @@ private code * cnext(code *c)
         if (c.Iflags & (CFtarg | CFtarg2))
             break;
         if (!(c.Iop == NOP ||
-              c.Iop == (ESCAPE | ESClinnum)))
+              c.Iop == PSOP.linnum))
             break;
     }
     return c;
@@ -2783,7 +2783,7 @@ private code * csnip(code *c)
             if (c.Iflags & (CFtarg | CFtarg2))
                 break;
             if (!(c.Iop == NOP ||
-                  c.Iop == (ESCAPE | ESClinnum) ||
+                  c.Iop == PSOP.linnum ||
                   c.Iflags & iflags))
                 break;
         }
@@ -2809,7 +2809,7 @@ private code *schedule(code *c,regm_t scratch)
     while (c)
     {
         if ((c.Iop == NOP ||
-             ((c.Iop & ESCAPEmask) == ESCAPE && c.Iop != (ESCAPE | ESCadjfpu)) ||
+             ((c.Iop & PSOP.mask) == PSOP.root && c.Iop != PSOP.adjfpu) ||
              c.Iflags & CFclassinit) &&
             !(c.Iflags & (CFtarg | CFtarg2)))
         {   code *cn;

--- a/compiler/src/dmd/backend/cod2.d
+++ b/compiler/src/dmd/backend/cod2.d
@@ -2488,12 +2488,12 @@ void cdcond(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 
         // This is necessary so that any cleanup code on one branch
         // is redone on the other branch.
-        cs.Iop = ESCAPE | ESCmark2;
+        cs.Iop = PSOP.mark2;
         cs.Iflags = 0;
         cs.Irex = 0;
         cdb.gen(&cs);
         cdb.append(cdb1);
-        cs.Iop = ESCAPE | ESCrelease2;
+        cs.Iop = PSOP.release2;
         cdb.gen(&cs);
     }
     else
@@ -5604,7 +5604,7 @@ void cdinfo(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 void cddctor(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 {
     /* Generate:
-        ESCAPE | ESCdctor
+        PSOP.dctor
         MOV     sindex[BP],index
      */
     usednteh |= EHcleanup;
@@ -5614,7 +5614,7 @@ void cddctor(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     }
     assert(*pretregs == 0);
     code cs;
-    cs.Iop = ESCAPE | ESCdctor;         // mark start of EH range
+    cs.Iop = PSOP.dctor;         // mark start of EH range
     cs.Iflags = 0;
     cs.Irex = 0;
     cs.IFL1 = FLctor;
@@ -5637,7 +5637,7 @@ void cdddtor(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         usednteh |= EHcleanup;
 
         code cs;
-        cs.Iop = ESCAPE | ESCddtor;     // mark end of EH range and where landing pad is
+        cs.Iop = PSOP.ddtor;     // mark end of EH range and where landing pad is
         cs.Iflags = 0;
         cs.Irex = 0;
         cs.IFL1 = FLdtor;
@@ -5654,7 +5654,7 @@ void cdddtor(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     else
     {
         /* Generate:
-            ESCAPE | ESCddtor
+            PSOP.ddtor
             MOV     sindex[BP],index
             CALL    dtor
             JMP     L1
@@ -5670,7 +5670,7 @@ void cdddtor(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         }
 
         code cs;
-        cs.Iop = ESCAPE | ESCddtor;
+        cs.Iop = PSOP.ddtor;
         cs.Iflags = 0;
         cs.Irex = 0;
         cs.IFL1 = FLdtor;

--- a/compiler/src/dmd/backend/code_x86.d
+++ b/compiler/src/dmd/backend/code_x86.d
@@ -462,31 +462,34 @@ enum
 
     ASM     = SEGSS,   // string of asm bytes
 
-    ESCAPE  = SEGDS,   // marker that special information is here
+    //PSOP.root  = SEGDS,  // marker that special information is here
                        // (Iop2 is the type of special information)
     ENDBR32 = 0xF30F1EFB,
     ENDBR64 = 0xF30F1EFA,
 }
 
 
-enum ESCAPEmask = 0xFF; // code.Iop & ESCAPEmask ==> actual Iop
-
-enum
+/* Pseudo instructions inserted into the code stream to trigger special
+ * behaviors in the code generator
+ */
+enum PSOP : ushort
 {
-    ESClinnum   = (1 << 8),      // line number information
-    ESCctor     = (2 << 8),      // object is constructed
-    ESCdtor     = (3 << 8),      // object is destructed
-    ESCmark     = (4 << 8),      // mark eh stack
-    ESCrelease  = (5 << 8),      // release eh stack
-    ESCoffset   = (6 << 8),      // set code offset for eh
-    ESCadjesp   = (7 << 8),      // adjust ESP by IEV2.Vint
-    ESCmark2    = (8 << 8),      // mark eh stack
-    ESCrelease2 = (9 << 8),      // release eh stack
-    ESCframeptr = (10 << 8),     // replace with load of frame pointer
-    ESCdctor    = (11 << 8),     // D object is constructed
-    ESCddtor    = (12 << 8),     // D object is destructed
-    ESCadjfpu   = (13 << 8),     // adjust fpustackused by IEV2.Vint
-    ESCfixesp   = (14 << 8),     // reset ESP to end of local frame
+    root     = SEGDS,            // unused instruction used to identify a PSOP
+    mask     = 0xFF,             // used to determine if this is an actual PSOP
+    linnum   = (1 << 8)  | root, // line number information
+    ctor     = (2 << 8)  | root, // object is constructed
+    dtor     = (3 << 8)  | root, // object is destructed
+    mark     = (4 << 8)  | root, // mark eh stack
+    release  = (5 << 8)  | root, // release eh stack
+    offset   = (6 << 8)  | root, // set code offset for eh
+    adjesp   = (7 << 8)  | root, // adjust ESP by IEV2.Vint
+    mark2    = (8 << 8)  | root, // mark eh stack
+    release2 = (9 << 8)  | root, // release eh stack
+    frameptr = (10 << 8) | root, // replace with load of frame pointer
+    dctor    = (11 << 8) | root, // D object is constructed
+    ddtor    = (12 << 8) | root, // D object is destructed
+    adjfpu   = (13 << 8) | root, // adjust fpustackused by IEV2.Vint
+    fixesp   = (14 << 8) | root, // reset ESP to end of local frame
 }
 
 /*********************************

--- a/compiler/src/dmd/backend/codebuilder.d
+++ b/compiler/src/dmd/backend/codebuilder.d
@@ -290,7 +290,7 @@ struct CodeBuilder
     {
         code cs;
         //srcpos.print("genlinnum");
-        cs.Iop = ESCAPE | ESClinnum;
+        cs.Iop = PSOP.linnum;
         cs.Iflags = 0;
         cs.Iea = 0;
         cs.IEV1.Vsrcpos = srcpos;
@@ -307,7 +307,7 @@ struct CodeBuilder
         if (!I16 && offset)
         {
             code cs;
-            cs.Iop = ESCAPE | ESCadjesp;
+            cs.Iop = PSOP.adjesp;
             cs.Iflags = 0;
             cs.Iea = 0;
             cs.IEV1.Vint = offset;
@@ -325,7 +325,7 @@ struct CodeBuilder
         if (!I16 && offset)
         {
             code cs;
-            cs.Iop = ESCAPE | ESCadjfpu;
+            cs.Iop = PSOP.adjfpu;
             cs.Iflags = 0;
             cs.Iea = 0;
             cs.IEV1.Vint = offset;

--- a/compiler/src/dmd/backend/dwarfeh.d
+++ b/compiler/src/dmd/backend/dwarfeh.d
@@ -149,7 +149,7 @@ static if (0)
             int n = 0;
             for (code *c = b.Bcode; c; c = code_next(c))
             {
-                if (c.Iop == (ESCAPE | ESCdctor))
+                if (c.Iop == PSOP.dctor)
                 {
                     uint i = cast(uint) deh.length;
                     DwEhTableEntry *d = deh.push();
@@ -159,7 +159,7 @@ static if (0)
                     ++n;
                 }
 
-                if (c.Iop == (ESCAPE | ESCddtor))
+                if (c.Iop == PSOP.ddtor)
                 {
                     assert(n > 0);
                     --n;

--- a/compiler/src/dmd/backend/eh.d
+++ b/compiler/src/dmd/backend/eh.d
@@ -138,7 +138,7 @@ void except_fillInEHTable(Symbol *s)
 
     // First, calculate starting catch offset
     int guarddim = 0;                               // max dimension of guard[]
-    int ndctors = 0;                                // number of ESCdctor's
+    int ndctors = 0;                                // number of PSOP.dctor's
     foreach (b; BlockRange(startblock))
     {
         if (b.BC == BC_try && b.Bscope_index >= guarddim)
@@ -148,7 +148,7 @@ void except_fillInEHTable(Symbol *s)
         if (usednteh & EHcleanup)
             for (code *c = b.Bcode; c; c = code_next(c))
             {
-                if (c.Iop == (ESCAPE | ESCddtor))
+                if (c.Iop == PSOP.ddtor)
                     ndctors++;
             }
     }
@@ -232,7 +232,7 @@ void except_fillInEHTable(Symbol *s)
 
     /* Append to guard[] the guard blocks for temporaries that are created and destroyed
      * within a single expression. These are marked by the special instruction pairs
-     * (ESCAPE | ESCdctor) and (ESCAPE | ESCddtor).
+     * PSOP.dctor and PSOP.ddtor.
      */
     if (usednteh & EHcleanup)
     {
@@ -248,7 +248,7 @@ void except_fillInEHTable(Symbol *s)
         uint boffset = cast(uint)b.Boffset;
         for (code *c = b.Bcode; c; c = code_next(c))
         {
-            if (c.Iop == (ESCAPE | ESCdctor))
+            if (c.Iop == PSOP.dctor)
             {
                 code *c2 = code_next(c);
                 if (config.ehmethod == EHmethod.EH_WIN32)
@@ -266,7 +266,7 @@ void except_fillInEHTable(Symbol *s)
                     if (!c2)
                         goto Lnodtor;
 
-                    if (c2.Iop == (ESCAPE | ESCddtor))
+                    if (c2.Iop == PSOP.ddtor)
                     {
                         if (n)
                             n--;
@@ -294,7 +294,7 @@ void except_fillInEHTable(Symbol *s)
                             break;
                         }
                     }
-                    else if (c2.Iop == (ESCAPE | ESCdctor))
+                    else if (c2.Iop == PSOP.dctor)
                     {
                         n++;
                     }
@@ -315,7 +315,7 @@ void except_fillInEHTable(Symbol *s)
                 ++scopeindex;
                 sz += GUARD_SIZE;
             }
-            else if (c.Iop == (ESCAPE | ESCddtor))
+            else if (c.Iop == PSOP.ddtor)
             {
                 stack.setLength(stack.length - 1);
                 assert(stack.length != 0);


### PR DESCRIPTION
The ESCAPE pseudo-ops were spread over two names, ESCAPE and ESC. This simplifies things by combining them into one, PSOP (for pseudo-op). It also eliminates confusion with the ESC() function.