### PR TITLE
dub build: Fix cross-compilation

### DIFF
--- a/.github/workflows/build_with_dub.yml
+++ b/.github/workflows/build_with_dub.yml
@@ -17,5 +17,8 @@ jobs:
             - name: Install Host D compiler
               uses: dlang-community/setup-dlang@v1
 
-            - name: Invoke dub
+            - name: Build and run compiler
               run: dub run dmd:compiler -- --version
+
+            - name: Build frontend library
+              run: dub build dmd:frontend

--- a/config.d
+++ b/config.d
@@ -20,16 +20,14 @@ void main(const string[] args)
     const outputDirectory = args[1];
     const versionFile = args[2];
 
-    version (Posix)
-        const sysConfigDirectory = args[3];
-
     mkdirRecurse(outputDirectory);
     const version_ = generateVersion(versionFile);
 
     updateIfChanged(buildPath(outputDirectory, "VERSION"), version_);
 
-    version (Posix)
+    if (args.length > 3)
     {
+        const sysConfigDirectory = args[3];
         const path = buildPath(outputDirectory, "SYSCONFDIR.imp");
         updateIfChanged(path, sysConfigDirectory);
     }

--- a/dub.sdl
+++ b/dub.sdl
@@ -3,6 +3,7 @@ description "The DMD compiler"
 authors "Walter Bright"
 copyright "Copyright © 1999-2018, The D Language Foundation"
 license "BSL-1.0"
+toolchainRequirements dub=">=1.29.0" # can use $DUB_EXE etc. in custom commands
 
 targetType "none"
 dependency ":frontend" version="*"
@@ -50,17 +51,9 @@ subPackage {
     "CallbackAPI" \
     "DMDLIB"
 
-  preGenerateCommands `
-    "$${DUB_EXE}" \
-    --arch=$${DUB_ARCH} \
-    --compiler=$${DC} \
-    --single "$${DUB_PACKAGE_DIR}config.d" \
-    -- "$${DUB_PACKAGE_DIR}generated/dub" \
-    "$${DUB_PACKAGE_DIR}VERSION" \
-    /etc
-   ` platform="posix"
-
-  preGenerateCommands `"%DUB_EXE%" --arch=%DUB_ARCH% --compiler="%DC%" --single "%DUB_PACKAGE_DIR%config.d" -- "%DUB_PACKAGE_DIR%generated/dub" "%DUB_PACKAGE_DIR%VERSION"` platform="windows"
+  # generate files `generated/dub/{VERSION,SYSCONFDIR.imp}` for string-imports
+  # by building & running the config.d tool
+  preGenerateCommands `"$DUB_EXE" "--compiler=$DC" --single "${DUB_PACKAGE_DIR}config.d" -- "${DUB_PACKAGE_DIR}generated/dub" "${DUB_PACKAGE_DIR}VERSION" /etc`
 
   stringImportPaths \
     "compiler/src/dmd/res" \


### PR DESCRIPTION
The build of the `lexer` dub subpackage requires running and building a little `config.d` tool as custom pregenerate command.

Forwarding the target architecture via `--arch=$DUB_ARCH` to the nested dub build of config.d was added in #9275, to fix cross- compilation, but in reality broke it.

Not specifying the architecture explicitly for the little helper build lets the compiler pick the default one, the host's native platform in practice, which is guaranteed to be runnable on that compiling **host**, independent from the **target** platform for the main dub build. Suppose one cross-compiles the `dmd:lexer` subpackage from x86_64 to AArch64 - an AArch64 config.d executable will hardly run on the x86_64 host, and won't be able to generate the `VERSION` and `SYSCONFDIR.imp` string-import files as pre- requisite of the build.

Side note: using little separately-built `.d` tools/scripts as build helpers for autogenerating little VERSION files etc. is IMO bad practice - when cross-compiling, you require a D compiler that can a) cross-compile, and b) build successfully for the native platform too. Not sure this approach will e.g. ever work with GDC, where you have different toolchains for each host->target combination.