### PR TITLE
Reduce reliance on Loc constructors

### DIFF
--- a/compiler/src/dmd/common/outbuffer.d
+++ b/compiler/src/dmd/common/outbuffer.d
@@ -785,10 +785,11 @@ struct OutBuffer
 
     Returns: `true` iff the operation succeeded.
     */
-    extern(D) bool moveToFile(const char* filename) @system
+    extern(D) bool moveToFile(const char[] filename) @system
     {
         bool result = true;
-        const bool identical = this[] == FileMapping!(const ubyte)(filename)[];
+        const filenameZ = (filename ~ "\0").ptr;
+        const bool identical = this[] == FileMapping!(const ubyte)(filenameZ)[];
 
         if (fileMapping && fileMapping.active)
         {
@@ -801,7 +802,7 @@ struct OutBuffer
             {
                 // Resize to fit to get rid of the slack bytes at the end
                 fileMapping.resize(offset);
-                result = fileMapping.moveToFile(filename);
+                result = fileMapping.moveToFile(filenameZ);
             }
             // Can't call destroy() here because the file mapping is already closed.
             data = null;
@@ -810,12 +811,12 @@ struct OutBuffer
         else
         {
             if (!identical)
-                writeFile(filename, this[]);
+                writeFile(filenameZ, this[]);
             destroy();
         }
 
         return identical
-            ? result && touchFile(filename)
+            ? result && touchFile(filenameZ)
             : result;
     }
 }

--- a/compiler/src/dmd/dinifile.d
+++ b/compiler/src/dmd/dinifile.d
@@ -372,8 +372,7 @@ bool parseConfFile(ref StringTable!(char*) environment, const(char)[] filename, 
                     auto pns = cast(char*)Mem.check(strdup(pn));
                     if (!writeToEnv(environment, pns))
                     {
-                        const loc = Loc(filename.xarraydup.ptr, lineNum, 0); // TODO: use r-value when `error` supports it
-                        error(loc, "use `NAME=value` syntax, not `%s`", pn);
+                        error(filename.xarraydup.ptr, lineNum, 0, "use `NAME=value` syntax, not `%s`", pn);
                         return true;
                     }
                     static if (LOG)

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -275,13 +275,13 @@ extern (C++) class Dsymbol : ASTNode
     final extern (D) this() nothrow @safe
     {
         //printf("Dsymbol::Dsymbol(%p)\n", this);
-        loc = Loc(null, 0, 0);
+        loc = Loc.initial;
     }
 
     final extern (D) this(Identifier ident) nothrow @safe
     {
         //printf("Dsymbol::Dsymbol(%p, ident)\n", this);
-        this.loc = Loc(null, 0, 0);
+        this.loc = Loc.initial;
         this.ident = ident;
     }
 

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -169,23 +169,22 @@ public void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
     if (writeLibrary && !global.errors)
     {
         if (verbose)
-            eSink.message(Loc.initial, "library   %s", library.loc.filename);
+            eSink.message(Loc.initial, "library   %.*s", library.filename.fTuple.expand);
 
-        auto filenameString = library.loc.filename.toDString;
-        if (!ensurePathToNameExists(Loc.initial, filenameString))
+        if (!ensurePathToNameExists(Loc.initial, library.filename))
             fatal();
 
         /* Write library to temporary file. If that is successful,
          * then and only then replace the existing file with the temporary file
          */
-        auto tmpname = filenameString ~ ".tmp\0";
+        auto tmpname = library.filename ~ ".tmp\0";
 
         auto libbuf = OutBuffer(tmpname.ptr);
         library.writeLibToBuffer(libbuf);
 
-        if (!libbuf.moveToFile(library.loc.filename))
+        if (!libbuf.moveToFile(library.filename))
         {
-            eSink.error(library.loc, "error writing file '%s'", library.loc.filename);
+            eSink.error(Loc.initial, "error writing file '%.*s'", library.filename.fTuple.expand);
             destroy(tmpname);
             fatal();
         }

--- a/compiler/src/dmd/lib/elf.d
+++ b/compiler/src/dmd/lib/elf.d
@@ -93,8 +93,8 @@ final class LibElf : Library
 
         void corrupt(int reason)
         {
-            eSink.error(loc, "corrupt ELF object module %.*s %d",
-                  cast(int)module_name.length, module_name.ptr, reason);
+            eSink.error(Loc.initial, "corrupt ELF object `%.*s` module %.*s %d",
+                filename.fTuple.expand, module_name.fTuple.expand, reason);
         }
 
         int fromfile = 0;
@@ -329,7 +329,7 @@ final class LibElf : Library
                 s = tab.lookup(name.ptr, name.length);
                 assert(s);
                 ElfObjSymbol* os = s.value;
-                eSink.error(loc, "multiple definition of %s: %s and %s: %s", om.name.ptr, name.ptr, os.om.name.ptr, os.name.ptr);
+                eSink.error(Loc.initial, "multiple definition of %s: %s and %s: %s", om.name.ptr, name.ptr, os.om.name.ptr, os.name.ptr);
             }
         }
         else
@@ -359,7 +359,7 @@ private:
             this.addSymbol(om, name, pickAny);
         }
 
-        scanElfObjModule(&addSymbol, om.base[0 .. om.length], om.name.ptr, loc, eSink);
+        scanElfObjModule(&addSymbol, om.base[0 .. om.length], om.name.ptr, filename, eSink);
     }
 
     /*****************************************************************************/

--- a/compiler/src/dmd/lib/mach.d
+++ b/compiler/src/dmd/lib/mach.d
@@ -94,8 +94,8 @@ final class LibMach : Library
 
         void corrupt(int reason)
         {
-            eSink.error(loc, "corrupt Mach object module %.*s %d",
-                  cast(int)module_name.length, module_name.ptr, reason);
+            eSink.error(Loc.initial, "corrupt Mach object `%.*s` module %.*s %d",
+                filename.fTuple.expand, module_name.fTuple.expand, reason);
         }
 
         int fromfile = 0;
@@ -323,7 +323,7 @@ private:
             this.addSymbol(om, name, pickAny);
         }
 
-        scanMachObjModule(&addSymbol, om.base[0 .. om.length], om.name.ptr, loc, eSink);
+        scanMachObjModule(&addSymbol, om.base[0 .. om.length], om.name.ptr, filename, eSink);
     }
 
     /*****************************************************************************/

--- a/compiler/src/dmd/lib/mscoff.d
+++ b/compiler/src/dmd/lib/mscoff.d
@@ -101,8 +101,8 @@ final class LibMSCoff : Library
 
         void corrupt(int reason)
         {
-            eSink.error(loc, "corrupt MS Coff object module %.*s %d",
-                  cast(int)module_name.length, module_name.ptr, reason);
+            eSink.error(Loc.initial, "corrupt MS Coff object `%.*s` module %.*s %d",
+                filename.fTuple.expand, module_name.fTuple.expand, reason);
         }
 
         int fromfile = 0;
@@ -400,7 +400,7 @@ private:
             this.addSymbol(om, name, pickAny);
         }
 
-        scanMSCoffObjModule(&addSymbol, om.base[0 .. om.length], om.name.ptr, loc, eSink);
+        scanMSCoffObjModule(&addSymbol, om.base[0 .. om.length], om.name.ptr, filename, eSink);
     }
 
     /*****************************************************************************/

--- a/compiler/src/dmd/lib/package.d
+++ b/compiler/src/dmd/lib/package.d
@@ -67,5 +67,4 @@ class Library
 
   public:
     const(char)[] filename; /// the filename of the library
-    Loc loc; /// used for error printing
 }

--- a/compiler/src/dmd/lib/package.d
+++ b/compiler/src/dmd/lib/package.d
@@ -62,19 +62,10 @@ class Library
                    cast(int)filename.length, filename.ptr);
         }
 
-        loc = Loc(filename.ptr, 0, 0);
-    }
-
-    /*************
-     * Retrieve library file name
-     * Returns:
-     *  filename = name of library file
-     */
-    final const(char)* getFilename() const
-    {
-        return loc.filename;
+        this.filename = filename;
     }
 
   public:
-    Loc loc;                  // the filename of the library
+    const(char)[] filename; /// the filename of the library
+    Loc loc; /// used for error printing
 }

--- a/compiler/src/dmd/lib/scanmach.d
+++ b/compiler/src/dmd/lib/scanmach.d
@@ -16,9 +16,9 @@ import core.stdc.stdint;
 
 import dmd.errorsink;
 import dmd.location;
-
 //import core.sys.darwin.mach.loader;
 import dmd.backend.mach;
+import dmd.root.string : fTuple;
 
 nothrow:
 
@@ -31,12 +31,12 @@ private enum LOG = false;
  *      pAddSymbol =  function to pass the names to
  *      base =        array of contents of object module
  *      module_name = name of the object module (used for error messages)
- *      loc =         location to use for error printing
+ *      filename =    object file name for error printing
  *      eSink =       where the error messages go
  */
 package(dmd.lib)
 void scanMachObjModule(void delegate(const(char)[] name, int pickAny) nothrow pAddSymbol,
-        const ubyte[] base, const char* module_name, Loc loc, ErrorSink eSink)
+        const ubyte[] base, const char* module_name, const(char)[] filename, ErrorSink eSink)
 {
     static if (LOG)
     {
@@ -45,7 +45,7 @@ void scanMachObjModule(void delegate(const(char)[] name, int pickAny) nothrow pA
 
     void corrupt(int reason)
     {
-        eSink.error(loc, "corrupt Mach-O object module `%s` %d", module_name, reason);
+        eSink.error(Loc.initial, "corrupt Mach-O object `%.*s` module `%s` %d", filename.fTuple.expand, module_name, reason);
     }
 
     const buf = base.ptr;
@@ -62,12 +62,12 @@ void scanMachObjModule(void delegate(const(char)[] name, int pickAny) nothrow pA
     {
         if (header.cputype != CPU_TYPE_I386)
         {
-            eSink.error(loc, "Mach-O object module `%s` has cputype = %d, should be %d", module_name, header.cputype, CPU_TYPE_I386);
+            eSink.error(Loc.initial, "Mach-O object module `%s` has cputype = %d, should be %d", module_name, header.cputype, CPU_TYPE_I386);
             return;
         }
         if (header.filetype != MH_OBJECT)
         {
-            eSink.error(loc, "Mach-O object module `%s` has file type = %d, should be %d", module_name, header.filetype, MH_OBJECT);
+            eSink.error(Loc.initial, "Mach-O object module `%s` has file type = %d, should be %d", module_name, header.filetype, MH_OBJECT);
             return;
         }
         if (buflen < mach_header.sizeof + header.sizeofcmds)
@@ -81,12 +81,12 @@ void scanMachObjModule(void delegate(const(char)[] name, int pickAny) nothrow pA
             return corrupt(__LINE__);
         if (header64.cputype != CPU_TYPE_X86_64)
         {
-            eSink.error(loc, "Mach-O object module `%s` has cputype = %d, should be %d", module_name, header64.cputype, CPU_TYPE_X86_64);
+            eSink.error(Loc.initial, "Mach-O object module `%s` has cputype = %d, should be %d", module_name, header64.cputype, CPU_TYPE_X86_64);
             return;
         }
         if (header64.filetype != MH_OBJECT)
         {
-            eSink.error(loc, "Mach-O object module `%s` has file type = %d, should be %d", module_name, header64.filetype, MH_OBJECT);
+            eSink.error(Loc.initial, "Mach-O object module `%s` has file type = %d, should be %d", module_name, header64.filetype, MH_OBJECT);
             return;
         }
         if (buflen < mach_header_64.sizeof + header64.sizeofcmds)

--- a/compiler/src/dmd/root/string.d
+++ b/compiler/src/dmd/root/string.d
@@ -20,6 +20,27 @@ inout(char)[] toDString (inout(char)* s) pure nothrow @nogc
     return s ? s[0 .. strlen(s)] : null;
 }
 
+private struct FTuple(T...)
+{
+    T expand;
+}
+
+/// Returns: a (length, ptr) tuple for passing a D string to `printf`-style functions with the format string `%.*s`
+auto fTuple(const(char)[] str)
+{
+    return FTuple!(int, const(char)*)(cast(int) str.length, str.ptr);
+}
+
+///
+unittest
+{
+    import core.stdc.stdio: snprintf;
+    char[6] buf = '.';
+    const(char)[] str = "cutoff"[0..4];
+    snprintf(buf.ptr, buf.length, "%.*s", str.fTuple.expand);
+    assert(buf[] == "cuto\0.");
+}
+
 /**
 Compare two slices for equality, in a case-insensitive way
 

--- a/compiler/test/fail_compilation/invalid_lib.d
+++ b/compiler/test/fail_compilation/invalid_lib.d
@@ -9,7 +9,7 @@ Use a regex because the path is really strange on Azure (OMF_32, 64):
 
 TEST_OUTPUT:
 ----
-Error: corrupt $?:windows=MS Coff|osx=Mach|ELF$ object module $?:windows=fail_compilation\extra-files\fake.lib|fail_compilation/extra-files/fake.a$ $n$
+Error: corrupt $?:windows=MS Coff|osx=Mach|ELF$ object `$r:.*$` module $?:windows=fail_compilation\extra-files\fake.lib|fail_compilation/extra-files/fake.a$ $n$
 ----
 */
 void main() {}

--- a/compiler/test/fail_compilation/invalid_lib.d
+++ b/compiler/test/fail_compilation/invalid_lib.d
@@ -9,7 +9,7 @@ Use a regex because the path is really strange on Azure (OMF_32, 64):
 
 TEST_OUTPUT:
 ----
-$r:.*$: Error: corrupt $?:windows=MS Coff|osx=Mach|ELF$ object module $?:windows=fail_compilation\extra-files\fake.lib|fail_compilation/extra-files/fake.a$ $n$
+Error: corrupt $?:windows=MS Coff|osx=Mach|ELF$ object module $?:windows=fail_compilation\extra-files\fake.lib|fail_compilation/extra-files/fake.a$ $n$
 ----
 */
 void main() {}


### PR DESCRIPTION
Continuation of https://github.com/dlang/dmd/pull/16977

Only the lexer should generate `Loc`.

`Library` uses `Loc` just as a container for a filename, it doesn't use line or column numbers. Also, `Library.setFilename` takes a slice and just assumes it is zero-terminated, which is dangerous. The loc is passed to `eSink`, but it's not like there is a line / column you could jump to to inspect the corrupted part: it's a binary file.