### PR TITLE
split AttributeViolation into two distinct uses

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2073,6 +2073,14 @@ public void errorSupplementalInferredAttr(FuncDeclaration fd, int maxDepth, bool
                 s.arg0 ? s.arg0.toChars() : "", s.arg1 ? s.arg1.toChars() : "", s.arg2 ? s.arg2.toChars() : "");
         }
     }
+    else if (s.fd)
+    {
+        if (maxDepth > 0)
+        {
+            errorFunc(s.loc, "which calls `%s`", s.fd.toPrettyChars());
+            errorSupplementalInferredAttr(s.fd, maxDepth - 1, deprecation, stc, eSink);
+        }
+    }
     else if (auto sa = s.arg0.isDsymbol())
     {
         if (FuncDeclaration fd2 = sa.isFuncDeclaration())
@@ -2284,7 +2292,7 @@ private bool checkSafety(FuncDeclaration f, ref Loc loc, Scope* sc)
         else if (!sc.func.safetyViolation)
         {
             import dmd.func : AttributeViolation;
-            sc.func.safetyViolation = new AttributeViolation(loc, null, f, null, null);
+            sc.func.safetyViolation = new AttributeViolation(loc, f);
         }
     }
     return false;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -3001,7 +3001,15 @@ extern (D) bool setImpure(FuncDeclaration fd, Loc loc = Loc.init, const(char)* f
         if (fmt)
             fd.pureViolation = new AttributeViolation(loc, fmt, fd, arg0); // impure action
         else if (arg0)
-            fd.pureViolation = new AttributeViolation(loc, fmt, arg0); // call to impure function
+        {
+            if (auto sa = arg0.isDsymbol())
+            {
+                if (FuncDeclaration fd2 = sa.isFuncDeclaration())
+                {
+                    fd.pureViolation = new AttributeViolation(loc, fd2); // call to impure function
+                }
+            }
+        }
 
         if (fd.fes)
             fd.fes.func.setImpure(loc, fmt, arg0);

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -302,7 +302,15 @@ extern (D) bool setGC(FuncDeclaration fd, Loc loc, const(char)* fmt, RootObject 
         if (fmt)
             fd.nogcViolation = new AttributeViolation(loc, fmt, fd, arg0); // action that requires GC
         else if (arg0)
-            fd.nogcViolation = new AttributeViolation(loc, fmt, arg0); // call to non-@nogc function
+        {
+            if (auto sa = arg0.isDsymbol())
+            {
+                if (FuncDeclaration fd2 = sa.isFuncDeclaration())
+                {
+                    fd.nogcViolation = new AttributeViolation(loc, fd2); // call to non-@nogc function
+                }
+            }
+        }
 
         fd.type.toTypeFunction().isNogc = false;
         if (fd.fes)


### PR DESCRIPTION
Ongoing effort to split the undocumented and complex use of null formats and null arg0.

Also changed `fmt` and `fmtStr` into `format` for consistency.

Split fields of AttributeViolation into two distinct groups, using a constructor for each.