### PR TITLE
initialize cgstate.allregs in cod3.d

### DIFF
--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -166,6 +166,7 @@ struct CGstate
 
     int BPoff;                  // offset from BP
     int EBPtoESP;               // add to EBP offset to get ESP offset
+    reg_t BP;                   // frame pointer
     REGSAVE regsave;
 
     targ_size_t spoff;
@@ -219,6 +220,8 @@ struct CGstate
 
     int dfoidx;                 // which block we are in
     regm_t allregs;             // ALLREGS optionally including mBP
+    regm_t fpregs;              // all floating point registers
+    regm_t xmmregs;             // all XMM registers
     regm_t mfuncreg;            // mask of registers preserved by function
     regm_t msavereg;            // Mask of registers that we would like to save.
                                 // they are temporaries (set by scodelem())
@@ -226,6 +229,8 @@ struct CGstate
     uint usednteh;              // if !=0, then used NT exception handling
     con_t regcon;               // register contents
     BackendPass pass;
+
+    bool AArch64;               // true if AArch64 code generator
 
     int cmp_flag;               // pass extra flag from cdcod() to cdcmp()
     /**********************************

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -81,7 +81,6 @@ void codgen(Symbol *sfunc)
 
     cgreg_init();
     CSE.initialize();
-    cgstate.allregs = ALLREGS;
     cgstate.Alloca.initialize();
     cgstate.anyiasm = 0;
 

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -348,6 +348,7 @@ void cod3_set32()
         v = W|T|6;
 
     TARGET_STACKALIGN = config.fpxmmregs ? 16 : 4;
+    cgstate.allregs = mAX|mBX|mCX|mDX|mSI|mDI;
 }
 
 /********************************
@@ -375,6 +376,7 @@ void cod3_set64()
         v = W|T|6;
 
     TARGET_STACKALIGN = config.fpxmmregs ? 16 : 8;
+    cgstate.allregs = mAX|mBX|mCX|mDX|mSI|mDI| mR8|mR9|mR10|mR11|mR12|mR13|mR14|mR15;
 }
 
 /*********************************


### PR DESCRIPTION
To make AArch64 less complex, I moved the initialization of cgstate.allregs to cod3.d.

I would have done it in https://github.com/dlang/dmd/pull/16554, but testing on that one is blocked by https://github.com/dlang/dmd/pull/16815