### PR TITLE
rework common array operations into functions that can be migrated to the GC

### DIFF
--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -265,5 +265,5 @@ bool __setArrayAllocLength(T)(ref BlkInfo info, size_t newLength, bool isShared,
 {
     import core.lifetime : TypeInfoSize;
     import core.internal.gc.blockmeta : __setArrayAllocLengthImpl;
-    return __setArrayAllocLengthImpl(info, newLength, isShared, typeid(T), oldLength, TypeInfoSize!T);
+    return __setArrayAllocLengthImpl(info, newLength, isShared, oldLength, TypeInfoSize!T);
 }

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -264,6 +264,8 @@ void *__arrayStart()(return scope BlkInfo info) nothrow pure
 bool __setArrayAllocLength(T)(ref BlkInfo info, size_t newLength, bool isShared, size_t oldLength = ~0)
 {
     import core.lifetime : TypeInfoSize;
-    import core.internal.gc.blockmeta : __setArrayAllocLengthImpl;
+    import core.internal.gc.blockmeta : __setArrayAllocLengthImpl, __setBlockFinalizerInfo;
+    static if (TypeInfoSize!T)
+        __setBlockFinalizerInfo(info, typeid(T));
     return __setArrayAllocLengthImpl(info, newLength, isShared, oldLength, TypeInfoSize!T);
 }

--- a/druntime/src/core/internal/gc/blkcache.d
+++ b/druntime/src/core/internal/gc/blkcache.d
@@ -241,3 +241,16 @@ void __insertBlkInfoCache(BlkInfo bi, BlkInfo *curpos) nothrow @nogc
         }
     }
 }
+
+debug(PRINTF)
+{
+    extern(C) void printArrayCache()
+    {
+        auto ptr = __blkcache;
+        printf("CACHE: \n");
+        foreach (i; 0 .. N_CACHE_BLOCKS)
+        {
+            printf("  %d\taddr:% .8x\tsize:% .10d\tflags:% .8x\n", i, ptr[i].base, ptr[i].size, ptr[i].attr);
+        }
+    }
+}

--- a/druntime/src/core/internal/gc/blkcache.d
+++ b/druntime/src/core/internal/gc/blkcache.d
@@ -38,7 +38,7 @@ else
     int __nextBlkIdx;
 }
 
-@property BlkInfo *__blkcache() nothrow
+@property BlkInfo *__blkcache() nothrow @nogc
 {
     if (!__blkcache_storage)
     {
@@ -135,7 +135,7 @@ unittest
         so any use of the returned BlkInfo should copy it and then check the
         base ptr of the copy before actually using it.
   */
-BlkInfo *__getBlkInfo(void *interior) nothrow
+BlkInfo *__getBlkInfo(void *interior) nothrow @nogc
 {
     BlkInfo *ptr = __blkcache;
     if (ptr is null)
@@ -175,7 +175,7 @@ BlkInfo *__getBlkInfo(void *interior) nothrow
     return null; // not in cache.
 }
 
-void __insertBlkInfoCache(BlkInfo bi, BlkInfo *curpos) nothrow
+void __insertBlkInfoCache(BlkInfo bi, BlkInfo *curpos) nothrow @nogc
 {
     auto cache = __blkcache;
     if (cache is null)

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -50,7 +50,7 @@ private void[] getArrayUsed(void *ptr, bool atomic = false) nothrow
         __insertBlkInfoCache(info, null);
 
     auto usedSize = atomic ? __arrayAllocLengthAtomic(info) : __arrayAllocLength(info);
-    return info.base[0 .. usedSize];
+    return __arrayStart(info)[0 .. usedSize];
 }
 
 private bool expandArrayUsed(void[] slice, size_t newUsed, bool atomic = false) nothrow
@@ -178,12 +178,12 @@ private size_t reserveArrayCapacity(void[] slice, size_t request, bool atomic = 
         // update the block info cache if it was used
         if (bic)
             *bic = info;
+        else if (!atomic)
+            __insertBlkInfoCache(info, null);
 
         existingCapacity = __arrayAllocCapacity(info);
     }
 
-    if (!bic && !atomic)
-        __insertBlkInfoCache(info, null);
     return existingCapacity - offset;
 }
 
@@ -415,55 +415,43 @@ Params:
 */
 extern(C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow
 {
-    // note, we do not care about shared.  We are setting the length no matter
-    // what, so no lock is required.
     debug(PRINTF) printf("_d_arrayshrinkfit, elemsize = %d, arr.ptr = x%x arr.length = %d\n", ti.next.tsize, arr.ptr, arr.length);
     auto tinext = unqualify(ti.next);
     auto size = tinext.tsize;                  // array element size
-    auto cursize = arr.length * size;
+    auto reqsize = arr.length * size;
     auto isshared = typeid(ti) is typeid(TypeInfo_Shared);
-    auto bic = isshared ? null : __getBlkInfo(arr.ptr);
-    auto info = bic ? *bic : GC.query(arr.ptr);
-    if (info.base && (info.attr & BlkAttr.APPENDABLE))
+
+    auto curArr = getArrayUsed(arr.ptr, isshared);
+    if (curArr.ptr is null)
+        // not a valid GC pointer
+        return;
+
+    // align the array.
+    auto offset = arr.ptr - curArr.ptr;
+    auto cursize = curArr.length - offset;
+    if (cursize <= reqsize)
+        // invalid situation, or no change.
+        return;
+
+    // if the type has a destructor, destroy elements we are about to remove.
+    if (typeid(tinext) is typeid(TypeInfo_Struct)) // avoid a complete dynamic type cast
     {
-        auto newsize = (arr.ptr - __arrayStart(info)) + cursize;
-
-        debug(PRINTF) printf("setting allocated size to %d\n", (arr.ptr - info.base) + cursize);
-
-        // destroy structs that become unused memory when array size is shrinked
-        if (typeid(tinext) is typeid(TypeInfo_Struct)) // avoid a complete dynamic type cast
+        auto sti = cast(TypeInfo_Struct)cast(void*)tinext;
+        if (sti.xdtor)
         {
-            auto sti = cast(TypeInfo_Struct)cast(void*)tinext;
-            if (sti.xdtor)
+            try
             {
-                auto oldsize = isshared ? __arrayAllocLengthAtomic(info) :
-                    __arrayAllocLength(info);
-                if (oldsize > cursize)
-                {
-                    try
-                    {
-                        finalize_array(arr.ptr + cursize, oldsize - cursize, sti);
-                    }
-                    catch (Exception e)
-                    {
-                        import core.exception : onFinalizeError;
-                        onFinalizeError(sti, e);
-                    }
-                }
+                finalize_array(arr.ptr + reqsize, cursize - reqsize, sti);
+            }
+            catch (Exception e)
+            {
+                import core.exception : onFinalizeError;
+                onFinalizeError(sti, e);
             }
         }
-        // Note: Since we "assume" the append is safe, it means it is not shared.
-        // Since it is not shared, we also know it won't throw (no lock).
-        if (!__setArrayAllocLength(info, newsize, false, tinext))
-        {
-            import core.exception : onInvalidMemoryOperationError;
-            onInvalidMemoryOperationError();
-        }
-
-        // cache the block if not already done.
-        if (!isshared && !bic)
-            __insertBlkInfoCache(info, null);
     }
+
+    shrinkArrayUsed(arr.ptr[0 .. reqsize], cursize, isshared);
 }
 
 package bool hasPostblit(in TypeInfo ti) nothrow pure
@@ -528,10 +516,7 @@ do
     import core.stdc.string;
     import core.exception : onOutOfMemoryError;
 
-    // step 1, get the block
     auto isshared = typeid(ti) is typeid(TypeInfo_Shared);
-    auto bic = isshared ? null : __getBlkInfo((*p).ptr);
-    auto info = bic ? *bic : GC.query((*p).ptr);
     auto tinext = unqualify(ti.next);
     auto size = tinext.tsize;
     version (D_InlineAsm_X86)
@@ -572,77 +557,21 @@ Loverflow:
     assert(0);
 Lcontinue:
 
-    // step 2, get the actual "allocated" size.  If the allocated size does not
-    // match what we expect, then we will need to reallocate anyways.
-
-    // TODO: this probably isn't correct for shared arrays
-    size_t curallocsize = void;
-    size_t curcapacity = void;
-    size_t offset = void;
-    size_t arraypad = void;
-    if (info.base && (info.attr & BlkAttr.APPENDABLE))
-    {
-        if (info.size <= 256)
-        {
-            arraypad = SMALLPAD + structTypeInfoSize(tinext);
-            curallocsize = *(cast(ubyte *)(info.base + info.size - arraypad));
-        }
-        else if (info.size < PAGESIZE)
-        {
-            arraypad = MEDPAD + structTypeInfoSize(tinext);
-            curallocsize = *(cast(ushort *)(info.base + info.size - arraypad));
-        }
-        else
-        {
-            curallocsize = *(cast(size_t *)(info.base));
-            arraypad = LARGEPAD;
-        }
-
-
-        offset = (*p).ptr - __arrayStart(info);
-        if (offset + (*p).length * size != curallocsize)
-        {
-            curcapacity = 0;
-        }
-        else
-        {
-            // figure out the current capacity of the block from the point
-            // of view of the array.
-            curcapacity = info.size - offset - arraypad;
-        }
-    }
-    else
-    {
-        curallocsize = curcapacity = offset = 0;
-    }
-    debug(PRINTF) printf("_d_arraysetcapacity, p = x%d,%d, newcapacity=%d, info.size=%d, reqsize=%d, curallocsize=%d, curcapacity=%d, offset=%d\n", (*p).ptr, (*p).length, newcapacity, info.size, reqsize, curallocsize, curcapacity, offset);
-
-    if (curcapacity >= reqsize)
-    {
-        // no problems, the current allocated size is large enough.
-        return curcapacity / size;
-    }
-
-    // step 3, try to extend the array in place.
-    if (info.size >= PAGESIZE && curcapacity != 0)
-    {
-        auto extendsize = reqsize + offset + LARGEPAD - info.size;
-        auto u = GC.extend(info.base, extendsize, extendsize);
-        if (u)
-        {
-            // extend worked, save the new current allocated size
-            if (bic)
-                bic.size = u; // update cache
-            curcapacity = u - offset - LARGEPAD;
-            return curcapacity / size;
-        }
-    }
-
-    // step 4, if extending doesn't work, allocate a new array with at least the requested allocated size.
+    // step 1, see if we can ensure the capacity is valid in-place
     auto datasize = (*p).length * size;
-    // copy attributes from original block, or from the typeinfo if the
-    // original block doesn't exist.
-    info = __arrayAlloc(reqsize, info, ti, tinext);
+    auto curCapacity = reserveArrayCapacity((*p).ptr[0 .. datasize], reqsize, isshared);
+    if (curCapacity != 0)
+        // in-place worked!
+        return curCapacity / size;
+
+    if (reqsize <= datasize)
+        // requested size is less than array size, the current array satisfies
+        // the request. But this is not an appendable GC array, so return 0.
+        return 0;
+
+    // step 2, if reserving in-place doesn't work, allocate a new array with at
+    // least the requested allocated size.
+    auto info = __arrayAlloc(reqsize, ti, tinext);
     if (info.base is null)
         goto Loverflow;
     // copy the data over.
@@ -668,22 +597,12 @@ Lcontinue:
     // set up the correct length
     __setArrayAllocLength(info, datasize, isshared, tinext);
     if (!isshared)
-        __insertBlkInfoCache(info, bic);
+        __insertBlkInfoCache(info, null);
 
     *p = (cast(void*)tgt)[0 .. (*p).length];
 
-    // determine the padding.  This has to be done manually because __arrayPad
-    // assumes you are not counting the pad size, and info.size does include
-    // the pad.
-    if (info.size <= 256)
-        arraypad = SMALLPAD + structTypeInfoSize(tinext);
-    else if (info.size < PAGESIZE)
-        arraypad = MEDPAD + structTypeInfoSize(tinext);
-    else
-        arraypad = LARGEPAD;
-
-    curcapacity = info.size - arraypad;
-    return curcapacity / size;
+    curCapacity = __arrayAllocCapacity(info);
+    return curCapacity / size;
 }
 
 /**
@@ -829,23 +748,10 @@ extern (C) void* _d_newitemU(scope const TypeInfo _ti) pure nothrow @weak
     {
         // the GC might not have cleared the padding area in the block
         *cast(TypeInfo*)(p + (itemSize & ~(size_t.sizeof - 1))) = null;
-        *cast(TypeInfo*)(p + blkInf.size - tiSize) = cast() ti;
+        __setBlockFinalizerInfo(blkInf, cast() ti);
     }
 
     return p;
-}
-
-debug(PRINTF)
-{
-    extern(C) void printArrayCache()
-    {
-        auto ptr = __blkcache;
-        printf("CACHE: \n");
-        foreach (i; 0 .. N_CACHE_BLOCKS)
-        {
-            printf("  %d\taddr:% .8x\tsize:% .10d\tflags:% .8x\n", i, ptr[i].base, ptr[i].size, ptr[i].attr);
-        }
-    }
 }
 
 /**
@@ -960,33 +866,30 @@ void finalize_array2(void* p, size_t size) nothrow
 {
     debug(PRINTF) printf("rt_finalize_array2(p = %p)\n", p);
 
-    TypeInfo_Struct si = void;
+    // construct a BlkInfo to match the array API
+    auto info = BlkInfo(
+            base: p,
+            size: size,
+            attr: BlkAttr.APPENDABLE | BlkAttr.STRUCTFINAL
+    );
+    auto usedsize = __arrayAllocLength(info);
+    auto arrptr = __arrayStart(info);
+
     debug (VALGRIND)
     {
         auto block = p[0..size];
         disableAddrReportingInRange(block);
     }
-    if (size <= 256)
-    {
-        si = *cast(TypeInfo_Struct*)(p + size - size_t.sizeof);
-        size = *cast(ubyte*)(p + size - size_t.sizeof - SMALLPAD);
-    }
-    else if (size < PAGESIZE)
-    {
-        si = *cast(TypeInfo_Struct*)(p + size - size_t.sizeof);
-        size = *cast(ushort*)(p + size - size_t.sizeof - MEDPAD);
-    }
-    else
-    {
-        si = *cast(TypeInfo_Struct*)(p + size_t.sizeof);
-        size = *cast(size_t*)p;
-        p += LARGEPREFIX;
-    }
+
+    TypeInfo_Struct si = size < PAGESIZE ?
+        *cast(TypeInfo_Struct*)(p + size - size_t.sizeof) : // small
+        *cast(TypeInfo_Struct*)(p + size_t.sizeof); // large
+
     debug (VALGRIND) enableAddrReportingInRange(block);
 
     try
     {
-        finalize_array(p, size, si);
+        finalize_array(arrptr, usedsize, si);
     }
     catch (Exception e)
     {
@@ -1133,8 +1036,7 @@ do
     if (newlength <= (*p).length)
     {
         *p = (*p)[0 .. newlength];
-        void* newdata = (*p).ptr;
-        return newdata[0 .. newlength];
+        return *p;
     }
     auto tinext = unqualify(ti.next);
     size_t sizeelem = tinext.tsize;
@@ -1183,6 +1085,7 @@ do
 
     if (!(*p).ptr)
     {
+        assert((*p).length == 0);
         // pointer was null, need to allocate
         auto info = __arrayAlloc(newsize, ti, tinext);
         if (info.base is null)
@@ -1200,102 +1103,31 @@ do
     }
 
     const size_t size = (*p).length * sizeelem;
-    auto   bic = isshared ? null : __getBlkInfo((*p).ptr);
-    auto   info = bic ? *bic : GC.query((*p).ptr);
 
     /* Attempt to extend past the end of the existing array.
      * If not possible, allocate new space for entire array and copy.
      */
-    bool allocateAndCopy = false;
     void* newdata = (*p).ptr;
-    if (info.base && (info.attr & BlkAttr.APPENDABLE))
+    if (!expandArrayUsed(newdata[0 .. size], newsize, isshared))
     {
-        // calculate the extent of the array given the base.
-        const size_t offset = (*p).ptr - __arrayStart(info);
-        if (info.size >= PAGESIZE)
-        {
-            // size of array is at the front of the block
-            if (!__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-            {
-                // check to see if it failed because there is not
-                // enough space
-                if (*(cast(size_t*)info.base) == size + offset)
-                {
-                    // not enough space, try extending
-                    auto extendsize = newsize + offset + LARGEPAD - info.size;
-                    auto u = GC.extend(info.base, extendsize, extendsize);
-                    if (u)
-                    {
-                        // extend worked, now try setting the length
-                        // again.
-                        info.size = u;
-                        if (__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-                        {
-                            if (!isshared)
-                                __insertBlkInfoCache(info, bic);
-                            memset(newdata + size, 0, newsize - size);
-                            *p = newdata[0 .. newlength];
-                            return *p;
-                        }
-                    }
-                }
-
-                // couldn't do it, reallocate
-                allocateAndCopy = true;
-            }
-            else if (!isshared && !bic)
-            {
-                // add this to the cache, it wasn't present previously.
-                __insertBlkInfoCache(info, null);
-            }
-        }
-        else if (!__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-        {
-            // could not resize in place
-            allocateAndCopy = true;
-        }
-        else if (!isshared && !bic)
-        {
-            // add this to the cache, it wasn't present previously.
-            __insertBlkInfoCache(info, null);
-        }
-    }
-    else
-        allocateAndCopy = true;
-
-    if (allocateAndCopy)
-    {
-        if (info.base)
-        {
-            if (bic)
-            {
-                // a chance that flags have changed since this was cached, we should fetch the most recent flags
-                info.attr = GC.getAttr(info.base) | BlkAttr.APPENDABLE;
-            }
-            info = __arrayAlloc(newsize, info, ti, tinext);
-        }
-        else
-        {
-            info = __arrayAlloc(newsize, ti, tinext);
-        }
-
+        auto info = __arrayAlloc(newsize, ti, tinext);
         if (info.base is null)
         {
             onOutOfMemoryError();
             assert(0);
         }
 
-        __setArrayAllocLength(info, newsize, isshared, tinext);
-        if (!isshared)
-            __insertBlkInfoCache(info, bic);
-        newdata = cast(byte *)__arrayStart(info);
+        newdata = __arrayStart(info);
         newdata[0 .. size] = (*p).ptr[0 .. size];
 
-        /* Do postblit processing, as we are making a copy and the
-         * original array may have references.
-         * Note that this may throw.
-         */
+        __setArrayAllocLength(info, newsize, isshared, tinext);
+
+        // Do postblit processing, as we are making a copy.
         __doPostblit(newdata, size, tinext);
+
+        // this hasn't been added to the cache yet.
+        if (!isshared)
+            __insertBlkInfoCache(info, null);
     }
 
     // Zero the unused portion of the newly allocated space
@@ -1318,7 +1150,7 @@ do
 
     debug(PRINTF)
     {
-        //printf("_d_arraysetlengthiT(p = %p, sizeelem = %d, newlength = %d)\n", p, sizeelem, newlength);
+        //printf("_d_arraysetlengthT(p = %p, sizeelem = %d, newlength = %d)\n", p, sizeelem, newlength);
         if (p)
             printf("\tp.ptr = %p, p.length = %d\n", (*p).ptr, (*p).length);
     }
@@ -1326,8 +1158,7 @@ do
     if (newlength <= (*p).length)
     {
         *p = (*p)[0 .. newlength];
-        void* newdata = (*p).ptr;
-        return newdata[0 .. newlength];
+        return *p;
     }
     auto tinext = unqualify(ti.next);
     size_t sizeelem = tinext.tsize;
@@ -1393,6 +1224,7 @@ do
 
     if (!(*p).ptr)
     {
+        assert((*p).length == 0);
         // pointer was null, need to allocate
         auto info = __arrayAlloc(newsize, ti, tinext);
         if (info.base is null)
@@ -1410,103 +1242,31 @@ do
     }
 
     const size_t size = (*p).length * sizeelem;
-    auto   bic = isshared ? null : __getBlkInfo((*p).ptr);
-    auto   info = bic ? *bic : GC.query((*p).ptr);
 
     /* Attempt to extend past the end of the existing array.
      * If not possible, allocate new space for entire array and copy.
      */
-    bool allocateAndCopy = false;
     void* newdata = (*p).ptr;
-
-    if (info.base && (info.attr & BlkAttr.APPENDABLE))
+    if (!expandArrayUsed(newdata[0 .. size], newsize, isshared))
     {
-        // calculate the extent of the array given the base.
-        const size_t offset = (*p).ptr - __arrayStart(info);
-        if (info.size >= PAGESIZE)
-        {
-            // size of array is at the front of the block
-            if (!__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-            {
-                // check to see if it failed because there is not
-                // enough space
-                if (*(cast(size_t*)info.base) == size + offset)
-                {
-                    // not enough space, try extending
-                    auto extendsize = newsize + offset + LARGEPAD - info.size;
-                    auto u = GC.extend(info.base, extendsize, extendsize);
-                    if (u)
-                    {
-                        // extend worked, now try setting the length
-                        // again.
-                        info.size = u;
-                        if (__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-                        {
-                            if (!isshared)
-                                __insertBlkInfoCache(info, bic);
-                            doInitialize(newdata + size, newdata + newsize, tinext.initializer);
-                            *p = newdata[0 .. newlength];
-                            return *p;
-                        }
-                    }
-                }
-
-                // couldn't do it, reallocate
-                allocateAndCopy = true;
-            }
-            else if (!isshared && !bic)
-            {
-                // add this to the cache, it wasn't present previously.
-                __insertBlkInfoCache(info, null);
-            }
-        }
-        else if (!__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-        {
-            // could not resize in place
-            allocateAndCopy = true;
-        }
-        else if (!isshared && !bic)
-        {
-            // add this to the cache, it wasn't present previously.
-            __insertBlkInfoCache(info, null);
-        }
-    }
-    else
-        allocateAndCopy = true;
-
-    if (allocateAndCopy)
-    {
-        if (info.base)
-        {
-            if (bic)
-            {
-                // a chance that flags have changed since this was cached, we should fetch the most recent flags
-                info.attr = GC.getAttr(info.base) | BlkAttr.APPENDABLE;
-            }
-            info = __arrayAlloc(newsize, info, ti, tinext);
-        }
-        else
-        {
-            info = __arrayAlloc(newsize, ti, tinext);
-        }
-
+        auto info = __arrayAlloc(newsize, ti, tinext);
         if (info.base is null)
         {
             onOutOfMemoryError();
             assert(0);
         }
 
-        __setArrayAllocLength(info, newsize, isshared, tinext);
-        if (!isshared)
-            __insertBlkInfoCache(info, bic);
-        newdata = cast(byte *)__arrayStart(info);
+        newdata = __arrayStart(info);
         newdata[0 .. size] = (*p).ptr[0 .. size];
 
-        /* Do postblit processing, as we are making a copy and the
-         * original array may have references.
-         * Note that this may throw.
-         */
+        __setArrayAllocLength(info, newsize, isshared, tinext);
+
+        // Do postblit processing, as we are making a copy.
         __doPostblit(newdata, size, tinext);
+
+        // this hasn't been added to the cache yet.
+        if (!isshared)
+            __insertBlkInfoCache(info, null);
     }
 
     // Initialize the unused portion of the newly allocated space
@@ -1598,100 +1358,53 @@ extern (C)
 byte[] _d_arrayappendcTX(const TypeInfo ti, return scope ref byte[] px, size_t n) @weak
 {
     import core.stdc.string;
+    import core.exception : onOutOfMemoryError;
     // This is a cut&paste job from _d_arrayappendT(). Should be refactored.
 
     // only optimize array append where ti is not a shared type
     auto tinext = unqualify(ti.next);
     auto sizeelem = tinext.tsize;              // array element size
     auto isshared = typeid(ti) is typeid(TypeInfo_Shared);
-    auto bic = isshared ? null : __getBlkInfo(px.ptr);
-    auto info = bic ? *bic : GC.query(px.ptr);
     auto length = px.length;
     auto newlength = length + n;
     auto newsize = newlength * sizeelem;
     auto size = length * sizeelem;
-    size_t newcap = void; // for scratch space
 
-    // calculate the extent of the array given the base.
-    size_t offset = cast(void*)px.ptr - __arrayStart(info);
-    if (info.base && (info.attr & BlkAttr.APPENDABLE))
+    if (!expandArrayUsed(px.ptr[0 .. size], newsize, isshared))
     {
-        if (info.size >= PAGESIZE)
+        // could not set the size, we must reallocate.
+        auto newcap = newCapacity(newlength, sizeelem);
+        auto info = __arrayAlloc(newcap, ti, tinext);
+        if (info.base is null)
         {
-            // size of array is at the front of the block
-            if (!__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-            {
-                // check to see if it failed because there is not
-                // enough space
-                newcap = newCapacity(newlength, sizeelem);
-                if (*(cast(size_t*)info.base) == size + offset)
-                {
-                    // not enough space, try extending
-                    auto extendoffset = offset + LARGEPAD - info.size;
-                    auto u = GC.extend(info.base, newsize + extendoffset, newcap + extendoffset);
-                    if (u)
-                    {
-                        // extend worked, now try setting the length
-                        // again.
-                        info.size = u;
-                        if (__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-                        {
-                            if (!isshared)
-                                __insertBlkInfoCache(info, bic);
-                            goto L1;
-                        }
-                    }
-                }
+            onOutOfMemoryError();
+            assert(0);
+        }
 
-                // couldn't do it, reallocate
-                goto L2;
-            }
-            else if (!isshared && !bic)
-            {
-                __insertBlkInfoCache(info, null);
-            }
-        }
-        else if (!__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-        {
-            // could not resize in place
-            newcap = newCapacity(newlength, sizeelem);
-            goto L2;
-        }
-        else if (!isshared && !bic)
-        {
-            __insertBlkInfoCache(info, null);
-        }
-    }
-    else
-    {
-        // not appendable or is null
-        newcap = newCapacity(newlength, sizeelem);
-        if (info.base)
-        {
-    L2:
-            if (bic)
-            {
-                // a chance that flags have changed since this was cached, we should fetch the most recent flags
-                info.attr = GC.getAttr(info.base) | BlkAttr.APPENDABLE;
-            }
-            info = __arrayAlloc(newcap, info, ti, tinext);
-        }
-        else
-        {
-            info = __arrayAlloc(newcap, ti, tinext);
-        }
         __setArrayAllocLength(info, newsize, isshared, tinext);
         if (!isshared)
-            __insertBlkInfoCache(info, bic);
+            __insertBlkInfoCache(info, null);
+
         auto newdata = cast(byte*)__arrayStart(info);
-        memcpy(newdata, px.ptr, length * sizeelem);
-        // do postblit processing
-        __doPostblit(newdata, length * sizeelem, tinext);
-        (cast(void**)&px)[1] = newdata;
+        memcpy(newdata, px.ptr, size);
+
+
+        // For small blocks that are always fully scanned, if we allocated more
+        // capacity than was requested, we are responsible for zeroing that
+        // memory.
+        // large blocks are only scanned up to the used size.
+        if (!(info.attr & BlkAttr.NO_SCAN) && newcap > newcap && info.size < PAGESIZE)
+            memset(newdata + newsize, 0, newcap - newsize);
+
+        // do potsblit processing.
+        __doPostblit(newdata, size, tinext);
+
+        px = newdata[0 .. newlength];
+        return px;
     }
 
-  L1:
-    *cast(size_t*)&px = newlength;
+    // we were able to expand in place, just update the length
+    px = px.ptr[0 .. newlength];
     return px;
 }
 
@@ -2049,7 +1762,13 @@ unittest
     assert(info2.base is carr2.ptr); // no offset, the capacity is small.
 }
 
-unittest
+// I think this whole test is invalid, as is the bug report. Setting internal
+// bits after allocation should not be supported as a general mechanism
+// (setting bits). This prevents valid optimizations such as segregating
+// scanning and non-scanning memory into different pools. It is also trivial to
+// break invariants this way. For example, you could set the finalizer bit, but
+// not set up the block to have a finalizer.
+/+unittest
 {
     // https://issues.dlang.org/show_bug.cgi?id=13878
     auto arr = new ubyte[1];
@@ -2103,6 +1822,7 @@ unittest
     info = GC.query(carr2.ptr);
     assert(!(info.attr & BlkAttr.NO_SCAN)); // ensure attribute sticks
 }
++/
 
 // test struct finalizers
 debug(SENTINEL) {} else

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -32,6 +32,161 @@ private
 
 }
 
+// NOTE: these are going to be migrated to the GC soon. They are here to allow
+// for better review for now.
+private void[] getArrayUsed(void *ptr, bool atomic = false) nothrow
+{
+    // lookup the block info, using the cache if possible.
+    auto bic = atomic ? null : __getBlkInfo(ptr);
+    auto info = bic ? *bic : GC.query(ptr);
+
+    if (!(info.attr & BlkAttr.APPENDABLE))
+        // not appendable
+        return null;
+
+    assert(info.base); // sanity check.
+    if (!bic && !atomic)
+        // cache the lookup for next time
+        __insertBlkInfoCache(info, null);
+
+    auto usedSize = atomic ? __arrayAllocLengthAtomic(info) : __arrayAllocLength(info);
+    return info.base[0 .. usedSize];
+}
+
+private bool expandArrayUsed(void[] slice, size_t newUsed, bool atomic = false) nothrow
+{
+    if (newUsed < slice.length)
+        // cannot "expand" by shrinking.
+        return false;
+
+    // lookup the block info, using the cache if possible
+    auto bic = atomic ? null : __getBlkInfo(slice.ptr);
+    auto info = bic ? *bic : GC.query(slice.ptr);
+
+    if (!(info.attr & BlkAttr.APPENDABLE))
+        // not appendable
+        return false;
+
+    assert(info.base); // sanity check.
+
+    immutable offset = slice.ptr - __arrayStart(info);
+    newUsed += offset;
+    auto existingUsed = slice.length + offset;
+
+    size_t typeInfoSize = (info.attr & BlkAttr.STRUCTFINAL) ? size_t.sizeof : 0;
+    if (__setArrayAllocLengthImpl(info, offset + newUsed, atomic, existingUsed, typeInfoSize))
+    {
+        // could expand without extending
+        if (!bic && !atomic)
+            // cache the lookup for next time
+            __insertBlkInfoCache(info, null);
+        return true;
+    }
+
+    // if we got here, just setting the used size did not work.
+    if (info.size < PAGESIZE)
+        // nothing else we can do
+        return false;
+
+    // try extending the block into subsequent pages.
+    immutable requiredExtension = newUsed - info.size - LARGEPAD;
+    auto extendedSize = GC.extend(info.base, requiredExtension, requiredExtension);
+    if (extendedSize == 0)
+        // could not extend, can't satisfy the request
+        return false;
+
+    info.size = extendedSize;
+    if (bic)
+        *bic = info;
+    else if (!atomic)
+        __insertBlkInfoCache(info, null);
+
+    // this should always work.
+    return __setArrayAllocLengthImpl(info, newUsed, atomic, existingUsed, typeInfoSize);
+}
+
+private bool shrinkArrayUsed(void[] slice, size_t existingUsed, bool atomic = false) nothrow
+{
+    if(existingUsed < slice.length)
+        // cannot "shrink" by growing.
+        return false;
+
+    // lookup the block info, using the cache if possible.
+    auto bic = atomic ? null : __getBlkInfo(slice.ptr);
+    auto info = bic ? *bic : GC.query(slice.ptr);
+
+    if (!(info.attr & BlkAttr.APPENDABLE))
+        // not appendable
+        return false;
+
+    assert(info.base); // sanity check
+
+    immutable offset = slice.ptr - __arrayStart(info);
+    existingUsed += offset;
+    auto newUsed = slice.length + offset;
+
+    size_t typeInfoSize = (info.attr & BlkAttr.STRUCTFINAL) ? size_t.sizeof : 0;
+
+    if (__setArrayAllocLengthImpl(info, newUsed, atomic, existingUsed, typeInfoSize))
+    {
+        if (!bic && !atomic)
+            __insertBlkInfoCache(info, null);
+        return true;
+    }
+
+    return false;
+}
+
+private size_t reserveArrayCapacity(void[] slice, size_t request, bool atomic = false) nothrow
+{
+    // lookup the block info, using the cache if possible.
+    auto bic = atomic ? null : __getBlkInfo(slice.ptr);
+    auto info = bic ? *bic : GC.query(slice.ptr);
+
+    if (!(info.attr & BlkAttr.APPENDABLE))
+        // not appendable
+        return 0;
+
+    assert(info.base); // sanity check
+
+    immutable offset = slice.ptr - __arrayStart(info);
+    request += offset;
+    auto existingUsed = slice.length + offset;
+
+    // make sure this slice ends at the used space
+    auto blockUsed = atomic ? __arrayAllocLengthAtomic(info) : __arrayAllocLength(info);
+    if (existingUsed != blockUsed)
+        // not an expandable slice.
+        return 0;
+
+    // see if the capacity can contain the existing data
+    auto existingCapacity = __arrayAllocCapacity(info);
+    if (existingCapacity < request)
+    {
+        if (info.size < PAGESIZE)
+            // no possibility to extend
+            return 0;
+
+        immutable requiredExtension = request - existingCapacity;
+        auto extendedSize = GC.extend(info.base, requiredExtension, requiredExtension);
+        if (extendedSize == 0)
+            // could not extend, can't satisfy the request
+            return 0;
+
+        info.size = extendedSize;
+
+        // update the block info cache if it was used
+        if (bic)
+            *bic = info;
+
+        existingCapacity = __arrayAllocCapacity(info);
+    }
+
+    if (!bic && !atomic)
+        __insertBlkInfoCache(info, null);
+    return existingCapacity - offset;
+}
+
 // Now-removed symbol, kept around for ABI
 // Some programs are dynamically linked, so best to err on the side of keeping symbols around for a while (especially extern(C) ones)
 // https://github.com/dlang/druntime/pull/3361
@@ -281,7 +436,8 @@ extern(C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow
             auto sti = cast(TypeInfo_Struct)cast(void*)tinext;
             if (sti.xdtor)
             {
-                auto oldsize = __arrayAllocLength(info, tinext);
+                auto oldsize = isshared ? __arrayAllocLengthAtomic(info) :
+                    __arrayAllocLength(info);
                 if (oldsize > cursize)
                 {
                     try


### PR DESCRIPTION
The entire purpose of this PR is to rework the array code in lifetime.d to use a small set of functions to avoid having intimate knowledge of the array metdata details leaking into lifetime.d

In a future PR these mechanisms will be moved into the GC, and lifetime will implement its features by calling these functions on the GC directly.

This was split into 2 commits. It may need to be split further. It might even need to be split into multiple PRs.

This also separates out the setting of the finalizer with setting array length. I did not realize before this PR that the finalizer was always being set when the length was set. I'm also removing some dependence on TypeInfo there. In retrospect, maybe this part should be moved to a later PR.

There is one unittest I commented out, because it depends on array appending forwarding current bits to the expanded array instead of using the expected type bits from the type directly. I'm not entirely sure if we want to keep this piece. I want to see how buildkite does with this.