### PR TITLE
refactor gensaverestore()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.deps
 .B*
 *~
+/compiler/src/bug2
 /compiler/test/test_results
 /compiler/test/trace.def
 /compiler/test/trace.log

--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -112,7 +112,7 @@ struct REGSAVE
   nothrow:
     @trusted
     void reset() { off = 0; top = 0; idx = 0; alignment = _tysize[TYnptr]/*REGSIZE*/; }
-    void save(ref CodeBuilder cdb, reg_t reg, uint *pidx) { REGSAVE_save(this, cdb, reg, *pidx); }
+    void save(ref CodeBuilder cdb, reg_t reg, out uint pidx) { REGSAVE_save (this, cdb, reg, pidx); }
     void restore(ref CodeBuilder cdb, reg_t reg, uint idx) { REGSAVE_restore(this, cdb, reg, idx); }
 }
 


### PR DESCRIPTION
Make code more self-consistent, void initialize array, use `out`, and factor out common code.

(I find this stuff while examining code to support AArch64.)