### PR TITLE
docs(errors): add Ddoc comments and README entry

### DIFF
--- a/compiler/src/dmd/README.md
+++ b/compiler/src/dmd/README.md
@@ -41,6 +41,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | [frontend.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/frontend.d)   | An interface for using DMD as a library                               |
 | [errors.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/errors.d)       | Error reporting implementation                                        |
 | [errorsink.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/errorsink.d) | Error reporting interface                                             |
+| [sarif.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/sarif.d)         | Generates SARIF reports for errors and warnings.                      |
 | [target.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/target.d)       | Manage target-specific parameters for cross-compiling (for LDC/GDC)   |
 | [compiler.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/compiler.d)   | Describe a back-end compiler and implements compiler-specific actions |
 | [deps.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/deps.d)           | Implement the `-deps` and `-makedeps` switches                        |


### PR DESCRIPTION
Feedback- https://github.com/dlang/dmd/pull/17032#issuecomment-2445061949
- Added Ddoc header like other source files
- Added Ddoc function documentation for all public functions
- Added source file description for `sarif.d` in `src/dmd/README.md`
- Removed unused `sourceLocToJson()` function