### PR TITLE
Tweak message for unsafe cast to bool array/pointer

### DIFF
--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -234,7 +234,7 @@ bool isSafeCast(Expression e, Type tfrom, Type tto, ref string msg)
         // For bool, only 0 and 1 are safe values
         // Runtime array cast reinterprets data
         if (ttobn.ty == Tbool && tfromn.ty != Tbool && e.op != EXP.arrayLiteral)
-            msg = "Array data may have bytes which are not 0 or 1";
+            msg = "Source element may have bytes which are not 0 or 1";
 
         // If the struct is opaque we don't know about the struct members then the cast becomes unsafe
         if (ttobn.ty == Tstruct && !(cast(TypeStruct)ttobn).sym.members)

--- a/compiler/test/fail_compilation/bool_cast.d
+++ b/compiler/test/fail_compilation/bool_cast.d
@@ -1,9 +1,11 @@
 /*
-REQUIRED_ARGS: -de
+REQUIRED_ARGS: -de -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/bool_cast.d(13): Deprecation: cast from `ubyte[]` to `bool[]` not allowed in safe code
-fail_compilation/bool_cast.d(13):        Array data may have bytes which are not 0 or 1
+fail_compilation/bool_cast.d(15): Deprecation: cast from `ubyte[]` to `bool[]` not allowed in safe code
+fail_compilation/bool_cast.d(15):        Source element may have bytes which are not 0 or 1
+fail_compilation/bool_cast.d(19): Deprecation: cast from `int*` to `bool*` not allowed in safe code
+fail_compilation/bool_cast.d(19):        Source element may have bytes which are not 0 or 1
 ---
 */
 
@@ -12,4 +14,7 @@ void main() @safe
     ubyte[] a = [2, 4];
     auto b = cast(bool[]) a; // reinterprets a's data
     auto c = cast(bool[]) [2, 4]; // literal cast applies to each element
+
+    int i = 2;
+    auto p = cast(bool*) &i;
 }


### PR DESCRIPTION
Add test for cast to `bool*`.
See https://issues.dlang.org/show_bug.cgi?id=24582.