### PR TITLE
Extract dsymbol.addComment to dsymbolsem and turn it into a visitor

### DIFF
--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -104,16 +104,6 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         return sc2;
     }
 
-
-    override void addComment(const(char)* comment)
-    {
-        //printf("AttribDeclaration::addComment %s\n", comment);
-        if (comment)
-        {
-            this.include(null).foreachDsymbol( s => s.addComment(comment) );
-        }
-    }
-
     override const(char)* kind() const
     {
         return "attribute";
@@ -653,20 +643,6 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
         }
     }
 
-    override final void addComment(const(char)* comment)
-    {
-        /* Because addComment is called by the parser, if we called
-         * include() it would define a version before it was used.
-         * But it's no problem to drill down to both decl and elsedecl,
-         * so that's the workaround.
-         */
-        if (comment)
-        {
-            decl    .foreachDsymbol( s => s.addComment(comment) );
-            elsedecl.foreachDsymbol( s => s.addComment(comment) );
-        }
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -760,12 +736,6 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
         }
         ps = null; // a `static foreach` declaration may in general expand to multiple symbols
         return false;
-    }
-
-    override void addComment(const(char)* comment)
-    {
-        // do nothing
-        // change this to give semantics to documentation comments on static foreach declarations
     }
 
     override const(char)* kind() const

--- a/compiler/src/dmd/attrib.h
+++ b/compiler/src/dmd/attrib.h
@@ -28,7 +28,6 @@ class AttribDeclaration : public Dsymbol
 {
 public:
     Dsymbols *decl;     // array of Dsymbol's
-    void addComment(const utf8_t *comment) override;
     const char *kind() const override;
     bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     bool hasPointers() override final;
@@ -148,7 +147,6 @@ public:
 
     ConditionalDeclaration *syntaxCopy(Dsymbol *s) override;
     bool oneMember(Dsymbol *&ps, Identifier *ident) override final;
-    void addComment(const utf8_t *comment) override final;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -176,7 +174,6 @@ public:
 
     StaticForeachDeclaration *syntaxCopy(Dsymbol *s) override;
     bool oneMember(Dsymbol *&ps, Identifier *ident) override;
-    void addComment(const utf8_t *comment) override;
     const char *kind() const override;
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -925,22 +925,8 @@ extern (C++) class Dsymbol : ASTNode
      */
     void addComment(const(char)* comment)
     {
-        if (!comment || !*comment)
-            return;
-
-        //printf("addComment '%s' to Dsymbol %p '%s'\n", comment, this, toChars());
-        void* h = cast(void*)this;      // just the pointer is the key
-        auto p = h in commentHashTable;
-        if (!p)
-        {
-            commentHashTable[h] = comment;
-            return;
-        }
-        if (strcmp(*p, comment) != 0)
-        {
-            // Concatenate the two
-            *p = Lexer.combineComments((*p).toDString(), comment.toDString(), true);
-        }
+        import dmd.dsymbolsem;
+        dmd.dsymbolsem.addComment(this, comment);
     }
 
     /// get documentation comment for this Dsymbol
@@ -958,7 +944,7 @@ extern (C++) class Dsymbol : ASTNode
     /* Shell around addComment() to avoid disruption for the moment */
     final void comment(const(char)* comment) { addComment(comment); }
 
-    private extern (D) __gshared const(char)*[void*] commentHashTable;
+    extern (D) __gshared const(char)*[void*] commentHashTable;
 
 
     /**********************************

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -433,4 +433,5 @@ namespace dmd
     Dsymbols *include(Dsymbol *d, Scope *sc);
     void setScope(Dsymbol *d, Scope *sc);
     void importAll(Dsymbol *d, Scope *sc);
+    void addComment(Dsymbol *d, const char *comment);
 }

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -53,6 +53,7 @@ import dmd.init;
 import dmd.initsem;
 import dmd.intrange;
 import dmd.hdrgen;
+import dmd.lexer;
 import dmd.location;
 import dmd.mtype;
 import dmd.mustuse;
@@ -64,6 +65,7 @@ import dmd.parse;
 debug import dmd.printast;
 import dmd.root.array;
 import dmd.root.filename;
+import dmd.root.string;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
 import dmd.rootobject;
@@ -7844,4 +7846,58 @@ Lfail:
         ad.errors = true;
     }
     return false;
+}
+
+extern (C++) void addComment(Dsymbol d, const(char)* comment)
+{
+    scope v = new AddCommentVisitor(comment);
+    d.accept(v);
+}
+
+extern (C++) class AddCommentVisitor: Visitor
+{
+    alias visit = Visitor.visit;
+
+    const(char)* comment;
+
+    this(const(char)* comment)
+    {
+        this.comment = comment;
+    }
+
+    override void visit(Dsymbol d)
+    {
+        if (!comment || !*comment)
+            return;
+
+        //printf("addComment '%s' to Dsymbol %p '%s'\n", comment, this, toChars());
+        void* h = cast(void*)d;      // just the pointer is the key
+        auto p = h in d.commentHashTable;
+        if (!p)
+        {
+            d.commentHashTable[h] = comment;
+            return;
+        }
+        if (strcmp(*p, comment) != 0)
+        {
+            // Concatenate the two
+            *p = Lexer.combineComments((*p).toDString(), comment.toDString(), true);
+        }
+    }
+    override void visit(AttribDeclaration atd)
+    {
+        if (comment)
+        {
+            atd.include(null).foreachDsymbol( s => s.addComment(comment) );
+        }
+    }
+    override void visit(ConditionalDeclaration cd)
+    {
+        if (comment)
+        {
+            cd.decl    .foreachDsymbol( s => s.addComment(comment) );
+            cd.elsedecl.foreachDsymbol( s => s.addComment(comment) );
+        }
+    }
+    override void visit(StaticForeachDeclaration sfd) {}
 }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6204,7 +6204,6 @@ class AttribDeclaration : public Dsymbol
 {
 public:
     Array<Dsymbol* >* decl;
-    void addComment(const char* comment) override;
     const char* kind() const override;
     bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     bool hasPointers() final override;
@@ -6314,7 +6313,6 @@ public:
     Array<Dsymbol* >* elsedecl;
     ConditionalDeclaration* syntaxCopy(Dsymbol* s) override;
     bool oneMember(Dsymbol*& ps, Identifier* ident) final override;
-    void addComment(const char* comment) final override;
     void accept(Visitor* v) override;
 };
 
@@ -6340,7 +6338,6 @@ public:
     Array<Dsymbol* >* cache;
     StaticForeachDeclaration* syntaxCopy(Dsymbol* s) override;
     bool oneMember(Dsymbol*& ps, Identifier* ident) override;
-    void addComment(const char* comment) override;
     const char* kind() const override;
     void accept(Visitor* v) override;
 };
@@ -7393,6 +7390,20 @@ public:
     void visit(AttribDeclaration* ad) override;
     void visit(ConditionalDeclaration* cdc) override;
     void visit(StaticIfDeclaration* sif) override;
+    void visit(StaticForeachDeclaration* sfd) override;
+};
+
+extern void addComment(Dsymbol* d, const char* comment);
+
+class AddCommentVisitor : public Visitor
+{
+public:
+    using Visitor::visit;
+    const char* comment;
+    AddCommentVisitor(const char* comment);
+    void visit(Dsymbol* d) override;
+    void visit(AttribDeclaration* atd) override;
+    void visit(ConditionalDeclaration* cd) override;
     void visit(StaticForeachDeclaration* sfd) override;
 };
 


### PR DESCRIPTION
Implemented a visitor in dsymbolsem.d to successfully relocate addComment functions from attrib.d.