### PR TITLE
escape.d: Remove special case for `hasDualContext`

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -2009,9 +2009,7 @@ void escapeByRef(Expression e, ref scope EscapeByResults er, bool retRefTransiti
 
     void visitThis(ThisExp e)
     {
-        if (e.var && e.var.toParent2().isFuncDeclaration().hasDualContext())
-            escapeByValue(e, er, retRefTransition);
-        else if (e.var)
+        if (e.var)
             er.byRef(e.var, retRefTransition);
     }
 


### PR DESCRIPTION
I don't get this special case, it implies that returning `&this.x` in a struct member with dual context is actually returning `this.x`. While dual context does add an extra layer of indirection to the `this` pointer under the hood, dip1000 shouldn't treat struct field access differently because of it. The branch is not covered by tests, and dual context is in deprecated state, so I think it's safe to remove.