### PR TITLE
Don't allow short constructor with non-void expression except `this()` and `super()`

### DIFF
--- a/changelog/dmd.shortened-method-constructor.dd
+++ b/changelog/dmd.shortened-method-constructor.dd
@@ -7,9 +7,12 @@ struct Number
 {
     int x;
 
-    this(int x) => this.x = x;
+    void vf(int);
+    this(int x) => vf(x);
     this(float x) => this(cast(int) x);
 }
 ---
+
+The expression body must be a `this`/`super` call or have type `void`.
 
 Postblits and destructors already supported shortened method syntax because they return `void`.

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2432,6 +2432,24 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         sc.stc &= ~STC.static_; // not a static constructor
 
         funcDeclarationSemantic(sc, ctd);
+        // Check short constructor: this() => expr;
+        if (ctd.fbody)
+        {
+            if (auto s = ctd.fbody.isExpStatement())
+            {
+                if (s.exp)
+                {
+                    auto ce = s.exp.isCallExp();
+                    // check this/super before semantic
+                    if (!ce || (!ce.e1.isThisExp() && !ce.e1.isSuperExp()))
+                    {
+                        s.exp = s.exp.expressionSemantic(sc);
+                        if (s.exp.type.ty != Tvoid)
+                            error(s.loc, "can only return void expression, `this` call or `super` call from constructor");
+                    }
+                }
+            }
+        }
 
         sc.pop();
 

--- a/compiler/test/compilable/shortened_methods.d
+++ b/compiler/test/compilable/shortened_methods.d
@@ -15,7 +15,7 @@ class A {
     bool isNull() => this is null;
 
     this() {}
-    this(int x) => _x = x;
+    this(int x) { _x = x; }
     this(float y) => this(cast(int) y);
 }
 

--- a/compiler/test/fail_compilation/short_fn.d
+++ b/compiler/test/fail_compilation/short_fn.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/short_fn.d(13): Error: can only return void expression, `this` call or `super` call from constructor
+fail_compilation/short_fn.d(14): Error: can only return void expression, `this` call or `super` call from constructor
+---
+*/
+
+struct Number
+{
+    int x;
+
+    this(int x) => this.x = x;
+    this(byte x) => Number();
+}


### PR DESCRIPTION
Follow up to #17079.

@dkorpel 