### PR TITLE
Fix dub recipe for the lexer subpackage

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -43,6 +43,7 @@ subPackage {
     "compiler/src/dmd/identifier.d" \
     "compiler/src/dmd/lexer.d" \
     "compiler/src/dmd/location.d" \
+    "compiler/src/dmd/sarif.d" \
     "compiler/src/dmd/tokens.d" \
     "compiler/src/dmd/utils.d" \
     "compiler/src/dmd/errorsink.d"


### PR DESCRIPTION
Some of the `errors.d` code has been moved in `sarif.d`.

When using dmd in a dub project, dub fails to build the lexer subpackage due to the missing dependency.

This PR fixes the issue by specifying the `sarif.d` dependency in the lexer subpackage