### PR TITLE
Fix bugzilla 23812 - ImportC: allow adding function attributes to imp…

### DIFF
--- a/changelog/dmd.importc-pragma-stc.dd
+++ b/changelog/dmd.importc-pragma-stc.dd
@@ -1,0 +1,26 @@
+A pragma for ImportC allows to set `nothrow`, `@nogc` or `pure`
+
+The following new pragma for ImportC allows to set default storage
+classes for function declarations:
+```
+#pragma attribute(push, [storage classes...])
+```
+The storage classes `nothrow`, `nogc` and `pure` are supported.
+Unrecognized attributes are ignored.
+Enabling a default storage class affects all function declarations
+after the pragma until it is disabled with another pragma.
+Declarations in includes are also affected. The following example
+enables `@nogc` and `nothrow` for a library:
+
+```
+#pragma attribute(push, nogc, nothrow)
+#include <somelibrary.h>
+```
+
+The changed storage classes are pushed on a stack. The last change can
+be undone with the following pragma:
+```
+#pragma attribute(pop)
+```
+This can also disable multiple default storage classes at the same time,
+if they were enabled with a single `#pragma attribute(push, ...)` directive.

--- a/compiler/test/compilable/imports/imp23812.c
+++ b/compiler/test/compilable/imports/imp23812.c
@@ -1,0 +1,35 @@
+
+void funcDefault(void);
+
+#pragma attribute(push, nothrow)
+void funcNothrow(void);
+#pragma attribute(pop)
+
+#pragma attribute(push, nogc)
+void funcNogc(void);
+#pragma attribute(pop)
+
+#pragma attribute(push, pure)
+void funcPure(void);
+#pragma attribute(pop)
+
+#pragma attribute(push, nothrow, nogc)
+void funcNothrowNogc(void);
+#pragma attribute(pop)
+
+void funcDefault2(void);
+
+#pragma attribute(push, nothrow)
+#pragma attribute(push, nogc)
+void funcNothrowNogc2(void);
+#pragma attribute(pop)
+void funcNothrow2(void);
+#pragma attribute(pop)
+
+#pragma attribute(push, nothrow)
+void funcWithCallback(void (*f)(void));
+struct Callbacks
+{
+    void (*f)(void);
+};
+#pragma attribute(pop)

--- a/compiler/test/compilable/test23812.d
+++ b/compiler/test/compilable/test23812.d
@@ -1,0 +1,75 @@
+// EXTRA_FILES: imports/imp23812.c
+
+import imports.imp23812;
+
+void callDefault()
+{
+    funcDefault();
+    funcDefault2();
+}
+
+static assert(!__traits(compiles, () nothrow { funcDefault(); } ));
+static assert(!__traits(compiles, () @nogc { funcDefault(); } ));
+static assert(!__traits(compiles, () pure { funcDefault(); } ));
+
+static assert(!__traits(compiles, () nothrow { funcDefault2(); } ));
+static assert(!__traits(compiles, () @nogc { funcDefault2(); } ));
+static assert(!__traits(compiles, () pure { funcDefault2(); } ));
+
+void callNothrow() nothrow
+{
+    funcNothrow();
+    funcNothrow2();
+}
+
+static assert(!__traits(compiles, () @nogc { funcNothrow(); } ));
+static assert(!__traits(compiles, () pure { funcNothrow(); } ));
+
+static assert(!__traits(compiles, () @nogc { funcNothrow2(); } ));
+static assert(!__traits(compiles, () pure { funcNothrow2(); } ));
+
+void callNogc() @nogc
+{
+    funcNogc();
+}
+
+static assert(!__traits(compiles, () nothrow { funcNogc(); } ));
+static assert(!__traits(compiles, () pure { funcNogc(); } ));
+
+void callPure() pure
+{
+    funcPure();
+}
+
+static assert(!__traits(compiles, () nothrow { funcPure(); } ));
+static assert(!__traits(compiles, () @nogc { funcPure(); } ));
+
+void callNothrowNogc() nothrow @nogc
+{
+    funcNothrowNogc();
+    funcNothrowNogc2();
+}
+
+static assert(!__traits(compiles, () pure { funcNothrowNogc(); } ));
+
+static assert(!__traits(compiles, () pure { funcNothrowNogc2(); } ));
+
+extern(C) void callbackDefault()
+{
+}
+
+extern(C) void callbackNothrow() nothrow
+{
+}
+
+void callFuncWithCallback() nothrow
+{
+    funcWithCallback(&callbackNothrow);
+
+    Callbacks callbacks;
+    callbacks.f = &callbackNothrow;
+}
+
+static assert(!__traits(compiles, () { funcWithCallback(&callbackDefault); } ));
+
+static assert(!__traits(compiles, () { Callbacks callbacks; callbacks.f = &callbackDefault; } ));


### PR DESCRIPTION
…orted C functions

This adds a new pragma for ImportC, which allows to set default storage classes. Only `nothrow`, `@nogc` and `pure` are supported for now. They can be disabled later ~~with the same pragma using a minus~~ using ~~`#pragma D pop`~~ `#pragma attribute(pop)`.

Unknown pragmas are ignored.

~~The pragma starts with identifier `D` to avoid conflicts.~~