### PR TITLE
backend: Remove unneeded extern(C)

### DIFF
--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -60,7 +60,7 @@ nothrow:
  */
 public
 @trusted
-extern (C) void out_config_init(
+void out_config_init(
         bool arm,       // true for generating AArch64 code
         int model,
         bool exe,

--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -45,7 +45,7 @@ nothrow:
 @safe:
 
 @trusted
-extern (C) void TOOFFSET(void* p, targ_size_t value)
+void TOOFFSET(void* p, targ_size_t value)
 {
     switch (_tysize[TYnptr])
     {

--- a/compiler/src/dmd/backend/divcoeff.d
+++ b/compiler/src/dmd/backend/divcoeff.d
@@ -117,7 +117,7 @@ void u128Div(ullong xh, ullong xl, ullong yh, ullong yl, ullong *pqh, ullong *pq
  */
 
 @trusted
-extern (C) bool choose_multiplier(int N, ullong d, int prec, ullong *pm, int *pshpost)
+bool choose_multiplier(int N, ullong d, int prec, ullong *pm, int *pshpost)
 {
     assert(N == 32 || N == 64);
     assert(prec <= N);
@@ -233,7 +233,7 @@ extern (C) bool choose_multiplier(int N, ullong d, int prec, ullong *pm, int *ps
  *              q = SRL(MULUH(m, SRL(n, shpre)), shpost)
  */
 
-extern (C) bool udiv_coefficients(int N, ullong d, int *pshpre, ullong *pm, int *pshpost)
+bool udiv_coefficients(int N, ullong d, int *pshpre, ullong *pm, int *pshpost)
 {
     bool mhighbit = choose_multiplier(N, d, N, pm, pshpost);
     if (mhighbit && (d & 1) == 0)

--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -52,8 +52,8 @@ bool symbol_iscomdat2(Symbol* s)
  * Output function thunk.
  */
 @trusted
-extern (C) void outthunk(Symbol *sthunk,Symbol *sfunc,uint p,tym_t thisty,
-        targ_size_t d,int i,targ_size_t d2)
+void outthunk(Symbol* sthunk, Symbol* sfunc, uint p, tym_t thisty,
+        targ_size_t d, int i, targ_size_t d2)
 {
     sthunk.Sseg = cseg;
     cod3_thunk(sthunk,sfunc,p,thisty,cast(uint)d,i,cast(uint)d2);

--- a/compiler/src/dmd/backend/dtype.d
+++ b/compiler/src/dmd/backend/dtype.d
@@ -360,7 +360,7 @@ type *type_dyn_array(type *tnext)
  *      Tcount already incremented
  */
 
-extern (C) type *type_static_array(targ_size_t dim, type *tnext)
+type* type_static_array(targ_size_t dim, type *tnext)
 {
     type *t = type_allocn(TYarray, tnext);
     t.Tdim = dim;
@@ -410,7 +410,6 @@ type *type_delegate(type *tnext)
  *      Tcount already incremented
  */
 @trusted
-extern (C)
 type *type_function(tym_t tyf, type*[] ptypes, bool variadic, type *tret)
 {
     param_t *paramtypes = null;

--- a/compiler/src/dmd/backend/dvec.d
+++ b/compiler/src/dmd/backend/dvec.d
@@ -20,8 +20,6 @@ import core.bitop;
 
 import dmd.backend.global : err_nomem;
 
-extern (C):
-
 nothrow:
 @nogc:
 @safe:

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -404,7 +404,7 @@ void el_opFree(elem *e, OPER op)
  */
 
 @trusted
-extern (C) elem *el_opCombine(elem **args, size_t length, OPER op, tym_t ty)
+elem *el_opCombine(elem **args, size_t length, OPER op, tym_t ty)
 {
     if (length == 0)
         return null;
@@ -883,7 +883,7 @@ elem* el_una(OPER op,tym_t ty,elem *e1)
  */
 
 @trusted
-extern (C) elem * el_longt(type *t,targ_llong val)
+elem* el_longt(type *t,targ_llong val)
 {
     assert(PARSER);
     elem* e = el_calloc();
@@ -898,9 +898,7 @@ extern (C) elem * el_longt(type *t,targ_llong val)
     return e;
 }
 
-extern (C) // necessary because D <=> C++ mangling of "long long" is not consistent across memory models
-{
-elem * el_long(tym_t t,targ_llong val)
+elem* el_long(tym_t t,targ_llong val)
 {
     elem* e = el_calloc();
     e.Eoper = OPconst;
@@ -1002,7 +1000,6 @@ elem* el_vectorConst(tym_t ty, ulong val)
             assert(0);
     }
     return e;
-}
 }
 
 /*******************************

--- a/compiler/src/dmd/backend/gloop.d
+++ b/compiler/src/dmd/backend/gloop.d
@@ -1308,7 +1308,6 @@ private void markInvariants(ref GlobalOptimizer go, int gref, block* gblock, vec
  *      vecdim  go.defnod.length
  */
 
-extern (C) {
 @trusted
 void updaterd(ref GlobalOptimizer go, elem *n,vec_t GEN,vec_t KILL)
 {
@@ -1363,7 +1362,6 @@ void updaterd(ref GlobalOptimizer go, elem *n,vec_t GEN,vec_t KILL)
     }
 
     vec_setbit(ni,GEN);                 // set bit in GEN for this def
-}
 }
 
 /***************************

--- a/compiler/src/dmd/backend/mem.d
+++ b/compiler/src/dmd/backend/mem.d
@@ -18,8 +18,6 @@ import core.stdc.string : strdup;
 
 import dmd.backend.global : err_nomem;
 
-extern (C):
-
 nothrow:
 @nogc:
 @safe:

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -51,7 +51,7 @@ extern(C) void qsort(void* base, size_t nmemb, size_t size, _compare_fp_t compar
  *      uppercased string
  */
 @trusted
-extern (C) char* strupr(char* s)
+char* strupr(char* s)
 {
     for (char* p = s; *p; ++p)
     {

--- a/compiler/src/dmd/backend/oper.d
+++ b/compiler/src/dmd/backend/oper.d
@@ -384,7 +384,7 @@ public import dmd.backend.cgelem : swaprel;
 
 extern (D):
 
-extern (C) immutable ubyte[OPMAX] optab1 =
+immutable ubyte[OPMAX] optab1 =
 () {
     ubyte[OPMAX] tab;
     foreach (i; Ebinary) { tab[i] |= _OTbinary; }

--- a/compiler/src/dmd/backend/symbol.d
+++ b/compiler/src/dmd/backend/symbol.d
@@ -243,7 +243,6 @@ const(char)* symbol_ident(return ref const Symbol s)
  */
 
 @trusted @nogc
-extern (C)
 Symbol * symbol_calloc(const(char)[] id)
 {
     //printf("sizeof(symbol)=%d, sizeof(s.Sident)=%d, len=%d\n", symbol.sizeof, s.Sident.sizeof, cast(int)id.length);
@@ -268,7 +267,6 @@ Symbol * symbol_calloc(const(char)[] id)
  */
 
 @nogc
-extern (C)
 Symbol * symbol_name(const(char)[] name, SC sclass, type *t)
 {
     type_debug(t);

--- a/compiler/src/dmd/backend/var.d
+++ b/compiler/src/dmd/backend/var.d
@@ -67,16 +67,13 @@ char debugy = 0; /// watch output to il buffer
 /* File variables: */
 
 char *argv0;                    // argv[0] (program name)
-extern (C)
-{
-FILE *fdep = null;              // dependency file stream pointer
-FILE *flst = null;              // list file stream pointer
-FILE *fin = null;               // input file
-}
+FILE* fdep = null;              // dependency file stream pointer
+FILE* flst = null;              // list file stream pointer
+FILE* fin = null;               // input file
 
 // htod
 char *fdmodulename = null;
-extern (C) FILE *fdmodule = null;
+FILE* fdmodule = null;
 
 char*   foutdir = null,       // directory to place output files in
         finname = null,
@@ -164,7 +161,7 @@ char[SCMAX] sytab =
     /* adl */      0                ,      /* list of ADL symbols for overloading  */
 ];
 
-extern (C) int controlc_saw = 0;              /* a control C was seen         */
+int controlc_saw = 0;              /* a control C was seen         */
 symtab_t globsym;               /* global symbol table                  */
 Pstate pstate;                  // parser state
 Cstate cstate;                  // compiler state
@@ -216,7 +213,7 @@ extern (D) private enum tytab_init =
 } ();
 
 /// Give an ascii string for a type
-extern (C) __gshared const(char)*[TYMAX] tystring =
+__gshared const(char)*[TYMAX] tystring =
 () {
     const(char)*[TYMAX] ret = [
         TYbool    : "bool",

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -1554,8 +1554,6 @@ regm_t allocretregs(const tym_t ty, type* t, const tym_t tyf, out reg_t reg1, ou
 private alias _compare_fp_t = extern(C) nothrow int function(const void*, const void*);
 extern(C) void qsort(void* base, size_t nmemb, size_t size, _compare_fp_t compar);
 
-extern (C)  // qsort cmp functions need to be "C"
-{
 struct CaseVal
 {
     targ_ullong val;
@@ -1569,7 +1567,6 @@ struct CaseVal
         const(CaseVal)* c2 = cast(const(CaseVal)*)q;
         return (c1.val < c2.val) ? -1 : ((c1.val == c2.val) ? 0 : 1);
     }
-}
 }
 
 /***
@@ -8089,7 +8086,7 @@ void code_print(scope code* c)
  *      cf = CF mask
  */
 @trusted
-extern (C) void CF_print(uint cf)
+void CF_print(uint cf)
 {
     void print(uint mask, const(char)* string)
     {


### PR DESCRIPTION
It's still needed for callbacks passed to `qsort`, but all other uses are relics from when the backend was shared with the Digital Mars C++ compiler. 