### PR TITLE
fix issue24534 : goto can skip declarations in labeled statements without error

### DIFF
--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -898,6 +898,12 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
     if (ty & mTYvolatile)
         pcs.Iflags |= CFvolatile;
 
+    void Lptr(){
+        if (config.flags3 & CFG3ptrchk)
+            cod3_ptrchk(cdb, pcs, keepmsk);        // validate pointer code
+    }
+
+
     switch (fl)
     {
         case FLoper:
@@ -1177,7 +1183,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                 freenode(e12);
                 if (e1free)
                     freenode(e1);
-                goto Lptr;
+                return Lptr();
             }
 
             L1:
@@ -1264,7 +1270,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                     scodelem(cdb, e11, &idxregs, keepmsk, true); // load index reg
                     setaddrmode(pcs, idxregs);
                 }
-                goto Lptr;
+                return Lptr();
             }
 
             /* Look for *(v1 + v2)
@@ -1326,7 +1332,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                 if (e1free)
                     freenode(e1);
 
-                goto Lptr;
+                return Lptr();
             }
 
             /* give up and replace *e1 with
@@ -1340,10 +1346,8 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
             assert(e1free);
             scodelem(cdb, e1, &idxregs, keepmsk, true);  // load index register
             setaddrmode(pcs, idxregs);
-        Lptr:
-            if (config.flags3 & CFG3ptrchk)
-                cod3_ptrchk(cdb, pcs, keepmsk);        // validate pointer code
-            break;
+
+            return Lptr();
 
         case FLdatseg:
             assert(0);

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3542,6 +3542,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             ls2.statement = ls;
 
         sc = sc.push();
+        sc.lastVar = sc.enclosing.lastVar;
         sc.scopesym = sc.enclosing.scopesym;
 
         sc.ctorflow.orCSX(CSX.label);
@@ -3549,6 +3550,10 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         sc.slabel = ls;
         if (ls.statement)
             ls.statement = ls.statement.statementSemantic(sc);
+
+        //issue 24534: lastVar may have been updated in the nested scope
+        sc.enclosing.lastVar = sc.lastVar;
+
         sc.pop();
 
         result = ls;

--- a/compiler/test/fail_compilation/issue24534.d
+++ b/compiler/test/fail_compilation/issue24534.d
@@ -1,0 +1,25 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/issue24534.d(12): Error: `goto` skips declaration of variable `issue24534.f1.y1`
+fail_compilation/issue24534.d(13):        declared here
+fail_compilation/issue24534.d(20): Error: `goto` skips declaration of variable `issue24534.f2.y2`
+fail_compilation/issue24534.d(22):        declared here
+---
+*/
+void f1(){ //always failed with error about skipping a declaration
+    int x1;
+    goto Label1;
+    int y1;
+    Label1:
+    int z1;
+}
+
+void f2(){ //compiled fine before this bug was fixed
+    int x2;
+    goto Label2;
+    Dummy2:
+    int y2;
+    Label2:
+    int z2;
+}


### PR DESCRIPTION
Seems like a hacky fix to me since it doesn't seem like a label statement should be creating a new scope at all.  I didn't look at what analysis the ctorflow call is doing, but I assume that's the reason it was like this?

Thoughts?