### PR TITLE
 Add supplemental messages to explain unsafe casts

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9252,13 +9252,17 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         // Check for unsafe casts
         string msg;
-        if (!isSafeCast(ex, t1b, tob, &msg))
+        if (!isSafeCast(ex, t1b, tob, msg))
         {
             if (sc.setUnsafe(false, exp.loc,
                 "cast from `%s` to `%s` not allowed in safe code", exp.e1.type, exp.to))
+            {
+                if (msg.length)
+                    errorSupplemental(exp.loc, "%s", (msg ~ '\0').ptr);
                 return setError();
+            }
         }
-        else if (msg) // deprecated unsafe
+        else if (msg.length) // deprecated unsafe
         {
             const err = sc.setUnsafePreview(FeatureState.default_, false, exp.loc,
                 "cast from `%s` to `%s` not allowed in safe code", exp.e1.type, exp.to);

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -160,7 +160,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
  * Returns:
  *      true if @safe or deprecated
  */
-bool isSafeCast(Expression e, Type tfrom, Type tto, string* msg = null)
+bool isSafeCast(Expression e, Type tfrom, Type tto, ref string msg)
 {
     // Implicit conversions are always safe
     if (tfrom.implicitConvTo(tto))
@@ -176,23 +176,34 @@ bool isSafeCast(Expression e, Type tfrom, Type tto, string* msg = null)
     {
         ClassDeclaration cdfrom = tfromb.isClassHandle();
         ClassDeclaration cdto = ttob.isClassHandle();
-
         int offset;
+
+        if (cdfrom == cdto)
+            goto Lsame;
+
         if (!cdfrom.isBaseOf(cdto, &offset) &&
             !((cdfrom.isInterfaceDeclaration() || cdto.isInterfaceDeclaration())
                 && cdfrom.classKind == ClassKind.d && cdto.classKind == ClassKind.d))
+        {
+            msg = "Source object type is incompatible with target type";
             return false;
+        }
 
         // no RTTI
         if (cdfrom.isCPPinterface() || cdto.isCPPinterface())
-            return false;
-        if (cdfrom.classKind == ClassKind.cpp || cdto.classKind == ClassKind.cpp)
         {
-            if (msg)
-                *msg = "No dynamic type information for extern(C++) classes";
-        }
-        if (!MODimplicitConv(tfromb.mod, ttob.mod))
+            msg = "No dynamic type information for extern(C++) classes";
             return false;
+        }
+        if (cdfrom.classKind == ClassKind.cpp || cdto.classKind == ClassKind.cpp)
+            msg = "No dynamic type information for extern(C++) classes";
+
+    Lsame:
+        if (!MODimplicitConv(tfromb.mod, ttob.mod))
+        {
+            msg = "Incompatible type qualifier";
+            return false;
+        }
         return true;
     }
 
@@ -216,30 +227,41 @@ bool isSafeCast(Expression e, Type tfrom, Type tto, string* msg = null)
         {
             if (ttob.ty == Tarray && e.op == EXP.arrayLiteral)
                 return true;
+            msg = "`void` data may contain pointers and target element type is mutable";
             return false;
         }
 
         // For bool, only 0 and 1 are safe values
         // Runtime array cast reinterprets data
         if (ttobn.ty == Tbool && tfromn.ty != Tbool && e.op != EXP.arrayLiteral)
-        {
-            if (msg)
-                *msg = "Array data may have bytes which are not 0 or 1";
-        }
+            msg = "Array data may have bytes which are not 0 or 1";
 
         // If the struct is opaque we don't know about the struct members then the cast becomes unsafe
-        if (ttobn.ty == Tstruct && !(cast(TypeStruct)ttobn).sym.members ||
-            tfromn.ty == Tstruct && !(cast(TypeStruct)tfromn).sym.members)
+        if (ttobn.ty == Tstruct && !(cast(TypeStruct)ttobn).sym.members)
+        {
+            msg = "Target element type is opaque";
             return false;
+        }
+        if (tfromn.ty == Tstruct && !(cast(TypeStruct)tfromn).sym.members)
+        {
+            msg = "Source element type is opaque";
+            return false;
+        }
 
         const frompointers = tfromn.hasPointers();
         const topointers = ttobn.hasPointers();
 
         if (frompointers && !topointers && ttobn.isMutable())
+        {
+            msg = "Target element type is mutable and source element type contains a pointer";
             return false;
+        }
 
         if (!frompointers && topointers)
+        {
+            msg = "Target element type contains a pointer";
             return false;
+        }
 
         if (!topointers &&
             ttobn.ty != Tfunction && tfromn.ty != Tfunction &&
@@ -249,6 +271,7 @@ bool isSafeCast(Expression e, Type tfrom, Type tto, string* msg = null)
             return true;
         }
     }
+    msg = "Source type is incompatible with target type containing a pointer";
     return false;
 }
 

--- a/compiler/test/fail_compilation/cast_qual.d
+++ b/compiler/test/fail_compilation/cast_qual.d
@@ -2,8 +2,10 @@
 REQUIRED_ARGS: -preview=dip1000 -de
 TEST_OUTPUT:
 ---
-fail_compilation/cast_qual.d(15): Deprecation: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
 fail_compilation/cast_qual.d(17): Deprecation: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
+fail_compilation/cast_qual.d(19): Deprecation: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
+fail_compilation/cast_qual.d(25): Error: cast from `const(Object)` to `object.Object` not allowed in safe code
+fail_compilation/cast_qual.d(25):        Incompatible type qualifier
 ---
 */
 
@@ -16,4 +18,9 @@ void main() {
     *p = 4; // oops
     cast() i = 5; // NG
     auto q = &cast(const) j; // OK, int* to const int*
+}
+
+void test() {
+    const Object co;
+    auto o = cast() co;
 }

--- a/compiler/test/fail_compilation/cpp_cast.d
+++ b/compiler/test/fail_compilation/cpp_cast.d
@@ -3,16 +3,21 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/cpp_cast.d(16): Deprecation: cast from `cpp_cast.C` to `cpp_cast.D` not allowed in safe code
-fail_compilation/cpp_cast.d(16):        No dynamic type information for extern(C++) classes
+fail_compilation/cpp_cast.d(19): Error: cast from `cpp_cast.I` to `cpp_cast.C` not allowed in safe code
+fail_compilation/cpp_cast.d(19):        No dynamic type information for extern(C++) classes
+fail_compilation/cpp_cast.d(21): Deprecation: cast from `cpp_cast.C` to `cpp_cast.D` not allowed in safe code
+fail_compilation/cpp_cast.d(21):        No dynamic type information for extern(C++) classes
 ---
 */
-extern(C++) class C { void f() { } }
+extern(C++) interface I { void f(); }
+extern(C++) class C : I { void f() { } }
 extern(C++) class D : C { }
 
 void main() @safe
 {
-    C c;
-    c = cast(D) new C; // reinterpret cast
+    I i;
+    C c = cast(C) i; // unsafe
+    i = cast(I) c; // OK
+    c = cast(D) c; // reinterpret cast
     c = cast(C) new D; // OK
 }

--- a/compiler/test/fail_compilation/fail20000.d
+++ b/compiler/test/fail_compilation/fail20000.d
@@ -1,18 +1,30 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20000.d(25): Error: cast from `fail20000.DClass` to `fail20000.CppClass` not allowed in safe code
-fail_compilation/fail20000.d(26): Error: cast from `fail20000.DInterface` to `fail20000.CppClass` not allowed in safe code
-fail_compilation/fail20000.d(27): Error: cast from `fail20000.CppClass2` to `fail20000.CppClass` not allowed in safe code
-fail_compilation/fail20000.d(28): Error: cast from `fail20000.CppInterface2` to `fail20000.CppClass` not allowed in safe code
-fail_compilation/fail20000.d(30): Error: cast from `fail20000.DClass` to `fail20000.CppInterface` not allowed in safe code
-fail_compilation/fail20000.d(31): Error: cast from `fail20000.DInterface` to `fail20000.CppInterface` not allowed in safe code
-fail_compilation/fail20000.d(32): Error: cast from `fail20000.CppClass2` to `fail20000.CppInterface` not allowed in safe code
-fail_compilation/fail20000.d(33): Error: cast from `fail20000.CppInterface2` to `fail20000.CppInterface` not allowed in safe code
-fail_compilation/fail20000.d(35): Error: cast from `fail20000.CppClass` to `fail20000.DClass` not allowed in safe code
-fail_compilation/fail20000.d(36): Error: cast from `fail20000.CppInterface` to `fail20000.DClass` not allowed in safe code
-fail_compilation/fail20000.d(38): Error: cast from `fail20000.CppClass` to `fail20000.DInterface` not allowed in safe code
-fail_compilation/fail20000.d(39): Error: cast from `fail20000.CppInterface` to `fail20000.DInterface` not allowed in safe code
+fail_compilation/fail20000.d(37): Error: cast from `fail20000.DClass` to `fail20000.CppClass` not allowed in safe code
+fail_compilation/fail20000.d(37):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(38): Error: cast from `fail20000.DInterface` to `fail20000.CppClass` not allowed in safe code
+fail_compilation/fail20000.d(38):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(39): Error: cast from `fail20000.CppClass2` to `fail20000.CppClass` not allowed in safe code
+fail_compilation/fail20000.d(39):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(40): Error: cast from `fail20000.CppInterface2` to `fail20000.CppClass` not allowed in safe code
+fail_compilation/fail20000.d(40):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(42): Error: cast from `fail20000.DClass` to `fail20000.CppInterface` not allowed in safe code
+fail_compilation/fail20000.d(42):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(43): Error: cast from `fail20000.DInterface` to `fail20000.CppInterface` not allowed in safe code
+fail_compilation/fail20000.d(43):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(44): Error: cast from `fail20000.CppClass2` to `fail20000.CppInterface` not allowed in safe code
+fail_compilation/fail20000.d(44):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(45): Error: cast from `fail20000.CppInterface2` to `fail20000.CppInterface` not allowed in safe code
+fail_compilation/fail20000.d(45):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(47): Error: cast from `fail20000.CppClass` to `fail20000.DClass` not allowed in safe code
+fail_compilation/fail20000.d(47):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(48): Error: cast from `fail20000.CppInterface` to `fail20000.DClass` not allowed in safe code
+fail_compilation/fail20000.d(48):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(50): Error: cast from `fail20000.CppClass` to `fail20000.DInterface` not allowed in safe code
+fail_compilation/fail20000.d(50):        Source object type is incompatible with target type
+fail_compilation/fail20000.d(51): Error: cast from `fail20000.CppInterface` to `fail20000.DInterface` not allowed in safe code
+fail_compilation/fail20000.d(51):        Source object type is incompatible with target type
 ---
 */
 extern(C++) class CppClass { int a; }

--- a/compiler/test/fail_compilation/shared.d
+++ b/compiler/test/fail_compilation/shared.d
@@ -241,9 +241,13 @@ struct BitRange
 TEST_OUTPUT:
 ---
 fail_compilation/shared.d(3004): Error: cast from `void*` to `shared(int*)` not allowed in safe code
+fail_compilation/shared.d(3004):        `void` data may contain pointers and target element type is mutable
 fail_compilation/shared.d(3005): Error: cast from `void*` to `shared(const(int*))` not allowed in safe code
+fail_compilation/shared.d(3005):        Source type is incompatible with target type containing a pointer
 fail_compilation/shared.d(3008): Error: cast from `shared(void*)` to `int*` not allowed in safe code
+fail_compilation/shared.d(3008):        `void` data may contain pointers and target element type is mutable
 fail_compilation/shared.d(3009): Error: cast from `shared(void*)` to `shared(const(int*))` not allowed in safe code
+fail_compilation/shared.d(3009):        Source type is incompatible with target type containing a pointer
 ---
 */
 

--- a/compiler/test/fail_compilation/test15672.d
+++ b/compiler/test/fail_compilation/test15672.d
@@ -1,8 +1,10 @@
 /*
  * TEST_OUTPUT:
 ---
-fail_compilation/test15672.d(15): Error: cast from `void[]` to `byte[]` not allowed in safe code
-fail_compilation/test15672.d(25): Error: cast from `void*` to `byte*` not allowed in safe code
+fail_compilation/test15672.d(17): Error: cast from `void[]` to `byte[]` not allowed in safe code
+fail_compilation/test15672.d(17):        `void` data may contain pointers and target element type is mutable
+fail_compilation/test15672.d(27): Error: cast from `void*` to `byte*` not allowed in safe code
+fail_compilation/test15672.d(27):        `void` data may contain pointers and target element type is mutable
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=15672

--- a/compiler/test/fail_compilation/test15703.d
+++ b/compiler/test/fail_compilation/test15703.d
@@ -2,9 +2,16 @@
 REQUIRED_ARGS: -m32
 TEST_OUTPUT:
 ---
-fail_compilation/test15703.d(16): Error: cast from `Object[]` to `uint[]` not allowed in safe code
-fail_compilation/test15703.d(18): Error: cast from `object.Object` to `const(uint)*` not allowed in safe code
-fail_compilation/test15703.d(21): Error: cast from `uint[]` to `Object[]` not allowed in safe code
+fail_compilation/test15703.d(23): Error: cast from `Object[]` to `uint[]` not allowed in safe code
+fail_compilation/test15703.d(23):        Target element type is mutable and source element type contains a pointer
+fail_compilation/test15703.d(25): Error: cast from `object.Object` to `const(uint)*` not allowed in safe code
+fail_compilation/test15703.d(25):        Source type is incompatible with target type containing a pointer
+fail_compilation/test15703.d(28): Error: cast from `uint[]` to `Object[]` not allowed in safe code
+fail_compilation/test15703.d(28):        Target element type contains a pointer
+fail_compilation/test15703.d(44): Error: cast from `int[]` to `S[]` not allowed in safe code
+fail_compilation/test15703.d(44):        Target element type is opaque
+fail_compilation/test15703.d(45): Error: cast from `S[]` to `int[]` not allowed in safe code
+fail_compilation/test15703.d(45):        Source element type is opaque
 ---
 */
 
@@ -27,4 +34,13 @@ void test2() @safe
 {
     const(ubyte)[] a;
     auto b = cast(const(uint[])) a;
+}
+
+struct S;
+
+void opaque() @safe
+{
+    auto a = [1, 2];
+    S[] b = cast(S[]) a;
+    a = cast(int[]) b;
 }

--- a/compiler/test/fail_compilation/test19646.d
+++ b/compiler/test/fail_compilation/test19646.d
@@ -1,7 +1,8 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test19646.d(11): Error: cast from `const(int)*` to `int*` not allowed in safe code
-fail_compilation/test19646.d(17): Error: `@safe` variable `z` cannot be initialized by calling `@system` function `f`
+fail_compilation/test19646.d(12): Error: cast from `const(int)*` to `int*` not allowed in safe code
+fail_compilation/test19646.d(12):        Source type is incompatible with target type containing a pointer
+fail_compilation/test19646.d(18): Error: `@safe` variable `z` cannot be initialized by calling `@system` function `f`
 ---
 https://issues.dlang.org/show_bug.cgi?id=19646
  */


### PR DESCRIPTION
Following on from #15294 and #16558.

Change msg parameter to use `ref`.
Add test for existing extern(C++) interface cast error.
Add test for class qualifier cast in safe code.
Add test for casting with opaque array element type.