### PR TITLE
make X86 a positive affirmation

### DIFF
--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -322,12 +322,14 @@ void setTargetBuildDefaults(ref Target target)
     target.osMajor = defaultTargetOSMajor();
     target.cpu = CPU.baseline;
     target.isX86_64 = (size_t.sizeof == 8);
+    target.isX86 = !target.isX86_64;
 }
 
 void setTriple(ref Target target, const ref Triple triple) @safe
 {
     target.cpu     = triple.cpu;
     target.isX86_64 = triple.isX86_64;
+    target.isX86    = !target.isX86_64;
     target.isLP64  = triple.isLP64;
     target.os      = triple.os;
     target.osMajor = triple.osMajor;

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -5431,7 +5431,7 @@ elem *callfunc(const ref Loc loc,
         /* Delegates use the same calling convention as member functions.
          * For extern(C++) on Win32 this differs from other functions.
          */
-        if (tf.linkage == LINK.cpp && !target.isX86_64 && target.os == Target.OS.Windows)
+        if (tf.linkage == LINK.cpp && target.isX86 && target.os == Target.OS.Windows)
             tym = (tf.parameterList.varargs == VarArg.variadic) ? TYnfunc : TYmfunc;
         else
             tym = totym(tf);
@@ -5688,7 +5688,7 @@ elem *callfunc(const ref Loc loc,
             assert(cast(int)vindex >= 0);
 
             // Build *(ev + vindex * 4)
-            if (!target.isX86_64)
+            if (target.isX86)
                 assert(tysize(TYnptr) == 4);
             ec = el_bin(OPadd,TYnptr,ev,el_long(TYsize_t, vindex * tysize(TYnptr)));
             ec = el_una(OPind,TYnptr,ec);
@@ -6239,20 +6239,20 @@ Lagain:
             break;
         case Tfloat32:
         case Timaginary32:
-            if (!target.isX86_64)
+            if (target.isX86)
                 goto default;          // legacy binary compatibility
             r = RTLSYM.MEMSETFLOAT;
             break;
         case Tfloat64:
         case Timaginary64:
-            if (!target.isX86_64)
+            if (target.isX86)
                 goto default;          // legacy binary compatibility
             r = RTLSYM.MEMSETDOUBLE;
             break;
 
         case Tstruct:
         {
-            if (!target.isX86_64)
+            if (target.isX86)
                 goto default;
 
             TypeStruct tc = cast(TypeStruct)tb2;

--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -145,6 +145,7 @@ void initDMD(
 
     target.os = defaultTargetOS();
     target.isX86_64 = (size_t.sizeof == 8);
+    target.isX86 = !target.isX86_64;
     target._init(global.params);
     Type._init();
     Id.initialize();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7542,6 +7542,7 @@ struct Target final
     _d_dynamicArray< const char > architectureName;
     CPU cpu;
     bool isX86_64;
+    bool isX86;
     bool isLP64;
     _d_dynamicArray< const char > obj_ext;
     _d_dynamicArray< const char > lib_ext;
@@ -7613,6 +7614,7 @@ public:
         objc(),
         architectureName(),
         isX86_64(),
+        isX86(),
         isLP64(),
         obj_ext(),
         lib_ext(),
@@ -7625,7 +7627,7 @@ public:
         params()
     {
     }
-    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(), TargetCPP cpp = TargetCPP(), TargetObjC objc = TargetObjC(), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)0u, bool isX86_64 = false, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(), Type* tvalist = nullptr, const Param* params = nullptr) :
+    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(), TargetCPP cpp = TargetCPP(), TargetObjC objc = TargetObjC(), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)0u, bool isX86_64 = false, bool isX86 = false, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(), Type* tvalist = nullptr, const Param* params = nullptr) :
         os(os),
         osMajor(osMajor),
         ptrsize(ptrsize),
@@ -7640,6 +7642,7 @@ public:
         architectureName(architectureName),
         cpu(cpu),
         isX86_64(isX86_64),
+        isX86(isX86),
         isLP64(isLP64),
         obj_ext(obj_ext),
         lib_ext(lib_ext),

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -295,7 +295,7 @@ public int runLINK(bool verbose, ErrorSink eSink)
             if (!linkcmd)
                 linkcmd = vsopt.linkerPath(target.isX86_64);
 
-            if (!target.isX86_64 && FileName.equals(FileName.name(linkcmd), "lld-link.exe"))
+            if (target.isX86 && FileName.equals(FileName.name(linkcmd), "lld-link.exe"))
             {
                 // object files not SAFESEH compliant, but LLD is more picky than MS link
                 cmdbuf.writestring(" /SAFESEH:NO");

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -883,14 +883,17 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         }
         else if (arg == "-m32") // https://dlang.org/dmd.html#switch-m32
         {
+            target.isX86    = true;
             target.isX86_64 = false;
         }
         else if (arg == "-m64") // https://dlang.org/dmd.html#switch-m64
         {
+            target.isX86    = false;
             target.isX86_64 = true;
         }
         else if (arg == "-m32mscoff") // https://dlang.org/dmd.html#switch-m32mscoff
         {
+            target.isX86    = true;
             target.isX86_64 = false;
         }
         else if (startsWith(p + 1, "mscrtlib="))

--- a/compiler/src/dmd/target.h
+++ b/compiler/src/dmd/target.h
@@ -154,6 +154,7 @@ struct Target
     DString architectureName;    // name of the platform architecture (e.g. X86_64)
     CPU cpu;                // CPU instruction set to target
     d_bool isX86_64;          // generate 64 bit code for x86_64; true by default for 64 bit dmd
+    d_bool isX86;             // generate 32 bit Intel x86 code
     d_bool isLP64;            // pointers are 64 bits
 
     // Environmental

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -596,7 +596,7 @@ int intrinsic_op(FuncDeclaration fd)
         }
     }
 
-    if (!target.isX86_64)
+    if (target.isX86)
     // No 64-bit bsf bsr in 32bit mode
     {
         if ((op == OPbsf || op == OPbsr) && argtype1 is Type.tuns64)


### PR DESCRIPTION
`X86` sometimes means all Intel processors designed from the 8086, sometimes it means 32 bit Intel architecture. The D compiler predefines "X86" as a version meaning 32 bit Intel architecture. Unfortunately, the logic in target.d uses `!isX86_64` to mean `isX32`.

This kind of mess is a slew of bugs waiting to happen if any other CPU type is used. Hence, I added `isX32` as positive affirmation of 32 bit Intel architecture, and added asserts if both `isX86` and `isX86_64` are not explicitly accounted for.

This also gets rid of a lot of naughty nots.