### PR TITLE
Print full CommaExp with -vcg-ast

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2609,9 +2609,9 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
         // the `sideeffect.copyToTemp` function.
         auto ve = e.e2.isVarExp();
 
-        // not a CommaExp introduced for temporaries, go on
-        // the old path
-        if (!ve || !(ve.var.storage_class & STC.temp))
+        // Not a CommaExp introduced for temporaries, or -vcg-ast,
+        // print the full comma
+        if (!ve || !(ve.var.storage_class & STC.temp) || hgs.vcg_ast)
         {
             visitBin(cast(BinExp)e);
             return;


### PR DESCRIPTION
See https://forum.dlang.org/post/zapmlgjycqpzqafuyvmc@forum.dlang.org

I was considering adding a test, but I don't think we should be expecting specific internal expressions. -vcg-ast leaks implementation details for debugging, it's not a well-defined output.