### PR TITLE
Merge `escapeByValue` and `escapeByRef` for `CallExp`

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -1746,200 +1746,6 @@ void escapeByValue(Expression e, ref scope EscapeByResults er, bool retRefTransi
         escapeByValue(e.e2, er, retRefTransition);
     }
 
-    static void escapeCallExp(CallExp e, ref scope EscapeByResults er, bool retRefTransition, bool byRef = false)
-    {
-        //printf("CallExp(): %s\n", e.toChars());
-        /* Check each argument that is
-         * passed as 'return scope'.
-         */
-        TypeFunction tf = e.calledFunctionType();
-        if (!tf)
-            return;
-
-        if (byRef && !tf.isref)
-        {
-            er.byExp(e, retRefTransition);
-            return;
-        }
-
-        // A function may have a return scope struct parameter, but only return an `int` field of that struct
-        if (!byRef && !e.type.hasPointers())
-            return;
-
-        if (e.arguments && e.arguments.length)
-        {
-            /* j=1 if _arguments[] is first argument,
-             * skip it because it is not passed by ref
-             */
-            int j = tf.isDstyleVariadic();
-            for (size_t i = j; i < e.arguments.length; ++i)
-            {
-                Expression arg = (*e.arguments)[i];
-                size_t nparams = tf.parameterList.length;
-                if (i - j < nparams && i >= j)
-                {
-                    Parameter p = tf.parameterList[i - j];
-                    const stc = tf.parameterStorageClass(null, p);
-                    ScopeRef psr = buildScopeRef(stc);
-                    if (psr == ScopeRef.ReturnRef || psr == ScopeRef.ReturnRef_Scope)
-                    {
-                        if (tf.isref && !byRef)
-                        {
-                            /* Treat:
-                             *   ref P foo(return ref P p)
-                             * as:
-                             *   p;
-                             */
-                            escapeByValue(arg, er, retRefTransition);
-                        }
-                        else
-                            escapeByRef(arg, er, retRefTransition);
-                    }
-                    else if (psr == ScopeRef.ReturnScope || psr == ScopeRef.Ref_ReturnScope)
-                    {
-                        if (byRef)
-                        {
-                            if (auto de = arg.isDelegateExp())
-                            {
-                                if (de.func.isNested())
-                                    er.byExp(de, false);
-                            }
-                            else
-                                escapeByValue(arg, er, retRefTransition);
-                        }
-                        else if (tf.isref)
-                        {
-                            /* ignore `ref` on struct constructor return because
-                             *   struct S { this(return scope int* q) { this.p = q; } int* p; }
-                             * is different from:
-                             *   ref char* front(return scope char** q) { return *q; }
-                             * https://github.com/dlang/dmd/pull/14869
-                             */
-                            if (auto dve = e.e1.isDotVarExp())
-                                if (auto fd = dve.var.isFuncDeclaration())
-                                    if (fd.isCtorDeclaration() && tf.next.toBasetype().isTypeStruct())
-                                    {
-                                        escapeByValue(arg, er, retRefTransition);
-                                    }
-                        }
-                        else
-                            escapeByValue(arg, er, true);
-                    }
-                }
-            }
-        }
-        // If 'this' is returned, check it too
-        Type t1 = e.e1.type.toBasetype();
-        DotVarExp dve = e.e1.isDotVarExp();
-        if (dve && t1.ty == Tfunction)
-        {
-            FuncDeclaration fd = dve.var.isFuncDeclaration();
-
-            // https://issues.dlang.org/show_bug.cgi?id=20149#c10
-            if (byRef && dve.var.isCtorDeclaration())
-            {
-                er.byExp(e, false);
-                return;
-            }
-
-            if (byRef)
-            {
-                StorageClass stc = dve.var.storage_class & (STC.return_ | STC.scope_ | STC.ref_);
-                if (tf.isreturn)
-                    stc |= STC.return_;
-                if (tf.isref)
-                    stc |= STC.ref_;
-                if (tf.isScopeQual)
-                    stc |= STC.scope_;
-                if (tf.isreturnscope)
-                    stc |= STC.returnScope;
-
-                const psr = buildScopeRef(stc);
-                if (psr == ScopeRef.ReturnRef || psr == ScopeRef.ReturnRef_Scope)
-                {
-                    escapeByRef(dve.e1, er, psr == ScopeRef.ReturnRef_Scope);
-                }
-                else if (psr == ScopeRef.ReturnScope || psr == ScopeRef.Ref_ReturnScope)
-                {
-                    escapeByValue(dve.e1, er, retRefTransition);
-                }
-            }
-            else if (fd && fd.isThis())
-            {
-                /* Calling a non-static member function dve.var, which is returning `this`, and with dve.e1 representing `this`
-                 */
-                const psr = buildScopeRef(getThisStorageClass(fd));
-                if (psr == ScopeRef.ReturnScope || psr == ScopeRef.Ref_ReturnScope)
-                {
-                    if (!tf.isref || tf.isctor)
-                        escapeByValue(dve.e1, er, retRefTransition);
-                }
-                else if (psr == ScopeRef.ReturnRef || psr == ScopeRef.ReturnRef_Scope)
-                {
-                    if (tf.isref)
-                    {
-                        /* Treat calling:
-                         *   struct S { ref S foo() return; }
-                         * as:
-                         *   this;
-                         */
-                        escapeByValue(dve.e1, er, retRefTransition);
-                    }
-                    else
-                        escapeByRef(dve.e1, er, psr == ScopeRef.ReturnRef_Scope);
-                }
-            }
-
-            // If it's also a nested function that is 'return scope' / 'return ref'
-            if (fd && fd.isNested() && tf.isreturn)
-            {
-                if (byRef)
-                {
-                    er.byExp(e, false);
-                }
-                else if (tf.isScopeQual)
-                {
-                    if (tf.isreturnscope)
-                        er.byFunc(fd, true);
-                    else
-                        er.byExp(e, false);
-                }
-            }
-        }
-
-        /* If returning the result of a delegate call, the .ptr
-         * field of the delegate must be checked.
-         */
-        if (t1.isTypeDelegate())
-        {
-            if (byRef && e.e1.isVarExp())
-                escapeByValue(e.e1, er, retRefTransition);
-            if (!byRef && tf.isreturn)
-                escapeByValue(e.e1, er, retRefTransition);
-        }
-
-        /* If it's a nested function that is 'return scope'
-         */
-        if (auto ve = e.e1.isVarExp())
-        {
-            FuncDeclaration fd = ve.var.isFuncDeclaration();
-            if (fd && fd.isNested())
-            {
-                if (byRef && tf.isreturn)
-                {
-                    er.byExp(e, false);
-                }
-                else if (!byRef && tf.isreturn && tf.isScopeQual)
-                {
-                    if (tf.isreturnscope)
-                        er.byFunc(fd, true);
-                    else
-                        er.byExp(e, false);
-                }
-            }
-        }
-    }
-
     switch (e.op)
     {
         case EXP.address: return visitAddr(e.isAddrExp());
@@ -1993,6 +1799,192 @@ StorageClass getThisStorageClass(FuncDeclaration fd)
     if (ad.isStructDeclaration())
         stc |= STC.ref_;        // `this` for a struct member function is passed by `ref`
     return stc;
+}
+
+// byRef = `true` for escapeByRef, `false` for `escapeByValue`
+void escapeCallExp(CallExp e, ref scope EscapeByResults er, bool retRefTransition, bool byRef)
+{
+    //printf("CallExp(): %s\n", e.toChars());
+    // Check each argument that is passed as 'return scope'.
+    TypeFunction tf = e.calledFunctionType();
+    if (!tf)
+        return;
+
+    if (byRef && !tf.isref)
+    {
+        er.byExp(e, retRefTransition);
+        return;
+    }
+
+    // A function may have a return scope struct parameter, but only return an `int` field of that struct
+    if (!byRef && !e.type.hasPointers())
+        return;
+
+    if (e.arguments && e.arguments.length)
+    {
+        // j=1 if _arguments[] is first argument,
+        // skip it because it is not passed by ref
+        int j = tf.isDstyleVariadic();
+        for (size_t i = j; i < e.arguments.length; ++i)
+        {
+            Expression arg = (*e.arguments)[i];
+            size_t nparams = tf.parameterList.length;
+            if (i - j < nparams && i >= j)
+            {
+                Parameter p = tf.parameterList[i - j];
+                const stc = tf.parameterStorageClass(null, p);
+                ScopeRef psr = buildScopeRef(stc);
+                if (psr == ScopeRef.ReturnRef || psr == ScopeRef.ReturnRef_Scope)
+                {
+                    if (tf.isref && !byRef)
+                    {
+                        // Treat:
+                        //   ref P foo(return ref P p)
+                        // as:
+                        //   p;
+                        escapeByValue(arg, er, retRefTransition);
+                    }
+                    else
+                        escapeByRef(arg, er, retRefTransition);
+                }
+                else if (psr == ScopeRef.ReturnScope || psr == ScopeRef.Ref_ReturnScope)
+                {
+                    if (byRef)
+                    {
+                        if (auto de = arg.isDelegateExp())
+                        {
+                            if (de.func.isNested())
+                                er.byExp(de, false);
+                        }
+                        else
+                            escapeByValue(arg, er, retRefTransition);
+                    }
+                    else if (tf.isref)
+                    {
+                        // ignore `ref` on struct constructor return because
+                        //   struct S { this(return scope int* q) { this.p = q; } int* p; }
+                        // is different from:
+                        //   ref char* front(return scope char** q) { return *q; }
+                        // https://github.com/dlang/dmd/pull/14869
+                        if (auto dve = e.e1.isDotVarExp())
+                            if (auto fd = dve.var.isFuncDeclaration())
+                                if (fd.isCtorDeclaration() && tf.next.toBasetype().isTypeStruct())
+                                {
+                                    escapeByValue(arg, er, retRefTransition);
+                                }
+                    }
+                    else
+                        escapeByValue(arg, er, true);
+                }
+            }
+        }
+    }
+    // If 'this' is returned, check it too
+    Type t1 = e.e1.type.toBasetype();
+    DotVarExp dve = e.e1.isDotVarExp();
+    if (dve && t1.ty == Tfunction)
+    {
+        FuncDeclaration fd = dve.var.isFuncDeclaration();
+
+        // https://issues.dlang.org/show_bug.cgi?id=20149#c10
+        if (byRef && dve.var.isCtorDeclaration())
+        {
+            er.byExp(e, false);
+            return;
+        }
+
+        if (byRef)
+        {
+            StorageClass stc = dve.var.storage_class & (STC.return_ | STC.scope_ | STC.ref_);
+            if (tf.isreturn)
+                stc |= STC.return_;
+            if (tf.isref)
+                stc |= STC.ref_;
+            if (tf.isScopeQual)
+                stc |= STC.scope_;
+            if (tf.isreturnscope)
+                stc |= STC.returnScope;
+
+            const psr = buildScopeRef(stc);
+            if (psr == ScopeRef.ReturnRef || psr == ScopeRef.ReturnRef_Scope)
+            {
+                escapeByRef(dve.e1, er, psr == ScopeRef.ReturnRef_Scope);
+            }
+            else if (psr == ScopeRef.ReturnScope || psr == ScopeRef.Ref_ReturnScope)
+            {
+                escapeByValue(dve.e1, er, retRefTransition);
+            }
+        }
+        else if (fd && fd.isThis())
+        {
+            // Calling a non-static member function dve.var, which is returning `this`, and with dve.e1 representing `this`
+            const psr = buildScopeRef(getThisStorageClass(fd));
+            if (psr == ScopeRef.ReturnScope || psr == ScopeRef.Ref_ReturnScope)
+            {
+                if (!tf.isref || tf.isctor)
+                    escapeByValue(dve.e1, er, retRefTransition);
+            }
+            else if (psr == ScopeRef.ReturnRef || psr == ScopeRef.ReturnRef_Scope)
+            {
+                if (tf.isref)
+                {
+                    // Treat calling:
+                    //   struct S { ref S foo() return; }
+                    // as:
+                    //   this;
+                    escapeByValue(dve.e1, er, retRefTransition);
+                }
+                else
+                    escapeByRef(dve.e1, er, psr == ScopeRef.ReturnRef_Scope);
+            }
+        }
+
+        // If it's also a nested function that is 'return scope' / 'return ref'
+        if (fd && fd.isNested() && tf.isreturn)
+        {
+            if (byRef)
+            {
+                er.byExp(e, false);
+            }
+            else if (tf.isScopeQual)
+            {
+                if (tf.isreturnscope)
+                    er.byFunc(fd, true);
+                else
+                    er.byExp(e, false);
+            }
+        }
+    }
+
+    // If returning the result of a delegate call, the .ptr
+    // field of the delegate must be checked.
+    if (t1.isTypeDelegate())
+    {
+        if (byRef && e.e1.isVarExp())
+            escapeByValue(e.e1, er, retRefTransition);
+        if (!byRef && tf.isreturn)
+            escapeByValue(e.e1, er, retRefTransition);
+    }
+
+    // If it's a nested function that is 'return scope'
+    if (auto ve = e.e1.isVarExp())
+    {
+        FuncDeclaration fd = ve.var.isFuncDeclaration();
+        if (fd && fd.isNested())
+        {
+            if (byRef && tf.isreturn)
+            {
+                er.byExp(e, false);
+            }
+            else if (!byRef && tf.isreturn && tf.isScopeQual)
+            {
+                if (tf.isreturnscope)
+                    er.byFunc(fd, true);
+                else
+                    er.byExp(e, false);
+            }
+        }
+    }
 }
 
 /****************************************
@@ -2122,117 +2114,6 @@ void escapeByRef(Expression e, ref scope EscapeByResults er, bool retRefTransiti
         escapeByRef(e.e2, er, retRefTransition);
     }
 
-    void visitCall(CallExp e)
-    {
-        //printf("escapeByRef.CallExp(): %s\n", e.toChars());
-        /* If the function returns by ref, check each argument that is
-         * passed as 'return ref'.
-         */
-        TypeFunction tf = e.calledFunctionType();
-        if (!tf)
-            return;
-
-        if (!tf.isref)
-        {
-            er.byExp(e, retRefTransition);
-            return;
-        }
-
-        if (e.arguments && e.arguments.length)
-        {
-            /* j=1 if _arguments[] is first argument,
-             * skip it because it is not passed by ref
-             */
-            int j = tf.isDstyleVariadic();
-            for (size_t i = j; i < e.arguments.length; ++i)
-            {
-                Expression arg = (*e.arguments)[i];
-                size_t nparams = tf.parameterList.length;
-                if (i - j < nparams && i >= j)
-                {
-                    Parameter p = tf.parameterList[i - j];
-                    const stc = tf.parameterStorageClass(null, p);
-                    ScopeRef psr = buildScopeRef(stc);
-                    if (psr == ScopeRef.ReturnRef || psr == ScopeRef.ReturnRef_Scope)
-                    {
-                        escapeByRef(arg, er, retRefTransition);
-                    }
-                    else if (psr == ScopeRef.ReturnScope || psr == ScopeRef.Ref_ReturnScope)
-                    {
-                        if (auto de = arg.isDelegateExp())
-                        {
-                            if (de.func.isNested())
-                                er.byExp(de, false);
-                        }
-                        else
-                            escapeByValue(arg, er, retRefTransition);
-                    }
-                }
-            }
-        }
-        // If 'this' is returned by ref, check it too
-        Type t1 = e.e1.type.toBasetype();
-        if (e.e1.op == EXP.dotVariable && t1.ty == Tfunction)
-        {
-            DotVarExp dve = e.e1.isDotVarExp();
-            FuncDeclaration fd = dve.var.isFuncDeclaration();
-
-            // https://issues.dlang.org/show_bug.cgi?id=20149#c10
-            if (dve.var.isCtorDeclaration())
-            {
-                er.byExp(e, false);
-                return;
-            }
-
-            StorageClass stc = dve.var.storage_class & (STC.return_ | STC.scope_ | STC.ref_);
-            if (tf.isreturn)
-                stc |= STC.return_;
-            if (tf.isref)
-                stc |= STC.ref_;
-            if (tf.isScopeQual)
-                stc |= STC.scope_;
-            if (tf.isreturnscope)
-                stc |= STC.returnScope;
-
-            const psr = buildScopeRef(stc);
-            if (psr == ScopeRef.ReturnRef || psr == ScopeRef.ReturnRef_Scope)
-            {
-                escapeByRef(dve.e1, er, psr == ScopeRef.ReturnRef_Scope);
-            }
-            else if (psr == ScopeRef.ReturnScope || psr == ScopeRef.Ref_ReturnScope)
-            {
-                escapeByValue(dve.e1, er, retRefTransition);
-            }
-
-            // If it's also a nested function that is 'return ref'
-            if (fd)
-            {
-                if (fd.isNested() && tf.isreturn)
-                {
-                    er.byExp(e, false);
-                }
-            }
-        }
-        // If it's a delegate, check it too
-        if (e.e1.isVarExp() && t1.isTypeDelegate())
-        {
-            escapeByValue(e.e1, er, retRefTransition);
-        }
-
-        /* If it's a nested function that is 'return ref'
-         */
-        if (auto ve = e.e1.isVarExp())
-        {
-            FuncDeclaration fd = ve.var.isFuncDeclaration();
-            if (fd && fd.isNested())
-            {
-                if (tf.isreturn)
-                    er.byExp(e, false);
-            }
-        }
-
-    }
-
     switch (e.op)
     {
         case EXP.variable: return visitVar(e.isVarExp());
@@ -2246,7 +2127,7 @@ void escapeByRef(Expression e, ref scope EscapeByResults er, bool retRefTransiti
         case EXP.assign: return visitAssign(e.isAssignExp());
         case EXP.comma: return visitComma(e.isCommaExp());
         case EXP.question: return visitCond(e.isCondExp());
-        case EXP.call: return visitCall(e.isCallExp());
+        case EXP.call: return escapeCallExp(e.isCallExp(), er, retRefTransition, true);
         default:
             if (auto ba = e.isBinAssignExp())
                 return visitBinAssign(ba);


### PR DESCRIPTION
The `CallExp` cases of `escapeByValue` and `escapeByRef` were copy-pasted from the same base, with a few differences because of different semantics, but also a lot of sketchy differences, likely from ad-hoc bug fixes over the years making the functions diverge.

I want to merge them to remove code duplication, and straighten out the logic. 

I recommend reviewing the first commit with whitespace differences off, because that shows how `escapeByValue.visit(CallExp)` was adopted to also handle `ByRef` cases, while the second commit extracts the function to global scope and makes the function used by `escapeByRef` as well.

There's still more deduplicating / straightening out of the logic to do. For example, byRef and byValue still have their own sketchy way to find storage classes for the `this` parameter to pass to `buildScopeRef`, but that's for subsequent PRs. 