### PR TITLE
refactor FuncParamRegs_alloc()

### DIFF
--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -226,7 +226,7 @@ struct CGstate
     con_t regcon;               // register contents
     BackendPass pass;
 
-    int cmp_flag;		// pass extra flag from cdcod() to cdcmp()
+    int cmp_flag;               // pass extra flag from cdcod() to cdcmp()
     /**********************************
      * Set value in regimmed for reg.
      * NOTE: For 16 bit generator, this is always a (targ_short) sign-extended
@@ -328,7 +328,7 @@ struct FuncParamRegs
     //this(tym_t tyf);
     static FuncParamRegs create(tym_t tyf) { return FuncParamRegs_create(tyf); }
 
-    int alloc(type *t, tym_t ty, ubyte *reg1, ubyte *reg2)
+    bool alloc(type *t, tym_t ty, out reg_t reg1, out reg_t reg2)
     { return FuncParamRegs_alloc(this, t, ty, reg1, reg2); }
 
   private:
@@ -339,8 +339,8 @@ struct FuncParamRegs
     int xmmcnt;                 // how many fp registers are allocated
     uint numintegerregs;        // number of gp registers that can be allocated
     uint numfloatregs;          // number of fp registers that can be allocated
-    const(ubyte)* argregs;      // map to gp register
-    const(ubyte)* floatregs;    // map to fp register
+    const(reg_t)* argregs;      // map to gp register
+    const(reg_t)* floatregs;    // map to fp register
 }
 
 public import dmd.backend.cg : BPRM, FLOATREGS, FLOATREGS2, DOUBLEREGS,

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -1048,8 +1048,9 @@ public void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
 
         foreach (sp; params[0 .. pi])
         {
-            if (fpr.alloc(sp.Stype, sp.Stype.Tty, &sp.Spreg, &sp.Spreg2))
+            if (fpr.alloc(sp.Stype, sp.Stype.Tty, sp.Spreg, sp.Spreg2))
             {
+                // successful allocation
                 sp.Sclass = (target.os == Target.OS.Windows && target.isX86_64) ? SC.shadowreg : SC.fastpar;
                 sp.Sfl = (sp.Sclass == SC.shadowreg) ? FLpara : FLfast;
             }


### PR DESCRIPTION
Refactored to use:

1. `reg_t` instead of `ubyte` for registers
2. use `out` instead of pointers
3. move `type_jparam2()` to nested function
4. add Ddoc documentation
5. use `bool` instead of `int`