### PR TITLE
Fix bugzilla 24663 - dip1000 doesn't check slice expression implicitl…

### DIFF
--- a/compiler/test/fail_compilation/fail13902.d
+++ b/compiler/test/fail_compilation/fail13902.d
@@ -335,7 +335,7 @@ int[3]  testDynamicArrayVariadic3(int[] vda...) { return vda[0..3]; }   // no er
 TEST_OUTPUT:
 ---
 fail_compilation/fail13902.d(335): Error: returning `vsa[0]` escapes a reference to parameter `vsa`
-fail_compilation/fail13902.d(336): Error: returning `vsa[]` escapes a reference to variadic parameter `vsa`
+fail_compilation/fail13902.d(336): Error: returning `vsa[]` escapes a reference to parameter `vsa`
 ---
 */
 ref int testStaticArrayVariadic1(int[3] vsa...) { return vsa[0]; }

--- a/compiler/test/fail_compilation/retscope.d
+++ b/compiler/test/fail_compilation/retscope.d
@@ -299,15 +299,31 @@ struct S7
 
 /***************************************************/
 
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope.d(315): Error: scope parameter `p` may not be returned
+fail_compilation/retscope.d(316): Error: returning `p[]` escapes a reference to parameter `p`
+fail_compilation/retscope.d(319): Error: scope parameter `p` may not be returned
+---
+*/
+
 int[3] escape8(scope int[] p) @safe { return p[0 .. 3]; } // should not error
 char*[3] escape9(scope char*[] p) @safe { return p[0 .. 3]; }
+
+// https://issues.dlang.org/show_bug.cgi?id=24663
+    int*[3] escape8b(scope int*[3] p) @safe { return p[]; }
+ref int*[3] escape9b(      int*[3] p) @safe { return p[]; }
+
+ref int[3] asStatic(return scope int[] p) @safe { return p[0 .. 3]; }
+ref int[3] asStatic2(      scope int[] p) @safe { return p[0 .. 3]; }
 
 /***************************************************/
 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(319): Error: reference to local variable `i` assigned to non-scope `f`
+fail_compilation/retscope.d(335): Error: reference to local variable `i` assigned to non-scope `f`
 ---
 */
 
@@ -331,7 +347,7 @@ int* bar10( scope int** ptr ) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(342): Error: cannot take address of `scope` variable `aa` since `scope` applies to first indirection only
+fail_compilation/retscope.d(358): Error: cannot take address of `scope` variable `aa` since `scope` applies to first indirection only
 ---
 */
 

--- a/compiler/test/fail_compilation/retscope3.d
+++ b/compiler/test/fail_compilation/retscope3.d
@@ -53,7 +53,7 @@ void bar4()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope3.d(4003): Error: copying `u[]` into allocated memory escapes a reference to variadic parameter `u`
+fail_compilation/retscope3.d(4003): Error: copying `u[]` into allocated memory escapes a reference to parameter `u`
 fail_compilation/retscope3.d(4016): Error: storing reference to outer local variable `i` into allocated memory causes it to escape
 fail_compilation/retscope3.d(4025): Error: storing reference to stack allocated value returned by `makeSA()` into allocated memory causes it to escape
 ---


### PR DESCRIPTION
…y converted to static array

This replaces the weird special case for `e1.isVarExp` in the process, which alters the message for variadic arrays. However, the old message puts unnecessary attention on the variadic parameter. When it's a dynamic array, it's implicitly scope so it's worth to mention. When it's a static array, this isn't really relevant:

```D
int[]  f1(int[] vsa...) { return vsa; } // Here, vsa is implicitly `scope`

int[]  f1(int[3] vsa...) { return vsa[]; } // here, the variadic array doesn't make a difference
int[]  v2(int[3] vsa)    { return vsa[]; } // it's the same situation as this
```
