### PR TITLE
Fix issue 24441 - Member function template parameters are not mangled as template parameters

### DIFF
--- a/compiler/test/runnable_cxx/test24441.d
+++ b/compiler/test/runnable_cxx/test24441.d
@@ -1,0 +1,18 @@
+    version(CppRuntime_Gcc)
+        version = Non_ms;
+    else version(CppRuntime_Clang)
+        version = Non_ms;
+
+    version(Non_ms)
+    {
+        extern(C++) struct A
+        {
+            void foo(T)(T a);
+        }
+
+        void main()
+        {
+            A a;
+            assert(a.foo!int.mangleof == "_ZN1A3fooIiEEvi");
+        }
+    }


### PR DESCRIPTION
extern(C++) struct A
{
    void foo(T)(T a);
}
void main()
{
    A a;
    assert(a.foo!int.mangleof == "_ZN1A3fooIiEEvT_");
}
This assertion fails as the function parameters are not mangled as template arguments.
D's mangling : ZN1A3fooIiEEvi