### PR TITLE
escape.d: Remove special case for DelegateExp argument

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -1862,16 +1862,6 @@ void escapeCallExp(CallExp e, ref scope EscapeByResults er, int deref)
                 const stc = tf.parameterStorageClass(null, p);
                 ScopeRef psr = buildScopeRef(stc);
 
-                if (deref < 0 && paramDeref(psr) == 0)
-                {
-                    if (auto de = arg.isDelegateExp())
-                    {
-                        if (de.func.isNested())
-                            er.byExp(de, false);
-
-                        continue;
-                    }
-                }
                 // For struct constructors, `tf.isref` is true, but for escape analysis,
                 // it's as if they return `void` and escape through the first (`this`) parameter:
                 // void assign(ref S this, return scope constructorArgs...)

--- a/compiler/test/fail_compilation/test14238.d
+++ b/compiler/test/fail_compilation/test14238.d
@@ -1,17 +1,19 @@
 /* REQUIRED_ARGS: -preview=dip1000
    TEST_OUTPUT:
 ---
-fail_compilation/test14238.d(20): Error: scope parameter `fn` may not be returned
-fail_compilation/test14238.d(28): Error: escaping reference to stack allocated value returned by `&baz`
+fail_compilation/test14238.d(22): Error: scope parameter `fn` may not be returned
+fail_compilation/test14238.d(25): Error: function `test14238.bar` is `@nogc` yet allocates closure for `bar()` with the GC
+fail_compilation/test14238.d(27):        function `test14238.bar.baz` closes over variable `x`
+fail_compilation/test14238.d(26):        `x` declared here
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=14238
 
 @safe:
 
-alias Fn = ref int delegate() return;
+alias Fn = ref int delegate() return @nogc;
 
-ref int foo(return scope Fn fn)
+ref int call(return scope Fn fn) @nogc
 {
     return fn(); // Ok
 }
@@ -20,10 +22,14 @@ ref int foo2(scope Fn fn) {
     return fn(); // Error
 }
 
-ref int bar() {
+ref int bar() @nogc {
     int x;
     ref int baz() {
             return x;
     }
-    return foo(&baz);
+
+    if (x == 0)
+        return call(&baz);
+    else
+        return (&baz)();
 }


### PR DESCRIPTION
There's two problems with the check:

It's in the wrong place. The same situation can occur when the delegate is the thing being called:
```D
return call(&dg); // Error
return (&dg)(); // Same, but no error?
```

It's the wrong outcome. There's no reference to a stack temporary being returned, it's a reference to a closure in this case, which is fine when it's GC-allocated.

So remove the check, remove the expected error and check instead that a closure is being created.

