### PR TITLE
compiler/test/unit/semantic/imports.d: call deinitializeDMD

### DIFF
--- a/compiler/test/unit/semantic/imports.d
+++ b/compiler/test/unit/semantic/imports.d
@@ -10,10 +10,21 @@ import dmd.common.outbuffer;
 
 import support;
 
+@beforeEach void initializeFrontend()
+{
+    import dmd.frontend : initDMD;
+    initDMD();
+}
+
+@afterEach void deinitializeFrontend()
+{
+    import dmd.frontend : deinitializeDMD;
+    deinitializeDMD();
+}
+
 @("semantics - imported modules")
 unittest
 {
-    initDMD();
     defaultImportPaths.each!addImport;
 
     auto t = parseModule!ASTCodegen("test.d", q{


### PR DESCRIPTION
There is the unit/deinitialization.d test that checks that variables are empty before calling `initDMD`. If this test happens to be run right before that one then the latter will fail.