### PR TITLE
Fix Bugzilla Issue 24760 - ICE on variadic after default argument

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -835,7 +835,9 @@ extern (D) MATCH callMatch(TypeFunction tf, Type tthis, ArgumentList argumentLis
         L1:
             if (parameterList.varargs == VarArg.typesafe && u + 1 == nparams) // if last varargs param
             {
-                auto trailingArgs = args[u .. $];
+                Expression[] trailingArgs;
+                if (args.length >= u)
+                    trailingArgs = args[u .. $];
                 if (auto vmatch = matchTypeSafeVarArgs(tf, p, trailingArgs, pMessage))
                     return vmatch < match ? vmatch : match;
                 // Error message was already generated in `matchTypeSafeVarArgs`

--- a/compiler/test/compilable/test24760.d
+++ b/compiler/test/compilable/test24760.d
@@ -1,0 +1,4 @@
+// https://issues.dlang.org/show_bug.cgi?id=24760
+
+long f(int e = 0, uint[] optional...) => optional.length;
+long f0() => f(); // compiler segfaults


### PR DESCRIPTION
This used to be illegal prior to the addition of named arguments, however, now it has become legal. One way to fix this would have been to disallow this pattern, but since the fix is quite simple I just went ahead and accepted it as valid code.

Not targeting stable as I'm having doubts that this is a pattern we should support.