### PR TITLE
Fix bugzilla 24579 - stat_t has wrong size for Android armv7a

### DIFF
--- a/druntime/src/core/sys/posix/dirent.d
+++ b/druntime/src/core/sys/posix/dirent.d
@@ -42,7 +42,18 @@ struct dirent
 }
 */
 
-version (linux)
+version (CRuntime_Bionic)
+{
+    struct dirent
+    {
+        ulong       d_ino;
+        long        d_off;
+        ushort      d_reclen;
+        ubyte       d_type;
+        char[256]   d_name = 0;
+    }
+}
+else version (linux)
 {
     struct dirent
     {

--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -33,6 +33,11 @@ version (RISCV64) version = RISCV_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
 
+// Android uses 64-bit offsets for stat, but 32-bit offsets for most
+// other types on 32-bit architectures.
+version (CRuntime_Bionic)
+    private enum __USE_FILE_OFFSET64 = true;
+
 version (Posix):
 extern (C) nothrow @nogc:
 


### PR DESCRIPTION
Offsets in stat_t and dirent are 64-bit on Android, but 32-bit for most other types on 32-bit architectures.

For comparison the headers can be seen here:
https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/sys/stat.h https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/dirent.h

DMD does not support armv7a and does not run tests on Android. I have only tested this patch with LDC for Android armv7a.