### PR TITLE
escape.d: simplify expression temporary assignment

### DIFF
--- a/compiler/test/fail_compilation/fail20183.d
+++ b/compiler/test/fail_compilation/fail20183.d
@@ -3,15 +3,15 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail20183.d(1016): Error: function `addr` is not callable using argument types `(int)`
 fail_compilation/fail20183.d(1016):        cannot pass rvalue argument `S(0).i` of type `int` to parameter `return ref int b`
-fail_compilation/fail20183.d(1005):        `fail20183.addr(return ref int b)` declared here
-fail_compilation/fail20183.d(1017): Error: address of struct temporary returned by `s()` assigned to longer lived variable `q`
+fail_compilation/fail20183.d(1004):        `fail20183.addr(return ref int b)` declared here
+fail_compilation/fail20183.d(1017): Error: address of expression temporary returned by `s()` assigned to `q` with longer lifetime
+fail_compilation/fail20183.d(1018): Error: address of struct literal `S(0)` assigned to `r` with longer lifetime
 ---
  */
 
 #line 1000
 
 // https://issues.dlang.org/show_bug.cgi?id=20183
-
 @safe:
 
 int* addr(return ref int b) { return &b; }
@@ -19,20 +19,22 @@ int* addr(return ref int b) { return &b; }
 struct S
 {
     int i;
+    S* addrOf() return => &this;
 }
 
 S s() { return S(); }
 
 void test()
 {
-    int* p = addr(S().i);  // struct literal
-    int* q = addr(s().i);  // struct temporary
+    scope int* p = addr(S().i);  // struct literal
+    scope int* q = addr(s().i);  // struct temporary
+    scope S* r = S().addrOf();   // struct literal
 }
 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20183.d(1107): Error: address of struct temporary returned by `s()` assigned to longer lived variable `this.ptr`
+fail_compilation/fail20183.d(1107): Error: address of expression temporary returned by `s()` assigned to `this.ptr` with longer lifetime
 ---
  */
 #line 1100

--- a/compiler/test/fail_compilation/retscope.d
+++ b/compiler/test/fail_compilation/retscope.d
@@ -7,7 +7,7 @@ fail_compilation/retscope.d(32): Error: returning `b ? nested1(& i) : nested2(& 
 fail_compilation/retscope.d(45): Error: scope variable `p` assigned to global variable `q`
 fail_compilation/retscope.d(47): Error: address of variable `i` assigned to `q` with longer lifetime
 fail_compilation/retscope.d(48): Error: scope variable `a` assigned to global variable `b`
-fail_compilation/retscope.d(49): Error: address of struct temporary returned by `(*fp2)()` assigned to longer lived variable `q`
+fail_compilation/retscope.d(49): Error: address of expression temporary returned by `(*fp2)()` assigned to `q` with longer lifetime
 ---
 */
 


### PR DESCRIPTION
What I was talking about in: https://github.com/dlang/dmd/pull/16747

```D
S* s = S(1, 2).addressOf();
```

Whether `s` is scope, and what kind of expression temporary it is don't matter: the temporary gets destructed at the end of the expression, and the assignment leaves a variable with a dangling pointer, so don't allow any of it.

The only special case I leave is slicing a returned static array, because that's apparently a deprecation even in non-dip1000 code.