### PR TITLE
Add visit for ClassReferenceExp to SemanticTimeTransitiveVisitor

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7805,6 +7805,7 @@ public:
     void visit(DebugStatement* s) override;
     void visit(ForwardingStatement* s) override;
     void visit(StructLiteralExp* e) override;
+    void visit(ClassReferenceExp* e) override;
     void visit(CompoundLiteralExp* e) override;
     void visit(DotTemplateExp* e) override;
     void visit(DotVarExp* e) override;

--- a/compiler/src/dmd/visitor.d
+++ b/compiler/src/dmd/visitor.d
@@ -162,6 +162,11 @@ extern (C++) class SemanticTimeTransitiveVisitor : SemanticTimePermissiveVisitor
         }
     }
 
+    override void visit(ASTCodegen.ClassReferenceExp e)
+    {
+        e.value.accept(this);
+    }
+
     override void visit(ASTCodegen.CompoundLiteralExp e)
     {
         if (e.initializer)


### PR DESCRIPTION
In response to https://github.com/dlang/dmd/pull/16592

Seeing how the test suite responds to this.