### PR TITLE
feat(errors): generate sarif report on successful execution

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -476,7 +476,7 @@ private extern(C++) void verrorReport(const SourceLoc loc, const(char)* format, 
             info.headerColor = Classification.error;
             if (global.params.v.messageStyle == MessageStyle.sarif)
             {
-                generateSarifReport(loc, format, ap, info.kind);
+                generateSarifReport(loc, format, ap, info.kind, false);
                 return;
             }
             verrorPrint(format, ap, info);
@@ -510,7 +510,7 @@ private extern(C++) void verrorReport(const SourceLoc loc, const(char)* format, 
                     info.headerColor = Classification.deprecation;
                     if (global.params.v.messageStyle == MessageStyle.sarif)
                     {
-                        generateSarifReport(loc, format, ap, info.kind);
+                        generateSarifReport(loc, format, ap, info.kind, false);
                         return;
                     }
                     verrorPrint(format, ap, info);
@@ -531,7 +531,7 @@ private extern(C++) void verrorReport(const SourceLoc loc, const(char)* format, 
                 info.headerColor = Classification.warning;
                 if (global.params.v.messageStyle == MessageStyle.sarif)
                 {
-                    generateSarifReport(loc, format, ap, info.kind);
+                    generateSarifReport(loc, format, ap, info.kind, false);
                     return;
                 }
                 verrorPrint(format, ap, info);
@@ -551,7 +551,7 @@ private extern(C++) void verrorReport(const SourceLoc loc, const(char)* format, 
             info.headerColor = Classification.tip;
             if (global.params.v.messageStyle == MessageStyle.sarif)
             {
-                generateSarifReport(loc, format, ap, info.kind);
+                generateSarifReport(loc, format, ap, info.kind, false);
                 return;
             }
             verrorPrint(format, ap, info);
@@ -571,7 +571,7 @@ private extern(C++) void verrorReport(const SourceLoc loc, const(char)* format, 
         fflush(stdout);     // ensure it gets written out in case of compiler aborts
         if (global.params.v.messageStyle == MessageStyle.sarif)
         {
-            generateSarifReport(loc, format, ap, info.kind);
+            generateSarifReport(loc, format, ap, info.kind, false);
             return;
         }
         return;

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -162,6 +162,8 @@ private:
 private int tryMain(size_t argc, const(char)** argv, ref Param params)
 {
     import dmd.common.charactertables;
+    import dmd.sarif;
+    import core.stdc.stdarg;
 
     Strings files;
     Strings libmodules;
@@ -172,6 +174,13 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         // If we are here then compilation has ended
         // gracefully as opposed to with `fatal`
         global.plugErrorSinks();
+
+        if (global.errors == 0 && global.params.v.messageStyle == MessageStyle.sarif)
+        {
+            SourceLoc defaultLoc = SourceLoc(null, 0u, 0u);
+            va_list ap;
+            generateSarifReport(defaultLoc, "", ap, ErrorKind.message, true);
+        }
     }
 
     target.setTargetBuildDefaults();

--- a/compiler/test/compilable/sarif_success_test.d
+++ b/compiler/test/compilable/sarif_success_test.d
@@ -1,0 +1,27 @@
+// REQUIRED_ARGS: -verror-style=sarif
+/*
+TEST_OUTPUT:
+---
+{
+	"version": "2.1.0",
+	"$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+	"runs": [{
+		"tool": {
+			"driver": {
+				"name": "Digital Mars D",
+				"version": "$r:\d+\.\d+\.\d+$",
+				"informationUri": "https://dlang.org/dmd.html"
+			}
+		},
+		"invocations": [{
+			"executionSuccessful": true
+		}],
+		"results": []
+	}]
+}
+---
+*/
+
+void main() {
+    int x = 5;
+}

--- a/compiler/test/fail_compilation/sarif_test.d
+++ b/compiler/test/fail_compilation/sarif_test.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -verror-style=sarif
 /*
 TEST_OUTPUT:
 ---
@@ -8,7 +9,7 @@ TEST_OUTPUT:
 		"tool": {
 			"driver": {
 				"name": "Digital Mars D",
-				"version": "2.110.0",
+				"version": "$r:\d+\.\d+\.\d+$",
 				"informationUri": "https://dlang.org/dmd.html"
 			}
 		},
@@ -37,7 +38,6 @@ TEST_OUTPUT:
 }
 ---
 */
-// REQUIRED_ARGS: -verror-style=sarif
 
 void main() {
     x = 5; // Undefined variable to trigger the error


### PR DESCRIPTION
- Add SARIF report generation for successful executions, ensuring consistent error reporting format. This change outputs a minimal SARIF structure with `executionSuccessful: true` and an empty results array, providing uniformity in SARIF output across all executions.
- Use regex for version.