### PR TITLE
Use selective imports when importing platform-specific modules (core.sys)

### DIFF
--- a/druntime/dub.sdl
+++ b/druntime/dub.sdl
@@ -6,3 +6,9 @@ copyright "Copyright © 1999-2018, The D Language Foundation"
 
 targetType "library"
 targetPath "generated"
+
+#dflags "-target=x86_64-linux"
+#dflags "-target=x86_64-freebsd14"
+#dflags "-target=x86_64-openbsd"
+#dflags "-target=x86_64-dragonfly"
+#dflags "-target=x86_64-darwin"

--- a/druntime/dub.sdl
+++ b/druntime/dub.sdl
@@ -6,9 +6,3 @@ copyright "Copyright © 1999-2018, The D Language Foundation"
 
 targetType "library"
 targetPath "generated"
-
-#dflags "-target=x86_64-linux"
-#dflags "-target=x86_64-freebsd14"
-#dflags "-target=x86_64-openbsd"
-#dflags "-target=x86_64-dragonfly"
-#dflags "-target=x86_64-darwin"

--- a/druntime/src/core/internal/atomic.d
+++ b/druntime/src/core/internal/atomic.d
@@ -10,7 +10,7 @@
 
 module core.internal.atomic;
 
-import core.atomic : MemoryOrder, has128BitCAS;
+import core.atomic : has128BitCAS, MemoryOrder;
 
 version (DigitalMars)
 {
@@ -912,7 +912,7 @@ else version (GNU)
         {
             static if (GNU_Thread_Model == ThreadModel.Posix)
             {
-                import core.sys.posix.pthread;
+                import core.sys.posix.sys.types : pthread_mutex_t, pthread_mutexattr_t;
                 alias atomicMutexHandle = pthread_mutex_t;
 
                 pragma(mangle, "pthread_mutex_init") int fakePureMutexInit(pthread_mutex_t*, pthread_mutexattr_t*);
@@ -921,7 +921,7 @@ else version (GNU)
             }
             else static if (GNU_Thread_Model == ThreadModel.Win32)
             {
-                import core.sys.windows.winbase;
+                import core.sys.windows.winbase : CRITICAL_SECTION;
                 alias atomicMutexHandle = CRITICAL_SECTION;
 
                 pragma(mangle, "InitializeCriticalSection") int fakePureMutexInit(CRITICAL_SECTION*);

--- a/druntime/src/core/internal/backtrace/elf.d
+++ b/druntime/src/core/internal/backtrace/elf.d
@@ -13,27 +13,27 @@ module core.internal.backtrace.elf;
 
 version (linux)
 {
-    import core.sys.linux.elf;
+    import core.sys.linux.elf : SHF_COMPRESSED, ET_DYN;
     version = LinuxOrBSD;
 }
 else version (FreeBSD)
 {
-    import core.sys.freebsd.sys.elf;
+    import core.sys.freebsd.sys.elf : SHF_COMPRESSED, ET_DYN;
     version = LinuxOrBSD;
 }
 else version (DragonFlyBSD)
 {
-    import core.sys.dragonflybsd.sys.elf;
+    import core.sys.dragonflybsd.sys.elf : SHF_COMPRESSED, ET_DYN;
     version = LinuxOrBSD;
 }
 else version (OpenBSD)
 {
-    import core.sys.openbsd.sys.elf;
+    import core.sys.openbsd.sys.elf : SHF_COMPRESSED, ET_DYN;
     version = LinuxOrBSD;
 }
 else version (Solaris)
 {
-    import core.sys.solaris.sys.elf;
+    import core.sys.solaris.sys.elf : SHF_COMPRESSED, ET_DYN;
     version = LinuxOrBSD;
 }
 

--- a/druntime/src/core/internal/backtrace/handler.d
+++ b/druntime/src/core/internal/backtrace/handler.d
@@ -26,7 +26,7 @@ version (DRuntime_Use_Libunwind):
 import core.internal.backtrace.dwarf;
 import core.internal.backtrace.libunwind;
 import core.stdc.string;
-import core.sys.posix.dlfcn;
+import core.sys.posix.dlfcn : Dl_info, dladdr;
 
 /// Ditto
 class LibunwindHandler : Throwable.TraceInfo

--- a/druntime/src/core/internal/backtrace/macho.d
+++ b/druntime/src/core/internal/backtrace/macho.d
@@ -20,9 +20,8 @@ else version (WatchOS)
 version (Darwin):
 
 import core.stdc.config : c_ulong;
-import core.sys.darwin.crt_externs;
-import core.sys.darwin.mach.getsect;
-import core.sys.darwin.mach.loader;
+import core.sys.darwin.crt_externs : _NSGetMachExecuteHeader;
+import core.sys.darwin.mach.getsect : mach_header_64, getsectiondata;
 
 struct Image
 {

--- a/druntime/src/core/internal/elf/dl.d
+++ b/druntime/src/core/internal/elf/dl.d
@@ -13,32 +13,32 @@ module core.internal.elf.dl;
 
 version (linux)
 {
-    import core.sys.linux.link;
+    import core.sys.linux.link : dl_iterate_phdr, dl_phdr_info, ElfW;
     version = LinuxOrBSD;
 }
 else version (FreeBSD)
 {
-    import core.sys.freebsd.sys.link_elf;
+    import core.sys.freebsd.sys.link_elf : _rtld_addr_phdr, dl_iterate_phdr, dl_phdr_info, ElfW;
     version = LinuxOrBSD;
 }
 else version (DragonFlyBSD)
 {
-    import core.sys.dragonflybsd.sys.link_elf;
+    import core.sys.dragonflybsd.sys.link_elf : _rtld_addr_phdr, dl_iterate_phdr, dl_phdr_info, ElfW;
     version = LinuxOrBSD;
 }
 else version (NetBSD)
 {
-    import core.sys.netbsd.sys.link_elf;
+    import core.sys.netbsd.sys.link_elf : dl_iterate_phdr, dl_phdr_info, ElfW;
     version = LinuxOrBSD;
 }
 else version (OpenBSD)
 {
-    import core.sys.openbsd.sys.link_elf;
+    import core.sys.openbsd.sys.link_elf : dl_iterate_phdr, dl_phdr_info, ElfW;
     version = LinuxOrBSD;
 }
 else version (Solaris)
 {
-    import core.sys.solaris.link;
+    import core.sys.solaris.link : dl_iterate_phdr, dl_phdr_info, ElfW;
     version = LinuxOrBSD;
 }
 
@@ -146,7 +146,9 @@ struct SharedObject
     char[] getPath(size_t N)(ref char[N] buffer) const
     if (N > 1)
     {
-        import core.stdc.stdio, core.stdc.string, core.sys.posix.unistd;
+        import core.stdc.stdio;
+        import core.stdc.string;
+        import core.sys.posix.unistd : getpid;
 
         char[N + 128] lineBuffer = void;
 
@@ -219,7 +221,7 @@ version (Linux_Use_GNU)
 {
     const(char)* getprogname()
     {
-        import core.sys.linux.errno;
+        import core.sys.linux.errno : program_invocation_name;
         return program_invocation_name;
     }
 }

--- a/druntime/src/core/internal/elf/io.d
+++ b/druntime/src/core/internal/elf/io.d
@@ -13,41 +13,41 @@ module core.internal.elf.io;
 
 version (Posix):
 
-import core.memory : pageSize;
 import core.lifetime : move;
-import core.stdc.stdlib : malloc, free;
-import core.sys.posix.fcntl;
-import core.sys.posix.sys.mman;
-import core.sys.posix.unistd;
+import core.memory : pageSize;
+import core.stdc.stdlib : free, malloc;
+import core.sys.posix.fcntl : O_RDONLY, open;
+import core.sys.posix.sys.mman : MAP_FAILED, MAP_PRIVATE, mmap, munmap, PROT_READ;
+import core.sys.posix.unistd : close, lseek, readlink;
 
 version (linux)
 {
-    import core.sys.linux.link;
+    import core.sys.linux.link : ElfW;
     version = LinuxOrBSD;
 }
 else version (FreeBSD)
 {
-    import core.sys.freebsd.sys.link_elf;
+    import core.sys.freebsd.sys.link_elf : ElfW;
     version = LinuxOrBSD;
 }
 else version (DragonFlyBSD)
 {
-    import core.sys.dragonflybsd.sys.link_elf;
+    import core.sys.dragonflybsd.sys.link_elf : ElfW;
     version = LinuxOrBSD;
 }
 else version (NetBSD)
 {
-    import core.sys.netbsd.sys.link_elf;
+    import core.sys.netbsd.sys.link_elf : ElfW;
     version = LinuxOrBSD;
 }
 else version (OpenBSD)
 {
-    import core.sys.openbsd.sys.link_elf;
+    import core.sys.openbsd.sys.link_elf : ElfW;
     version = LinuxOrBSD;
 }
 else version (Solaris)
 {
-    import core.sys.solaris.link;
+    import core.sys.solaris.link : ElfW;
     version = LinuxOrBSD;
 }
 
@@ -374,9 +374,6 @@ private struct MMapRegion
 
 @nogc nothrow:
 
-version (OpenBSD)
-private extern(C) const(char)* getprogname();
-
 /// Returns the path to the process' executable as newly allocated C string
 /// (free() when done), or null on error.
 version (LinuxOrBSD)
@@ -403,23 +400,24 @@ char* thisExePath()
     {
         // there's apparently no proper way :/
         import core.stdc.string : strdup;
+        import core.sys.openbsd.stdlib : getprogname;
         return strdup(getprogname());
     }
     else
     {
         version (DragonFlyBSD)
         {
-            import core.sys.dragonflybsd.sys.sysctl : sysctl, CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME;
+            import core.sys.dragonflybsd.sys.sysctl : CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, sysctl;
             int[4] mib = [CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1];
         }
         else version (FreeBSD)
         {
-            import core.sys.freebsd.sys.sysctl : sysctl, CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME;
+            import core.sys.freebsd.sys.sysctl : CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, sysctl;
             int[4] mib = [CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1];
         }
         else version (NetBSD)
         {
-            import core.sys.netbsd.sys.sysctl : sysctl, CTL_KERN, KERN_PROC_ARGS, KERN_PROC_PATHNAME;
+            import core.sys.netbsd.sys.sysctl : CTL_KERN, KERN_PROC_ARGS, KERN_PROC_PATHNAME, sysctl;
             int[4] mib = [CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME];
         }
         else

--- a/druntime/src/core/internal/execinfo.d
+++ b/druntime/src/core/internal/execinfo.d
@@ -50,24 +50,24 @@ else version (ExtExecinfo_SolarisFmt)
 version (linux)
 {
     version (CRuntime_Glibc)
-        import _execinfo = core.sys.linux.execinfo;
+        import _execinfo = core.sys.linux.execinfo : backtrace, backtrace_symbols, backtrace_symbols_fd;
     else version (CRuntime_UClibc)
-        import _execinfo = core.sys.linux.execinfo;
+        import _execinfo = core.sys.linux.execinfo : backtrace, backtrace_symbols, backtrace_symbols_fd;
     else version (_extExecinfo)
-        import _execinfo = core.sys.linux.execinfo;
+        import _execinfo = core.sys.linux.execinfo : backtrace, backtrace_symbols, backtrace_symbols_fd;
 }
 else version (Darwin)
-    import _execinfo = core.sys.darwin.execinfo;
+    import _execinfo = core.sys.darwin.execinfo : backtrace, backtrace_symbols, backtrace_symbols_fd;
 else version (FreeBSD)
-    import _execinfo = core.sys.freebsd.execinfo;
+    import _execinfo = core.sys.freebsd.execinfo : backtrace, backtrace_symbols, backtrace_symbols_fd;
 else version (NetBSD)
-    import _execinfo = core.sys.netbsd.execinfo;
+    import _execinfo = core.sys.netbsd.execinfo : backtrace, backtrace_symbols, backtrace_symbols_fd;
 else version (OpenBSD)
-    import _execinfo = core.sys.openbsd.execinfo;
+    import _execinfo = core.sys.openbsd.execinfo : backtrace, backtrace_symbols, backtrace_symbols_fd;
 else version (DragonFlyBSD)
-    import _execinfo = core.sys.dragonflybsd.execinfo;
+    import _execinfo = core.sys.dragonflybsd.execinfo : backtrace, backtrace_symbols, backtrace_symbols_fd;
 else version (Solaris)
-    import _execinfo = core.sys.solaris.execinfo;
+    import _execinfo = core.sys.solaris.execinfo : backtrace, backtrace_symbols, backtrace_symbols_fd;
 
 /// Indicates the availability of backtrace functions
 enum bool hasExecinfo = is(_execinfo == module);

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -3575,7 +3575,7 @@ Lmark:
 
         version (Posix)
         {
-            import core.sys.posix.signal;
+            import core.sys.posix.signal : pthread_sigmask, SIG_BLOCK, SIG_SETMASK, sigfillset, sigset_t;
             // block all signals, scanBackground inherits this mask.
             // see https://issues.dlang.org/show_bug.cgi?id=20256
             sigset_t new_mask, old_mask;

--- a/druntime/src/core/internal/gc/os.d
+++ b/druntime/src/core/internal/gc/os.d
@@ -33,8 +33,8 @@ else version (Posix)
     else version (WatchOS)
         version = Darwin;
 
-    import core.sys.posix.sys.mman;
     import core.stdc.stdlib;
+    import core.sys.posix.sys.mman : MAP_ANON, MAP_FAILED, MAP_PRIVATE, MAP_SHARED, mmap, munmap, PROT_READ, PROT_WRITE;
 
 
     /// Possible results for the wait_pid() function.
@@ -74,9 +74,9 @@ else version (Posix)
         return ChildStatus.done;
     }
 
-    public import core.sys.posix.unistd: pid_t, fork;
-    import core.sys.posix.sys.wait: waitpid, WNOHANG;
-    import core.stdc.errno: errno, EINTR, ECHILD;
+    public import core.sys.posix.unistd : fork, pid_t;
+    import core.stdc.errno : ECHILD, EINTR, errno;
+    import core.sys.posix.sys.wait : waitpid, WNOHANG;
 
     //version = GC_Use_Alloc_MMap;
 }
@@ -292,12 +292,18 @@ else version (Posix)
 {
     ulong os_physical_mem(bool avail) nothrow @nogc
     {
-        import core.sys.posix.unistd;
+        static import core.sys.posix.unistd;
+        import core.sys.posix.unistd : _SC_PAGESIZE, _SC_PHYS_PAGES, sysconf;
         const pageSize = sysconf(_SC_PAGESIZE);
-        static if (__traits(compiles, _SC_AVPHYS_PAGES)) // not available on all platforms
+        static if (__traits(compiles, core.sys.posix.unistd._SC_AVPHYS_PAGES)) // not available on all platforms
+        {
+            import core.sys.posix.unistd : _SC_AVPHYS_PAGES;
             const sc = avail ? _SC_AVPHYS_PAGES : _SC_PHYS_PAGES;
+        }
         else
+        {
             const sc = _SC_PHYS_PAGES;
+        }
         const pages = sysconf(sc);
         return pageSize * pages;
     }

--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -1167,7 +1167,7 @@ extern (C) private @system @nogc nothrow
 {
     ref int fakePureErrnoImpl()
     {
-        import core.stdc.errno;
+        import core.stdc.errno : errno;
         return errno();
     }
 }

--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -1167,7 +1167,7 @@ extern (C) private @system @nogc nothrow
 {
     ref int fakePureErrnoImpl()
     {
-        import core.stdc.errno : errno;
+        import core.stdc.errno;
         return errno();
     }
 }

--- a/druntime/src/core/runtime.d
+++ b/druntime/src/core/runtime.d
@@ -564,7 +564,9 @@ extern (C) UnitTestResult runModuleUnitTests()
 
     static if (hasExecinfo)
     {
-        import core.sys.posix.signal; // segv handler
+        // segv handler
+        import core.sys.posix.signal : SA_RESETHAND, SA_SIGINFO, sigaction, sigaction_t, SIGBUS, sigfillset, siginfo_t,
+            SIGSEGV;
 
         static extern (C) void unittestSegvHandler( int signum, siginfo_t* info, void* ptr ) nothrow
         {

--- a/druntime/src/core/sync/condition.d
+++ b/druntime/src/core/sync/condition.d
@@ -35,10 +35,11 @@ version (Windows)
 }
 else version (Posix)
 {
-    import core.sync.config;
     import core.stdc.errno;
-    import core.sys.posix.pthread;
-    import core.sys.posix.time;
+    import core.sync.config;
+    import core.sys.posix.pthread : pthread_cond_broadcast, pthread_cond_destroy, pthread_cond_init,
+        pthread_cond_signal, pthread_cond_t, pthread_cond_timedwait, pthread_cond_wait;
+    import core.sys.posix.time : CLOCK_MONOTONIC, timespec;
 }
 else
 {
@@ -127,8 +128,11 @@ class Condition
             {
                 m_assocMutex = m;
             }
-            static if ( is( typeof( pthread_condattr_setclock ) ) )
+            static if ( is( typeof( imported!"core.sys.posix.pthread".pthread_condattr_setclock ) ) )
             {
+                import core.sys.posix.pthread : pthread_condattr_destroy, pthread_condattr_init,
+                    pthread_condattr_setclock;
+                import core.sys.posix.sys.types : pthread_condattr_t;
                 () @trusted
                 {
                     pthread_condattr_t attr = void;
@@ -620,9 +624,9 @@ private:
 
 unittest
 {
-    import core.thread;
     import core.sync.mutex;
     import core.sync.semaphore;
+    import core.thread;
 
 
     void testNotify()
@@ -786,9 +790,9 @@ unittest
 
 unittest
 {
-    import core.thread;
     import core.sync.mutex;
     import core.sync.semaphore;
+    import core.thread;
 
 
     void testNotify()

--- a/druntime/src/core/sync/condition.d
+++ b/druntime/src/core/sync/condition.d
@@ -39,7 +39,7 @@ else version (Posix)
     import core.sync.config;
     import core.sys.posix.pthread : pthread_cond_broadcast, pthread_cond_destroy, pthread_cond_init,
         pthread_cond_signal, pthread_cond_t, pthread_cond_timedwait, pthread_cond_wait;
-    import core.sys.posix.time : CLOCK_MONOTONIC, timespec;
+    import core.sys.posix.time : timespec;
 }
 else
 {
@@ -133,6 +133,7 @@ class Condition
                 import core.sys.posix.pthread : pthread_condattr_destroy, pthread_condattr_init,
                     pthread_condattr_setclock;
                 import core.sys.posix.sys.types : pthread_condattr_t;
+                import core.sys.posix.time : CLOCK_MONOTONIC;
                 () @trusted
                 {
                     pthread_condattr_t attr = void;

--- a/druntime/src/core/sync/config.d
+++ b/druntime/src/core/sync/config.d
@@ -19,7 +19,7 @@ module core.sync.config;
 version (Posix)
 {
     import core.sys.posix.sys.time : gettimeofday, timeval;
-    import core.sys.posix.time : clock_gettime, CLOCK_MONOTONIC, timespec;
+    import core.sys.posix.time : timespec;
     import core.time;
 
 
@@ -27,6 +27,7 @@ version (Posix)
     {
         static if ( is (typeof ( imported!"core.sys.posix.pthread".pthread_condattr_setclock ) ) )
         {
+            import core.sys.posix.time : clock_gettime, CLOCK_MONOTONIC;
             clock_gettime( CLOCK_MONOTONIC, &t );
         }
         else

--- a/druntime/src/core/sync/config.d
+++ b/druntime/src/core/sync/config.d
@@ -18,15 +18,14 @@ module core.sync.config;
 
 version (Posix)
 {
-    import core.sys.posix.pthread;
-    import core.sys.posix.time;
-    import core.sys.posix.sys.time;
+    import core.sys.posix.sys.time : gettimeofday, timeval;
+    import core.sys.posix.time : clock_gettime, CLOCK_MONOTONIC, timespec;
     import core.time;
 
 
     void mktspec( ref timespec t ) nothrow @nogc
     {
-        static if ( is (typeof ( pthread_condattr_setclock ) ) )
+        static if ( is (typeof ( imported!"core.sys.posix.pthread".pthread_condattr_setclock ) ) )
         {
             clock_gettime( CLOCK_MONOTONIC, &t );
         }

--- a/druntime/src/core/sync/mutex.d
+++ b/druntime/src/core/sync/mutex.d
@@ -26,7 +26,10 @@ version (Windows)
 }
 else version (Posix)
 {
-    import core.sys.posix.pthread;
+    import core.sys.posix.pthread : pthread_mutex_destroy, pthread_mutex_init, pthread_mutex_lock,
+        PTHREAD_MUTEX_RECURSIVE, pthread_mutex_trylock, pthread_mutex_unlock, pthread_mutexattr_destroy,
+        pthread_mutexattr_init, pthread_mutexattr_settype;
+    import core.sys.posix.sys.types : pthread_mutex_t, pthread_mutexattr_t;
 }
 else
 {
@@ -344,8 +347,8 @@ unittest
 // Test @nogc usage.
 @system @nogc nothrow unittest
 {
-    import core.stdc.stdlib : malloc, free;
     import core.lifetime : emplace;
+    import core.stdc.stdlib : free, malloc;
 
     auto mtx = cast(shared Mutex) malloc(__traits(classInstanceSize, Mutex));
     emplace(mtx);

--- a/druntime/src/core/sync/rwmutex.d
+++ b/druntime/src/core/sync/rwmutex.d
@@ -21,11 +21,6 @@ import core.sync.condition;
 import core.sync.mutex;
 import core.memory;
 
-version (Posix)
-{
-    import core.sys.posix.pthread;
-}
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // ReadWriteMutex

--- a/druntime/src/core/sync/semaphore.d
+++ b/druntime/src/core/sync/semaphore.d
@@ -37,17 +37,17 @@ version (Windows)
 }
 else version (Darwin)
 {
-    import core.sync.config;
     import core.stdc.errno;
-    import core.sys.posix.time;
+    import core.sync.config;
     import core.sys.darwin.mach.semaphore;
+    import core.sys.posix.time;
 }
 else version (Posix)
 {
-    import core.sync.config;
     import core.stdc.errno;
-    import core.sys.posix.pthread;
-    import core.sys.posix.semaphore;
+    import core.sync.config;
+    import core.sys.posix.semaphore : sem_destroy, sem_init, sem_post, sem_t, sem_timedwait, sem_trywait, sem_wait;
+    import core.sys.posix.time : timespec;
 }
 else
 {
@@ -364,7 +364,8 @@ protected:
 
 unittest
 {
-    import core.thread, core.atomic;
+    import core.atomic;
+    import core.thread;
 
     void testWait()
     {

--- a/druntime/src/core/sync/semaphore.d
+++ b/druntime/src/core/sync/semaphore.d
@@ -39,15 +39,16 @@ else version (Darwin)
 {
     import core.stdc.errno;
     import core.sync.config;
-    import core.sys.darwin.mach.semaphore;
-    import core.sys.posix.time;
+    import core.sys.darwin.mach.kern_return : KERN_ABORTED, KERN_OPERATION_TIMED_OUT;
+    import core.sys.darwin.mach.semaphore : mach_task_self, mach_timespec_t, semaphore_create, semaphore_destroy,
+        semaphore_signal, semaphore_t, semaphore_timedwait, semaphore_wait, SYNC_POLICY_FIFO;
 }
 else version (Posix)
 {
     import core.stdc.errno;
     import core.sync.config;
     import core.sys.posix.semaphore : sem_destroy, sem_init, sem_post, sem_t, sem_timedwait, sem_trywait, sem_wait;
-    import core.sys.posix.time : timespec;
+    import core.sys.posix.time : clock_gettime, CLOCK_REALTIME, timespec;
 }
 else
 {
@@ -253,8 +254,6 @@ class Semaphore
         }
         else version (Posix)
         {
-            import core.sys.posix.time : clock_gettime, CLOCK_REALTIME;
-
             timespec t = void;
             clock_gettime( CLOCK_REALTIME, &t );
             mvtspec( t, period );

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -105,7 +105,10 @@ else version (Posix)
 
     version (Darwin)
     {
-        import core.sys.darwin.mach.thread_act;
+        import core.sys.darwin.mach.kern_return : KERN_SUCCESS;
+        import core.sys.darwin.mach.port : mach_port_t;
+        import core.sys.darwin.mach.thread_act : mach_msg_type_number_t, thread_get_state, thread_resume,
+            thread_suspend, x86_THREAD_STATE64, x86_THREAD_STATE64_COUNT, x86_thread_state64_t;
         import core.sys.darwin.pthread : pthread_mach_thread_np;
     }
 }
@@ -113,8 +116,8 @@ else version (Posix)
 version (Solaris)
 {
     import core.sys.posix.sys.wait : idtype_t;
-    import core.sys.solaris.sys.priocntl;
-    import core.sys.solaris.sys.types;
+    import core.sys.solaris.sys.priocntl : PC_CLNULL, PC_GETCLINFO, PC_GETPARMS, PC_SETPARMS, pcinfo_t, pcparms_t, priocntl;
+    import core.sys.solaris.sys.types : P_MYID, pri_t;
 }
 
 version (GNU)
@@ -1426,7 +1429,7 @@ private extern(D) void* getStackBottom() nothrow @nogc
     }
     else version (Darwin)
     {
-        import core.sys.darwin.pthread;
+        import core.sys.darwin.pthread : pthread_get_stackaddr_np;
         return pthread_get_stackaddr_np(pthread_self());
     }
     else version (PThread_Getattr_NP)

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -93,12 +93,12 @@ else version (Posix)
     static import core.sys.posix.pthread;
     static import core.sys.posix.signal;
     import core.stdc.errno;
-    import core.sys.posix.pthread : pthread_attr_destroy, pthread_attr_getstack, pthread_attr_init,
+    import core.sys.posix.pthread : pthread_atfork, pthread_attr_destroy, pthread_attr_getstack, pthread_attr_init,
         pthread_attr_setstacksize, pthread_create, pthread_detach, pthread_getschedparam, pthread_join, pthread_self,
         pthread_setschedparam, sched_get_priority_max, sched_get_priority_min, sched_param, sched_yield;
     import core.sys.posix.semaphore : sem_init, sem_post, sem_t, sem_wait;
-    import core.sys.posix.signal : pthread_kill, sigaction, sigaction_t, sigdelset, sigfillset, SIGRTMAX, SIGRTMIN,
-        sigset_t, sigsuspend;
+    import core.sys.posix.signal : pthread_kill, sigaction, sigaction_t, sigdelset, sigfillset, sigset_t, sigsuspend,
+        SIGUSR1, stack_t;
     import core.sys.posix.stdlib : free, malloc, realloc;
     import core.sys.posix.sys.types : pthread_attr_t, pthread_key_t, pthread_t;
     import core.sys.posix.time : nanosleep, timespec;
@@ -1906,6 +1906,10 @@ extern (C) void thread_init() @nogc nothrow
             enum SIGRTMIN = SIGUSR1;
             enum SIGRTMAX = 32;
         }
+        else
+        {
+            import core.sys.posix.signal : SIGRTMAX, SIGRTMIN;
+        }
 
         if ( suspendSignalNumber == 0 )
         {
@@ -2372,10 +2376,9 @@ private
     // Note: if the DLL is never unloaded, process termination kills all threads
     // and signals their handles before unconditionally calling DllMain(DLL_PROCESS_DETACH).
 
-    import core.sys.windows.winbase : FreeLibraryAndExitThread, GetModuleHandleExW,
-        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
-    import core.sys.windows.windef : HMODULE;
     import core.sys.windows.dll : dll_getRefCount;
+    import core.sys.windows.winbase : FreeLibraryAndExitThread, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, GetModuleHandleExW;
+    import core.sys.windows.windef : HMODULE;
 
     version (CRuntime_Microsoft)
         extern(C) extern __gshared ubyte msvcUsesUCRT; // from rt/msvc.d

--- a/druntime/src/core/thread/types.d
+++ b/druntime/src/core/thread/types.d
@@ -20,7 +20,7 @@ version (Windows)
 else
 version (Posix)
 {
-    import core.sys.posix.pthread;
+    import core.sys.posix.sys.types : pthread_t;
 
     alias ThreadID = pthread_t;
 }
@@ -55,7 +55,7 @@ shared static this()
 {
     version (Posix)
     {
-        import core.sys.posix.unistd;
+        import core.sys.posix.unistd : _SC_THREAD_STACK_MIN, sysconf;
 
         PTHREAD_STACK_MIN = cast(size_t)sysconf(_SC_THREAD_STACK_MIN);
     }

--- a/druntime/src/core/time.d
+++ b/druntime/src/core/time.d
@@ -100,7 +100,7 @@ else version (Posix)
 version (Darwin)
 {
 
-public import core.sys.darwin.mach.kern_return;
+import core.sys.darwin.mach.kern_return : kern_return_t;
 
 extern(C) nothrow @nogc
 {

--- a/druntime/src/core/time.d
+++ b/druntime/src/core/time.d
@@ -66,9 +66,9 @@
 module core.time;
 
 import core.exception;
-import core.stdc.time;
-import core.stdc.stdio;
 import core.internal.string;
+import core.stdc.stdio;
+import core.stdc.time;
 
 version (Windows)
 {
@@ -76,8 +76,8 @@ import core.sys.windows.winbase /+: QueryPerformanceCounter, QueryPerformanceFre
 }
 else version (Posix)
 {
-import core.sys.posix.time;
-import core.sys.posix.sys.time;
+import core.sys.posix.sys.time : gettimeofday, timeval;
+import core.sys.posix.time : clock_getres, clock_gettime, CLOCK_MONOTONIC, timespec;
 }
 
 version (OSX)

--- a/druntime/src/core/time.d
+++ b/druntime/src/core/time.d
@@ -70,16 +70,6 @@ import core.internal.string;
 import core.stdc.stdio;
 import core.stdc.time;
 
-version (Windows)
-{
-import core.sys.windows.winbase /+: QueryPerformanceCounter, QueryPerformanceFrequency+/;
-}
-else version (Posix)
-{
-import core.sys.posix.sys.time : gettimeofday, timeval;
-import core.sys.posix.time : clock_getres, clock_gettime, CLOCK_MONOTONIC, timespec;
-}
-
 version (OSX)
     version = Darwin;
 else version (iOS)
@@ -88,6 +78,22 @@ else version (TVOS)
     version = Darwin;
 else version (WatchOS)
     version = Darwin;
+
+version (Windows)
+{
+    import core.sys.windows.winbase /+: QueryPerformanceCounter, QueryPerformanceFrequency+/;
+}
+else version (Darwin)
+{
+    import core.sys.posix.sys.time : gettimeofday, timeval;
+    import core.sys.posix.time : timespec;
+}
+else version (Posix)
+{
+    import core.sys.posix.sys.time : gettimeofday, timeval;
+    import core.sys.posix.time : clock_getres, clock_gettime, CLOCK_MONOTONIC, timespec;
+}
+
 
 //This probably should be moved somewhere else in druntime which
 //is Darwin-specific.

--- a/druntime/src/etc/linux/memoryerror.d
+++ b/druntime/src/etc/linux/memoryerror.d
@@ -25,8 +25,8 @@ version (CRuntime_Glibc)
 version (MemoryErrorSupported):
 @system:
 
-import core.sys.posix.signal;
-import core.sys.posix.ucontext;
+import core.sys.posix.signal : SA_SIGINFO, sigaction, sigaction_t, siginfo_t, SIGSEGV;
+import ucontext = core.sys.posix.ucontext;
 
 // Register and unregister memory error handler.
 
@@ -121,7 +121,7 @@ private:
 
 __gshared sigaction_t old_sigaction;
 
-alias typeof(ucontext_t.init.uc_mcontext.gregs[0]) RegType;
+alias typeof(ucontext.ucontext_t.init.uc_mcontext.gregs[0]) RegType;
 
 version (X86_64)
 {
@@ -130,18 +130,18 @@ version (X86_64)
     extern(C)
     void handleSignal(int signum, siginfo_t* info, void* contextPtr) nothrow
     {
-        auto context = cast(ucontext_t*)contextPtr;
+        auto context = cast(ucontext.ucontext_t*)contextPtr;
 
         // Save registers into global thread local, to allow recovery.
-        savedRDI = context.uc_mcontext.gregs[REG_RDI];
-        savedRSI = context.uc_mcontext.gregs[REG_RSI];
+        savedRDI = context.uc_mcontext.gregs[ucontext.REG_RDI];
+        savedRSI = context.uc_mcontext.gregs[ucontext.REG_RSI];
 
         // Hijack current context so we call our handler.
-        auto rip = context.uc_mcontext.gregs[REG_RIP];
+        auto rip = context.uc_mcontext.gregs[ucontext.REG_RIP];
         auto addr = cast(RegType) info.si_addr;
-        context.uc_mcontext.gregs[REG_RDI] = addr;
-        context.uc_mcontext.gregs[REG_RSI] = rip;
-        context.uc_mcontext.gregs[REG_RIP] = cast(RegType) ((rip != addr)?&sigsegvDataHandler:&sigsegvCodeHandler);
+        context.uc_mcontext.gregs[ucontext.REG_RDI] = addr;
+        context.uc_mcontext.gregs[ucontext.REG_RSI] = rip;
+        context.uc_mcontext.gregs[ucontext.REG_RIP] = cast(RegType) ((rip != addr)?&sigsegvDataHandler:&sigsegvCodeHandler);
     }
 
     // All handler functions must be called with faulting address in RDI and original RIP in RSI.
@@ -227,7 +227,7 @@ else version (X86)
     extern(C)
     void handleSignal(int signum, siginfo_t* info, void* contextPtr) nothrow
     {
-        auto context = cast(ucontext_t*)contextPtr;
+        auto context = cast(ucontext.ucontext_t*)contextPtr;
 
         // Save registers into global thread local, to allow recovery.
         savedEAX = context.uc_mcontext.gregs[REG_EAX];

--- a/druntime/src/etc/linux/memoryerror.d
+++ b/druntime/src/etc/linux/memoryerror.d
@@ -230,15 +230,15 @@ else version (X86)
         auto context = cast(ucontext.ucontext_t*)contextPtr;
 
         // Save registers into global thread local, to allow recovery.
-        savedEAX = context.uc_mcontext.gregs[REG_EAX];
-        savedEDX = context.uc_mcontext.gregs[REG_EDX];
+        savedEAX = context.uc_mcontext.gregs[ucontext.REG_EAX];
+        savedEDX = context.uc_mcontext.gregs[ucontext.REG_EDX];
 
         // Hijack current context so we call our handler.
-        auto eip = context.uc_mcontext.gregs[REG_EIP];
+        auto eip = context.uc_mcontext.gregs[ucontext.REG_EIP];
         auto addr = cast(RegType) info.si_addr;
-        context.uc_mcontext.gregs[REG_EAX] = addr;
-        context.uc_mcontext.gregs[REG_EDX] = eip;
-        context.uc_mcontext.gregs[REG_EIP] = cast(RegType) ((eip != addr)?&sigsegvDataHandler:&sigsegvCodeHandler);
+        context.uc_mcontext.gregs[ucontext.REG_EAX] = addr;
+        context.uc_mcontext.gregs[ucontext.REG_EDX] = eip;
+        context.uc_mcontext.gregs[ucontext.REG_EIP] = cast(RegType) ((eip != addr)?&sigsegvDataHandler:&sigsegvCodeHandler);
     }
 
     // All handler functions must be called with faulting address in EAX and original EIP in EDX.

--- a/druntime/src/rt/cover.d
+++ b/druntime/src/rt/cover.d
@@ -11,7 +11,7 @@
 
 module rt.cover;
 
-import core.internal.util.math : min, max;
+import core.internal.util.math : max, min;
 
 private
 {
@@ -22,13 +22,13 @@ private
     }
     else version (Posix)
     {
-        import core.sys.posix.fcntl;
-        import core.sys.posix.unistd;
+        import core.sys.posix.fcntl : O_CREAT, O_RDWR, open, S_IRGRP, S_IROTH, S_IRUSR, S_IWGRP, S_IWOTH, S_IWUSR;
+        import core.sys.posix.unistd : F_LOCK, ftruncate, lockf;
     }
+    import core.internal.utf;
     import core.stdc.config : c_long;
     import core.stdc.stdio;
     import core.stdc.stdlib;
-    import core.internal.utf;
 
     struct BitArray
     {
@@ -467,7 +467,7 @@ FILE* openOrCreateFile(string name)
     version (CRuntime_Microsoft)
         alias fdopen = _fdopen;
     version (Posix)
-        import core.sys.posix.stdio;
+        import core.sys.posix.stdio : fdopen;
     return fdopen(fd, "r+b");
 }
 

--- a/druntime/src/rt/monitor_.d
+++ b/druntime/src/rt/monitor_.d
@@ -185,7 +185,10 @@ version (Windows)
 }
 else version (Posix)
 {
-    import core.sys.posix.pthread;
+    import core.sys.posix.pthread : pthread_mutex_destroy, pthread_mutex_init, pthread_mutex_lock,
+        PTHREAD_MUTEX_RECURSIVE, pthread_mutex_unlock, pthread_mutexattr_destroy, pthread_mutexattr_init,
+        pthread_mutexattr_settype;
+    import core.sys.posix.sys.types : pthread_mutex_t, pthread_mutexattr_t;
 
 @nogc:
     alias Mutex = pthread_mutex_t;

--- a/druntime/src/rt/sections_darwin_64.d
+++ b/druntime/src/rt/sections_darwin_64.d
@@ -23,9 +23,14 @@ else version (WatchOS)
 version (Darwin):
 version (D_LP64):
 
-import core.sys.darwin.mach.dyld;
-import core.sys.darwin.mach.getsect;
-import core.sys.posix.pthread;
+import core.stdc.stdint : intptr_t, uintptr_t;
+import core.sys.darwin.mach.dyld : _dyld_get_image_header, _dyld_image_count;
+import core.sys.darwin.mach.getsect : getsectbynamefromheader_64, section_64;
+import core.sys.darwin.mach.loader : LC_SEGMENT_64, load_command, mach_header, mach_header_64, MH_MAGIC_64,
+    S_THREAD_LOCAL_VARIABLES, SECT_BSS, SECT_COMMON, SECT_DATA, SECTION_TYPE, SEG_DATA, segment_command_64,
+    tlv_descriptor;
+import core.sys.posix.pthread : pthread_getspecific;
+import core.sys.posix.sys.types : pthread_key_t;
 
 import rt.util.utility : safeAssert;
 

--- a/druntime/src/rt/sections_elf_shared.d
+++ b/druntime/src/rt/sections_elf_shared.d
@@ -30,42 +30,43 @@ import core.internal.elf.dl;
 import core.memory;
 import core.stdc.config;
 import core.stdc.stdio;
-import core.stdc.stdlib : calloc, exit, free, malloc, EXIT_FAILURE;
+import core.stdc.stdlib : calloc, exit, EXIT_FAILURE, free, malloc;
 import core.stdc.string : strlen;
 version (linux)
 {
-    import core.sys.linux.dlfcn;
-    import core.sys.linux.elf;
-    import core.sys.linux.link;
+    import core.sys.linux.dlfcn : Dl_info, dladdr, dlclose, dlinfo, dlopen, RTLD_DI_LINKMAP, RTLD_LAZY, RTLD_NOLOAD;
+    import core.sys.linux.elf : DT_AUXILIARY, DT_FILTER, DT_NEEDED, DT_STRTAB, PF_W, PF_X, PT_DYNAMIC, PT_LOAD, PT_TLS;
+    import core.sys.linux.link : ElfW, link_map;
 }
 else version (FreeBSD)
 {
-    import core.sys.freebsd.dlfcn;
-    import core.sys.freebsd.sys.elf;
-    import core.sys.freebsd.sys.link_elf;
+    import core.sys.freebsd.dlfcn : Dl_info, dladdr, dlclose, dlinfo, dlopen, RTLD_DI_LINKMAP, RTLD_LAZY, RTLD_NOLOAD;
+    import core.sys.freebsd.sys.elf : DT_AUXILIARY, DT_FILTER, DT_NEEDED, DT_STRTAB, PF_W, PF_X, PT_DYNAMIC, PT_LOAD, PT_TLS;
+    import core.sys.freebsd.sys.link_elf : ElfW, link_map;
 }
 else version (NetBSD)
 {
-    import core.sys.netbsd.dlfcn;
-    import core.sys.netbsd.sys.elf;
-    import core.sys.netbsd.sys.link_elf;
+    import core.sys.netbsd.dlfcn : Dl_info, dladdr, dlclose, dlinfo, dlopen, RTLD_DI_LINKMAP, RTLD_LAZY, RTLD_NOLOAD;
+    import core.sys.netbsd.sys.elf : DT_AUXILIARY, DT_FILTER, DT_NEEDED, DT_STRTAB, PF_W, PF_X, PT_DYNAMIC, PT_LOAD, PT_TLS;
+    import core.sys.netbsd.sys.link_elf : ElfW, link_map;
 }
 else version (DragonFlyBSD)
 {
-    import core.sys.dragonflybsd.dlfcn;
-    import core.sys.dragonflybsd.sys.elf;
-    import core.sys.dragonflybsd.sys.link_elf;
+    import core.sys.dragonflybsd.dlfcn : Dl_info, dladdr, dlclose, dlinfo, dlopen, RTLD_DI_LINKMAP, RTLD_LAZY, RTLD_NOLOAD;
+    import core.sys.dragonflybsd.sys.elf : DT_AUXILIARY, DT_FILTER, DT_NEEDED, DT_STRTAB, PF_W, PF_X, PT_DYNAMIC, PT_LOAD, PT_TLS;
+    import core.sys.dragonflybsd.sys.link_elf : ElfW, link_map;
 }
 else
 {
     static assert(0, "unimplemented");
 }
-import core.sys.posix.pthread;
+import core.internal.container.array;
+import core.internal.container.hashtab;
+import core.sys.posix.pthread : pthread_mutex_destroy, pthread_mutex_init, pthread_mutex_lock, pthread_mutex_unlock;
+import core.sys.posix.sys.types : pthread_mutex_t;
 import rt.deh;
 import rt.dmain2;
 import rt.minfo;
-import core.internal.container.array;
-import core.internal.container.hashtab;
 import rt.util.utility : safeAssert;
 
 alias DSO SectionGroup;

--- a/druntime/src/rt/sections_osx_x86.d
+++ b/druntime/src/rt/sections_osx_x86.d
@@ -24,13 +24,18 @@ version (Darwin):
 version (X86):
 
 // debug = PRINTF;
-import core.stdc.stdio;
-import core.stdc.string, core.stdc.stdlib;
-import core.sys.posix.pthread;
-import core.sys.darwin.mach.dyld;
-import core.sys.darwin.mach.getsect;
-import rt.deh, rt.minfo;
 import core.internal.container.array;
+import core.stdc.stdint : intptr_t;
+import core.stdc.stdio;
+import core.stdc.stdlib;
+import core.stdc.string;
+import core.sys.darwin.mach.dyld : _dyld_register_func_for_add_image;
+import core.sys.darwin.mach.getsect : getsectbynamefromheader;
+import core.sys.darwin.mach.loader : mach_header, MH_MAGIC, SECT_BSS, SECT_COMMON, SECT_DATA, SEG_DATA;
+import core.sys.posix.pthread : pthread_getspecific, pthread_key_create, pthread_key_delete, pthread_key_t,
+    pthread_setspecific;
+import rt.deh;
+import rt.minfo;
 
 struct SectionGroup
 {

--- a/druntime/src/rt/sections_osx_x86_64.d
+++ b/druntime/src/rt/sections_osx_x86_64.d
@@ -25,15 +25,16 @@ version (X86_64):
 
 // debug = PRINTF;
 import core.stdc.stdio;
-import core.stdc.string, core.stdc.stdlib;
-import core.sys.posix.pthread;
-import core.sys.darwin.mach.dyld;
-import core.sys.darwin.mach.getsect;
+import core.stdc.stdlib;
+import core.stdc.string;
+import core.stdc.stdint : intptr_t;
+import core.sys.darwin.mach.dyld : _dyld_register_func_for_add_image;
+import core.sys.darwin.mach.getsect : mach_header;
 
+import core.internal.container.array;
 import rt.deh;
 import rt.minfo;
 import rt.sections_darwin_64;
-import core.internal.container.array;
 import rt.util.utility : safeAssert;
 
 struct SectionGroup

--- a/druntime/test/shared/src/load.d
+++ b/druntime/test/shared/src/load.d
@@ -3,6 +3,13 @@ import core.stdc.stdio;
 import core.stdc.string;
 import core.thread;
 
+version (DragonFlyBSD) import core.sys.dragonflybsd.dlfcn : RTLD_NOLOAD;
+version (FreeBSD) import core.sys.freebsd.dlfcn : RTLD_NOLOAD;
+version (linux) import core.sys.linux.dlfcn : RTLD_NOLOAD;
+version (NetBSD) import core.sys.netbsd.dlfcn : RTLD_NOLOAD;
+version (OSX) import core.sys.darwin.dlfcn : RTLD_NOLOAD;
+version (Solaris) import core.sys.solaris.dlfcn : RTLD_NOLOAD;
+
 void* openLib(string s)
 {
     auto h = Runtime.loadLibrary(s);
@@ -138,7 +145,7 @@ void main(string[] args)
     }
     else
     {
-        import core.sys.posix.dlfcn : dlopen, RTLD_LAZY, RTLD_NOLOAD;
+        import core.sys.posix.dlfcn : dlopen, RTLD_LAZY;
         assert(dlopen(name.ptr, RTLD_LAZY | RTLD_NOLOAD) is null);
     }
     name = name[0 .. $-1];

--- a/druntime/test/shared/src/load.d
+++ b/druntime/test/shared/src/load.d
@@ -3,13 +3,6 @@ import core.stdc.stdio;
 import core.stdc.string;
 import core.thread;
 
-version (DragonFlyBSD) import core.sys.dragonflybsd.dlfcn : RTLD_NOLOAD;
-version (FreeBSD) import core.sys.freebsd.dlfcn : RTLD_NOLOAD;
-version (linux) import core.sys.linux.dlfcn : RTLD_NOLOAD;
-version (NetBSD) import core.sys.netbsd.dlfcn : RTLD_NOLOAD;
-version (OSX) import core.sys.darwin.dlfcn : RTLD_NOLOAD;
-version (Solaris) import core.sys.solaris.dlfcn : RTLD_NOLOAD;
-
 void* openLib(string s)
 {
     auto h = Runtime.loadLibrary(s);
@@ -145,7 +138,7 @@ void main(string[] args)
     }
     else
     {
-        import core.sys.posix.dlfcn;
+        import core.sys.posix.dlfcn : dlopen, RTLD_LAZY, RTLD_NOLOAD;
         assert(dlopen(name.ptr, RTLD_LAZY | RTLD_NOLOAD) is null);
     }
     name = name[0 .. $-1];

--- a/druntime/test/thread/src/external_threads.d
+++ b/druntime/test/thread/src/external_threads.d
@@ -1,5 +1,6 @@
-import core.sys.posix.pthread;
 import core.memory;
+import core.sys.posix.pthread : pthread_create, pthread_join;
+import core.sys.posix.sys.types : pthread_t;
 import core.thread;
 
 extern (C) void  rt_moduleTlsCtor();

--- a/druntime/test/thread/src/fiber_guard_page.d
+++ b/druntime/test/thread/src/fiber_guard_page.d
@@ -1,5 +1,5 @@
+import core.sys.posix.sys.mman : MAP_ANON, MAP_PRIVATE, mmap, PROT_READ, PROT_WRITE;
 import core.thread;
-import core.sys.posix.sys.mman;
 
 version (LDC) import ldc.attributes;
 else struct optStrategy { string a; }


### PR DESCRIPTION
### Why

This makes it easier to add support for new platforms to druntime, and maintain platform-specific differences in existing ones. It better reveals the actual dependencies of each module by avoiding implicit public imports.

### Progress

This is done for linux and most posix platforms.
Most imports for ~~darwin, solaris~~ and windows are still TODO.

### Future work

I'd also like to attempt this with `core.stdc`. That would (in combination with this pr) open up the possibility for developers working with a `Freestanding` platform to get parts of druntime to work without needing an entire supported libc, just specific functions.
Also, contrary to what druntime assumes, not every platform has concepts like a filesystem, stdio, processes... This could help in determining what modules have those features as hard dependencies, and what modules could also work without them on such platforms.