### PR TITLE
Fix bugzilla 24431 - dmd -vcg-ast crashes printing failed template in…

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -1720,10 +1720,10 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         //printf("FuncDeclaration::toCBuffer() '%s'\n", f.toChars());
         if (stcToBuffer(buf, f.storage_class))
             buf.writeByte(' ');
+        typeToBuffer(f.type, f.ident, buf, hgs);
         auto tf = f.type.isTypeFunction();
-        typeToBuffer(tf, f.ident, buf, hgs);
 
-        if (hgs.hdrgen)
+        if (hgs.hdrgen && tf)
         {
             // if the return type is missing (e.g. ref functions or auto)
             // https://issues.dlang.org/show_bug.cgi?id=20090

--- a/compiler/test/compilable/vcg_ast_compilable.d
+++ b/compiler/test/compilable/vcg_ast_compilable.d
@@ -1,0 +1,69 @@
+/*
+REQUIRED_ARGS: -vcg-ast -o-
+OUTPUT_FILES: compilable/vcg_ast_compilable.d.cg
+TEST_OUTPUT:
+---
+=== compilable/vcg_ast_compilable.d.cg
+import object;
+auto binaryFun(E)(E b)
+{
+	return 'a' == b;
+}
+void find(Element)(Element needle) if (is(typeof(binaryFun(needle))))
+{
+}
+void find()(string needle)
+{
+}
+void splitter()
+{
+	find(3);
+	find("");
+}
+binaryFun!int
+{
+	auto pure nothrow @nogc @safe bool binaryFun(int b)
+	{
+		return 97 == b;
+	}
+
+}
+find!int
+{
+	pure nothrow @nogc @safe void find(int needle)
+	{
+	}
+
+}
+binaryFun!string
+{
+	auto _error_ binaryFun
+	{
+		__error__
+	}
+
+}
+find!()
+{
+	pure nothrow @nogc @safe void find(string needle)
+	{
+	}
+
+}
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=24431
+auto binaryFun(E)(E b)
+{
+    return 'a' == b;
+}
+
+void find(Element)(Element needle) if (is(typeof(binaryFun(needle)))) { }
+void find()(string needle) { }
+
+void splitter()
+{
+    find!int(3);
+    find!()("");
+}


### PR DESCRIPTION
…stantiation

A function in a failed template instantiation can have a TypeError instead of TypeFunction.

I'll dustmite a Phobos-independent test case later.