### PR TITLE
Remove C++ bitflags / _padding fields from SCOPE

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -64,21 +64,11 @@ private extern (D) struct BitFields
     Contract contract;
     bool ctfe;              /// inside a ctfe-only expression
     bool traitsCompiles;    /// inside __traits(compile)
-
     /// ignore symbol visibility
     /// https://issues.dlang.org/show_bug.cgi?id=15907
     bool ignoresymbolvisibility;
-
-    bool _padding0; // To keep the layout the same as when the old `SCOPE` enum bitflags were used
-
     bool inCfile;            /// C semantics apply
-
-    bool _padding1;
-    bool _padding2;
-    bool _padding3;
-
     bool canFree;            /// is on free list
-
     bool fullinst;          /// fully instantiate templates
     bool ctfeBlock;         /// inside a `if (__ctfe)` block
     bool dip1000;           /// dip1000 errors enabled for this scope

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7109,16 +7109,8 @@ struct Scope final
     bool traitsCompiles(bool v);
     bool ignoresymbolvisibility() const;
     bool ignoresymbolvisibility(bool v);
-    bool _padding0() const;
-    bool _padding0(bool v);
     bool inCfile() const;
     bool inCfile(bool v);
-    bool _padding1() const;
-    bool _padding1(bool v);
-    bool _padding2() const;
-    bool _padding2(bool v);
-    bool _padding3() const;
-    bool _padding3(bool v);
     bool canFree() const;
     bool canFree(bool v);
     bool fullinst() const;

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -40,33 +40,15 @@ enum class CSX : uint16_t
     halt       = 0x20,   // assert(0)
 };
 
-enum class SCOPE
+enum class Contract : uint8_t
 {
-    // Flags that would not be inherited beyond scope nesting
-    ctor          = 0x0001,  // constructor type
-    noaccesscheck = 0x0002,  // don't do access checks
-    condition     = 0x0004,  // inside static if/assert condition
-    debug_        = 0x0008,  // inside debug conditional
-
-    // Flags that would be inherited beyond scope nesting
-    constraint    = 0x0010,  // inside template constraint
-    invariant_    = 0x0020,  // inside invariant code
-    require       = 0x0040,  // inside in contract code
-    ensure        = 0x0060,  // inside out contract code
-    contract      = 0x0060,  // [mask] we're inside contract code
-    ctfe          = 0x0080,  // inside a ctfe-only expression
-    compile       = 0x0100,  // inside __traits(compile)
-    ignoresymbolvisibility = 0x0200,  // ignore symbol visibility (Bugzilla 15907)
-
-    Cfile         = 0x0800,  // C semantics apply
-    free          = 0x8000,  // is on free list
-    fullinst      = 0x10000, // fully instantiate templates
-    ctfeBlock     = 0x20000, // inside a `if (__ctfe)` block
-    dip1000       = 0x40000, // dip1000 errors enabled for this scope
-    dip25         = 0x80000, // dip25 errors enabled for this scope
+    none = 0u,
+    invariant_ = 1u,
+    require = 2u,
+    ensure = 3u,
 };
 
-struct Scope
+struct Scope final
 {
     Scope *enclosing;           // enclosing Scope
 
@@ -121,6 +103,37 @@ struct Scope
     DeprecatedDeclaration *depdecl; // customized deprecation message
 
     unsigned flags;
+
+    bool ctor() const;
+    bool ctor(bool v);
+    bool noAccessCheck() const;
+    bool noAccessCheck(bool v);
+    bool condition() const;
+    bool condition(bool v);
+    bool debug_() const;
+    bool debug_(bool v);
+    bool inTemplateConstraint() const;
+    bool inTemplateConstraint(bool v);
+    Contract contract() const;
+    Contract contract(Contract v);
+    bool ctfe() const;
+    bool ctfe(bool v);
+    bool traitsCompiles() const;
+    bool traitsCompiles(bool v);
+    bool ignoresymbolvisibility() const;
+    bool ignoresymbolvisibility(bool v);
+    bool inCfile() const;
+    bool inCfile(bool v);
+    bool canFree() const;
+    bool canFree(bool v);
+    bool fullinst() const;
+    bool fullinst(bool v);
+    bool ctfeBlock() const;
+    bool ctfeBlock(bool v);
+    bool dip1000() const;
+    bool dip1000(bool v);
+    bool dip25() const;
+    bool dip25(bool v);
 
     UserAttributeDeclaration *userAttribDecl;   // user defined attributes
 


### PR DESCRIPTION
The separate bitflag enum is fragile, add methods for the C++ interface instead