### PR TITLE
Enable -preview=fieldwise by default

### DIFF
--- a/changelog/dmd.fieldwise.dd
+++ b/changelog/dmd.fieldwise.dd
@@ -1,0 +1,8 @@
+`-preview=fieldwise` is now enabled by default
+
+This fixes a bug that affected some struct comparisons using the `==` operator.
+For more information, see [the entry for `-preview=fieldwise` in the 2.085.0
+changelog](https://dlang.org/changelog/2.085.0.html#no-cmpsb).
+
+The new `-revert=fieldwise` switch can be used to disable the bug fix and
+restore the original behavior of the `==` operator.

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -939,6 +939,8 @@ dmd -cov -unittest myprog.d
                 "https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1000.md"),
         Feature("intpromote", "fix16997", "revert integral promotions for unary + - ~ operators"),
         Feature("dtorfields", "dtorFields", "don't destruct fields of partially constructed objects"),
+        Feature("fieldwise", "fieldwise", "don't use fieldwise comparisons for struct equality",
+            "https://dlang.org/changelog/2.085.0.html#no-cmpsb"),
     ];
 
     /// Returns all available previews
@@ -959,7 +961,7 @@ dmd -cov -unittest myprog.d
         Feature("bitfields", "bitfields", "add C-like bitfields",
             "https://github.com/dlang/dlang.org/pull/3190"),
         Feature("fieldwise", "fieldwise", "use fieldwise comparisons for struct equality",
-            "https://dlang.org/changelog/2.085.0.html#no-cmpsb"),
+            "https://dlang.org/changelog/2.085.0.html#no-cmpsb", false, false),
         Feature("fixAliasThis", "fixAliasThis",
             "when a symbol is resolved, check alias this scope before going to upper scopes",
             "https://github.com/dlang/dmd/pull/8885"),

--- a/compiler/test/compilable/previewhelp.d
+++ b/compiler/test/compilable/previewhelp.d
@@ -10,7 +10,6 @@ Upcoming language changes listed by -preview=name:
   =dip1008          implement @nogc Throwable DIP (https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1008.md)
   =dip1021          implement Mutable Function Arguments DIP (https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1021.md)
   =bitfields        add C-like bitfields (https://github.com/dlang/dlang.org/pull/3190)
-  =fieldwise        use fieldwise comparisons for struct equality (https://dlang.org/changelog/2.085.0.html#no-cmpsb)
   =fixAliasThis     when a symbol is resolved, check alias this scope before going to upper scopes (https://github.com/dlang/dmd/pull/8885)
   =rvaluerefparam   enable rvalue arguments to ref parameters (https://gist.github.com/andralex/e5405a5d773f07f73196c05f8339435a)
   =safer            more safety checks by default (https://github.com/WalterBright/documents/blob/38f0a846726b571f8108f6e63e5e217b91421c86/safer.md)

--- a/compiler/test/compilable/reverthelp.d
+++ b/compiler/test/compilable/reverthelp.d
@@ -9,5 +9,6 @@ Revertable language changes listed by -revert=name:
   =dip1000          revert DIP1000 changes (Scoped Pointers) (https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1000.md)
   =intpromote       revert integral promotions for unary + - ~ operators
   =dtorfields       don't destruct fields of partially constructed objects
+  =fieldwise        don't use fieldwise comparisons for struct equality (https://dlang.org/changelog/2.085.0.html#no-cmpsb)
 ----
 */


### PR DESCRIPTION
Introduced in PR #9331, this was changed from a normal bug fix to a -preview switch because enabling it triggered a suprious "statement is not reachable" warning in Phobos. That warning has since been removed (in PR #15568).