### PR TITLE
Remove backend dependency on frontend error function

### DIFF
--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -83,10 +83,12 @@ extern (C) void out_config_init(
         exefmt_t exefmt,
         bool generatedMain,     // a main entrypoint is generated
         bool dataimports,
-        ref GlobalOptimizer go)
+        ref GlobalOptimizer go,
+        ErrorCallbackBackend errorCallback)
 {
     //printf("out_config_init()\n");
 
+    errorCallbackBackend = errorCallback;
     auto cfg = &config;
 
     cfg._version = _version;
@@ -112,7 +114,7 @@ extern (C) void out_config_init(
     {
         if (dwarf)
         {
-            error(null, 0, 0, "DWARF version %u is not supported", dwarf);
+            error(Srcpos.init, "DWARF version %u is not supported", dwarf);
         }
 
         // Default DWARF version

--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -2543,7 +2543,7 @@ private elem * elremquo(elem *e, Goal goal)
 {
     static if (0)
     if (cnst(e.E2) && !boolres(e.E2))
-        error(e.Esrcpos.Sfilename, e.Esrcpos.Slinnum, e.Esrcpos.Scharnum, "divide by zero\n");
+        error(e.Esrcpos, "divide by zero\n");
 
     return e;
 }
@@ -2576,7 +2576,7 @@ private elem * eldiv(elem *e, Goal goal)
     {
         static if (0)
         if (!boolres(e2))
-            error(e.Esrcpos.Sfilename, e.Esrcpos.Slinnum, e.Esrcpos.Scharnum, "divide by zero\n");
+            error(e.Esrcpos, "divide by zero\n");
 
         if (uns)
         {
@@ -6235,7 +6235,7 @@ void postoptelem(elem *e)
                     const targ_ullong v = el_tolong(e.E1);
                     if (v < 4096 && !(e.Ety & mTYvolatile))
                     {
-                        error(pos.Sfilename, pos.Slinnum, pos.Scharnum, "null dereference in function %s", funcsym_p.Sident.ptr);
+                        error(pos, "null dereference in function %s", funcsym_p.Sident.ptr);
                         e.E1.Vlong = 4096;     // suppress redundant messages
                     }
                 }

--- a/compiler/src/dmd/backend/cgen.d
+++ b/compiler/src/dmd/backend/cgen.d
@@ -339,7 +339,7 @@ static if (TARGET_SEGMENTED)
             // outdata(Symbol *s)
             if (f.sym.Sseg == UNKNOWN)
             {
-                error(null, 0, 0, "no definition found for static `%s` in this module, statics defined in one module cannot be referenced from another",
+                error(Srcpos.init, "no definition found for static `%s` in this module, statics defined in one module cannot be referenced from another",
                     prettyident(f.sym)); // no definition found for static
                 err_exit(); // BUG: do better
             }

--- a/compiler/src/dmd/backend/eh.d
+++ b/compiler/src/dmd/backend/eh.d
@@ -47,7 +47,7 @@ Symbol *except_gentables()
         // BUG: alloca() changes the stack size, which is not reflected
         // in the fixed eh tables.
         if (cgstate.Alloca.size)
-            error(null, 0, 0, "cannot mix `core.std.stdlib.alloca()` and exception handling in `%s()`", &funcsym_p.Sident[0]);
+            error(Srcpos.init, "cannot mix `core.std.stdlib.alloca()` and exception handling in `%s()`", &funcsym_p.Sident[0]);
 
         char[13+5+1] name = void;
         __gshared int tmpnum;

--- a/compiler/src/dmd/backend/evalu8.d
+++ b/compiler/src/dmd/backend/evalu8.d
@@ -1096,11 +1096,11 @@ static if (0)
             if (!boolres(e2))
             {
                 div0:
-                    error(e.Esrcpos.Sfilename, e.Esrcpos.Slinnum, e.Esrcpos.Scharnum, "divide by zero");
+                    error(e.Esrcpos, "divide by zero");
                     break;
 
                 overflow:
-                    error(e.Esrcpos.Sfilename, e.Esrcpos.Slinnum, e.Esrcpos.Scharnum, "integer overflow");
+                    error(e.Esrcpos, "integer overflow");
                     break;
             }
         }
@@ -1834,8 +1834,7 @@ static if (0) // && MARS
          */
         if (l1 >= 0 && l1 < 4096)
         {
-            error(e.Esrcpos.Sfilename, e.Esrcpos.Slinnum, e.Esrcpos.Scharnum,
-                "dereference of null pointer");
+            error(e.Esrcpos, "dereference of null pointer");
             e.E1.Vlong = 4096;     // suppress redundant messages
         }
 }

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -19,7 +19,7 @@ import core.stdc.stdint;
 
 import dmd.backend.barray;
 import dmd.backend.cdef;
-import dmd.backend.cc : Symbol, block, Classsym, BlockState, FLdata;
+import dmd.backend.cc : Symbol, block, Classsym, BlockState, FLdata, Srcpos;
 import dmd.backend.code;
 import dmd.backend.dlist;
 import dmd.backend.el : elem;
@@ -30,11 +30,26 @@ import dmd.backend.type;
 import dmd.backend.var : _tysize;
 
 nothrow:
-@safe:
 @nogc:
 
-// FIXME: backend can't import front end modules because missing -J flag
-extern (C++) void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
+/// Callback for errors raised by the backend
+alias ErrorCallbackBackend = void function(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
+
+package(dmd.backend) __gshared ErrorCallbackBackend errorCallbackBackend;
+
+/**
+ * Backend error report function
+ * Params:
+ *     srcPos = source location
+ *     format = printf format string with error message
+ *     args = printf format string arguments
+ */
+void error(T...)(Srcpos srcPos, const(char)* format, T args)
+{
+    errorCallbackBackend(srcPos.Sfilename, srcPos.Slinnum, srcPos.Scharnum, format, args);
+}
+
+@safe:
 
 /***********************************
  * Returns: aligned `offset` if it is of size `size`.

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -33,7 +33,7 @@ nothrow:
 @nogc:
 
 /// Callback for errors raised by the backend
-alias ErrorCallbackBackend = void function(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
+alias ErrorCallbackBackend = extern(C++) void function(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
 
 package(dmd.backend) __gshared ErrorCallbackBackend errorCallbackBackend;
 

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -35,7 +35,6 @@ nothrow:
 
 // FIXME: backend can't import front end modules because missing -J flag
 extern (C++) void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
-package extern (C++) void fatal();
 
 /***********************************
  * Returns: aligned `offset` if it is of size `size`.

--- a/compiler/src/dmd/backend/gother.d
+++ b/compiler/src/dmd/backend/gother.d
@@ -475,8 +475,7 @@ private void chkrd(elem *n, Barray!(elem*) rdlist)
          */
         if (type_size(sv.Stype) != 0)
         {
-            error(n.Esrcpos.Sfilename, n.Esrcpos.Slinnum, n.Esrcpos.Scharnum,
-                "variable %s used before set", sv.Sident.ptr);
+            error(n.Esrcpos, "variable %s used before set", sv.Sident.ptr);
         }
     }
 

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -2964,7 +2964,7 @@ Version operatingSystemVersion()
         if (version_.isValid)
             return version_;
 
-        error(null, 0, 0, "invalid version number in 'MACOSX_DEPLOYMENT_TARGET=%s'", deploymentTarget);
+        error(Srcpos.init, "invalid version number in 'MACOSX_DEPLOYMENT_TARGET=%s'", deploymentTarget);
     }
     return Version();
 }

--- a/compiler/src/dmd/backend/x86/cgxmm.d
+++ b/compiler/src/dmd/backend/x86/cgxmm.d
@@ -1348,7 +1348,7 @@ static if (0)
                 if (n == 3)
                 {
                     if (cgstate.pass == BackendPass.final_)
-                        error(e.Esrcpos.Sfilename, e.Esrcpos.Slinnum, e.Esrcpos.Scharnum, "missing 4th parameter to `__simd()`");
+                        error(e.Esrcpos, "missing 4th parameter to `__simd()`");
                     cs.IFL2 = FLconst;
                     cs.IEV2.Vsize_t = 0;
                 }
@@ -1363,7 +1363,7 @@ static if (0)
             cs.IFL2 = FLconst;
             if (imm8.Eoper != OPconst)
             {
-                error(imm8.Esrcpos.Sfilename, imm8.Esrcpos.Slinnum, imm8.Esrcpos.Scharnum, "last parameter to `__simd()` must be a constant");
+                error(imm8.Esrcpos, "last parameter to `__simd()` must be a constant");
                 cs.IEV2.Vsize_t = 0;
             }
             else

--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -19,6 +19,7 @@ import dmd.globals;
 import dmd.dclass;
 import dmd.dmdparams;
 import dmd.dmodule;
+import dmd.errors : errorBackend;
 import dmd.mtype;
 import dmd.target;
 
@@ -93,7 +94,9 @@ void backend_init(const ref Param params, const ref DMDparams driverParams, cons
         exfmt,
         params.addMain,
         driverParams.symImport != SymImport.none,
-        go
+        go,
+        // FIXME: casting to @nogc because errors.d is not marked @nogc yet
+        cast(ErrorCallbackBackend) &errorBackend,
     );
 
     out_config_debug(

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -204,6 +204,16 @@ else
         va_end(ap);
     }
 
+/// Callback for when the backend wants to report an error
+void errorBackend(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...)
+{
+    const loc = Loc(filename, linnum, charnum);
+    va_list ap;
+    va_start(ap, format);
+    verrorReport(loc, format, ap, ErrorKind.error);
+    va_end(ap);
+}
+
 /**
  * Print additional details about an error message.
  * Doesn't increase the error count or print an additional error prefix.

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -205,9 +205,9 @@ else
     }
 
 /// Callback for when the backend wants to report an error
-void errorBackend(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...)
+extern(C++) void errorBackend(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...)
 {
-    const loc = Loc(filename, linnum, charnum);
+    const loc = SourceLoc(filename.toDString, linnum, charnum);
     va_list ap;
     va_start(ap, format);
     verrorReport(loc, format, ap, ErrorKind.error);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8076,6 +8076,8 @@ extern void error(const Loc& loc, const char* format, ...);
 
 extern void error(const char* filename, uint32_t linnum, uint32_t charnum, const char* format, ...);
 
+extern void errorBackend(const char* filename, uint32_t linnum, uint32_t charnum, const char* format, ...);
+
 extern void errorSupplemental(const Loc& loc, const char* format, ...);
 
 extern void warning(const Loc& loc, const char* format, ...);


### PR DESCRIPTION
The backend shouldn't import the frontend, or link frontend functions with extern declarations (which amounts to the same thing). Let the frontend pass an error callback to the backend.