### PR TITLE
Fix missing overloadApply import

### DIFF
--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -26,6 +26,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem : dsymbolSemantic, addMember, search, setFieldOffset;
 import dmd.errors;
 import dmd.func;
+import dmd.funcsem : overloadApply;
 import dmd.id;
 import dmd.identifier;
 import dmd.location;


### PR DESCRIPTION
Two refactoring PRs got merged which passed on their own, but together create a compile error.