### PR TITLE
[stable] Fix missing new CastExp field in C++ header

### DIFF
--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -889,6 +889,7 @@ public:
     // Possible to cast to one type while painting to another type
     Type *to;                   // type to cast to
     unsigned char mod;          // MODxxxxx
+    d_bool trusted; // assume cast is safe
 
     CastExp *syntaxCopy() override;
     bool isLvalue() override;


### PR DESCRIPTION
See https://github.com/dlang/dmd/blob/f053ab07d02bfd93c0f77fdc7a1919eabc6a1057/compiler/src/dmd/expression.d#L3823-L3827