### PR TITLE
Replace SCOPE flags with bitfields

### DIFF
--- a/compiler/src/dmd/access.d
+++ b/compiler/src/dmd/access.d
@@ -163,7 +163,7 @@ private bool hasProtectedAccess(Scope *sc, Dsymbol s)
  */
 bool checkAccess(Loc loc, Scope* sc, Expression e, Dsymbol d)
 {
-    if (sc.flags & SCOPE.noaccesscheck)
+    if (sc.noAccessCheck)
         return false;
     static if (LOG)
     {

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -824,7 +824,7 @@ FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
      * Note that it would only be necessary if it has floating point fields.
      * For now, we'll just not generate a toHash() for C files.
      */
-    if (sc.flags & SCOPE.Cfile)
+    if (sc.inCfile)
         return null;
 
     //printf("StructDeclaration::buildXtoHash() %s\n", sd.toPrettyChars());

--- a/compiler/src/dmd/common/bitfields.d
+++ b/compiler/src/dmd/common/bitfields.d
@@ -36,7 +36,8 @@ if (__traits(isUnsigned, T))
     enum BitInfo bitInfo = () {
         BitInfo result;
         int bitOffset = 0;
-        foreach (size_t i, mem; __traits(allMembers, S)) {
+        foreach (size_t i, mem; __traits(allMembers, S))
+        {
             alias memType = typeof(__traits(getMember, S, mem));
             enum int bitSize = bsr(memType.max | 1) + 1;
             result.offset ~= bitOffset;
@@ -56,24 +57,20 @@ if (__traits(isUnsigned, T))
 
     foreach (size_t i, mem; __traits(allMembers, S))
     {
-        // propagate private/public from field to getter/setter
-        // Note: The traits was renamed to `getVisibility` in 2.096,
-        // use `getProtection` until the bootstrap compiler is new enough
-        enum visibility = __traits(getProtection, __traits(getMember, S, mem));
-
         enum typeName = typeof(__traits(getMember, S, mem)).stringof;
         enum shift = toString!(bitInfo.offset[i]);
         enum sizeMask = toString!((1 << bitInfo.size[i]) - 1); // 0x01 for bool, 0xFF for ubyte etc.
         result ~= "
-        "~visibility~" "~typeName~" "~mem~"() const scope { return cast("~typeName~") ((bitFields >>> "~shift~") & "~sizeMask~"); }
-        "~visibility~" "~typeName~" "~mem~"("~typeName~" v) scope
+        "~typeName~" "~mem~"() const scope { return cast("~typeName~") ((bitFields >>> "~shift~") & "~sizeMask~"); }
+        "~typeName~" "~mem~"("~typeName~" v) scope
         {
             bitFields &= ~("~sizeMask~" << "~shift~");
             bitFields |= v << "~shift~";
             return v;
         }";
     }
-    return result ~ "\n}\n private "~T.stringof~" bitFields = " ~ toString!(bitInfo.initialValue) ~ ";\n";
+    enum TP initVal = bitInfo.initialValue;
+    return result ~ "\n}\n private "~T.stringof~" bitFields = " ~ toString!(initVal) ~ ";\n";
 }
 
 ///
@@ -110,11 +107,11 @@ unittest
     assert(!s.x);
 
     assert(s.e == E.c);
+    s.e = E.a;
+    assert(s.e == E.a);
+
     assert(s.z);
     assert(s.w == 77);
     s.w = 3;
     assert(s.w == 3);
-
-    static assert(__traits(getProtection, S.x) == "public");
-    static assert(__traits(getProtection, S.w) == "private");
 }

--- a/compiler/src/dmd/common/bitfields.d
+++ b/compiler/src/dmd/common/bitfields.d
@@ -20,43 +20,80 @@ module dmd.common.bitfields;
 extern (D) string generateBitFields(S, T)()
 if (__traits(isUnsigned, T))
 {
-    string result = "extern (C++) pure nothrow @nogc @safe final {";
-    enum structName = __traits(identifier, S);
+    import core.bitop: bsr;
 
-    string initialValue = "";
+    string result = "extern (C++) pure nothrow @nogc @safe final {";
+
+    struct BitInfo
+    {
+        int[] offset;
+        int[] size;
+        T initialValue;
+        int totalSize;
+    }
+
+    // Iterate over members to compute bit offset and bit size for each of them
+    enum BitInfo bitInfo = () {
+        BitInfo result;
+        int bitOffset = 0;
+        foreach (size_t i, mem; __traits(allMembers, S)) {
+            alias memType = typeof(__traits(getMember, S, mem));
+            enum int bitSize = bsr(memType.max | 1) + 1;
+            result.offset ~= bitOffset;
+            result.size ~= bitSize;
+            result.initialValue |= cast(T) __traits(getMember, S.init, mem) << bitOffset;
+            bitOffset += bitSize;
+        }
+        result.totalSize = bitOffset;
+        return result;
+    } ();
+
+    alias TP = typeof(T.init + 0u); // type that `T` gets promoted to, uint or ulong
+    enum string toString(TP i) = i.stringof; // compile time 'integer to string'
+
+    static assert(bitInfo.totalSize <= T.sizeof * 8,
+        "sum of bit field size "~toString!(bitInfo.totalSize)~" exceeds storage type `"~T.stringof~"`");
+
     foreach (size_t i, mem; __traits(allMembers, S))
     {
-        static assert(is(typeof(__traits(getMember, S, mem)) == bool));
-        static assert(i < T.sizeof * 8, "too many fields for bit field storage of type `"~T.stringof~"`");
-        enum mask = "(1 << "~i.stringof~")";
+        // propagate private/public from field to getter/setter
+        enum visibility = __traits(getVisibility, __traits(getMember, S, mem));
+
+        enum typeName = typeof(__traits(getMember, S, mem)).stringof;
+        enum shift = toString!(bitInfo.offset[i]);
+        enum sizeMask = toString!((1 << bitInfo.size[i]) - 1); // 0x01 for bool, 0xFF for ubyte etc.
         result ~= "
-        /// set or get the corresponding "~structName~" member
-        bool "~mem~"() const scope { return !!(bitFields & "~mask~"); }
-        /// ditto
-        bool "~mem~"(bool v)
+        "~visibility~" "~typeName~" "~mem~"() const scope { return cast("~typeName~") ((bitFields >>> "~shift~") & "~sizeMask~"); }
+        "~visibility~" "~typeName~" "~mem~"("~typeName~" v) scope
         {
-            v ? (bitFields |= "~mask~") : (bitFields &= ~"~mask~");
+            bitFields &= ~("~sizeMask~" << "~shift~");
+            bitFields |= v << "~shift~";
             return v;
         }";
-
-        initialValue = (__traits(getMember, S.init, mem) ? "1" : "0") ~ initialValue;
     }
-    return result ~ "}\n private "~T.stringof~" bitFields = 0b" ~ initialValue ~ ";\n";
+    return result ~ "\n}\n private "~T.stringof~" bitFields = " ~ toString!(bitInfo.initialValue) ~ ";\n";
 }
 
 ///
 unittest
 {
+    enum E
+    {
+        a, b, c,
+    }
+
     static struct B
     {
         bool x;
         bool y;
+        E e = E.c;
         bool z = 1;
+        private ubyte w = 77;
     }
 
     static struct S
     {
-        mixin(generateBitFields!(B, ubyte));
+        mixin(generateBitFields!(B, ushort));
     }
 
     S s;
@@ -69,5 +106,13 @@ unittest
     s.y = true;
     assert(s.y);
     assert(!s.x);
+
+    assert(s.e == E.c);
     assert(s.z);
+    assert(s.w == 77);
+    s.w = 3;
+    assert(s.w == 3);
+
+    static assert(__traits(getVisibility, S.x) == "public");
+    static assert(__traits(getVisibility, S.w) == "private");
 }

--- a/compiler/src/dmd/common/bitfields.d
+++ b/compiler/src/dmd/common/bitfields.d
@@ -57,7 +57,9 @@ if (__traits(isUnsigned, T))
     foreach (size_t i, mem; __traits(allMembers, S))
     {
         // propagate private/public from field to getter/setter
-        enum visibility = __traits(getVisibility, __traits(getMember, S, mem));
+        // Note: The traits was renamed to `getVisibility` in 2.096,
+        // use `getProtection` until the bootstrap compiler is new enough
+        enum visibility = __traits(getProtection, __traits(getMember, S, mem));
 
         enum typeName = typeof(__traits(getMember, S, mem)).stringof;
         enum shift = toString!(bitInfo.offset[i]);
@@ -113,6 +115,6 @@ unittest
     s.w = 3;
     assert(s.w == 3);
 
-    static assert(__traits(getVisibility, S.x) == "public");
-    static assert(__traits(getVisibility, S.w) == "private");
+    static assert(__traits(getProtection, S.x) == "public");
+    static assert(__traits(getProtection, S.w) == "private");
 }

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -71,7 +71,7 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
     Expression visit(Expression e)
     {
         //printf("Expression.implicitCastTo(%s of type %s) => %s\n", e.toChars(), e.type.toChars(), t.toChars());
-        if (const match = (sc && sc.flags & SCOPE.Cfile) ? e.cimplicitConvTo(t) : e.implicitConvTo(t))
+        if (const match = (sc && sc.inCfile) ? e.cimplicitConvTo(t) : e.implicitConvTo(t))
         {
             // no need for an extra cast when matching is exact
 
@@ -2304,7 +2304,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         //printf("StringExp::castTo(t = %s), '%s' committed = %d\n", t.toChars(), e.toChars(), e.committed);
 
         if (!e.committed && t.ty == Tpointer && t.nextOf().ty == Tvoid &&
-            (!sc || !(sc.flags & SCOPE.Cfile)))
+            (!sc || !sc.inCfile))
         {
             error(e.loc, "cannot convert string literal to `void*`");
             return ErrorExp.get();
@@ -3356,7 +3356,7 @@ Type typeMerge(Scope* sc, EXP op, ref Expression pe1, ref Expression pe2)
     Type t1b = e1.type.toBasetype();
     Type t2b = e2.type.toBasetype();
 
-    if (sc && sc.flags & SCOPE.Cfile)
+    if (sc && sc.inCfile)
     {
         // Integral types can be implicitly converted to pointers
         if ((t1b.ty == Tpointer) != (t2b.ty == Tpointer))
@@ -4216,7 +4216,7 @@ Expression integralPromotions(Expression e, Scope* sc)
 
 void fix16997(Scope* sc, UnaExp ue)
 {
-    if (global.params.fix16997 || sc.flags & SCOPE.Cfile)
+    if (global.params.fix16997 || sc.inCfile)
         ue.e1 = integralPromotions(ue.e1, sc);          // desired C-like behavor
     else
     {

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -396,7 +396,7 @@ extern (C++) abstract class Declaration : Dsymbol
         {
             for (Scope* scx = sc; scx; scx = scx.enclosing)
             {
-                if (scx.func == parent && (scx.flags & SCOPE.contract))
+                if (scx.func == parent && scx.contract != Contract.none)
                 {
                     const(char)* s = isParameter() && parent.ident != Id.ensure ? "parameter" : "result";
                     if (!(flag & ModifyFlags.noError))
@@ -411,7 +411,7 @@ extern (C++) abstract class Declaration : Dsymbol
             VarDeclaration vthis = e1.isThisExp().var;
             for (Scope* scx = sc; scx; scx = scx.enclosing)
             {
-                if (scx.func == vthis.parent && (scx.flags & SCOPE.contract))
+                if (scx.func == vthis.parent && scx.contract != Contract.none)
                 {
                     if (!(flag & ModifyFlags.noError))
                         error(loc, "%s `%s` cannot modify parameter `this` in contract", kind, toPrettyChars);
@@ -1577,7 +1577,7 @@ extern (C++) class VarDeclaration : Declaration
     extern (D) final bool checkNestedReference(Scope* sc, Loc loc)
     {
         //printf("VarDeclaration::checkNestedReference() %s\n", toChars());
-        if (sc.intypeof == 1 || (sc.flags & SCOPE.ctfe))
+        if (sc.intypeof == 1 || sc.ctfe)
             return false;
         if (!parent || parent == sc.parent)
             return false;
@@ -1612,7 +1612,7 @@ extern (C++) class VarDeclaration : Declaration
         }
 
         // Add this VarDeclaration to fdv.closureVars[] if not already there
-        if (!sc.intypeof && !(sc.flags & SCOPE.compile) &&
+        if (!sc.intypeof && !sc.traitsCompiles &&
             // https://issues.dlang.org/show_bug.cgi?id=17605
             (fdv.skipCodegen || !fdthis.skipCodegen))
         {

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -69,13 +69,13 @@ private extern (D) struct BitFields
     /// https://issues.dlang.org/show_bug.cgi?id=15907
     bool ignoresymbolvisibility;
 
-    private bool _padding0; // To keep the layout the same as when the old `SCOPE` enum bitflags were used
+    bool _padding0; // To keep the layout the same as when the old `SCOPE` enum bitflags were used
 
     bool inCfile;            /// C semantics apply
 
-    private bool _padding1;
-    private bool _padding2;
-    private bool _padding3;
+    bool _padding1;
+    bool _padding2;
+    bool _padding3;
 
     bool canFree;            /// is on free list
 

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -45,37 +45,45 @@ import dmd.tokens;
 
 //version=LOGSEARCH;
 
-
-// List of flags that can be applied to this `Scope`
-enum SCOPE
+/// What kind of contract function we're in, if any
+enum Contract : ubyte
 {
-    ctor          = 0x0001,   /// constructor type
-    noaccesscheck = 0x0002,   /// don't do access checks
-    condition     = 0x0004,   /// inside static if/assert condition
-    debug_        = 0x0008,   /// inside debug conditional
-    constraint    = 0x0010,   /// inside template constraint
-    invariant_    = 0x0020,   /// inside invariant code
-    require       = 0x0040,   /// inside in contract code
-    ensure        = 0x0060,   /// inside out contract code
-    contract      = 0x0060,   /// [mask] we're inside contract code
-    ctfe          = 0x0080,   /// inside a ctfe-only expression
-    compile       = 0x0100,   /// inside __traits(compile)
-    ignoresymbolvisibility    = 0x0200,   /// ignore symbol visibility
-                                          /// https://issues.dlang.org/show_bug.cgi?id=15907
-    Cfile         = 0x0800,   /// C semantics apply
-    free          = 0x8000,   /// is on free list
-
-    fullinst      = 0x10000,  /// fully instantiate templates
-    ctfeBlock     = 0x20000,  /// inside a `if (__ctfe)` block
-    dip1000       = 0x40000,  /// dip1000 errors enabled for this scope
-    dip25         = 0x80000,  /// dip25 errors enabled for this scope
+    none = 0,
+    invariant_ = 1,
+    require = 2, // in contract
+    ensure = 3, // out contract
 }
 
-/// Flags that are carried along with a scope push()
-private enum PersistentFlags =
-    SCOPE.contract | SCOPE.debug_ | SCOPE.ctfe | SCOPE.compile | SCOPE.constraint |
-    SCOPE.noaccesscheck | SCOPE.ignoresymbolvisibility |
-    SCOPE.Cfile | SCOPE.ctfeBlock | SCOPE.dip1000 | SCOPE.dip25;
+private extern (D) struct BitFields
+{
+    bool ctor;              /// constructor type
+    bool noAccessCheck;     /// don't do access checks
+    bool condition;         /// inside static if/assert condition
+    bool debug_;            /// inside debug conditional
+    bool inTemplateConstraint; /// inside template constraint
+    Contract contract;
+    bool ctfe;              /// inside a ctfe-only expression
+    bool traitsCompiles;    /// inside __traits(compile)
+
+    /// ignore symbol visibility
+    /// https://issues.dlang.org/show_bug.cgi?id=15907
+    bool ignoresymbolvisibility;
+
+    private bool _padding0; // To keep the layout the same as when the old `SCOPE` enum bitflags were used
+
+    bool inCfile;            /// C semantics apply
+
+    private bool _padding1;
+    private bool _padding2;
+    private bool _padding3;
+
+    bool canFree;            /// is on free list
+
+    bool fullinst;          /// fully instantiate templates
+    bool ctfeBlock;         /// inside a `if (__ctfe)` block
+    bool dip1000;           /// dip1000 errors enabled for this scope
+    bool dip25;             /// dip25 errors enabled for this scope
+}
 
 extern (C++) struct Scope
 {
@@ -136,7 +144,8 @@ extern (C++) struct Scope
 
     DeprecatedDeclaration depdecl;  /// customized deprecation message
 
-    uint flags;
+    import dmd.common.bitfields : generateBitFields;
+    mixin(generateBitFields!(BitFields, uint));
 
     // user defined attributes
     UserAttributeDeclaration userAttribDecl;
@@ -157,8 +166,8 @@ extern (C++) struct Scope
             Scope* s = freelist;
             freelist = s.enclosing;
             //printf("freelist %p\n", s);
-            assert(s.flags & SCOPE.free);
-            s.flags &= ~SCOPE.free;
+            assert(s.canFree);
+            s.canFree = false;
             return s;
         }
         return new Scope();
@@ -181,11 +190,11 @@ extern (C++) struct Scope
         m.addMember(null, sc.scopesym);
         m.parent = null; // got changed by addMember()
         if (global.params.useDIP1000 == FeatureState.enabled)
-            sc.flags |= SCOPE.dip1000;
+            sc.dip1000 = true;
         if (global.params.useDIP25 == FeatureState.enabled)
-            sc.flags |= SCOPE.dip25;
+            sc.dip25 = true;
         if (_module.filetype == FileType.c)
-            sc.flags |= SCOPE.Cfile;
+            sc.inCfile = true;
         // Create the module scope underneath the global scope
         sc = sc.push(_module);
         sc.parent = _module;
@@ -207,13 +216,13 @@ extern (C++) struct Scope
     {
         Scope* s = copy();
         //printf("Scope::push(this = %p) new = %p\n", this, s);
-        assert(!(flags & SCOPE.free));
+        assert(!this.canFree);
         s.scopesym = null;
         s.enclosing = &this;
         debug
         {
             if (enclosing)
-                assert(!(enclosing.flags & SCOPE.free));
+                assert(!enclosing.canFree);
             if (s == enclosing)
             {
                 printf("this = %p, enclosing = %p, enclosing.enclosing = %p\n", s, &this, enclosing);
@@ -223,10 +232,36 @@ extern (C++) struct Scope
         s.slabel = null;
         s.nofree = false;
         s.ctorflow.fieldinit = ctorflow.fieldinit.arraydup;
-        s.flags = (flags & PersistentFlags);
+
+        // Only keep persistent flags
+        s.resetAllFlags();
+        s.contract = this.contract;
+        s.debug_ = this.debug_;
+        s.ctfe = this.ctfe;
+        s.traitsCompiles = this.traitsCompiles;
+        s.inTemplateConstraint = this.inTemplateConstraint;
+        s.noAccessCheck = this.noAccessCheck;
+        s.ignoresymbolvisibility = this.ignoresymbolvisibility;
+        s.inCfile = this.inCfile;
+        s.ctfeBlock = this.ctfeBlock;
+        s.dip1000 = this.dip1000;
+        s.dip25 = this.dip25;
+
         s.lastdc = null;
         assert(&this != s);
         return s;
+    }
+
+    /// Copy flags from scope `other`
+    extern(D) void copyFlagsFrom(Scope* other)
+    {
+        this.bitFields = other.bitFields;
+    }
+
+    /// Set all scope flags to their initial value
+    extern(D) void resetAllFlags()
+    {
+        this.bitFields = 0;
     }
 
     extern (D) Scope* push(ScopeDsymbol ss)
@@ -251,7 +286,7 @@ extern (C++) struct Scope
                 this = this.init;
             enclosing = freelist;
             freelist = &this;
-            flags |= SCOPE.free;
+            this.canFree = true;
         }
         return enc;
     }
@@ -270,7 +305,8 @@ extern (C++) struct Scope
     extern (D) Scope* startCTFE()
     {
         Scope* sc = this.push();
-        sc.flags = this.flags | SCOPE.ctfe;
+        sc.copyFlagsFrom(&this);
+        sc.ctfe = true;
         version (none)
         {
             /* TODO: Currently this is not possible, because we need to
@@ -300,7 +336,7 @@ extern (C++) struct Scope
 
     extern (D) Scope* endCTFE()
     {
-        assert(flags & SCOPE.ctfe);
+        assert(this.ctfe);
         return pop();
     }
 
@@ -470,7 +506,7 @@ extern (C++) struct Scope
 
                 if (sc.scopesym.isModule())
                     flags |= SearchOpt.unqualifiedModule;    // tell Module.search() that SearchOpt.localsOnly is to be obeyed
-                else if (sc.flags & SCOPE.Cfile && sc.scopesym.isStructDeclaration())
+                else if (sc.inCfile && sc.scopesym.isStructDeclaration())
                     continue;                                // C doesn't have struct scope
 
                 if (Dsymbol s = sc.scopesym.search(loc, ident, flags))
@@ -510,7 +546,7 @@ extern (C++) struct Scope
             return null;
         }
 
-        if (this.flags & SCOPE.ignoresymbolvisibility)
+        if (this.ignoresymbolvisibility)
             flags |= SearchOpt.ignoreVisibility;
 
         // First look in local scopes
@@ -657,7 +693,7 @@ extern (C++) struct Scope
         //printf("\t\tscopesym = %p\n", scopesym);
         if (!scopesym.symtab)
             scopesym.symtab = new DsymbolTable();
-        if (!(flags & SCOPE.Cfile))
+        if (!this.inCfile)
             return scopesym.symtabInsert(s);
 
         // ImportC insert
@@ -752,7 +788,7 @@ extern (C++) struct Scope
         {
             //printf("\tsc = %p\n", sc);
             sc.nofree = true;
-            assert(!(flags & SCOPE.free));
+            assert(!this.canFree);
             //assert(sc != sc.enclosing);
             //assert(!sc.enclosing || sc != sc.enclosing.enclosing);
             //if (++i == 10)
@@ -813,7 +849,7 @@ extern (C++) struct Scope
      */
     extern (D) bool isFromSpeculativeSemanticContext() scope
     {
-        return this.intypeof || this.flags & SCOPE.compile;
+        return this.intypeof || this.traitsCompiles;
     }
 
 
@@ -823,19 +859,19 @@ extern (C++) struct Scope
      */
     extern (D) bool needsCodegen()
     {
-        return (flags & (SCOPE.ctfe | SCOPE.ctfeBlock | SCOPE.compile)) == 0;
+        return !this.ctfe && !this.ctfeBlock && !this.traitsCompiles;
     }
 
     /// Returns: whether to raise DIP1000 warnings (FeatureStabe.default) or errors (FeatureState.enabled)
     extern (D) FeatureState useDIP1000()
     {
-        return (flags & SCOPE.dip1000 || hasEdition(Edition.v2024)) ? FeatureState.enabled : FeatureState.disabled;
+        return (this.dip1000 || hasEdition(Edition.v2024)) ? FeatureState.enabled : FeatureState.disabled;
     }
 
     /// Returns: whether to raise DIP25 warnings (FeatureStabe.default) or errors (FeatureState.enabled)
     extern (D) FeatureState useDIP25()
     {
-        return (flags & SCOPE.dip25 || hasEdition(Edition.v2024)) ? FeatureState.enabled : FeatureState.disabled;
+        return (this.dip25 || hasEdition(Edition.v2024)) ? FeatureState.enabled : FeatureState.disabled;
     }
 
     /// Returns: whether this scope compiles with `edition` or later

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -129,7 +129,7 @@ AlignDeclaration getAlignment(AlignDeclaration ad, Scope* sc)
         else
         {
             auto n = e.toInteger();
-            if (sc.flags & SCOPE.Cfile && n == 0)       // C11 6.7.5-6 allows 0 for alignment
+            if (sc.inCfile && n == 0)       // C11 6.7.5-6 allows 0 for alignment
                 continue;
 
             if (n < 1 || n & (n - 1) || ushort.max < n || !e.type.isintegral())
@@ -181,7 +181,7 @@ bool checkDeprecated(Dsymbol d, const ref Loc loc, Scope* sc)
         return false;
     // Don't complain if we're inside a template constraint
     // https://issues.dlang.org/show_bug.cgi?id=21831
-    if (sc.flags & SCOPE.constraint)
+    if (sc.inTemplateConstraint)
         return false;
 
     const(char)* message = null;
@@ -599,7 +599,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (dsym.storage_class & STC.extern_ && dsym._init)
         {
-            if (sc.flags & SCOPE.Cfile)
+            if (sc.inCfile)
             {
                 // https://issues.dlang.org/show_bug.cgi?id=24447
                 // extern int x = 3; is allowed in C
@@ -626,12 +626,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             bool needctfe = (dsym.storage_class & (STC.manifest | STC.static_)) != 0 || !sc.func;
             if (needctfe)
             {
-                sc.flags |= SCOPE.condition;
+                sc.condition = true;
                 sc = sc.startCTFE();
             }
             //printf("inferring type for %s with init %s\n", dsym.toChars(), dsym._init.toChars());
             dsym._init = dsym._init.inferType(sc);
-            dsym.type = dsym._init.initializerToExpression(null, (sc.flags & SCOPE.Cfile) != 0).type;
+            dsym.type = dsym._init.initializerToExpression(null, sc.inCfile).type;
             if (needctfe)
                 sc = sc.endCTFE();
 
@@ -740,7 +740,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
              * and add those.
              */
             size_t nelems = Parameter.dim(tt.arguments);
-            Expression ie = (dsym._init && !dsym._init.isVoidInitializer()) ? dsym._init.initializerToExpression(null, (sc.flags & SCOPE.Cfile) != 0) : null;
+            Expression ie = (dsym._init && !dsym._init.isVoidInitializer()) ? dsym._init.initializerToExpression(null, sc.inCfile) : null;
             if (ie)
                 ie = ie.expressionSemantic(sc);
             if (nelems > 0 && ie)
@@ -1141,7 +1141,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         bool isBlit = false;
         uinteger_t sz;
-        if (sc.flags & SCOPE.Cfile && !dsym._init)
+        if (sc.inCfile && !dsym._init)
         {
             addDefaultCInitializer(dsym);
         }
@@ -1206,7 +1206,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             sc = sc.push();
             sc.stc &= ~(STC.TYPECTOR | STC.pure_ | STC.nothrow_ | STC.nogc | STC.ref_ | STC.disable);
 
-            if (sc.flags & SCOPE.Cfile &&
+            if (sc.inCfile &&
                 dsym.type.isTypeSArray() &&
                 dsym.type.isTypeSArray().isIncomplete() &&
                 dsym._init.isVoidInitializer() &&
@@ -1236,12 +1236,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         if (ai && tb.ty == Taarray)
                             e = ai.toAssocArrayLiteral();
                         else
-                            e = dsym._init.initializerToExpression(null, (sc.flags & SCOPE.Cfile) != 0);
+                            e = dsym._init.initializerToExpression(null, sc.inCfile);
                         if (!e)
                         {
                             // Run semantic, but don't need to interpret
                             dsym._init = dsym._init.initializerSemantic(sc, dsym.type, INITnointerpret);
-                            e = dsym._init.initializerToExpression(null, (sc.flags & SCOPE.Cfile) != 0);
+                            e = dsym._init.initializerToExpression(null, sc.inCfile);
                             if (!e)
                             {
                                 .error(dsym.loc, "%s `%s` is not a static and cannot have static initializer", dsym.kind, dsym.toPrettyChars);
@@ -1251,7 +1251,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         ei = new ExpInitializer(dsym._init.loc, e);
                         dsym._init = ei;
                     }
-                    else if (sc.flags & SCOPE.Cfile && dsym.type.isTypeSArray() &&
+                    else if (sc.inCfile && dsym.type.isTypeSArray() &&
                              dsym.type.isTypeSArray().isIncomplete())
                     {
                         // C11 6.7.9-22 determine the size of the incomplete array,
@@ -1367,7 +1367,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
             else if (dsym.storage_class & (STC.const_ | STC.immutable_ | STC.manifest) ||
                      dsym.type.isConst() || dsym.type.isImmutable() ||
-                     sc.flags & SCOPE.Cfile)
+                     sc.inCfile)
             {
                 /* Because we may need the results of a const declaration in a
                  * subsequent type, such as an array dimension, before semantic2()
@@ -1512,7 +1512,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dsym.errors)
             return;
 
-        if (!(global.params.bitfields || sc.flags & SCOPE.Cfile))
+        if (!(global.params.bitfields || sc.inCfile))
         {
             version (IN_GCC)
                 .error(dsym.loc, "%s `%s` use `-fpreview=bitfields` for bitfield support", dsym.kind, dsym.toPrettyChars);
@@ -1732,7 +1732,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         sc = sc.push();
         sc.stc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.gshared);
         sc.inunion = scd.isunion ? scd : null;
-        sc.flags = 0;
+        sc.resetAllFlags();
         for (size_t i = 0; i < scd.decl.length; i++)
         {
             Dsymbol s = (*scd.decl)[i];
@@ -2779,7 +2779,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         sc = sc.push();
         sc.stc &= ~STC.static_; // not a static invariant
         sc.stc |= STC.const_; // invariant() is always const
-        sc.flags = (sc.flags & ~SCOPE.contract) | SCOPE.invariant_;
+        sc.contract = Contract.invariant_;
         sc.linkage = LINK.d;
 
         funcDeclarationSemantic(sc, invd);
@@ -2998,7 +2998,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         buildOpAssign(sd, sc2);
         buildOpEquals(sd, sc2);
 
-        if (!(sc2.flags & SCOPE.Cfile) &&
+        if (!sc2.inCfile &&
             global.params.useTypeInfo && Type.dtypeinfo)  // these functions are used for TypeInfo
         {
             sd.xeq = buildXopEquals(sd, sc2);
@@ -4134,7 +4134,7 @@ private extern(C++) class AddMemberVisitor : Visitor
             }
 
             // If using C tag/prototype/forward declaration rules
-            if (sc.flags & SCOPE.Cfile && !dsym.isImport())
+            if (sc.inCfile && !dsym.isImport())
             {
                 if (handleTagSymbols(*sc, dsym, s2, sds))
                     return;
@@ -4155,7 +4155,7 @@ private extern(C++) class AddMemberVisitor : Visitor
         if (sds.isAggregateDeclaration() || sds.isEnumDeclaration())
         {
             if (dsym.ident == Id.__sizeof ||
-                !(sc && sc.flags & SCOPE.Cfile) && (dsym.ident == Id.__xalignof || dsym.ident == Id._mangleof))
+                !(sc && sc.inCfile) && (dsym.ident == Id.__xalignof || dsym.ident == Id._mangleof))
             {
                 .error(dsym.loc, "%s `%s` `.%s` property cannot be redefined", dsym.kind, dsym.toPrettyChars, dsym.ident.toChars());
                 dsym.errors = true;
@@ -4431,7 +4431,7 @@ private extern(C++) class AddMemberVisitor : Visitor
  */
 void addEnumMembersToSymtab(EnumDeclaration ed, Scope* sc, ScopeDsymbol sds)
 {
-    const bool isCEnum = (sc.flags & SCOPE.Cfile) != 0; // it's an ImportC enum
+    const bool isCEnum = sc.inCfile; // it's an ImportC enum
     //printf("addEnumMembersToSymtab(ed: %s added: %d Cfile: %d)\n", ed.toChars(), ed.added, isCEnum);
     if (ed.added)
         return;
@@ -4967,7 +4967,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     if (global.errors != errorsave)
         goto Laftersemantic;
 
-    if ((sc.func || (sc.flags & SCOPE.fullinst)) && !tempinst.tinst)
+    if ((sc.func || sc.fullinst) && !tempinst.tinst)
     {
         /* If a template is instantiated inside function, the whole instantiation
          * should be done at that position. But, immediate running semantic3 of

--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -192,7 +192,7 @@ void enumSemantic(Scope* sc, EnumDeclaration ed)
         return;
     }
 
-    if (!(sc.flags & SCOPE.Cfile))  // C enum remains incomplete until members are done
+    if (!sc.inCfile)  // C enum remains incomplete until members are done
         ed.semanticRun = PASS.semanticdone;
 
     version (none)
@@ -229,7 +229,7 @@ void enumSemantic(Scope* sc, EnumDeclaration ed)
      */
     addEnumMembersToSymtab(ed, sc, sc.getScopesym());
 
-    if (sc.flags & SCOPE.Cfile)
+    if (sc.inCfile)
     {
         /* C11 6.7.2.2
          */

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -548,7 +548,7 @@ private Expression extractOpDollarSideEffect(Scope* sc, UnaExp ue)
     // https://issues.dlang.org/show_bug.cgi?id=12585
     // Extract the side effect part if ue.e1 is comma.
 
-    if ((sc.flags & SCOPE.ctfe) ? hasSideEffect(e1) : !isTrivialExp(e1)) // match logic in extractSideEffect()
+    if (sc.ctfe ? hasSideEffect(e1) : !isTrivialExp(e1)) // match logic in extractSideEffect()
     {
         /* Even if opDollar is needed, 'e1' should be evaluate only once. So
          * Rewrite:
@@ -949,7 +949,7 @@ private Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
     SearchOptFlags flags = SearchOpt.all;
     Dsymbol s;
 
-    if (sc.flags & SCOPE.ignoresymbolvisibility)
+    if (sc.ignoresymbolvisibility)
         flags |= SearchOpt.ignoreVisibility;
 
     // First look in local scopes
@@ -1351,7 +1351,7 @@ private Expression resolveUFCSProperties(Scope* sc, Expression e1, Expression e2
         e = new CallExp(loc, e, arguments);
 
         // https://issues.dlang.org/show_bug.cgi?id=24017
-        if (sc.flags & SCOPE.debug_)
+        if (sc.debug_)
             e.isCallExp().inDebugStatement = true;
 
         e = e.expressionSemantic(sc);
@@ -1865,7 +1865,7 @@ private bool checkPurity(FuncDeclaration f, const ref Loc loc, Scope* sc)
         return false;
     if (sc.intypeof == 1)
         return false;
-    if (sc.flags & (SCOPE.ctfe | SCOPE.debug_))
+    if (sc.ctfe || sc.debug_)
         return false;
 
     // If the call has a pure parent, then the called func must be pure.
@@ -1974,7 +1974,7 @@ private bool checkPurity(VarDeclaration v, const ref Loc loc, Scope* sc)
         return false;
     if (sc.intypeof == 1)
         return false; // allow violations inside typeof(expression)
-    if (sc.flags & (SCOPE.ctfe | SCOPE.debug_))
+    if (sc.ctfe || sc.debug_)
         return false; // allow violations inside compile-time evaluated expressions and debug conditionals
     if (v.ident == Id.ctfe)
         return false; // magic variable never violates pure and safe
@@ -2104,9 +2104,9 @@ private bool checkSafety(FuncDeclaration f, ref Loc loc, Scope* sc)
         return false;
     if (sc.intypeof == 1)
         return false;
-    if (sc.flags & SCOPE.debug_)
+    if (sc.debug_)
         return false;
-    if ((sc.flags & SCOPE.ctfe) && sc.func)
+    if (sc.ctfe && sc.func)
         return false;
 
     if (!sc.func)
@@ -2179,7 +2179,7 @@ private bool checkNogc(FuncDeclaration f, ref Loc loc, Scope* sc)
         return false;
     if (sc.intypeof == 1)
         return false;
-    if (sc.flags & (SCOPE.ctfe | SCOPE.debug_))
+    if (sc.ctfe || sc.debug_)
         return false;
     /* The original expressions (`new S(...)` or `new S[...]``) will be
      * verified instead. This is to keep errors related to the original code
@@ -2391,7 +2391,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         tthis = dve.e1.type;
         goto Lfd;
     }
-    else if (sc && sc.flags & SCOPE.Cfile && e1.isVarExp() && !e2)
+    else if (sc && sc.inCfile && e1.isVarExp() && !e2)
     {
         // ImportC: do not implicitly call function if no ( ) are present
     }
@@ -3724,7 +3724,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         if (!e.type)
             e.type = Type.tfloat64;
-        else if (e.type.isimaginary && sc.flags & SCOPE.Cfile)
+        else if (e.type.isimaginary && sc.inCfile)
         {
             /* Convert to core.stdc.config.complex
              */
@@ -3905,7 +3905,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (exp.ident == Id.ctfe)
         {
-            if (sc.flags & SCOPE.ctfe)
+            if (sc.ctfe)
             {
                 error(exp.loc, "variable `__ctfe` cannot be read at compile time");
                 return setError();
@@ -4289,7 +4289,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             buffer.write4(0);
             e.setData(buffer.extractData(), newlen, 4);
-            if (sc && sc.flags & SCOPE.Cfile)
+            if (sc && sc.inCfile)
                 e.type = Type.tuns32.sarrayOf(e.len + 1);
             else
                 e.type = Type.tdchar.immutableOf().arrayOf();
@@ -4314,7 +4314,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             buffer.writeUTF16(0);
             e.setData(buffer.extractData(), newlen, 2);
-            if (sc && sc.flags & SCOPE.Cfile)
+            if (sc && sc.inCfile)
                 e.type = Type.tuns16.sarrayOf(e.len + 1);
             else
                 e.type = Type.twchar.immutableOf().arrayOf();
@@ -4326,7 +4326,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             goto default;
 
         default:
-            if (sc && sc.flags & SCOPE.Cfile)
+            if (sc && sc.inCfile)
                 e.type = Type.tchar.sarrayOf(e.len + 1);
             else
                 e.type = Type.tchar.immutableOf().arrayOf();
@@ -4525,7 +4525,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         Type t = cle.type.typeSemantic(cle.loc, sc);
         auto init = initializerSemantic(cle.initializer, sc, t, INITnointerpret);
-        auto e = initializerToExpression(init, t, (sc.flags & SCOPE.Cfile) != 0);
+        auto e = initializerToExpression(init, t, sc.inCfile);
         if (!e)
         {
             error(cle.loc, "cannot convert initializer `%s` to expression", toChars(init));
@@ -5426,7 +5426,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         Expression d = new DeclarationExp(e.loc, e.cd);
         sc = sc.push(); // just create new scope
-        sc.flags &= ~SCOPE.ctfe; // temporary stop CTFE
+        sc.ctfe = false; // temporary stop CTFE
         d = d.expressionSemantic(sc);
         sc = sc.pop();
 
@@ -5594,7 +5594,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         uint olderrors;
 
         sc = sc.push(); // just create new scope
-        sc.flags &= ~SCOPE.ctfe; // temporary stop CTFE
+        sc.ctfe = false; // temporary stop CTFE
         sc.visibility = Visibility(Visibility.Kind.public_); // https://issues.dlang.org/show_bug.cgi?id=12506
 
         /* fd.treq might be incomplete type,
@@ -5821,7 +5821,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return;
             }
         }
-        if (sc.flags & SCOPE.Cfile)
+        if (sc.inCfile)
         {
             /* See if need to rewrite the AST because of cast/call ambiguity
              */
@@ -6004,7 +6004,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // Rewrite (*fp)(arguments) to fp(arguments)
                 exp.e1 = (cast(PtrExp)exp.e1).e1;
             }
-            else if (exp.e1.op == EXP.type && (sc && sc.flags & SCOPE.Cfile))
+            else if (exp.e1.op == EXP.type && (sc && sc.inCfile))
             {
                 const numArgs = exp.arguments ? exp.arguments.length : 0;
 
@@ -6621,7 +6621,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (exp.f.checkNestedReference(sc, exp.loc))
                     return setError();
             }
-            else if (sc.func && sc.intypeof != 1 && !(sc.flags & (SCOPE.ctfe | SCOPE.debug_)))
+            else if (sc.func && sc.intypeof != 1 && !(sc.ctfe || sc.debug_))
             {
                 bool err = false;
                 if (!tf.purity && sc.func.setImpure(exp.loc, "`pure` %s `%s` cannot call impure `%s`", exp.e1))
@@ -6885,7 +6885,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             VarDeclaration v = s.isVarDeclaration();
             if (v)
             {
-                if (sc.flags & SCOPE.Cfile)
+                if (sc.inCfile)
                 {
                     /* Do semantic() on the type before inserting v into the symbol table
                      */
@@ -6919,7 +6919,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
 
-            if (v && (sc.flags & SCOPE.Cfile))
+            if (v && sc.inCfile)
             {
                 /* Do semantic() on initializer last so this will be legal:
                  *      int a = a;
@@ -6957,7 +6957,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     // The mangling change only works for D mangling
                 }
 
-                if (!(sc.flags & SCOPE.Cfile))
+                if (!sc.inCfile)
                 {
                     /* https://issues.dlang.org/show_bug.cgi?id=21272
                      * If we are in a foreach body we need to extract the
@@ -7095,7 +7095,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // https://issues.dlang.org/show_bug.cgi?id=23650
             // We generate object code for typeinfo, required
             // by typeid, only if in non-speculative context
-            if (sc.flags & SCOPE.compile)
+            if (sc.traitsCompiles)
             {
                 genObjCode = false;
             }
@@ -7178,7 +7178,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             printf("IsExp::semantic(%s)\n", e.toChars());
         }
-        if (e.id && !(sc.flags & SCOPE.condition))
+        if (e.id && !sc.condition)
         {
             error(e.loc, "can only declare type aliases within `static if` conditionals or `static assert`s");
             return setError();
@@ -7207,7 +7207,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Scope* sc2 = sc.copy(); // keep sc.flags
             sc2.tinst = null;
             sc2.minst = null;
-            sc2.flags |= SCOPE.fullinst;
+            sc2.fullinst = true;
             Type t = dmd.typesem.trySemantic(e.targ, e.loc, sc2);
             sc2.pop();
             if (!t) // errors, so condition is false
@@ -8088,7 +8088,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             //printf("e1.op = %d, '%s'\n", e1.op, Token.toChars(e1.op));
         }
 
-        if (sc.flags & SCOPE.Cfile)
+        if (sc.inCfile)
         {
             /* See if need to rewrite the AST because of cast/call ambiguity
              */
@@ -8481,7 +8481,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (sc.flags & SCOPE.Cfile)
+        if (sc.inCfile)
         {
             /* Special handling for &"string"/&(T[]){0, 1}
              * since C regards string/array literals as lvalues
@@ -8721,7 +8721,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         result = e;
                         return;
                     }
-                    if (sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_))
+                    if (sc.func && !sc.intypeof && !sc.debug_)
                     {
                         sc.setUnsafe(false, exp.loc,
                             "`this` reference necessary to take address of member `%s` in `@safe` function `%s`",
@@ -8812,7 +8812,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             goto case Terror;
         }
 
-        if (sc.flags & SCOPE.Cfile && exp.type && exp.type.toBasetype().ty == Tvoid)
+        if (sc.inCfile && exp.type && exp.type.toBasetype().ty == Tvoid)
         {
             // https://issues.dlang.org/show_bug.cgi?id=23752
             // `&*((void*)(0))` is allowed in C
@@ -8983,7 +8983,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (checkNonAssignmentArrayOp(e.e1))
             return setError();
 
-        e.type = (sc && sc.flags & SCOPE.Cfile) ? Type.tint32 : Type.tbool;
+        e.type = (sc && sc.inCfile) ? Type.tint32 : Type.tbool;
         result = e;
     }
 
@@ -9062,7 +9062,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if ((sc && sc.flags & SCOPE.Cfile) &&
+        if ((sc && sc.inCfile) &&
             exp.to && (exp.to.ty == Tident || exp.to.ty == Tsarray) &&
             (exp.e1.op == EXP.address || exp.e1.op == EXP.star ||
              exp.e1.op == EXP.uadd || exp.e1.op == EXP.negate))
@@ -9316,7 +9316,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
-        if (sc && sc.flags & SCOPE.Cfile)
+        if (sc && sc.inCfile)
         {
             /* C11 6.5.4-5: A cast does not yield an lvalue.
              * So ensure that castTo does not strip away the cast so that this
@@ -9722,7 +9722,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         assert(!exp.type);
 
-        if (sc.flags & SCOPE.Cfile)
+        if (sc.inCfile)
         {
             /* See if need to rewrite the AST because of cast/call ambiguity
              */
@@ -9820,7 +9820,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         e.type = e.e2.type;
         result = e;
 
-        if (sc.flags & SCOPE.Cfile)
+        if (sc.inCfile)
             return;
 
         if (e.type is Type.tvoid)
@@ -10119,7 +10119,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     // OR it in, because it might already be set for C array indexing
                     exp.indexIsInBounds |= bounds.contains(getIntRange(exp.e2));
                 }
-                else if (sc.flags & SCOPE.Cfile && t1b.ty == Tsarray)
+                else if (sc.inCfile && t1b.ty == Tsarray)
                 {
                     if (auto ve = exp.e1.isVarExp())
                     {
@@ -10150,7 +10150,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (sc.flags & SCOPE.Cfile)
+        if (sc.inCfile)
         {
             /* See if need to rewrite the AST because of cast/call ambiguity
              */
@@ -10326,7 +10326,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (auto e2comma = exp.e2.isCommaExp())
         {
-            if (!e2comma.isGenerated && !(sc.flags & SCOPE.Cfile))
+            if (!e2comma.isGenerated && !sc.inCfile)
                 error(exp.loc, "using the result of a comma expression is not allowed");
 
             /* Rewrite to get rid of the comma from rvalue
@@ -10471,7 +10471,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 e1x = e;
             }
-            else if (sc.flags & SCOPE.Cfile && e1x.isDotIdExp())
+            else if (sc.inCfile && e1x.isDotIdExp())
             {
                 auto die = e1x.isDotIdExp();
                 e1x = fieldLookup(die.e1, sc, die.ident, die.arrow);
@@ -11066,7 +11066,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
              * string to match the size of e1.
              */
             Type t2 = e2x.type.toBasetype();
-            if (sc.flags & SCOPE.Cfile && e2x.isStringExp() && t2.isTypeSArray())
+            if (sc.inCfile && e2x.isStringExp() && t2.isTypeSArray())
             {
                 uinteger_t dim1 = t1.isTypeSArray().dim.toInteger();
                 uinteger_t dim2 = t2.isTypeSArray().dim.toInteger();
@@ -13272,14 +13272,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         e1x = resolveProperties(sc, e1x);
         e1x = e1x.toBoolean(sc);
 
-        if (sc.flags & SCOPE.condition)
+        if (sc.condition)
         {
             /* If in static if, don't evaluate e2 if we don't have to.
              */
             e1x = e1x.optimize(WANTvalue);
             if (e1x.toBool().hasValue(exp.op == EXP.orOr))
             {
-                if (sc.flags & SCOPE.Cfile)
+                if (sc.inCfile)
                     result = new IntegerExp(exp.op == EXP.orOr);
                 else
                     result = IntegerExp.createBool(exp.op == EXP.orOr);
@@ -13327,7 +13327,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (e2x.type.ty == Tvoid)
             exp.type = Type.tvoid;
         else
-            exp.type = (sc && sc.flags & SCOPE.Cfile) ? Type.tint32 : Type.tbool;
+            exp.type = (sc && sc.inCfile) ? Type.tint32 : Type.tbool;
 
         exp.e1 = e1x;
         exp.e2 = e2x;
@@ -13424,7 +13424,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (f1 || f2)
             return setError();
 
-        exp.type = (sc && sc.flags & SCOPE.Cfile) ? Type.tint32 : Type.tbool;
+        exp.type = (sc && sc.inCfile) ? Type.tint32 : Type.tbool;
 
         // Special handling for array comparisons
         Expression arrayLowering = null;
@@ -13719,7 +13719,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (f1 || f2)
             return setError();
 
-        exp.type = (sc && sc.flags & SCOPE.Cfile) ? Type.tint32 : Type.tbool;
+        exp.type = (sc && sc.inCfile) ? Type.tint32 : Type.tbool;
 
         if (!isArrayComparison)
         {
@@ -13935,7 +13935,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // https://issues.dlang.org/show_bug.cgi?id=23767
         // `cast(void*) 0` should be treated as `null` so the ternary expression
         // gets the pointer type of the other branch
-        if (sc.flags & SCOPE.Cfile)
+        if (sc.inCfile)
         {
             static void rewriteCNull(ref Expression e, ref Type t)
             {
@@ -14251,7 +14251,7 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
     if (Expression ex = unaSemantic(exp, sc))
         return ex;
 
-    if (!(sc.flags & SCOPE.Cfile) && exp.ident == Id._mangleof)
+    if (!sc.inCfile && exp.ident == Id._mangleof)
     {
         // symbol.mangleof
 
@@ -14387,7 +14387,7 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
 
     //{ static int z; fflush(stdout); if (++z == 10) *(char*)0=0; }
 
-    const cfile = (sc.flags & SCOPE.Cfile) != 0;
+    const cfile = sc.inCfile;
 
     /* Special case: rewrite this.id and super.id
      * to be classtype.id and baseclasstype.id
@@ -14442,13 +14442,13 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
          */
         if (ie.sds.isModule() && ie.sds != sc._module)
             flags |= SearchOpt.ignorePrivateImports;
-        if (sc.flags & SCOPE.ignoresymbolvisibility)
+        if (sc.ignoresymbolvisibility)
             flags |= SearchOpt.ignoreVisibility;
         Dsymbol s = ie.sds.search(exp.loc, exp.ident, flags);
         /* Check for visibility before resolving aliases because public
          * aliases to private symbols are public.
          */
-        if (s && !(sc.flags & SCOPE.ignoresymbolvisibility) && !symbolIsVisible(sc._module, s))
+        if (s && !sc.ignoresymbolvisibility && !symbolIsVisible(sc._module, s))
         {
             s = null;
         }
@@ -15106,7 +15106,7 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
     if (global.params.noSharedAccess != FeatureState.enabled ||
         !sc ||
         sc.intypeof ||
-        sc.flags & SCOPE.ctfe)
+        sc.ctfe)
     {
         return false;
     }
@@ -15677,7 +15677,7 @@ private Expression toLvalueImpl(Expression _this, Scope* sc, const(char)* action
 
     Expression visitStructLiteral(StructLiteralExp _this)
     {
-        if (sc.flags & SCOPE.Cfile)
+        if (sc.inCfile)
             return _this;  // C struct literals are lvalues
         else
             return visit(_this);
@@ -15724,7 +15724,7 @@ private Expression toLvalueImpl(Expression _this, Scope* sc, const(char)* action
         auto e1 = _this.e1;
         auto var = _this.var;
         //printf("DotVarExp::toLvalue(%s)\n", toChars());
-        if (sc && sc.flags & SCOPE.Cfile)
+        if (sc && sc.inCfile)
         {
             /* C11 6.5.2.3-3: A postfix expression followed by the '.' or '->' operator
              * is an lvalue if the first expression is an lvalue.
@@ -15770,7 +15770,7 @@ private Expression toLvalueImpl(Expression _this, Scope* sc, const(char)* action
 
     Expression visitCast(CastExp _this)
     {
-        if (sc && sc.flags & SCOPE.Cfile)
+        if (sc && sc.inCfile)
         {
             /* C11 6.5.4-5: A cast does not yield an lvalue.
              */
@@ -16273,7 +16273,7 @@ bool checkAddressable(Expression e, Scope* sc)
                 continue;
 
             case EXP.variable:
-                if (sc.flags & SCOPE.Cfile)
+                if (sc.inCfile)
                 {
                     // C11 6.5.3.2: A variable that has its address taken cannot be
                     // stored in a register.
@@ -16575,7 +16575,7 @@ Expression getVarExp(EnumMember em, const ref Loc loc, Scope* sc)
         return ErrorExp.get();
     Expression e = new VarExp(loc, em);
     e = e.expressionSemantic(sc);
-    if (!(sc.flags & SCOPE.Cfile) && em.isCsymbol())
+    if (!sc.inCfile && em.isCsymbol())
     {
         /* C11 types them as int. But if in D file,
          * type qualified names as the enum
@@ -16616,7 +16616,7 @@ Expression toBoolean(Expression exp, Scope* sc)
         case EXP.construct:
         case EXP.blit:
         case EXP.loweredAssignExp:
-            if (sc.flags & SCOPE.Cfile)
+            if (sc.inCfile)
                 return exp;
             // Things like:
             //  if (a = b) ...
@@ -16755,7 +16755,7 @@ bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool 
         const uint nerrors = global.errors;
 
         sc = sc.startCTFE();
-        sc.flags |= SCOPE.condition;
+        sc.condition = true;
 
         e = e.expressionSemantic(sc);
         e = resolveProperties(sc, e);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -950,6 +950,14 @@ struct CtorFlow final
         {}
 };
 
+enum class Contract : uint8_t
+{
+    none = 0u,
+    invariant_ = 1u,
+    require = 2u,
+    ensure = 3u,
+};
+
 template <typename K, typename V>
 struct AssocArray final
 {
@@ -7141,7 +7149,39 @@ struct Scope final
     int32_t explicitVisibility;
     StorageClass stc;
     DeprecatedDeclaration* depdecl;
-    uint32_t flags;
+    bool ctor() const;
+    bool ctor(bool v);
+    bool noAccessCheck() const;
+    bool noAccessCheck(bool v);
+    bool condition() const;
+    bool condition(bool v);
+    bool debug_() const;
+    bool debug_(bool v);
+    bool inTemplateConstraint() const;
+    bool inTemplateConstraint(bool v);
+    Contract contract() const;
+    Contract contract(Contract v);
+    bool ctfe() const;
+    bool ctfe(bool v);
+    bool traitsCompiles() const;
+    bool traitsCompiles(bool v);
+    bool ignoresymbolvisibility() const;
+    bool ignoresymbolvisibility(bool v);
+    bool inCfile() const;
+    bool inCfile(bool v);
+    bool canFree() const;
+    bool canFree(bool v);
+    bool fullinst() const;
+    bool fullinst(bool v);
+    bool ctfeBlock() const;
+    bool ctfeBlock(bool v);
+    bool dip1000() const;
+    bool dip1000(bool v);
+    bool dip25() const;
+    bool dip25(bool v);
+private:
+    uint32_t bitFields;
+public:
     UserAttributeDeclaration* userAttribDecl;
     DocComment* lastdc;
     void* anchorCounts;
@@ -7183,14 +7223,14 @@ struct Scope final
         explicitVisibility(),
         stc(),
         depdecl(),
-        flags(),
+        bitFields(0u),
         userAttribDecl(),
         lastdc(),
         prevAnchor(),
         aliasAsg()
     {
     }
-    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* sw = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tf = nullptr, ScopeGuardStatement* os = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, bool inDefaultArg = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, uint64_t stc = 0LLU, DeprecatedDeclaration* depdecl = nullptr, uint32_t flags = 0u, UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr) :
+    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* sw = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tf = nullptr, ScopeGuardStatement* os = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, bool inDefaultArg = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, uint64_t stc = 0LLU, DeprecatedDeclaration* depdecl = nullptr, uint32_t bitFields = 0u, UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr) :
         enclosing(enclosing),
         _module(_module),
         scopesym(scopesym),
@@ -7225,7 +7265,7 @@ struct Scope final
         explicitVisibility(explicitVisibility),
         stc(stc),
         depdecl(depdecl),
-        flags(flags),
+        bitFields(bitFields),
         userAttribDecl(userAttribDecl),
         lastdc(lastdc),
         anchorCounts(anchorCounts),

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7167,8 +7167,16 @@ struct Scope final
     bool traitsCompiles(bool v);
     bool ignoresymbolvisibility() const;
     bool ignoresymbolvisibility(bool v);
+    bool _padding0() const;
+    bool _padding0(bool v);
     bool inCfile() const;
     bool inCfile(bool v);
+    bool _padding1() const;
+    bool _padding1(bool v);
+    bool _padding2() const;
+    bool _padding2(bool v);
+    bool _padding3() const;
+    bool _padding3(bool v);
     bool canFree() const;
     bool canFree(bool v);
     bool fullinst() const;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -214,11 +214,11 @@ void funcDeclarationSemantic(Scope* sc, FuncDeclaration funcdecl)
 
     //printf("function storage_class = x%llx, sc.stc = x%llx, %x\n", storage_class, sc.stc, Declaration.isFinal());
 
-    if (sc.flags & SCOPE.compile)
+    if (sc.traitsCompiles)
         funcdecl.skipCodegen = true;
 
     funcdecl._linkage = sc.linkage;
-    if (sc.flags & SCOPE.Cfile && funcdecl.isFuncLiteralDeclaration())
+    if (sc.inCfile && funcdecl.isFuncLiteralDeclaration())
         funcdecl._linkage = LINK.d; // so they are uniquely mangled
 
     if (auto fld = funcdecl.isFuncLiteralDeclaration())
@@ -263,7 +263,7 @@ void funcDeclarationSemantic(Scope* sc, FuncDeclaration funcdecl)
         return null;
     }
 
-    if (sc.flags & SCOPE.Cfile)
+    if (sc.inCfile)
     {
         /* C11 allows a function to be declared with a typedef, D does not.
          */
@@ -2181,7 +2181,7 @@ int getLevelAndCheck(FuncDeclaration fd, const ref Loc loc, Scope* sc, FuncDecla
     if (level != fd.LevelError)
         return level;
     // Don't give error if in template constraint
-    if (!(sc.flags & SCOPE.constraint))
+    if (!sc.inTemplateConstraint)
     {
         const(char)* xstatic = fd.isStatic() ? "`static` " : "";
         // better diagnostics for static functions
@@ -2290,7 +2290,7 @@ bool checkNestedReference(FuncDeclaration fd, Scope* sc, const ref Loc loc)
                 if (!found)
                 {
                     //printf("\tadding sibling %s to %s\n", fdthis.toPrettyChars(), toPrettyChars());
-                    if (!sc.intypeof && !(sc.flags & SCOPE.compile))
+                    if (!sc.intypeof && !sc.traitsCompiles)
                     {
                         fd.siblingCallers.push(fdthis);
                         fd.computedEscapingSiblings = false;
@@ -2776,7 +2776,7 @@ void modifyReturns(FuncLiteralDeclaration fld, Scope* sc, Type tret)
  */
 bool isRootTraitsCompilesScope(Scope* sc)
 {
-    return (sc.flags & SCOPE.compile) && !sc.func.skipCodegen;
+    return (sc.traitsCompiles) && !sc.func.skipCodegen;
 }
 
 /**************************************
@@ -2800,7 +2800,7 @@ bool setUnsafe(Scope* sc,
     if (sc.intypeof)
         return false; // typeof(cast(int*)0) is safe
 
-    if (sc.flags & SCOPE.debug_) // debug {} scopes are permissive
+    if (sc.debug_) // debug {} scopes are permissive
         return false;
 
     if (!sc.func)

--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -41,7 +41,7 @@ import dmd.typesem;
  */
 Type cAdjustParamType(Type t, Scope* sc)
 {
-    if (!(sc.flags & SCOPE.Cfile))
+    if (!sc.inCfile)
         return t;
 
     Type tb = t.toBasetype();
@@ -77,7 +77,7 @@ Type cAdjustParamType(Type t, Scope* sc)
 Expression arrayFuncConv(Expression e, Scope* sc)
 {
     //printf("arrayFuncConv() %s\n", e.toChars());
-    if (!(sc.flags & SCOPE.Cfile))
+    if (!sc.inCfile)
         return e;
 
     auto t = e.type.toBasetype();
@@ -154,7 +154,7 @@ Expression fieldLookup(Expression e, Scope* sc, Identifier id, bool arrow)
  */
 Expression carraySemantic(ArrayExp ae, Scope* sc)
 {
-    if (!(sc.flags & SCOPE.Cfile))
+    if (!sc.inCfile)
         return null;
 
     auto e1 = ae.e1.expressionSemantic(sc);

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -201,7 +201,7 @@ public:
 
 Expression checkGC(Scope* sc, Expression e)
 {
-    if (sc.flags & SCOPE.ctfeBlock)     // ignore GC in ctfe blocks
+    if (sc.ctfeBlock)     // ignore GC in ctfe blocks
         return e;
 
     /* If betterC, allow GC to happen in non-CTFE code.
@@ -211,10 +211,10 @@ Expression checkGC(Scope* sc, Expression e)
     const betterC = !global.params.useGC;
     FuncDeclaration f = sc.func;
     if (e && e.op != EXP.error && f && sc.intypeof != 1 &&
-           (!(sc.flags & SCOPE.ctfe) || betterC) &&
+           (!sc.ctfe || betterC) &&
            (f.type.ty == Tfunction &&
             (cast(TypeFunction)f.type).isnogc || f.nogcInprocess || global.params.v.gc) &&
-           !(sc.flags & SCOPE.debug_))
+           !sc.debug_)
     {
         scope NOGCVisitor gcv = new NOGCVisitor(f);
         gcv.checkOnly = betterC;

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1033,7 +1033,7 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                 e.e2 = new DotIdExp(e.loc, e.e2, Id._tupleof);
 
                 auto sc2 = sc.push();
-                sc2.flags |= SCOPE.noaccesscheck;
+                sc2.noAccessCheck = true;
                 Expression r = e.expressionSemantic(sc2);
                 sc2.pop();
                 return r;

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -246,7 +246,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
             // https://issues.dlang.org/show_bug.cgi?id=14166
             // https://issues.dlang.org/show_bug.cgi?id=20417
             // Don't run CTFE for the temporary variables inside typeof or __traits(compiles)
-            vd._init = vd._init.initializerSemantic(sc, vd.type, sc.intypeof == 1 || sc.flags & SCOPE.compile ? INITnointerpret : INITinterpret);
+            vd._init = vd._init.initializerSemantic(sc, vd.type, sc.intypeof == 1 || sc.traitsCompiles ? INITnointerpret : INITinterpret);
             lowerStaticAAs(vd, sc);
             vd.inuse--;
         }

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -408,7 +408,7 @@ Expression extractSideEffect(Scope* sc, const char[] name,
      * https://issues.dlang.org/show_bug.cgi?id=17145
      */
     if (!alwaysCopy &&
-        ((sc.flags & SCOPE.ctfe) ? !hasSideEffect(e) : isTrivialExp(e)))
+        (sc.ctfe ? !hasSideEffect(e) : isTrivialExp(e)))
         return e;
 
     auto vd = copyToTemp(0, name, e);

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -82,13 +82,13 @@ version (DMDLIB)
  */
 private Identifier fixupLabelName(Scope* sc, Identifier ident)
 {
-    uint flags = (sc.flags & SCOPE.contract);
+    Contract c = sc.contract;
     const id = ident.toString();
-    if (flags && flags != SCOPE.invariant_ &&
+    if (c != Contract.none && c != Contract.invariant_ &&
         !(id.length >= 2 && id[0] == '_' && id[1] == '_'))  // does not start with "__"
     {
         OutBuffer buf;
-        buf.writestring(flags == SCOPE.require ? "__in_" : "__out_");
+        buf.writestring(c == Contract.require ? "__in_" : "__out_");
         buf.writestring(ident.toString());
 
         ident = Identifier.idPool(buf[]);
@@ -123,7 +123,7 @@ private LabelStatement checkLabeledLoop(Scope* sc, Statement statement) @safe
  */
 private Expression checkAssignmentAsCondition(Expression e, Scope* sc)
 {
-    if (sc.flags & SCOPE.Cfile)
+    if (sc.inCfile)
         return e;
     auto ec = lastComma(e);
     if (ec.op == EXP.assign)
@@ -205,7 +205,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         }
         if (checkMustUse(s.exp, sc))
             s.exp = ErrorExp.get();
-        if (!(sc.flags & SCOPE.Cfile) && discardValue(s.exp))
+        if (!sc.inCfile && discardValue(s.exp))
             s.exp = ErrorExp.get();
 
         s.exp = s.exp.optimize(WANTvalue);
@@ -1697,7 +1697,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         if (ifs.isIfCtfeBlock())
         {
             Scope* scd2 = scd.push();
-            scd2.flags |= SCOPE.ctfeBlock;
+            scd2.ctfeBlock = true;
             ifs.ifbody = ifs.ifbody.semanticNoScope(scd2);
             scd2.pop();
         }
@@ -1736,7 +1736,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             if (DebugCondition dc = cs.condition.isDebugCondition())
             {
                 sc = sc.push();
-                sc.flags |= SCOPE.debug_;
+                sc.debug_ = true;
                 cs.ifbody = cs.ifbody.statementSemantic(sc);
                 sc.pop();
             }
@@ -1963,7 +1963,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             !(!ss.isFinal || needswitcherror || global.params.useAssert == CHECKENABLE.on || sc.func.isSafe);
         if (!ss.hasDefault)
         {
-            if (!ss.isFinal && (!ss._body || !ss._body.isErrorStatement()) && !(sc.flags & SCOPE.Cfile))
+            if (!ss.isFinal && (!ss._body || !ss._body.isErrorStatement()) && !sc.inCfile)
                 error(ss.loc, "`switch` statement without a `default`; use `final switch` or add `default: assert(0);` or add `default: break;`");
 
             // Generate runtime error if the default is hit
@@ -1971,7 +1971,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             CompoundStatement cs;
             Statement s;
 
-            if (sc.flags & SCOPE.Cfile)
+            if (sc.inCfile)
             {
                 s = new BreakStatement(ss.loc, null);   // default for C is `default: break;`
             }
@@ -2022,7 +2022,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             ss._body = cs;
         }
 
-        if (!(sc.flags & SCOPE.Cfile) && ss.checkLabel())
+        if (!sc.inCfile && ss.checkLabel())
         {
             sc.pop();
             return setError();
@@ -2473,7 +2473,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         Expression e0 = null;
 
         bool errors = false;
-        if (sc.flags & SCOPE.contract)
+        if (sc.contract)
         {
             error(rs.loc, "`return` statements cannot be in contracts");
             errors = true;
@@ -3330,7 +3330,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 /* If catch exception type is derived from Exception
                  */
                 if (c.type.toBasetype().implicitConvTo(ClassDeclaration.exception.type) &&
-                    (!c.handler || !c.handler.comeFrom()) && !(sc.flags & SCOPE.debug_))
+                    (!c.handler || !c.handler.comeFrom()) && !sc.debug_)
                 {
                     // Remove c from the array of catches
                     tcs.catches.remove(i);
@@ -3458,7 +3458,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         if (ds.statement)
         {
             sc = sc.push();
-            sc.flags |= SCOPE.debug_;
+            sc.debug_ = true;
             ds.statement = ds.statement.statementSemantic(sc);
             sc.pop();
         }
@@ -3479,7 +3479,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         gs.tf = sc.tf;
         gs.os = sc.os;
         gs.lastVar = sc.lastVar;
-        gs.inCtfeBlock = (sc.flags & SCOPE.ctfeBlock) != 0;
+        gs.inCtfeBlock = sc.ctfeBlock;
 
         if (!gs.label.statement && sc.fes)
         {
@@ -3503,7 +3503,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 fd.gotos = new GotoStatements();
             fd.gotos.push(gs);
         }
-        else if (!(sc.flags & SCOPE.Cfile) && gs.checkLabel())
+        else if (!sc.inCfile && gs.checkLabel())
             return setError();
 
         result = gs;
@@ -3519,7 +3519,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         ls.tf = sc.tf;
         ls.os = sc.os;
         ls.lastVar = sc.lastVar;
-        ls.inCtfeBlock = (sc.flags & SCOPE.ctfeBlock) != 0;
+        ls.inCtfeBlock = sc.ctfeBlock;
 
         LabelDsymbol ls2 = fd.searchLabel(ls.ident, ls.loc);
         if (ls2.statement && !ls2.duplicated)

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -457,7 +457,7 @@ bool evaluateConstraint(TemplateDeclaration td, TemplateInstance ti, Scope* sc, 
     // (previously, this was immediately before calling evalStaticCondition), so the
     // semantic pass knows not to issue deprecation warnings for these throw-away decls.
     // https://issues.dlang.org/show_bug.cgi?id=21831
-    scx.flags |= SCOPE.constraint;
+    scx.inTemplateConstraint = true;
 
     assert(!ti.symtab);
     if (fd)

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -736,7 +736,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return dimError(1);
 
         Scope* sc2 = sc.push();
-        sc2.flags = sc.flags | SCOPE.noaccesscheck | SCOPE.ignoresymbolvisibility;
+        sc2.copyFlagsFrom(sc);
+        sc2.noAccessCheck = true;
+        sc2.ignoresymbolvisibility = true;
         bool ok = TemplateInstance.semanticTiargs(e.loc, sc2, e.args, 1);
         sc2.pop();
         if (!ok)
@@ -772,7 +774,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return dimError(1);
 
         Scope* sc2 = sc.push();
-        sc2.flags = sc.flags | SCOPE.noaccesscheck | SCOPE.ignoresymbolvisibility;
+        sc2.copyFlagsFrom(sc);
+        sc2.noAccessCheck = true;
+        sc2.ignoresymbolvisibility = true;
         bool ok = TemplateInstance.semanticTiargs(e.loc, sc2, e.args, 1);
         sc2.pop();
         if (!ok)
@@ -1003,7 +1007,8 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     doSemantic:
         // ignore symbol visibility and disable access checks for these traits
         Scope* scx = sc.push();
-        scx.flags |= SCOPE.ignoresymbolvisibility | SCOPE.noaccesscheck;
+        scx.ignoresymbolvisibility = true;
+        scx.noAccessCheck = true;
         scope (exit) scx.pop();
 
         if (e.ident == Id.hasMember)
@@ -1737,7 +1742,11 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             Scope* sc2 = sc.push();
             sc2.tinst = null;
             sc2.minst = null;   // this is why code for these are not emitted to object file
-            sc2.flags = (sc.flags & ~(SCOPE.ctfe | SCOPE.condition)) | SCOPE.compile | SCOPE.fullinst;
+            sc2.copyFlagsFrom(sc);
+            sc2.ctfe = false;
+            sc2.condition = false;
+            sc2.traitsCompiles = true;
+            sc2.fullinst = true;
 
             bool err = false;
 

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -42,7 +42,7 @@ bool genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc)
     // Even when compiling without `useTypeInfo` (e.g. -betterC) we should
     // still be able to evaluate `TypeInfo` at compile-time, just not at runtime.
     // https://issues.dlang.org/show_bug.cgi?id=18472
-    if (!sc || !(sc.flags & SCOPE.ctfe))
+    if (!sc || !sc.ctfe)
     {
         if (!global.params.useTypeInfo)
         {


### PR DESCRIPTION
In light of the recent https://github.com/dlang/dmd/pull/16752, get rid of error-prone bitmasking logic.

While we're at it, I renamed some of the fields because without `flags` they can be misleading: `sc.free` sounds like it calls `free(sc)`, so rename it to `sc.canFree`.

There's 2 flags which aren't booleans, but instead form an ad-hoc enumeration of contracts, so I converted that to an `enum Contract` and added `enum` support to `dmd.common.bitfields`. I can split that improvement off in its own PR to make this one easier to review.

I kept the layout the same as with the `SCOPE` flag to be sure, but those `_padding` fields can be removed in a next PR.