### PR TITLE
Modify core.stdc.stdlib.d is missing some type definitions for wasm32-unknown-unknown-wasm target #4673

### DIFF
--- a/druntime/src/core/stdc/config.d
+++ b/druntime/src/core/stdc/config.d
@@ -132,6 +132,37 @@ version (Windows)
     alias long  cpp_longlong;
     alias ulong cpp_ulonglong;
 }
+else version (WebAssembly)
+{
+    static if ( (void*).sizeof > int.sizeof )
+    {
+        enum __c_longlong  : long;
+        enum __c_ulonglong : ulong;
+
+        alias long  c_long;
+        alias ulong c_ulong;
+
+        alias long   cpp_long;
+        alias ulong  cpp_ulong;
+
+        alias __c_longlong  cpp_longlong;
+        alias __c_ulonglong cpp_ulonglong;
+    }
+    else
+    {
+        enum __c_long  : int;
+        enum __c_ulong : uint;
+
+        alias int   c_long;
+        alias uint  c_ulong;
+
+        alias __c_long   cpp_long;
+        alias __c_ulong  cpp_ulong;
+
+        alias long  cpp_longlong;
+        alias ulong cpp_ulonglong;
+    }
+}
 else version (Posix)
 {
   static if ( (void*).sizeof > int.sizeof )

--- a/druntime/src/core/stdc/stddef.d
+++ b/druntime/src/core/stdc/stddef.d
@@ -29,6 +29,11 @@ version (Windows)
     ///
     alias wchar wchar_t;
 }
+else version (WebAssembly)
+{
+    ///
+    alias dchar wchar_t;
+}
 else version (Posix)
 {
     ///

--- a/druntime/src/core/stdc/stdlib.d
+++ b/druntime/src/core/stdc/stdlib.d
@@ -102,6 +102,7 @@ else version (CRuntime_Musl) enum RAND_MAX = 0x7fffffff;
 else version (CRuntime_Newlib) enum RAND_MAX = 0x7fffffff;
 else version (CRuntime_UClibc) enum RAND_MAX = 0x7fffffff;
 else version (WASI) enum RAND_MAX = 0x7fffffff;
+else version (WebAssembly) enum RAND_MAX = 0x7fffffff;
 else static assert( false, "Unsupported platform" );
 
 ///


### PR DESCRIPTION
When import core.stdc.stdlib.d (for example,to use malloc) in wasm project and build next command
```
ldc2 -c -betterC -mtriple=wasm32-unknown-unknown-wasm src/wasmproject.d  
```
these errors ocuured.
```
C:\ldc2\bin\..\import\core\stdc\stdlib.d(73): Error: undefined identifier `c_long`
C:\ldc2\bin\..\import\core\stdc\stdlib.d(74): Error: undefined identifier `c_long`
C:\ldc2\bin\..\import\core\stdc\stdlib.d(112): Error: undefined identifier `c_long`
C:\ldc2\bin\..\import\core\stdc\stdlib.d(121): Error: undefined identifier `c_long`
C:\ldc2\bin\..\import\core\stdc\stdlib.d(125): Error: undefined identifier `c_ulong`
C:\ldc2\bin\..\import\core\stdc\stdlib.d(202): Error: undefined identifier `c_long`
C:\ldc2\bin\..\import\core\stdc\stdlib.d(209): Error: undefined identifier `c_long`
C:\ldc2\bin\..\import\core\stdc\stdlib.d(209): Error: undefined identifier `c_long`
C:\ldc2\bin\..\import\core\stdc\stdlib.d(217): Error: undefined identifier `wchar_t`, did you mean `dchar`? 
C:\ldc2\bin\..\import\core\stdc\stdlib.d(221): Error: undefined identifier `wchar_t`, did you mean `dchar`? 
C:\ldc2\bin\..\import\core\stdc\stdlib.d(223): Error: undefined identifier `wchar_t`, did you mean `dchar`? 
```
These problems solved by adding  type definitions to the three files (config.d,stddef.d,stdlib.d) in the binary directory(ldc\import\core\stdc).

config.d
```
Add to line 135 
else version (WebAssembly)
{
    static if ( (void*).sizeof > int.sizeof )
    {
        enum __c_longlong  : long;
        enum __c_ulonglong : ulong;

        alias long  c_long;
        alias ulong c_ulong;

        alias long   cpp_long;
        alias ulong  cpp_ulong;

        alias __c_longlong  cpp_longlong;
        alias __c_ulonglong cpp_ulonglong;
    }
    else
    {
        enum __c_long  : int;
        enum __c_ulong : uint;

        alias int   c_long;
        alias uint  c_ulong;

        alias __c_long   cpp_long;
        alias __c_ulong  cpp_ulong;

        alias long  cpp_longlong;
        alias ulong cpp_ulonglong;
    }
}
```
stddef.d
```
Add to line 32
else version (WebAssembly)
{
    ///
    alias dchar wchar_t;
}
```
stdlib.d
```
Add to line 105
else version (WebAssembly) enum RAND_MAX = 0x7fffffff;
```