### PR TITLE
build.d: support machine hardware name aarch64

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1717,7 +1717,7 @@ string detectModel()
     else
         uname = ["uname", "-m"].execute.output;
 
-    if (uname.canFind("x86_64", "amd64", "arm64", "64-bit", "64-Bit", "64 bit"))
+    if (uname.canFind("x86_64", "amd64", "aarch64", "arm64", "64-bit", "64-Bit", "64 bit"))
         return "64";
     if (uname.canFind("i386", "i586", "i686", "32-bit", "32-Bit", "32 bit"))
         return "32";


### PR DESCRIPTION
On a Pi using Debian 12 and NixOS 24.05, `uname -m` outputs aarch64.