### PR TITLE
swap error and verror in ErrorSink

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -59,60 +59,39 @@ class ErrorSinkCompiler : ErrorSink
   extern (C++):
   override:
 
-    void error(const ref Loc loc, const(char)* format, ...)
+    void verror(const ref Loc loc, const(char)* format, va_list ap)
     {
-        va_list ap;
-        va_start(ap, format);
         verrorReport(loc, format, ap, ErrorKind.error);
-        va_end(ap);
     }
 
-    void errorSupplemental(const ref Loc loc, const(char)* format, ...)
+    void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap)
     {
-        va_list ap;
-        va_start(ap, format);
         verrorReportSupplemental(loc, format, ap, ErrorKind.error);
-        va_end(ap);
     }
 
-    void warning(const ref Loc loc, const(char)* format, ...)
+    void vwarning(const ref Loc loc, const(char)* format, va_list ap)
     {
-        va_list ap;
-        va_start(ap, format);
         verrorReport(loc, format, ap, ErrorKind.warning);
-        va_end(ap);
     }
 
-    void warningSupplemental(const ref Loc loc, const(char)* format, ...)
+    void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap)
     {
-        va_list ap;
-        va_start(ap, format);
         verrorReportSupplemental(loc, format, ap, ErrorKind.warning);
-        va_end(ap);
     }
 
-    void deprecation(const ref Loc loc, const(char)* format, ...)
+    void vdeprecation(const ref Loc loc, const(char)* format, va_list ap)
     {
-        va_list ap;
-        va_start(ap, format);
         verrorReport(loc, format, ap, ErrorKind.deprecation);
-        va_end(ap);
     }
 
-    void deprecationSupplemental(const ref Loc loc, const(char)* format, ...)
+    void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap)
     {
-        va_list ap;
-        va_start(ap, format);
         verrorReportSupplemental(loc, format, ap, ErrorKind.deprecation);
-        va_end(ap);
     }
 
-    void message(const ref Loc loc, const(char)* format, ...)
+    void vmessage(const ref Loc loc, const(char)* format, va_list ap)
     {
-        va_list ap;
-        va_start(ap, format);
         verrorReport(loc, format, ap, ErrorKind.message);
-        va_end(ap);
     }
 
     void plugSink()

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -11,6 +11,8 @@
 
 module dmd.errorsink;
 
+import core.stdc.stdarg;
+
 import dmd.location;
 
 /***************************************
@@ -21,19 +23,69 @@ abstract class ErrorSink
   nothrow:
   extern (C++):
 
-    void error(const ref Loc loc, const(char)* format, ...);
+    void verror(const ref Loc loc, const(char)* format, va_list ap);
+    void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap);
+    void vwarning(const ref Loc loc, const(char)* format, va_list ap);
+    void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap);
+    void vmessage(const ref Loc loc, const(char)* format, va_list ap);
+    void vdeprecation(const ref Loc loc, const(char)* format, va_list ap);
+    void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap);
 
-    void errorSupplemental(const ref Loc loc, const(char)* format, ...);
+    void error(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        verror(loc, format, ap);
+        va_end(ap);
+    }
 
-    void warning(const ref Loc loc, const(char)* format, ...);
+    void errorSupplemental(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        verrorSupplemental(loc, format, ap);
+        va_end(ap);
+    }
 
-    void warningSupplemental(const ref Loc loc, const(char)* format, ...);
+    void warning(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vwarning(loc, format, ap);
+        va_end(ap);
+    }
 
-    void message(const ref Loc loc, const(char)* format, ...);
+    void warningSupplemental(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vwarningSupplemental(loc, format, ap);
+        va_end(ap);
+    }
 
-    void deprecation(const ref Loc loc, const(char)* format, ...);
+    void message(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vmessage(loc, format, ap);
+        va_end(ap);
+    }
 
-    void deprecationSupplemental(const ref Loc loc, const(char)* format, ...);
+    void deprecation(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vdeprecation(loc, format, ap);
+        va_end(ap);
+    }
+
+    void deprecationSupplemental(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vdeprecationSupplemental(loc, format, ap);
+        va_end(ap);
+    }
 
     /**
      * This will be called to indicate compilation has either
@@ -54,19 +106,19 @@ class ErrorSinkNull : ErrorSink
   extern (C++):
   override:
 
-    void error(const ref Loc loc, const(char)* format, ...) { }
+    void verror(const ref Loc loc, const(char)* format, va_list ap) { }
 
-    void errorSupplemental(const ref Loc loc, const(char)* format, ...) { }
+    void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
 
-    void warning(const ref Loc loc, const(char)* format, ...) { }
+    void vwarning(const ref Loc loc, const(char)* format, va_list ap) { }
 
-    void warningSupplemental(const ref Loc loc, const(char)* format, ...) { }
+    void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
 
-    void message(const ref Loc loc, const(char)* format, ...) { }
+    void vmessage(const ref Loc loc, const(char)* format, va_list ap) { }
 
-    void deprecation(const ref Loc loc, const(char)* format, ...) { }
+    void vdeprecation(const ref Loc loc, const(char)* format, va_list ap) { }
 
-    void deprecationSupplemental(const ref Loc loc, const(char)* format, ...) { }
+    void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
 }
 
 /*****************************************
@@ -80,7 +132,7 @@ class ErrorSinkLatch : ErrorSinkNull
 
     bool sawErrors;
 
-    void error(const ref Loc loc, const(char)* format, ...) { sawErrors = true; }
+    void verror(const ref Loc loc, const(char)* format, va_list ap) { sawErrors = true; }
 }
 
 /*****************************************
@@ -96,7 +148,7 @@ class ErrorSinkStderr : ErrorSink
   extern (C++):
   override:
 
-    void error(const ref Loc loc, const(char)* format, ...)
+    void verror(const ref Loc loc, const(char)* format, va_list ap)
     {
         fputs("Error: ", stderr);
         const p = loc.toChars();
@@ -106,16 +158,13 @@ class ErrorSinkStderr : ErrorSink
             //mem.xfree(cast(void*)p); // loc should provide the free()
         }
 
-        va_list ap;
-        va_start(ap, format);
         vfprintf(stderr, format, ap);
         fputc('\n', stderr);
-        va_end(ap);
     }
 
-    void errorSupplemental(const ref Loc loc, const(char)* format, ...) { }
+    void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
 
-    void warning(const ref Loc loc, const(char)* format, ...)
+    void vwarning(const ref Loc loc, const(char)* format, va_list ap)
     {
         fputs("Warning: ", stderr);
         const p = loc.toChars();
@@ -125,16 +174,13 @@ class ErrorSinkStderr : ErrorSink
             //mem.xfree(cast(void*)p); // loc should provide the free()
         }
 
-        va_list ap;
-        va_start(ap, format);
         vfprintf(stderr, format, ap);
         fputc('\n', stderr);
-        va_end(ap);
     }
 
-    void warningSupplemental(const ref Loc loc, const(char)* format, ...) { }
+    void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
 
-    void deprecation(const ref Loc loc, const(char)* format, ...)
+    void vdeprecation(const ref Loc loc, const(char)* format, va_list ap)
     {
         fputs("Deprecation: ", stderr);
         const p = loc.toChars();
@@ -144,14 +190,11 @@ class ErrorSinkStderr : ErrorSink
             //mem.xfree(cast(void*)p); // loc should provide the free()
         }
 
-        va_list ap;
-        va_start(ap, format);
         vfprintf(stderr, format, ap);
         fputc('\n', stderr);
-        va_end(ap);
     }
 
-    void message(const ref Loc loc, const(char)* format, ...)
+    void vmessage(const ref Loc loc, const(char)* format, va_list ap)
     {
         const p = loc.toChars();
         if (*p)
@@ -160,12 +203,9 @@ class ErrorSinkStderr : ErrorSink
             //mem.xfree(cast(void*)p); // loc should provide the free()
         }
 
-        va_list ap;
-        va_start(ap, format);
         vfprintf(stderr, format, ap);
         fputc('\n', stderr);
-        va_end(ap);
     }
 
-    void deprecationSupplemental(const ref Loc loc, const(char)* format, ...) { }
+    void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
 }

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -3673,14 +3673,11 @@ unittest
         string expected;
         bool gotError;
 
-        void error(const ref Loc loc, const(char)* format, ...)
+        void verror(const ref Loc loc, const(char)* format, va_list ap)
         {
             gotError = true;
             char[100] buffer = void;
-            va_list ap;
-            va_start(ap, format);
             auto actual = buffer[0 .. vsnprintf(buffer.ptr, buffer.length, format, ap)];
-            va_end(ap);
             assert(expected == actual);
         }
     }

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1569,7 +1569,7 @@ ld: Undefined symbols:
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
 `;
 
-    class ErrorSinkTest : ErrorSink
+    class ErrorSinkTest : ErrorSinkNull
     {
         public int errorCount = 0;
         string expectedFormat = "undefined reference to `%.*s`";
@@ -1577,27 +1577,19 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)
 
         extern(C++): override:
 
-        void error(const ref Loc loc, const(char)* format, ...)
+        void verror(const ref Loc loc, const(char)* format, va_list ap)
         {
             assert(format[0 .. strlen(format)] == expectedFormat);
-            va_list ap;
-            va_start(ap, format);
             const expectedSymbol = expectedSymbols[errorCount++];
             assert(va_arg!int(ap) == expectedSymbol.length);
             const actualSymbol = va_arg!(char*)(ap)[0 .. expectedSymbol.length];
             assert(actualSymbol == expectedSymbol, "expected " ~ expectedSymbol ~ ", not " ~ actualSymbol);
         }
 
-        void errorSupplemental(const ref Loc loc, const(char)* format, ...)
+        void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap)
         {
             assert(format.startsWith("perhaps") || format.startsWith("referenced from "));
         }
-
-        void warning(const ref Loc loc, const(char)* format, ...) {}
-        void warningSupplemental(const ref Loc loc, const(char)* format, ...) {}
-        void message(const ref Loc loc, const(char)* format, ...) {}
-        void deprecation(const ref Loc loc, const(char)* format, ...) {}
-        void deprecationSupplemental(const ref Loc loc, const(char)* format, ...) {}
     }
 
     void test(T...)(string linkerName, string output, T expectedSymbols)


### PR DESCRIPTION
There are a number of places in dmd where error argument lists are forwarded around. This is pretty awkward with ErrorSink's `...` variadic argument lists. This PR swaps the roles of the `...` parameters with the `va_arg ap` parameter. `va_arg` is the right way to forward variadic argument lists.