### PR TITLE
Bit-shift expressions: Cast scalar right-hand-sides to vectors if needed

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -13114,9 +13114,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp.incompatibleTypes();
             return;
         }
+
         exp.e1 = integralPromotions(exp.e1, sc);
         if (exp.e2.type.toBasetype().ty != Tvector)
-            exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
+        {
+            Type tb1 = exp.e1.type.toBasetype();
+            exp.e2 = exp.e2.castTo(sc, tb1.ty == Tvector ? tb1 : Type.tshiftcnt);
+        }
 
         exp.type = exp.e1.type;
         result = exp;


### PR DESCRIPTION
This promotion from scalar right-hand-sides to vectors already happens for the arithmetic binops, via `typeCombine()` side effects. Handle bit-shift expressions too now, by casting a scalar to the left-hand-side vector type.

This can't be tested with DMD, as DMD's `Target.isVectorOpSupported()` doesn't support bit-shifts yet. It is ~required/useful for LDC though.