### PR TITLE
separate RMload/RMstore into separate argument

### DIFF
--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -382,3 +382,11 @@ regm_t iasm_regs(block *bp)
 
     return bp.usIasmregs;
 }
+
+// Flags for getlvalue
+enum RM
+{
+    rw = 0,
+    load = 1,
+    store = 2,
+}

--- a/compiler/src/dmd/backend/x86/cgxmm.d
+++ b/compiler/src/dmd/backend/x86/cgxmm.d
@@ -310,12 +310,12 @@ void xmmeq(ref CodeBuilder cdb, elem *e, opcode_t op, elem *e1, elem *e2,regm_t 
         postinc = e11.E2.Vint;
         if (e11.Eoper == OPpostdec)
             postinc = -postinc;
-        getlvalue(cdb,cs,e11,RMstore | retregs);
+        getlvalue(cdb,cs,e11,retregs,RM.store);
         freenode(e11.E2);
     }
     else
     {   postinc = 0;
-        getlvalue(cdb,cs,e1,RMstore | retregs);       // get lvalue (cl == CNIL if regvar)
+        getlvalue(cdb,cs,e1,retregs,RM.store);       // get lvalue (cl == CNIL if regvar)
     }
 
     getregs_imm(cdb,regvar ? varregm : 0);
@@ -561,7 +561,7 @@ void xmmopass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 
     if (!regvar)
     {
-        getlvalue(cdb,cs,e1,rretregs);         // get EA
+        getlvalue(cdb,cs,e1,rretregs,RM.rw);         // get EA
         retregs = *pretregs & XMMREGS & ~rretregs;
         if (!retregs)
             retregs = XMMREGS & ~rretregs;
@@ -630,7 +630,7 @@ void xmmpost(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     code cs;
     if (!regvar)
     {
-        getlvalue(cdb,cs,e1,0);                // get EA
+        getlvalue(cdb,cs,e1,0,RM.rw);                // get EA
         retregs = XMMREGS & ~*pretregs;
         if (!retregs)
             retregs = XMMREGS;
@@ -1276,7 +1276,7 @@ static if (0)
 
         if ((op1.Eoper == OPind && !op1.Ecount) || op1.Eoper == OPvar)
         {
-            getlvalue(cdb,cs, op1, RMload);     // get addressing mode
+            getlvalue(cdb,cs, op1, 0, RM.load);     // get addressing mode
         }
         else
         {
@@ -1323,7 +1323,7 @@ static if (0)
 
         if (((op2.Eoper == OPind && !op2.Ecount) || op2.Eoper == OPvar) && !isMOVHLPS)
         {
-            getlvalue(cdb,cs, op2, RMload | retregs);     // get addressing mode
+            getlvalue(cdb,cs, op2, retregs, RM.load);     // get addressing mode
         }
         else
         {
@@ -1424,7 +1424,7 @@ static if (0)
 {
     if ((e1.Eoper == OPind && !e1.Ecount) || e1.Eoper == OPvar)
     {
-        cr = getlvalue(cs, e1, RMload | retregs);     // get addressing mode
+        cr = getlvalue(cs, e1, retregs, RM.load);     // get addressing mode
     }
     else
     {
@@ -1477,7 +1477,7 @@ static if (0)
             if (config.avx && e1.Eoper == OPind && !e1.Ecount)
             {
                 // VBROADCASTSS X/YMM,MEM
-                getlvalue(cdb,cs, e1, 0);         // get addressing mode
+                getlvalue(cdb,cs, e1, 0, RM.rw);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 const reg = allocreg(cdb,retregs,ty);
                 cs.Iop = VBROADCASTSS;
@@ -1517,7 +1517,7 @@ static if (0)
             if (config.avx && tysize(ty) == 32 && e1.Eoper == OPind && !e1.Ecount)
             {
                 // VBROADCASTSD YMM,MEM
-                getlvalue(cdb,cs, e1, 0);         // get addressing mode
+                getlvalue(cdb,cs, e1, 0, RM.rw);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 const reg = allocreg(cdb,retregs,ty);
                 cs.Iop = VBROADCASTSD;
@@ -1559,7 +1559,7 @@ static if (0)
             if (config.avx >= 2 && e1.Eoper == OPind && !e1.Ecount)
             {
                 // VPBROADCASTB X/YMM,MEM
-                getlvalue(cdb,cs, e1, 0);         // get addressing mode
+                getlvalue(cdb,cs, e1, 0, RM.rw);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 reg_t reg = allocreg(cdb,retregs,ty);
                 cs.Iop = VPBROADCASTB;
@@ -1625,7 +1625,7 @@ static if (0)
             if (config.avx >= 2 && e1.Eoper == OPind && !e1.Ecount)
             {
                 // VPBROADCASTW X/YMM,MEM
-                getlvalue(cdb,cs, e1, 0);         // get addressing mode
+                getlvalue(cdb,cs, e1, 0, RM.rw);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 reg_t reg = allocreg(cdb,retregs,ty);
                 cs.Iop = VPBROADCASTW;
@@ -1677,7 +1677,7 @@ static if (0)
             if (config.avx && e1.Eoper == OPind && !e1.Ecount)
             {
                 // VPBROADCASTD/VBROADCASTSS X/YMM,MEM
-                getlvalue(cdb,cs, e1, 0);         // get addressing mode
+                getlvalue(cdb,cs, e1, 0, RM.rw);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 reg_t reg = allocreg(cdb,retregs,ty);
                 cs.Iop = config.avx >= 2 ? VPBROADCASTD : VBROADCASTSS;
@@ -1719,7 +1719,7 @@ static if (0)
             if (e1.Eoper == OPind && !e1.Ecount)
             {
                 // VPBROADCASTQ/VBROADCASTSD/(V)PUNPCKLQDQ X/YMM,MEM
-                getlvalue(cdb,cs, e1, 0);         // get addressing mode
+                getlvalue(cdb,cs, e1, 0, RM.rw);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 reg_t reg = allocreg(cdb,retregs,ty);
                 cs.Iop = config.avx >= 2 ? VPBROADCASTQ : tysize(ty) == 32 ? VBROADCASTSD : PUNPCKLQDQ;
@@ -1931,12 +1931,12 @@ void cloadxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
 
         regm_t retregs0 = mXMM0;
         reg_t reg0 = allocreg(cdb, retregs0, ty);
-        loadea(cdb, e, cs, opmv, reg0, 0, RMload, 0);  // MOVSS/MOVSD XMM0,data
+        loadea(cdb, e, cs, opmv, reg0, 0, 0, 0, RM.load);  // MOVSS/MOVSD XMM0,data
         checkSetVex(cdb.last(), ty);
 
         regm_t retregs1 = mXMM1;
         reg_t reg1 = allocreg(cdb, retregs1, ty);
-        loadea(cdb, e, cs, opmv, reg1, tysize(ty), RMload, mXMM0); // MOVSS/MOVSD XMM1,data+offset
+        loadea(cdb, e, cs, opmv, reg1, tysize(ty), 0, mXMM0, RM.load); // MOVSS/MOVSD XMM1,data+offset
         checkSetVex(cdb.last(), ty);
 
         return;

--- a/compiler/src/dmd/backend/x86/cod2.d
+++ b/compiler/src/dmd/backend/x86/cod2.d
@@ -3249,7 +3249,7 @@ void cdind(ref CGstate cg, ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 
     code cs;
 
-     getlvalue(cdb,cs,e,RMload);          // get addressing mode
+     getlvalue(cdb,cs,e,0,RM.load);          // get addressing mode
     //printf("Irex = %02x, Irm = x%02x, Isib = x%02x\n", cs.Irex, cs.Irm, cs.Isib);
     //fprintf(stderr,"cd2 :\n"); WRcodlst(c);
     if (*pretregs == 0)

--- a/compiler/src/dmd/backend/x86/cod4.d
+++ b/compiler/src/dmd/backend/x86/cod4.d
@@ -444,13 +444,13 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                 postinc = e11.E2.Vint;
                 if (e11.Eoper == OPpostdec)
                     postinc = -postinc;
-                getlvalue(cdb,cs,e1,RMstore);
+                getlvalue(cdb,cs,e1,0,RM.store);
                 freenode(e11.E2);
             }
             else
             {
                 postinc = 0;
-                getlvalue(cdb,cs,e1,RMstore);
+                getlvalue(cdb,cs,e1,0,RM.store);
 
                 if (e2oper == OPconst &&
                     config.flags4 & CFG4speed &&
@@ -712,13 +712,13 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         postinc = e11.E2.Vint;
         if (e11.Eoper == OPpostdec)
             postinc = -postinc;
-        getlvalue(cdb,cs,e1,RMstore | retregs);
+        getlvalue(cdb,cs,e1,retregs,RM.store);
         freenode(e11.E2);
     }
     else
     {
         postinc = 0;
-        getlvalue(cdb,cs,e1,RMstore | retregs);     // get lvalue (cl == null if regvar)
+        getlvalue(cdb,cs,e1,retregs,RM.store);     // get lvalue (cl == null if regvar)
     }
 
     getregs(cdb,varregm);
@@ -2864,7 +2864,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                  e1.Eoper == OPind) &&
                 !evalinregister(e1))
             {
-                getlvalue(cdb,cs,e1,RMload);
+                getlvalue(cdb,cs,e1,0,RM.load);
                 freenode(e1);
                 if (evalinregister(e2))
                 {
@@ -3041,7 +3041,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                )
             {
                 // CMP EA,e2
-                getlvalue(cdb,cs,e1,RMload);
+                getlvalue(cdb,cs,e1,0,RM.load);
                 freenode(e1);
                 cs.Iop = 0x39 ^ isbyte ^ reverse;
                 code_newreg(&cs,reg);
@@ -3057,14 +3057,14 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             {
                 reg = findreg(retregs & cgstate.allregs);   // get reg that e1 is in
                 uint opsize = cs.Iflags & CFopsize;
-                loadea(cdb,e2,cs,0x3B ^ isbyte ^ reverse,reg,0,RMload | retregs,0);
+                loadea(cdb,e2,cs,0x3B ^ isbyte ^ reverse,reg,0,retregs,0,RM.load);
                 code_orflag(cdb.last(),opsize);
             }
             else if (sz <= 2 * REGSIZE)
             {
                 reg = findregmsw(retregs);   // get reg that e1 is in
                 // CMP reg,EA
-                loadea(cdb,e2,cs,0x3B ^ reverse,reg,REGSIZE,RMload | retregs,0);
+                loadea(cdb,e2,cs,0x3B ^ reverse,reg,REGSIZE,retregs,0,RM.load);
                 if (I32 && sz == 6)
                     cdb.last().Iflags |= CFopsize;        // seg is only 16 bits
                 genjmp(cdb,JNE,FLcode, cast(block *) ce);  // JNE ce
@@ -3076,7 +3076,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                     cdb.gen(&cs);
                 }
                 else
-                    loadea(cdb,e2,cs,0x3B ^ reverse,reg,0,RMload | retregs,0);
+                    loadea(cdb,e2,cs,0x3B ^ reverse,reg,0,retregs,0,RM.load);
             }
             else
                 assert(0);
@@ -4200,7 +4200,7 @@ void cdbtst(ref CGstate cg, ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     regm_t idxregs;
     if ((e1.Eoper == OPind && !e1.Ecount) || e1.Eoper == OPvar)
     {
-        getlvalue(cdb, cs, e1, RMload);    // get addressing mode
+        getlvalue(cdb, cs, e1, 0, RM.load);  // get addressing mode
         idxregs = idxregm(&cs);             // mask if index regs used
     }
     else
@@ -4337,7 +4337,7 @@ void cdbt(ref CGstate cg, ref CodeBuilder cdb,elem *e, regm_t *pretregs)
     code cs;
     cs.Iflags = 0;
 
-    getlvalue(cdb, cs, e, RMload);      // get addressing mode
+    getlvalue(cdb, cs, e, 0, RM.load);      // get addressing mode
     if (e.Eoper == OPbt && *pretregs == 0)
     {
         codelem(cgstate,cdb,e2,pretregs,false);
@@ -4449,7 +4449,7 @@ void cdbscan(ref CGstate cg, ref CodeBuilder cdb, elem *e, regm_t *pretregs)
 
     if ((e.E1.Eoper == OPind && !e.E1.Ecount) || e.E1.Eoper == OPvar)
     {
-        getlvalue(cdb, cs, e.E1, RMload);     // get addressing mode
+        getlvalue(cdb, cs, e.E1, 0, RM.load);     // get addressing mode
     }
     else
     {
@@ -4503,7 +4503,7 @@ void cdpopcnt(ref CGstate cg, ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     code cs = void;
     if ((e.E1.Eoper == OPind && !e.E1.Ecount) || e.E1.Eoper == OPvar)
     {
-        getlvalue(cdb, cs, e.E1, RMload);     // get addressing mode
+        getlvalue(cdb, cs, e.E1, 0, RM.load);     // get addressing mode
     }
     else
     {

--- a/compiler/src/dmd/backend/x86/code_x86.d
+++ b/compiler/src/dmd/backend/x86/code_x86.d
@@ -130,10 +130,6 @@ enum
     mST01   = (1 << ST01),    // 0x40000000
 }
 
-// Flags for getlvalue (must fit in regm_t)
-enum RMload  = (1 << 30);
-enum RMstore = (1 << 31);
-
     // To support positional independent code,
     // must be able to remove BX from available registers
     enum ALLREGS_INIT          = (mAX|mBX|mCX|mDX|mSI|mDI);


### PR DESCRIPTION
They won't be fitting into `regm_t` any more, and it was hackish anyway.