### PR TITLE
Replace scope(success) with scope(exit)

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3934,7 +3934,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        scope (success) result.rvalue = exp.rvalue;
+        scope (exit) result.rvalue = exp.rvalue;
 
         Dsymbol scopesym;
         Dsymbol s = sc.search(exp.loc, exp.ident, scopesym);

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2871,7 +2871,8 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
 
     if (e.rvalue)
         buf.writestring("__rvalue(");
-    scope (success)
+
+    scope (exit)
         if (e.rvalue)
             buf.writeByte(')');
 


### PR DESCRIPTION
To allow compiling dmd with -nothrow / -fno-exceptions. (I guess we should add that flag to the build script at some point)