### PR TITLE
Disallow qualified types in base class list

### DIFF
--- a/changelog/dmd.basic-vs-primary-type.dd
+++ b/changelog/dmd.basic-vs-primary-type.dd
@@ -1,0 +1,13 @@
+The term *basic type* is now *primary type*
+
+The parser now uses the term *primary type* for what used to be referred to as *basic type.*
+The term *basic type* is used specifically for type expressions that are not immediately recursive.
+
+A *basic type* is a *fundamental type* (those which have keywords)
+or a type given by an identifier, a `typeof`, a `mixin`, or a `__traits`.
+Absent from this list are `__vector` types and types spelled out using a qualifier and parentheses (e.g. `const(int)`).
+
+A *primary type* is a *basic type* or a `__vector` type or a qualified type.
+
+For the most part, *primary type* is the term you want to use and will see in error messages now.
+There are some corners where indeed a *basic type* is required.

--- a/changelog/dmd.const-base.dd
+++ b/changelog/dmd.const-base.dd
@@ -1,0 +1,18 @@
+Specifying a qualified type as a base class or interface is an error now
+
+A type like `const(Object)` could be used as a base class in the base class list
+of a class or interface declaration or of an anonymous class object.
+There, qualifiers were simply ignored semantically.
+
+Explicitly qualifying types in base class lists is a parse error now.
+
+This only affects parsing.
+If a `mixin` or `typeof` or an identifier is used, nothing changes.
+If it resolves to a qualified type,
+the qualifier is ignored.
+---
+class C : const(Object) { } // Parse error now
+auto obj = new class const(Object) { }; // Parse error now
+---
+There is no deprecation period.
+The fix is to remove the unnecessary and misleading qualifier from your code.

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3702,8 +3702,6 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     private AST.Type parsePrimaryType(bool dontLookDotIdents = false)
     {
         AST.Type t;
-        Loc loc;
-        Identifier id;
         //printf("parsePrimaryType()\n");
         switch (token.value)
         {

--- a/compiler/test/compilable/test1353.d
+++ b/compiler/test/compilable/test1353.d
@@ -6,9 +6,9 @@ interface D(X) {}
 
 void fun()
 {
-    class T : typeof(new A), .B, const(C), D!int {}
+    class T : typeof(new A), .B, C, D!int {}
     version(none)
     {
-        class U : int, float, __vector(int[3]) {}
+        class U : int, float {}
     }
 }

--- a/compiler/test/fail_compilation/b20780.d
+++ b/compiler/test/fail_compilation/b20780.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/b20780.d(10): Error: `@identifier` or `@(ArgumentList)` expected, not `@)`
 fail_compilation/b20780.d(11): Error: `@identifier` or `@(ArgumentList)` expected, not `@,`
-fail_compilation/b20780.d(11): Error: basic type expected, not `,`
+fail_compilation/b20780.d(11): Error: primary type expected, not `,`
 ---
 */
 

--- a/compiler/test/fail_compilation/diag19225.d
+++ b/compiler/test/fail_compilation/diag19225.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag19225.d(14): Error: basic type expected, not `else`
+fail_compilation/diag19225.d(14): Error: primary type expected, not `else`
 fail_compilation/diag19225.d(14):        There's no `static else`, use `else` instead.
 fail_compilation/diag19225.d(14): Error: found `else` without a corresponding `if`, `version` or `debug` statement
 fail_compilation/diag19225.d(15): Error: unmatched closing brace

--- a/compiler/test/fail_compilation/e15876_3.d
+++ b/compiler/test/fail_compilation/e15876_3.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/e15876_3.d(28): Error: unexpected `(` in declarator
-fail_compilation/e15876_3.d(28): Error: basic type expected, not `=`
+fail_compilation/e15876_3.d(28): Error: primary type expected, not `=`
 fail_compilation/e15876_3.d(29): Error: found `End of File` when expecting `(`
 fail_compilation/e15876_3.d(29): Error: found `End of File` instead of statement
 fail_compilation/e15876_3.d(29): Error: expression expected, not `End of File`

--- a/compiler/test/fail_compilation/e15876_5.d
+++ b/compiler/test/fail_compilation/e15876_5.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/e15876_5.d(17): Error: basic type expected, not `End of File`
+fail_compilation/e15876_5.d(17): Error: primary type expected, not `End of File`
 fail_compilation/e15876_5.d(17): Error: semicolon expected to close `alias` declaration, not `End of File`
 fail_compilation/e15876_5.d(17): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/e15876_5.d(16):        unmatched `{`

--- a/compiler/test/fail_compilation/enum_member.d
+++ b/compiler/test/fail_compilation/enum_member.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/enum_member.d(14): Error: basic type expected, not `for`
+fail_compilation/enum_member.d(14): Error: primary type expected, not `for`
 fail_compilation/enum_member.d(15): Error: no identifier for declarator `T`
 fail_compilation/enum_member.d(15): Error: found `@` when expecting `,`
 fail_compilation/enum_member.d(22): Error: found `}` when expecting `identifier`

--- a/compiler/test/fail_compilation/fail15667.d
+++ b/compiler/test/fail_compilation/fail15667.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/imports/a15667.d(16): Error: basic type expected, not `;`
+fail_compilation/imports/a15667.d(16): Error: primary type expected, not `;`
 fail_compilation/imports/a15667.d(19): Error: declaration expected following attribute, not end of file
 ---
 */

--- a/compiler/test/fail_compilation/ice11982.d
+++ b/compiler/test/fail_compilation/ice11982.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11982.d(22): Error: basic type expected, not `scope`
+fail_compilation/ice11982.d(22): Error: primary type expected, not `scope`
 fail_compilation/ice11982.d(22): Error: found `scope` when expecting `;` following expression
 fail_compilation/ice11982.d(22):        expression: `new _error_`
-fail_compilation/ice11982.d(22): Error: basic type expected, not `}`
+fail_compilation/ice11982.d(22): Error: primary type expected, not `}`
 fail_compilation/ice11982.d(22): Error: missing `{ ... }` for function literal
 fail_compilation/ice11982.d(22): Error: C style cast illegal, use `cast(funk)function _error_()
 {

--- a/compiler/test/fail_compilation/ice15127.d
+++ b/compiler/test/fail_compilation/ice15127.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice15127.d(17): Error: basic type expected, not `struct`
+fail_compilation/ice15127.d(17): Error: primary type expected, not `struct`
 fail_compilation/ice15127.d(17): Error: identifier expected for template value parameter
 fail_compilation/ice15127.d(17): Error: found `struct` when expecting `)`
 fail_compilation/ice15127.d(17): Error: found `ExampleStruct` when expecting `=`

--- a/compiler/test/fail_compilation/misc_parser_err_cov1.d
+++ b/compiler/test/fail_compilation/misc_parser_err_cov1.d
@@ -2,8 +2,8 @@
 REQUIRED_ARGS: -verrors=0
 TEST_OUTPUT:
 ---
-fail_compilation/misc_parser_err_cov1.d(29): Error: basic type expected, not `)`
-fail_compilation/misc_parser_err_cov1.d(30): Error: basic type expected, not `)`
+fail_compilation/misc_parser_err_cov1.d(29): Error: primary type expected, not `)`
+fail_compilation/misc_parser_err_cov1.d(30): Error: primary type expected, not `)`
 fail_compilation/misc_parser_err_cov1.d(31): Error: `__traits(identifier, args...)` expected
 fail_compilation/misc_parser_err_cov1.d(31): Error: semicolon expected following auto declaration, not `o`
 fail_compilation/misc_parser_err_cov1.d(31): Error: expression expected, not `)`

--- a/compiler/test/fail_compilation/qualbaseclass1.d
+++ b/compiler/test/fail_compilation/qualbaseclass1.d
@@ -1,0 +1,12 @@
+/* TEST_OUTPUT:
+---
+fail_compilation\qualbaseclass1.d(101): Error: basic type expected, not `const`
+fail_compilation\qualbaseclass1.d(101): Error: { } expected following `class` declaration
+fail_compilation\qualbaseclass1.d(101): Error: no identifier for declarator `const(Object)`
+fail_compilation\qualbaseclass1.d(101): Error: declaration expected, not `{`
+---
+ */
+
+#line 100
+
+class C : const(Object) { }

--- a/compiler/test/fail_compilation/qualbaseclass2.d
+++ b/compiler/test/fail_compilation/qualbaseclass2.d
@@ -1,0 +1,15 @@
+/* TEST_OUTPUT:
+---
+fail_compilation\qualbaseclass2.d(103): Error: basic type expected, not `const`
+fail_compilation\qualbaseclass2.d(103): Error: `{ members }` expected for anonymous class
+fail_compilation\qualbaseclass2.d(103): Error: semicolon expected following auto declaration, not `const`
+fail_compilation\qualbaseclass2.d(103): Error: no identifier for declarator `const(Object)`
+---
+ */
+
+#line 100
+
+void test()
+{
+    auto obj = new class () const(Object) { };
+}

--- a/compiler/test/fail_compilation/udaparams.d
+++ b/compiler/test/fail_compilation/udaparams.d
@@ -18,10 +18,10 @@ fail_compilation/udaparams.d(53): Error: semicolon expected to close `alias` dec
 fail_compilation/udaparams.d(53): Error: declaration expected, not `=>`
 fail_compilation/udaparams.d(54): Error: semicolon expected to close `alias` declaration, not `=>`
 fail_compilation/udaparams.d(54): Error: declaration expected, not `=>`
-fail_compilation/udaparams.d(57): Error: basic type expected, not `@`
+fail_compilation/udaparams.d(57): Error: primary type expected, not `@`
 fail_compilation/udaparams.d(57): Error: identifier expected for template value parameter
 fail_compilation/udaparams.d(57): Error: found `@` when expecting `)`
-fail_compilation/udaparams.d(57): Error: basic type expected, not `3`
+fail_compilation/udaparams.d(57): Error: primary type expected, not `3`
 fail_compilation/udaparams.d(57): Error: found `3` when expecting `)`
 fail_compilation/udaparams.d(57): Error: semicolon expected following function declaration, not `)`
 fail_compilation/udaparams.d(57): Error: declaration expected, not `)`


### PR DESCRIPTION
Currently, it is allowed that a base class is a qualified type.
```d
class C : const(Object) { }
auto obj = new class const(Object) { };
```
The qualifier is ignored. For that reason, this change makes it a parse error, so no code fools a reader into thinking the `const` does something. Semantics are unaffected, i.e. if a `typeof` type is used which ends up being a qualified class type, the unqualified version of that class type remains a base class (no error).

The assumption of this PR is that no-one actually has qualified base classes in their code base (because the qualifier does nothing but mislead the reader).

It is in the interest of the Primary Type Syntax DIP and possibly future tuple DIPs to avoid parsing ambiguities. This can be done by requiring the base class list to be lexically comprised of new-terminology basic types. Refer to the [accompanying spec PR](https://github.com/dlang/dlang.org/pull/3917) for details.