### PR TITLE
use OutBuffer for getMatchError()

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2602,16 +2602,20 @@ extern (C++) final class TypeFunction : TypeNext
         return linkage == LINK.d && parameterList.varargs == VarArg.variadic;
     }
 
-    extern(C) static const(char)* getMatchError(const(char)* format, ...)
+    /*********************************
+     * Append error message to buf.
+     * Input:
+     *  buf = message sink
+     *  format = printf format
+     */
+    extern(C) static void getMatchError(ref OutBuffer buf, const(char)* format, ...)
     {
         if (global.gag && !global.params.v.showGaggedErrors)
-            return null;
-        OutBuffer buf;
+            return;
         va_list ap;
         va_start(ap, format);
         buf.vprintf(format, ap);
         va_end(ap);
-        return buf.extractChars();
     }
 
     /********************************
@@ -2648,7 +2652,7 @@ extern (C++) final class TypeFunction : TypeNext
                 if (pi == -1)
                 {
                     if (buf)
-                        buf.writestring(getMatchError("no parameter named `%s`", name.toChars()));
+                        getMatchError(*buf, "no parameter named `%s`", name.toChars());
                     return null;
                 }
                 ci = pi;
@@ -2659,7 +2663,7 @@ extern (C++) final class TypeFunction : TypeNext
                 {
                     // Without named args, let the caller diagnose argument overflow
                     if (hasNamedArgs && buf)
-                        buf.writestring(getMatchError("argument `%s` goes past end of parameter list", arg.toChars()));
+                        getMatchError(*buf, "argument `%s` goes past end of parameter list", arg.toChars());
                     return null;
                 }
                 while (ci >= newArgs.length)
@@ -2669,7 +2673,7 @@ extern (C++) final class TypeFunction : TypeNext
             if ((*newArgs)[ci])
             {
                 if (buf)
-                    buf.writestring(getMatchError("parameter `%s` assigned twice", parameterList[ci].toChars()));
+                    getMatchError(*buf, "parameter `%s` assigned twice", parameterList[ci].toChars());
                 return null;
             }
             (*newArgs)[ci++] = arg;
@@ -2688,8 +2692,8 @@ extern (C++) final class TypeFunction : TypeNext
                 continue;
 
             if (buf)
-                buf.writestring(getMatchError("missing argument for parameter #%d: `%s`",
-                    i + 1, parameterToChars(parameterList[i], this, false)));
+                getMatchError(*buf, "missing argument for parameter #%d: `%s`",
+                    i + 1, parameterToChars(parameterList[i], this, false));
             return null;
         }
         // strip trailing nulls from default arguments

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -855,8 +855,8 @@ extern (D) MATCH callMatch(TypeFunction tf, Type tthis, ArgumentList argumentLis
             if (errorHelper)
             {
                 if (u >= args.length)
-                    buf.writestring(tf.getMatchError("missing argument for parameter #%d: `%s`",
-                        u + 1, parameterToChars(p, tf, false)));
+                    TypeFunction.getMatchError(buf, "missing argument for parameter #%d: `%s`",
+                        u + 1, parameterToChars(p, tf, false));
                 // If an error happened previously, `pMessage` was already filled
                 else if (buf.length == 0)
                     buf.writestring(tf.getParamError(args[u], p));
@@ -872,7 +872,9 @@ extern (D) MATCH callMatch(TypeFunction tf, Type tthis, ArgumentList argumentLis
     if (errorHelper && !parameterList.varargs && args.length > nparams)
     {
         // all parameters had a match, but there are surplus args
-        errorHelper(tf.getMatchError("expected %d argument(s), not %d", nparams, args.length));
+        OutBuffer buf2;
+        TypeFunction.getMatchError(buf2, "expected %d argument(s), not %d", nparams, args.length);
+        errorHelper(buf2.extractChars());
         return MATCH.nomatch;
     }
     //printf("match = %d\n", match);
@@ -1182,8 +1184,12 @@ private extern(D) MATCH matchTypeSafeVarArgs(TypeFunction tf, Parameter p,
         if (sz != trailingArgs.length)
         {
             if (pMessage)
-                *pMessage = tf.getMatchError("expected %llu variadic argument(s), not %zu",
+            {
+                OutBuffer buf;
+                TypeFunction.getMatchError(buf, "expected %llu variadic argument(s), not %zu",
                     sz, trailingArgs.length);
+                *pMessage = buf.extractChars();
+            }
             return MATCH.nomatch;
         }
         goto case Tarray;


### PR DESCRIPTION
The idea is to do memory management at a higher level rather than at the bottom of the call stack. This removes one layer. More to come!