### PR TITLE
Fix `FUNCFLAG` with `SCOPE`  bitmask error

### DIFF
--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -729,12 +729,12 @@ extern (C++) class FuncDeclaration : Declaration
         inferScope = true;
     }
 
-    extern (D) final uint flags()
+    extern (D) final uint saveFlags()
     {
         return bitFields;
     }
 
-    extern (D) final uint flags(uint f)
+    extern (D) final uint restoreFlags(uint f)
     {
         bitFields = f;
         return bitFields;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2776,7 +2776,7 @@ void modifyReturns(FuncLiteralDeclaration fld, Scope* sc, Type tret)
  */
 bool isRootTraitsCompilesScope(Scope* sc)
 {
-    return (sc.flags & SCOPE.compile) && !(sc.func.flags & SCOPE.compile);
+    return (sc.flags & SCOPE.compile) && !sc.func.skipCodegen;
 }
 
 /**************************************

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1337,10 +1337,10 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
                          * We also save/restore sc.func.flags to avoid messing up
                          * attribute inference in the evaluation.
                         */
-                        const oldflags = sc.func ? sc.func.flags : 0;
+                        const oldflags = sc.func ? sc.func.saveFlags : 0;
                         auto e = resolveAliasThis(sc, farg, true);
                         if (sc.func)
-                            sc.func.flags = oldflags;
+                            sc.func.restoreFlags(oldflags);
                         if (e)
                         {
                             farg = e;


### PR DESCRIPTION
What the?! :raised_eyebrow: 

So in https://github.com/dlang/dmd/pull/14846, an extra check was added related to the enclosing function of `__traits(compiles)`:
```diff
- (sc.flags & SCOPE.compile) 
+ (sc.flags & SCOPE.compile) && !(sc.func.flags & SCOPE.compile);
```
However, `sc.func.flags` is not of type `SCOPE`, it's `FUNCFLAGS`. 

`SCOPE.compile` is `0x100` and by sheer coincidence, *it just happened to line up* with `FUNCFLAG.isCompileTimeOnly`.
That flag was introduced in https://github.com/dlang/dmd/pull/7897, and there seems no reason why it should have the same mask as `SCOPE.compile`.

Then, when the `isCompileTimeOnly` flag was removed in https://github.com/dlang/dmd/pull/14847, it lined up with the equivalent `FUNCFLAG.skipCodegen`. Only when I tried to remove a flag before it in https://github.com/dlang/dmd/pull/16751 did I notice *very confusing* breakage in `__traits(compiles)`. 

There's barely any use for the `FuncDeclaration.flags` property anymore, so I renamed it to avoid future confusion.

@RazvanN7 since you wrote the code, can you verify whether it indeed was magically correct all along?