### PR TITLE
Move .di generator to after semantic analysis

### DIFF
--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -141,6 +141,9 @@ enum STC : ulong  // transfer changes to declaration.h
                          STC.TYPECTOR | STC.final_ | STC.tls | STC.gshared | STC.ref_ | STC.return_ | STC.property |
                          STC.nothrow_ | STC.pure_ | STC.safe | STC.trusted | STC.system), /// for a FuncDeclaration
 
+    // These storage classes when used as attributes should emitted differently as part of .di header generator
+    lhsHeaderAttributes = STC.static_ | STC.extern_ | STC.final_ | STC.abstract_ | STC.override_ |
+        STC.synchronized_ | STC.deprecated_ | STC.disable,
 }
 
 alias StorageClass = ulong;

--- a/compiler/src/dmd/identifier.d
+++ b/compiler/src/dmd/identifier.d
@@ -110,6 +110,8 @@ nothrow:
             p = "this";
         else if (this == Id.dtor)
             p = "~this";
+        else if (this == Id.postblit)
+            p = "this(this)";
         else if (this == Id.unitTest)
             p = "unittest";
         else if (this == Id.dollar)


### PR DESCRIPTION
First PR to try and get the .di generator work.

Currently, any output of it does not match mangling (due to inference), it has no possibility of being used so breakage isn't a concern as things just are not working.

This moves it to after semantic analysis.

Known issues:

1. FIXED IN PR: s/~this/__dtor/
2. FIXED IN PR: Remove stray semicolons
3. FIXED IN PR: Rewrite alias to be ``= Identifier;``
4. FIXED IN PR: Scope and return are not emitted correctly: https://issues.dlang.org/show_bug.cgi?id=24583
   Actual: ``nothrow @nogc return scope @trusted sidero.base.text.unicode.builder_utf8.StringBuilder_UTF8 sidero.base.text.unicode.builder_utf8.StringBuilder_UTF8.append(const(char)[]...)``
  Generated: ``nothrow @nogc scope return @trusted sidero.base.text.unicode.builder_utf8.StringBuilder_UTF8 sidero.base.text.unicode.builder_utf8.StringBuilder_UTF8.append(const(char)[]...)``
5. FIXED IN PR: Destructors don't have inferred attributes: https://issues.dlang.org/show_bug.cgi?id=20423
6. Remove last line of generated symbols:
> setupIterator!()opApplyImpl!(int delegate(ref char) @system)opApplyImpl!(int delegate(ref char) @nogc @system)opApplyImpl!(int delegate(ref char) nothrow @system)opApplyImpl!(int delegate(ref char) nothrow @nogc @system)opApplyImpl!(int delegate(ref char) @safe)opApplyImpl!(int delegate(ref char) @nogc @safe)opApplyImpl!(int delegate(ref char) nothrow @safe)opApplyImpl!(int delegate(ref char) nothrow @nogc @safe)opApplyReverseImpl!(int delegate(ref char) @system)opApplyReverseImpl!(int delegate(ref char) @nogc @system)opApplyReverseImpl!(int delegate(ref char) nothrow @system)opApplyReverseImpl!(int delegate(ref char) nothrow @nogc @system)opApplyReverseImpl!(int delegate(ref char) @safe)opApplyReverseImpl!(int delegate(ref char) @nogc @safe)opApplyReverseImpl!(int delegate(ref char) nothrow @safe)opApplyReverseImpl!(int delegate(ref char) nothrow @nogc @safe)initForLiteral!(const(char)[], const(char)[])initForLiteral!(const(wchar)[], const(wchar)[])initForLiteral!(const(dchar)[], const(dchar)[])copy!(const(char)[])ignoreCaseCompareImplSlice!charignoreCaseCompareImplSlice!wcharignoreCaseCompareImplSlice!dcharignoreCaseEqualsImplReadOnly!(String_UTF8)ignoreCaseEqualsImplReadOnly!(String_UTF16)ignoreCaseEqualsImplReadOnly!(String_UTF32)opCmpImplSlice!charmatches!(const(char)[])needDecode!(const(wchar)[])needDecode!(const(dchar)[])opCmpImplSlice!wcharneedDecode!(const(char)[])matches!(const(wchar)[])needDecode!(const(dchar)[])opCmpImplSlice!dcharneedDecode!(const(char)[])needDecode!(const(wchar)[])matches!(const(dchar)[])opCmpImplReadOnly!(String_UTF8)opCmpImplReadOnly!(String_UTF16)opCmpImplReadOnly!(String_UTF32)ignoreCaseCompareImplReadOnly!(String_UTF8)ignoreCaseCompareImplReadOnly!(String_UTF16)ignoreCaseCompareImplReadOnly!(String_UTF32)startsWithImplSlice!charstartsWithImplSlice!wcharstartsWithImplSlice!dcharstartsWithImplStrReadOnly!(String_UTF8)startsWithImplStrReadOnly!(String_UTF16)startsWithImplStrReadOnly!(String_UTF32)endsWithImplSlice!charendsWithImplSlice!wcharendsWithImplSlice!dcharendsWithImplReadOnly!(String_UTF8)endsWithImplReadOnly!(String_UTF16)endsWithImplReadOnly!(String_UTF32)countImplSlice!charcountImplSlice!wcharcountImplSlice!dcharcountImplReadOnly!(String_UTF8)countImplReadOnly!(String_UTF16)countImplReadOnly!(String_UTF32)containsImplSlice!charcontainsImplSlice!wcharcontainsImplSlice!dcharcontainsImplReadOnly!(String_UTF8)containsImplReadOnly!(String_UTF16)containsImplReadOnly!(String_UTF32)indexofImplSlice!charindexofImplSlice!wcharindexofImplSlice!dcharindexOfImplReadOnly!(String_UTF8)indexOfImplReadOnly!(String_UTF16)indexOfImplReadOnly!(String_UTF32)lastIndexOfImplSlice!charlastIndexOfImplSlice!wcharlastIndexOfImplSlice!dcharlastIndexOfImplReadOnly!(String_UTF8)lastIndexOfImplReadOnly!(String_UTF16)lastIndexOfImplReadOnly!(String_UTF32)needDecode!(const(char)[])needDecode!(const(wchar)[])needDecode!(const(dchar)[])copy!(char[], const(char)[])copy!(char[], const(char)[])
