### PR TITLE
[stable] Don't needlessly cross-preprocess in 2 tests

### DIFF
--- a/compiler/test/compilable/test24504.c
+++ b/compiler/test/compilable/test24504.c
@@ -1,7 +1,4 @@
-// REQUIRED_ARGS: -os=windows -g
-// DISABLED: osx
-// This is disabled on macOS because ld complains about _main being undefined
-// when clang attempts to preprocess the C file.
+// REQUIRED_ARGS: -g
 
 typedef enum
 {

--- a/compiler/test/compilable/test24511.d
+++ b/compiler/test/compilable/test24511.d
@@ -1,8 +1,4 @@
-// REQUIRED_ARGS: -os=windows
 // EXTRA_SOURCES: imports/test24511_c.c
-// DISABLED: osx
-// This is disabled on macOS because ld complains about _main being undefined
-// when clang attempts to preprocess the C file.
 
 import test24511_c;
 


### PR DESCRIPTION
When running these tests on non-Windows, the compiler would need to cross-preprocess the .c sources before cross-compiling. DMD doesn't handle that properly (on Linux, just uses the native preprocessor, and failing badly with Apple clang on macOS). And for LDC, that would require an installed C cross-toolchain. That'd be a ridiculous effort for these 2 tests, so just preprocess and compile them like all other tests, even if the original problems were on Windows only. No harm in running these tests on Posix too while targeting Posix.