### PR TITLE
Remove never used functions from unwind.d

### DIFF
--- a/druntime/src/core/internal/backtrace/unwind.d
+++ b/druntime/src/core/internal/backtrace/unwind.d
@@ -166,17 +166,8 @@ void* _Unwind_GetLanguageSpecificData(_Unwind_Context*);
 _Unwind_Ptr _Unwind_GetRegionStart(_Unwind_Context* context);
 void* _Unwind_FindEnclosingFunction(void* pc);
 
-version (X68_64)
+version (X86_64)
 {
-    _Unwind_Ptr _Unwind_GetDataRelBase(_Unwind_Context* context)
-    {
-        return _Unwind_GetGR(context, 1);
-    }
-
-    _Unwind_Ptr _Unwind_GetTextRelBase(_Unwind_Context* context)
-    {
-        assert(0);
-    }
 }
 else
 {


### PR DESCRIPTION
Note the X86_64 typo. These functions are never used in druntime, and if the typo is fixed, it adds two unused function _definitions_ to druntime. Let's not do that, and instead remove these function definitions all-together.