### PR TITLE
fix(errors): adhere to SARIF 2.1.0 schema

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -121,40 +121,73 @@ void generateSarifReport(const ref Loc loc, const(char)* format, va_list ap, Err
 
     // Create an OutBuffer to store the SARIF report
     OutBuffer ob;
+    ob.doindent = true;
 
-    // Build SARIF report using OutBuffer
-    ob.writestring("{\n");
-    ob.writestring("  \"invocation\": {\n");
-    ob.writestring("    \"executionSuccessful\": false\n");
-    ob.writestring("  },\n");
-    ob.writestring("  \"results\": [\n    {\n");
+    // Extract and clean the version string
+    const(char)* rawVersionChars = global.versionChars();
 
-    // Write location information with relative path
-    ob.writestring("      \"location\": {\n");
-    ob.writestring("        \"artifactLocation\": {\n");
-    ob.printf("          \"uri\": \"%s\"\n", loc.filename);
-    ob.writestring("        },\n");
-    ob.writestring("        \"region\": {\n");
-    ob.printf("          \"startLine\": %d,\n", loc.linnum);
-    ob.printf("          \"startColumn\": %d\n", loc.charnum);
-    ob.writestring("        }\n");
-    ob.writestring("      },\n");
+    // Remove 'v' prefix if it exists
+    if (*rawVersionChars == 'v') {
+        rawVersionChars += 1;
+    }
 
-    // Write message and ruleId
-    ob.printf("      \"message\": \"%s\",\n", formattedMessage.ptr);
-    ob.writestring("      \"ruleId\": \"DMD\"\n");
+    // Find the first non-numeric character after the version number
+    const(char)* nonNumeric = strchr(rawVersionChars, '-');
+    size_t length = nonNumeric ? cast(size_t)(nonNumeric - rawVersionChars) : strlen(rawVersionChars);
 
-    // Close the results and SARIF report
-    ob.writestring("    }\n  ],\n");
-    ob.writestring("  \"tool\": {\n");
-    ob.printf("    \"name\": \"DMD\"\n");
-    ob.writestring("  }\n");
-    ob.writestring("}\n");
+    // Build SARIF report
+    ob.level = 0;
+    ob.writestringln("{");
+    ob.level = 1;
+
+    ob.writestringln(`"version": "2.1.0",`);
+    ob.writestringln(`"$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",`);
+    ob.writestringln(`"runs": [{`);
+
+    // Tool Information
+    ob.level += 1;
+    ob.writestringln(`"tool": {`);
+    ob.writestringln(`"driver": {`);
+    ob.printf(`"name": "%s",`, global.compileEnv.vendor.ptr);
+    ob.printf(`"version": "%.*s",`, cast(int)length, rawVersionChars);
+    ob.writestringln(`"informationUri": "https://dlang.org/dmd.html"`);
+    ob.writestringln("}");
+    ob.writestringln("},");
+
+    // Invocation Information
+    ob.writestringln(`"invocations": [{`);
+    ob.writestringln(`"executionSuccessful": false`);
+    ob.writestringln("}],");
+
+    // Results Array
+    ob.writestringln(`"results": [{`);
+    ob.writestringln(`"ruleId": "DMD",`);
+    ob.printf(`"message": { "text": "%s" },`, formattedMessage.ptr);
+
+    // Location Information
+    ob.writestringln(`"locations": [{`);
+    ob.writestringln(`"physicalLocation": {`);
+    ob.writestringln(`"artifactLocation": {`);
+    ob.printf(`"uri": "%s"`, loc.filename);
+    ob.writestringln("},");
+    ob.writestringln(`"region": {`);
+    ob.printf(`"startLine": %d,`, loc.linnum);
+    ob.printf(`"startColumn": %d`, loc.charnum);
+    ob.writestringln("}");
+    ob.writestringln("}");
+    ob.writestringln("}]");
+    ob.writestringln("}]");
+
+    // Close the run and SARIF JSON
+    ob.level -= 1;
+    ob.writestringln("}]");
+    ob.level = 0;
+    ob.writestringln("}");
 
     // Extract the final null-terminated string and print it to stdout
-    const(char)* sarifOutput = ob.extractChars();  // Ensure null-terminated output
-    fputs(sarifOutput, stdout);  // Output the SARIF report
-    fflush(stdout);  // Ensure it gets written immediately
+    const(char)* sarifOutput = ob.extractChars();
+    fputs(sarifOutput, stdout);
+    fflush(stdout);
 }
 
 // Helper function to format error messages

--- a/compiler/test/fail_compilation/sarif_test.d
+++ b/compiler/test/fail_compilation/sarif_test.d
@@ -3,27 +3,29 @@ TEST_OUTPUT:
 ---
 fail_compilation/sarif_test.d: Error: undefined identifier `x`
 {
-  "invocation": {
-    "executionSuccessful": false
-  },
-  "results": [
-    {
-      "location": {
-        "artifactLocation": {
-          "uri": "fail_compilation/sarif_test.d"
-        },
-        "region": {
-          "startLine": 33,
-          "startColumn": 5
-        }
-      },
-      "message": "undefined identifier `x`",
-      "ruleId": "DMD"
-    }
-  ],
-  "tool": {
-    "name": "DMD"
-  }
+	"version": "2.1.0",
+	"$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+	"runs": [{
+		"tool": {
+		"driver": {
+		"name": "Digital Mars D","version": "2.110.0","informationUri": "https://dlang.org/dmd.html"
+		}
+		},
+		"invocations": [{
+		"executionSuccessful": false
+		}],
+		"results": [{
+		"ruleId": "DMD",
+		"message": { "text": "undefined identifier `x`" },"locations": [{
+		"physicalLocation": {
+		"artifactLocation": {
+		"uri": "fail_compilation/sarif_test.d"},
+		"region": {
+		"startLine": 35,"startColumn": 5}
+		}
+		}]
+		}]
+	}]
 }
 ---
 */


### PR DESCRIPTION
Addressed feedback to align with the SARIF 2.1.0 schema: [Feedback reference](https://forum.dlang.org/post/nluhtkvkyzkumjzuizwh@forum.dlang.org)  
- Followed [SARIF Schema 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/sarif-schema-2.1.0.json)  
- Validated the output here: [SARIF Web Validator](https://sarifweb.azurewebsites.net/Validation)  