### PR TITLE
Add missing word to CLI documentation of UAX31 table selection flag

### DIFF
--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -473,7 +473,7 @@ dmd -cov -unittest myprog.d
                     $(LI $(I UAX31): UAX31)
                     $(LI $(I c99): C99)
                     $(LI $(I c11): C11)
-                    $(LI $(I all): All, the least restrictive set, which comes all others (default))
+                    $(LI $(I all): All, the least restrictive set, which comes with all others (default))
                 )`
         ),
         Option("identifiers-importc=<table>",
@@ -483,7 +483,7 @@ dmd -cov -unittest myprog.d
                     $(LI $(I UAX31): UAX31)
                     $(LI $(I c99): C99)
                     $(LI $(I c11): C11 (default))
-                    $(LI $(I all): All, the least restrictive set, which comes all others)
+                    $(LI $(I all): All, the least restrictive set, which comes with all others)
                 )`
         ),
         Option("ignore",


### PR DESCRIPTION
Looks like I accidentally missed out on a word in CLI docs.

@kinke caught it right as I had my IDE open to dmd by chance (Intellij D plugin just updated with a reworked parser and its a lot better)!