### PR TITLE
GHA: Add workflow for testing bootstrap with every release from D 2.076.1

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,76 @@
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+
+name: Bootstrap
+on:
+  pull_request:
+    branches:
+      - stable
+  push:
+    branches:
+      - master
+      - stable
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [
+                                                                2.076.1, 2.077.1, 2.078.3, 2.079.1,
+          2.080.1, 2.081.2, 2.082.1, 2.083.1, 2.084.1, 2.085.1, 2.086.1, 2.087.1, 2.088.1, 2.089.1,
+          2.090.1, 2.091.1, 2.092.1, 2.093.1, 2.094.2, 2.095.1, 2.096.1, 2.097.2, 2.098.1, 2.099.1,
+          2.100.2, 2.101.2, 2.102.2, 2.103.1, 2.104.2, 2.105.3, 2.106.1, 2.107.1
+        ]
+
+    name: Build with dmd-${{ matrix.version }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    env:
+      # for ci/run.sh:
+      OS_NAME: linux
+      MODEL: 64
+      HOST_DMD: dmd-${{ matrix.version }}
+      # N is set dynamically below
+      FULL_BUILD: true
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 50
+
+    - name: Set environment variable N (parallelism)
+      run: echo "N=$(nproc)" >> $GITHUB_ENV
+
+    - name: Install host compiler
+      run: ci/run.sh install_host_compiler
+
+    - name: Set up repos
+      run: |
+        set -uexo pipefail
+        ref='${{ github.ref }}'
+        if [[ "$ref" =~ ^refs/pull/ ]]; then
+          # PR: clone the Phobos head with the same name as this DMD PR's target branch
+          # e.g., Phobos stable when targeting DMD stable
+          REPO_BRANCH="$GITHUB_BASE_REF"
+        elif [[ "$ref" =~ ^refs/(heads|tags)/(.*)$ ]]; then
+          # no PR: try to clone the Phobos head with the same name as this DMD head, falling back to master
+          # e.g., Phobos stable for a push to DMD stable, or Phobos v2.105.2 for DMD tag v2.105.2
+          REPO_BRANCH="${BASH_REMATCH[2]}"
+        else
+          echo "Error: unexpected GitHub ref '$ref'" >&2
+          exit 1
+        fi
+        ci/run.sh setup_repos "$REPO_BRANCH"
+
+    - name: Build dmd
+      run: ENABLE_RELEASE=0 ENABLE_DEBUG=0 ci/run.sh build 0
+
+    - name: Rebuild dmd
+      run: ENABLE_RELEASE=0 ENABLE_DEBUG=0 ci/run.sh rebuild

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -58,12 +58,15 @@ clone() {
 
 # build dmd (incl. building and running the unittests), druntime, phobos
 build() {
+    local unittest=${1:-1}
     if [ "$OS_NAME" != "windows" ]; then
         source ~/dlang/*/activate # activate host compiler, incl. setting `DMD`
     fi
     $DMD compiler/src/build.d -ofgenerated/build
-    generated/build -j$N MODEL=$MODEL HOST_DMD=$DMD DFLAGS="$CI_DFLAGS" BUILD=debug unittest
-    generated/build -j$N MODEL=$MODEL HOST_DMD=$DMD DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=1 dmd
+    if [ $unittest -eq 1 ]; then
+        generated/build -j$N MODEL=$MODEL HOST_DMD=$DMD DFLAGS="$CI_DFLAGS" BUILD=debug unittest
+    fi
+    generated/build -j$N MODEL=$MODEL HOST_DMD=$DMD DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=${ENABLE_RELEASE:-1} dmd
     make -j$N -C druntime MODEL=$MODEL
     make -j$N -C ../phobos MODEL=$MODEL
     if [ "$OS_NAME" != "windows" ]; then
@@ -249,7 +252,7 @@ if [ "$#" -gt 0 ]; then
   case $1 in
     install_host_compiler) install_host_compiler ;;
     setup_repos) setup_repos "$2" ;; # ci/run.sh setup_repos <git branch>
-    build) build ;;
+    build) build "${2:-}" ;; # ci/run.sh build [0]  (use `0` to skip running compiler unittests)
     rebuild) rebuild "${2:-}" ;; # ci/run.sh rebuild [1] (use `1` to compare binaries to test reproducible build)
     test) test ;;
     test_dmd) test_dmd ;;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -597,6 +597,14 @@ extern (C++) abstract class Type : ASTNode
         tsize_t    = basic[isLP64 ? Tuns64 : Tuns32];
         tptrdiff_t = basic[isLP64 ? Tint64 : Tint32];
         thash_t = tsize_t;
+
+        static if (__VERSION__ == 2081)
+        {
+            // Related issue: https://issues.dlang.org/show_bug.cgi?id=19134
+            // D 2.081.x regressed initializing class objects at compile time.
+            // As a workaround initialize this global at run-time instead.
+            TypeTuple.empty = new TypeTuple();
+        }
     }
 
     /**
@@ -4405,7 +4413,10 @@ extern (C++) final class TypeClass : Type
 extern (C++) final class TypeTuple : Type
 {
     // 'logically immutable' cached global - don't modify!
-    __gshared TypeTuple empty = new TypeTuple();
+    static if (__VERSION__ == 2081)
+        __gshared TypeTuple empty;  // See comment in Type._init
+    else
+        __gshared TypeTuple empty = new TypeTuple();
 
     Parameters* arguments;  // types making up the tuple
 


### PR DESCRIPTION
- Only builds and rebuilds DMD, doesn't go through the whole testsuite/unittests.
- Pipelines are only triggered by pull requests to the `stable`, or pushes to either `stable` or `master` branches.
To inspect pipelines, see: https://github.com/dlang/dmd/actions/runs/9322029780/job/25662227838?pr=16545
- Of all compilers in the matrix, only 2.081.x failed due to a CTFE regression in that release, a workaround has been added targeting just that host compiler.
