### PR TITLE
Remove `prettyString` field from Dsymbol

### DIFF
--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -267,7 +267,6 @@ extern (C++) class Dsymbol : ASTNode
     Symbol* csym;           // symbol for code generator
     const Loc loc;          // where defined
     Scope* _scope;          // !=null means context to use for semantic()
-    const(char)* prettystring;  // cached value of toPrettyChars()
     private DsymbolAttributes* atts; /// attached attribute declarations
     bool errors;            // this symbol failed to pass semantic()
     PASS semanticRun = PASS.initial;
@@ -655,15 +654,10 @@ extern (C++) class Dsymbol : ASTNode
 
     const(char)* toPrettyChars(bool QualifyTypes = false)
     {
-        if (prettystring && !QualifyTypes)
-            return prettystring; // value cached for speed
-
         //printf("Dsymbol::toPrettyChars() '%s'\n", toChars());
         if (!parent)
         {
             auto s = toChars();
-            if (!QualifyTypes)
-                prettystring = s;
             return s;
         }
 
@@ -683,8 +677,6 @@ extern (C++) class Dsymbol : ASTNode
         addQualifiers(this);
         auto s = buf.extractSlice(true).ptr;
 
-        if (!QualifyTypes)
-            prettystring = s;
         return s;
     }
 

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -194,7 +194,6 @@ public:
     Symbol *csym;               // symbol for code generator
     Loc loc;                    // where defined
     Scope *_scope;               // !=NULL means context to use for semantic()
-    const utf8_t *prettystring;
 private:
     DsymbolAttributes* atts;
 public:

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4469,6 +4469,8 @@ void addEnumMembersToSymtab(EnumDeclaration ed, Scope* sc, ScopeDsymbol sds)
                  * the enum members to both symbol tables.
                  */
                 em.addMember(sc, ed);   // add em to ed's symbol table
+                if (em.errors)
+                    return;
                 em.addMember(sc, sds);  // add em to symbol table that ed is in
                 em.parent = ed; // restore it after previous addMember() changed it
             }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -459,7 +459,6 @@ public:
     Symbol* csym;
     const Loc loc;
     Scope* _scope;
-    const char* prettystring;
 private:
     DsymbolAttributes* atts;
 public:

--- a/compiler/test/fail_compilation/cenums.c
+++ b/compiler/test/fail_compilation/cenums.c
@@ -3,7 +3,6 @@
 fail_compilation/cenums.c(202): Error: `enum E2` is incomplete without members
 fail_compilation/cenums.c(303): Error: redeclaring `union E3` as `enum E3`
 fail_compilation/cenums.c(502): Error: enum member `cenums.test5.F.a` conflicts with enum member `cenums.test5.F.a` at fail_compilation/cenums.c(502)
-fail_compilation/cenums.c(502): Error: enum member `cenums.test5.F.a` conflicts with enum member `cenums.test5.F.a` at fail_compilation/cenums.c(502)
 ---
 */
 


### PR DESCRIPTION
This caching was added in 2016 because compiling `std.uni` for unittests would apparently call the function 29000 times: https://github.com/dlang/dmd/pull/5536

However, I don't believe the cache field `prettyString` is worth the 8 bytes of memory added to every single `DSymbol`. Benchmarking it today with `hyperfine`:

```
Benchmark 1: dmdmaster -c -unittest -version=StdUnittest -preview=dip1000 std/uni/package.d
  Time (mean ± σ):      1.238 s ±  0.008 s    [User: 1.005 s, System: 0.225 s]
  Range (min … max):    1.224 s …  1.249 s    10 runs
 
Benchmark 2: dmdbranch -c -unittest -version=StdUnittest -preview=dip1000 std/uni/package.d
  Time (mean ± σ):      1.234 s ±  0.014 s    [User: 1.002 s, System: 0.226 s]
  Range (min … max):    1.214 s …  1.258 s    10 runs
 
Summary
  dmdbranch -c -unittest -version=StdUnittest -preview=dip1000 std/uni/package.d ran
    1.00 ± 0.01 times faster than dmdmaster -c -unittest -version=StdUnittest -preview=dip1000 std/uni/package.d
```

No measurable difference. Furthermore, when compiling the entirety of Phobos, removing the caching makes the compile time go down from 34.0 to 33.7 seconds, and memory usage go down from 16.2 GB to 16.0 GB.
