### PR TITLE
Allow compilation with -fno-exceptions

### DIFF
--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -135,7 +135,9 @@ extern (C) int _Dmain(char[][])
         dmd_coverDestPath(sourcePath);
         dmd_coverSetMerge(true);
     }
-    scope(failure) stderr.printInternalFailure;
+    version (D_Exceptions)
+        scope(failure) stderr.printInternalFailure;
+
     auto args = Runtime.cArgs();
     return tryMain(args.argc, cast(const(char)**)args.argv, global.params);
 }


### PR DESCRIPTION
When compiling itself with `-nothrow` or `-fno-exceptions`:
```
dmd/main.d(138): Error: `scope(failure)` cannot be used with -betterC
```
