### PR TITLE
Ensure thread_preSuspend and thread_postSuspend can be called in detached threads.

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -2197,27 +2197,37 @@ else version (Posix)
         __gshared sem_t suspendCount;
 
 
-        extern (C) void thread_preSuspend( void* sp ) nothrow {
+        extern (C) bool thread_preSuspend( void* sp ) nothrow {
             // NOTE: Since registers are being pushed and popped from the
             //       stack, any other stack data used by this function should
             //       be gone before the stack cleanup code is called below.
             Thread obj = Thread.getThis();
-            assert(obj !is null);
+            if (obj is null)
+            {
+                return false;
+            }
 
             if ( !obj.m_lock )
             {
                 obj.m_curr.tstack = sp;
             }
+
+            return true;
         }
 
-        extern (C) void thread_postSuspend() nothrow {
+        extern (C) bool thread_postSuspend() nothrow {
             Thread obj = Thread.getThis();
-            assert(obj !is null);
+            if (obj is null)
+            {
+                return false;
+            }
 
             if ( !obj.m_lock )
             {
                 obj.m_curr.tstack = obj.m_curr.bstack;
             }
+
+            return true;
         }
 
         extern (C) void thread_suspendHandler( int sig ) nothrow
@@ -2229,8 +2239,14 @@ else version (Posix)
         {
             void op(void* sp) nothrow
             {
-                thread_preSuspend(getStackTop());
-                scope(exit) thread_postSuspend();
+                bool supported = thread_preSuspend(getStackTop());
+                assert(supported, "Tried to suspend a detached tread!");
+
+                scope(exit)
+                {
+                    supported = thread_postSuspend();
+                    assert(supported, "Tried to suspend a detached tread!");
+                }
 
                 sigset_t    sigres = void;
                 int         status;


### PR DESCRIPTION
It's difficult for a 3rd party software interacting with this to know if a thread is detached or not, so making them transparent is easier.