### PR TITLE
WIP: Drop Phobos dependency for compiler tests

### DIFF
--- a/compiler/test/fail_compilation/fail18243.d
+++ b/compiler/test/fail_compilation/fail18243.d
@@ -1,5 +1,5 @@
 /*
-EXTRA_FILES: imports/a18243.d
+EXTRA_FILES: imports/a18243.d imports/b18243.d
 TEST_OUTPUT:
 ---
 fail_compilation/fail18243.d(15): Error: none of the overloads of `isNaN` are callable using argument types `!()(float)`

--- a/compiler/test/fail_compilation/imports/a18243.d
+++ b/compiler/test/fail_compilation/imports/a18243.d
@@ -1,5 +1,5 @@
-module a18243;
+module imports.a18243;
 
-import std.math : isNaN;
+import imports.b18243 : isNaN;
 
 public bool isNaN() { return false; }

--- a/compiler/test/fail_compilation/imports/b18243.d
+++ b/compiler/test/fail_compilation/imports/b18243.d
@@ -1,0 +1,3 @@
+module imports.b18243;
+
+bool isNaN(T)(T x) { return false; }

--- a/compiler/test/fail_compilation/issue11070.d
+++ b/compiler/test/fail_compilation/issue11070.d
@@ -1,14 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/issue11070.d(16): Error: undefined identifier `x`
+fail_compilation/issue11070.d(15): Error: undefined identifier `x`
 ---
 */
 
 int get() { return 1; }
 
 void test() {
-    import std.stdio : writeln;
     switch (auto x = get()) {
         default:
             auto z = x;

--- a/compiler/test/fail_compilation/operator_undefined.d
+++ b/compiler/test/fail_compilation/operator_undefined.d
@@ -1,11 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/operator_undefined.d(19): Error: operator `-` is not defined for `toJson(2)` of type `Json`
+fail_compilation/operator_undefined.d(17): Error: operator `-` is not defined for `toJson(2)` of type `Json`
 ---
 */
-
-import std.stdio;
 
 struct Json
 {

--- a/compiler/test/runnable/arrayop.d
+++ b/compiler/test/runnable/arrayop.d
@@ -1,5 +1,4 @@
 // RUNNABLE_PHOBOS_TEST
-import std.math;
 
 extern(C) int printf(const char*, ...);
 

--- a/compiler/test/runnable/dhry.d
+++ b/compiler/test/runnable/dhry.d
@@ -343,7 +343,6 @@ Deprecation caused by https://issues.dlang.org/show_bug.cgi?id=20645
 import core.stdc.stdio;
 import core.stdc.string;
 import core.stdc.stdlib;
-import std.string;
 
 
 /* Compiler and system dependent definitions: */

--- a/compiler/test/runnable/extra-files/importc_main.d
+++ b/compiler/test/runnable/extra-files/importc_main.d
@@ -1,11 +1,11 @@
 
-import std.stdio;
+import core.stdc.stdio;
 import importc_test;
 
 int main()
 {
     auto rc = someCodeInC(3, 4);
-    writeln("Result of someCodeInC(3,4) = ", rc );
+    printf("Result of someCodeInC(3,4) = %d\n", rc);
     assert( rc == 7, "Wrong result");
     return 0;
 }

--- a/compiler/test/runnable/extra-files/importc_main2.d
+++ b/compiler/test/runnable/extra-files/importc_main2.d
@@ -1,5 +1,4 @@
 
-import std.stdio;
 import importc_test;
 
 int main()

--- a/compiler/test/runnable/test18076.sh
+++ b/compiler/test/runnable/test18076.sh
@@ -2,7 +2,7 @@
 
 output_file=${OUTPUT_BASE}.log
 
-echo 'import std.stdio; void main() { writeln("Success"); }' | \
+echo 'import core.stdc.stdio; void main() { puts("Success"); }' | \
 	$DMD -m${MODEL} -run - > ${output_file}
 grep -q 'Success' ${output_file}
 

--- a/compiler/test/runnable/test19.d
+++ b/compiler/test/runnable/test19.d
@@ -1,7 +1,5 @@
 // REQUIRED_ARGS: -unittest
 
-import std.algorithm: cmp;
-
 extern(C) int printf(const char*, ...);
 
 /* ================================ */
@@ -269,7 +267,7 @@ void test13()
 
     s1 = s1.dup;
     s2 = tolower13(s1);
-    assert(cmp(s2, "fol") == 0);
+    assert(s2 == "fol");
     assert(s2 == s1);
 }
 

--- a/compiler/test/runnable/test8544.d
+++ b/compiler/test/runnable/test8544.d
@@ -1,7 +1,6 @@
 // EXECUTE_ARGS: foo bar doo
 // PERMUTE_ARGS:
-import core.stdc.stdio;
-import std.conv;
+import core.stdc.string : strlen;
 import core.runtime;
 
 void main(string[] args)
@@ -12,6 +11,7 @@ void main(string[] args)
     assert(dArgs.length && cArgs.argc);  // ensure we've passed some args
     assert(dArgs.length == cArgs.argc);
 
-    assert(dArgs[1] == to!string(cArgs.argv[1]));
-    assert(args[1] == to!string(cArgs.argv[1]));
+    const cArg = cArgs.argv[1][0 .. strlen(cArgs.argv[1])];
+    assert(dArgs[1] == cArg);
+    assert(args[1] == cArg);
 }

--- a/compiler/test/runnable/test9287.sh
+++ b/compiler/test/runnable/test9287.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo 'import std.stdio; void main() { writeln("Success"); }' | \
+echo 'import core.stdc.stdio; void main() { puts("Success"); }' | \
 	$DMD -m${MODEL} -of${OUTPUT_BASE}${EXE} -
 
 ${OUTPUT_BASE}${EXE}


### PR DESCRIPTION
The goal here is to render `make dmd-test` totally independent from Phobos, only depending on druntime in the same repo here.