### PR TITLE
[stable] compilable/stdcheaders.c: Work around unsupported NAN in new WinSDK headers

### DIFF
--- a/compiler/test/compilable/stdcheaders.c
+++ b/compiler/test/compilable/stdcheaders.c
@@ -21,7 +21,9 @@
 
 #ifndef __APPLE__ // /Applications/Xcode-14.2.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/tgmath.h(39): Error: named parameter required before `...`
 #include <math.h>
+#ifndef _MSC_VER // C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\ucrt\corecrt_math.h(93): Error: reinterpretation through overlapped field `f` is not allowed in CTFE
 float x = NAN;
+#endif
 #endif
 
 #ifndef _MSC_VER // setjmp.h(51): Error: missing tag `identifier` after `struct


### PR DESCRIPTION
GitHub Actions upgraded the WinSDK in the latest image, and its `NAN` is apparently not supported by ImportC anymore, breaking CI.