### PR TITLE
Fix Bugzilla 3538 - Default value of alias template parameter is inst…

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -3555,6 +3555,8 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
             default:
             }
         }
+        else if (Expression ea = isExpression(defaultAlias))
+            da = ea.syntaxCopy();
 
         RootObject o = aliasParameterSemantic(loc, sc, da, null); // use the parameter loc
         return o;

--- a/compiler/test/compilable/alias_param_expr.d
+++ b/compiler/test/compilable/alias_param_expr.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+A
+B
+---
+*/
+
+template Tpl(T, alias S = "" ~ T.stringof) {
+	pragma(msg, S);
+}
+class A { }
+class B { }
+alias TA = Tpl!A;
+alias TB = Tpl!B;


### PR DESCRIPTION
…antiated only once

The original bug there was fixed long ago, but it was reopened with this case: https://issues.dlang.org/show_bug.cgi?id=3538#c3

@RazvanN7 suggested committing just this fix here:
https://github.com/dlang/dmd/pull/13352/files/05a0dc3b4e2a35b872b8f15f59c94c1c70e64093#r794354512