### PR TITLE
fix Bugzilla 24745 - improve associative array syntax error message

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -6812,7 +6812,6 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             {
                 case TOK.identifier:
                 {
-
                     if (commaExpected)
                         error("comma expected separating field initializers");
                     const t = peek(&token);
@@ -6846,6 +6845,20 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 default:
                     if (commaExpected)
                         error("comma expected separating field initializers");
+                    const t = peek(&token);
+                    if (t.value == TOK.colon)
+                    {
+                        error("incorrect syntax for associative array, expected `[]`, found `{}`");
+                        while (token.value != TOK.rightCurly && token.value != TOK.endOfFile)
+                        {
+                            nextToken();
+                        }
+                        if (token.value == TOK.rightCurly)
+                        {
+                            nextToken();
+                        }
+                        break;
+                    }
                     auto value = parseInitializer();
                     _is.addInit(null, value);
                     commaExpected = true;

--- a/compiler/test/fail_compilation/test24745.d
+++ b/compiler/test/fail_compilation/test24745.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=24745
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test24745.d(12): Error: incorrect syntax for associative array, expected `[]`, found `{}`
+---
+*/
+
+void main()
+{
+    int[int] f = {1: 1, 2: 2};
+}


### PR DESCRIPTION
Enhance error messages for associative array syntax.