### PR TITLE
fix Bugzilla Issue 24749 throw block moved to end of function

### DIFF
--- a/compiler/src/dmd/backend/blockopt.d
+++ b/compiler/src/dmd/backend/blockopt.d
@@ -2262,7 +2262,8 @@ private void blassertsplit()
 @trusted
 private void blexit()
 {
-    debug if (debugc) printf("blexit()\n");
+    debug if (debugc)
+        printf("blexit()\n");
 
     Barray!(block*) bexits;
     for (block *b = startblock; b; b = b.Bnext)
@@ -2273,7 +2274,14 @@ private void blexit()
             continue;
 
         if (b.BC == BCexit)
+        {
+            /* If b is not already at the end, put it at the end
+             * because we don't care about speed for BCexit blocks
+             */
+            if (b != startblock && b.Bnext && b.Bnext.BC != BCexit)
+                bexits.push(b);
             continue;
+        }
 
         if (!b.Belem || el_returns(b.Belem))
             continue;

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -88,15 +88,12 @@ void codgen(Symbol *sfunc)
     cgstate.AArch64 = config.target_cpu == TARGET_AArch64;
     cgstate.BP = cgstate.AArch64 ? 29 : BP;
 
-    if (config.ehmethod == EHmethod.EH_DWARF)
+    /* Sadly, the dwarf and Windows unwinders relies on the function epilog to exist
+     */
+    for (block* b = startblock; b; b = b.Bnext)
     {
-        /* The dwarf unwinder relies on the function epilog to exist
-         */
-        for (block* b = startblock; b; b = b.Bnext)
-        {
-            if (b.BC == BCexit)
-                b.BC = BCret;
-        }
+        if (b.BC == BCexit)
+            b.BC = BCret;
     }
 
     /* Generate code repeatedly until we cannot do any better. Each


### PR DESCRIPTION
A branch optimization thing.

Doesn't need a test case, there are likely many of these.