### PR TITLE
compiler/test/fail_compilation/needspkgmod.d: pass -L--no-demangle

### DIFF
--- a/compiler/test/fail_compilation/needspkgmod.d
+++ b/compiler/test/fail_compilation/needspkgmod.d
@@ -3,7 +3,7 @@
 // ARG_SETS: -i=,imports.pkgmod313
 // ARG_SETS: -i=imports.pkgmod313,-imports.pkgmod313.mod
 // ARG_SETS: -i=imports.pkgmod313.package,-imports.pkgmod313.mod
-// REQUIRED_ARGS: -Icompilable
+// REQUIRED_ARGS: -Icompilable -L--no-demangle
 // LINK:
 /*
 TEST_OUTPUT:


### PR DESCRIPTION
The bfd linker since version 2.43 automatically demangles D symbols. It could do this before as well, though it was not automatic, it required the `--demangle=dlang` switch.

I wasn't sure whether to modify the regex to match the demangled symbol as well or just pass `--no-demangle` but since other parts of the test suite use `--no-demangle` I went with it.