### PR TITLE
Fix Bugzilla 24602 - Internal compiler error: failed to detect static…

### DIFF
--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -888,4 +888,11 @@ private extern(C++) final class StaticAAVisitor : SemanticTimeTransitiveVisitor
 
         aaExp.lowering = loweredExp;
     }
+
+    // https://issues.dlang.org/show_bug.cgi?id=24602
+    // TODO: Is this intionally not visited by SemanticTimeTransitiveVisitor?
+    override void visit(ClassReferenceExp crExp)
+    {
+        this.visit(crExp.value);
+    }
 }

--- a/compiler/test/runnable/staticaa.d
+++ b/compiler/test/runnable/staticaa.d
@@ -181,6 +181,32 @@ void testStaticArray()
 
 /////////////////////////////////////////////
 
+// https://issues.dlang.org/show_bug.cgi?id=24602
+
+class Set
+{
+    bool[string] aa;
+
+    this(bool[string] aa)
+    {
+        this.aa = aa;
+    }
+}
+
+class Bar
+{
+    Set x = new Set(["a": 1, "b": 0]);
+}
+
+void testClassLiteral()
+{
+    assert(new Bar().x.aa["a"] == 1);
+    assert(new Bar().x.aa["b"] == 0);
+}
+
+/////////////////////////////////////////////
+
+
 void main()
 {
     testSimple();
@@ -192,4 +218,5 @@ void main()
     testLocalStatic();
     testEnumInit();
     testStaticArray();
+    testClassLiteral();
 }


### PR DESCRIPTION
… initialization of associative array