### PR TITLE
escape.d: improve handling of nested function calls

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -1108,7 +1108,12 @@ bool checkNewEscape(ref Scope sc, Expression e, bool gag)
         }
     }
 
-    void onFunc(FuncDeclaration fd, bool called) {}
+    void onFunc(FuncDeclaration fd, bool called)
+    {
+        if (called)
+            result |= sc.setUnsafeDIP1000(gag, e.loc,
+                "nested function `%s` returns `scope` values and escapes them into allocated memory", fd);
+    }
 
     void onExp(Expression ee, bool retRefTransition)
     {
@@ -1832,10 +1837,7 @@ void escapeExp(Expression e, ref scope EscapeByResults er, int deref)
         {
             if (fd.isNested() && tf.isreturn)
             {
-                if (deref < 0 || !tf.isreturnscope)
-                    er.byExp(e, false);
-                else if (tf.isScopeQual)
-                    er.byFunc(fd, true);
+                er.byFunc(fd, true);
             }
         }
 

--- a/compiler/test/fail_compilation/test18644.d
+++ b/compiler/test/fail_compilation/test18644.d
@@ -1,9 +1,9 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test18644.d(15): Error: storing reference to stack allocated value returned by `foo()` into allocated memory causes it to escape
-fail_compilation/test18644.d(16): Error: escaping reference to stack allocated value returned by `foo()`
-fail_compilation/test18644.d(22): Error: escaping reference to stack allocated value returned by `foo()`
+fail_compilation/test18644.d(15): Error: nested function `foo` returns `scope` values and escapes them into allocated memory
+fail_compilation/test18644.d(16): Error: escaping local variable through nested function `foo`
+fail_compilation/test18644.d(22): Error: escaping local variable through nested function `foo`
 ---
 */
 

--- a/compiler/test/fail_compilation/test22977.d
+++ b/compiler/test/fail_compilation/test22977.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test22977.d(16): Error: escaping local variable through nested function `scfunc`
-fail_compilation/test22977.d(22): Error: escaping reference to stack allocated value returned by `scfunc2()`
+fail_compilation/test22977.d(22): Error: escaping local variable through nested function `scfunc2`
 ---
 */
 


### PR DESCRIPTION
Escaping `byExp` should be reserved for taking the address of temporaries, calls to nested functions escaping closure variables should always be handled with `byFunc`. This improves the error message and unblocks a simplification of the `byExp` code in `checkAssignEscape`.