### PR TITLE
make backend.x86 package

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1618,7 +1618,7 @@ auto sourceFiles()
         backend: fileArray(env["C"], "
             backend.d bcomplex.d evalu8.d divcoeff.d dvec.d go.d gsroa.d glocal.d gdag.d gother.d gflow.d
             dout.d inliner.d
-            gloop.d compress.d cgelem.d cgcs.d ee.d cod4.d cod5.d eh.d nteh.d blockopt.d mem.d cg.d cgreg.d
+            gloop.d compress.d cgelem.d cgcs.d ee.d cod4.d cod5.d eh.d nteh.d blockopt.d mem.d cg.d x86/cgreg.d
             dtype.d debugprint.d fp.d symbol.d symtab.d elem.d dcode.d cgsched.d cg87.d cgxmm.d cgcod.d cod1.d cod2.d
             cod3.d cv8.d dcgcv.d pdata.d util2.d var.d backconfig.d drtlsym.d dwarfeh.d ptrntab.d
             dvarstats.d dwarfdbginf.d cgen.d goh.d barray.d cgcse.d elpicpie.d

--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -242,7 +242,7 @@ struct CGstate
 
 public import dmd.backend.nteh;
 public import dmd.backend.cgen;
-public import dmd.backend.cgreg : cgreg_init, cgreg_term, cgreg_reset, cgreg_used,
+public import dmd.backend.x86.cgreg : cgreg_init, cgreg_term, cgreg_reset, cgreg_used,
     cgreg_spillreg_prolog, cgreg_spillreg_epilog, cgreg_assign, cgreg_unregister;
 
 public import dmd.backend.cgsched : cgsched_block;

--- a/compiler/src/dmd/backend/x86/cgreg.d
+++ b/compiler/src/dmd/backend/x86/cgreg.d
@@ -11,7 +11,7 @@
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cgreg.c, backend/cgreg.d)
  */
 
-module dmd.backend.cgreg;
+module dmd.backend.x86.cgreg;
 
 import core.stdc.stdio;
 import core.stdc.stdlib;


### PR DESCRIPTION
The backend is fairly confusing as to the distinction between the x86-specific code generator, and the optimizer and general routines. This PR is a start on separating the x86-specific code into a separate package.