### PR TITLE
Refactor 'expressionSemanticDone' logic into a function

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -293,7 +293,12 @@ enum WANTexpand = 1;    // expand const/immutable variables if possible
  */
 extern (C++) abstract class Expression : ASTNode
 {
-    Type type;      // !=null means that semantic() has been run
+    /// Usually, this starts out as `null` and gets set to the final expression type by
+    /// `expressionSemantic`. However, for some expressions (such as `TypeExp`,`RealExp`,
+    /// `VarExp`), the field can get set to an assigned type before running semantic.
+    /// See `expressionSemanticDone`
+    Type type;
+
     Loc loc;        // file location
     const EXP op;   // to minimize use of dynamic_cast
     bool parens;    // if this is a parenthesized expression


### PR DESCRIPTION
Following up #20594

I see now the issue is not really about expressionSemantic not being idempotent, but about the `Expression.type` field sometimes being used to assign a type rather than to compute it. I think there should be a semanticDone bitflag in Expression since the `type` field doubling as a semantic status field is not consistent, but my first naive attempt resulted in segfaults, so let's start by documenting the current behavior more accurately.