### PR TITLE
Moved _d_newThrowable in the semantic phase to lowering

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -1150,8 +1150,8 @@ elem* toElem(Expression e, ref IRState irs)
             }
             else
             {
-                assert(!(irs.params.ehnogc && ne.thrownew),
-                    "This should have been rewritten to `_d_newThrowable` in the semantic phase.");
+                // assert(!(irs.params.ehnogc && ne.thrownew),
+                //     "This should have been rewritten to `_d_newThrowable` in the semantic phase.");
 
                 ex = toElem(ne.lowering, irs);
                 ectype = null;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5197,21 +5197,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 auto tiargs = new Objects();
                 tiargs.push(exp.newtype);
+
                 id = new DotTemplateInstanceExp(exp.loc, id, Id._d_newThrowable, tiargs);
+
                 id = new CallExp(exp.loc, id).expressionSemantic(sc);
 
-                Expression idVal;
-                Expression tmp = extractSideEffect(sc, "__tmpThrowable", idVal, id, true);
-                // auto castTmp = new CastExp(exp.loc, tmp, exp.type);
+                exp.lowering = id.expressionSemantic(sc);
 
-                auto ctor = new DotIdExp(exp.loc, tmp, Id.ctor).expressionSemantic(sc);
-                auto ctorCall = new CallExp(exp.loc, ctor, exp.arguments);
-
-                id = Expression.combine(idVal, exp.argprefix).expressionSemantic(sc);
-                id = Expression.combine(id, ctorCall).expressionSemantic(sc);
-                // id = Expression.combine(id, castTmp).expressionSemantic(sc);
-
-                result = id.expressionSemantic(sc);
+                result = exp;
                 return;
             }
             else if (sc.needsCodegen() && // interpreter doesn't need this lowered


### PR DESCRIPTION
Pr #14837 added templated lowering for _d_newclass and lowering field to NewExp. Pr #13494 added templated lowering for _d_newThroable. This Pr merges those two.

In expressionsem.d, instead of giving up the expression node and keeping just the id.expressionSemantic of it, the result is the whole node with all its previous fields and a new one, lowering, that is set to the previously returned value.

In e2ir.d, for a newExpression, the expression is already created in the semantic phase with all the arguments needed, so the visitor will not recreate it, therefore the assert at line 1153 is no longer necessary.