### PR TITLE
babysteps, I16 removal -- hard code to false

### DIFF
--- a/compiler/src/dmd/backend/ty.d
+++ b/compiler/src/dmd/backend/ty.d
@@ -352,7 +352,7 @@ uint tysimd(tym_t ty) { return tytab[ty & 0xFF] & TYFLsimd; }
 uint tyrelax(tym_t ty) { return _tyrelax[tybasic(ty)]; }
 
 @trusted
-bool I16() { return _tysize[TYnptr] == 2; }
+bool I16() { return false; }
 @trusted
 bool I32() { return _tysize[TYnptr] == 4; }
 @trusted


### PR DESCRIPTION
Next steps, sweep the code base and collapse code removing always conditions in bite size chunks.

Is this something it's time to do or does the 16 bit code generator need to continue to live for some reason?