### PR TITLE
increase REGMAX to account for AArch64 registers (#16620)

### DIFF
--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -180,7 +180,7 @@ enum
     DGROUPIDX = 1,     // group index of DGROUP
 }
 
-enum REGMAX = 31;      // registers are numbered 0...31
+enum REGMAX = 32;      // registers are numbered 0...31
 enum reg_t NOREG = REGMAX;  // no register
 
 alias tym_t = uint;    // data type big enough for type masks

--- a/compiler/src/dmd/backend/gsroa.d
+++ b/compiler/src/dmd/backend/gsroa.d
@@ -395,6 +395,13 @@ if (enable) // disable while we test the inliner
                     if (log) printf(" can't because XMM reg\n");
                     sia[si].canSlice = false;
                 }
+                else if (sz == 2 * SLICESIZE &&
+                         (tybasic(s.Stype.Tty) == TYdouble || tybasic(s.Stype.Tty) == TYidouble) &&
+                         config.fpxmmregs)
+                {
+                    if (log) printf(" can't because XMM double\n");
+                    sia[si].canSlice = false;
+                }
                 else
                 {
                     anySlice = true;


### PR DESCRIPTION
The acid test that all the register math is 64 bits now.