### PR TITLE
fix Bugzilla 23803 - compile-time error for concatenation in -betterC

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -1742,7 +1742,7 @@ elem* toElem(Expression e, ref IRState irs)
          */
         if (!irs.params.useGC)
         {
-            irs.eSink.error(ce.loc, "array concatenation of expression `%s` requires the GC which is not available with -betterC", ce.toChars());
+            irs.eSink.error(ce.loc, "`%s` is not allowed in -betterC mode because it requires the garbage collector.", ce.toChars());
             return el_long(TYint, 0);
         }
 

--- a/compiler/test/fail_compilation/test18312.d
+++ b/compiler/test/fail_compilation/test18312.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -betterC
 TEST_OUTPUT:
 ---
-fail_compilation/test18312.d(14): Error: array concatenation of expression `"[" ~ s ~ "]"` requires the GC which is not available with -betterC
+fail_compilation/test18312.d(14): Error: `"[" ~ s ~ "]"` is not allowed in -betterC mode because it requires the garbage collector.
 ---
 */
 

--- a/compiler/test/fail_compilation/test23710.d
+++ b/compiler/test/fail_compilation/test23710.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -betterC
 TEST_OUTPUT:
 ---
-fail_compilation/test23710.d(111): Error: array concatenation of expression `foo ~ [1, 2, 3]` requires the GC which is not available with -betterC
+fail_compilation/test23710.d(111): Error: `foo ~ [1, 2, 3]` is not allowed in -betterC mode because it requires the garbage collector.
 ---
  */
 // https://issues.dlang.org/show_bug.cgi?id=23710

--- a/compiler/test/fail_compilation/test23803.d
+++ b/compiler/test/fail_compilation/test23803.d
@@ -1,0 +1,20 @@
+// https://issues.dlang.org/show_bug.cgi?id=23803
+
+/*
+REQUIRED_ARGS: -betterC
+TEST_OUTPUT:
+---
+fail_compilation/test23803.d(14): Error: `a ~ b` is not allowed in -betterC mode because it requires the garbage collector.
+---
+*/
+
+string foo()
+{
+    string a, b;
+    return a ~ b;
+}
+
+extern(C) void main()
+{
+    foo();
+}


### PR DESCRIPTION
Fixes an issue where string/array concatenation (`~`) in `-betterC` mode caused a linker error instead of a compile-time error. 