### PR TITLE
Add druntime hook to stop the world

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -1699,6 +1699,13 @@ private extern (D) bool suspend( Thread t ) nothrow @nogc
 }
 
 /**
+ * Runs the necessary operations required before stopping the world.
+ */
+extern (C) void thread_preStopTheWorld() nothrow {
+    Thread.slock.lock_nothrow();
+}
+
+/**
  * Suspend all threads but the calling thread for "stop the world" garbage
  * collection runs.  This function may be called multiple times, and must
  * be followed by a matching number of calls to thread_resumeAll before
@@ -1730,7 +1737,7 @@ extern (C) void thread_suspendAll() nothrow
         return;
     }
 
-    Thread.slock.lock_nothrow();
+    thread_preStopTheWorld();
     {
         if ( ++suspendDepth > 1 )
             return;
@@ -2199,7 +2206,7 @@ else version (Posix)
 
             if ( !obj.m_lock )
             {
-                obj.m_curr.tstack = getStackTop();
+                obj.m_curr.tstack = sp;
             }
         }
 

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -966,6 +966,13 @@ package __gshared uint suspendDepth = 0;
 private alias resume = externDFunc!("core.thread.osthread.resume", void function(ThreadBase) nothrow @nogc);
 
 /**
+ * Run the necessary operation required after the world was resumed.
+ */
+extern (C) void thread_postRestartTheWorld() nothrow {
+    ThreadBase.slock.unlock_nothrow();
+}
+
+/**
  * Resume all threads but the calling thread for "stop the world" garbage
  * collection runs.  This function must be called once for each preceding
  * call to thread_suspendAll before the threads are actually resumed.
@@ -991,7 +998,7 @@ do
         return;
     }
 
-    scope(exit) ThreadBase.slock.unlock_nothrow();
+    scope(exit) thread_postRestartTheWorld();
     {
         if (--suspendDepth > 0)
             return;


### PR DESCRIPTION
When working on our own GC, we ran into the fact that the critical section feature was broken. This lead us to have to write or own stop the world routine. However, there were important pieces of druntime that were not accessible to us when doing so. This adds the appropriate hooks into druntime required for a 3rd party GC to stop the world.