### PR TITLE
fix(errors): align errorKindToString with SARIF level values

### DIFF
--- a/compiler/src/dmd/sarif.d
+++ b/compiler/src/dmd/sarif.d
@@ -178,22 +178,22 @@ string formatErrorMessage(const(char)* format, va_list ap) nothrow {
 }
 
 /**
-Converts an `ErrorKind` value to a string representation.
+Converts an `ErrorKind` value to a SARIF-compatible string representation for the severity level.
 
 Params:
   kind = The `ErrorKind` value to convert (e.g., error, warning, deprecation).
 
 Returns:
-  A string representing the `ErrorKind` value, such as "Error" or "Warning".
+  A SARIF-compatible string representing the `ErrorKind` level, such as "error" or "warning".
 */
 string errorKindToString(ErrorKind kind) nothrow
 {
     final switch (kind) {
-        case ErrorKind.error: return "Error";
-        case ErrorKind.warning: return "Warning";
-        case ErrorKind.deprecation: return "Deprecation";
-        case ErrorKind.tip: return "Tip";
-        case ErrorKind.message: return "Message";
+        case ErrorKind.error: return "error";       // Serious problem
+        case ErrorKind.warning: return "warning";   // Problem found
+        case ErrorKind.deprecation: return "note";  // Minor problem, opportunity for improvement
+        case ErrorKind.tip: return "note";          // Minor improvement suggestion
+        case ErrorKind.message: return "none";      // Not applicable for "fail" kind, so use "none"
     }
 }
 

--- a/compiler/test/fail_compilation/sarif_test.d
+++ b/compiler/test/fail_compilation/sarif_test.d
@@ -18,11 +18,11 @@ TEST_OUTPUT:
 		}],
 		"results": [
 			{
-				"ruleId": "DMD-Error",
+				"ruleId": "DMD-error",
 				"message": {
 					"text": "undefined identifier `x`"
 				},
-				"level": "Error",
+				"level": "error",
 				"locations": [{
 					"physicalLocation": {
 						"artifactLocation": {

--- a/compiler/test/fail_compilation/sarifmultiple_test.d
+++ b/compiler/test/fail_compilation/sarifmultiple_test.d
@@ -18,11 +18,11 @@ TEST_OUTPUT:
 		}],
 		"results": [
 			{
-				"ruleId": "DMD-Error",
+				"ruleId": "DMD-error",
 				"message": {
 					"text": "undefined identifier `x`"
 				},
-				"level": "Error",
+				"level": "error",
 				"locations": [{
 					"physicalLocation": {
 						"artifactLocation": {
@@ -36,11 +36,11 @@ TEST_OUTPUT:
 				}]
 			},
 			{
-				"ruleId": "DMD-Error",
+				"ruleId": "DMD-error",
 				"message": {
 					"text": "undefined identifier `y`"
 				},
-				"level": "Error",
+				"level": "error",
 				"locations": [{
 					"physicalLocation": {
 						"artifactLocation": {


### PR DESCRIPTION
This PR introduces modifications to the `errorKindToString` function, aligning it with the SARIF specification for the `level` property in `result` objects (SARIF §3.27.10). The function now returns SARIF-compatible severity levels based on the `ErrorKind` values, facilitating accurate reporting in SARIF format.

Validated the output- [SARIF Validator](https://sarifweb.azurewebsites.net/Validation)