### PR TITLE
[trivial] [core.attribute] Add top link for `@standalone`

### DIFF
--- a/druntime/src/core/attribute.d
+++ b/druntime/src/core/attribute.d
@@ -13,6 +13,9 @@
  *         Makes an Objective-C interface method optional.)
  * $(TROW $(LREF selector), Objective-C,
  *          Attaches an Objective-C selector to a method.)
+ * $(TROW $(LREF standalone),,
+ *          Marks a shared module constructor as not depending on any
+ *          other module constructor being run first.)
  * $(TROW $(LREF weak),,
  *         Specifies that a global symbol should be emitted with weak linkage.)
  * )


### PR DESCRIPTION
Part of Bugzilla 24693 - [SPEC] The `@standalone` attribute should be documented in the spec