### PR TITLE
Fix bugzilla 24670 - importC: .di generation does not place parenthes…

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -4279,13 +4279,23 @@ private void typeToBufferx(Type t, ref OutBuffer buf, ref HdrGenState hgs)
 
     void visitTag(TypeTag t)
     {
-        if (t.mod & MODFlags.const_)
-            buf.writestring("const ");
         if (hgs.importcHdr && t.id)
         {
+            // https://issues.dlang.org/show_bug.cgi?id=24670
+            // `const` must be parenthesized because it can be a return type
+            if (t.mod & MODFlags.const_)
+                buf.writestring("const(");
+
+            // For C to D translation, `struct S` or `enum S` simply becomes `S`
             buf.writestring(t.id.toString());
+
+            if (t.mod & MODFlags.const_)
+                buf.writestring(")");
             return;
         }
+        // The following produces something like "const enum E : short"
+        if (t.mod & MODFlags.const_)
+            buf.writestring("const ");
         buf.writestring(Token.toString(t.tok));
         buf.writeByte(' ');
         if (t.id)

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -31,6 +31,11 @@ extern (C)
 	{
 		A,
 	}
+	struct S24326
+	{
+		int x = void;
+	}
+	const(S24326) fun(int y);
 	/+enum int __DATE__ = 1+/;
 	/+enum int __TIME__ = 1+/;
 	/+enum int __TIMESTAMP__ = 1+/;
@@ -76,3 +81,7 @@ typedef S T;
 
 // https://issues.dlang.org/show_bug.cgi?id=24326
 enum { A };
+
+// https://issues.dlang.org/show_bug.cgi?id=24670
+struct S24326 { int x; };
+const struct S24326 fun(int y);

--- a/compiler/test/compilable/jsonc.i
+++ b/compiler/test/compilable/jsonc.i
@@ -12,12 +12,12 @@ TEST_OUTPUT:
                 "baseDeco": "i",
                 "char": 9,
                 "kind": "enum",
-                "line": 43,
+                "line": 68,
                 "members": [
                     {
                         "char": 17,
                         "kind": "enum member",
-                        "line": 43,
+                        "line": 68,
                         "name": "a"
                     }
                 ],
@@ -28,9 +28,34 @@ TEST_OUTPUT:
                 "char": 22,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "alias",
-                "line": 43,
+                "line": 68,
                 "name": "E",
                 "originalType": "enum E",
+                "protection": "public"
+            },
+            {
+                "baseDeco": "s",
+                "char": 15,
+                "kind": "enum",
+                "line": 70,
+                "members": [
+                    {
+                        "char": 32,
+                        "kind": "enum member",
+                        "line": 70,
+                        "name": "a2"
+                    }
+                ],
+                "name": "E2",
+                "protection": "public"
+            },
+            {
+                "char": 38,
+                "deco": "VALUE_REMOVED_FOR_TEST",
+                "kind": "alias",
+                "line": 70,
+                "name": "E2",
+                "originalType": "const enum E2 : short",
                 "protection": "public"
             }
         ]
@@ -41,3 +66,5 @@ TEST_OUTPUT:
 
 // https://issues.dlang.org/show_bug.cgi?id=24108
 typedef enum { a, } E;
+
+typedef const enum : short { a2, } E2; // C23 feature


### PR DESCRIPTION
…es around const struct return types