### PR TITLE
backend: refactor duplicated aarray structs

### DIFF
--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -1075,12 +1075,12 @@ static if (1)
         {
             if (infoFileName_table)
             {
-                AAchars.destroy(infoFileName_table);
+                infoFileName_table.destroy();
                 infoFileName_table = null;
             }
             if (lineDirectories)
             {
-                AAchars.destroy(lineDirectories);
+                lineDirectories.destroy();
                 lineDirectories = null;
             }
 
@@ -1191,7 +1191,7 @@ static if (1)
             // Free only if starting another file. Waste of time otherwise.
             if (abbrev_table)
             {
-                AApair.destroy(abbrev_table);
+                abbrev_table.destroy();
                 abbrev_table = null;
             }
 
@@ -1389,7 +1389,7 @@ static if (1)
         uint *pidx = aachars.get(str);
         if (!*pidx)                 // if no idx assigned yet
         {
-            *pidx = aachars.length(); // assign newly computed idx
+            *pidx = cast(uint) aachars.length(); // assign newly computed idx
         }
         return *pidx;
     }
@@ -1488,13 +1488,13 @@ static if (1)
 
             if (config.dwarf >= 5)
             {
-                debug_line.buf.writeuLEB128(lineDirectories ? lineDirectories.length() : 0);   // directories_count
+                debug_line.buf.writeuLEB128(lineDirectories ? cast(uint) lineDirectories.length() : 0);   // directories_count
             }
 
             if (lineDirectories)
             {
                 // include_directories
-                auto dirkeys = lineDirectories.aa.keys();
+                auto dirkeys = lineDirectories.keys();
                 if (dirkeys)
                 {
                     foreach (id; 1 .. lineDirectories.length() + 1)
@@ -1533,13 +1533,13 @@ static if (1)
                 auto file_name_entry_format = FileNameEntryFormat.init;
                 debug_line.buf.write(&file_name_entry_format, file_name_entry_format.sizeof);
 
-                debug_line.buf.writeuLEB128(infoFileName_table ? infoFileName_table.length() : 0);  // file_names_count
+                debug_line.buf.writeuLEB128(infoFileName_table ? cast(uint) infoFileName_table.length() : 0);  // file_names_count
             }
 
             if (infoFileName_table)
             {
                 // file_names
-                auto filekeys = infoFileName_table.aa.keys();
+                auto filekeys = infoFileName_table.keys();
                 if (filekeys)
                 {
                     foreach (id; 1 .. infoFileName_table.length() + 1)
@@ -1706,12 +1706,12 @@ static if (1)
         // Free only if starting another file. Waste of time otherwise.
         if (type_table)
         {
-            AApair.destroy(type_table);
+            type_table.destroy();
             type_table = null;
         }
         if (functype_table)
         {
-            AApair.destroy(functype_table);
+            functype_table.destroy();
             functype_table = null;
         }
         if (functypebuf)
@@ -2626,7 +2626,7 @@ static if (1)
                  */
                 if (!functype_table)
                     functype_table = AApair.create(functypebuf.bufptr);
-                uint *pidx = cast(uint *)functype_table.get(functypebufidx, cast(uint)functypebuf.length());
+                uint *pidx = cast(uint *)functype_table.get(Pair(functypebufidx, cast(uint)functypebuf.length()));
                 if (*pidx)
                 {
                     // Reuse existing typidx
@@ -3044,7 +3044,7 @@ static if (1)
              */
             type_table = AApair.create(debug_info.buf.bufptr);
 
-        uint *pidx = type_table.get(idx, cast(uint)debug_info.buf.length());
+        uint *pidx = type_table.get(Pair(idx, cast(uint)debug_info.buf.length()));
         if (!*pidx)                 // if no idx assigned yet
         {
             *pidx = idx;            // assign newly computed idx
@@ -3174,7 +3174,7 @@ static if (1)
          * discard this one and use the previous one.
          */
 
-        uint *pcode = abbrev_table.get(cast(uint)start, cast(uint)end);
+        uint *pcode = abbrev_table.get(Pair(cast(uint) start, cast(uint) end));
         if (!*pcode)
         {
             // if no code assigned yet, assign newly computed code

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -481,7 +481,7 @@ private Pair* elf_addsectionname(const(char)* name, const(char)* suffix = null, 
         elfobj.section_names.setsize(cast(uint)elfobj.section_names.length() - 1);  // back up over terminating 0
         elfobj.section_names.writeStringz(suffix);
     }
-    Pair* pidx = elfobj.section_names_hashtable.get(namidx, cast(uint)elfobj.section_names.length() - 1);
+    Pair* pidx = elfobj.section_names_hashtable.get(Pair(namidx, cast(uint)elfobj.section_names.length() - 1));
     if (pidx.start)
     {
         // this section name already exists, remove addition
@@ -654,7 +654,7 @@ Obj ElfObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
         elfobj.section_names.writen(section_names_init64.ptr, section_names_init64.sizeof);
 
         if (elfobj.section_names_hashtable)
-            AApair2.destroy(elfobj.section_names_hashtable);
+            elfobj.section_names_hashtable.destroy();
         elfobj.section_names_hashtable = AApair2.create(elfobj.section_names.bufptr);
 
         // name,type,flags,addr,offset,size,link,info,addralign,entsize
@@ -676,7 +676,7 @@ Obj ElfObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
         foreach (idxname; __traits(allMembers, NAMIDX)[1 .. $])
         {
             NAMIDX idx = mixin("NAMIDX." ~ idxname);
-            elfobj.section_names_hashtable.get(idx, cast(uint)section_names_init64.sizeof).start = idx;
+            elfobj.section_names_hashtable.get(Pair(idx, cast(uint)section_names_init64.sizeof)).start = idx;
         }
     }
     else
@@ -688,7 +688,7 @@ Obj ElfObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
         elfobj.section_names.writen(section_names_init.ptr, section_names_init.sizeof);
 
         if (elfobj.section_names_hashtable)
-            AApair2.destroy(elfobj.section_names_hashtable);
+            elfobj.section_names_hashtable.destroy();
         elfobj.section_names_hashtable = AApair2.create(elfobj.section_names.bufptr);
 
         // name,type,flags,addr,offset,size,link,info,addralign,entsize
@@ -710,7 +710,7 @@ Obj ElfObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
         foreach (idxname; __traits(allMembers, NAMIDX)[1 .. $])
         {
             NAMIDX idx = mixin("NAMIDX." ~ idxname);
-            elfobj.section_names_hashtable.get(idx, cast(uint)section_names_init.sizeof).start = idx;
+            elfobj.section_names_hashtable.get(Pair(idx, cast(uint)section_names_init.sizeof)).start = idx;
         }
     }
 


### PR DESCRIPTION
AAchars, AApair, and AApair2 are copy pasted thin wrappers around `AArray`, as an "Interface for C++ code". Since the C++ compiler DMC is now separated, they are now redundant.