### PR TITLE
macOS CI: Upgrade GNU make in ci/cirrusci.sh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,11 +115,6 @@ jobs:
         uses: dlang-community/setup-dlang@v1.3.0
         with:
           compiler: ${{ matrix.host_dmd }}
-      - name: 'MacOS: Install recent make'
-        if: runner.os == 'macOS'
-        run: |
-          brew install make
-          echo "PATH=/usr/local/opt/make/libexec/gnubin:$PATH" >> $GITHUB_ENV
 
       - name: Set up repos
         run: |

--- a/ci/cirrusci.sh
+++ b/ci/cirrusci.sh
@@ -27,6 +27,10 @@ if [ "$OS_NAME" == "linux" ]; then
   fi
   apt-get -q update
   apt-get install -yq $packages
+elif [ "$OS_NAME" == "osx" ]; then
+  # upgrade GNU make
+  brew install make
+  sudo ln -s /usr/local/opt/make/libexec/gnubin/make /usr/local/bin/make
 elif [ "$OS_NAME" == "freebsd" ]; then
   packages="git gmake devel/llvm12"
   if [ "$HOST_DMD" == "dmd-2.079.0" ] ; then


### PR DESCRIPTION
This should fix Phobos CI, which expects such prerequisites provisioning to happen in DMD's `ci/cirrusci.sh`. Because this YAML addition hasn't been duplicated in Phobos, Phobos CI is still using the default make on macOS, which is too old and doesn't support the newly required `private` modifier.