### PR TITLE
dsymbolsem/InstMemberWalker: also visit generated structs' members

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4715,6 +4715,15 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
                     visit(cast(Dsymbol)sds);
                 }
 
+                override void visit(StructDeclaration sd)
+                {
+                    // need to visit auto-generated methods as well
+                    if (sd.xeq) visit(sd.xeq);
+                    if (sd.xcmp) visit(sd.xcmp);
+                    if (sd.xhash) visit(sd.xhash);
+                    visit(cast(ScopeDsymbol)sd);
+                }
+
                 override void visit(AttribDeclaration ad)
                 {
                     ad.include(null).foreachDsymbol( s => s.accept(this) );

--- a/compiler/test/compilable/issue24830.sh
+++ b/compiler/test/compilable/issue24830.sh
@@ -1,0 +1,34 @@
+#! /usr/bin/env bash
+
+TEST_DIR=${OUTPUT_BASE}
+# create two modules each depending on each other.
+# They both do the same template instantiation.
+D_FILE1=$TEST_DIR/first.d
+D_FILE2=$TEST_DIR/second.d
+D_OBJ1=$TEST_DIR/first${OBJ}
+D_OBJ2=$TEST_DIR/second${OBJ}
+APP=$TEST_DIR/app
+
+mkdir -p $TEST_DIR
+
+cat >$D_FILE1 <<EOF
+module first;
+import second;
+
+struct S(T) {
+    int opCmp()(const(S) rhs) const { return 0; }
+}
+S!int f;
+EOF
+
+cat >$D_FILE2 <<EOF
+module second;
+import first;
+S!int s;
+EOF
+
+${DMD} -m${MODEL} -c -of${D_OBJ1} -I${TEST_DIR} ${D_FILE1}
+${DMD} -m${MODEL} -c -of${D_OBJ2} -I${TEST_DIR} ${D_FILE2}
+
+# Try to link them
+${DMD} -main -m${MODEL} -of${APP} ${D_OBJ1} ${D_OBJ2}


### PR DESCRIPTION
While updating children's `minst` only going over `members` is not enough: structs may also have generated methods that are not in `members`.

As a result, if a generated method instantiates a template, it gets a poentially wrong `minst`, so can be omitted from the compilation result.

Fixes Bugzilla Issue 24830