### PR TITLE
Separate location formatting from Loc

### DIFF
--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -16,6 +16,7 @@ import core.stdc.stdio;
 import dmd.common.outbuffer;
 import dmd.root.array;
 import dmd.root.filename;
+import dmd.root.string: toDString;
 
 version (DMDLIB)
 {
@@ -126,35 +127,7 @@ nothrow:
         MessageStyle messageStyle = Loc.messageStyle) const nothrow
     {
         OutBuffer buf;
-        if (fileIndex)
-        {
-            buf.writestring(filename);
-        }
-        if (linnum)
-        {
-            final switch (messageStyle)
-            {
-                case MessageStyle.digitalmars:
-                    buf.writeByte('(');
-                    buf.print(linnum);
-                    if (showColumns && charnum)
-                    {
-                        buf.writeByte(',');
-                        buf.print(charnum);
-                    }
-                    buf.writeByte(')');
-                    break;
-                case MessageStyle.gnu: // https://www.gnu.org/prep/standards/html_node/Errors.html
-                    buf.writeByte(':');
-                    buf.print(linnum);
-                    if (showColumns && charnum)
-                    {
-                        buf.writeByte(':');
-                        buf.print(charnum);
-                    }
-                    break;
-            }
-        }
+        writeSourceLoc(buf, filename.toDString(), linnum, charnum, showColumns, messageStyle);
         return buf.extractChars();
     }
 
@@ -208,5 +181,51 @@ nothrow:
     bool isValid() const pure @safe
     {
         return fileIndex != 0;
+    }
+}
+
+/**
+ * Format a source location for error messages
+ *
+ * Params:
+ *   buf = buffer to write string into
+ *   filename = source file name
+ *   linnum = line number
+ *   charnum = column number
+ *   showColumns = include column number in message
+ *   messageStyle = select error message format
+ */
+void writeSourceLoc(ref OutBuffer buf,
+    const(char)[] filename,
+    int linnum,
+    int charnum,
+    bool showColumns = Loc.showColumns,
+    MessageStyle messageStyle = Loc.messageStyle) nothrow
+{
+    buf.writestring(filename);
+    if (linnum)
+    {
+        final switch (messageStyle)
+        {
+            case MessageStyle.digitalmars:
+                buf.writeByte('(');
+                buf.print(linnum);
+                if (showColumns && charnum)
+                {
+                    buf.writeByte(',');
+                    buf.print(charnum);
+                }
+                buf.writeByte(')');
+                break;
+            case MessageStyle.gnu: // https://www.gnu.org/prep/standards/html_node/Errors.html
+                buf.writeByte(':');
+                buf.print(linnum);
+                if (showColumns && charnum)
+                {
+                    buf.writeByte(':');
+                    buf.print(charnum);
+                }
+                break;
+        }
     }
 }


### PR DESCRIPTION
The goal is to separate errors.d from location.d. Currently, the C++ interface for errors.d creates a `Loc` just so it can call `Loc.toChars` on it later:
```D
extern (C++) void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...)
{
    const loc = Loc(filename, linnum, charnum);
    va_list ap;
    va_start(ap, format);
    verrorReport(loc, format, ap, ErrorKind.error);
    va_end(ap);
}
```

This was fine when `Loc` was a simple tuple of (file, line, column), but for optimization purposes, constructing a Loc now pushes a filename to a global array so it can store a smaller index rather than a pointer. The more opaque `Loc` becomes, the easier it is to optimize it. Only the lexer/parser should create `Loc` objects, the rest should pass it around.