### PR TITLE
Fix bugzilla 23830 - Azure failure for OMF: Module name not printed b…

### DIFF
--- a/compiler/test/fail_compilation/bug9631.d
+++ b/compiler/test/fail_compilation/bug9631.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/bug9631.d(20): Error: cannot implicitly convert expression `F()` of type `bug9631.T1!().F` to `bug9631.T2!().F`
 ---
 */
-// DISABLED: win32
+
 template T1()
 {
     struct F { }

--- a/compiler/test/fail_compilation/fail19948.d
+++ b/compiler/test/fail_compilation/fail19948.d
@@ -1,5 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=19948
-// DISABLED: win32
+
 /*
 TEST_OUTPUT:
 ---
@@ -8,7 +8,7 @@ fail_compilation/fail19948.d(16):        cannot pass argument `X()` of type `fai
 fail_compilation/fail19948.d(19):        `fail19948.func(const(X))` declared here
 ---
 */
-// DISABLED: win32
+
 struct X {}
 void main()
 {


### PR DESCRIPTION
…efore struct symbol

The issue has been 'fixed' by the removal of OMF support, so remove the workaround.