### PR TITLE
Fix Bugzilla 12885 - const union wrongly converts implicitly to mutable

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4028,7 +4028,7 @@ extern (C++) final class TypeStruct : Type
              * The check should check for overlap of v with the previous field,
              * not just starting at the same point
              */
-            if (v.offset == offset) // v is at same offset as previous field
+            if (!global.params.fixImmutableConv && v.offset == offset) // v is at same offset as previous field
                 continue;       // ignore
 
             Type tvf = v.type.addMod(mod);    // from type

--- a/compiler/test/fail_compilation/union_conv.d
+++ b/compiler/test/fail_compilation/union_conv.d
@@ -1,0 +1,19 @@
+/*
+REQUIRED_ARGS: -preview=fixImmutableConv
+TEST_OUTPUT:
+---
+fail_compilation/union_conv.d(18): Error: cannot implicitly convert expression `c` of type `const(U)` to `U`
+---
+*/
+
+union U
+{
+    int i;
+    int* p;
+}
+
+void main()
+{
+    const U c;
+    U m = c;
+}


### PR DESCRIPTION
This disables code that breaks immutable which was added for https://issues.dlang.org/show_bug.cgi?id=11257#c3, for `-preview=fixImmutableConv` only.