### PR TITLE
Fix bugzilla 24883 - Speculative template overload error escapes with…

### DIFF
--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1252,7 +1252,13 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
                 //printf("farg = %s %s\n", farg.type.toChars(), farg.toChars());
 
                 RootObject oarg = farg;
-                if ((fparam.storageClass & STC.ref_) && (!(fparam.storageClass & STC.auto_) || farg.isLvalue()))
+
+                if (farg.isFuncExp())
+                {
+                    // When assigning an untyped (void) lambda `x => y` to a `(F)(ref F)` parameter,
+                    // we don't want to deduce type void creating a void parameter
+                }
+                else if ((fparam.storageClass & STC.ref_) && (!(fparam.storageClass & STC.auto_) || farg.isLvalue()))
                 {
                     /* Allow expressions that have CT-known boundaries and type [] to match with [dim]
                      */

--- a/compiler/test/compilable/rvalueref.d
+++ b/compiler/test/compilable/rvalueref.d
@@ -11,3 +11,9 @@ struct AS
 
 void popFront(ref string) { }
 static assert(!is(typeof((R r) => r.popFront)));
+
+// https://issues.dlang.org/show_bug.cgi?id=24883
+int toString(Writer)(ref Writer sink) => 3;
+int toString(void delegate(scope const(char)[]) sink) => 4;
+void put() {}
+static assert(toString(dst => put()) == 4);


### PR DESCRIPTION
… `-preview=rvaluerefparam`

See https://github.com/dlang/dmd/pull/17068#issuecomment-2500268843