### PR TITLE
Move global variables related to diagnostics into a separate struct.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,7 +239,7 @@ without control flow statements.
 This was done successfully in src/dmd/escape.d, it wasn't easy, but
 it was well worth it.
 
-17. Try to eliminate reliance on `global.errors`, use `dmd.errorsink: ErrorSink` instead.
+17. Try to eliminate reliance on `global.diag.errors`, use `dmd.errorsink: ErrorSink` instead.
 
 18. For aggregates that expose public access to fields, think hard about why this is
 necessary and if it can be done better. Merely replacing them with read/write properties

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -2502,7 +2502,7 @@ struct ASTBase
         extern (D) this()
         {
             super(Loc.initial, STMT.Error);
-            assert(global.gaggedErrors || global.errors);
+            assert(global.diag.gaggedErrors || global.diag.errors);
         }
 
         override void accept(Visitor v)
@@ -6350,7 +6350,7 @@ struct ASTBase
             if (errorexp is null)
                 errorexp = new ErrorExp();
 
-            if (global.errors == 0 && global.gaggedErrors == 0)
+            if (global.diag.errors == 0 && global.diag.gaggedErrors == 0)
             {
                 /* Unfortunately, errors can still leak out of gagged errors,
                 * and we need to set the error count to prevent bogus code

--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -108,7 +108,7 @@ int blockExit(Statement s, FuncDeclaration func, ErrorSink eSink)
 
         void visitMixin(MixinStatement s)
         {
-            assert(global.errors);
+            assert(global.diag.errors);
             result = BE.fallthru;
         }
 
@@ -177,7 +177,7 @@ int blockExit(Statement s, FuncDeclaration func, ErrorSink eSink)
 
         void visitWhile(WhileStatement s)
         {
-            assert(global.errors);
+            assert(global.diag.errors);
             result = BE.fallthru;
         }
 
@@ -249,7 +249,7 @@ int blockExit(Statement s, FuncDeclaration func, ErrorSink eSink)
 
         void visitForeachRange(ForeachRangeStatement s)
         {
-            assert(global.errors);
+            assert(global.diag.errors);
             result = BE.fallthru;
         }
 

--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -106,7 +106,7 @@ CT canThrow(Expression e, FuncDeclaration func, ErrorSink eSink)
             if (ce.inDebugStatement)
                 return;
 
-            if (global.errors && !ce.e1.type)
+            if (global.diag.errors && !ce.e1.type)
                 return; // error recovery
 
             if (ce.f && ce.arguments.length > 0)

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -110,7 +110,7 @@ FuncDeclaration hasIdentityOpAssign(AggregateDeclaration ad, Scope* sc)
     scope er = new NullExp(ad.loc, ad.type);    // dummy rvalue
     scope el = new IdentifierExp(ad.loc, Id.p); // dummy lvalue
     el.type = ad.type;
-    const errors = global.startGagging(); // Do not report errors, even if the template opAssign fbody makes it.
+    const errors = global.diag.startGagging(); // Do not report errors, even if the template opAssign fbody makes it.
     sc = sc.push();
     sc.tinst = null;
     sc.minst = null;
@@ -125,7 +125,7 @@ FuncDeclaration hasIdentityOpAssign(AggregateDeclaration ad, Scope* sc)
     }
 
     sc = sc.pop();
-    global.endGagging(errors);
+    global.diag.endGagging(errors);
     if (!f)
         return null;
     if (f.errors)
@@ -385,7 +385,7 @@ FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
     sd.members.push(fop);
     fop.addMember(sc, sd);
     sd.hasIdentityAssign = true; // temporary mark identity assignable
-    const errors = global.startGagging(); // Do not report errors, even if the template opAssign fbody makes it.
+    const errors = global.diag.startGagging(); // Do not report errors, even if the template opAssign fbody makes it.
     Scope* sc2 = sc.push();
     sc2.stc = 0;
     sc2.linkage = LINK.d;
@@ -395,7 +395,7 @@ FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
     //semantic3(fop, sc2); // isn't run here for lazy forward reference resolution.
 
     sc2.pop();
-    if (global.endGagging(errors)) // if errors happened
+    if (global.diag.endGagging(errors)) // if errors happened
     {
         // Disable generated opAssign, because some members forbid identity assignment.
         fop.storage_class |= STC.disable;
@@ -494,7 +494,7 @@ private FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope* sc)
 
     bool hasIt(Type tthis)
     {
-        const errors = global.startGagging(); // Do not report errors, even if the template opAssign fbody makes it
+        const errors = global.diag.startGagging(); // Do not report errors, even if the template opAssign fbody makes it
         sc = sc.push();
         sc.tinst = null;
         sc.minst = null;
@@ -511,7 +511,7 @@ private FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope* sc)
             f = rfc(el);
 
         sc = sc.pop();
-        global.endGagging(errors);
+        global.diag.endGagging(errors);
 
         return f !is null;
     }
@@ -614,14 +614,14 @@ FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     Expression e2 = new IdentifierExp(loc, Id.p);
     Expression e = new EqualExp(EXP.equal, loc, e1, e2);
     fop.fbody = new ReturnStatement(loc, e);
-    const errors = global.startGagging(); // Do not report errors
+    const errors = global.diag.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
     sc2.stc = 0;
     sc2.linkage = LINK.d;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
     sc2.pop();
-    if (global.endGagging(errors)) // if errors happened
+    if (global.diag.endGagging(errors)) // if errors happened
         fop = sd.xerreq;
     return fop;
 }
@@ -738,14 +738,14 @@ FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     Expression e2 = new IdentifierExp(loc, Id.p);
     Expression e = new CallExp(loc, new DotIdExp(loc, e1, Id.cmp), e2);
     fop.fbody = new ReturnStatement(loc, e);
-    const errors = global.startGagging(); // Do not report errors
+    const errors = global.diag.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
     sc2.stc = 0;
     sc2.linkage = LINK.d;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
     sc2.pop();
-    if (global.endGagging(errors)) // if errors happened
+    if (global.diag.endGagging(errors)) // if errors happened
         fop = sd.xerrcmp;
     return fop;
 }
@@ -1617,7 +1617,7 @@ private Statement generateCopyCtorBody(StructDeclaration sd)
  */
 bool needCopyCtor(StructDeclaration sd, out bool hasCpCtor)
 {
-    if (global.errors)
+    if (global.diag.errors)
         return false;
 
     auto ctor = sd.search(sd.loc, Id.ctor);
@@ -1731,7 +1731,7 @@ bool buildCopyCtor(StructDeclaration sd, Scope* sc)
     ccd.fbody = copyCtorBody;
     sd.members.push(ccd);
     ccd.addMember(sc, sd);
-    const errors = global.startGagging();
+    const errors = global.diag.startGagging();
     Scope* sc2 = sc.push();
     sc2.stc = 0;
     sc2.linkage = LINK.d;
@@ -1740,7 +1740,7 @@ bool buildCopyCtor(StructDeclaration sd, Scope* sc)
     ccd.semantic3(sc2);
     //printf("ccd semantic: %s\n", ccd.type.toChars());
     sc2.pop();
-    if (global.endGagging(errors) || sd.isUnionDeclaration())
+    if (global.diag.endGagging(errors) || sd.isUnionDeclaration())
     {
         ccd.storage_class |= STC.disable;
         ccd.fbody = null;

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -382,9 +382,9 @@ extern (C++) final class StaticForeach : RootObject
 
         // Run 'typeof' gagged to avoid duplicate errors and if it fails just create
         // an empty foreach to expose them.
-        const olderrors = global.startGagging();
+        const olderrors = global.diag.startGagging();
         ety = ety.typeSemantic(aloc, sc);
-        if (global.endGagging(olderrors))
+        if (global.diag.endGagging(olderrors))
             s2.push(createForeach(aloc, pparams[1], null));
         else
         {
@@ -924,7 +924,7 @@ extern (C++) final class StaticIfCondition : Condition
 
         int errorReturn()
         {
-            if (!global.gag)
+            if (!global.diag.gag)
                 inc = Include.no; // so we don't see the error message again
             return 0;
         }

--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -654,7 +654,7 @@ UnionExp Equal(EXP op, const ref Loc loc, Type type, Expression e1, Expression e
         StringExp es2 = e2.isStringExp();
         if (es1.sz != es2.sz)
         {
-            assert(global.errors);
+            assert(global.diag.errors);
             cantExp(ue);
             return ue;
         }
@@ -1477,7 +1477,7 @@ UnionExp Cat(const ref Loc loc, Type type, Expression e1, Expression e2)
             /* Can happen with:
              *   auto s = "foo"d ~ "bar"c;
              */
-            assert(global.errors);
+            assert(global.diag.errors);
             cantExp(ue);
             assert(ue.exp().type);
             return ue;

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -2068,9 +2068,9 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
              *   cast(to)e1.aliasthis
              */
             auto exp = resolveAliasThis(sc, e);
-            const errors = global.startGagging();
+            const errors = global.diag.startGagging();
             exp = castTo(exp, sc, t, att);
-            return global.endGagging(errors) ? null : exp;
+            return global.diag.endGagging(errors) ? null : exp;
         }
 
         bool hasAliasThis;

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -619,7 +619,7 @@ extern (C++) final class AliasDeclaration : Declaration
         Dsymbol err()
         {
             // Avoid breaking "recursive alias" state during errors gagged
-            if (global.gag)
+            if (global.diag.gag)
                 return this;
             aliassym = new AliasDeclaration(loc, ident, Type.terror);
             type = Type.terror;
@@ -632,15 +632,15 @@ extern (C++) final class AliasDeclaration : Declaration
         if (inuse == 1 && type && _scope)
         {
             inuse = 2;
-            const olderrors = global.errors;
+            const olderrors = global.diag.errors;
             Dsymbol s = type.toDsymbol(_scope);
             //printf("[%s] type = %s, s = %p, this = %p\n", loc.toChars(), type.toChars(), s, this);
-            if (global.errors != olderrors)
+            if (global.diag.errors != olderrors)
                 return err();
             if (s)
             {
                 s = s.toAlias();
-                if (global.errors != olderrors)
+                if (global.diag.errors != olderrors)
                     return err();
                 aliassym = s;
                 inuse = 0;
@@ -650,7 +650,7 @@ extern (C++) final class AliasDeclaration : Declaration
                 Type t = type.typeSemantic(loc, _scope);
                 if (t.ty == Terror)
                     return err();
-                if (global.errors != olderrors)
+                if (global.diag.errors != olderrors)
                     return err();
                 //printf("t = %s\n", t.toChars());
                 inuse = 0;
@@ -1099,12 +1099,12 @@ extern (C++) class VarDeclaration : Declaration
         assert(type && _init);
 
         // Ungag errors when not speculative
-        const oldgag = global.gag;
-        if (global.gag)
+        const oldgag = global.diag.gag;
+        if (global.diag.gag)
         {
             Dsymbol sym = isMember();
             if (sym && !sym.isSpeculative())
-                global.gag = 0;
+                global.diag.gag = 0;
         }
 
         if (_scope)
@@ -1118,7 +1118,7 @@ extern (C++) class VarDeclaration : Declaration
         }
 
         Expression e = _init.initializerToExpression(needFullType ? type : null);
-        global.gag = oldgag;
+        global.diag.gag = oldgag;
         return e;
     }
 

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -2121,7 +2121,7 @@ public:
                     v.inuse++;
                     e = interpret(e, istate);
                     v.inuse--;
-                    if (CTFEExp.isCantExp(e) && !global.gag && !ctfeGlobals.stackTraceCallsToSuppress)
+                    if (CTFEExp.isCantExp(e) && !global.diag.gag && !ctfeGlobals.stackTraceCallsToSuppress)
                         errorSupplemental(loc, "while evaluating %s.init", v.toChars());
                     if (exceptionOrCantInterpret(e))
                         return e;
@@ -4992,7 +4992,7 @@ public:
             result = paintTypeOntoLiteral(pue, e.type, result);
             result.loc = e.loc;
         }
-        else if (CTFEExp.isCantExp(result) && !global.gag)
+        else if (CTFEExp.isCantExp(result) && !global.diag.gag)
             showCtfeBackTrace(e, fd); // Print a stack trace.
     }
 

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -655,7 +655,7 @@ extern (C++) final class Module : Package
                     cast(int)name.length, name.ptr, cast(int)pkgfile.length, pkgfile.ptr);
             }
         }
-        if (!global.gag)
+        if (!global.diag.gag)
         {
             /* Print path
              */
@@ -929,7 +929,7 @@ extern (C++) final class Module : Package
                     error(md ? md.loc : loc, "%s `%s` from file %s conflicts with package name %s", kind, toPrettyChars, srcname, pkg.toChars());
             }
             else
-                assert(global.errors);
+                assert(global.diag.errors);
         }
         else
         {
@@ -1085,7 +1085,7 @@ extern (C++) final class Module : Package
             //printf("[%d] %s semantic2a\n", i, s.toPrettyChars());
             s.semantic2(null);
 
-            if (global.errors)
+            if (global.diag.errors)
                 break;
         }
         a.setDim(0);
@@ -1102,7 +1102,7 @@ extern (C++) final class Module : Package
             //printf("[%d] %s semantic3a\n", i, s.toPrettyChars());
             s.semantic3(null);
 
-            if (global.errors)
+            if (global.diag.errors)
                 break;
         }
         a.setDim(0);
@@ -1260,14 +1260,14 @@ extern (C++) final class Module : Package
         auto imp = new Import(Loc.initial, pkgids[], modid, null, true);
         // Module.load will call fatal() if there's no module available.
         // Gag the error here, pushing the error handling to the caller.
-        const errors = global.startGagging();
+        const errors = global.diag.startGagging();
         imp.load(null);
         if (imp.mod)
         {
             imp.mod.importAll(null);
             imp.mod.dsymbolSemantic(null);
         }
-        global.endGagging(errors);
+        global.diag.endGagging(errors);
         mod = imp.mod;
         return mod;
     }

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -562,7 +562,7 @@ extern (C++) struct Scope
 
     extern (D) Dsymbol search_correct(Identifier ident)
     {
-        if (global.gag)
+        if (global.diag.gag)
             return null; // don't do it for speculative compiles; too time consuming
 
         /************************************************

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -118,7 +118,7 @@ struct Ungag
 
     extern (C++) ~this() nothrow
     {
-        global.gag = oldgag;
+        global.diag.gag = oldgag;
     }
 }
 
@@ -605,9 +605,9 @@ extern (C++) class Dsymbol : ASTNode
 
     final Ungag ungagSpeculative() const
     {
-        const oldgag = global.gag;
-        if (global.gag && !isSpeculative() && !toParent2().isFuncDeclaration())
-            global.gag = 0;
+        const oldgag = global.diag.gag;
+        if (global.diag.gag && !isSpeculative() && !toParent2().isFuncDeclaration())
+            global.diag.gag = 0;
         return Ungag(oldgag);
     }
 

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -86,7 +86,7 @@ struct Ungag
     unsigned oldgag;
 
     Ungag(unsigned old) : oldgag(old) {}
-    ~Ungag() { global.gag = oldgag; }
+    ~Ungag() { global.diag.gag = oldgag; }
 };
 
 enum class ThreeState : uint8_t

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -3858,9 +3858,9 @@ extern (C++) class TemplateInstance : ScopeDsymbol
      *  max_shown = maximum number of trace elements printed (controlled with -v/-verror-limit)
      */
     extern(D) final void printInstantiationTrace(Classification cl = Classification.error,
-                                                 const(uint) max_shown = global.params.v.errorSupplementCount())
+                                                 const(uint) max_shown = global.diag.errorSupplementCount())
     {
-        if (global.gag)
+        if (global.diag.gag)
             return;
 
         // Print full trace for verbose mode, otherwise only short traces
@@ -3888,8 +3888,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             // Set error here as we don't want it to depend on the number of
             // entries that are being printed.
             if (cl == Classification.error ||
-                (cl == Classification.warning && global.params.useWarnings == DiagnosticReporting.error) ||
-                (cl == Classification.deprecation && global.params.useDeprecated == DiagnosticReporting.error))
+                (cl == Classification.warning && global.diag.useWarnings == DiagnosticReporting.error) ||
+                (cl == Classification.deprecation && global.diag.useDeprecated == DiagnosticReporting.error))
                 cur.errors = true;
 
             // If two instantiations use the same declaration, they are recursive.
@@ -4431,7 +4431,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             return true;
 
         // Error already issued, just return `false`
-        if (!s.parent && global.errors)
+        if (!s.parent && global.diag.errors)
             return false;
 
         if (!s.parent && s.getType())
@@ -4534,7 +4534,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     goto Ldsym;
                 if (ta is null)
                 {
-                    assert(global.errors);
+                    assert(global.diag.errors);
                     ta = Type.terror;
                 }
 
@@ -4607,9 +4607,9 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     {
                         if (ea.checkValue()) // check void expression
                             ea = ErrorExp.get();
-                        const olderrs = global.errors;
+                        const olderrs = global.diag.errors;
                         ea = ea.ctfeInterpret();
-                        if (global.errors != olderrs)
+                        if (global.diag.errors != olderrs)
                             ea = ErrorExp.get();
                     }
                 }
@@ -4819,7 +4819,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             printf("TemplateInstance.findBestMatch()\n");
         }
 
-        const errs = global.errors;
+        const errs = global.diag.errors;
         TemplateDeclaration td_last = null;
         Objects dedtypes;
 
@@ -4949,14 +4949,14 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         else if (errors && inst)
         {
             // instantiation was failed with error reporting
-            assert(global.errors);
+            assert(global.diag.errors);
             return false;
         }
         else
         {
             auto tdecl = tempdecl.isTemplateDeclaration();
 
-            if (errs != global.errors)
+            if (errs != global.diag.errors)
                 errorSupplemental(loc, "while looking for match for `%s`", toChars());
             else if (tdecl && !tdecl.overnext)
             {
@@ -5031,7 +5031,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         {
             printf("\tIt's a match with template declaration '%s'\n", tempdecl.toChars());
         }
-        return (errs == global.errors);
+        return (errs == global.diag.errors);
     }
 
     /*****************************************
@@ -5328,7 +5328,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         //printf("%d\n", nest);
         if (++nest > global.recursionLimit)
         {
-            global.gag = 0; // ensure error message gets printed
+            global.diag.gag = 0; // ensure error message gets printed
             .error(loc, "%s `%s` recursive expansion exceeded allowed nesting limit", kind, toPrettyChars);
             fatal();
         }
@@ -5345,7 +5345,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         //printf("%d\n", nest);
         if (++nest > global.recursionLimit)
         {
-            global.gag = 0; // ensure error message gets printed
+            global.diag.gag = 0; // ensure error message gets printed
             .error(loc, "%s `%s` recursive expansion exceeded allowed nesting limit", kind, toPrettyChars);
             fatal();
         }
@@ -5856,10 +5856,10 @@ MATCH matchArg(TemplateParameter tp, Scope* sc, RootObject oarg, size_t i, Templ
             /* If a function is really property-like, and then
              * it's CTFEable, ei will be a literal expression.
              */
-            const olderrors = global.startGagging();
+            const olderrors = global.diag.startGagging();
             ei = resolveProperties(sc, ei);
             ei = ei.ctfeInterpret();
-            if (global.endGagging(olderrors) || ei.op == EXP.error)
+            if (global.diag.endGagging(olderrors) || ei.op == EXP.error)
                 return matchArgNoMatch();
 
             /* https://issues.dlang.org/show_bug.cgi?id=14520

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -512,7 +512,7 @@ public:
             }
         }
 
-        if (global.params.useWarnings != DiagnosticReporting.off || canFix)
+        if (global.diag.useWarnings != DiagnosticReporting.off || canFix)
         {
             // Warn about identifiers that are keywords in C++.
             if (auto kc = keywordClass(ident))

--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -589,10 +589,10 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
             if (!em.ed.isAnonymous())
                 em.ed.memtype = t;
         }
-        const errors = global.startGagging();
+        const errors = global.diag.startGagging();
         Expression e = new IntegerExp(em.loc, 0, t);
         e = e.ctfeInterpret();
-        if (global.endGagging(errors))
+        if (global.diag.endGagging(errors))
         {
             error(em.loc, "cannot generate 0 value of type `%s` for `%s`",
                 t.toChars(), em.toChars());
@@ -630,7 +630,7 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
         if (emprev.errors)
             return errorReturn();
 
-        auto errors = global.startGagging();
+        auto errors = global.diag.startGagging();
         Expression eprev = emprev.value;
         assert(eprev);
         // .toHeadMutable() due to https://issues.dlang.org/show_bug.cgi?id=18645
@@ -650,7 +650,7 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
         Expression e = new EqualExp(EXP.equal, em.loc, eprev, emax);
         e = e.expressionSemantic(sc);
         e = e.ctfeInterpret();
-        if (global.endGagging(errors))
+        if (global.diag.endGagging(errors))
         {
             // display an introductory error before showing what actually failed
             error(em.loc, "cannot check `%s` value for overflow", em.toPrettyChars());
@@ -672,13 +672,13 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
                 emprev.ed.toChars(), emprev.toChars(), mt.toChars());
             return errorReturn();
         }
-        errors = global.startGagging();
+        errors = global.diag.startGagging();
         // Now set e to (eprev + 1)
         e = new AddExp(em.loc, eprev, IntegerExp.literal!1);
         e = e.expressionSemantic(sc);
         e = e.castTo(sc, eprev.type);
         e = e.ctfeInterpret();
-        if (global.endGagging(errors))
+        if (global.diag.endGagging(errors))
         {
             error(em.loc, "cannot generate value for `%s`", em.toPrettyChars());
             // rerun to show errors

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -522,7 +522,7 @@ extern (C++) abstract class Expression : ASTNode
         {
             error(loc, "expression `%s` is `void` and has no value", toChars());
             //print(); assert(0);
-            if (!global.gag)
+            if (!global.diag.gag)
                 type = Type.terror;
             return true;
         }
@@ -1062,7 +1062,7 @@ extern (C++) final class ErrorExp : Expression
         if (errorexp is null)
             errorexp = new ErrorExp();
 
-        if (global.errors == 0 && global.gaggedErrors == 0)
+        if (global.diag.errors == 0 && global.diag.gaggedErrors == 0)
         {
             /* Unfortunately, errors can still leak out of gagged errors,
               * and we need to set the error count to prevent bogus code

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -514,7 +514,7 @@ private Expression checkOpAssignTypes(BinExp binExp, Scope* sc)
         }
         if (type.isReal() || type.isImaginary())
         {
-            assert(global.errors || t2.isFloating());
+            assert(global.diag.errors || t2.isFloating());
             e2 = e2.castTo(sc, t1);
         }
     }
@@ -714,11 +714,11 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
             (*fargs)[0] = ie.lwr;
             (*fargs)[1] = ie.upr;
 
-            const xerrors = global.startGagging();
+            const xerrors = global.diag.startGagging();
             sc = sc.push();
             FuncDeclaration fslice = resolveFuncCall(ae.loc, sc, slice, tiargs, ae.e1.type, ArgumentList(fargs), FuncResolveFlag.quiet);
             sc = sc.pop();
-            global.endGagging(xerrors);
+            global.diag.endGagging(xerrors);
             if (!fslice)
                 return fallback();
 
@@ -1214,9 +1214,9 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
                     // check them for issues.
                     Expressions* originalArguments = Expression.arraySyntaxCopy(ce.arguments);
 
-                    const errors = global.startGagging();
+                    const errors = global.diag.startGagging();
                     e = ce.expressionSemantic(sc);
-                    if (!global.endGagging(errors))
+                    if (!global.diag.endGagging(errors))
                         return e;
 
                     if (arrayExpressionSemantic(originalArguments.peekSlice(), sc))
@@ -1248,10 +1248,10 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
          *      s.remove("foo");
          * }
          */
-        const errors = global.startGagging();
+        const errors = global.diag.startGagging();
         e = searchUFCS(sc, die, ident);
         // if there were any errors and the identifier was remove
-        if (global.endGagging(errors))
+        if (global.diag.endGagging(errors))
         {
             if (ident == Id.remove)
             {
@@ -2954,7 +2954,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
     assert(arguments);
     assert(fd || tf.next);
     const size_t nparams = tf.parameterList.length;
-    const olderrors = global.errors;
+    const olderrors = global.diag.errors;
     bool err = false;
     Expression eprefix = null;
     *peprefix = null;
@@ -3715,7 +3715,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
         //    wildmatch, tf.isWild(), fd.isReturnIsolated());
         if (!tthis)
         {
-            assert(sc.intypeof || global.errors);
+            assert(sc.intypeof || global.diag.errors);
             tthis = fd.isThis().type.addMod(fd.type.mod);
         }
         if (tf.isWild() && !fd.isReturnIsolated())
@@ -3743,7 +3743,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
 
     *prettype = tret;
     *peprefix = eprefix;
-    return (err || olderrors != global.errors);
+    return (err || olderrors != global.diag.errors);
 }
 
 /**
@@ -4620,7 +4620,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
              * in the enclosing function or template, since the initializer
              * will be part of the stuct declaration.
              */
-            global.increaseErrorCount();
+            global.diag.increaseErrorCount();
             return setError();
         }
 
@@ -5757,15 +5757,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return done();
         }
 
-        const olderrors = global.errors;
+        const olderrors = global.diag.errors;
         exp.fd.dsymbolSemantic(sc);
-        if (olderrors == global.errors)
+        if (olderrors == global.diag.errors)
         {
             exp.fd.semantic2(sc);
-            if (olderrors == global.errors)
+            if (olderrors == global.diag.errors)
                 exp.fd.semantic3(sc);
         }
-        if (olderrors != global.errors)
+        if (olderrors != global.diag.errors)
         {
             if (exp.fd.type && exp.fd.type.ty == Tfunction && !exp.fd.type.nextOf())
                 (cast(TypeFunction)exp.fd.type).next = Type.terror;
@@ -6969,7 +6969,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             printf("DeclarationExp::semantic() %s\n", e.toChars());
         }
 
-        const olderrors = global.errors;
+        const olderrors = global.diag.errors;
 
         /* This is here to support extern(linkage) declaration,
          * where the extern(linkage) winds up being an AttribDeclaration
@@ -7115,10 +7115,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 sc2.pop();
             s.parent = sc.parent;
         }
-        if (global.errors == olderrors)
+        if (global.diag.errors == olderrors)
         {
             e.declaration.semantic2(sc);
-            if (global.errors == olderrors)
+            if (global.diag.errors == olderrors)
             {
                 e.declaration.semantic3(sc);
             }
@@ -7283,9 +7283,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (e.tok2 == TOK.package_ || e.tok2 == TOK.module_) // These is() expressions are special because they can work on modules, not just types.
         {
-            const oldErrors = global.startGagging();
+            const oldErrors = global.diag.startGagging();
             Dsymbol sym = e.targ.toDsymbol(sc);
-            global.endGagging(oldErrors);
+            global.diag.endGagging(oldErrors);
 
             if (sym is null)
                 return no();
@@ -7494,7 +7494,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             // current scope is itself deprecated, or deprecations are not errors
             const bool deprecationAllowed = sc.isDeprecated
-                || global.params.useDeprecated != DiagnosticReporting.error;
+                || global.diag.useDeprecated != DiagnosticReporting.error;
             const bool preventAliasThis = e.targ.hasDeprecatedAliasThis && !deprecationAllowed;
 
             if (preventAliasThis && e.targ.ty == Tstruct)
@@ -7701,7 +7701,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (expressionsToString(buf, sc, exp.exps, exp.loc, null, true))
             return null;
 
-        const errors = global.errors;
+        const errors = global.diag.errors;
         const len = buf.length;
         const str = buf.extractChars()[0 .. len];
         const bool doUnittests = global.params.parsingUnittestsRequired();
@@ -7711,7 +7711,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         //printf("p.loc.linnum = %d\n", p.loc.linnum);
 
         Expression e = p.parseExpression();
-        if (global.errors != errors)
+        if (global.diag.errors != errors)
             return null;
 
         if (p.token.value != TOK.endOfFile)
@@ -8233,10 +8233,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (e && isDotOpDispatch(e))
         {
             auto ode = e;
-            const errors = global.startGagging();
+            const errors = global.diag.startGagging();
             e = resolvePropertiesX(sc, e);
             // Any error or if 'e' is not resolved, go to UFCS
-            if (global.endGagging(errors) || e is ode)
+            if (global.diag.endGagging(errors) || e is ode)
                 e = null; /* fall down to UFCS */
             else
             {
@@ -8386,7 +8386,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         else
         {
             exp.type = exp.var.type;
-            if (!exp.type && global.errors) // var is goofed up, just return error.
+            if (!exp.type && global.diag.errors) // var is goofed up, just return error.
                 return setError();
             assert(exp.type);
 
@@ -10596,10 +10596,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                      */
                     auto ode = e;
                     exp.e2 = exp.e2.expressionSemantic(sc);
-                    const errors = global.startGagging();
+                    const errors = global.diag.startGagging();
                     e = resolvePropertiesX(sc, e, exp.e2);
                     // Any error or if 'e' is not resolved, go to UFCS
-                    if (global.endGagging(errors) || e is ode)
+                    if (global.diag.endGagging(errors) || e is ode)
                         e = null; /* fall down to UFCS */
                     else
                         return setResult(e);
@@ -14278,9 +14278,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 Expression trySemantic(Expression exp, Scope* sc)
 {
     //printf("+trySemantic(%s)\n", exp.toChars());
-    const errors = global.startGagging();
+    const errors = global.diag.startGagging();
     Expression e = expressionSemantic(exp, sc);
-    if (global.endGagging(errors))
+    if (global.diag.endGagging(errors))
     {
         e = null;
     }
@@ -16859,7 +16859,7 @@ bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool 
         }
 
         Expression before = e;
-        const uint nerrors = global.errors;
+        const uint nerrors = global.diag.errors;
 
         sc = sc.startCTFE();
         sc.condition = true;
@@ -16871,7 +16871,7 @@ bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool 
         sc = sc.endCTFE();
         e = e.optimize(WANTvalue);
 
-        if (nerrors != global.errors ||
+        if (nerrors != global.diag.errors ||
             e.isErrorExp() ||
             e.type.toBasetype() == Type.terror)
         {
@@ -17382,7 +17382,7 @@ private bool needsTypeInference(TemplateInstance ti, Scope* sc, int flag = 0)
     if (ti.semanticRun != PASS.initial)
         return false;
 
-    const olderrs = global.errors;
+    const olderrs = global.diag.errors;
     Objects dedtypes;
     size_t count = 0;
 
@@ -17484,9 +17484,9 @@ private bool needsTypeInference(TemplateInstance ti, Scope* sc, int flag = 0)
             return true;
     }
 
-    if (olderrs != global.errors)
+    if (olderrs != global.diag.errors)
     {
-        if (!global.gag)
+        if (!global.diag.gag)
         {
             errorSupplemental(ti.loc, "while looking for match for `%s`", ti.toChars());
             ti.semanticRun = PASS.semanticdone;

--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -25,28 +25,6 @@ import core.stdc.stdarg;
 version (Windows) private enum sep = ";", exe = ".exe";
 version (Posix) private enum sep = ":", exe = "";
 
-/// Contains aggregated diagnostics information.
-immutable struct Diagnostics
-{
-    /// Number of errors diagnosed
-    uint errors;
-
-    /// Number of warnings diagnosed
-    uint warnings;
-
-    /// Returns: `true` if errors have been diagnosed
-    bool hasErrors()
-    {
-        return errors > 0;
-    }
-
-    /// Returns: `true` if warnings have been diagnosed
-    bool hasWarnings()
-    {
-        return warnings > 0;
-    }
-}
-
 /// Indicates the checking state of various contracts.
 enum ContractChecking : CHECKENABLE
 {
@@ -410,12 +388,7 @@ Tuple!(Module, "module_", Diagnostics, "diagnostics") parseModule(AST = ASTCodeg
     m.importedFrom = m;
     m = m.parseModule!AST();
 
-    Diagnostics diagnostics = {
-        errors: global.errors,
-        warnings: global.warnings
-    };
-
-    return typeof(return)(m, diagnostics);
+    return typeof(return)(m, global.diag);
 }
 
 /**

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8051,6 +8051,58 @@ extern bool c_isxdigit(const int32_t c);
 
 extern bool c_isalnum(const int32_t c);
 
+struct Diagnostics final
+{
+    uint32_t errors;
+    uint32_t deprecations;
+    uint32_t warnings;
+    uint32_t gag;
+    uint32_t gaggedErrors;
+    uint32_t gaggedWarnings;
+    uint32_t errorLimit;
+    uint32_t errorSupplementLimit;
+    uint32_t errorSupplementCount();
+    MessageStyle messageStyle;
+    bool showGaggedErrors;
+    bool printErrorContext;
+    DiagnosticReporting useDeprecated;
+    DiagnosticReporting useWarnings;
+    uint32_t startGagging();
+    bool endGagging(uint32_t oldGagged);
+    void increaseErrorCount();
+    Diagnostics() :
+        errors(),
+        deprecations(),
+        warnings(),
+        gag(),
+        gaggedErrors(),
+        gaggedWarnings(),
+        errorLimit(20u),
+        errorSupplementLimit(6u),
+        messageStyle((MessageStyle)0u),
+        showGaggedErrors(),
+        printErrorContext(),
+        useDeprecated((DiagnosticReporting)1u),
+        useWarnings((DiagnosticReporting)2u)
+    {
+    }
+    Diagnostics(uint32_t errors, uint32_t deprecations = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, uint32_t errorLimit = 20u, uint32_t errorSupplementLimit = 6u, MessageStyle messageStyle = (MessageStyle)0u, bool showGaggedErrors = false, bool printErrorContext = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, DiagnosticReporting useWarnings = (DiagnosticReporting)2u) :
+        errors(errors),
+        deprecations(deprecations),
+        warnings(warnings),
+        gag(gag),
+        gaggedErrors(gaggedErrors),
+        gaggedWarnings(gaggedWarnings),
+        errorLimit(errorLimit),
+        errorSupplementLimit(errorSupplementLimit),
+        messageStyle(messageStyle),
+        showGaggedErrors(showGaggedErrors),
+        printErrorContext(printErrorContext),
+        useDeprecated(useDeprecated),
+        useWarnings(useWarnings)
+        {}
+};
+
 extern void error(const Loc& loc, const char* format, ...);
 
 extern void error(const char* filename, uint32_t linnum, uint32_t charnum, const char* format, ...);
@@ -8157,15 +8209,9 @@ struct Verbose final
     bool field;
     bool complex;
     bool vin;
-    bool showGaggedErrors;
-    bool printErrorContext;
     bool logo;
     bool color;
     bool cov;
-    MessageStyle messageStyle;
-    uint32_t errorLimit;
-    uint32_t errorSupplementLimit;
-    uint32_t errorSupplementCount();
     Verbose() :
         verbose(),
         showColumns(),
@@ -8176,17 +8222,12 @@ struct Verbose final
         field(),
         complex(true),
         vin(),
-        showGaggedErrors(),
-        printErrorContext(),
         logo(),
         color(),
-        cov(),
-        messageStyle((MessageStyle)0u),
-        errorLimit(20u),
-        errorSupplementLimit(6u)
+        cov()
     {
     }
-    Verbose(bool verbose, bool showColumns = false, bool tls = false, bool templates = false, bool templatesListInstances = false, bool gc = false, bool field = false, bool complex = true, bool vin = false, bool showGaggedErrors = false, bool printErrorContext = false, bool logo = false, bool color = false, bool cov = false, MessageStyle messageStyle = (MessageStyle)0u, uint32_t errorLimit = 20u, uint32_t errorSupplementLimit = 6u) :
+    Verbose(bool verbose, bool showColumns = false, bool tls = false, bool templates = false, bool templatesListInstances = false, bool gc = false, bool field = false, bool complex = true, bool vin = false, bool logo = false, bool color = false, bool cov = false) :
         verbose(verbose),
         showColumns(showColumns),
         tls(tls),
@@ -8196,14 +8237,9 @@ struct Verbose final
         field(field),
         complex(complex),
         vin(vin),
-        showGaggedErrors(showGaggedErrors),
-        printErrorContext(printErrorContext),
         logo(logo),
         color(color),
-        cov(cov),
-        messageStyle(messageStyle),
-        errorLimit(errorLimit),
-        errorSupplementLimit(errorSupplementLimit)
+        cov(cov)
         {}
 };
 
@@ -8214,12 +8250,10 @@ struct Param final
     bool trace;
     bool tracegc;
     bool vcg_ast;
-    DiagnosticReporting useDeprecated;
     bool useUnitTests;
     bool useInline;
     bool release;
     bool preservePaths;
-    DiagnosticReporting useWarnings;
     bool cov;
     uint8_t covPercent;
     bool ctfe_cov;
@@ -8301,12 +8335,10 @@ struct Param final
         trace(),
         tracegc(),
         vcg_ast(),
-        useDeprecated((DiagnosticReporting)1u),
         useUnitTests(),
         useInline(false),
         release(),
         preservePaths(),
-        useWarnings((DiagnosticReporting)2u),
         cov(),
         covPercent(),
         ctfe_cov(false),
@@ -8376,18 +8408,16 @@ struct Param final
         timeTraceFile()
     {
     }
-    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting useWarnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* > imppath = Array<const char* >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, uint32_t versionlevel = 0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool fullyQualifiedObjectFiles = false, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
+    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* > imppath = Array<const char* >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, uint32_t versionlevel = 0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool fullyQualifiedObjectFiles = false, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
         obj(obj),
         multiobj(multiobj),
         trace(trace),
         tracegc(tracegc),
         vcg_ast(vcg_ast),
-        useDeprecated(useDeprecated),
         useUnitTests(useUnitTests),
         useInline(useInline),
         release(release),
         preservePaths(preservePaths),
-        useWarnings(useWarnings),
         cov(cov),
         covPercent(covPercent),
         ctfe_cov(ctfe_cov),
@@ -8475,12 +8505,6 @@ struct Global final
     char datetime[26LLU];
     CompileEnv compileEnv;
     Param params;
-    uint32_t errors;
-    uint32_t deprecations;
-    uint32_t warnings;
-    uint32_t gag;
-    uint32_t gaggedErrors;
-    uint32_t gaggedWarnings;
     void* console;
     Array<Identifier* > versionids;
     Array<Identifier* > debugids;
@@ -8489,12 +8513,10 @@ struct Global final
     FileManager* fileManager;
     enum : int32_t { recursionLimit = 500 };
 
+    Diagnostics diag;
     ErrorSink* errorSink;
     ErrorSink* errorSinkNull;
     DArray<uint8_t >(*preprocess)(FileName , const Loc& , OutBuffer& );
-    uint32_t startGagging();
-    bool endGagging(uint32_t oldGagged);
-    void increaseErrorCount();
     void _init();
     uint32_t versionNumber();
     const char* const versionChars();
@@ -8506,24 +8528,19 @@ struct Global final
         filePath(),
         compileEnv(),
         params(),
-        errors(),
-        deprecations(),
-        warnings(),
-        gag(),
-        gaggedErrors(),
-        gaggedWarnings(),
         console(),
         versionids(),
         debugids(),
         hasMainFunction(),
         varSequenceNumber(1u),
         fileManager(),
+        diag(),
         errorSink(),
         errorSinkNull(),
         preprocess()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* > path = Array<const char* >(), Array<const char* > filePath = Array<const char* >(), CompileEnv compileEnv = CompileEnv(), Param params = Param(), uint32_t errors = 0u, uint32_t deprecations = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* > versionids = Array<Identifier* >(), Array<Identifier* > debugids = Array<Identifier* >(), bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, ErrorSink* errorSink = nullptr, ErrorSink* errorSinkNull = nullptr, DArray<uint8_t >(*preprocess)(FileName , const Loc& , OutBuffer& ) = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* > path = Array<const char* >(), Array<const char* > filePath = Array<const char* >(), CompileEnv compileEnv = CompileEnv(), Param params = Param(), void* console = nullptr, Array<Identifier* > versionids = Array<Identifier* >(), Array<Identifier* > debugids = Array<Identifier* >(), bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, Diagnostics diag = Diagnostics(), ErrorSink* errorSink = nullptr, ErrorSink* errorSinkNull = nullptr, DArray<uint8_t >(*preprocess)(FileName , const Loc& , OutBuffer& ) = nullptr) :
         inifilename(inifilename),
         copyright(copyright),
         written(written),
@@ -8531,18 +8548,13 @@ struct Global final
         filePath(filePath),
         compileEnv(compileEnv),
         params(params),
-        errors(errors),
-        deprecations(deprecations),
-        warnings(warnings),
-        gag(gag),
-        gaggedErrors(gaggedErrors),
-        gaggedWarnings(gaggedWarnings),
         console(console),
         versionids(versionids),
         debugids(debugids),
         hasMainFunction(hasMainFunction),
         varSequenceNumber(varSequenceNumber),
         fileManager(fileManager),
+        diag(diag),
         errorSink(errorSink),
         errorSinkNull(errorSinkNull),
         preprocess(preprocess)

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1167,15 +1167,15 @@ bool functionSemantic(FuncDeclaration fd)
     if (!fd.originalType) // semantic not yet run
     {
         TemplateInstance spec = fd.isSpeculative();
-        const olderrs = global.errors;
-        const oldgag = global.gag;
-        if (global.gag && !spec)
-            global.gag = 0;
+        const olderrs = global.diag.errors;
+        const oldgag = global.diag.gag;
+        if (global.diag.gag && !spec)
+            global.diag.gag = 0;
         dsymbolSemantic(fd, fd._scope);
-        global.gag = oldgag;
-        if (spec && global.errors != olderrs)
-            spec.errors = (global.errors - olderrs != 0);
-        if (olderrs != global.errors) // if errors compiling this function
+        global.diag.gag = oldgag;
+        if (spec && global.diag.errors != olderrs)
+            spec.errors = (global.diag.errors - olderrs != 0);
+        if (olderrs != global.diag.errors) // if errors compiling this function
             return false;
     }
 
@@ -1223,18 +1223,18 @@ bool functionSemantic3(FuncDeclaration fd)
          * we need to temporarily ungag errors.
          */
         TemplateInstance spec = fd.isSpeculative();
-        const olderrs = global.errors;
-        const oldgag = global.gag;
-        if (global.gag && !spec)
-            global.gag = 0;
+        const olderrs = global.diag.errors;
+        const oldgag = global.diag.gag;
+        if (global.diag.gag && !spec)
+            global.diag.gag = 0;
         semantic3(fd, fd._scope);
-        global.gag = oldgag;
+        global.diag.gag = oldgag;
 
         // If it is a speculatively-instantiated template, and errors occur,
         // we need to mark the template as having errors.
-        if (spec && global.errors != olderrs)
-            spec.errors = (global.errors - olderrs != 0);
-        if (olderrs != global.errors) // if errors compiling this function
+        if (spec && global.diag.errors != olderrs)
+            spec.errors = (global.diag.errors - olderrs != 0);
+        if (olderrs != global.diag.errors) // if errors compiling this function
             return false;
     }
 
@@ -1627,7 +1627,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
             }
 
 
-            if (!global.gag || global.params.v.showGaggedErrors)
+            if (!global.diag.gag || global.diag.showGaggedErrors)
                 printCandidates(loc, td, sc.isDeprecated());
             return null;
         }
@@ -1644,7 +1644,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
     {
         .error(loc, "none of the overloads of `%s` are callable using argument types `!(%s)%s`",
                od.ident.toChars(), tiargsBuf.peekChars(), fargsBuf.peekChars());
-        if (!global.gag || global.params.v.showGaggedErrors)
+        if (!global.diag.gag || global.diag.showGaggedErrors)
             printCandidates(loc, od, sc.isDeprecated());
         return null;
     }
@@ -1679,7 +1679,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
                 .error(loc, "none of the overloads of `%s` are callable using a %sobject with argument types `(%s)`",
                     fd.toChars(), thisBuf.peekChars(), buf.peekChars());
 
-            if (!global.gag || global.params.v.showGaggedErrors)
+            if (!global.diag.gag || global.diag.showGaggedErrors)
                 printCandidates(loc, fd, sc.isDeprecated());
             return null;
         }
@@ -1717,7 +1717,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
     {
         .error(loc, "none of the overloads of `%s` are callable using argument types `%s`",
                fd.toChars(), fargsBuf.peekChars());
-        if (!global.gag || global.params.v.showGaggedErrors)
+        if (!global.diag.gag || global.diag.showGaggedErrors)
             printCandidates(loc, fd, sc.isDeprecated());
         return null;
     }
@@ -1726,7 +1726,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
            fd.kind(), fd.toPrettyChars(), parametersTypeToChars(tf.parameterList),
            tf.modToChars(), fargsBuf.peekChars());
 
-    if (global.gag && !global.params.v.showGaggedErrors)
+    if (global.diag.gag && !global.diag.showGaggedErrors)
         return null;
 
     // re-resolve to check for supplemental message
@@ -1773,7 +1773,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
 private void printCandidates(Decl)(const ref Loc loc, Decl declaration, bool showDeprecated)
 {
     // max num of overloads to print (-v or -verror-supplements overrides this).
-    const uint DisplayLimit = global.params.v.errorSupplementCount();
+    const uint DisplayLimit = global.diag.errorSupplementCount();
     const(char)* constraintsTip;
 
     int printed = 0; // number of candidates printed

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -336,7 +336,7 @@ void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
                 eSink.message(Loc.initial, "code      %s", m.toChars());
             genObjFile(m, false);
         }
-        if (!global.errors && firstm)
+        if (!global.diag.errors && firstm)
         {
             obj_end(objbuf, library, firstm.objfile.toString());
         }
@@ -354,11 +354,11 @@ void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
             genObjFile(m, multiobj);
             obj_end(objbuf, library, m.objfile.toString());
             obj_write_deferred(objbuf, library, glue.obj_symbols_towrite);
-            if (global.errors && !writeLibrary)
+            if (global.diag.errors && !writeLibrary)
                 m.deleteObjFile();
         }
     }
-    if (writeLibrary && !global.errors)
+    if (writeLibrary && !global.diag.errors)
     {
         if (verbose)
             eSink.message(Loc.initial, "library   %.*s", library.filename.fTuple.expand);
@@ -443,7 +443,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     if (fd.hasSemantic3Errors)
         return;
 
-    if (global.errors)
+    if (global.diag.errors)
         return;
 
     if (!fd.fbody)
@@ -880,7 +880,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
 
     Statement_toIR(sbody, irs);
 
-    if (global.errors)
+    if (global.diag.errors)
     {
         // Restore symbol table
         cstate.CSpsymtab = symtabsave;
@@ -958,7 +958,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         glue.stests.push(s);
     }
 
-    if (global.errors)
+    if (global.diag.errors)
     {
         // Restore symbol table
         cstate.CSpsymtab = symtabsave;

--- a/compiler/src/dmd/iasmdmd.d
+++ b/compiler/src/dmd/iasmdmd.d
@@ -95,7 +95,7 @@ public Statement inlineAsmSemantic(InlineAsmStatement s, Scope *sc)
     asmstate.ucItype = 0;
     asmstate.bReturnax = false;
     asmstate.lbracketNestCount = 0;
-    asmstate.startErrors = global.errors;
+    asmstate.startErrors = global.diag.errors;
 
     asmstate.statement = s;
     asmstate.sc = sc;
@@ -320,7 +320,7 @@ struct ASM_STATE
     ucItype_t ucItype;  /// Instruction type
     Loc loc;
     bool bInit;
-    uint startErrors;  // global.errors at start of iasm
+    uint startErrors;  // global.diag.errors at start of iasm
     LabelDsymbol psDollar;
     Dsymbol psLocalsize;
     bool bReturnax;
@@ -329,7 +329,7 @@ struct ASM_STATE
     Token* tok;
     TOK tokValue;
     int lbracketNestCount;
-    bool errors() { return global.errors > startErrors; }
+    bool errors() { return global.diag.errors > startErrors; }
 }
 
 __gshared ASM_STATE asmstate;

--- a/compiler/src/dmd/iasmgcc.d
+++ b/compiler/src/dmd/iasmgcc.d
@@ -58,9 +58,9 @@ public Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
     p.scanloc = s.loc;
 
     // Parse the gcc asm statement.
-    const errors = global.errors;
+    const errors = global.diag.errors;
     s = p.parseGccAsm(s);
-    if (errors != global.errors)
+    if (errors != global.diag.errors)
         return null;
     s.stc = sc.stc;
 
@@ -410,8 +410,8 @@ unittest
     if (!global.errorSink)
         global.errorSink = new ErrorSinkCompiler;
 
-    const errors = global.startGagging();
-    scope(exit) global.endGagging(errors);
+    const errors = global.diag.startGagging();
+    scope(exit) global.diag.endGagging(errors);
 
     // If this check fails, then Type._init() was called before reaching here,
     // and the entire chunk of code that follows can be removed.
@@ -430,13 +430,13 @@ unittest
     // Imitates asmSemantic if version = IN_GCC.
     static int semanticAsm(Token* tokens)
     {
-        const errors = global.errors;
+        const errors = global.diag.errors;
         scope gas = new GccAsmStatement(Loc.initial, tokens);
         const bool doUnittests = false;
         scope p = new Parser!ASTCodegen(null, ";", false, global.errorSink, &global.compileEnv, doUnittests);
         p.token = *tokens;
         p.parseGccAsm(gas);
-        return global.errors - errors;
+        return global.diag.errors - errors;
     }
 
     // Imitates parseStatement for asm statements.

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -350,7 +350,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             sc = sc.endCTFE();
         if (i.exp.op == EXP.error)
             return err();
-        const olderrors = global.errors;
+        const olderrors = global.diag.errors;
 
         /* ImportC: convert arrays to pointers, functions to pointers to functions
          */
@@ -372,7 +372,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             {
                 i.exp = i.exp.implicitCastTo(sc, t);
             }
-            if (!global.gag && olderrors != global.errors)
+            if (!global.diag.gag && olderrors != global.diag.errors)
             {
                 return i;
             }
@@ -401,7 +401,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             i.exp = i.exp.optimize(WANTvalue);
         }
 
-        if (!global.gag && olderrors != global.errors)
+        if (!global.diag.gag && olderrors != global.diag.errors)
         {
             return i; // Failed, suppress duplicate error messages
         }
@@ -582,9 +582,9 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                 }
             }
             Type et = i.exp.type;
-            const errors = global.startGagging();
+            const errors = global.diag.startGagging();
             i.exp = i.exp.implicitCastTo(sc, t);
-            if (global.endGagging(errors))
+            if (global.diag.endGagging(errors))
                 error(currExp.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`", currExp.toChars(), et.toChars(), t.toChars());
         }
         }

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -1738,7 +1738,7 @@ private bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool stat
         if (!functionSemantic3(fd))
             return false;
         Module.runDeferredSemantic3();
-        if (global.errors)
+        if (global.diag.errors)
             return false;
         assert(fd.semanticRun >= PASS.semantic3done);
     }
@@ -1923,7 +1923,7 @@ private bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool stat
     return true;
 
 Lno:
-    if (fd.inlining == PINLINE.always && global.params.useWarnings == DiagnosticReporting.inform)
+    if (fd.inlining == PINLINE.always && global.diag.useWarnings == DiagnosticReporting.inform)
         warning(fd.loc, "cannot inline function `%s`", fd.toPrettyChars());
 
     if (!hdrscan) // Don't modify inlineStatus for header content scan

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -241,7 +241,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     static int printHelpUsage(string help)
     {
         printf("%.*s", cast(int)help.length, &help[0]);
-        return global.errors ? EXIT_FAILURE : EXIT_SUCCESS;
+        return global.diag.errors ? EXIT_FAILURE : EXIT_SUCCESS;
     }
 
     /*
@@ -256,10 +256,10 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     // In case deprecation messages were omitted, inform the user about it
     static void mentionOmittedDeprecations()
     {
-        if (global.params.v.errorLimit != 0 &&
-            global.deprecations > global.params.v.errorLimit)
+        if (global.diag.errorLimit != 0 &&
+            global.diag.deprecations > global.diag.errorLimit)
         {
-            const omitted = global.deprecations - global.params.v.errorLimit;
+            const omitted = global.diag.deprecations - global.diag.errorLimit;
             message(Loc.initial, "%d deprecation warning%s omitted, use `-verrors=0` to show all",
                 omitted, omitted == 1 ? "".ptr : "s".ptr);
         }
@@ -329,9 +329,9 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         global.console = cast(void*) createConsole(core.stdc.stdio.stderr);
 
     target.setCPU();
-    Loc.set(params.v.showColumns, params.v.messageStyle);
+    Loc.set(params.v.showColumns, global.diag.messageStyle);
 
-    if (global.errors)
+    if (global.diag.errors)
     {
         fatal();
     }
@@ -514,7 +514,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         error(Loc.initial, "conflicting Ddoc and obj generation options");
         fatal();
     }
-    if (global.errors)
+    if (global.diag.errors)
         fatal();
 
     if (params.dihdr.doOutput)
@@ -538,7 +538,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
                 fatal();
         }
     }
-    if (global.errors)
+    if (global.diag.errors)
         removeHdrFilesAndFail(params, modules);
 
     {
@@ -552,7 +552,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
             message("importall %s", m.toChars());
         m.importAll(null);
     }
-    if (global.errors)
+    if (global.diag.errors)
         removeHdrFilesAndFail(params, modules);
 
     backend_init(params, driverParams, target);
@@ -564,7 +564,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
             message("semantic  %s", m.toChars());
         m.dsymbolSemantic(null);
     }
-    //if (global.errors)
+    //if (global.diag.errors)
     //    fatal();
     Module.runDeferredSemantic();
     if (Module.deferred.length)
@@ -585,7 +585,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         m.semantic2(null);
     }
     Module.runDeferredSemantic2();
-    if (global.errors)
+    if (global.diag.errors)
         removeHdrFilesAndFail(params, modules);
 
     // Do pass 3 semantic analysis
@@ -610,7 +610,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         }
     }
     Module.runDeferredSemantic3();
-    if (global.errors)
+    if (global.diag.errors)
         removeHdrFilesAndFail(params, modules);
 
     // Scan for functions to inline
@@ -624,14 +624,14 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         }
     }
 
-    if (global.warnings)
+    if (global.diag.warnings)
         errorOnWarning();
 
-    if (global.params.useDeprecated == DiagnosticReporting.inform)
+    if (global.diag.useDeprecated == DiagnosticReporting.inform)
         mentionOmittedDeprecations();
 
     // Do not attempt to generate output files if errors or warnings occurred
-    if (global.errors || global.warnings)
+    if (global.diag.errors || global.diag.warnings)
         removeHdrFilesAndFail(params, modules);
 
     // inlineScan incrementally run semantic3 of each expanded functions.
@@ -662,7 +662,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         if (generateJson(modules, global.errorSink))
             fatal();
     }
-    if (!global.errors && params.ddoc.doOutput)
+    if (!global.diag.errors && params.ddoc.doOutput)
     {
         foreach (m; modules)
         {
@@ -694,7 +694,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (global.params.cxxhdr.doOutput)
         genCppHdrFiles(modules);
 
-    if (global.errors)
+    if (global.diag.errors)
         fatal();
 
     if (driverParams.lib && params.objfiles.length == 0)
@@ -721,7 +721,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 
     backend_term();
 
-    if (global.errors)
+    if (global.diag.errors)
         fatal();
     int status = EXIT_SUCCESS;
     if (!params.objfiles.length)
@@ -810,10 +810,10 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
             printf("%.*s", cast(int) data.length, data.ptr);
     }
 
-    if (global.warnings)
+    if (global.diag.warnings)
         errorOnWarning();
 
-    if (global.errors || global.warnings)
+    if (global.diag.errors || global.diag.warnings)
         removeHdrFilesAndFail(params, modules);
 
     return status;

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -830,9 +830,9 @@ public:
                     continue;
                 }
                 // Now that we know it is not an alias, we MUST obtain a value
-                const olderr = global.errors;
+                const olderr = global.diag.errors;
                 ea = ea.ctfeInterpret();
-                if (ea.op == EXP.error || olderr != global.errors)
+                if (ea.op == EXP.error || olderr != global.diag.errors)
                     continue;
 
                 /* Use type mangling that matches what it would be for a function parameter

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -646,11 +646,11 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             }
         }
         else if (arg == "-de")               // https://dlang.org/dmd.html#switch-de
-            params.useDeprecated = DiagnosticReporting.error;
+            global.diag.useDeprecated = DiagnosticReporting.error;
         else if (arg == "-d")                // https://dlang.org/dmd.html#switch-d
-            params.useDeprecated = DiagnosticReporting.off;
+           global.diag.useDeprecated = DiagnosticReporting.off;
         else if (arg == "-dw")               // https://dlang.org/dmd.html#switch-dw
-            params.useDeprecated = DiagnosticReporting.inform;
+           global.diag.useDeprecated = DiagnosticReporting.inform;
         else if (arg == "-c")                // https://dlang.org/dmd.html#switch-c
             driverParams.link = false;
         else if (startsWith(p + 1, "checkaction")) // https://dlang.org/dmd.html#switch-checkaction
@@ -1002,13 +1002,13 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             }
             if (startsWith(p + 9, "spec"))
             {
-                params.v.showGaggedErrors = true;
+                global.diag.showGaggedErrors = true;
             }
             else if (startsWith(p + 9, "context"))
             {
-                params.v.printErrorContext = true;
+                global.diag.printErrorContext = true;
             }
-            else if (!params.v.errorLimit.parseDigits(p.toDString()[9 .. $]))
+            else if (!global.diag.errorLimit.parseDigits(p.toDString()[9 .. $]))
             {
                 errorInvalidSwitch(p, "Only number, `spec`, or `context` are allowed for `-verrors`");
                 return true;
@@ -1016,7 +1016,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         }
         else if (startsWith(p + 1, "verror-supplements"))
         {
-            if (!params.v.errorSupplementLimit.parseDigits(p.toDString()[20 .. $]))
+            if (!global.diag.errorSupplementLimit.parseDigits(p.toDString()[20 .. $]))
             {
                 errorInvalidSwitch(p, "Only a number is allowed for `-verror-supplements`");
                 return true;
@@ -1029,10 +1029,10 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             switch (style)
             {
             case "digitalmars":
-                params.v.messageStyle = MessageStyle.digitalmars;
+                global.diag.messageStyle = MessageStyle.digitalmars;
                 break;
             case "gnu":
-                params.v.messageStyle = MessageStyle.gnu;
+                global.diag.messageStyle = MessageStyle.gnu;
                 break;
             default:
                 error("unknown error style '%.*s', must be 'digitalmars' or 'gnu'", cast(int) style.length, style.ptr);
@@ -1242,9 +1242,9 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             }
         }
         else if (arg == "-w")   // https://dlang.org/dmd.html#switch-w
-            params.useWarnings = DiagnosticReporting.error;
+            global.diag.useWarnings = DiagnosticReporting.error;
         else if (arg == "-wi")  // https://dlang.org/dmd.html#switch-wi
-            params.useWarnings = DiagnosticReporting.inform;
+            global.diag.useWarnings = DiagnosticReporting.inform;
         else if (arg == "-wo")  // https://dlang.org/dmd.html#switch-wo
         {
             // Obsolete features has been obsoleted until a DIP for "editions"

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2604,7 +2604,7 @@ extern (C++) final class TypeFunction : TypeNext
 
     extern(D) static const(char)* getMatchError(A...)(const(char)* format, A args)
     {
-        if (global.gag && !global.params.v.showGaggedErrors)
+        if (global.diag.gag && !global.diag.showGaggedErrors)
             return null;
         OutBuffer buf;
         buf.printf(format, args);

--- a/compiler/src/dmd/pragmasem.d
+++ b/compiler/src/dmd/pragmasem.d
@@ -335,7 +335,7 @@ void pragmaDeclSemantic(PragmaDeclaration pd, Scope* sc)
     buf.writestring(pd.ident.toString());
     if (pd.args)
     {
-        const errors_save = global.startGagging();
+        const errors_save = global.diag.startGagging();
         for (size_t i = 0; i < pd.args.length; i++)
         {
             Expression e = (*pd.args)[i];
@@ -352,7 +352,7 @@ void pragmaDeclSemantic(PragmaDeclaration pd, Scope* sc)
         }
         if (pd.args.length)
             buf.writeByte(')');
-        global.endGagging(errors_save);
+        global.diag.endGagging(errors_save);
     }
     message("pragma    %s", buf.peekChars());
     return declarations();

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -433,7 +433,7 @@ bool setUnsafe(Scope* sc,
     {
         if (sc.func.isSafeBypassingInference())
         {
-            // Message wil be gagged, but still call error() to update global.errors and for
+            // Message wil be gagged, but still call error() to update global.diag.errors and for
             // -verrors=spec
             .error(loc, fmt, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
             return true;

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -146,9 +146,9 @@ private extern(C++) final class Semantic2Visitor : Visitor
         sc.tinst = tempinst;
         sc.minst = tempinst.minst;
 
-        const needGagging = (tempinst.gagged && !global.gag);
-        const olderrors = global.errors;
-        const oldGaggedErrors = needGagging ? global.startGagging() : -1;
+        const needGagging = (tempinst.gagged && !global.diag.gag);
+        const olderrors = global.diag.errors;
+        const oldGaggedErrors = needGagging ? global.diag.startGagging() : -1;
 
         for (size_t i = 0; i < tempinst.members.length; i++)
         {
@@ -158,11 +158,11 @@ private extern(C++) final class Semantic2Visitor : Visitor
                 printf("\tmember '%s', kind = '%s'\n", s.toChars(), s.kind());
             }
             s.semantic2(sc);
-            if (tempinst.gagged && global.errors != olderrors)
+            if (tempinst.gagged && global.diag.errors != olderrors)
                 break;
         }
 
-        if (global.errors != olderrors)
+        if (global.diag.errors != olderrors)
         {
             if (!tempinst.errors)
             {
@@ -174,7 +174,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
             tempinst.errors = true;
         }
         if (needGagging)
-            global.endGagging(oldGaggedErrors);
+            global.diag.endGagging(oldGaggedErrors);
 
         sc = sc.pop();
         sc.pop();
@@ -730,7 +730,7 @@ private void doGNUABITagSemantic(ref Expression e, ref Expression* lastTag)
     auto sle = e.isStructLiteralExp();
     if (sle is null)
     {
-        assert(global.errors);
+        assert(global.diag.errors);
         return;
     }
     // The definition of `gnuAttributes` only have 1 member, `string[] tags`
@@ -884,7 +884,7 @@ void staticAssertFail(StaticAssert sa, Scope* sc)
             if (e.op == EXP.error)
             {
                 errorSupplemental(sa.loc, "while evaluating `static assert` argument `%s`", (*sa.msgs)[i].toChars());
-                if (!global.gag)
+                if (!global.diag.gag)
                     fatal();
                 return;
             }
@@ -906,6 +906,6 @@ void staticAssertFail(StaticAssert sa, Scope* sc)
         error(sa.loc, "static assert:  `%s` is false", sa.exp.toChars());
     if (sc.tinst)
         sc.tinst.printInstantiationTrace();
-    if (!global.gag)
+    if (!global.diag.gag)
         fatal();
 }

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -331,7 +331,7 @@ extern (C++) final class ErrorStatement : Statement
         super(Loc.initial, STMT.Error);
 
         import dmd.globals;
-        assert(global.gaggedErrors || global.errors);
+        assert(global.diag.gaggedErrors || global.diag.errors);
     }
 
     override ErrorStatement syntaxCopy()

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -661,9 +661,9 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             // @@@DEPRECATED_2.112@@@
             // remove gagging and deprecation() to turn deprecation into an error when
             // deprecation cycle is over
-            const olderrors = global.startGagging();
+            const olderrors = global.diag.startGagging();
             discardValue(fs.increment);
-            if (global.endGagging(olderrors))
+            if (global.diag.endGagging(olderrors))
                 deprecation(fs.increment.loc, "`%s` has no effect", fs.increment.toChars());
             if (checkNonAssignmentArrayOp(fs.increment))
                 fs.increment = ErrorExp.get();
@@ -1927,7 +1927,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             if (ed && ss.cases.length < ed.members.length)
             {
                 int missingMembers = 0;
-                const maxShown = global.params.v.errorSupplementCount();
+                const maxShown = global.diag.errorSupplementCount();
             Lmembers:
                 foreach (es; *ed.members)
                 {
@@ -2569,14 +2569,14 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 rs.exp = checkNoreturnVarAccess(rs.exp);
 
                 // @@@DEPRECATED_2.111@@@
-                const olderrors = global.startGagging();
+                const olderrors = global.diag.startGagging();
                 // uncomment to turn deprecation into an error when
                 // deprecation cycle is over
                 if (discardValue(rs.exp))
                 {
                     //errors = true;
                 }
-                if (global.endGagging(olderrors))
+                if (global.diag.endGagging(olderrors))
                     deprecation(rs.exp.loc, "`%s` has no effect", rs.exp.toChars());
 
                 /* Replace:
@@ -4806,7 +4806,7 @@ private Statements* flatten(Statement statement, Scope* sc)
             if (expressionsToString(buf, sc, cs.exps, cs.loc, null, true))
                 return errorStatements();
 
-            const errors = global.errors;
+            const errors = global.diag.errors;
             const len = buf.length;
             buf.writeByte(0);
             const str = buf.extractSlice()[0 .. len];
@@ -4819,7 +4819,7 @@ private Statements* flatten(Statement statement, Scope* sc)
             while (p.token.value != TOK.endOfFile)
             {
                 Statement s = p.parseStatement(ParseStatementFlags.curlyScope);
-                if (!s || global.errors != errors)
+                if (!s || global.diag.errors != errors)
                     return errorStatements();
                 a.push(s);
             }

--- a/compiler/src/dmd/templateparamsem.d
+++ b/compiler/src/dmd/templateparamsem.d
@@ -173,10 +173,10 @@ RootObject aliasParameterSemantic(Loc loc, Scope* sc, RootObject o, TemplatePara
         else if (TypeInstance ti = ta.isTypeInstance())
         {
             Type t;
-            const errors = global.errors;
+            const errors = global.diag.errors;
             ta.resolve(loc, sc, ea, t, s);
             // if we had an error evaluating the symbol, suppress further errors
-            if (!t && errors != global.errors)
+            if (!t && errors != global.diag.errors)
                 return Type.terror;
             // We might have something that looks like a type
             // but is actually an expression or a dsymbol

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -353,9 +353,9 @@ MATCH matchWithInstance(Scope* sc, TemplateDeclaration td, TemplateInstance ti, 
 
             // Resolve parameter types and 'auto ref's.
             tf.inferenceArguments = argumentList;
-            const olderrors = global.startGagging();
+            const olderrors = global.diag.startGagging();
             fd.type = tf.typeSemantic(td.loc, paramscope);
-            global.endGagging(olderrors);
+            global.diag.endGagging(olderrors);
             if (fd.type.ty != Tfunction)
                 return nomatch();
             fd.originalType = fd.type; // for mangling
@@ -1421,7 +1421,7 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
                             Dsymbol s;
                             Scope *sco;
 
-                            const errors = global.startGagging();
+                            const errors = global.diag.startGagging();
                             /* ref: https://issues.dlang.org/show_bug.cgi?id=11118
                              * The parameter isn't part of the template
                              * ones, let's try to find it in the
@@ -1434,7 +1434,7 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
                                 sco = paramscope;
                                 taa.index.resolve(instLoc, sco, e, t, s);
                             }
-                            global.endGagging(errors);
+                            global.diag.endGagging(errors);
 
                             if (!e)
                                 return nomatch();

--- a/compiler/src/dmd/toctype.d
+++ b/compiler/src/dmd/toctype.d
@@ -162,7 +162,7 @@ type* Type_toCtype(Type t)
             /* Add in fields of the struct
              * (after setting ctype to avoid infinite recursion)
              */
-            if (driverParams.symdebug && !global.errors)
+            if (driverParams.symdebug && !global.diag.errors)
             {
                 foreach (v; sym.fields)
                 {

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1038,10 +1038,10 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                  e.ident == Id.getVirtualMethods ||
                  e.ident == Id.getOverloads)
         {
-            const errors = global.errors;
+            const errors = global.diag.errors;
             Expression eorig = ex;
             ex = ex.expressionSemantic(scx);
-            if (errors < global.errors)
+            if (errors < global.diag.errors)
                 error(e.loc, "`%s` cannot be resolved", eorig.toChars());
 
             if (e.ident == Id.getVirtualFunctions)
@@ -1746,7 +1746,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
         foreach (o; *e.args)
         {
-            const errors = global.startGagging();
+            const errors = global.diag.startGagging();
             Scope* sc2 = sc.push();
             sc2.tinst = null;
             sc2.minst = null;   // this is why code for these are not emitted to object file
@@ -1793,7 +1793,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             // https://issues.dlang.org/show_bug.cgi?id=15428
             sc2.detach();
 
-            if (global.endGagging(errors) || err)
+            if (global.diag.endGagging(errors) || err)
             {
                 return False();
             }

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -46,7 +46,7 @@ bool genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc)
     {
         if (!global.params.useTypeInfo)
         {
-            global.gag = 0;
+            global.diag.gag = 0;
             if (e)
                 .error(loc, "expression `%s` uses the GC and cannot be used with switch `-betterC`", e.toChars());
             else

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -276,7 +276,7 @@ void test_semantic()
 
     Module *m = Module::create("object.d", Identifier::idPool("object"), 0, 0);
 
-    unsigned errors = global.startGagging();
+    unsigned errors = global.diag.startGagging();
 
     m->src = src;
     m->parse();
@@ -297,7 +297,7 @@ void test_semantic()
     ClassDeclaration *cd = ad->isClassDeclaration();
     assert(cd && cd->hasMonitor());
 
-    assert(!global.endGagging(errors));
+    assert(!global.diag.endGagging(errors));
 }
 
 /**********************************/
@@ -314,7 +314,7 @@ void test_skip_importall()
 
     Module *m = Module::create("rootobject.d", Identifier::idPool("rootobject"), 0, 0);
 
-    unsigned errors = global.startGagging();
+    unsigned errors = global.diag.startGagging();
 
     m->src = src;
     m->parse();
@@ -323,7 +323,7 @@ void test_skip_importall()
     dmd::semantic2(m, NULL);
     dmd::semantic3(m, NULL);
 
-    assert(!global.endGagging(errors));
+    assert(!global.diag.endGagging(errors));
 }
 
 /**********************************/
@@ -500,7 +500,7 @@ void test_cppmangle()
 
     Module *m = Module::create("cppa.d", Identifier::idPool("cppa"), 0, 0);
 
-    unsigned errors = global.startGagging();
+    unsigned errors = global.diag.startGagging();
     FuncDeclaration *fd;
     const char *mangle;
 
@@ -530,15 +530,15 @@ void test_cppmangle()
     mangle = dmd::cppThunkMangleItanium(fd, b->offset);
     assert(strcmp(mangle, "_ZThn8_N7Derived7MethodDEv") == 0);
 
-    assert(!global.endGagging(errors));
+    assert(!global.diag.endGagging(errors));
 }
 
 void test_module()
 {
-    unsigned errors = global.startGagging();
+    unsigned errors = global.diag.startGagging();
     Module *mod = Module::load(Loc(), NULL, Identifier::idPool("doesnotexist.d"));
     assert(mod == NULL);
-    assert(global.endGagging(errors));
+    assert(global.diag.endGagging(errors));
 }
 
 void test_optional()
@@ -1624,7 +1624,7 @@ public:
             dmd::functionSemantic3(d);
             Module::runDeferredSemantic3();
         }
-        if (global.errors)
+        if (global.diag.errors)
             return;
         visitDeclaration(d);
         if (!d->fbody)

--- a/compiler/test/dub_package/retrieve_scope.d
+++ b/compiler/test/dub_package/retrieve_scope.d
@@ -74,7 +74,7 @@ int main()
                             va_list args,
                             const(char)* prefix1,
                             const(char)* prefix2) => true;
-    global.gag = 1;
+    global.diag.gag = 1;
     initDMD(diagnosticHandler);
 
     Module m = parseModule("testfiles/correct.d").module_;

--- a/compiler/test/fail_compilation/fail134.d
+++ b/compiler/test/fail_compilation/fail134.d
@@ -8,7 +8,7 @@ fail_compilation/fail134.d(15): Error: template instance `fail134.bar!(f)` error
 */
 
 // https://issues.dlang.org/show_bug.cgi?id=651
-// Assertion failure: 'global.errors' on line 2622 in file 'template.c'
+// Assertion failure: 'global.diag.errors' on line 2622 in file 'template.c'
 void f() {}
 template foo(T) {}
 template bar(T...) { alias foo!(T) buz; }

--- a/compiler/test/fail_compilation/ice15172.d
+++ b/compiler/test/fail_compilation/ice15172.d
@@ -28,6 +28,6 @@ void onThreadError()
     // 7. ctfeInterpret
     //    Finally, FuncDeclaration::interpret may encounter a function which is semantic3Errors == true. So
     //    7a. functionSemantic3() should return false if semantic3Errors is true.
-    //    7b. the function body errors may not happen during ctfeInterpret call and global.errors could be unincremented.
+    //    7b. the function body errors may not happen during ctfeInterpret call and global.diag.errors could be unincremented.
     __gshared auto ThreadError = new ThreadError(null);
 }

--- a/compiler/test/unit/compilable/searching.d
+++ b/compiler/test/unit/compilable/searching.d
@@ -173,11 +173,11 @@ Dsymbol findSymbol(Dsymbol sym, string name, bool allowMissing = false)
 {
     assert(sym, "Missing symbol while searching for: " ~ name);
 
-    const oldErrors = global.errors;
+    const oldErrors = global.diag.errors;
     Identifier id = Identifier.idPool(name);
     Dsymbol found = sym.search(Loc.initial, id, SearchOpt.ignoreErrors);
 
-    assert(global.errors == oldErrors, "Searching " ~ name ~ " caused errors!");
+    assert(global.diag.errors == oldErrors, "Searching " ~ name ~ " caused errors!");
     assert(allowMissing || found, name ~ " not found!");
     return found;
 }

--- a/compiler/test/unit/frontend.d
+++ b/compiler/test/unit/frontend.d
@@ -205,7 +205,7 @@ unittest
 
     t.module_.fullSemantic();
 
-    assert(global.errors == 0);
+    assert(global.diag.errors == 0);
 }
 
 @("initDMD - version identifiers")
@@ -233,7 +233,7 @@ unittest
 
     t.module_.fullSemantic();
 
-    assert(global.errors == 0);
+    assert(global.diag.errors == 0);
 }
 
 @("initDMD - custom diagnostic handling")
@@ -296,7 +296,7 @@ unittest
 
     t.module_.fullSemantic();
 
-    assert(global.errors == 0);
+    assert(global.diag.errors == 0);
 }
 
 @("initDMD - floating-point")
@@ -319,7 +319,7 @@ unittest
 
     t.module_.fullSemantic();
 
-    assert(global.errors == 0);
+    assert(global.diag.errors == 0);
 }
 
 @("inline assembly")
@@ -348,7 +348,7 @@ unittest
 
     t.module_.fullSemantic();
 
-    assert(global.errors == 0);
+    assert(global.diag.errors == 0);
 }
 
 // Issue https://issues.dlang.org/show_bug.cgi?id=22906
@@ -387,7 +387,7 @@ unittest
 
     t.module_.fullSemantic();
 
-    assert(global.errors == 1);
+    assert(global.diag.errors == 1);
     assert(endsWith(diagnosticMessages[0], "is a Ddoc file, cannot import it"));
 }
 

--- a/compiler/test/unit/parser/diagnostic_reporter.d
+++ b/compiler/test/unit/parser/diagnostic_reporter.d
@@ -86,7 +86,7 @@ unittest
         }
     }
 
-    global.params.useWarnings = DiagnosticReporting.inform;
+    global.diag.useWarnings = DiagnosticReporting.inform;
     scope reporter = new WarningCountingDiagnosticReporter;
 
     parseModule("test.d", q{

--- a/compiler/test/unit/semantic/control_flow.d
+++ b/compiler/test/unit/semantic/control_flow.d
@@ -898,7 +898,7 @@ void testBlockExit(FuncDeclaration fd, Statement stmt, const BE expected)
     const actual = blockExit(stmt, fd, null);
     assert(actual == expected, beToString(actual) ~ " != " ~ beToString(expected));
 
-    assert(!global.errors, "`blockExit` raised an error!");
+    assert(!global.diag.errors, "`blockExit` raised an error!");
 }
 
 //========================================================================================

--- a/compiler/test/unit/semantic/covariance.d
+++ b/compiler/test/unit/semantic/covariance.d
@@ -859,7 +859,7 @@ void testCovariant(Type base, Type target, in Result expected, const size_t line
 
     StorageClass actualStc;
     const actual = base.covariant(target, &actualStc);
-    enforce(!global.errors, line, "`covariant` raised an error!");
+    enforce(!global.diag.errors, line, "`covariant` raised an error!");
 
     enforce(actual == expected.result, line, cast(string) (
         "Unexpected result!\n\n" ~


### PR DESCRIPTION
Many modules `import dmd.globals;` to access only a set of these fields. This will enable further refactoring to both restrict imports of `dmd.globals` and to pass these parameters explicitly. 