### PR TITLE
Use new `SourceLoc` for error printing

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6010,6 +6010,19 @@ enum class ErrorKind
     message = 4,
 };
 
+struct SourceLoc final
+{
+    _d_dynamicArray< const char > filename;
+    uint32_t line;
+    uint32_t column;
+    SourceLoc() :
+        filename(),
+        line(),
+        column()
+    {
+    }
+};
+
 enum class DiagnosticReporting : uint8_t
 {
     error = 0u,
@@ -8079,9 +8092,13 @@ extern void message(const char* format, ...);
 
 extern void tip(const char* format, ...);
 
-extern void verrorReport(const Loc& loc, const char* format, va_list ap, ErrorKind kind, const char* p1 = nullptr, const char* p2 = nullptr);
+extern void verrorReport(const Loc loc, const char* format, va_list ap, ErrorKind kind, const char* p1 = nullptr, const char* p2 = nullptr);
+
+extern void verrorReport(const SourceLoc loc, const char* format, va_list ap, ErrorKind kind, const char* p1 = nullptr, const char* p2 = nullptr);
 
 extern void verrorReportSupplemental(const Loc& loc, const char* format, va_list ap, ErrorKind kind);
+
+extern void verrorReportSupplemental(const SourceLoc loc, const char* format, va_list ap, ErrorKind kind);
 
 extern void fatal();
 


### PR DESCRIPTION
Continuation of https://github.com/dlang/dmd/pull/16973

Best reviewed with white space off.

This is a breaking change for DMD as a library users that provide a custom `DiagnosticHandler` using `Loc`, since the callback now takes a `SourceLoc`. I think it's okay, it only requires a simple rename to fix. I'm considering reconstructing the `Loc`, which isn't very performant, but error printing doesn't need to be.