### PR TITLE
Fix Bugzilla 16763 - Associative array literal inside array or AA lit…

### DIFF
--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1303,6 +1303,10 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
                 assert(0);
             }
         }
+        else if (init.isAssociativeArray())
+        {
+            return init.toAssocArrayLiteral();
+        }
         else
         {
             /* Calculate the length of the array literal

--- a/compiler/test/runnable/aa_init.d
+++ b/compiler/test/runnable/aa_init.d
@@ -1,0 +1,15 @@
+void main()
+{
+    int[int][] a = [[1 : 2]]; // ok
+    int[int][] b = [[0 : 2]]; // expression ([[2]]) of type int[][]
+    int[int][int] c = [1 : [0 : 2]]; // expression ([1:[2]]) of type int[][int]
+    int[int][int] d = [1 : [3 : 2]]; // Error: not an associative array initializer
+
+    assert(a[0][1] == 2);
+    assert(b[0][0] == 2);
+    assert(c[1][0] == 2);
+    assert(d[1][3] == 2);
+
+    static assert(!__traits(compiles, { int[][] x = [[0 : 2]]; })); // fails
+    static assert(!__traits(compiles, { int[][int] x = [1 : [0 : 2]]; })); // fails
+}


### PR DESCRIPTION
…eral doesn't work as initializer if variable type is known