### PR TITLE
importc.h: Don't undefine __has_(feature|extension) on >=gcc-14

### DIFF
--- a/compiler/test/compilable/test23616.c
+++ b/compiler/test/compilable/test23616.c
@@ -1,5 +1,11 @@
 // https://issues.dlang.org/show_bug.cgi?id=23616
 
+// __has_extension is a clang feature:
+// https://clang.llvm.org/docs/LanguageExtensions.html#has-feature-and-has-extension
+#ifndef __has_extension
+#define __has_extension(x) 0
+#endif
+
 #if __has_extension(gnu_asm)
 void _hreset(int __eax)
 {

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -97,12 +97,17 @@ typedef unsigned long long __uint64_t;
  * __has_extension is a clang thing:
  *    https://clang.llvm.org/docs/LanguageExtensions.html
  * ImportC no has extensions.
+ *
+ * >=gcc-14 prints a warning for each #undef. This breaks a lot of
+ * things like the testsuite which expects clean output.
  */
+#ifdef __clang__
 #undef __has_feature
 #define __has_feature(x) 0
 
 #undef __has_extension
 #define __has_extension(x) 0
+#endif
 
 /*************************************
  * OS-specific macros


### PR DESCRIPTION
GCC 14 started emitting a warning about those two `#undef`s. This breaks basically all C tests as it interferes with the output.