### PR TITLE
druntime: add support for LoongArch64 on musl and libunwind

### DIFF
--- a/druntime/src/core/internal/backtrace/libunwind.d
+++ b/druntime/src/core/internal/backtrace/libunwind.d
@@ -154,5 +154,10 @@ else version (RISCV64) // 32 is not supported
     enum _LIBUNWIND_CONTEXT_SIZE = 64;
     enum _LIBUNWIND_CURSOR_SIZE = 76;
 }
+else version (LoongArch64)
+{
+    enum _LIBUNWIND_CONTEXT_SIZE = 65;
+    enum _LIBUNWIND_CURSOR_SIZE = 77;
+}
 else
     static assert(0, "Platform not supported");

--- a/druntime/src/core/stdc/fenv.d
+++ b/druntime/src/core/stdc/fenv.d
@@ -432,6 +432,14 @@ else version (CRuntime_Musl)
         }
         alias ushort fexcept_t;
     }
+    else version (LoongArch64)
+    {
+        struct fenv_t
+        {
+            uint __cw;
+        }
+        alias uint fexcept_t;
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/druntime/src/core/sys/posix/signal.d
+++ b/druntime/src/core/sys/posix/signal.d
@@ -2758,6 +2758,11 @@ else version (CRuntime_Musl)
         enum MINSIGSTKSZ = 2048;
         enum SIGSTKSZ    = 8192;
     }
+    else version (LoongArch64)
+    {
+        enum MINSIGSTKSZ = 4096;
+        enum SIGSTKSZ    = 16384;
+    }
     else
         static assert(0, "unimplemented");
 


### PR DESCRIPTION
Add support for LoongArch64 on musl and libunwind.