### PR TITLE
move `checkClosure` to semantic3.d

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -419,6 +419,11 @@ void semanticTypeInfoMembers(StructDeclaration sd)
     return dmd.semantic3.semanticTypeInfoMembers(sd);
 }
 
+bool checkClosure(FuncDeclaration fd)
+{
+    import dmd.semantic3;
+    return dmd.semantic3.checkClosure(fd);
+}
 /***********************************************************
  * statementsem.d
  */

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -34,6 +34,7 @@ namespace dmd
 {
     bool functionSemantic(FuncDeclaration* fd);
     bool functionSemantic3(FuncDeclaration* fd);
+    bool checkClosure(FuncDeclaration* fd);
     MATCH leastAsSpecialized(FuncDeclaration *f, FuncDeclaration *g, Identifiers *names);
     PURE isPure(FuncDeclaration *f);
 }
@@ -732,7 +733,6 @@ public:
     const char *kind() const override;
     bool isUnique();
     bool needsClosure();
-    bool checkClosure();
     bool hasNestedFrameRefs();
     ParameterList getParameterList();
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3803,7 +3803,6 @@ public:
     const char* kind() const override;
     bool isUnique() const;
     bool needsClosure();
-    bool checkClosure();
     bool hasNestedFrameRefs();
     ParameterList getParameterList();
     static FuncDeclaration* genCfunc(Array<Parameter* >* fparams, Type* treturn, const char* name, StorageClass stc = 0);

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -18,6 +18,7 @@ import core.stdc.stdio;
 import dmd.aggregate;
 import dmd.astenums;
 import dmd.declaration;
+import dmd.dmodule;
 import dmd.dscope;
 import dmd.dtemplate : isDsymbol;
 import dmd.errors;
@@ -25,6 +26,7 @@ import dmd.expression;
 import dmd.func;
 import dmd.globals;
 import dmd.init;
+import dmd.location;
 import dmd.mtype;
 import dmd.postordervisitor;
 import dmd.tokens;
@@ -232,6 +234,18 @@ Expression checkGC(Scope* sc, Expression e)
         }
     }
     return e;
+}
+
+extern (D) void printGCUsage(FuncDeclaration fd, const ref Loc loc, const(char)* warn)
+{
+    if (!global.params.v.gc)
+        return;
+
+    Module m = fd.getModule();
+    if (m && m.isRoot() && !fd.inUnittest())
+    {
+        message(loc, "vgc: %s", warn);
+    }
 }
 
 /**

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -53,6 +53,7 @@ import dmd.identifier;
 import dmd.id;
 import dmd.location;
 import dmd.mtype;
+import dmd.semantic3 : checkClosure;
 import dmd.typesem;
 import dmd.target;
 import dmd.tocvdebug;


### PR DESCRIPTION
This is unused directly by LDC I'm making the assumption the same is true for GDC

e: apparently not, https://github.com/D-Programming-GDC/gcc/blob/507bbf95116dacbc87c79e6b9ae4b39b2f7bd886/gcc/d/d-codegen.cc#L2918

that's a tomorrow problem