### PR TITLE
POC: automatically move scope array literals to the stack

### DIFF
--- a/compiler/test/fail_compilation/test21477.d
+++ b/compiler/test/fail_compilation/test21477.d
@@ -1,16 +1,17 @@
 /* REQUIRED_ARGS: -betterC
 TEST_OUTPUT:
 ---
-fail_compilation/test21477.d(103): Error: expression `[1]` uses the GC and cannot be used with switch `-betterC`
+fail_compilation/test21477.d(14): Error: expression `[1]` uses the GC and cannot be used with switch `-betterC`
 ---
 */
 
 // https://issues.dlang.org/show_bug.cgi?id=21477
 
-#line 100
+int[] global;
 
 int test()
 {
     int[] foo = [1];
+    global = foo;
     return 0;
 }

--- a/compiler/test/runnable/betterc.d
+++ b/compiler/test/runnable/betterc.d
@@ -43,6 +43,7 @@ extern (C) void main()
     testRuntimeLowerings();
     test18457();
     test20737();
+    testScopeInferenceArrayLiteral();
 }
 
 /*******************************************/
@@ -220,4 +221,16 @@ void test22427()
 
     char[] p;
     auto a = cast(int[])p;
+}
+
+/*******************************************/
+// Test that local variable can be inferred scope, moving
+// array literal from GC to stack, allowing usage in betterC
+
+int testScopeInferenceArrayLiteral()
+{
+    auto x = [10, 20, 30] ~ [40];
+    x[0] = 50;
+    assert(x[0] + x[1] == 70);
+    return x[0];
 }


### PR DESCRIPTION
See https://github.com/dlang/dmd/pull/16888#issuecomment-2379226685

Just a proof of concept, I don't think this is worth merging at this stage. Maybe under `-preview=dip1000` only.