### PR TITLE
Use `SourceLoc` for generateSarifReport

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -476,11 +476,9 @@ private extern(C++) void verrorReport(const SourceLoc loc, const(char)* format, 
             info.headerColor = Classification.error;
             verrorPrint(format, ap, info);
 
-            // Fix: Convert filename to const(char)* using .ptr
-            Loc sourceLoc = Loc(info.loc.filename.ptr, info.loc.linnum, info.loc.charnum);
             if (global.params.v.messageStyle == MessageStyle.sarif)
             {
-                generateSarifReport(sourceLoc, format, ap, info.kind);
+                generateSarifReport(loc, format, ap, info.kind);
             }
             if (global.params.v.errorLimit && global.errors >= global.params.v.errorLimit)
             {
@@ -512,11 +510,9 @@ private extern(C++) void verrorReport(const SourceLoc loc, const(char)* format, 
                     info.headerColor = Classification.deprecation;
                     verrorPrint(format, ap, info);
 
-                    // Fix: Convert filename to const(char)* using .ptr
-                    Loc sourceLoc = Loc(info.loc.filename.ptr, info.loc.linnum, info.loc.charnum);
                     if (global.params.v.messageStyle == MessageStyle.sarif)
                     {
-                        generateSarifReport(sourceLoc, format, ap, info.kind);
+                        generateSarifReport(loc, format, ap, info.kind);
                     }
                 }
             }
@@ -551,10 +547,9 @@ private extern(C++) void verrorReport(const SourceLoc loc, const(char)* format, 
             verrorPrint(format, ap, info);
 
             // Fix: Convert filename to const(char)* using .ptr
-            Loc sourceLoc = Loc(info.loc.filename.ptr, info.loc.linnum, info.loc.charnum);
             if (global.params.v.messageStyle == MessageStyle.sarif)
             {
-                generateSarifReport(sourceLoc, format, ap, info.kind);
+                generateSarifReport(loc, format, ap, info.kind);
             }
         }
         return;
@@ -570,11 +565,9 @@ private extern(C++) void verrorReport(const SourceLoc loc, const(char)* format, 
         fputs(tmp.peekChars(), stdout);
         fputc('\n', stdout);
         fflush(stdout);     // ensure it gets written out in case of compiler aborts
-        // Fix: Convert filename to const(char)* using .ptr
-        Loc sourceLoc = Loc(info.loc.filename.ptr, info.loc.linnum, info.loc.charnum);
         if (global.params.v.messageStyle == MessageStyle.sarif)
         {
-            generateSarifReport(sourceLoc, format, ap, info.kind);
+            generateSarifReport(loc, format, ap, info.kind);
         }
         return;
     }

--- a/compiler/src/dmd/sarif.d
+++ b/compiler/src/dmd/sarif.d
@@ -101,7 +101,7 @@ string formatErrorMessage(const(char)* format, va_list ap) nothrow
     return buffer[0 .. buffer.length].dup;
 }
 
-void generateSarifReport(const ref Loc loc, const(char)* format, va_list ap, ErrorKind kind) nothrow
+void generateSarifReport(const ref SourceLoc loc, const(char)* format, va_list ap, ErrorKind kind) nothrow
 {
     // Format the error message
     string formattedMessage = formatErrorMessage(format, ap);
@@ -155,8 +155,9 @@ void generateSarifReport(const ref Loc loc, const(char)* format, va_list ap, Err
     ob.writestringln(`"locations": [{`);
     ob.writestringln(`"physicalLocation": {`);
     ob.writestringln(`"artifactLocation": {`);
-    ob.printf(`"uri": "%s"`, loc.filename);
-    ob.writestringln("},");
+    ob.writestring(`"uri": "`);
+    ob.writestring(loc.filename);
+    ob.writestringln(`"},`);
     ob.writestringln(`"region": {`);
     ob.printf(`"startLine": %d,`, loc.linnum);
     ob.printf(`"startColumn": %d`, loc.charnum);


### PR DESCRIPTION
Avoid redundantly creating new `Loc` objects