### PR TITLE
escape.d: Fix handling of isTypesafeVariadicArray

### DIFF
--- a/compiler/test/fail_compilation/fail13902.d
+++ b/compiler/test/fail_compilation/fail13902.d
@@ -323,9 +323,9 @@ int[] testSlice2() { int[3] sa; int n; return sa[n..2][1..2]; }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(324): Error: returning `vda[0]` escapes a reference to parameter `vda`
+fail_compilation/fail13902.d(324): Error: returning `vda[0]` escapes a reference to variadic parameter `vda`
+fail_compilation/fail13902.d(325): Error: returning `vda[]` escapes a reference to variadic parameter `vda`
 ---
-
 */
 ref int testDynamicArrayVariadic1(int[] vda...) { return vda[0]; }
 @safe int[]   testDynamicArrayVariadic2(int[] vda...) { return vda[]; }

--- a/compiler/test/fail_compilation/test23022.d
+++ b/compiler/test/fail_compilation/test23022.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test23022.d(14): Error: scope parameter `p` may not be returned
+fail_compilation/test23022.d(14): Error: returning `p` escapes a reference to variadic parameter `p`
 ---
 */
 


### PR DESCRIPTION
TypesafeVariadicArray used to be completely handled with special cases, but then it was given the `scope` storage class which caused some of those branches to become redundant, and some to become dead. This PR removes a redundant branch in `escapeByRef` and revives one in `checkReturnEscapeImpl`, making errors more consistent.