### PR TITLE
Rename `Type.isscope` to `isScopeClass`

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1054,7 +1054,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
 
         FuncDeclaration fd = parent.isFuncDeclaration();
-        if (dsym.type.isscope() && !(dsym.storage_class & STC.nodtor))
+        if (dsym.type.isScopeClass() && !(dsym.storage_class & STC.nodtor))
         {
             if (dsym.storage_class & (STC.field | STC.out_ | STC.ref_ | STC.static_ | STC.manifest | STC.gshared) || !fd)
             {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5098,7 +5098,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return;
             }
             else if (sc.needsCodegen() && // interpreter doesn't need this lowered
-                     !exp.onstack && !exp.type.isscope()) // these won't use the GC
+                     !exp.onstack && !exp.type.isScopeClass()) // these won't use the GC
             {
                 /* replace `new T(arguments)` with `core.lifetime._d_newclassT!T(arguments)`
                  * or `_d_newclassTTrace`

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1836,7 +1836,7 @@ public:
     virtual bool iscomplex();
     virtual bool isscalar();
     virtual bool isunsigned();
-    virtual bool isscope();
+    virtual bool isScopeClass();
     virtual bool isString();
     virtual bool isAssignable();
     virtual bool isBoolean();
@@ -4256,7 +4256,7 @@ public:
     TypeClass* syntaxCopy() override;
     ClassDeclaration* isClassHandle() override;
     uint8_t deduceWild(Type* t, bool isRef) override;
-    bool isscope() override;
+    bool isScopeClass() override;
     bool isBoolean() override;
     void accept(Visitor* v) override;
 };

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -677,7 +677,7 @@ extern (C++) abstract class Type : ASTNode
         return false;
     }
 
-    bool isscope()
+    bool isScopeClass()
     {
         return false;
     }
@@ -3537,7 +3537,7 @@ extern (C++) final class TypeClass : Type
         return wm;
     }
 
-    override bool isscope()
+    override bool isScopeClass()
     {
         return sym.stack;
     }

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -239,7 +239,7 @@ public:
     virtual bool iscomplex();
     virtual bool isscalar();
     virtual bool isunsigned();
-    virtual bool isscope();
+    virtual bool isScopeClass();
     virtual bool isString();
     virtual bool isAssignable();
     virtual bool isBoolean();
@@ -748,7 +748,7 @@ public:
     TypeClass *syntaxCopy() override;
     ClassDeclaration *isClassHandle() override;
     unsigned char deduceWild(Type *t, bool isRef) override;
-    bool isscope() override;
+    bool isScopeClass() override;
     bool isBoolean() override;
 
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1810,7 +1810,7 @@ Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         default:
             break;
         }
-        if (tbn.isscope())
+        if (tbn.isScopeClass())
         {
             .error(loc, "cannot have array of scope `%s`", tbn.toChars());
             return error();
@@ -1844,7 +1844,7 @@ Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         default:
             break;
         }
-        if (tn.isscope())
+        if (tn.isScopeClass())
         {
             .error(loc, "cannot have array of scope `%s`", tn.toChars());
             return error();
@@ -2050,7 +2050,7 @@ Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         default:
             break;
         }
-        if (mtype.next.isscope())
+        if (mtype.next.isScopeClass())
         {
             .error(loc, "cannot have array of scope `%s`", mtype.next.toChars());
             return error();
@@ -2216,7 +2216,7 @@ Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             tf.next = tf.next.typeSemantic(loc, sc);
             sc = sc.pop();
             errors |= tf.checkRetType(loc);
-            if (tf.next.isscope() && !tf.isctor)
+            if (tf.next.isScopeClass() && !tf.isctor)
             {
                 .error(loc, "functions cannot return `scope %s`", tf.next.toChars());
                 errors = true;

--- a/compiler/test/fail_compilation/typeerrors.d
+++ b/compiler/test/fail_compilation/typeerrors.d
@@ -17,12 +17,12 @@ fail_compilation/typeerrors.d(52): Error: cannot have associative array of `void
 fail_compilation/typeerrors.d(54): Error: cannot have parameter of type `void`
 fail_compilation/typeerrors.d(56): Error: slice `[1..5]` is out of range of [0..4]
 fail_compilation/typeerrors.d(57): Error: slice `[2..1]` is out of range of [0..4]
+fail_compilation/typeerrors.d(59): Error: variable `typeerrors.foo.globalC` globals, statics, fields, manifest constants, ref and out parameters cannot be `scope`
+fail_compilation/typeerrors.d(59): Error: variable `typeerrors.foo.globalC` reference to `scope class` must be `scope`
+fail_compilation/typeerrors.d(60): Error: variable `typeerrors.foo.manifestC` globals, statics, fields, manifest constants, ref and out parameters cannot be `scope`
+fail_compilation/typeerrors.d(60): Error: variable `typeerrors.foo.manifestC` reference to `scope class` must be `scope`
 ---
 */
-
-
-
-
 
 
 template tuple(T...) { alias T tuple; }
@@ -55,4 +55,7 @@ void foo()
 
     alias T2 = T[1 .. 5];
     alias T3 = T[2 .. 1];
+
+    static C globalC;
+    enum C manifestC = new C();
 }


### PR DESCRIPTION
`Type.isscope` is easily confused with `FunctionFlag.isscope`, and it is not related to the `scope` storage class, but the deprecated (and revived :slightly_frowning_face: ) feature `scope class C {}`.

Add a test case to fix missing error message coverage while we're at it.