### PR TITLE
Revert "[target.d] refactor 64bit logic"

### DIFF
--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -43,16 +43,15 @@ void backend_init(const ref Param params, const ref DMDparams driverParams, cons
 {
     //printf("backend_init()\n");
     exefmt_t exfmt;
-    const is64 = target.isLP64;
     switch (target.os)
     {
-        case Target.OS.Windows: exfmt = is64 ? EX_WIN64     : EX_WIN32;   break;
-        case Target.OS.linux:   exfmt = is64 ? EX_LINUX64   : EX_LINUX;   break;
-        case Target.OS.OSX:     exfmt = is64 ? EX_OSX64     : EX_OSX;     break;
-        case Target.OS.FreeBSD: exfmt = is64 ? EX_FREEBSD64 : EX_FREEBSD; break;
-        case Target.OS.OpenBSD: exfmt = is64 ? EX_OPENBSD64 : EX_OPENBSD; break;
-        case Target.OS.Solaris: exfmt = is64 ? EX_SOLARIS64 : EX_SOLARIS; break;
-        case Target.OS.DragonFlyBSD: assert(is64); exfmt = EX_DRAGONFLYBSD64; break;
+        case Target.OS.Windows: exfmt = target.isX86_64 ? EX_WIN64     : EX_WIN32;   break;
+        case Target.OS.linux:   exfmt = target.isX86_64 ? EX_LINUX64   : EX_LINUX;   break;
+        case Target.OS.OSX:     exfmt = target.isX86_64 ? EX_OSX64     : EX_OSX;     break;
+        case Target.OS.FreeBSD: exfmt = target.isX86_64 ? EX_FREEBSD64 : EX_FREEBSD; break;
+        case Target.OS.OpenBSD: exfmt = target.isX86_64 ? EX_OPENBSD64 : EX_OPENBSD; break;
+        case Target.OS.Solaris: exfmt = target.isX86_64 ? EX_SOLARIS64 : EX_SOLARIS; break;
+        case Target.OS.DragonFlyBSD: exfmt = EX_DRAGONFLYBSD64; break;
         default: assert(0);
     }
 

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -1088,7 +1088,7 @@ public void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     if (fd.v_argptr)
     {
         // Declare va_argsave
-        if (target.isLP64 &&
+        if (target.isX86_64 &&
             target.os & Target.OS.Posix)
         {
             type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3 + 8, null, null, false, false, true, false);

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -465,7 +465,7 @@ extern (C++) struct Target
         }
         else
             assert(0);
-        if (isLP64)
+        if (isX86_64)
         {
             if (os & (Target.OS.linux | Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.DragonFlyBSD | Target.OS.Solaris))
             {
@@ -605,7 +605,7 @@ extern (C++) struct Target
     {
         const size = type.alignsize();
 
-        if ((isLP64 || os == Target.OS.OSX) && (size == 16 || size == 32))
+        if ((isX86_64 || os == Target.OS.OSX) && (size == 16 || size == 32))
             return size;
 
         return (8 < size) ? 8 : size;
@@ -630,7 +630,7 @@ extern (C++) struct Target
         }
         else if (os & Target.OS.Posix)
         {
-            if (isLP64)
+            if (isX86_64)
             {
                 import dmd.identifier : Identifier;
                 import dmd.mtype : TypeIdentifier;
@@ -957,7 +957,7 @@ extern (C++) struct Target
     {
         import dmd.argtypes_x86 : toArgTypes_x86;
         import dmd.argtypes_sysv_x64 : toArgTypes_sysv_x64;
-        if (isLP64)
+        if (isX86_64)
         {
             // no argTypes for Win64 yet
             return isPOSIX ? toArgTypes_sysv_x64(t) : null;
@@ -1005,7 +1005,7 @@ extern (C++) struct Target
         const sz = tn.size();
         Type tns = tn;
 
-        if (os == Target.OS.Windows && isLP64)
+        if (os == Target.OS.Windows && isX86_64)
         {
             // https://msdn.microsoft.com/en-us/library/7572ztz4%28v=vs.100%29.aspx
             if (tns.ty == TY.Tcomplex32)
@@ -1039,7 +1039,7 @@ extern (C++) struct Target
                     return true;
             }
         }
-        else if (isLP64 && isPOSIX)
+        else if (isX86_64 && isPOSIX)
         {
             TypeTuple tt = toArgTypes_sysv_x64(tn);
             if (!tt)
@@ -1114,7 +1114,7 @@ extern (C++) struct Target
                         return false;     // return small structs in regs
                                             // (not 3 byte structs!)
                     case 16:
-                        if (os & Target.OS.Posix && isLP64)
+                        if (os & Target.OS.Posix && isX86_64)
                            return false;
                         break;
 
@@ -1163,7 +1163,7 @@ extern (C++) struct Target
     extern (C++) bool preferPassByRef(Type t)
     {
         const size = t.size();
-        if (isLP64)
+        if (isX86_64)
         {
             if (os == Target.OS.Windows)
             {
@@ -1405,14 +1405,14 @@ struct TargetC
             longsize = 4;
         else
             assert(0);
-        if (target.isLP64)
+        if (target.isX86_64)
         {
             if (os & (Target.OS.linux | Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.DragonFlyBSD | Target.OS.Solaris))
                 longsize = 8;
             else if (os == Target.OS.OSX)
                 longsize = 8;
         }
-        if (target.isLP64 && os == Target.OS.Windows)
+        if (target.isX86_64 && os == Target.OS.Windows)
             long_doublesize = 8;
         else
             long_doublesize = target.realsize;
@@ -1626,7 +1626,7 @@ struct TargetObjC
 
     extern (D) void initialize(ref const Param params, ref const Target target) @safe
     {
-        if (target.os == Target.OS.OSX && target.isLP64)
+        if (target.os == Target.OS.OSX && target.isX86_64)
             supported = true;
     }
 }

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -1417,7 +1417,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoStructDeclaration d)
     {
         //printf("TypeInfoStructDeclaration.toDt() '%s'\n", d.toChars());
-        if (target.isLP64)
+        if (target.isX86_64)
             verifyStructSize(Type.typeinfostruct, 17 * target.ptrsize);
         else
             verifyStructSize(Type.typeinfostruct, 15 * target.ptrsize);


### PR DESCRIPTION
Reverts dlang/dmd#16669

I object to this because nobody knows what isLP64 actually means. I know it's supposed to mean 64 bit pointers. But, in usage, it gets conflated with "are registers 64 bits". When starting the AArch64 support, I noticed a fair amount of confused use of it in the source code.

So, I switched it to x86_64 and AArch64, and tried to use them completely consistently in the source code. Those both have very specific meanings - 64 bit registers and 64 bit pointers. They are industry standard terms. I refactored all use of them to be consistent with this.

isLP64 is like strcpy to me. Always I have to stop and check if it is used properly. I have to always check if it is set properly. It sucks up time again and again. When I see `isX86_64 || isAArch64` I don't have to check.

A refactoring that would help would be to change target.isAArch64 to target.AArch64 so that it exactly matches the predefined version for it (I've already made this change in the backend). I'd prefer to rename X86_64 usage to x86_64 as well, as that capitalization is the industry standard casing. (Unfortunately, X86_64 is the version condition.)

It's better to not have to mentally do these translations all the time.

I also have long experience with the tangle of overlapping and constantly misused architecture #defines in the C DOS/Windows/Linux world, and really do not want to relive it.