### PR TITLE
Fix bugzilla 24680 - [dip1000] final auto class method infers scope b…

### DIFF
--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -638,12 +638,12 @@ public:
     bool nothrowInprocess(bool v);
     bool nogcInprocess() const;
     bool nogcInprocess(bool v);
-    bool returnInprocess() const;
-    bool returnInprocess(bool v);
+    bool scopeInprocess() const;
+    bool scopeInprocess(bool v);
     bool inlineScanned() const;
     bool inlineScanned(bool v);
-    bool inferScope() const;
-    bool inferScope(bool v);
+    bool dummy() const;
+    bool dummy(bool v);
     bool hasCatches() const;
     bool hasCatches(bool v);
     bool skipCodegen() const;

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -642,8 +642,6 @@ public:
     bool scopeInprocess(bool v);
     bool inlineScanned() const;
     bool inlineScanned(bool v);
-    bool dummy() const;
-    bool dummy(bool v);
     bool hasCatches() const;
     bool hasCatches(bool v);
     bool skipCodegen() const;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3702,8 +3702,6 @@ public:
     bool scopeInprocess(bool v);
     bool inlineScanned() const;
     bool inlineScanned(bool v);
-    bool dummy() const;
-    bool dummy(bool v);
     bool hasCatches() const;
     bool hasCatches(bool v);
     bool skipCodegen() const;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3698,12 +3698,12 @@ public:
     bool nothrowInprocess(bool v);
     bool nogcInprocess() const;
     bool nogcInprocess(bool v);
-    bool returnInprocess() const;
-    bool returnInprocess(bool v);
+    bool scopeInprocess() const;
+    bool scopeInprocess(bool v);
     bool inlineScanned() const;
     bool inlineScanned(bool v);
-    bool inferScope() const;
-    bool inferScope(bool v);
+    bool dummy() const;
+    bool dummy(bool v);
     bool hasCatches() const;
     bool hasCatches(bool v);
     bool skipCodegen() const;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -121,7 +121,6 @@ private struct FUNCFLAG
     bool nogcInprocess;      /// working on determining @nogc
     bool scopeInprocess;     /// infer `return` and `scope` for parameters
     bool inlineScanned;      /// function has been scanned for inline possibilities
-    bool dummy;              /// unused
     bool hasCatches;         /// function has try-catch statements
     bool skipCodegen;        /// do not generate code for this function.
     bool printf;             /// is a printf-like function

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -119,9 +119,9 @@ private struct FUNCFLAG
     bool safetyInprocess;    /// working on determining safety
     bool nothrowInprocess;   /// working on determining nothrow
     bool nogcInprocess;      /// working on determining @nogc
-    bool returnInprocess;    /// working on inferring 'return' for parameters
+    bool scopeInprocess;     /// infer `return` and `scope` for parameters
     bool inlineScanned;      /// function has been scanned for inline possibilities
-    bool inferScope;         /// infer 'scope' for parameters
+    bool dummy;              /// unused
     bool hasCatches;         /// function has try-catch statements
     bool skipCodegen;        /// do not generate code for this function.
     bool printf;             /// is a printf-like function
@@ -722,11 +722,8 @@ extern (C++) class FuncDeclaration : Declaration
         if (!tf.isnogc)
             nogcInprocess = true;
 
-        if (!isVirtual() || this.isIntroducing())
-            returnInprocess = true;
-
         // Initialize for inferring STC.scope_
-        inferScope = true;
+        scopeInprocess = true;
     }
 
     extern (D) final uint saveFlags()
@@ -1674,7 +1671,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
         this.fes = fes;
         // Always infer scope for function literals
         // See https://issues.dlang.org/show_bug.cgi?id=20362
-        this.inferScope = true;
+        this.scopeInprocess = true;
         //printf("FuncLiteralDeclaration() id = '%s', type = '%s'\n", this.ident.toChars(), type.toChars());
     }
 

--- a/compiler/test/fail_compilation/test24680.d
+++ b/compiler/test/fail_compilation/test24680.d
@@ -1,0 +1,20 @@
+/**
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test24680.d(19): Error: returning `c.peek(buf[])` escapes a reference to local variable `buf`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=24680
+
+class C
+{
+    final auto peek(ubyte[] buf) { return buf; }
+}
+
+@safe escape(C c)
+{
+    ubyte[5] buf;
+    return c.peek(buf[]);
+}


### PR DESCRIPTION
…ut no return

Likely for historical reasons, it's possible to enable `scope` inference but disable `return` inference, which breaks escape.d in the case of the bug report. Unify them under `scopeInprocess` to be consistent with `nogcInprocess` etc., and to disambiguate it from the function `inferScope(VarDeclaration)`.