### PR TITLE
Always accept .o and .obj files extensions from CLI for all platforms

### DIFF
--- a/changelog/dmd.obj_extensions.dd
+++ b/changelog/dmd.obj_extensions.dd
@@ -1,0 +1,6 @@
+Object file extensions `.o` and `.obj` are now accepted on all platforms
+
+Accepting .o and .obj file extensions on all platforms makes DMD behave
+the same as Clang and other modern compilers. There is no point in
+discarding *.o or *.obj depending on the current OS, as both extensions
+indicate that this is an object file.

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1836,7 +1836,7 @@ bool createModule(const(char)* file, ref Strings libmodules, const ref Target ta
 
     /* Deduce what to do with a file based on its extension
         */
-    if (FileName.equals(ext, target.obj_ext))
+    if (FileName.equals(ext, "obj") || FileName.equals(ext, "o"))
     {
         global.params.objfiles.push(file);
         libmodules.push(file);


### PR DESCRIPTION
Proposal to discuss
Explanation: https://github.com/ldc-developers/ldc/issues/4733

This patch makes DMD behave the same as clang and maybe all other modern compilers. Seems, there is no point in discarding *.o or *.obj depending on current OS - both extensions point us that this is object file