### PR TITLE
druntime: Streamline `make clean` for integration tests

### DIFF
--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -496,6 +496,12 @@ test/%/.run: test/%/Makefile $(DMD)
 		DRUNTIME=$(abspath $(DRUNTIME)) DRUNTIMESO=$(abspath $(DRUNTIMESO)) LINKDL=$(LINKDL) \
 		QUIET=$(QUIET) TIMELIMIT='$(TIMELIMIT)' PIC=$(PIC) SHARED=$(SHARED)
 
+test/%/.clean: test/%/Makefile
+	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) BUILD=$(BUILD) clean
+ifeq (0,$(BUILD_WAS_SPECIFIED))
+	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) BUILD=debug clean
+endif
+
 #################### benchmark suite ##########################
 
 $(ROOT)/benchmark$(DOTEXE): benchmark/runbench.d target $(DMD)
@@ -546,9 +552,6 @@ endif
 
 clean: $(addsuffix /.clean,$(ADDITIONAL_TESTS))
 	rm -rf $(ROOT_OF_THEM_ALL) $(IMPDIR) $(DOC_OUTPUT_DIR) druntime.zip
-
-test/%/.clean: test/%/Makefile
-	$(MAKE) -C test/$* clean
 
 %/.directory :
 	mkdir -p $* || exists $*

--- a/druntime/test/aa/Makefile
+++ b/druntime/test/aa/Makefile
@@ -14,4 +14,4 @@ $(ROOT)/%$(DOTEXE): $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)

--- a/druntime/test/allocations/Makefile
+++ b/druntime/test/allocations/Makefile
@@ -25,4 +25,4 @@ $(ROOT)/%$(DOTEXE): $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)

--- a/druntime/test/coverage/Makefile
+++ b/druntime/test/coverage/Makefile
@@ -74,4 +74,4 @@ $(ROOT)/%$(DOTEXE): $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $^
 
 clean:
-	rm -rf $(GENERATED) *.lst
+	rm -rf $(ROOT) *.lst

--- a/druntime/test/cpuid/Makefile
+++ b/druntime/test/cpuid/Makefile
@@ -14,4 +14,4 @@ $(ROOT)/%$(DOTEXE): $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)

--- a/druntime/test/cycles/Makefile
+++ b/druntime/test/cycles/Makefile
@@ -25,4 +25,4 @@ $(ROOT)/test_cycles$(DOTEXE): $(SRC)/*.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $^
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)

--- a/druntime/test/exceptions/Makefile
+++ b/druntime/test/exceptions/Makefile
@@ -143,4 +143,4 @@ $(ROOT)/%$(DOTEXE): $(SRC)/%.d $(DMD) $(DRUNTIME)
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)

--- a/druntime/test/hash/Makefile
+++ b/druntime/test/hash/Makefile
@@ -14,4 +14,4 @@ $(ROOT)/%$(DOTEXE): $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)

--- a/druntime/test/imports/Makefile
+++ b/druntime/test/imports/Makefile
@@ -11,4 +11,4 @@ $(ROOT)/%.done:
 	$(QUIET)$(DMD) -version=Shared -o- -deps=$@ -Isrc -I../../import src/$*.d
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)

--- a/druntime/test/profile/Makefile
+++ b/druntime/test/profile/Makefile
@@ -68,4 +68,4 @@ $(ROOT)/%$(DOTEXE): $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$(ROOT)/$* $<
 
 clean:
-	rm -rf $(GENERATED) *.log *.def
+	rm -rf $(ROOT) *.log *.def

--- a/druntime/test/shared/Makefile
+++ b/druntime/test/shared/Makefile
@@ -118,4 +118,4 @@ $(ROOT)/%$(DOTDLL): $(SRC)/%.d $(DRUNTIMESO)
 	$(QUIET)$(DMD) -shared $(DFLAGS) -of$@ $< $(LINKDL)
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)

--- a/druntime/test/stdcpp/Makefile
+++ b/druntime/test/stdcpp/Makefile
@@ -118,4 +118,4 @@ $(ROOT)/%_old$(DOTEXE): $(SRC)/%.cpp $(SRC)/%_test.d
 endif # end Posix
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)

--- a/druntime/test/thread/Makefile
+++ b/druntime/test/thread/Makefile
@@ -43,4 +43,4 @@ $(ROOT)/%$(DOTEXE): $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)

--- a/druntime/test/unittest/Makefile
+++ b/druntime/test/unittest/Makefile
@@ -42,4 +42,4 @@ $(ROOT)/%.done: customhandler.d
 	$(QUIET)test -n "$(TESTTEXT)" || ! grep -q "unittests" $@
 
 clean:
-	rm -rf $(GENERATED)
+	rm -rf $(ROOT)


### PR DESCRIPTION
The 22 integration tests came with a mix of removing only ROOT (`generated/OS/BUILD/MODEL`) or GENERATED (`generated`) subdirs as part of their `make clean`.

And running `make clean` in the druntime dir only cleaned up the default BUILD=release variant, while running `make unittest` without explicit BUILD type includes running the integration tests in both debug and release variants.

Streamline/fix this to always cleaning up ROOT, and running `make clean` in both variants when running druntime's `make clean`.