### PR TITLE
feat(errors): enable verrors=context globally

### DIFF
--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -400,6 +400,7 @@ extern (C++) struct Global
             params.v.color = detectTerminal();
         }
 
+        params.v.errorPrintMode = ErrorPrintMode.printErrorContext; // Enable error context globally by default
         compileEnv.versionNumber = parseVersionNumber(versionString());
 
         /* Initialize date, time, and timestamp

--- a/compiler/src/dmd/root/string.d
+++ b/compiler/src/dmd/root/string.d
@@ -365,13 +365,23 @@ auto splitLines(const char[] text)
         public this(const char[] text)
         {
             this.text = text;
+            this.index = 0;
+            this.eolIndex = 0;
+            this.nextIndex = 0;
         }
 
-        public bool empty() { return index == text.length; }
+        public bool empty() { advance(); return index >= text.length; }
 
         public void popFront() { advance(); index = nextIndex; }
 
-        public const(char)[] front() { advance(); return text[index .. eolIndex]; }
+        public const(char)[] front()
+        {
+            advance();
+            if (index > eolIndex || index >= text.length) {
+                return "";
+            }
+            return text[index .. eolIndex];
+        }
 
         private void advance()
         {
@@ -418,7 +428,7 @@ auto splitLines(const char[] text)
                         if (i + 2 < text.length &&
                             text[i + 1] == 0x80 &&
                             (text[i + 2] == 0xA8 || text[i + 2] == 0xA9)
-                           )
+                        )
                         {
                             eolIndex = i;
                             nextIndex = i + 3;
@@ -430,6 +440,10 @@ auto splitLines(const char[] text)
                         break;
                 }
             }
+
+            // No newline found; set indices to the end of the text
+            eolIndex = text.length;
+            nextIndex = text.length;
         }
     }
 

--- a/compiler/test/compilable/b16976.d
+++ b/compiler/test/compilable/b16976.d
@@ -1,4 +1,4 @@
-/* REQUIRED_ARGS: -m64
+/* REQUIRED_ARGS: -verrors=simple -m64
 TEST_OUTPUT:
 ---
 compilable/b16976.d(33): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`

--- a/compiler/test/compilable/chkformat.d
+++ b/compiler/test/compilable/chkformat.d
@@ -1,9 +1,10 @@
 // https://issues.dlang.org/show_bug.cgi?id=20643
 // https://issues.dlang.org/show_bug.cgi?id=20644
+// REQUIRED_ARGS: -verrors=simple
 /*
 TEST_OUTPUT:
 ----
-compilable/chkformat.d(14): Deprecation: more format specifiers than 0 arguments
+compilable/chkformat.d(15): Deprecation: more format specifiers than 0 arguments
 ----
 */
 import core.stdc.stdio;

--- a/compiler/test/compilable/compile1.d
+++ b/compiler/test/compilable/compile1.d
@@ -1,9 +1,10 @@
 // COMPILABLE_MATH_TEST
 // PERMUTE_ARGS:
+// REQUIRED_ARGS: -verrors=simple
 // EXTRA_FILES: imports/a12506.d
 /* TEST_OUTPUT:
 ---
-compilable/compile1.d(230): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
+compilable/compile1.d(231): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
 ---
 */
 

--- a/compiler/test/compilable/ddoc10236.d
+++ b/compiler/test/compilable/ddoc10236.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -wi -o-
+// REQUIRED_ARGS: -verrors=simple -D -Dd${RESULTS_DIR}/compilable -wi -o-
 
 /*
 TEST_OUTPUT:

--- a/compiler/test/compilable/ddoc10236b.d
+++ b/compiler/test/compilable/ddoc10236b.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -wi -o-
+// REQUIRED_ARGS: -verrors=simple -D -Dd${RESULTS_DIR}/compilable -wi -o-
 
 /*
 TEST_OUTPUT:

--- a/compiler/test/compilable/ddoc13502.d
+++ b/compiler/test/compilable/ddoc13502.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -wi -o-
+// REQUIRED_ARGS: -verrors=simple -D -Dd${RESULTS_DIR}/compilable -wi -o-
 /*
 TEST_OUTPUT:
 ---

--- a/compiler/test/compilable/ddoc4899.d
+++ b/compiler/test/compilable/ddoc4899.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -wi -o-
+// REQUIRED_ARGS: -verrors=simple -D -Dd${RESULTS_DIR}/compilable -wi -o-
 
 /*
 TEST_OUTPUT:

--- a/compiler/test/compilable/depmsg.d
+++ b/compiler/test/compilable/depmsg.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -dw
+REQUIRED_ARGS: -verrors=simple -dw
 TEST_OUTPUT:
 ---
 compilable/depmsg.d(39): Deprecation: struct `depmsg.main.Inner.A` is deprecated - With message!

--- a/compiler/test/compilable/deprecated_override.d
+++ b/compiler/test/compilable/deprecated_override.d
@@ -1,5 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=22668
-
+// REQUIRED_ARGS: -verrors=simple
 // Overrides with same deprecated'ness are allowed
 
 class SameParent

--- a/compiler/test/compilable/deprecationlimit.d
+++ b/compiler/test/compilable/deprecationlimit.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -verrors=3
+REQUIRED_ARGS: -verrors=simple -verrors=3
 TEST_OUTPUT:
 ---
 compilable/deprecationlimit.d(18): Deprecation: function `deprecationlimit.f` is deprecated

--- a/compiler/test/compilable/diag20916.d
+++ b/compiler/test/compilable/diag20916.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -verrors=simple
 /*
 TEST_OUTPUT:
 ---

--- a/compiler/test/compilable/dtoh_invalid_identifiers.d
+++ b/compiler/test/compilable/dtoh_invalid_identifiers.d
@@ -1,5 +1,5 @@
 /+
-REQUIRED_ARGS: -HC -c -o- -wi -extern-std=c++20
+REQUIRED_ARGS: -verrors=simple -HC -c -o- -wi -extern-std=c++20
 PERMUTE_ARGS:
 TEST_OUTPUT:
 ---

--- a/compiler/test/compilable/interpret3.d
+++ b/compiler/test/compilable/interpret3.d
@@ -1,8 +1,9 @@
 // PERMUTE_ARGS: -inline
+// REQUIRED_ARGS: -verrors=simple
 /*
 TEST_OUTPUT:
 ---
-compilable/interpret3.d(6350): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
+compilable/interpret3.d(6351): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
 ---
 */
 

--- a/compiler/test/compilable/pragmainline2.d
+++ b/compiler/test/compilable/pragmainline2.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -inline -wi
+REQUIRED_ARGS: -verrors=simple -inline -wi
 TEST_OUTPUT:
 ---
 compilable/pragmainline2.d(14): Warning: cannot inline function `pragmainline2.foo`

--- a/compiler/test/compilable/sw_transition_complex.d
+++ b/compiler/test/compilable/sw_transition_complex.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -unittest -verrors=0
+// REQUIRED_ARGS: -verrors=simple -unittest -verrors=0
 
 /*
 TEST_OUTPUT:

--- a/compiler/test/compilable/test12567c.d
+++ b/compiler/test/compilable/test12567c.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS:
+// REQUIRED_ARGS: -verrors=simple
 // EXTRA_FILES: imports/a12567.d
 // PERMUTE_ARGS:
 /*

--- a/compiler/test/compilable/test19227.d
+++ b/compiler/test/compilable/test19227.d
@@ -1,7 +1,8 @@
 // https://issues.dlang.org/show_bug.cgi?id=19227
+// REQUIRED_ARGS: -verrors=simple
 /* TEST_OUTPUT:
 ---
-compilable/test19227.d(16): Deprecation: use of complex type `cfloat` is deprecated, use `std.complex.Complex!(float)` instead
+compilable/test19227.d(17): Deprecation: use of complex type `cfloat` is deprecated, use `std.complex.Complex!(float)` instead
 Deprecation: use of complex type `const(cfloat)` is deprecated, use `std.complex.Complex!(float)` instead
 ---
 */

--- a/compiler/test/compilable/test19609.d
+++ b/compiler/test/compilable/test19609.d
@@ -1,11 +1,12 @@
 // https://issues.dlang.org/show_bug.cgi?id=19609
+// REQUIRED_ARGS: -verrors=simple
 // EXTRA_FILES: imports/test19609a.d imports/test19609b.d imports/test19609c.d
 /*
 TEST_OUTPUT:
 ---
-compilable/test19609.d(11): Deprecation: module `imports.test19609a` is deprecated
-compilable/test19609.d(12): Deprecation: module `imports.test19609b` is deprecated - hello
-compilable/test19609.d(13): Deprecation: module `imports.test19609c` is deprecated
+compilable/test19609.d(12): Deprecation: module `imports.test19609a` is deprecated
+compilable/test19609.d(13): Deprecation: module `imports.test19609b` is deprecated - hello
+compilable/test19609.d(14): Deprecation: module `imports.test19609c` is deprecated
 ---
 */
 import imports.test19609a;

--- a/compiler/test/compilable/test20063.d
+++ b/compiler/test/compilable/test20063.d
@@ -1,7 +1,8 @@
+// REQUIRED_ARGS: -verrors=simple
 /* TEST_OUTPUT:
 ---
-compilable/test20063.d(10): Deprecation: function `test20063.main.f!(delegate () pure nothrow @safe => new C).f` function requires a dual-context, which is deprecated
-compilable/test20063.d(19):        instantiated from here: `f!(delegate () pure nothrow @safe => new C)`
+compilable/test20063.d(11): Deprecation: function `test20063.main.f!(delegate () pure nothrow @safe => new C).f` function requires a dual-context, which is deprecated
+compilable/test20063.d(20):        instantiated from here: `f!(delegate () pure nothrow @safe => new C)`
 ---
 */
 

--- a/compiler/test/compilable/test21514.d
+++ b/compiler/test/compilable/test21514.d
@@ -1,15 +1,16 @@
 // https://issues.dlang.org/show_bug.cgi?id=21514
+// REQUIRED_ARGS: -verrors=simple
 // DISABLED: win32 win64
 /* TEST_OUTPUT:
 ---
-compilable/test21514.d(16): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
-compilable/test21514.d(16): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
-compilable/test21514.d(17): Deprecation: use of complex type `creal` is deprecated, use `std.complex.Complex!(real)` instead
-compilable/test21514.d(17): Deprecation: use of complex type `creal` is deprecated, use `std.complex.Complex!(real)` instead
-compilable/test21514.d(19): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
-compilable/test21514.d(19): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
-compilable/test21514.d(20): Deprecation: use of complex type `creal` is deprecated, use `std.complex.Complex!(real)` instead
-compilable/test21514.d(20): Deprecation: use of complex type `creal` is deprecated, use `std.complex.Complex!(real)` instead
+compilable/test21514.d(17): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
+compilable/test21514.d(17): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
+compilable/test21514.d(18): Deprecation: use of complex type `creal` is deprecated, use `std.complex.Complex!(real)` instead
+compilable/test21514.d(18): Deprecation: use of complex type `creal` is deprecated, use `std.complex.Complex!(real)` instead
+compilable/test21514.d(20): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
+compilable/test21514.d(20): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
+compilable/test21514.d(21): Deprecation: use of complex type `creal` is deprecated, use `std.complex.Complex!(real)` instead
+compilable/test21514.d(21): Deprecation: use of complex type `creal` is deprecated, use `std.complex.Complex!(real)` instead
 ---
 */
 

--- a/compiler/test/compilable/test23097.d
+++ b/compiler/test/compilable/test23097.d
@@ -1,5 +1,5 @@
 /* https://issues.dlang.org/show_bug.cgi?id=23097
-REQUIRED_ARGS: -verrors=spec
+REQUIRED_ARGS: -verrors=simple -verrors=spec
 TEST_OUTPUT:
 ---
 (spec:2) compilable/test23097.d(14): Error: `inout` constructor `test23097.S23097.this` creates const object, not mutable

--- a/compiler/test/compilable/test324.d
+++ b/compiler/test/compilable/test324.d
@@ -1,11 +1,12 @@
+// REQUIRED_ARGS: -verrors=simple
 /* TEST_OUTPUT:
 ---
-compilable/test324.d(17): Deprecation: function `test324.main.doStuff!((i)
+compilable/test324.d(18): Deprecation: function `test324.main.doStuff!((i)
 {
 return i;
 }
 ).doStuff` function requires a dual-context, which is deprecated
-compilable/test324.d(23):        instantiated from here: `doStuff!((i)
+compilable/test324.d(24):        instantiated from here: `doStuff!((i)
 {
 return i;
 }

--- a/compiler/test/compilable/test9701.d
+++ b/compiler/test/compilable/test9701.d
@@ -1,9 +1,10 @@
 // https://issues.dlang.org/show_bug.cgi?id=9701
+// REQUIRED_ARGS: -verrors=simple
 /*
 TEST_OUTPUT:
 ---
-compilable/test9701.d(68): Deprecation: enum member `test9701.Enum.value7` is deprecated
-compilable/test9701.d(68): Deprecation: enum member `test9701.Enum.value8` is deprecated - message
+compilable/test9701.d(69): Deprecation: enum member `test9701.Enum.value7` is deprecated
+compilable/test9701.d(69): Deprecation: enum member `test9701.Enum.value8` is deprecated - message
 ---
 */
 

--- a/compiler/test/compilable/testcolor.sh
+++ b/compiler/test/compilable/testcolor.sh
@@ -15,17 +15,24 @@ compare()
     fi
 }
 
-normalize() { tr -d "\n\r" ; }
+normalize()
+{
+    if uname | grep -qi "freebsd"; then
+        tr -d "\n\r" | sed 's/void foo() {} void main() { goo(); }//; s/[[:space:]]\+\^$//'
+    else
+        tr -d "\n\r" | sed -E 's/void foo\(\) \{\} void main\(\) \{ goo\(\); \}//; s/\s+\^$//'
+    fi
+}
 
 check()
 {
     local actual expected
-    actual=$(echo "$2" | ("$DMD" -c -o- "$1" - 2>&1 || true) | normalize)
+    actual=$(echo "$2" | ("$DMD" -c -o- -verrors=simple "$1" - 2>&1 || true) | normalize)
     compare "$actual" "$3"
 }
 
-expectedWithoutColor=__stdin.d\(2\):\ Error:\ no\ identifier\ for\ declarator\ \`test\`
-expectedWithColor=$'\033'\[1m__stdin.d\(2\):\ $'\033'\[1\;31mError:\ $'\033'\[mno\ identifier\ for\ declarator\ \`$'\033'\[0\;36m$'\033'\[m$'\033'\[1mtest$'\033'\[0\;36m$'\033'\[m\`
+expectedWithoutColor='__stdin.d(2): Error: no identifier for declarator `test`'
+expectedWithColor=$'\033[1m__stdin.d(2): \033[1;31mError: \033[mno identifier for declarator `\033[0;36m\033[m\033[1mtest\033[0;36m\033[m`'
 
 check -c "test" "$expectedWithoutColor"
 check -color=auto "test" "$expectedWithoutColor"
@@ -40,7 +47,7 @@ check -color=off "$gooCode" "$gooExpectedWithoutColor"
 
 if [[ "$(script --version)" == script\ from\ util-linux\ * ]]
 then
-    actual="$(SHELL="$(command -v bash)" TERM="faketerm" script -q -c "echo test | ( $DMD -c -o- -)" /dev/null | normalize)" || true
+    actual="$(SHELL="$(command -v bash)" TERM="faketerm" script -q -c "echo test | ( $DMD -c -o- -verrors=simple -)" /dev/null | normalize)" || true
 
     # Weird results for WSL, probably some environmental issue
     if uname -a | grep -i linux | grep -i microsoft &> /dev/null

--- a/compiler/test/compilable/udamodule1.d
+++ b/compiler/test/compilable/udamodule1.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS:
+// REQUIRED_ARGS: -verrors=simple
 // PERMUTE_ARGS:
 // EXTRA_FILES: imports/udamodule1.d
 /*

--- a/compiler/test/compilable/verrors_spec.d
+++ b/compiler/test/compilable/verrors_spec.d
@@ -1,6 +1,6 @@
 /*
 PERMUTE_ARGS:
-REQUIRED_ARGS: -verrors=spec
+REQUIRED_ARGS: -verrors=simple -verrors=spec
 TEST_OUTPUT:
 ---
 (spec:1) compilable/verrors_spec.d(13): Error: cannot implicitly convert expression `& i` of type `int*` to `int`

--- a/compiler/test/runnable/future.d
+++ b/compiler/test/runnable/future.d
@@ -1,8 +1,9 @@
 /* PERMUTE_ARGS:
+REQUIRED_ARGS: -verrors=simple
 TEST_OUTPUT:
 ---
-runnable/future.d(16): Deprecation: method `future.B.msg` implicitly overrides `@__future` base class method; rename the former
-runnable/future.d(11):        base method `future.A.msg` defined here
+runnable/future.d(17): Deprecation: method `future.B.msg` implicitly overrides `@__future` base class method; rename the former
+runnable/future.d(12):        base method `future.A.msg` defined here
 ---
  */
 

--- a/compiler/test/runnable/implicit.d
+++ b/compiler/test/runnable/implicit.d
@@ -1,8 +1,9 @@
 /*
+REQUIRED_ARGS: -verrors=simple
 TEST_OUTPUT:
 ---
-runnable/implicit.d(162): Deprecation: slice of static array temporary returned by `pureMaker3c()` assigned to longer lived variable `z1`
-runnable/implicit.d(163): Deprecation: slice of static array temporary returned by `pureMaker3c()` assigned to longer lived variable `z2`
+runnable/implicit.d(163): Deprecation: slice of static array temporary returned by `pureMaker3c()` assigned to longer lived variable `z1`
+runnable/implicit.d(164): Deprecation: slice of static array temporary returned by `pureMaker3c()` assigned to longer lived variable `z2`
 ---
 
 RUN_OUTPUT:

--- a/compiler/test/runnable/lexer.d
+++ b/compiler/test/runnable/lexer.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS:
+// REQUIRED_ARGS: -verrors=simple
 /*
 TEST_OUTPUT:
 ---

--- a/compiler/test/runnable/template10.d
+++ b/compiler/test/runnable/template10.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS: -inline
-// REQUIRED_ARGS: -verrors=0
+// REQUIRED_ARGS: -verrors=simple -verrors=0
 /* TEST_OUTPUT:
 ---
 runnable/template10.d(89): Deprecation: function `template10.test1b.f0.f!(a).f` function requires a dual-context, which is deprecated

--- a/compiler/test/runnable/test8.d
+++ b/compiler/test/runnable/test8.d
@@ -1,7 +1,8 @@
 /*
+REQUIRED_ARGS: -verrors=simple
 TEST_OUTPUT:
 ---
-runnable/test8.d(261): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
+runnable/test8.d(262): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
 ---
 */
 

--- a/compiler/test/tools/d_do_test.d
+++ b/compiler/test/tools/d_do_test.d
@@ -687,7 +687,7 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
 
     // tests can override -verrors by using REQUIRED_ARGS
     if (testArgs.mode == TestMode.FAIL_COMPILE)
-        testArgs.requiredArgs = "-verrors=0 " ~ testArgs.requiredArgs;
+        testArgs.requiredArgs = "-verrors=simple -verrors=0 " ~ testArgs.requiredArgs;
 
     {
         string argSetsStr;


### PR DESCRIPTION
Enable `verrors=context` globally and update test files to avoid visual noise with `verrors=simple` arg.