### PR TITLE
Fix Bugzilla Issue 24762 - @nogc false positive error

### DIFF
--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -338,7 +338,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         const save = sc.stc;
         if (e.ident == Id.isDeprecated)
             sc.stc |= STC.deprecated_;
-        if (!TemplateInstance.semanticTiargs(e.loc, sc, e.args, 1))
+        Scope* sc2 = sc.startCTFE();
+        scope(exit) { sc2.endCTFE(); }
+        if (!TemplateInstance.semanticTiargs(e.loc, sc2, e.args, 1))
         {
             sc.stc = save;
             return ErrorExp.get();

--- a/compiler/test/compilable/test24762.d
+++ b/compiler/test/compilable/test24762.d
@@ -1,0 +1,11 @@
+// https://issues.dlang.org/show_bug.cgi?id=24762
+
+struct S { int m; }
+
+string m() { return "m"; }
+@nogc void f()
+{
+    S s;
+    enum t = m();
+    auto x = __traits(getMember, s, m()); // Error: `@nogc` function `nogc.f` cannot call non-@nogc function `nogc.m`
+}


### PR DESCRIPTION
Push a ctfe scope when evaluating an expression inside a traits block.