### PR TITLE
Fix Bugzilla Issue 24687 - [REG2.110] Cannot cast string-imports to select overload anymore

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -704,7 +704,7 @@ MATCH implicitConvTo(Expression e, Type t)
                     return MATCH.nomatch;
                 m = MATCH.constant;
             }
-            if (e.hexString && tn.isintegral && (tn.size == e.sz || (!e.committed && (e.len % tn.size) == 0)))
+            if (e.type != t && e.hexString && tn.isintegral && (tn.size == e.sz || (!e.committed && (e.len % tn.size) == 0)))
             {
                 m = MATCH.convert;
                 return m;

--- a/compiler/test/compilable/import_exp.d
+++ b/compiler/test/compilable/import_exp.d
@@ -34,3 +34,11 @@ enum expectedStart = "module imports.imp16088;";
 immutable ubyte[] s0 = import("imp16088.d");
 
 static assert(s0[0 .. expectedStart.length] == "module imports.imp16088;");
+
+// https://issues.dlang.org/show_bug.cgi?id=24687
+
+void foo(string path);
+void foo(const(ubyte[]) data);
+
+void bar1() { foo(import("imp16088.d")); } // matches both
+void bar2() { foo(cast(const(ubyte[])) import("imp16088.d")); } // matches both!


### PR DESCRIPTION
When checking if an expression is implicitly convertible to a type the current implementation of hexstring assumes that the match is convert irrespective of what the actual types are. Fix this by considering the case where the types are identical.

cc @dkorpel as the original author.