### PR TITLE
improve logic in isCopyConstructable()

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -905,25 +905,19 @@ private extern(D) bool isCopyConstructorCallable (StructDeclaration argStruct,
      */
     OutBuffer buf;
     auto callExp = e.isCallExp();
-    void nocpctor()
+
+    bool nocpctor()
     {
         buf.printf("`struct %s` does not define a copy constructor for `%s` to `%s` copies",
                    argStruct.toChars(), arg.type.toChars(), tprm.toChars());
-    }
-    auto f = callExp.f;
-    if (!f)
-    {
-        nocpctor();
         *pMessage = buf.extractChars();
         return false;
     }
-    char[] s;
-    if (!f.isPure && sc.func.setImpure())
-        s ~= "pure ";
-    if (!f.isSafe() && !f.isTrusted() && sc.setUnsafe())
-        s ~= "@safe ";
-    if (!f.isNogc && sc.func.setGC(arg.loc, null))
-        s ~= "nogc ";
+
+    auto f = callExp.f;
+    if (!f)
+        return nocpctor();
+
     if (f.isDisabled() && !f.isGenerated())
     {
         /* https://issues.dlang.org/show_bug.cgi?id=24301
@@ -931,11 +925,21 @@ private extern(D) bool isCopyConstructorCallable (StructDeclaration argStruct,
          */
         buf.printf("`%s` copy constructor cannot be used because it is annotated with `@disable`",
             f.type.toChars());
+        *pMessage = buf.extractChars();
+        return false;
     }
-    else if (s)
+
+    bool bpure = !f.isPure && sc.func.setImpure();
+    bool bsafe = !f.isSafe() && !f.isTrusted() && sc.setUnsafe();
+    bool bnogc = !f.isNogc && sc.func.setGC(arg.loc, null);
+    if (bpure | bsafe | bnogc)
     {
-        s[$-1] = '\0';
-        buf.printf("`%s` copy constructor cannot be called from a `%s` context", f.type.toChars(), s.ptr);
+        const nullptr = "".ptr;
+        buf.printf("`%s` copy constructor cannot be called from a `%s%s%s` context",
+            f.type.toChars(),
+            bpure ? "pure " .ptr : nullptr,
+            bsafe ? "@safe ".ptr : nullptr,
+            bnogc ? "nogc"  .ptr : nullptr);
     }
     else if (f.isGenerated() && f.isDisabled())
     {
@@ -951,7 +955,7 @@ private extern(D) bool isCopyConstructorCallable (StructDeclaration argStruct,
          * i.e: `inout` constructor creates `const` object, not mutable.
          * Fallback to using the original generic error before https://issues.dlang.org/show_bug.cgi?id=22202.
          */
-        nocpctor();
+        return nocpctor();
     }
 
     *pMessage = buf.extractChars();


### PR DESCRIPTION
and removes unnecessary GC allocations