### PR TITLE
Fix bugzilla 24884 - backend generates wrong 32-bit code after inlini…

### DIFF
--- a/compiler/src/dmd/backend/x86/cod2.d
+++ b/compiler/src/dmd/backend/x86/cod2.d
@@ -4149,6 +4149,7 @@ void cdmemset(ref CGstate cg, ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     if (valueIsConst)
     {
         regwithvalue(cdb, mAX, value, I64?64:0);
+        getregs(cdb, mAX);
         freenode(evalue);
     }
     else

--- a/compiler/test/runnable/test24884.d
+++ b/compiler/test/runnable/test24884.d
@@ -1,0 +1,34 @@
+/*
+REQUIRED_ARGS: -inline
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=24884
+
+pragma(inline, false)
+bool norm(int a) => 0;
+
+pragma(inline, false)
+void inlinebug(ref double[4] point1, ref double[4] point2, ref double[4] point3, ref double[4] abcd)
+{
+    double[4] v1 = 0.0;
+    double[4] v2 = 0.0;
+
+    v1[0] = point1[0] - point2[0];
+    v1[1] = point1[1] - point2[1];
+    v1[2] = point1[2] - point2[2];
+    v1[3] = point1[3];
+    v2[0] = point2[0] - point3[0];
+    v2[1] = point2[1] - point3[1];
+    v2[2] = point2[2] - point3[2];
+
+    int p = cast(int) &abcd;
+    int q = cast(int) &point1;
+    abcd[0] = norm(7) + p;
+    abcd[1] = q + p;
+}
+
+extern(C) void main()
+{
+    double[4] a = 0.0;
+    inlinebug(a, a, a, a);
+}


### PR DESCRIPTION
…ng math with double[4]

The disassembly shows:
```
...
001d:   mov       EAX,05Ch[ESP]      <== EAX gets loaded for `v2[0] = point2[0] - point3[0];`
0021:   xor       EAX,EAX            <== EAX gets clobbered for `double[4] v2 = 0.0;`
0023:   lea       EDI,038h[ESP]
0027:   mov       ECX,8
002c:   rep
002d:   stosd
002e:   mov       EDI,064h[ESP]
0032:   fnld      qword ptr [EDI]
0034:   fnsub     qword ptr [EDX]
...
005d:   fnld      qword ptr 8[EDX]
0060:   fnsub     qword ptr 8[EAX]    <== clobbered EAX gets read, 0 pointer dereference
0063:   fnstp     qword ptr 040h[ESP]
...
```

The problem is that the memset operation for `double[4] v2 = 0.0;` uses EAX to store the initial value 0, but it doesn't mark it as used, so the load for the `double[4] point3` parameter gets overridden, resulting in a null-pointer access.