### PR TITLE
Improve Dsymbol field layout

### DIFF
--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -265,10 +265,10 @@ extern (C++) class Dsymbol : ASTNode
     Identifier ident;
     Dsymbol parent;
     Symbol* csym;           // symbol for code generator
-    const Loc loc;          // where defined
     Scope* _scope;          // !=null means context to use for semantic()
     const(char)* prettystring;  // cached value of toPrettyChars()
     private DsymbolAttributes* atts; /// attached attribute declarations
+    const Loc loc;          // where defined
     bool errors;            // this symbol failed to pass semantic()
     PASS semanticRun = PASS.initial;
     ushort localNum;        /// perturb mangled name to avoid collisions with those in FuncDeclaration.localsymtab

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -192,12 +192,12 @@ public:
     Identifier *ident;
     Dsymbol *parent;
     Symbol *csym;               // symbol for code generator
-    Loc loc;                    // where defined
     Scope *_scope;               // !=NULL means context to use for semantic()
     const utf8_t *prettystring;
 private:
     DsymbolAttributes* atts;
 public:
+    Loc loc;                    // where defined
     d_bool errors;                // this symbol failed to pass semantic()
     PASS semanticRun;
     unsigned short localNum;        // perturb mangled name to avoid collisions with those in FuncDeclaration.localsymtab

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -457,12 +457,12 @@ public:
     Identifier* ident;
     Dsymbol* parent;
     Symbol* csym;
-    const Loc loc;
     Scope* _scope;
     const char* prettystring;
 private:
     DsymbolAttributes* atts;
 public:
+    const Loc loc;
     bool errors;
     PASS semanticRun;
     uint16_t localNum;


### PR DESCRIPTION
classInstanceSize goes down from 76 to 72 this way (64 with https://github.com/dlang/dmd/pull/16762)