### PR TITLE
Fix Bugzilla 24724 - Error when @trusted function returns reference t…

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -1242,6 +1242,8 @@ private bool checkReturnEscapeImpl(ref Scope sc, Expression e, bool refs, bool g
                     sc.func.isSafeBypassingInference())
                 {
                     result = true;
+
+                Lsupplemental:
                     if (v.storage_class & STC.returnScope)
                     {
                         previewSupplementalFunc(sc.isDeprecated(), featureState)(v.loc,
@@ -1252,6 +1254,15 @@ private bool checkReturnEscapeImpl(ref Scope sc, Expression e, bool refs, bool g
                         const(char)* annotateKind = (v.ident is Id.This) ? "function" : "parameter";
                         previewSupplementalFunc(sc.isDeprecated(), featureState)(v.loc,
                             "perhaps annotate the %s with `return`", annotateKind);
+                    }
+                }
+                else if (sc.func.isTrusted())
+                {
+                    // @trusted functions must have a safe interface
+                    if (!gag)
+                    {
+                        previewErrorFunc(sc.isDeprecated(), FeatureState.default_)(e.loc, msg, e.toChars(), v.toChars());
+                        goto Lsupplemental;
                     }
                 }
             }

--- a/compiler/test/fail_compilation/trusted_escape.d
+++ b/compiler/test/fail_compilation/trusted_escape.d
@@ -1,0 +1,15 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/trusted_escape.d(13): Deprecation: returning `r` escapes a reference to parameter `r`
+fail_compilation/trusted_escape.d(13):        perhaps annotate the parameter with `return`
+fail_compilation/trusted_escape.d(15): Deprecation: returning `&r` escapes a reference to parameter `r`
+fail_compilation/trusted_escape.d(15):        perhaps annotate the parameter with `return`
+---
+*/
+
+// @trusted functions must have a safe interface
+@trusted ref int a(ref int r) { return r; }
+@system ref int a2(ref int r) { return r; } // OK
+@trusted int* b(ref int r) { return &r; }


### PR DESCRIPTION
…o parameter

Make it a deprecation for now.