### PR TITLE
gsroa.d: reduce dependency on code_x86.d

### DIFF
--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -250,7 +250,8 @@ enum
     DGROUPIDX = 1,     // group index of DGROUP
 }
 
-enum REGMAX = 29;      // registers are numbered 0..10
+enum REGMAX = 29;      // registers are numbered 0...28
+enum reg_t NOREG = REGMAX;  // no register
 
 alias tym_t = uint;    // data type big enough for type masks
 

--- a/compiler/src/dmd/backend/code_x86.d
+++ b/compiler/src/dmd/backend/code_x86.d
@@ -81,8 +81,6 @@ enum STACK   = 26;      // top of stack
 enum ST0     = 27;      // 8087 top of stack register
 enum ST01    = 28;      // top two 8087 registers; for complex types
 
-enum reg_t NOREG   = 29;     // no register
-
 enum
 {
     AL      = 0,

--- a/compiler/src/dmd/backend/gsroa.d
+++ b/compiler/src/dmd/backend/gsroa.d
@@ -23,7 +23,7 @@ import core.stdc.time;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
-import dmd.backend.code_x86 : isXMMreg, NOREG;
+import dmd.backend.code_x86 : isXMMreg;
 import dmd.backend.oper;
 import dmd.backend.global;
 import dmd.backend.el;
@@ -388,15 +388,18 @@ if (enable) // disable while we test the inliner
             case SC.auto_:
             case SC.shadowreg:
             case SC.parameter:
-                anySlice = true;
-                sia[si].canSlice = true;
-                sia[si].accessSlice = false;
                 // We can't slice whole XMM registers
                 if (tyxmmreg(s.Stype.Tty) &&
                     isXMMreg(s.Spreg) && s.Spreg2 == NOREG)
                 {
                     if (log) printf(" can't because XMM reg\n");
                     sia[si].canSlice = false;
+                }
+                else
+                {
+                    anySlice = true;
+                    sia[si].canSlice = true;
+                    sia[si].accessSlice = false;
                 }
                 break;
 


### PR DESCRIPTION
Ideally the global optimizer will have no dependencies on the code generator.