### PR TITLE
[ddoc] Show TypeCtor method attributes after parameters

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -3927,7 +3927,7 @@ private void visitFuncIdentWithPrefix(TypeFunction t, const Identifier ident, Te
 
     /* Use 'storage class' (prefix) style for attributes
      */
-    if (t.mod)
+    if (t.mod && !hgs.ddoc)
     {
         MODtoBuffer(buf, t.mod);
         buf.writeByte(' ');
@@ -3977,6 +3977,12 @@ private void visitFuncIdentWithPrefix(TypeFunction t, const Identifier ident, Te
         buf.writeByte(')');
     }
     parametersToBuffer(t.parameterList, buf, hgs);
+    // postfix TypeCtor attributes are more readable
+    if (t.mod && hgs.ddoc)
+    {
+        buf.writeByte(' ');
+        MODtoBuffer(buf, t.mod);
+    }
     if (t.isreturnscope && !t.isreturninferred)
     {
         buf.writestring(" return scope");

--- a/compiler/test/compilable/extra-files/ddoc10.html
+++ b/compiler/test/compilable/extra-files/ddoc10.html
@@ -1088,7 +1088,7 @@ void <code class="code">map2</code>()(int <code class="code">rs</code>);
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="S.this"></span>const pure nothrow this(long <code class="code">ticks</code>);
+            <span class="ddoc_anchor" id="S.this"></span>pure nothrow this(long <code class="code">ticks</code>) const;
 
           </code>
         </p>
@@ -1113,7 +1113,7 @@ void <code class="code">map2</code>()(int <code class="code">rs</code>);
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="S.foo"></span>const pure nothrow void <code class="code">foo</code>(long <code class="code">ticks</code>);
+            <span class="ddoc_anchor" id="S.foo"></span>pure nothrow void <code class="code">foo</code>(long <code class="code">ticks</code>) const;
 
           </code>
         </p>

--- a/compiler/test/compilable/extra-files/ddoc10869.html
+++ b/compiler/test/compilable/extra-files/ddoc10869.html
@@ -552,7 +552,7 @@
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="C.c1Foo"></span>const void <code class="code">c1Foo</code>();
+            <span class="ddoc_anchor" id="C.c1Foo"></span>void <code class="code">c1Foo</code>() const;
 
           </code>
         </p>
@@ -577,7 +577,7 @@
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="C.i1Foo"></span>immutable void <code class="code">i1Foo</code>();
+            <span class="ddoc_anchor" id="C.i1Foo"></span>void <code class="code">i1Foo</code>() immutable;
 
           </code>
         </p>
@@ -602,7 +602,7 @@
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="C.c2Foo"></span>immutable void <code class="code">c2Foo</code>();
+            <span class="ddoc_anchor" id="C.c2Foo"></span>void <code class="code">c2Foo</code>() immutable;
 
           </code>
         </p>
@@ -627,7 +627,7 @@
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="C.i2Foo"></span>immutable void <code class="code">i2Foo</code>();
+            <span class="ddoc_anchor" id="C.i2Foo"></span>void <code class="code">i2Foo</code>() immutable;
 
           </code>
         </p>


### PR DESCRIPTION
This is more readable and avoids confusion when there's a non-void return type.