### PR TITLE
Make immediately indexed array literals `@nogc`

### DIFF
--- a/changelog/dmd.nogc-array-literal-index.dd
+++ b/changelog/dmd.nogc-array-literal-index.dd
@@ -1,0 +1,12 @@
+Immediately indexed array literals are `@nogc`
+
+They are now put on the stack, allowing this pattern in `@nogc` code:
+
+---
+int getFormat(int channels) @nogc
+{
+    return [0, GL_RED, GL_RG, GL_RGB, GL_RGBA][channels];
+}
+---
+
+This is not done recursively on multi-dimensional arrays yet.

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9949,6 +9949,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.e1.type.ty == Terror)
             return setError();
 
+        /// Immediately indexed array literal [1, 2, 3][x] doesn't require GC allocation
+        if (auto ale = exp.e1.isArrayLiteralExp())
+            ale.onstack = true;
+
         // Note that unlike C we do not implement the int[ptr]
 
         Type t1b = exp.e1.type.toBasetype();

--- a/compiler/test/runnable/nogc.d
+++ b/compiler/test/runnable/nogc.d
@@ -68,12 +68,25 @@ void test12936() @nogc
 
 /***********************/
 
+void testIndexedArrayLiteral() @nogc
+{
+    int i = 2;
+    int x = [10, 20, 30, 40][i];
+    assert(x == 30);
+
+    enum arr = [100, 200, 300, 400][1 .. $];
+	assert(arr[i] == 400);
+}
+
+/***********************/
+
 int main()
 {
     test1();
     test3032();
     test12642();
     test12936();
+    testIndexedArrayLiteral();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Start simple, doing this on multi-dimensional arrays is a lot more complex.