### PR TITLE
Fix bugzilla issue 24716

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -114,7 +114,17 @@ private bool isNeedThisScope(Scope* sc, Declaration d)
         //printf("\ts = %s %s, toParent2() = %p\n", s.kind(), s.toChars(), s.toParent2());
         if (AggregateDeclaration ad2 = s.isAggregateDeclaration())
         {
+            bool isSubclassOf(ClassDeclaration base, ClassDeclaration sub)
+            {
+                if (!base || !sub) return false;
+                for (ClassDeclaration cd = sub; cd; cd = cd.baseClass)
+                    if (cd == base)
+                        return true;
+                return false;
+            }
             if (ad2 == ad)
+                return false;
+            else if (isSubclassOf(ad2.isClassDeclaration(), ad.isClassDeclaration()))
                 return false;
             else if (ad2.isNested())
                 continue;

--- a/compiler/test/runnable/issue24716.d
+++ b/compiler/test/runnable/issue24716.d
@@ -1,0 +1,38 @@
+// https://issues.dlang.org/show_bug.cgi?id=24716
+int i = 1;
+void foo(int arg)
+{
+    assert( arg == 100*i);
+    i++;
+}
+class Outer1 {
+    int value1 = 100;
+
+    class Inner1 {
+        void print() {
+            foo(value1);
+        }
+    }
+
+    Inner1 make() { return new Inner1; }
+}
+
+class Outer2 : Outer1 {
+    int value2 = 200;
+
+    class Inner2 : Outer1.Inner1 {
+        override void print() {
+            foo(value1); // <- no problem!
+            foo(value2); // error: accessing non-static variable `value2` requires an instance of `Outer2`
+        }
+    }
+
+    override Inner2 make() { return new Inner2; }
+}
+
+void main()
+{
+    auto oouter = new Outer2;
+    auto iinner = oouter.make();
+    iinner.print();
+}


### PR DESCRIPTION
checks for `isNeedThisScope` should check up the inheritance chain for nested classes.

E: Apparently this doesn't do what I thought it would. Will try again later.