### PR TITLE
Fix Bugzilla 24603 - Can copy from non-void array into void[] in safe…

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11425,12 +11425,19 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             if (t1n.toBasetype.ty == Tvoid && t2n.toBasetype.ty == Tvoid)
             {
-                if (sc.setUnsafe(false, exp.loc, "cannot copy `void[]` to `void[]` in `@safe` code"))
+                if (sc.setUnsafe(false, exp.loc, "cannot copy `%s` to `%s` in `@safe` code", t2, t1))
                     return setError();
             }
         }
         else
         {
+            if (exp.e1.op == EXP.slice &&
+                (t1.ty == Tarray || t1.ty == Tsarray) &&
+                t1.nextOf().toBasetype().ty == Tvoid &&
+                sc.setUnsafePreview(FeatureState.default_, false, exp.loc,
+                    "cannot copy `%s` to `%s` in `@safe` code", t2, t1))
+                return setError();
+
             if (exp.op == EXP.blit)
                 e2x = e2x.castTo(sc, exp.e1.type);
             else

--- a/compiler/test/fail_compilation/test15704.d
+++ b/compiler/test/fail_compilation/test15704.d
@@ -1,7 +1,9 @@
 /*
  * TEST_OUTPUT:
 ---
-fail_compilation/test15704.d(15): Error: cannot copy `void[]` to `void[]` in `@safe` code
+fail_compilation/test15704.d(17): Error: cannot copy `void[]` to `void[]` in `@safe` code
+fail_compilation/test15704.d(18): Error: cannot copy `const(void)[]` to `void[]` in `@safe` code
+fail_compilation/test15704.d(19): Deprecation: cannot copy `int[]` to `void[]` in `@safe` code
 ---
  */
 
@@ -13,4 +15,6 @@ void main() @safe {
     void[] arr2 = [ 123, 345, 567 ];
 
     arr1[] = arr2[];  // overwrites pointers with arbitrary ints
+    arr1[] = new const(void)[3];
+    arr1[] = [5];
 }


### PR DESCRIPTION
… code

Deprecate in safe code.
Also change copying `qualifier(void)[]` to `void[]` message to print source type, not `void[]`.