### PR TITLE
Cache TypeidExp::semantic

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7130,6 +7130,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             printf("TypeidExp::semantic() %s\n", exp.toChars());
         }
+        if (exp.type)
+        {
+            result = exp;
+            return;
+        }
         Type ta = isType(exp.obj);
         Expression ea = isExpression(exp.obj);
         Dsymbol sa = isDsymbol(exp.obj);

--- a/compiler/test/compilable/test19227.d
+++ b/compiler/test/compilable/test19227.d
@@ -1,9 +1,7 @@
 // https://issues.dlang.org/show_bug.cgi?id=19227
 /* TEST_OUTPUT:
 ---
-compilable/test19227.d(18): Deprecation: use of complex type `cfloat` is deprecated, use `std.complex.Complex!(float)` instead
-Deprecation: use of complex type `const(cfloat)` is deprecated, use `std.complex.Complex!(float)` instead
-Deprecation: use of complex type `const(cfloat)` is deprecated, use `std.complex.Complex!(float)` instead
+compilable/test19227.d(16): Deprecation: use of complex type `cfloat` is deprecated, use `std.complex.Complex!(float)` instead
 Deprecation: use of complex type `const(cfloat)` is deprecated, use `std.complex.Complex!(float)` instead
 ---
 */


### PR DESCRIPTION
Semantic is supposed to be idempotent, so most semantic routines return early when it has already been run. Some expressions don't, and this particular one results in duplicate error messages.