### PR TITLE
Add note when errors are omitted

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -458,7 +458,10 @@ extern (C++) void verrorReport(const ref Loc loc, const(char)* format, va_list a
             info.headerColor = Classification.error;
             verrorPrint(format, ap, info);
             if (global.params.v.errorLimit && global.errors >= global.params.v.errorLimit)
+            {
+                fprintf(stderr, "error limit (%d) reached, use `-verrors=0` to show all\n", global.params.v.errorLimit);
                 fatal(); // moderate blizzard of cascading messages
+            }
         }
         else
         {

--- a/compiler/test/fail_compilation/verrors5.d
+++ b/compiler/test/fail_compilation/verrors5.d
@@ -36,5 +36,6 @@ fail_compilation/verrors5.d(6): Error: undefined identifier `T`
 fail_compilation/verrors5.d(7): Error: undefined identifier `T`
 fail_compilation/verrors5.d(8): Error: undefined identifier `T`
 fail_compilation/verrors5.d(9): Error: undefined identifier `T`
+error limit (5) reached, use `-verrors=0` to show all
 ---
 */


### PR DESCRIPTION
Inspired by: [Issue 24645](https://issues.dlang.org/show_bug.cgi?id=24645) - Hidden static assert error messages if more than 20 errors.

I think I have a separate fix for that specific issue, but in general, I think it's worth mentioning in the output when errors were omitted.