### PR TITLE
fix bugzilla Issue 24822 - When passing a non-POD argument to an rvalue parame…

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -5505,9 +5505,9 @@ elem *callfunc(const ref Loc loc,
                  * to that temporary.
                  */
                 VarDeclaration v;
-                if (VarExp ve = arg.isVarExp())
+                if (VarExp ve = arg.lastComma().isVarExp())
                     v = ve.var.isVarDeclaration();
-                bool copy = !(v && v.isArgDtorVar); // copy unless the destructor is going to be run on it
+                bool copy = !(v && (v.isArgDtorVar || v.storage_class & STC.rvalue)); // copy unless the destructor is going to be run on it
                                                     // then assume the frontend took care of the copying and pass it by ref
 
                 elems[i] = addressElem(ea, arg.type, copy);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12258,7 +12258,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         if (tb1.ty == Tpointer && tb2.ty == Tpointer ||
-	    tb1.ty == Tnull && tb2.ty == Tnull)
+            tb1.ty == Tnull && tb2.ty == Tnull)
         {
             result = exp.incompatibleTypes();
             return;


### PR DESCRIPTION
…ter, an unnecessary blit is done

Since this is an optimization, not a decent way to test it.