### PR TITLE
add driverParams to parseCommandLine()

### DIFF
--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -824,7 +824,7 @@ bool parseCommandlineAndConfig(size_t argc, const(char)** argv, ref Param params
     updateRealEnvironment(environment);
     environment.reset(1); // don't need environment cache any more
 
-    if (parseCommandLine(arguments, argc, params, files, target))
+    if (parseCommandLine(arguments, argc, params, files, target, driverParams))
     {
         Loc loc;
         errorSupplemental(loc, "run `dmd` to print the compiler manual");

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -451,11 +451,12 @@ extern(C) void flushMixins()
  *      params = set to result of parsing `arguments`
  *      files = set to files pulled from `arguments`
  *      target = more things set to result of parsing `arguments`
+ *	driverParams = even more things to set
  * Returns:
  *      true if errors in command line
  */
 
-bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param params, ref Strings files, ref Target target)
+bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param params, ref Strings files, ref Target target, ref DMDparams driverParams)
 {
     bool errors;
 


### PR DESCRIPTION
globals bad