### PR TITLE
Fix Bugzilla 24705 - Arguments of synchronized method are wrongly sha…

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15155,10 +15155,8 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
             {
                 if (e.var.isThisDeclaration())
                     return false;
-                else
-                    return sharedError(e);
             }
-            else if (!allowRef && e.var.type.isShared())
+            if (!allowRef && e.var.type.isShared())
                 return sharedError(e);
 
             return false;

--- a/compiler/test/compilable/test22626.d
+++ b/compiler/test/compilable/test22626.d
@@ -20,4 +20,11 @@ class Oops
         // this shouldn't compile `k` is a field of class `Oops`
         static assert (!__traits(compiles, k = 2));
     }
+
+    // https://issues.dlang.org/show_bug.cgi?id=24705
+    synchronized void foo(int n)
+    {
+        // Error: direct access to shared `n` is not allowed, see `core.atomic`
+        int a = n;
+    }
 }


### PR DESCRIPTION
…red with -preview=nosharedaccess