### PR TITLE
feat(errors): implement verrors=simple to skip context printing

### DIFF
--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -841,8 +841,13 @@ dmd -cov -unittest myprog.d
         Option("verrors=<num>",
             "limit the number of error/deprecation messages (0 means unlimited)"
         ),
-        Option("verrors=context",
-            "show error messages with the context of the erroring source line"
+        Option("verrors=[context|simple]",
+            "set the verbosity of error messages",
+            `Set the verbosity of error messages:
+            $(DL
+            $(DT context)$(DD Show error messages with the context of the erroring source line (including caret).)
+            $(DT simple)$(DD Show error messages without the context of the erroring source line.)
+            )`,
         ),
         Option("verrors=spec",
             "show errors from speculative compiles such as __traits(compiles,...)"

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -722,7 +722,7 @@ private void verrorPrint(const(char)* format, va_list ap, ref ErrorInfo info)
 
     __gshared SourceLoc old_loc;
     auto loc = info.loc;
-    if (global.params.v.printErrorContext &&
+    if (global.params.v.errorPrintMode != ErrorPrintMode.simpleError &&
         // ignore supplemental messages with same loc
         (loc != old_loc || !info.supplemental) &&
         // ignore invalid files

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6005,6 +6005,12 @@ enum class CPU : uint8_t
     native = 12u,
 };
 
+enum class ErrorPrintMode : uint8_t
+{
+    simpleError = 0u,
+    printErrorContext = 1u,
+};
+
 enum class DiagnosticReporting : uint8_t
 {
     error = 0u,
@@ -8183,10 +8189,10 @@ struct Verbose final
     bool complex;
     bool vin;
     bool showGaggedErrors;
-    bool printErrorContext;
     bool logo;
     bool color;
     bool cov;
+    ErrorPrintMode errorPrintMode;
     MessageStyle messageStyle;
     uint32_t errorLimit;
     uint32_t errorSupplementLimit;
@@ -8202,7 +8208,6 @@ struct Verbose final
         complex(true),
         vin(),
         showGaggedErrors(),
-        printErrorContext(),
         logo(),
         color(),
         cov(),
@@ -8211,7 +8216,7 @@ struct Verbose final
         errorSupplementLimit(6u)
     {
     }
-    Verbose(bool verbose, bool showColumns = false, bool tls = false, bool templates = false, bool templatesListInstances = false, bool gc = false, bool field = false, bool complex = true, bool vin = false, bool showGaggedErrors = false, bool printErrorContext = false, bool logo = false, bool color = false, bool cov = false, MessageStyle messageStyle = (MessageStyle)0u, uint32_t errorLimit = 20u, uint32_t errorSupplementLimit = 6u) :
+    Verbose(bool verbose, bool showColumns = false, bool tls = false, bool templates = false, bool templatesListInstances = false, bool gc = false, bool field = false, bool complex = true, bool vin = false, bool showGaggedErrors = false, bool logo = false, bool color = false, bool cov = false, ErrorPrintMode errorPrintMode = (ErrorPrintMode)0u, MessageStyle messageStyle = (MessageStyle)0u, uint32_t errorLimit = 20u, uint32_t errorSupplementLimit = 6u) :
         verbose(verbose),
         showColumns(showColumns),
         tls(tls),
@@ -8222,10 +8227,10 @@ struct Verbose final
         complex(complex),
         vin(vin),
         showGaggedErrors(showGaggedErrors),
-        printErrorContext(printErrorContext),
         logo(logo),
         color(color),
         cov(cov),
+        errorPrintMode(errorPrintMode),
         messageStyle(messageStyle),
         errorLimit(errorLimit),
         errorSupplementLimit(errorSupplementLimit)

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -82,6 +82,13 @@ enum CLIIdentifierTable : ubyte
     All      = 4, /// The least restrictive set of all other tables
 }
 
+/// Specifies the mode for error printing
+enum ErrorPrintMode : ubyte
+{
+    simpleError,      // Print errors without squiggles and carets
+    printErrorContext, // Print errors with context (source line and caret)
+}
+
 extern(C++) struct Output
 {
     bool doOutput;      // Output is enabled
@@ -126,10 +133,10 @@ extern(C++) struct Verbose
     bool complex = true;    // identify complex/imaginary type usage
     bool vin;               // identify 'in' parameters
     bool showGaggedErrors;  // print gagged errors anyway
-    bool printErrorContext; // print errors with the error context (the error line in the source file)
     bool logo;              // print compiler logo
     bool color;             // use ANSI colors in console output
     bool cov;               // generate code coverage data
+    ErrorPrintMode errorPrintMode; // enum for error printing mode
     MessageStyle messageStyle = MessageStyle.digitalmars; // style of file/line annotations on messages
     uint errorLimit = 20;
     uint errorSupplementLimit = 6;      // Limit the number of supplemental messages for each error (0 means unlimited)

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -94,6 +94,13 @@ enum class CLIIdentifierTable : unsigned char
     All      = 4, /// The least restrictive set of all other tables
 };
 
+/// Specifies the mode for error printing
+enum class ErrorPrintMode : unsigned char
+{
+    simpleError,        // Print errors without squiggles and carets
+    printErrorContext,  // Print errors with the error line and caret
+};
+
 struct Output
 {
     /// Configuration for the compiler generator
@@ -138,10 +145,10 @@ struct Verbose
     d_bool complex = true;     // identify complex/imaginary type usage
     d_bool vin;                // identify 'in' parameters
     d_bool showGaggedErrors;   // print gagged errors anyway
-    d_bool printErrorContext;  // print errors with the error context (the error line in the source file)
     d_bool logo;               // print compiler logo
     d_bool color;              // use ANSI colors in console output
     d_bool cov;                // generate code coverage data
+    ErrorPrintMode errorPrintMode; // enum for error printing mode
     MessageStyle messageStyle; // style of file/line annotations on messages
     unsigned errorLimit;
     unsigned errorSupplementLimit; // Limit the number of supplemental messages for each error (0 means unlimited)

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1004,13 +1004,17 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             {
                 params.v.showGaggedErrors = true;
             }
+            else if (startsWith(p + 9, "simple"))
+            {
+                params.v.errorPrintMode = ErrorPrintMode.simpleError;
+            }
             else if (startsWith(p + 9, "context"))
             {
-                params.v.printErrorContext = true;
+                params.v.errorPrintMode = ErrorPrintMode.printErrorContext;
             }
             else if (!params.v.errorLimit.parseDigits(p.toDString()[9 .. $]))
             {
-                errorInvalidSwitch(p, "Only number, `spec`, or `context` are allowed for `-verrors`");
+                errorInvalidSwitch(p, "Only a number, `spec`, `simple`, or `context` are allowed for `-verrors`");
                 return true;
             }
         }

--- a/compiler/test/compilable/dmdcliflags.sh
+++ b/compiler/test/compilable/dmdcliflags.sh
@@ -159,4 +159,4 @@ echo "$output" | grep "Only a number between 0 and 100 can be passed to \`-cov=<
 
 output="$(! $DMD -verrors=foo 2>&1)"
 echo "$output" | grep "Error: switch \`-verrors=foo\` is invalid"
-echo "$output" | grep "Only number, \`spec\`, or \`context\` are allowed for \`-verrors\`"
+echo "$output" | grep "Only a number, \`spec\`, \`simple\`, or \`context\` are allowed for \`-verrors\`"


### PR DESCRIPTION
Add `verrors=simple` to suppress error context printing, applicable when `verrors=context` is enabled globally (as concluded in [PR #17085](https://github.com/dlang/dmd/pull/17085)).