### PR TITLE
func.d: Remove unused aav import

### DIFF
--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -46,7 +46,6 @@ import dmd.init;
 import dmd.location;
 import dmd.mtype;
 import dmd.objc;
-import dmd.root.aav;
 import dmd.common.outbuffer;
 import dmd.rootobject;
 import dmd.root.string;


### PR DESCRIPTION
Unused since its user has been moved from func.d to funcsem.d