### PR TITLE
Actually give deprecation for `-noboundscheck`

### DIFF
--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1494,7 +1494,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         else if (arg == "-noboundscheck") // https://dlang.org/dmd.html#switch-noboundscheck
         {
             /// @@@DEPRECATED_2.113@@@
-            // Deprecated since forever, deprecation message added in 2.111. Rmove in 2.113
+            // Deprecated since forever, deprecation message added in 2.111. Remove in 2.113
             eSink.deprecation(Loc.initial, "`-noboundscheck` is deprecated. Use `-boundscheck=off` instead");
             params.boundscheck = CHECKENABLE.off;
         }

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1493,6 +1493,9 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         }
         else if (arg == "-noboundscheck") // https://dlang.org/dmd.html#switch-noboundscheck
         {
+            /// @@@DEPRECATED_2.113@@@
+            // Deprecated since forever, deprecation message added in 2.111. Rmove in 2.113
+            eSink.deprecation(Loc.initial, "`-noboundscheck` is deprecated. Use `-boundscheck=off` instead");
             params.boundscheck = CHECKENABLE.off;
         }
         else if (startsWith(p + 1, "boundscheck")) // https://dlang.org/dmd.html#switch-boundscheck

--- a/compiler/test/runnable/link11069a.d
+++ b/compiler/test/runnable/link11069a.d
@@ -1,5 +1,5 @@
 // EXTRA_FILES: imports/std11069array.d imports/std11069container.d imports/std11069range.d imports/std11069typecons.d
-// REQUIRED_ARGS: -noboundscheck
+// REQUIRED_ARGS: -boundscheck=off
 // <-- To remove necessity of _D7imports13std11069array7__arrayZ
 
 class Bar

--- a/compiler/test/runnable/sroa13220.d
+++ b/compiler/test/runnable/sroa13220.d
@@ -1,4 +1,4 @@
-/* REQUIRED_ARGS: -O -inline -noboundscheck
+/* REQUIRED_ARGS: -O -inline -boundscheck=off
  */
 // https://github.com/dlang/pull/13220
 


### PR DESCRIPTION
This has been deprecated for at least 7 years...

Not sure what the comment policy is for such a long deprecated switch, see e.g.:
```d
// @@@DEPRECATED_2.111@@@
// Deprecated in 2.101, remove in 2.111
eSink.deprecation(Loc.initial, "`-debug=number` is deprecated, use debug identifiers instead");
```
for the `-debug=number` feature deprecation.