### PR TITLE
Add test case for return scope inference

### DIFF
--- a/compiler/test/compilable/scope.d
+++ b/compiler/test/compilable/scope.d
@@ -329,3 +329,28 @@ auto fsd() @safe
     SD[] a;
     a ~= SD(null);
 }
+
+/************************************/
+
+// Test that `return scope` inference from assignment doesn't force the function to be `scope`
+struct Scape
+{
+    int* p;
+
+    this()(int* input)
+    {
+        p = input; // return scope inferred here
+        notScope(); // not-scope inferred here
+    }
+
+    void notScope() @safe
+    {
+        static int* g;
+        g = p;
+    }
+}
+
+@safe testScape()
+{
+    Scape(null);
+}


### PR DESCRIPTION
Reduced from an std.array unittest failure in https://github.com/dlang/dmd/pull/14782

I'm not sure when that will be fixed, but the test case is good to add already any way.