### PR TITLE
Show nested template function signature in candidate message

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1799,13 +1799,16 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
             if (!print)
                 return true;
 
+            // if td.onemember is a function, toCharsMaybeConstraints can print it
+            // without us recursing, otherwise we have to handle it.
             // td.onemember may not have overloads set
             // (see fail_compilation/onemember_overloads.d)
             // assume if more than one member it is overloaded internally
-            bool recurse = td.onemember && td.members.length > 1;
+            bool recurse = td.onemember && (!td.onemember.isFuncDeclaration ||
+                td.members.length > 1);
             OutBuffer buf;
             HdrGenState hgs;
-            hgs.skipConstraints = true;
+            hgs.skipConstraints = true; // failing constraint should get printed below
             hgs.showOneMember = !recurse;
             toCharsMaybeConstraints(td, buf, hgs);
             const tmsg = buf.peekChars();

--- a/compiler/test/fail_compilation/nested_template_constraint.d
+++ b/compiler/test/fail_compilation/nested_template_constraint.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/nested_template_constraint.d(17): Error: template `foo` is not callable using argument types `!()(string, int)`
+fail_compilation/nested_template_constraint.d(10):        Candidate is: `foo(int x = 0)`
+fail_compilation/nested_template_constraint.d(11):          - Containing: `foo(T, U)(T t, U u)`
+---
+*/
+
+template foo(int x = 0) {
+    void foo(T, U)(T t, U u)
+        if (is(T == int) && is(U == int)) {}
+}
+
+void main()
+{
+    foo("hello", 4);
+}


### PR DESCRIPTION
The failing constraint message is still missing, but at least we can see the inner signature now.

Part of Bugzilla 20713 - Improve Template Deduction Error Message Given Template Parameter Default Values