### PR TITLE
Improve error locations when lexing number literals

### DIFF
--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -2571,19 +2571,19 @@ class Lexer
     Ldone:
         if (errorDigit)
         {
-            error(token.loc, "%s digit expected, not `%c`", base == 2 ? "binary".ptr :
+            error(scanloc, "%s digit expected, not `%c`", base == 2 ? "binary".ptr :
                                                  base == 8 ? "octal".ptr :
                                                  "decimal".ptr, errorDigit);
             err = true;
         }
         if (overflow && !err)
         {
-            error("integer overflow");
+            error(scanloc, "integer overflow");
             err = true;
         }
         if ((base == 2 && !anyBinaryDigitsNoSingleUS) ||
             (base == 16 && !anyHexDigitsNoSingleUS))
-            error(token.loc, "`%.*s` isn't a valid integer literal, use `%.*s0` instead", cast(int)(p - start), start, 2, start);
+            error(scanloc, "`%.*s` isn't a valid integer literal, use `%.*s0` instead", cast(int)(p - start), start, 2, start);
 
         t.unsvalue = n;
 
@@ -2612,7 +2612,7 @@ class Lexer
                 goto L1;
             case 'l':
                 f = FLAGS.long_;
-                error("lower case integer suffix 'l' is not allowed. Please use 'L' instead");
+                error(scanloc, "lower case integer suffix 'l' is not allowed. Please use 'L' instead");
                 goto L1;
             case 'L':
                 f = FLAGS.long_;
@@ -2620,7 +2620,7 @@ class Lexer
                 p++;
                 if ((flags & f) && !err)
                 {
-                    error("repeated integer suffix `%c`", p[-1]);
+                    error(scanloc, "repeated integer suffix `%c`", p[-1]);
                     err = true;
                 }
                 flags = cast(FLAGS)(flags | f);
@@ -2634,9 +2634,9 @@ class Lexer
         {
             if (err)
                 // can't translate invalid octal value, just show a generic message
-                error("octal literals larger than 7 are no longer supported");
+                error(scanloc, "octal literals larger than 7 are no longer supported");
             else
-                error(token.loc, "octal literals `0%llo%.*s` are no longer supported, use `std.conv.octal!\"%llo%.*s\"` instead",
+                error(scanloc, "octal literals `0%llo%.*s` are no longer supported, use `std.conv.octal!\"%llo%.*s\"` instead",
                     n, cast(int)(p - psuffix), psuffix, n, cast(int)(p - psuffix), psuffix);
         }
         TOK result;

--- a/compiler/test/fail_compilation/lexer23465.d
+++ b/compiler/test/fail_compilation/lexer23465.d
@@ -1,13 +1,16 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/lexer23465.d(19): Error: character 0x1f37a is not allowed as a continue character in an identifier
-fail_compilation/lexer23465.d(19): Error: character 0x1f37a is not a valid token
-fail_compilation/lexer23465.d(20): Error: character '\' is not a valid token
-fail_compilation/lexer23465.d(21): Error: unterminated /+ +/ comment
-fail_compilation/lexer23465.d(22): Error: found `End of File` instead of array initializer
-fail_compilation/lexer23465.d(22): Error: semicolon needed to end declaration of `arr`, instead of `End of File`
-fail_compilation/lexer23465.d(17):        `arr` declared here
+fail_compilation/lexer23465.d(22): Error: character 0x1f37a is not allowed as a continue character in an identifier
+fail_compilation/lexer23465.d(22): Error: character 0x1f37a is not a valid token
+fail_compilation/lexer23465.d(23): Error: character '\' is not a valid token
+fail_compilation/lexer23465.d(24): Error: octal digit expected, not `9`
+fail_compilation/lexer23465.d(24): Error: octal literals larger than 7 are no longer supported
+fail_compilation/lexer23465.d(25): Error: integer overflow
+fail_compilation/lexer23465.d(26): Error: unterminated /+ +/ comment
+fail_compilation/lexer23465.d(27): Error: found `End of File` instead of array initializer
+fail_compilation/lexer23465.d(27): Error: semicolon needed to end declaration of `arr`, instead of `End of File`
+fail_compilation/lexer23465.d(20):        `arr` declared here
 ---
 */
 
@@ -18,4 +21,6 @@ int[] arr = [
 	0,
     x🍺,
     3\,
+    09,
+    9999999999999999999999,
     5, /+


### PR DESCRIPTION
Use the lexer's scan location rather than that of the last succesfully parsed token.

*Edit*: that's not always the preferred option either, reducing the scope of this PR to number literals for now

Closes #17499 