### PR TITLE
backend: Put BlockOpt globals in a struct

### DIFF
--- a/compiler/src/dmd/backend/blockopt.d
+++ b/compiler/src/dmd/backend/blockopt.d
@@ -42,7 +42,7 @@ nothrow:
 
 import dmd.backend.gflow : util_realloc;
 
-__gshared
+struct BlockOpt
 {
     block *startblock;      // beginning block of function
                             // (can have no predecessors)
@@ -57,16 +57,18 @@ __gshared
     block blkzero;          // storage allocator
 }
 
+__gshared BlockOpt bo;
+
 @trusted
 pragma(inline, true) block *block_calloc_i()
 {
     block *b;
 
-    if (block_freelist)
+    if (bo.block_freelist)
     {
-        b = block_freelist;
-        block_freelist = b.Bnext;
-        *b = blkzero;
+        b = bo.block_freelist;
+        bo.block_freelist = b.Bnext;
+        *b = bo.blkzero;
     }
     else
         b = cast(block *) mem_calloc(block.sizeof);
@@ -102,11 +104,11 @@ void block_init()
 @trusted
 void block_term()
 {
-    while (block_freelist)
+    while (bo.block_freelist)
     {
-        block *b = block_freelist.Bnext;
-        mem_free(block_freelist);
-        block_freelist = b;
+        block *b = bo.block_freelist.Bnext;
+        mem_free(bo.block_freelist);
+        bo.block_freelist = b;
     }
 }
 
@@ -118,7 +120,7 @@ void block_term()
 void block_next(BlockState *bctx,int bc,block *bn)
 {
     bctx.curblock.BC = cast(ubyte) bc;
-    block_last = bctx.curblock;
+    bo.block_last = bctx.curblock;
     if (!bn)
         bn = block_calloc_i();
     bctx.curblock.Bnext = bn;                // next block
@@ -185,7 +187,7 @@ void block_ptr()
     //printf("block_ptr()\n");
 
     uint numblks = 0;
-    for (block *b = startblock; b; b = b.Bnext)       /* for each block        */
+    for (block *b = bo.startblock; b; b = b.Bnext)       /* for each block        */
     {
         b.Bblknum = numblks;
         numblks++;
@@ -200,10 +202,10 @@ void block_ptr()
 void block_pred()
 {
     //printf("block_pred()\n");
-    for (block *b = startblock; b; b = b.Bnext)       // for each block
+    for (block *b = bo.startblock; b; b = b.Bnext)       // for each block
         list_free(&b.Bpred,FPNULL);
 
-    for (block *b = startblock; b; b = b.Bnext)       // for each block
+    for (block *b = bo.startblock; b; b = b.Bnext)       // for each block
     {
         //printf("b = %p, BC = %s\n", b, bc_str(b.BC));
         foreach (bp; ListRange(b.Bsucc))
@@ -213,7 +215,7 @@ void block_pred()
             list_prepend(&(list_block(bp).Bpred),b);
         }
     }
-    assert(startblock.Bpred == null);  /* startblock has no preds      */
+    assert(bo.startblock.Bpred == null);  /* startblock has no preds      */
 }
 
 /********************************************
@@ -223,7 +225,7 @@ void block_pred()
 @trusted
 void block_clearvisit()
 {
-    for (block *b = startblock; b; b = b.Bnext)       // for each block
+    for (block *b = bo.startblock; b; b = b.Bnext)       // for each block
         b.Bflags = cast(BFL)(b.Bflags & ~cast(uint)BFL.visited); // mark as unvisited
 }
 
@@ -250,7 +252,7 @@ void block_visit(block *b)
 void block_compbcount(ref GlobalOptimizer go)
 {
     block_clearvisit();
-    block_visit(startblock);                    // visit all reachable blocks
+    block_visit(bo.startblock);                    // visit all reachable blocks
     elimblks(go);                               // eliminate unvisited blocks
 }
 
@@ -330,8 +332,8 @@ void block_free(block *b)
         default:
             break;
     }
-    b.Bnext = block_freelist;
-    block_freelist = b;
+    b.Bnext = bo.block_freelist;
+    bo.block_freelist = b;
 }
 
 /****************************
@@ -404,18 +406,18 @@ void block_initvar(Symbol *s)
 @trusted
 void block_endfunc(int flag)
 {
-    curblock.Bsymend = globsym.length;
-    curblock.Bendscope = curblock;
+    bo.curblock.Bsymend = globsym.length;
+    bo.curblock.Bendscope = bo.curblock;
     if (flag)
     {
         elem *e = el_longt(tstypes[TYint], 0);
-        block_appendexp(curblock, e);
-        curblock.BC = BCretexp;        // put a return at the end
+        block_appendexp(bo.curblock, e);
+        bo.curblock.BC = BCretexp;        // put a return at the end
     }
     else
-        curblock.BC = BCret;           // put a return at the end
-    curblock = null;                    // undefined from now on
-    block_last = null;
+        bo.curblock.BC = BCret;           // put a return at the end
+    bo.curblock = null;                    // undefined from now on
+    bo.block_last = null;
 }
 
 /******************************
@@ -430,8 +432,8 @@ void blockopt(ref GlobalOptimizer go, int iter)
         blassertsplit(go);              // only need this once
 
         int iterationLimit = 200;
-        if (iterationLimit < dfo.length)
-            iterationLimit = cast(int)dfo.length;
+        if (iterationLimit < bo.dfo.length)
+            iterationLimit = cast(int)bo.dfo.length;
         int count = 0;
         do
         {
@@ -453,7 +455,7 @@ void blockopt(ref GlobalOptimizer go, int iter)
 
             do
             {
-                compdfo(dfo, startblock); // compute depth first order (DFO)
+                compdfo(bo.dfo, bo.startblock); // compute depth first order (DFO)
                 elimblks(go);           /* remove blocks not in DFO      */
                 assert(count < iterationLimit);
                 count++;
@@ -462,18 +464,18 @@ void blockopt(ref GlobalOptimizer go, int iter)
 
         debug if (debugw)
         {
-            WRfunc("After blockopt()", funcsym_p, startblock);
+            WRfunc("After blockopt()", funcsym_p, bo.startblock);
         }
     }
     else
     {
         debug
         {
-            numberBlocks(startblock);
+            numberBlocks(bo.startblock);
         }
 
         /* canonicalize the trees        */
-        for (block *b = startblock; b; b = b.Bnext)
+        for (block *b = bo.startblock; b; b = b.Bnext)
         {
             debug if (debugb)
             {
@@ -500,7 +502,7 @@ void blockopt(ref GlobalOptimizer go, int iter)
             elem *e = el_long(TYnptr, 0);
             e.Eoper = OPgot;
             e = el_bin(OPeq, TYnptr, el_var(localgot), e);
-            startblock.Belem = el_combine(e, startblock.Belem);
+            bo.startblock.Belem = el_combine(e, bo.startblock.Belem);
         }
 
         bropt(go);                      /* branch optimization           */
@@ -509,7 +511,7 @@ void blockopt(ref GlobalOptimizer go, int iter)
 
         debug if (debugb)
         {
-            WRfunc("After blockopt()", funcsym_p, startblock);
+            WRfunc("After blockopt()", funcsym_p, bo.startblock);
         }
     }
 }
@@ -534,7 +536,7 @@ void brcombine(ref GlobalOptimizer go)
     do
     {
         int anychanges = 0;
-        for (block *b = startblock; b; b = b.Bnext)   // for each block
+        for (block *b = bo.startblock; b; b = b.Bnext)   // for each block
         {
             /* Look for [e1 IFFALSE L3,L2] L2: [e2 GOTO L3] L3: [e3]    */
             /* Replace with [(e1 && e2),e3]                             */
@@ -548,7 +550,7 @@ void brcombine(ref GlobalOptimizer go)
                     continue;
                 if (b2 == b3)
                     continue;
-                if (b2 == startblock)
+                if (b2 == bo.startblock)
                     continue;
                 if (!PARSER && b2.Belem && !OTleaf(b2.Belem.Eoper))
                     continue;
@@ -570,7 +572,7 @@ void brcombine(ref GlobalOptimizer go)
                     debug if (debugc) printf("brcombine(): if !e1 then e2 => e1 || e2\n");
                     anychanges++;
                 }
-                else if (list_next(b3.Bpred) || b3 == startblock)
+                else if (list_next(b3.Bpred) || b3 == bo.startblock)
                     continue;
                 else if ((bc2 == BCretexp && b3.BC == BCretexp)
                          //|| (bc2 == BCret && b3.BC == BCret)
@@ -671,7 +673,7 @@ void brcombine(ref GlobalOptimizer go)
             {
                 block *b2 = b.nthSucc(0);
                 if (!list_next(b2.Bpred) && b2.BC != BCasm    // if b is only parent
-                    && b2 != startblock
+                    && b2 != bo.startblock
                     && b2.BC != BCtry
                     && b2.BC != BC_try
                     && b.Btry == b2.Btry
@@ -729,7 +731,7 @@ private void bropt(ref GlobalOptimizer go)
 {
     debug if (debugc) printf("bropt()\n");
     assert(!PARSER);
-    for (block *b = startblock; b; b = b.Bnext)   // for each block
+    for (block *b = bo.startblock; b; b = b.Bnext)   // for each block
     {
         elem **pn = &(b.Belem);
         if (OPTIMIZER && *pn)
@@ -854,7 +856,7 @@ private void bropt(ref GlobalOptimizer go)
 private void brrear()
 {
     debug if (debugc) printf("brrear()\n");
-    for (block *b = startblock; b; b = b.Bnext)   // for each block
+    for (block *b = bo.startblock; b; b = b.Bnext)   // for each block
     {
         foreach (bl; ListRange(b.Bsucc))
         {   /* For each transfer of control block pointer   */
@@ -1002,7 +1004,7 @@ private void elimblks(ref GlobalOptimizer go)
     debug if (debugc) printf("elimblks()\n");
     block *bf = null;
     block *b;
-    for (block **pb = &startblock; (b = *pb) != null;)
+    for (block **pb = &bo.startblock; (b = *pb) != null;)
     {
         if (((b.Bflags & BFL.visited) == 0)   // if block is not visited
             && ((b.Bflags & BFL.label) == 0)  // need label offset
@@ -1059,7 +1061,7 @@ private int mergeblks()
 
     assert(OPTIMIZER);
     debug if (debugc) printf("mergeblks()\n");
-    foreach (b; dfo[])
+    foreach (b; bo.dfo[])
     {
         if (b.BC == BCgoto)
         {   block *bL2 = list_block(b.Bsucc);
@@ -1069,7 +1071,7 @@ private int mergeblks()
                 continue;
             }
             assert(bL2.Bpred);
-            if (!list_next(bL2.Bpred) && bL2 != startblock)
+            if (!list_next(bL2.Bpred) && bL2 != bo.startblock)
             {
                 if (b == bL2 || bL2.BC == BCasm)
                     continue;
@@ -1104,11 +1106,11 @@ private int mergeblks()
                 merge++;
                 debug if (debugc) printf("block %p merged with %p\n",b,bL2);
 
-                if (b == startblock)
+                if (b == bo.startblock)
                 {   /* bL2 is the new startblock */
                     debug if (debugc) printf("bL2 is new startblock\n");
                     /* Remove bL2 from list of blocks   */
-                    for (block **pb = &startblock; 1; pb = &(*pb).Bnext)
+                    for (block **pb = &bo.startblock; 1; pb = &(*pb).Bnext)
                     {
                         assert(*pb);
                         if (*pb == bL2)
@@ -1119,8 +1121,8 @@ private int mergeblks()
                     }
 
                     /* And relink bL2 at the start              */
-                    bL2.Bnext = startblock.Bnext;
-                    startblock = bL2;   // new start
+                    bL2.Bnext = bo.startblock.Bnext;
+                    bo.startblock = bL2;   // new start
 
                     block_free(b);
                     break;              // dfo[] is now invalid
@@ -1139,10 +1141,10 @@ private int mergeblks()
 private void blident(ref GlobalOptimizer go)
 {
     debug if (debugc) printf("blident()\n");
-    assert(startblock);
+    assert(bo.startblock);
 
     block *bnext;
-    for (block *bn = startblock; bn; bn = bnext)
+    for (block *bn = bo.startblock; bn; bn = bnext)
     {
         bnext = bn.Bnext;
         if (bn.Bflags & BFL.nomerg)
@@ -1222,7 +1224,7 @@ private void blident(ref GlobalOptimizer go)
                 }
 
                 // if bn is startblock, eliminate b instead of bn
-                if (bn == startblock)
+                if (bn == bo.startblock)
                 {
                     goto Lcontinue;     // can't handle predecessors to startblock
                     // unreachable code
@@ -1274,7 +1276,7 @@ private void blreturn(ref GlobalOptimizer go)
         int retcount = 0;               // number of return counts
 
         /* Find last return block       */
-        for (block *b = startblock; b; b = b.Bnext)
+        for (block *b = bo.startblock; b; b = b.Bnext)
         {
             if (b.BC == BCret)
                 retcount++;
@@ -1286,7 +1288,7 @@ private void blreturn(ref GlobalOptimizer go)
             return;
 
         /* Split return blocks  */
-        for (block *b = startblock; b; b = b.Bnext)
+        for (block *b = bo.startblock; b; b = b.Bnext)
         {
             if (b.BC != BCret)
                 continue;
@@ -1296,7 +1298,7 @@ private void blreturn(ref GlobalOptimizer go)
                 enum ifCondition = true;
                 if (ifCondition)
                 {
-                    for (block *b2 = startblock; b2; b2 = b2.Bnext)
+                    for (block *b2 = bo.startblock; b2; b2 = b2.Bnext)
                     {
                         if (b2.BC == BCret && b != b2 && b.Btry == b2.Btry)
                             goto L1;
@@ -1418,7 +1420,7 @@ private void bltailmerge(ref GlobalOptimizer go)
     if (!(go.mfoptim & MFtime))            /* if optimized for space       */
     {
         /* Split each block into a reversed linked list of elems        */
-        for (block *b = startblock; b; b = b.Bnext)
+        for (block *b = bo.startblock; b; b = b.Bnext)
             b.Blist = bl_enlist(b.Belem);
 
         /* Search for two blocks that have the same successor list.
@@ -1429,7 +1431,7 @@ private void bltailmerge(ref GlobalOptimizer go)
             enum additionalAnd = "b.Btry == bn.Btry";
         else
             enum additionalAnd = "true";
-        for (block *b = startblock; b; b = b.Bnext)
+        for (block *b = bo.startblock; b; b = b.Bnext)
         {
             if (!b.Blist)
                 continue;
@@ -1535,7 +1537,7 @@ private void bltailmerge(ref GlobalOptimizer go)
         }
 
         /* Recombine elem lists into expression trees   */
-        for (block *b = startblock; b; b = b.Bnext)
+        for (block *b = bo.startblock; b; b = b.Bnext)
             b.Belem = bl_delist(b.Blist);
     }
 }
@@ -1548,8 +1550,8 @@ private void bltailmerge(ref GlobalOptimizer go)
 private void brmin(ref GlobalOptimizer go)
 {
     debug if (debugc) printf("brmin()\n");
-    debug assert(startblock);
-    for (block *b = startblock.Bnext; b; b = b.Bnext)
+    debug assert(bo.startblock);
+    for (block *b = bo.startblock.Bnext; b; b = b.Bnext)
     {
         block *bnext = b.Bnext;
         if (!bnext)
@@ -1666,7 +1668,7 @@ private void brtailrecursion(ref GlobalOptimizer go)
         return;
     }
 
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block *b = bo.startblock; b; b = b.Bnext)
     {
         if (b.BC == BC_try)
             return;
@@ -1768,17 +1770,17 @@ private void brtailrecursion(ref GlobalOptimizer go)
                     list_subtract(&bn.Bpred,b);
                 }
                 b.BC = BCgoto;
-                list_append(&b.Bsucc,startblock);
-                list_append(&startblock.Bpred,b);
+                list_append(&b.Bsucc,bo.startblock);
+                list_append(&bo.startblock.Bpred,b);
 
                 // Create a new startblock, bs, because startblock cannot
                 // have predecessors.
                 block *bs = block_calloc();
                 bs.BC = BCgoto;
-                bs.Bnext = startblock;
-                list_append(&bs.Bsucc,startblock);
-                list_append(&startblock.Bpred,bs);
-                startblock = bs;
+                bs.Bnext = bo.startblock;
+                list_append(&bs.Bsucc,bo.startblock);
+                list_append(&bo.startblock.Bpred,bs);
+                bo.startblock = bs;
 
                 debug if (debugc) printf("tail recursion\n");
                 go.changes++;
@@ -1849,7 +1851,7 @@ private elem * assignparams(elem **pe,int *psi,elem **pe2)
 private void emptyloops(ref GlobalOptimizer go)
 {
     debug if (debugc) printf("emptyloops()\n");
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block *b = bo.startblock; b; b = b.Bnext)
     {
         if (b.BC == BCiftrue &&
             list_block(b.Bsucc) == b &&
@@ -1920,7 +1922,7 @@ private void emptyloops(ref GlobalOptimizer go)
 private void funcsideeffects()
 {
     //printf("funcsideeffects('%s')\n",funcsym_p.Sident);
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block *b = bo.startblock; b; b = b.Bnext)
     {
         if (b.Belem && funcsideeffect_walk(b.Belem))
         {
@@ -2005,7 +2007,7 @@ private void blassertsplit(ref GlobalOptimizer go)
 {
     debug if (debugc) printf("blassertsplit()\n");
     Barray!(elem*) elems;
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block *b = bo.startblock; b; b = b.Bnext)
     {
         /* Not sure of effect of jumping out of a try block
          */
@@ -2148,7 +2150,7 @@ private void blexit(ref GlobalOptimizer go)
         printf("blexit()\n");
 
     Barray!(block*) bexits;
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block *b = bo.startblock; b; b = b.Bnext)
     {
         /* Not sure of effect of jumping out of a try block
          */
@@ -2160,7 +2162,7 @@ private void blexit(ref GlobalOptimizer go)
             /* If b is not already at the end, put it at the end
              * because we don't care about speed for BCexit blocks
              */
-            if (b != startblock && b.Bnext && b.Bnext.BC != BCexit)
+            if (b != bo.startblock && b.Bnext && b.Bnext.BC != BCexit)
                 bexits.push(b);
             continue;
         }
@@ -2177,7 +2179,7 @@ private void blexit(ref GlobalOptimizer go)
         }
         list_free(&b.Bsucc, FPNULL);
 
-        if (b != startblock && b.Bnext)
+        if (b != bo.startblock && b.Bnext)
             bexits.push(b);
 
         debug if (debugc)
@@ -2191,7 +2193,7 @@ private void blexit(ref GlobalOptimizer go)
     /* First remove them from the list of blocks
      */
     size_t i = 0;
-    block** pb = &startblock.Bnext;
+    block** pb = &bo.startblock.Bnext;
     while (1)
     {
         if (i == bexits.length)

--- a/compiler/src/dmd/backend/cgcs.d
+++ b/compiler/src/dmd/backend/cgcs.d
@@ -44,9 +44,9 @@ nothrow:
 @trusted
 public void comsubs(ref GlobalOptimizer go)
 {
-    debug if (debugx) printf("comsubs(%p)\n",startblock);
+    debug if (debugx) printf("comsubs(%p)\n",bo.startblock);
 
-    comsubs2(startblock, cgcsdata, go);
+    comsubs2(bo.startblock, cgcsdata, go);
 
     debug if (debugx)
         printf("done with comsubs()\n");

--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -740,7 +740,7 @@ void out_regcand(symtab_t *psymtab)
     }
 
     bool addressOfParam = false;                  // haven't taken addr of param yet
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block *b = bo.startblock; b; b = b.Bnext)
     {
         if (b.Belem)
             out_regcand_walk(b.Belem, addressOfParam);
@@ -883,10 +883,10 @@ private void writefunc2(Symbol *sfunc, ref GlobalOptimizer go)
     foreach (si; 0 .. nsymbols)
         globsym[si] = f.Flocsym[si];
 
-    assert(startblock == null);
-    startblock = sfunc.Sfunc.Fstartblock;
+    assert(bo.startblock == null);
+    bo.startblock = sfunc.Sfunc.Fstartblock;
     sfunc.Sfunc.Fstartblock = null;
-    assert(startblock);
+    assert(bo.startblock);
 
     assert(funcsym_p == null);
     funcsym_p = sfunc;
@@ -951,7 +951,7 @@ private void writefunc2(Symbol *sfunc, ref GlobalOptimizer go)
 
     bool addressOfParam = false;  // see if any parameters get their address taken
     bool anyasm = false;
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block *b = bo.startblock; b; b = b.Bnext)
     {
         memset(&b._BLU,0,block.sizeof - block._BLU.offsetof);
         if (b.Belem)
@@ -996,7 +996,7 @@ private void writefunc2(Symbol *sfunc, ref GlobalOptimizer go)
     {
         if (debugb)
         {
-            WRfunc("codegen", funcsym_p, startblock);
+            WRfunc("codegen", funcsym_p, bo.startblock);
         }
     }
 
@@ -1035,16 +1035,16 @@ private void writefunc2(Symbol *sfunc, ref GlobalOptimizer go)
     //printf("codgen()\n");
     codgen(sfunc);                  // generate code
     //printf("after codgen for %s Coffset %x\n",sfunc.Sident.ptr,Offset(cseg));
-    sfunc.Sfunc.Fstartblock = startblock;
+    sfunc.Sfunc.Fstartblock = bo.startblock;
     bool saveForInlining = canInlineFunction(sfunc);
     if (saveForInlining)
     {
-        startblock = null;
+        bo.startblock = null;
     }
     else
     {
         sfunc.Sfunc.Fstartblock = null;
-        blocklist_free(&startblock);
+        blocklist_free(&bo.startblock);
     }
 
     objmod.func_term(sfunc);

--- a/compiler/src/dmd/backend/eh.d
+++ b/compiler/src/dmd/backend/eh.d
@@ -139,7 +139,7 @@ void except_fillInEHTable(Symbol *s)
     // First, calculate starting catch offset
     int guarddim = 0;                               // max dimension of guard[]
     int ndctors = 0;                                // number of PSOP.dctor's
-    foreach (b; BlockRange(startblock))
+    foreach (b; BlockRange(bo.startblock))
     {
         if (b.BC == BC_try && b.Bscope_index >= guarddim)
             guarddim = b.Bscope_index + 1;
@@ -164,7 +164,7 @@ void except_fillInEHTable(Symbol *s)
 
     // Generate guard[]
     int i = 0;
-    foreach (b; BlockRange(startblock))
+    foreach (b; BlockRange(bo.startblock))
     {
         //printf("b = %p, b.Btry = %p, b.offset = %x\n", b, b.Btry, b.Boffset);
         if (b.BC == BC_try)
@@ -182,7 +182,7 @@ void except_fillInEHTable(Symbol *s)
             if (config.ehmethod == EHmethod.EH_DM)
             {
             //printf("DHandlerInfo: offset = %x", cast(int)(b.Boffset - startblock.Boffset));
-            dtb.dword(cast(int)(b.Boffset - startblock.Boffset));    // offset to start of block
+            dtb.dword(cast(int)(b.Boffset - bo.startblock.Boffset));    // offset to start of block
 
             // Compute ending offset
             uint endoffset;
@@ -191,7 +191,7 @@ void except_fillInEHTable(Symbol *s)
                 //printf("\tbn = %p, bn.Btry = %p, bn.offset = %x\n", bn, bn.Btry, bn.Boffset);
                 assert(bn);
                 if (bn.Btry == b.Btry)
-                {    endoffset = cast(uint)(bn.Boffset - startblock.Boffset);
+                {    endoffset = cast(uint)(bn.Boffset - bo.startblock.Boffset);
                      break;
                 }
             }
@@ -220,8 +220,8 @@ void except_fillInEHTable(Symbol *s)
                 // finally handler address
                 if (config.ehmethod == EHmethod.EH_DM)
                 {
-                    assert(bhandler.Boffset > startblock.Boffset);
-                    dtb.size(bhandler.Boffset - startblock.Boffset);    // finally handler offset
+                    assert(bhandler.Boffset > bo.startblock.Boffset);
+                    dtb.size(bhandler.Boffset - bo.startblock.Boffset);    // finally handler offset
                 }
                 else
                     dtb.coff(cast(uint)bhandler.Boffset);
@@ -239,7 +239,7 @@ void except_fillInEHTable(Symbol *s)
         Barray!int stack;
 
     int scopeindex = guarddim;
-    foreach (b; BlockRange(startblock))
+    foreach (b; BlockRange(bo.startblock))
     {
         /* Set up stack of scope indices
          */
@@ -254,7 +254,7 @@ void except_fillInEHTable(Symbol *s)
                 if (config.ehmethod == EHmethod.EH_WIN32)
                     nteh_patchindex(c2, scopeindex);
                 if (config.ehmethod == EHmethod.EH_DM)
-                    dtb.dword(cast(int)(boffset - startblock.Boffset)); // guard offset
+                    dtb.dword(cast(int)(boffset - bo.startblock.Boffset)); // guard offset
                 // Find corresponding ddtor instruction
                 int n = 0;
                 uint eoffset = boffset;
@@ -290,7 +290,7 @@ void except_fillInEHTable(Symbol *s)
                             //cf = code_next(cf);
                             //foffset += calccodsize(cf);
                             if (config.ehmethod == EHmethod.EH_DM)
-                                dtb.dword(cast(int)(eoffset - startblock.Boffset)); // guard offset
+                                dtb.dword(cast(int)(eoffset - bo.startblock.Boffset)); // guard offset
                             break;
                         }
                     }
@@ -306,8 +306,8 @@ void except_fillInEHTable(Symbol *s)
                 dtb.dword(0);           // no catch offset
                 if (config.ehmethod == EHmethod.EH_DM)
                 {
-                    assert(foffset > startblock.Boffset);
-                    dtb.size(foffset - startblock.Boffset);    // finally handler offset
+                    assert(foffset > bo.startblock.Boffset);
+                    dtb.size(foffset - bo.startblock.Boffset);    // finally handler offset
                 }
                 else
                     dtb.coff(foffset);  // finally handler address
@@ -328,7 +328,7 @@ void except_fillInEHTable(Symbol *s)
     }
 
     // Generate catch[]
-    foreach (b; BlockRange(startblock))
+    foreach (b; BlockRange(bo.startblock))
     {
         if (b.BC == BC_try && b.jcatchvar)         // if try-catch
         {
@@ -347,8 +347,8 @@ void except_fillInEHTable(Symbol *s)
                 // catch handler address
                 if (config.ehmethod == EHmethod.EH_DM)
                 {
-                    assert(bcatch.Boffset > startblock.Boffset);
-                    dtb.size(bcatch.Boffset - startblock.Boffset);  // catch handler offset
+                    assert(bcatch.Boffset > bo.startblock.Boffset);
+                    dtb.size(bcatch.Boffset - bo.startblock.Boffset);  // catch handler offset
                 }
                 else
                     dtb.coff(cast(uint)bcatch.Boffset);

--- a/compiler/src/dmd/backend/gdag.d
+++ b/compiler/src/dmd/backend/gdag.d
@@ -75,7 +75,7 @@ void builddags(ref GlobalOptimizer go)
     vec_t aevec;
 
     debug if (debugc) printf("builddags()\n");
-    assert(dfo);
+    assert(bo.dfo);
     flowae(go);                       /* compute available expressions */
     if (go.exptop <= 1)             /* if no AEs                     */
         return;
@@ -130,14 +130,14 @@ void builddags(ref GlobalOptimizer go)
         /* the code generator can only track register contents          */
         /* properly across extended basic blocks.                       */
         aevec = vec_calloc(go.exptop);
-        foreach (i, b; dfo[])
+        foreach (i, b; bo.dfo[])
         {
             /* if not first block and (there are more than one      */
             /* predecessor or the only predecessor is not the       */
             /* previous block), then zero out the available         */
             /* expressions.                                         */
             if ((i != 0 &&
-                 (list_block(b.Bpred) != dfo[i - 1] ||
+                 (list_block(b.Bpred) != bo.dfo[i - 1] ||
                   list_next(b.Bpred) != null))
                 || b.BC == BCasm
                 || b.BC == BC_finally
@@ -154,7 +154,7 @@ void builddags(ref GlobalOptimizer go)
 
     // Need 2 passes to converge on solution
     foreach (j; 0 .. 2)
-        foreach (b; dfo[])
+        foreach (b; bo.dfo[])
         {
             if (b.Belem)
             {
@@ -598,8 +598,8 @@ void boolopt(ref GlobalOptimizer go)
     vec_t aevecval;
 
     debug if (debugc) printf("boolopt()\n");
-    if (!dfo.length)
-        compdfo(dfo, startblock);
+    if (!bo.dfo.length)
+        compdfo(bo.dfo, bo.startblock);
     flowae(go);                       /* compute available expressions */
     if (go.exptop <= 1)             /* if no AEs                     */
         return;
@@ -633,14 +633,14 @@ void boolopt(ref GlobalOptimizer go)
         }
     }
 
-    foreach (i, b; dfo[])
+    foreach (i, b; bo.dfo[])
     {
         /* if not first block and (there are more than one      */
         /* predecessor or the only predecessor is not the       */
         /* previous block), then zero out the available         */
         /* expressions.                                         */
         if ((i != 0 &&
-             (list_block(b.Bpred) != dfo[i - 1] ||
+             (list_block(b.Bpred) != bo.dfo[i - 1] ||
               list_next(b.Bpred) != null))
             || b.BC == BCasm
             || b.BC == BC_finally

--- a/compiler/src/dmd/backend/gflow.d
+++ b/compiler/src/dmd/backend/gflow.d
@@ -105,7 +105,7 @@ void flowrd(ref GlobalOptimizer go)
     /*      Bout = (Bin - Bkill) | Bgen                             */
     /* Using Ullman's algorithm:                                    */
 
-    foreach (b; dfo[])
+    foreach (b; bo.dfo[])
         vec_copy(b.Boutrd, b.Bgen);
 
     bool anychng;
@@ -113,7 +113,7 @@ void flowrd(ref GlobalOptimizer go)
     do
     {
         anychng = false;
-        foreach (b; dfo[])    // for each block
+        foreach (b; bo.dfo[])    // for each block
         {
             /* Binrd = union of Boutrds of all predecessors of b */
             vec_clear(b.Binrd);
@@ -160,7 +160,7 @@ private void rdgenkill(ref GlobalOptimizer go)
     /* Compute number of definition elems. */
     uint num_unambig_def = 0;
     uint deftop = 0;
-    foreach (b; dfo[])    // for each block
+    foreach (b; bo.dfo[])    // for each block
         if (b.Belem)
         {
             deftop += numdefelems(b.Belem, num_unambig_def);
@@ -183,14 +183,14 @@ private void rdgenkill(ref GlobalOptimizer go)
 
     go.defnod.setLength(deftop);
     size_t i = deftop;
-    foreach_reverse (b; dfo[])    // for each block
+    foreach_reverse (b; bo.dfo[])    // for each block
         if (b.Belem)
             asgdefelems(b, b.Belem, go.defnod[], i);    // fill in go.defnod[]
     assert(i == 0);
 
     initDNunambigVectors(go, go.defnod[]);
 
-    foreach (b; dfo[])    // for each block
+    foreach (b; bo.dfo[])    // for each block
     {
         /* dump any existing vectors */
         vec_free(b.Bgen);
@@ -552,13 +552,13 @@ private void flowaecp(ref GlobalOptimizer go, int flowxx)
     /*      Bout = (Bin - Bkill) | Bgen             */
     /* Using Ullman's algorithm:                    */
 
-    vec_clear(startblock.Bin);
-    vec_copy(startblock.Bout,startblock.Bgen); /* these never change */
-    if (startblock.BC == BCiftrue)
-        vec_copy(startblock.Bout2,startblock.Bgen2); // these never change
+    vec_clear(bo.startblock.Bin);
+    vec_copy(bo.startblock.Bout,bo.startblock.Bgen); /* these never change */
+    if (bo.startblock.BC == BCiftrue)
+        vec_copy(bo.startblock.Bout2,bo.startblock.Bgen2); // these never change
 
     /* For all blocks except startblock     */
-    foreach (b; dfo[1 .. $])
+    foreach (b; bo.dfo[1 .. $])
     {
         vec_set(b.Bin);        /* Bin = all expressions        */
 
@@ -579,7 +579,7 @@ private void flowaecp(ref GlobalOptimizer go, int flowxx)
         anychng = false;
 
         // For all blocks except startblock
-        foreach (b; dfo[1 .. $])
+        foreach (b; bo.dfo[1 .. $])
         {
             // Bin = & of Bout of all predecessors
             // Bout = (Bin - Bkill) | Bgen
@@ -782,7 +782,7 @@ private void aecpgenkill(ref GlobalOptimizer go, int flowxx)
     go.expblk.setLength(0);             // dump any existing one
     go.expblk.push(null);
 
-    foreach (b; dfo[])
+    foreach (b; bo.dfo[])
     {
         if (b.Belem)
         {
@@ -813,7 +813,7 @@ private void aecpgenkill(ref GlobalOptimizer go, int flowxx)
         {   dbg_printf("vptrkill "); vec_println(go.vptrkill); }
     }
 
-    foreach (i, b; dfo[])
+    foreach (i, b; bo.dfo[])
     {
         /* dump any existing vectors    */
         vec_free(b.Bin);
@@ -1026,7 +1026,7 @@ void genkillae(ref GlobalOptimizer go)
 {
     flowxx = AE;
     assert(go.exptop > 1);
-    foreach (b; dfo[])
+    foreach (b; bo.dfo[])
     {
         assert(b);
         vec_clear(b.Bgen);
@@ -1354,7 +1354,7 @@ void flowlv()
     /*      Bout = union of Bin of all successors to B.     */
     /* Using Ullman's algorithm:                            */
 
-    foreach (b; dfo[])
+    foreach (b; bo.dfo[])
     {
         vec_copy(b.Binlv, b.Bgen);   // Binlv = Bgen
     }
@@ -1367,7 +1367,7 @@ void flowlv()
         anychng = false;
 
         /* For each block B in reverse DFO order        */
-        foreach_reverse (b; dfo[])
+        foreach_reverse (b; bo.dfo[])
         {
             /* Bout = union of Bins of all successors to B. */
             bool first = true;
@@ -1444,7 +1444,7 @@ private void lvgenkill()
         }
     }
 
-    foreach (b; dfo[])
+    foreach (b; bo.dfo[])
     {
         vec_free(b.Bgen);
         vec_free(b.Bkill);
@@ -1690,7 +1690,7 @@ void flowvbe(ref GlobalOptimizer go)
     /*printf("defkill = "); vec_println(go.defkill);
     printf("starkill = "); vec_println(go.starkill);*/
 
-    foreach (b; dfo[])
+    foreach (b; bo.dfo[])
     {
         /*printf("block %p\n",b);
         printf("Bgen = "); vec_println(b.Bgen);
@@ -1713,7 +1713,7 @@ void flowvbe(ref GlobalOptimizer go)
         anychng = false;
 
         /* for all blocks except return blocks in reverse dfo order */
-        foreach_reverse (b; dfo[])
+        foreach_reverse (b; bo.dfo[])
         {
             if (b.BC == BCret || b.BC == BCretexp || b.BC == BCexit)
                 continue;

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -116,7 +116,7 @@ extern (D) regm_t mask(uint m) { return cast(regm_t)1 << m; }
 
 public import dmd.backend.var : OPTIMIZER, PARSER, globsym, controlc_saw, pointertype, sytab;
 public import dmd.backend.cg : fregsaved, localgot, tls_get_addr_sym;
-public import dmd.backend.blockopt : startblock, dfo, curblock, block_last;
+public import dmd.backend.blockopt : bo;
 
 __gshared Configv configv;                // non-ph part of configuration
 

--- a/compiler/src/dmd/backend/glocal.d
+++ b/compiler/src/dmd/backend/glocal.d
@@ -82,7 +82,7 @@ void localize(ref GlobalOptimizer go)
     // Table should not get any larger than the symbol table
     loctab.setLength(globsym.length);
 
-    foreach (b; BlockRange(startblock))       // for each block
+    foreach (b; BlockRange(bo.startblock))       // for each block
     {
         loctab.setLength(0);                     // start over for each block
         if (b.Belem &&

--- a/compiler/src/dmd/backend/gloop.d
+++ b/compiler/src/dmd/backend/gloop.d
@@ -207,8 +207,8 @@ bool blockinit()
 {
     bool hasasm = false;
 
-    assert(dfo);
-    foreach (b; BlockRange(startblock))
+    assert(bo.dfo);
+    foreach (b; BlockRange(bo.startblock))
     {
         debug                   /* check integrity of Bpred and Bsucc   */
           L1:
@@ -222,10 +222,10 @@ bool blockinit()
 
         hasasm |= (b.BC == BCasm);
     }
-    foreach (j, b; dfo[])
+    foreach (j, b; bo.dfo[])
     {
         assert(b.Bdfoidx == j);
-        b.Bdom = vec_realloc(b.Bdom, dfo.length); /* alloc Bdom vectors */
+        b.Bdom = vec_realloc(b.Bdom, bo.dfo.length); /* alloc Bdom vectors */
         vec_clear(b.Bdom);
     }
     return hasasm;
@@ -244,7 +244,7 @@ bool blockinit()
 @trusted
 void compdom()
 {
-    compdom(dfo[]);
+    compdom(bo.dfo[]);
 }
 
 @trusted
@@ -313,7 +313,7 @@ private extern (D) void compdom(block*[] dfo)
 @trusted
 bool dom(const block* A, const block* B)
 {
-    assert(A && B && dfo && dfo[A.Bdfoidx] == A);
+    assert(A && B && bo.dfo && bo.dfo[A.Bdfoidx] == A);
     return vec_testbit(A.Bdfoidx,B.Bdom) != 0;
 }
 
@@ -409,7 +409,7 @@ private void buildloop(ref Loops ploops,block *head,block *tail)
             // Calculate loop contents separately so we get the Bweights
             // done accurately.
 
-            vec_t v = vec_calloc(dfo.length);
+            vec_t v = vec_calloc(bo.dfo.length);
             vec_setbit(head.Bdfoidx,v);
             head.Bweight = loop_weight(head.Bweight, 1);
             insert(tail,v);
@@ -425,8 +425,8 @@ private void buildloop(ref Loops ploops,block *head,block *tail)
     /* Allocate loop entry        */
     l = ploops.push();
 
-    l.Lloop = vec_calloc(dfo.length);    // allocate loop bit vector
-    l.Lexit = vec_calloc(dfo.length);    // bit vector for exit blocks
+    l.Lloop = vec_calloc(bo.dfo.length);    // allocate loop bit vector
+    l.Lexit = vec_calloc(bo.dfo.length);    // bit vector for exit blocks
     l.Lhead = head;
     l.Ltail = tail;
     l.Lpreheader = null;
@@ -444,11 +444,11 @@ L1:
     // for each block in this loop
     foreach (i; VecRange(l.Lloop))
     {
-        if (dfo[i].BC == BCret || dfo[i].BC == BCretexp || dfo[i].BC == BCexit)
+        if (bo.dfo[i].BC == BCret || bo.dfo[i].BC == BCretexp || bo.dfo[i].BC == BCexit)
             vec_setbit(i,l.Lexit); /* ret blocks are exit blocks */
         else
         {
-            foreach (bl; ListRange(dfo[i].Bsucc))
+            foreach (bl; ListRange(bo.dfo[i].Bsucc))
                 if (!vec_testbit(list_block(bl).Bdfoidx,l.Lloop))
                 {
                     vec_setbit(i,l.Lexit);
@@ -626,7 +626,7 @@ private bool looprotate(ref GlobalOptimizer go, ref Loop l)
         go.changes++;
         return true;
     }
-    else if (startblock != head
+    else if (bo.startblock != head
             /* This screws up the OPctor/OPdtor sequence for:
              *   struct CString
              *   {   CString();
@@ -646,7 +646,7 @@ private bool looprotate(ref GlobalOptimizer go, ref Loop l)
             )
     {   // optimize for space
         // Simply position the header past the tail
-        foreach (b; BlockRange(startblock))
+        foreach (b; BlockRange(bo.startblock))
         {
             if (b.Bnext == head)
             {   // found parent b of head
@@ -686,13 +686,13 @@ void loopopt(ref GlobalOptimizer go)
 restart:
     if (blockinit())                    // init block data
     {
-        findloops(dfo[], startloop);    // Compute Bweights
+        findloops(bo.dfo[], startloop);    // Compute Bweights
         freeloop(startloop);            // free existing loops
         startloop_cache = startloop;
         return;                         // can't handle ASM blocks
     }
     compdom();                          // compute dominators
-    findloops(dfo[], startloop);              // find the loops
+    findloops(bo.dfo[], startloop);              // find the loops
 
   L3:
     while (1)
@@ -701,10 +701,10 @@ restart:
         {
             if (looprotate(go, l))              // rotate the loop
             {
-                compdfo(dfo, startblock);
+                compdfo(bo.dfo, bo.startblock);
                 blockinit();
                 compdom();
-                findloops(dfo[], startloop);
+                findloops(bo.dfo[], startloop);
                 continue L3;
             }
         }
@@ -726,11 +726,11 @@ restart:
             block* h = l.Lhead;         // loop header
 
             /* Find parent of h */
-            if (h == startblock)
-                startblock = p;
+            if (h == bo.startblock)
+                bo.startblock = p;
             else
             {
-                for (auto ph = startblock; 1; ph = ph.Bnext)
+                for (auto ph = bo.startblock; 1; ph = ph.Bnext)
                 {
                     assert(ph);         /* should have found it         */
                     if (ph.Bnext == h)
@@ -775,10 +775,10 @@ restart:
     } /* for */
     if (addblk)                         /* if any blocks were added      */
     {
-        compdfo(dfo, startblock);                      /* compute depth-first order    */
+        compdfo(bo.dfo, bo.startblock);                      /* compute depth-first order    */
         blockinit();
         compdom();
-        findloops(dfo[], startloop);          // recompute block info
+        findloops(bo.dfo[], startloop);          // recompute block info
         addblk = false;
     }
 
@@ -797,10 +797,10 @@ restart:
             {
                 if (loopunroll(go, l))
                 {
-                    compdfo(dfo, startblock);                      // compute depth-first order
+                    compdfo(bo.dfo, bo.startblock);                      // compute depth-first order
                     blockinit();
                     compdom();
-                    findloops(dfo[], startloop);    // recompute block info
+                    findloops(bo.dfo[], startloop);    // recompute block info
                     doflow = true;
                     continue L2;
                 }
@@ -833,16 +833,16 @@ restart:
         if (debugc) printf("...Loop %p start...\n",&l);
 
         /* Unmark all elems in this loop         */
-        for (uint i = 0; (i = cast(uint) vec_index(i, lv)) < dfo.length; ++i)
-            if (dfo[i].Belem)
-                unmarkall(dfo[i].Belem);       /* unmark all elems     */
+        for (uint i = 0; (i = cast(uint) vec_index(i, lv)) < bo.dfo.length; ++i)
+            if (bo.dfo[i].Belem)
+                unmarkall(bo.dfo[i].Belem);       /* unmark all elems     */
 
         /* Find & mark all LIs   */
         vec_t gin = vec_clone(l.Lpreheader.Bout);
         vec_t rd = vec_calloc(go.defnod.length);        /* allocate our running RD vector */
-        for (uint i = 0; (i = cast(uint) vec_index(i, lv)) < dfo.length; ++i) // for each block in loop
+        for (uint i = 0; (i = cast(uint) vec_index(i, lv)) < bo.dfo.length; ++i) // for each block in loop
         {
-            block *b = dfo[i];
+            block *b = bo.dfo[i];
 
             if (debugc) printf("B%d\n",i);
             if (b.Belem)
@@ -881,14 +881,14 @@ restart:
         vec_free(gin);
 
         /* Move loop invariants  */
-        for (uint i = 0; (i = cast(uint) vec_index(i, lv)) < dfo.length; ++i)
+        for (uint i = 0; (i = cast(uint) vec_index(i, lv)) < bo.dfo.length; ++i)
         {
             uint domexit;               // true if this block dominates all
                                         // exit blocks of the loop
 
-            for (uint j = 0; (j = cast(uint) vec_index(j, l.Lexit)) < dfo.length; ++j) // for each exit block
+            for (uint j = 0; (j = cast(uint) vec_index(j, l.Lexit)) < bo.dfo.length; ++j) // for each exit block
             {
-                if (!vec_testbit (i, dfo[j].Bdom))
+                if (!vec_testbit (i, bo.dfo[j].Bdom))
                 {
                     domexit = 0;
                     goto L1;                // break if !(i dom j)
@@ -897,13 +897,13 @@ restart:
             // if i dom (all exit blocks)
             domexit = 1;
         L1:
-            if (dfo[i].Belem)
+            if (bo.dfo[i].Belem)
             {   // If there is any hope of making an improvement
                 if (domexit || l.Llis.length)
                 {
                     //if (dfo[i] != l.Lhead)
                         //domexit |= 2;
-                    movelis(go, dfo[i].Belem, dfo[i], l, domexit);
+                    movelis(go, bo.dfo[i].Belem, bo.dfo[i], l, domexit);
                 }
             }
         }
@@ -914,7 +914,7 @@ restart:
             loopiv(go, l);          /* induction variables          */
             if (addblk)             /* if we added a block          */
             {
-                compdfo(dfo, startblock);
+                compdfo(bo.dfo, bo.startblock);
                 goto restart;       /* play it safe and start over  */
             }
         }
@@ -1545,9 +1545,9 @@ Lnextlis:
                 if (!(pdomexit & 1))                   // if not case 1
                 {
                     uint i;
-                    for (i = 0; (i = cast(uint) vec_index(i, l.Lexit)) < dfo.length; ++i)  // for each exit block
+                    for (i = 0; (i = cast(uint) vec_index(i, l.Lexit)) < bo.dfo.length; ++i)  // for each exit block
                     {
-                        foreach (bl; ListRange(dfo[i].Bsucc))
+                        foreach (bl; ListRange(bo.dfo[i].Bsucc))
                         {
                             block *s;           // successor to exit block
 
@@ -1562,9 +1562,9 @@ Lnextlis:
 
                 tmp = vec_calloc(go.defnod.length);
                 uint i;
-                for (i = 0; (i = cast(uint) vec_index(i, l.Lloop)) < dfo.length; ++i)  // for each block in loop
+                for (i = 0; (i = cast(uint) vec_index(i, l.Lloop)) < bo.dfo.length; ++i)  // for each block in loop
                 {
-                    if (dfo[i] == b)        // except this one
+                    if (bo.dfo[i] == b)        // except this one
                         continue;
 
                     //<if there are any RDs of v in Binrd other than n>
@@ -1572,14 +1572,14 @@ Lnextlis:
                     //        return;
 
                     //filterrd(tmp,dfo[i].Binrd,v);
-                    listrds(go, dfo[i].Binrd,n.E1,tmp,null);
+                    listrds(go, bo.dfo[i].Binrd,n.E1,tmp,null);
                     uint j;
                     for (j = 0; (j = cast(uint) vec_index(j, tmp)) < go.defnod.length; ++j)  // for each RD of v in Binrd
                     {
                         if (go.defnod[j].DNelem == n)
                             continue;
-                        if (dfo[i].Belem &&
-                            refs(v,dfo[i].Belem,cast(elem *)null)) //if refs of v
+                        if (bo.dfo[i].Belem &&
+                            refs(v,bo.dfo[i].Belem,cast(elem *)null)) //if refs of v
                         {
                             vec_free(tmp);
                             goto L3;
@@ -1987,7 +1987,7 @@ private void loopiv(ref GlobalOptimizer go, ref Loop l)
 {
     if (debugc) printf("loopiv(%p)\n", &l);
     assert(l.Livlist.length == 0 && l.Lopeqlist.length == 0);
-    elimspec(go, l, dfo);
+    elimspec(go, l, bo.dfo);
     if (doflow)
     {
         flowrd(go);             /* compute reaching defs                */
@@ -2307,9 +2307,9 @@ private void findivfams(ref Loop l)
     if (debugc) printf("findivfams(%p)\n", &l);
     foreach (ref biv; l.Livlist)
     {
-        for (uint i = 0; (i = cast(uint) vec_index(i, l.Lloop)) < dfo.length; ++i)  // for each block in loop
-            if (dfo[i].Belem)
-                ivfamelems(&biv,&(dfo[i].Belem));
+        for (uint i = 0; (i = cast(uint) vec_index(i, l.Lloop)) < bo.dfo.length; ++i)  // for each block in loop
+            if (bo.dfo[i].Belem)
+                ivfamelems(&biv,&(bo.dfo[i].Belem));
         /* Fold all the constant expressions in c1 and c2.      */
         foreach (ref fl; biv.IVfamily)
         {
@@ -3007,12 +3007,12 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
             /* if X is live on entry to any successor S outside loop */
             /*      prepend elem X=(T-c2)/c1 to S.Belem     */
 
-            for (uint i = 0; (i = cast(uint) vec_index(i, l.Lexit)) < dfo.length; ++i)  // for each exit block
+            for (uint i = 0; (i = cast(uint) vec_index(i, l.Lexit)) < bo.dfo.length; ++i)  // for each exit block
             {
                 elem *ne;
                 block *b;
 
-                foreach (bl; ListRange(dfo[i].Bsucc))
+                foreach (bl; ListRange(bo.dfo[i].Bsucc))
                 {   /* for each successor   */
                     b = list_block(bl);
                     if (vec_testbit(b.Bdfoidx,l.Lloop))
@@ -3053,13 +3053,13 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
                         block *bn = block_calloc();
                         bn.Btry = b.Btry;
                         bn.BC = BCgoto;
-                        bn.Bnext = dfo[i].Bnext;
-                        dfo[i].Bnext = bn;
+                        bn.Bnext = bo.dfo[i].Bnext;
+                        bo.dfo[i].Bnext = bn;
                         list_append(&(bn.Bsucc),b);
-                        list_append(&(bn.Bpred),dfo[i]);
+                        list_append(&(bn.Bpred),bo.dfo[i]);
                         bl.ptr = cast(void *)bn;
                         foreach (bl2; ListRange(b.Bpred))
-                            if (list_block(bl2) == dfo[i])
+                            if (list_block(bl2) == bo.dfo[i])
                             {
                                 bl2.ptr = cast(void *)bn;
                                 goto L2;
@@ -3086,9 +3086,9 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
         else if (refcount == 0)                 /* if no uses of IV in loop  */
         {
             /* Eliminate the basic IV if it is not live on any successor */
-            for (uint i = 0; (i = cast(uint) vec_index(i, l.Lexit)) < dfo.length; ++i)  // for each exit block
+            for (uint i = 0; (i = cast(uint) vec_index(i, l.Lexit)) < bo.dfo.length; ++i)  // for each exit block
             {
-                foreach (bl; ListRange(dfo[i].Bsucc))
+                foreach (bl; ListRange(bo.dfo[i].Bsucc))
                 {   /* for each successor   */
                     block *b = list_block(bl);
                     if (vec_testbit(b.Bdfoidx,l.Lloop))
@@ -3151,9 +3151,9 @@ private void elimopeqs(ref GlobalOptimizer go, ref Loop l)
         else if (refcount == 0)                 // if no uses of IV in loop
         {   // Eliminate the basic IV if it is not live on any successor
             uint i;
-            for (i = 0; (i = cast(uint) vec_index(i, l.Lexit)) < dfo.length; ++i)  // for each exit block
+            for (i = 0; (i = cast(uint) vec_index(i, l.Lexit)) < bo.dfo.length; ++i)  // for each exit block
             {
-                foreach (bl; ListRange(dfo[i].Bsucc))
+                foreach (bl; ListRange(bo.dfo[i].Bsucc))
                 {   // for each successor
                     block *b = list_block(bl);
                     if (vec_testbit(b.Bdfoidx,l.Lloop))
@@ -3342,7 +3342,7 @@ private bool catchRef(Symbol* x, ref Loop l)
     if (!btry)
         return false;   // not in a try block
 
-    foreach (i, b; dfo[])
+    foreach (i, b; bo.dfo[])
     {
         if (vec_testbit(b.Bdfoidx, l.Lloop))
             continue;
@@ -3394,9 +3394,9 @@ private elem ** onlyref(Symbol *x, ref Loop l,elem *incn, out int refcount)
     assert(X.Ssymnum < globsym.length && incn);
     int count = 0;
     nd = null;
-    for (i = 0; (i = cast(uint) vec_index(i, l.Lloop)) < dfo.length; ++i)  // for each block in loop
+    for (i = 0; (i = cast(uint) vec_index(i, l.Lloop)) < bo.dfo.length; ++i)  // for each block in loop
     {
-        block* b = dfo[i];
+        block* b = bo.dfo[i];
         if (b.Belem)
         {
             count += countrefs(&b.Belem,b.BC == BCiftrue);
@@ -3703,7 +3703,7 @@ bool loopunroll(ref GlobalOptimizer go, ref Loop l)
         return false;
     l.Lhead.Bflags |= BFL.nounroll;
     if (log)
-        WRfunc("loop", funcsym_p, startblock);
+        WRfunc("loop", funcsym_p, bo.startblock);
 
     if (l.Lhead.Btry || l.Ltail.Btry)
         return false;
@@ -3713,9 +3713,9 @@ bool loopunroll(ref GlobalOptimizer go, ref Loop l)
      */
     const numblocks = vec_numBitsSet(l.Lloop);
 {   // Ensure no changes
-    if (dfo.length != vec_numbits(l.Lloop)) assert(0);
+    if (bo.dfo.length != vec_numbits(l.Lloop)) assert(0);
     int n = 0;
-    for (int i = 0; (i = cast(uint) vec_index(i, l.Lloop)) < dfo.length; ++i)  // for each block in loop
+    for (int i = 0; (i = cast(uint) vec_index(i, l.Lloop)) < bo.dfo.length; ++i)  // for each block in loop
         ++n;
     if (n != numblocks) assert(0);
 }

--- a/compiler/src/dmd/backend/go.d
+++ b/compiler/src/dmd/backend/go.d
@@ -221,7 +221,7 @@ void optfunc(ref GlobalOptimizer go)
 
     debug if (debugb)
     {
-        WRfunc("before optimization", funcsym_p, startblock);
+        WRfunc("before optimization", funcsym_p, bo.startblock);
     }
 
     if (localgot)
@@ -230,14 +230,14 @@ void optfunc(ref GlobalOptimizer go)
         elem *e = el_long(TYnptr, 0);
         e.Eoper = OPgot;
         e = el_bin(OPeq, TYnptr, el_var(localgot), e);
-        startblock.Belem = el_combine(e, startblock.Belem);
+        bo.startblock.Belem = el_combine(e, bo.startblock.Belem);
     }
 
     // Each pass through the loop can reduce only one level of comma expression.
     // The infinite loop check needs to take this into account.
     // Add 100 just to give optimizer more rope to try to converge.
     int iterationLimit = 100;
-    for (block* b = startblock; b; b = b.Bnext)
+    for (block* b = bo.startblock; b; b = b.Bnext)
     {
         if (!b.Belem)
             continue;
@@ -261,7 +261,7 @@ void optfunc(ref GlobalOptimizer go)
 
         //printf("optelem\n");
         /* canonicalize the trees        */
-        foreach (b; BlockRange(startblock))
+        foreach (b; BlockRange(bo.startblock))
             if (b.Belem)
             {
                 debug if (debuge)
@@ -291,7 +291,7 @@ void optfunc(ref GlobalOptimizer go)
             blockopt(go, 0);            // do block optimization
         out_regcand(&globsym);          // recompute register candidates
         go.changes = 0;                 // no changes yet
-        sliceStructs(globsym, startblock);
+        sliceStructs(globsym, bo.startblock);
         if (go.mfoptim & MFcnp)
             constprop(go);              /* make relationals unsigned     */
         if (go.mfoptim & (MFli | MFliv))
@@ -299,7 +299,7 @@ void optfunc(ref GlobalOptimizer go)
                                         /* induction vars                */
                                         /* do loop rotation              */
         else
-            foreach (b; BlockRange(startblock))
+            foreach (b; BlockRange(bo.startblock))
                 b.Bweight = 1;
         dbg_optprint("boolopt\n");
 
@@ -318,7 +318,7 @@ void optfunc(ref GlobalOptimizer go)
          * This can result in localgot getting needed.
          */
         Symbol *localgotsave = localgot;
-        for (block* b = startblock; b; b = b.Bnext)
+        for (block* b = bo.startblock; b; b = b.Bnext)
         {
             if (b.Belem)
             {
@@ -334,7 +334,7 @@ void optfunc(ref GlobalOptimizer go)
             elem *e = el_long(TYnptr, 0);
             e.Eoper = OPgot;
             e = el_bin(OPeq, TYnptr, el_var(localgot), e);
-            startblock.Belem = el_combine(e, startblock.Belem);
+            bo.startblock.Belem = el_combine(e, bo.startblock.Belem);
         }
 
         /* localize() is after localgot, otherwise we wind up with
@@ -355,7 +355,7 @@ void optfunc(ref GlobalOptimizer go)
     if (go.mfoptim & MFdc)
         blockopt(go, 1);                // do block optimization
 
-    for (block* b = startblock; b; b = b.Bnext)
+    for (block* b = bo.startblock; b; b = b.Bnext)
     {
         if (b.Belem)
             postoptelem(b.Belem);
@@ -369,11 +369,11 @@ void optfunc(ref GlobalOptimizer go)
 
     debug if (debugb)
     {
-        WRfunc("after optimization", funcsym_p, startblock);
+        WRfunc("after optimization", funcsym_p, bo.startblock);
     }
 
     // Prepare for code generator
-    for (block* b = startblock; b; b = b.Bnext)
+    for (block* b = bo.startblock; b; b = b.Bnext)
     {
         block_optimizer_free(b);
     }

--- a/compiler/src/dmd/backend/gother.d
+++ b/compiler/src/dmd/backend/gother.d
@@ -147,13 +147,13 @@ void constprop(ref GlobalOptimizer go)
 private void rd_compute(ref GlobalOptimizer go, ref EqRelInc eqrelinc)
 {
     if (debugc) printf("constprop()\n");
-    assert(dfo);
+    assert(bo.dfo);
     flowrd(go);               /* compute reaching definitions (rd)    */
     if (go.defnod.length == 0)     /* if no reaching defs                  */
         return;
     assert(eqrelinc.rellist.length == 0 && eqrelinc.inclist.length == 0 && eqrelinc.eqeqlist.length == 0);
     block_clearvisit();
-    foreach (b; dfo[])    // for each block
+    foreach (b; bo.dfo[])    // for each block
     {
         switch (b.BC)
         {
@@ -170,7 +170,7 @@ private void rd_compute(ref GlobalOptimizer go, ref EqRelInc eqrelinc)
         }
     }
 
-    foreach (i, b; dfo[])    // for each block
+    foreach (i, b; bo.dfo[])    // for each block
     {
         //printf("block %d Bin ",i); vec_println(b.Binrd);
         //printf("       Bout "); vec_println(b.Boutrd);
@@ -438,7 +438,7 @@ private void chkrd(elem *n, Barray!(elem*) rdlist)
     }
 
     // If there are any asm blocks, don't print the message
-    foreach (b; dfo[])
+    foreach (b; bo.dfo[])
         if (b.BC == BCasm)
             return;
 
@@ -1079,7 +1079,7 @@ public void copyprop(ref GlobalOptimizer go)
 {
     out_regcand(&globsym);
     if (debugc) printf("copyprop()\n");
-    assert(dfo);
+    assert(bo.dfo);
 
 Louter:
     while (1)
@@ -1096,7 +1096,7 @@ Louter:
                 printf(");\n");
             }
         }
-        foreach (i, b; dfo[])    // for each block
+        foreach (i, b; bo.dfo[])    // for each block
         {
             if (b.Belem)
             {
@@ -1375,7 +1375,7 @@ public void rmdeadass(ref GlobalOptimizer go)
 {
     if (debugc) printf("rmdeadass()\n");
     flowlv();                       /* compute live variables       */
-    foreach (b; dfo[])         // for each block b
+    foreach (b; bo.dfo[])         // for each block b
     {
         if (!b.Belem)          /* if no elems at all           */
             continue;
@@ -1778,7 +1778,7 @@ private void accumda(elem *n,vec_t DEAD, vec_t POSS)
 @trusted
 public void deadvar()
 {
-        assert(dfo);
+        assert(bo.dfo);
 
         /* First, mark each candidate as dead.  */
         /* Initialize vectors for live ranges.  */
@@ -1789,14 +1789,14 @@ public void deadvar()
                 s.Sflags |= SFLdead;
                 if (s.Sflags & GTregcand)
                 {
-                    s.Srange = vec_realloc(s.Srange, dfo.length);
+                    s.Srange = vec_realloc(s.Srange, bo.dfo.length);
                     vec_clear(s.Srange);
                 }
             }
         }
 
         /* Go through trees and "liven" each one we see.        */
-        foreach (i, b; dfo[])
+        foreach (i, b; bo.dfo[])
             if (b.Belem)
                 dvwalk(b.Belem,cast(uint)i);
 
@@ -1806,7 +1806,7 @@ public void deadvar()
         foreach (i, s; globsym[])
         {
             if (s.Srange /*&& s.Sclass != CLMOS*/)
-                foreach (j, b; dfo[])
+                foreach (j, b; bo.dfo[])
                     if (vec_testbit(i,b.Binlv))
                         vec_setbit(j, globsym[i].Srange);
         }
@@ -1883,11 +1883,11 @@ public void verybusyexp(ref GlobalOptimizer go)
     genkillae(go);                  /* compute Bgen and Bkill for   */
                                     /* AEs                          */
     /*chkvecdim(go.exptop,0);*/
-    blockseen = vec_calloc(dfo.length);
+    blockseen = vec_calloc(bo.dfo.length);
 
     /* Go backwards through dfo so that VBEs are evaluated as       */
     /* close as possible to where they are used.                    */
-    foreach_reverse (i, b; dfo[])     // for each block
+    foreach_reverse (i, b; bo.dfo[])     // for each block
     {
         int done;
 

--- a/compiler/src/dmd/backend/inliner.d
+++ b/compiler/src/dmd/backend/inliner.d
@@ -162,7 +162,7 @@ void scanForInlines(Symbol *sfunc)
     if (1 || f.Fflags3 & Fdoinline)  // if any inline functions called
     {
         f.Fflags |= Finlinenest;
-        foreach (b; BlockRange(startblock))
+        foreach (b; BlockRange(bo.startblock))
             if (b.Belem)
             {
                 //elem_print(b.Belem);

--- a/compiler/src/dmd/backend/x86/cgreg.d
+++ b/compiler/src/dmd/backend/x86/cgreg.d
@@ -60,11 +60,11 @@ void cgreg_init()
 
     // Use calloc() instead because sometimes the alloc is too large
     //printf("1weights: dfo.length = %d, globsym.length = %d\n", dfo.length, globsym.length);
-    weights.setLength(dfo.length * globsym.length);
+    weights.setLength(bo.dfo.length * globsym.length);
     weights[] = 0;
 
     nretblocks = 0;
-    foreach (bi, b; dfo[])
+    foreach (bi, b; bo.dfo[])
     {
         if (b.BC == BCret || b.BC == BCretexp)
             nretblocks++;
@@ -82,7 +82,7 @@ void cgreg_init()
         //printf("considering candidate '%s' for register\n", s.Sident.ptr);
 
         if (s.Srange)
-            s.Srange = vec_realloc(s.Srange,dfo.length);
+            s.Srange = vec_realloc(s.Srange,bo.dfo.length);
 
         // Determine symbols that are not candidates
         uint sz;
@@ -133,10 +133,10 @@ void cgreg_init()
             s.Sflags |= GTbyte;
 
         if (!s.Slvreg)
-            s.Slvreg = vec_calloc(dfo.length);
+            s.Slvreg = vec_calloc(bo.dfo.length);
 
         //printf("dfo.length = %d, numbits = %d\n",dfo.length,vec_numbits(s.Srange));
-        assert(vec_numbits(s.Srange) == dfo.length);
+        assert(vec_numbits(s.Srange) == bo.dfo.length);
     }
 }
 
@@ -177,7 +177,7 @@ void cgreg_reset()
 {
     foreach (ref r; regrange[])
         if (!r)
-            r = vec_calloc(dfo.length);
+            r = vec_calloc(bo.dfo.length);
         else
             vec_clear(r);
 }
@@ -297,11 +297,11 @@ static if (1) // causes assert failure in std.range(4488) from std.parallelism's
     if (fregsaved & (1UL << reg) & cgstate.mfuncreg)
         benefit -= 1 + nretblocks;
 
-    for (bi = 0; (bi = cast(uint) vec_index(bi, s.Srange)) < dfo.length; ++bi)
+    for (bi = 0; (bi = cast(uint) vec_index(bi, s.Srange)) < bo.dfo.length; ++bi)
     {   int inoutp;
         int inout_;
 
-        b = dfo[bi];
+        b = bo.dfo[bi];
         switch (b.BC)
         {
             case BCjcatch:
@@ -823,7 +823,7 @@ int cgreg_assign(Symbol *retsym)
         }
     }
 
-    vec_t v = vec_calloc(dfo.length);
+    vec_t v = vec_calloc(bo.dfo.length);
 
     reg_t dst_integer_reg;
     reg_t dst_float_reg;


### PR DESCRIPTION
To make it easier to pass them as parameters, for reducing reliance on global variables. Similar to `GlobalOptimizer go`.