### PR TITLE
[stable] Prepare `TargetC` for ARM bit-fields special case

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -7186,15 +7186,11 @@ private extern(C++) class SetFieldOffsetVisitor : Visitor
             error(bfd.loc, "bit field width %d is larger than type", bfd.fieldWidth);
 
         const style = target.c.bitFieldStyle;
-        if (style != TargetC.BitFieldStyle.MS &&
-            style != TargetC.BitFieldStyle.Gcc_Clang &&
-            style != TargetC.BitFieldStyle.Gcc_Clang_ARM)
-        {
+        if (style != TargetC.BitFieldStyle.MS && style != TargetC.BitFieldStyle.Gcc_Clang)
             assert(0, "unsupported bit-field style");
-        }
 
         const isMicrosoftStyle = style == TargetC.BitFieldStyle.MS;
-        const contributesToAggregateAlignment = !anon || style != TargetC.BitFieldStyle.Gcc_Clang;
+        const contributesToAggregateAlignment = target.c.contributesToAggregateAlignment(bfd);
 
         void startNewField()
         {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5938,6 +5938,7 @@ struct TargetC final
         Unspecified = 0u,
         MS = 1u,
         Gcc_Clang = 2u,
+        Gcc_Clang_ARM = 3u,
     };
 
     bool crtDestructorsSupported;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5938,7 +5938,6 @@ struct TargetC final
         Unspecified = 0u,
         MS = 1u,
         Gcc_Clang = 2u,
-        Gcc_Clang_ARM = 3u,
     };
 
     bool crtDestructorsSupported;
@@ -5951,6 +5950,7 @@ struct TargetC final
     uint8_t wchar_tsize;
     Runtime runtime;
     BitFieldStyle bitFieldStyle;
+    bool contributesToAggregateAlignment(BitFieldDeclaration* bfd);
     TargetC() :
         crtDestructorsSupported(true),
         boolsize(),

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -1360,6 +1360,8 @@ extern (C++) struct Target
  */
 struct TargetC
 {
+    import dmd.declaration : BitFieldDeclaration;
+
     enum Runtime : ubyte
     {
         Unspecified,
@@ -1379,9 +1381,6 @@ struct TargetC
                               /// https://docs.microsoft.com/en-us/cpp/c-language/c-bit-fields?view=msvc-160
                               /// https://docs.microsoft.com/en-us/cpp/cpp/cpp-bit-fields?view=msvc-160
         Gcc_Clang,            /// gcc and clang
-        Gcc_Clang_ARM,        /// Like `Gcc_Clang`, except that anonymous and 0-length bit fields contribute
-                              /// to the aggregate alignment. Used for 32 & 64 bit ARM targets, except for
-                              /// Apple ARM64.
     }
     bool  crtDestructorsSupported = true; /// Not all platforms support crt_destructor
     ubyte boolsize;           /// size of a C `_Bool` type
@@ -1451,6 +1450,24 @@ struct TargetC
         {
             crtDestructorsSupported = false;
         }
+    }
+
+    /**
+     * Indicates whether the specified bit-field contributes to the alignment
+     * of the containing aggregate.
+     * E.g., (not all) ARM ABIs do NOT ignore anonymous (incl. 0-length)
+     * bit-fields.
+     */
+    extern (C++) bool contributesToAggregateAlignment(BitFieldDeclaration bfd)
+    {
+        if (bitFieldStyle == BitFieldStyle.MS)
+            return true;
+        if (bitFieldStyle == BitFieldStyle.Gcc_Clang)
+        {
+            // sufficient for DMD's currently supported architectures
+            return !bfd.isAnonymous();
+        }
+        assert(0);
     }
 }
 

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -1379,6 +1379,9 @@ struct TargetC
                               /// https://docs.microsoft.com/en-us/cpp/c-language/c-bit-fields?view=msvc-160
                               /// https://docs.microsoft.com/en-us/cpp/cpp/cpp-bit-fields?view=msvc-160
         Gcc_Clang,            /// gcc and clang
+        Gcc_Clang_ARM,        /// Like `Gcc_Clang`, except that anonymous and 0-length bit fields contribute
+                              /// to the aggregate alignment. Used for 32 & 64 bit ARM targets, except for
+                              /// Apple ARM64.
     }
     bool  crtDestructorsSupported = true; /// Not all platforms support crt_destructor
     ubyte boolsize;           /// size of a C `_Bool` type

--- a/compiler/src/dmd/target.h
+++ b/compiler/src/dmd/target.h
@@ -16,6 +16,7 @@
 #include "globals.h"
 #include "tokens.h"
 
+class BitFieldDeclaration;
 class ClassDeclaration;
 class Dsymbol;
 class Expression;
@@ -65,9 +66,6 @@ struct TargetC
                               // https://docs.microsoft.com/en-us/cpp/c-language/c-bit-fields?view=msvc-160
                               // https://docs.microsoft.com/en-us/cpp/cpp/cpp-bit-fields?view=msvc-160
         Gcc_Clang,            // gcc and clang
-        Gcc_Clang_ARM,        // Like `Gcc_Clang`, except that anonymous and 0-length bit fields contribute
-                              // to the aggregate alignment. Used for 32 & 64 bit ARM targets, except for
-                              // Apple ARM64.
     };
 
     uint8_t crtDestructorsSupported; // Not all platforms support crt_destructor
@@ -80,6 +78,8 @@ struct TargetC
     uint8_t wchar_tsize;         // size of a C 'wchar_t' type
     Runtime runtime;
     BitFieldStyle bitFieldStyle; // different C compilers do it differently
+
+    bool contributesToAggregateAlignment(BitFieldDeclaration *bfd);
 };
 
 struct TargetCPP

--- a/compiler/src/dmd/target.h
+++ b/compiler/src/dmd/target.h
@@ -65,6 +65,9 @@ struct TargetC
                               // https://docs.microsoft.com/en-us/cpp/c-language/c-bit-fields?view=msvc-160
                               // https://docs.microsoft.com/en-us/cpp/cpp/cpp-bit-fields?view=msvc-160
         Gcc_Clang,            // gcc and clang
+        Gcc_Clang_ARM,        // Like `Gcc_Clang`, except that anonymous and 0-length bit fields contribute
+                              // to the aggregate alignment. Used for 32 & 64 bit ARM targets, except for
+                              // Apple ARM64.
     };
 
     uint8_t crtDestructorsSupported; // Not all platforms support crt_destructor

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -958,6 +958,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
             switch (target.c.bitFieldStyle)
             {
                 case TargetC.BitFieldStyle.Gcc_Clang:
+                case TargetC.BitFieldStyle.Gcc_Clang_ARM:
                     bitFieldSize = (bf.bitOffset + bf.fieldWidth + 7) / 8;
                     break;
 

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -958,7 +958,6 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
             switch (target.c.bitFieldStyle)
             {
                 case TargetC.BitFieldStyle.Gcc_Clang:
-                case TargetC.BitFieldStyle.Gcc_Clang_ARM:
                     bitFieldSize = (bf.bitOffset + bf.fieldWidth + 7) / 8;
                     break;
 


### PR DESCRIPTION
Required for 32-bit ARM, and non-Apple 64-bit ARM targets.

The only difference to `Gcc_Clang` is that anonymous and 0-length bit-fields do contribute to the aggregate alignment.

Caught by existing proper C interop tests in `runnable_cxx/testbitfields.d` on such targets. The hardcoded bad tests in `runnable/{bitfieldsposix64.c,dbitfieldsposix64.d}` however now fail after the fix, on such targets again.

See https://github.com/ldc-developers/ldc/pull/4707#issuecomment-2239900730 and following.