### PR TITLE
Update changelog for unsafe bool expressions

### DIFF
--- a/changelog/dmd.unsafe-boolean-values.dd
+++ b/changelog/dmd.unsafe-boolean-values.dd
@@ -1,12 +1,15 @@
 `bool` values other than 0 or 1 are not `@safe`
 
-The spec has been updated so that only 0 and 1 are
+The spec [was updated](https://dlang.org/spec/type.html#bool)
+(for 2.109) so that only 0 and 1 are
 [safe values](https://dlang.org/spec/function.html#safe-values)
 for `bool`. This means that reading a `bool` value whose underlying byte representation
-has other bits set is implementation-defined and should be avoided. Consequently:
+has other bits set is implementation-defined and should be avoided.
+Consequently the following are deprecated in `@safe` code:
 
-* `void` initialization of booleans is now deprecated in `@safe` code.
-* Reading a `bool` field from a union is now deprecated in `@safe` code.
-
-Runtime array casting to `bool[]` is
-[yet to be deprecated](https://issues.dlang.org/show_bug.cgi?id=24582).
+* `void` initialization of booleans (since 2.109)
+* Reading a `bool` field from a union (since 2.109)
+* Runtime casting a dynamic array to a `bool` dynamic array type
+* Runtime casting a `bool` dynamic array to a tail mutable dynamic array type
+* Casting a pointer to a `bool` pointer type
+* Casting a `bool` pointer to a tail mutable pointer type


### PR DESCRIPTION
The original changelog item was added to stable after 2.109.0, so will appear in 2.109.1:
https://dlang.org/changelog/2.109.1.html#dmd.unsafe-boolean-values

However, fewer people may see point release changelogs, so its worth repeating those for 2.110 IMO.

This also adds new items for https://github.com/dlang/dmd/pull/16558 and https://github.com/dlang/dmd/pull/16622.