### PR TITLE
Fix bugzilla 24375 - ImportC: .di generator outputs C expression with…

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2682,10 +2682,7 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
     void visitDotId(DotIdExp e)
     {
         expToBuffer(e.e1, PREC.primary, buf, hgs);
-        if (e.arrow)
-            buf.writestring("->");
-        else
-            buf.writeByte('.');
+        buf.writeByte('.');
         buf.writestring(e.ident.toString());
     }
 

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -36,6 +36,11 @@ extern (C)
 		int x = void;
 	}
 	const(S24326) fun(int y);
+	struct foo
+	{
+		int x = void;
+	}
+	alias weird = int[(cast(foo*)cast(void*)0).x.sizeof];
 	/+enum int __DATE__ = 1+/;
 	/+enum int __TIME__ = 1+/;
 	/+enum int __TIMESTAMP__ = 1+/;
@@ -85,3 +90,9 @@ enum { A };
 // https://issues.dlang.org/show_bug.cgi?id=24670
 struct S24326 { int x; };
 const struct S24326 fun(int y);
+
+// https://issues.dlang.org/show_bug.cgi?id=24375
+struct foo {
+    int x;
+};
+typedef int weird[sizeof(((struct foo *)((void*)0))->x)];


### PR DESCRIPTION
… `->` operator