### PR TITLE
Memoize initializerSemantic

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4035,6 +4035,7 @@ class Initializer : public ASTNode
 public:
     Loc loc;
     InitKind kind;
+    bool semanticDone;
     DYNCAST dyncast() const override;
     ErrorInitializer* isErrorInitializer();
     VoidInitializer* isVoidInitializer();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4054,7 +4054,6 @@ public:
     Array<Initializer* > value;
     uint32_t dim;
     Type* type;
-    bool sem;
     bool isCarray;
     bool isAssociativeArray() const;
     void accept(Visitor* v) override;
@@ -4065,7 +4064,6 @@ class CInitializer final : public Initializer
 public:
     Array<DesigInit > initializerList;
     Type* type;
-    bool sem;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/init.d
+++ b/compiler/src/dmd/init.d
@@ -38,6 +38,7 @@ extern (C++) class Initializer : ASTNode
 {
     Loc loc;
     InitKind kind;
+    bool semanticDone = false; /// initializerSemantic has been run on this
 
     override DYNCAST dyncast() const
     {

--- a/compiler/src/dmd/init.d
+++ b/compiler/src/dmd/init.d
@@ -177,7 +177,6 @@ extern (C++) final class ArrayInitializer : Initializer
     Initializers value;     // of Initializer *'s
     uint dim;               // length of array being initialized
     Type type;              // type that array will be used to initialize
-    bool sem;               // true if semantic() is run
     bool isCarray;          // C array semantics
 
     extern (D) this(const ref Loc loc)
@@ -257,7 +256,6 @@ extern (C++) final class CInitializer : Initializer
 {
     DesigInits initializerList; /// initializer-list
     Type type;              /// type that array will be used to initialize
-    bool sem;               /// true if semantic() is run
 
     extern (D) this(const ref Loc loc)
     {

--- a/compiler/src/dmd/init.h
+++ b/compiler/src/dmd/init.h
@@ -33,6 +33,7 @@ class Initializer : public ASTNode
 public:
     Loc loc;
     unsigned char kind;
+    d_bool semanticDone;
 
     DYNCAST dyncast() const override { return DYNCAST_INITIALIZER; }
 

--- a/compiler/src/dmd/init.h
+++ b/compiler/src/dmd/init.h
@@ -86,7 +86,6 @@ public:
     Initializers value; // of Initializer *'s
     unsigned dim;       // length of array being initialized
     Type *type;         // type that array will be used to initialize
-    d_bool sem;           // true if semantic() is run
     d_bool isCarray;      // C array semantics
 
     bool isAssociativeArray() const;
@@ -120,7 +119,6 @@ class CInitializer final : public Initializer
 public:
     DesigInits initializerList;
     Type *type;         // type that array will be used to initialize
-    d_bool sem;           // true if semantic() is run
 
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -206,11 +206,6 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
         const(uint) amax = 0x80000000;
         bool errors = false;
         //printf("ArrayInitializer::semantic(%s), ai: %s\n", t.toChars(), toChars(i));
-        if (i.sem) // if semantic() already run
-        {
-            return i;
-        }
-        i.sem = true;
         t = t.toBasetype();
         switch (t.ty)
         {

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -106,6 +106,9 @@ Expression toAssocArrayLiteral(ArrayInitializer ai)
 Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedInterpret needInterpret)
 {
     //printf("initializerSemantic() tx: %p %s\n", tx, tx.toChars());
+    if (init.semanticDone)
+        return init;
+
     Type t = tx;
 
     static Initializer err()
@@ -1055,6 +1058,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
 
     mixin VisitInitializer!Initializer visit;
     auto result = visit.VisitInitializer(init);
+    result.semanticDone = true;
     return (result !is null) ? result : new ErrorInitializer();
 }
 


### PR DESCRIPTION
I found that on large global variables, the compiler spends lots of time creating GC pointer bitmaps by instantiating these templates in object.d:
```D
template RTInfoImpl(size_t[] pointerBitmap)
{
    immutable size_t[pointerBitmap.length] RTInfoImpl = pointerBitmap[];
}

template NoPointersBitmapPayload(size_t N)
{
    enum size_t[N] NoPointersBitmapPayload = 0;
}

template RTInfo(T)
{
    enum pointerBitmap = __traits(getPointerBitmap, T);
    static if (pointerBitmap[1 .. $] == NoPointersBitmapPayload!(pointerBitmap.length - 1))
        enum RTInfo = rtinfoNoPointers;
    else
        enum RTInfo = RTInfoImpl!(pointerBitmap).ptr;
}
```

A reduced test case is:
```D
enum uint[N] E(uint N) = 0;
immutable x = E!1000_000;
```

With templates, `initializerSemantic` is run twice, performing ctfe on a huge `ArrayLiteralExp` twice as well. semantic() should be an idempotent function, and 'semanticDone' flags are already in use on Dsymbol and Expression, so this PR extends that to Initializer.