### PR TITLE
escape.d: Remove parameter passing of retRetTransition

### DIFF
--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -2001,7 +2001,7 @@ void escapeLive(Expression e, scope void delegate(VarDeclaration) onVar)
         true,
     );
 
-    escapeByValue(e, er, true);
+    escapeByValue(e, er);
 }
 
 /***************************************


### PR DESCRIPTION
Make it a member of `EscapeByResults` so we don't have to pass it along as a separate parameter everywhere.