### PR TITLE
Fix bugzilla 24600 - DMD nightly builds are outdated

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -36,9 +36,10 @@ jobs:
       # Fetch all artifacts from the jobs defined above
       #
       - name: Download generated releases from the artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: dmd-release
+          pattern: dmd-release-*
+          merge-multiple: true
           path: ~/artifacts/
 
       #################################################################


### PR DESCRIPTION
The artifact names have been changed in https://github.com/dlang/installer/commit/a8422151226d92f22fc2b83ae3713005bbf22f20, because version 4 of actions/upload-artifact needs unique names. Also use version 4 of actions/download-artifact and use a pattern instead of a single name.

See also https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md