### PR TITLE
Fix 24855 - VRP fails to prevent overflow after division

### DIFF
--- a/compiler/src/dmd/intrange.d
+++ b/compiler/src/dmd/intrange.d
@@ -667,7 +667,7 @@ struct IntRange
             return widest();
 
         // Don't treat the whole range as divide by 0 if only one end of a range is 0.
-        // Issue 15289
+        // https://issues.dlang.org/show_bug.cgi?id=15289
         if (rhs.imax.value == 0)
         {
             rhs.imax.value--;
@@ -680,6 +680,11 @@ struct IntRange
         if (!imin.negative && !imax.negative && !rhs.imin.negative && !rhs.imax.negative)
         {
             return IntRange(imin / rhs.imax, imax / rhs.imin);
+        }
+        else if (rhs.imin.negative && !rhs.imax.negative) // divisor spans [-1, 0, 1]
+        {
+            SignExtendedNumber[4] bdy = [-imin, imin, -imax, imax];
+            return IntRange.fromNumbers4(bdy.ptr);
         }
         else
         {

--- a/compiler/test/compilable/testVRP.d
+++ b/compiler/test/compilable/testVRP.d
@@ -4,6 +4,7 @@
 // https://issues.dlang.org/show_bug.cgi?id=3147
 // https://issues.dlang.org/show_bug.cgi?id=6000
 // https://issues.dlang.org/show_bug.cgi?id=5225
+// https://issues.dlang.org/show_bug.cgi?id=24855
 
 void add()
 {
@@ -100,6 +101,10 @@ void divideFail()
     short w;
     byte y;
     static assert(!__traits(compiles, y = w / -1));
+    static assert(!__traits(compiles, y = y / w));
+
+    short z;
+    static assert(!__traits(compiles, z = w / z + 1));
 }
 
 void plus1Fail()

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -1426,7 +1426,7 @@ short[PAGESIZE / 16][Bins.B_NUMSMALL + 1] calcBinBase()
 
     foreach (i, size; binsize)
     {
-        short end = (PAGESIZE / size) * size;
+        short end = cast(short) ((PAGESIZE / size) * size);
         short bsz = size / 16;
         foreach (off; 0..PAGESIZE/16)
         {


### PR DESCRIPTION
Once again (https://github.com/dlang/dmd/pull/7317), graciously copying @tgehr's homework from https://github.com/tgehr/d-compiler/blob/master/vrange.d