### PR TITLE
[cparse.d] use early returns

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1120,75 +1120,74 @@ final class CParser(AST) : Parser!AST
      */
     private AST.Expression cparseCastExp()
     {
-        if (token.value == TOK.leftParenthesis)
+        if (token.value != TOK.leftParenthesis)
+            return cparseUnaryExp();
+
+        //printf("cparseCastExp()\n");
+        auto tk = peek(&token);
+        bool iscast;
+        bool isexp;
+        if (tk.value == TOK.identifier)
         {
-            //printf("cparseCastExp()\n");
-            auto tk = peek(&token);
-            bool iscast;
-            bool isexp;
-            if (tk.value == TOK.identifier)
-            {
-                iscast = isTypedef(tk.ident);
-                isexp = !iscast;
-            }
-            if (isexp)
-            {
-                // ( identifier ) is an expression
-                return cparseUnaryExp();
-            }
-
-            // If ( type-name )
-            auto pt = &token;
-
-            if (isCastExpression(pt))
-            {
-                // Expression may be either a cast or a compound literal, which
-                // requires checking whether the next token is leftCurly
-                const loc = token.loc;
-                nextToken();
-                auto t = cparseTypeName();
-                check(TOK.rightParenthesis);
-                pt = &token;
-
-                if (token.value == TOK.leftCurly)
-                {
-                    // C11 6.5.2.5 ( type-name ) { initializer-list }
-                    auto ci = cparseInitializer();
-                    auto ce = new AST.CompoundLiteralExp(loc, t, ci);
-                    return cparsePostfixOperators(ce);
-                }
-
-                if (iscast)
-                {
-                    // ( type-name ) cast-expression
-                    auto ce = cparseCastExp();
-                    return new AST.CastExp(loc, ce, t);
-                }
-
-                if (t.isTypeIdentifier() &&
-                    isexp &&
-                    token.value == TOK.leftParenthesis &&
-                    !isCastExpression(pt))
-                {
-                    /* (t)(...)... might be a cast expression or a function call,
-                     * with different grammars: a cast would be cparseCastExp(),
-                     * a function call would be cparsePostfixExp(CallExp(cparseArguments())).
-                     * We can't know until t is known. So, parse it as a function call
-                     * and let semantic() rewrite the AST as a CastExp if it turns out
-                     * to be a type.
-                     */
-                    auto ie = new AST.IdentifierExp(loc, t.isTypeIdentifier().ident);
-                    ie.parens = true;    // let semantic know it might be a CastExp
-                    AST.Expression e = new AST.CallExp(loc, ie, cparseArguments());
-                    return cparsePostfixOperators(e);
-                }
-
-                // ( type-name ) cast-expression
-                auto ce = cparseCastExp();
-                return new AST.CastExp(loc, ce, t);
-            }
+            iscast = isTypedef(tk.ident);
+            isexp = !iscast;
         }
-        return cparseUnaryExp();
+        if (isexp)
+        {
+            // ( identifier ) is an expression
+            return cparseUnaryExp();
+        }
+
+        // If ( type-name )
+        auto pt = &token;
+
+        if (!isCastExpression(pt))
+            return cparseUnaryExp();
+
+        // Expression may be either a cast or a compound literal, which
+        // requires checking whether the next token is leftCurly
+        const loc = token.loc;
+        nextToken();
+        auto t = cparseTypeName();
+        check(TOK.rightParenthesis);
+        pt = &token;
+
+        if (token.value == TOK.leftCurly)
+        {
+            // C11 6.5.2.5 ( type-name ) { initializer-list }
+            auto ci = cparseInitializer();
+            auto ce = new AST.CompoundLiteralExp(loc, t, ci);
+            return cparsePostfixOperators(ce);
+        }
+
+        if (iscast)
+        {
+            // ( type-name ) cast-expression
+            auto ce = cparseCastExp();
+            return new AST.CastExp(loc, ce, t);
+        }
+
+        if (t.isTypeIdentifier() &&
+            isexp &&
+            token.value == TOK.leftParenthesis &&
+            !isCastExpression(pt))
+        {
+            /* (t)(...)... might be a cast expression or a function call,
+             * with different grammars: a cast would be cparseCastExp(),
+             * a function call would be cparsePostfixExp(CallExp(cparseArguments())).
+             * We can't know until t is known. So, parse it as a function call
+             * and let semantic() rewrite the AST as a CastExp if it turns out
+             * to be a type.
+             */
+            auto ie = new AST.IdentifierExp(loc, t.isTypeIdentifier().ident);
+            ie.parens = true;    // let semantic know it might be a CastExp
+            AST.Expression e = new AST.CallExp(loc, ie, cparseArguments());
+            return cparsePostfixOperators(e);
+        }
+
+        // ( type-name ) cast-expression
+        auto ce = cparseCastExp();
+        return new AST.CastExp(loc, ce, t);
     }
 
     /**************


### PR DESCRIPTION
best reviewed with whitespace changes off