### PR TITLE
Fix bugzilla 24845 - Compiler error when trying to assign to an AA va…

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -4143,10 +4143,9 @@ extern (C++) final class IndexExp : BinExp
 
     override bool isLvalue()
     {
-        if (e1.op == EXP.assocArrayLiteral)
-            return false;
-        if (e1.type.ty == Tsarray ||
-            (e1.op == EXP.index && e1.type.ty != Tarray))
+        auto t1b = e1.type.toBasetype();
+        if (t1b.isTypeAArray() || t1b.isTypeSArray() ||
+            (e1.isIndexExp() && t1b != t1b.isTypeDArray()))
         {
             return e1.isLvalue();
         }

--- a/compiler/test/compilable/compile1.d
+++ b/compiler/test/compilable/compile1.d
@@ -861,7 +861,7 @@ S14166 s14166;
 
 struct X14166 { this(int) { } X14166 opAssign(int) { return this; } }
 X14166[int] aa14166;
-X14166[int] makeAA14166() { return aa14166; }
+ref X14166[int] makeAA14166() { return aa14166; }
 
 struct Tup14166(T...) { T field; alias field this; }
 Tup14166!(int, int) tup14166;

--- a/compiler/test/fail_compilation/fail6795.d
+++ b/compiler/test/fail_compilation/fail6795.d
@@ -8,9 +8,9 @@ fail_compilation/fail6795.d(22): Error: cannot modify expression `[0][0]` becaus
 fail_compilation/fail6795.d(23): Error: cannot modify expression `[0:0][0]` because it is not an lvalue
 fail_compilation/fail6795.d(25): Error: cannot take address of expression `[0][0]` because it is not an lvalue
 fail_compilation/fail6795.d(26): Error: cannot take address of expression `[0:0][0]` because it is not an lvalue
+fail_compilation/fail6795.d(30): Error: cannot modify expression `Some["zz"]` because it is not an lvalue
 ---
 */
-
 void test_wrong_line_num()
 {
     enum int[1] sa = [0];
@@ -24,4 +24,8 @@ void test_wrong_line_num()
 
     auto ps = &sa[0];
     auto pa = &aa[0];
+
+    // https://issues.dlang.org/show_bug.cgi?id=24845
+    enum Maps : int[string] { Some = ["aa" : 12], Other = ["bb" : 24] }
+    Maps.Some["zz"] = 44;
 }


### PR DESCRIPTION
…lue of an enum instance

There used to be a special case that indexing an associative array literal results in an rvalue, but any other result of indexing an AA rvalue is still an lvalue. This PR gives AA's the same rules as static arrays: the indexed value is an lvalue iff the array is an lvalue. This is different from dynamic arrays, where `&[x][0]` is allowed.

Targeting master because this could break code that relied on `makeAA()["key"] = 0` compiling.
