### PR TITLE
[stable] Cherry-pick #17102 to fix regression

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5582,7 +5582,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 symtab = sds.symtab;
             }
             assert(symtab);
-            Identifier id = Identifier.generateIdWithLoc(s, exp.loc);
+            Identifier id = Identifier.generateIdWithLoc(s, exp.loc, cast(string) toDString(sc.parent.toPrettyChars()));
             exp.fd.ident = id;
             if (exp.td)
                 exp.td.ident = id;

--- a/compiler/test/runnable/imports/test23722_2b.d
+++ b/compiler/test/runnable/imports/test23722_2b.d
@@ -1,0 +1,13 @@
+module imports.test23722_2b;
+
+struct T(alias fun) { }
+
+struct  S(int i) {
+    auto t = T!(x => i)();
+}
+
+string g() {
+    S!0 s0;
+    S!1 s1;
+    return s1.t.init.mangleof;
+}

--- a/compiler/test/runnable/test23722_2.d
+++ b/compiler/test/runnable/test23722_2.d
@@ -1,0 +1,10 @@
+// COMPILE_SEPARATELY:
+// EXTRA_SOURCES: imports/test23722_2b.d
+// https://issues.dlang.org/show_bug.cgi?id=23722
+// Lambdas are mangled incorrectly when using multiple compilation units, resulting in incorrect code
+import imports.test23722_2b;
+
+void main() {
+    S!1 s1;
+    assert(s1.t.init.mangleof == g);
+}


### PR DESCRIPTION
#15343 caused regressions in stable (breaking Phobos CI), which seem to have been fixed in #17102, which unfortunately targeted master. So cherry-picking the fix to `stable`.