### PR TITLE
Also make deprecationSupplemental adhere to error limit

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -567,8 +567,11 @@ extern (C++) void verrorReportSupplemental(const ref Loc loc, const(char)* forma
             goto case ErrorKind.error;
         else if (global.params.useDeprecated == DiagnosticReporting.inform && !global.gag)
         {
-            info.headerColor = Classification.deprecation;
-            verrorPrint(format, ap, info);
+            if (global.params.v.errorLimit == 0 || global.deprecations <= global.params.v.errorLimit)
+            {
+                info.headerColor = Classification.deprecation;
+                verrorPrint(format, ap, info);
+            }
         }
         break;
 

--- a/compiler/test/compilable/deprecationlimit.d
+++ b/compiler/test/compilable/deprecationlimit.d
@@ -18,5 +18,5 @@ void main()
     f();
     f();
     f();
-    f();
+    static assert("1"); // also surpress deprecationSupplemental
 }


### PR DESCRIPTION
I noticed supplemental errors still get printed after 20, I forgot to verify that in https://github.com/dlang/dmd/pull/16403

It's hard to make a sustainable test because deprecations eventually become errors. I just picked a recent one, but if anyone knows a reliable, long lasting way to generate supplemental deprecation messages, I'll change it,