### PR TITLE
Print match level for ambiguous overloads

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1616,9 +1616,26 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
         const(char)* lastprms = parametersTypeToChars(tf1.parameterList);
         const(char)* nextprms = parametersTypeToChars(tf2.parameterList);
 
-        .error(loc, "`%s.%s` called with argument types `%s` matches both:\n%s:     `%s%s%s`\nand:\n%s:     `%s%s%s`",
+        string match = "";
+        final switch (m.last)
+        {
+            case MATCH.convert:
+                match = "after implicit conversions";
+                break;
+            case MATCH.constant:
+                match = "after qualifier conversion";
+                break;
+            case MATCH.exact:
+                match = "exactly";
+                break;
+            case MATCH.nomatch:
+                assert(0);
+        }
+
+        .error(loc, "`%s.%s` called with argument types `%s` matches multiple overloads %.*s:\n%s:     `%s%s%s`\nand:\n%s:     `%s%s%s`",
             s.parent.toPrettyChars(), s.ident.toChars(),
             fargsBuf.peekChars(),
+            match.fTuple.expand,
             m.lastf.loc.toChars(), m.lastf.toPrettyChars(), lastprms, tf1.modToChars(),
             m.nextf.loc.toChars(), m.nextf.toPrettyChars(), nextprms, tf2.modToChars());
         return null;

--- a/compiler/test/fail_compilation/bug19569.d
+++ b/compiler/test/fail_compilation/bug19569.d
@@ -1,51 +1,51 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug19569.d(70): Error: `bug19569.test0` called with argument types `()` matches both:
+fail_compilation/bug19569.d(70): Error: `bug19569.test0` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(56):     `bug19569.test0()`
 and:
 fail_compilation/bug19569.d(57):     `bug19569.test0()`
-fail_compilation/bug19569.d(71): Error: `bug19569.test1` called with argument types `()` matches both:
+fail_compilation/bug19569.d(71): Error: `bug19569.test1` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(59):     `bug19569.test1()`
 and:
 fail_compilation/bug19569.d(60):     `bug19569.test1()`
-fail_compilation/bug19569.d(72): Error: `bug19569.test2` called with argument types `()` matches both:
+fail_compilation/bug19569.d(72): Error: `bug19569.test2` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(62):     `bug19569.test2!().test2()`
 and:
 fail_compilation/bug19569.d(63):     `bug19569.test2!().test2()`
-fail_compilation/bug19569.d(73): Error: `bug19569.test3` called with argument types `()` matches both:
+fail_compilation/bug19569.d(73): Error: `bug19569.test3` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(65):     `bug19569.test3!().test3()`
 and:
 fail_compilation/bug19569.d(66):     `bug19569.test3!().test3()`
-fail_compilation/bug19569.d(78): Error: `bug19569.test0` called with argument types `()` matches both:
+fail_compilation/bug19569.d(78): Error: `bug19569.test0` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(56):     `bug19569.test0()`
 and:
 fail_compilation/bug19569.d(57):     `bug19569.test0()`
-fail_compilation/bug19569.d(79): Error: `bug19569.test1` called with argument types `()` matches both:
+fail_compilation/bug19569.d(79): Error: `bug19569.test1` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(59):     `bug19569.test1()`
 and:
 fail_compilation/bug19569.d(60):     `bug19569.test1()`
-fail_compilation/bug19569.d(80): Error: `bug19569.test2` called with argument types `()` matches both:
+fail_compilation/bug19569.d(80): Error: `bug19569.test2` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(62):     `bug19569.test2!().test2()`
 and:
 fail_compilation/bug19569.d(63):     `bug19569.test2!().test2()`
-fail_compilation/bug19569.d(81): Error: `bug19569.test3` called with argument types `()` matches both:
+fail_compilation/bug19569.d(81): Error: `bug19569.test3` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(65):     `bug19569.test3!().test3()`
 and:
 fail_compilation/bug19569.d(66):     `bug19569.test3!().test3()`
-fail_compilation/bug19569.d(86): Error: `bug19569.test0` called with argument types `()` matches both:
+fail_compilation/bug19569.d(86): Error: `bug19569.test0` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(56):     `bug19569.test0()`
 and:
 fail_compilation/bug19569.d(57):     `bug19569.test0()`
-fail_compilation/bug19569.d(87): Error: `bug19569.test1` called with argument types `()` matches both:
+fail_compilation/bug19569.d(87): Error: `bug19569.test1` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(59):     `bug19569.test1()`
 and:
 fail_compilation/bug19569.d(60):     `bug19569.test1()`
-fail_compilation/bug19569.d(88): Error: `bug19569.test2` called with argument types `()` matches both:
+fail_compilation/bug19569.d(88): Error: `bug19569.test2` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(62):     `bug19569.test2!().test2()`
 and:
 fail_compilation/bug19569.d(63):     `bug19569.test2!().test2()`
-fail_compilation/bug19569.d(89): Error: `bug19569.test3` called with argument types `()` matches both:
+fail_compilation/bug19569.d(89): Error: `bug19569.test3` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/bug19569.d(65):     `bug19569.test3!().test3()`
 and:
 fail_compilation/bug19569.d(66):     `bug19569.test3!().test3()`

--- a/compiler/test/fail_compilation/diag11769.d
+++ b/compiler/test/fail_compilation/diag11769.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11769.d(18): Error: `diag11769.foo!string.bar` called with argument types `(string)` matches both:
+fail_compilation/diag11769.d(18): Error: `diag11769.foo!string.bar` called with argument types `(string)` matches multiple overloads after implicit conversions:
 fail_compilation/diag11769.d(13):     `diag11769.foo!string.bar(wstring __param_0)`
 and:
 fail_compilation/diag11769.d(14):     `diag11769.foo!string.bar(dstring __param_0)`

--- a/compiler/test/fail_compilation/fail14554.d
+++ b/compiler/test/fail_compilation/fail14554.d
@@ -3,11 +3,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14554.d(28): Error: `fail14554.issue14554_1.foo` called with argument types `(int)` matches both:
+fail_compilation/fail14554.d(28): Error: `fail14554.issue14554_1.foo` called with argument types `(int)` matches multiple overloads exactly:
 fail_compilation/fail14554.d(17):     `fail14554.issue14554_1.foo!bool.foo(int j)`
 and:
 fail_compilation/fail14554.d(18):     `fail14554.issue14554_1.foo!bool.foo(int j)`
-fail_compilation/fail14554.d(29): Error: `fail14554.issue14554_2.foo` called with argument types `(int)` matches both:
+fail_compilation/fail14554.d(29): Error: `fail14554.issue14554_2.foo` called with argument types `(int)` matches multiple overloads exactly:
 fail_compilation/fail14554.d(22):     `fail14554.issue14554_2.foo!bool.foo(int j)`
 and:
 fail_compilation/fail14554.d(23):     `fail14554.issue14554_2.foo!bool.foo(int j)`

--- a/compiler/test/fail_compilation/fail16600.d
+++ b/compiler/test/fail_compilation/fail16600.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail16600.d(22): Error: `fail16600.S.__ctor` called with argument types `(string) const` matches both:
+fail_compilation/fail16600.d(22): Error: `fail16600.S.__ctor` called with argument types `(string) const` matches multiple overloads exactly:
 fail_compilation/fail16600.d(16):     `fail16600.S.this(string __param_0)`
 and:
 fail_compilation/fail16600.d(17):     `fail16600.S.this(string __param_0) immutable`

--- a/compiler/test/fail_compilation/fail19729.d
+++ b/compiler/test/fail_compilation/fail19729.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail19729.d(35): Error: `fail19729.C.__ctor` called with argument types `(string)` matches both:
+fail_compilation/fail19729.d(35): Error: `fail19729.C.__ctor` called with argument types `(string)` matches multiple overloads exactly:
 fail_compilation/fail19729.d(18):     `fail19729.C.Templ!string.this(string t)`
 and:
 fail_compilation/fail19729.d(18):     `fail19729.C.Templ!string.this(string t)`
-fail_compilation/fail19729.d(36): Error: `fail19729.D.__ctor` called with argument types `(string)` matches both:
+fail_compilation/fail19729.d(36): Error: `fail19729.D.__ctor` called with argument types `(string)` matches multiple overloads after qualifier conversion:
 fail_compilation/fail19729.d(18):     `fail19729.D.Templ!(const(char)[]).this(const(char)[] t)`
 and:
 fail_compilation/fail19729.d(18):     `fail19729.D.Templ!(const(char)*).this(const(char)* t)`

--- a/compiler/test/fail_compilation/fail22157.d
+++ b/compiler/test/fail_compilation/fail22157.d
@@ -3,11 +3,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22157.d(32): Error: `fail22157.S!true.S.foo` called with argument types `()` matches both:
+fail_compilation/fail22157.d(32): Error: `fail22157.S!true.S.foo` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/fail22157.d(21):     `fail22157.S!true.S.foo()`
 and:
 fail_compilation/fail22157.d(22):     `fail22157.S!true.S.foo()`
-fail_compilation/fail22157.d(33): Error: `fail22157.S!false.S.foo` called with argument types `()` matches both:
+fail_compilation/fail22157.d(33): Error: `fail22157.S!false.S.foo` called with argument types `()` matches multiple overloads exactly:
 fail_compilation/fail22157.d(26):     `fail22157.S!false.S.foo()`
 and:
 fail_compilation/fail22157.d(27):     `fail22157.S!false.S.foo()`

--- a/compiler/test/fail_compilation/fail23626b.d
+++ b/compiler/test/fail_compilation/fail23626b.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail23626b.d(26): Error: `fail23626b.AmbigOpApply.opApply` called with argument types `(int delegate(int i) pure nothrow @nogc @system)` matches both:
+fail_compilation/fail23626b.d(26): Error: `fail23626b.AmbigOpApply.opApply` called with argument types `(int delegate(int i) pure nothrow @nogc @system)` matches multiple overloads after qualifier conversion:
 fail_compilation/fail23626b.d(12):     `fail23626b.AmbigOpApply.opApply(int delegate(int) dg)`
 and:
 fail_compilation/fail23626b.d(17):     `fail23626b.AmbigOpApply.opApply(int delegate(int) dg)`

--- a/compiler/test/fail_compilation/fail8313.d
+++ b/compiler/test/fail_compilation/fail8313.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8313.d(13): Error: `fail8313.bar` called with argument types `(int)` matches both:
+fail_compilation/fail8313.d(13): Error: `fail8313.bar` called with argument types `(int)` matches multiple overloads exactly:
 fail_compilation/fail8313.d(11):     `fail8313.bar!().bar(int x)`
 and:
 fail_compilation/fail8313.d(12):     `fail8313.bar!().bar(int x)`

--- a/compiler/test/fail_compilation/fail8373.d
+++ b/compiler/test/fail_compilation/fail8373.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8373.d(21): Error: `fail8373.fun1` called with argument types `(int)` matches both:
+fail_compilation/fail8373.d(21): Error: `fail8373.fun1` called with argument types `(int)` matches multiple overloads exactly:
 fail_compilation/fail8373.d(15):     `fail8373.fun1!().fun1!int.fun1(int)`
 and:
 fail_compilation/fail8373.d(16):     `fail8373.fun1!int.fun1(int)`
-fail_compilation/fail8373.d(22): Error: `fail8373.fun2` called with argument types `(int)` matches both:
+fail_compilation/fail8373.d(22): Error: `fail8373.fun2` called with argument types `(int)` matches multiple overloads exactly:
 fail_compilation/fail8373.d(18):     `fail8373.fun2!int.fun2(int)`
 and:
 fail_compilation/fail8373.d(19):     `fail8373.fun2!().fun2!int.fun2(int)`

--- a/compiler/test/fail_compilation/fail_scope.d
+++ b/compiler/test/fail_compilation/fail_scope.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail_scope.d(43): Error: returning `cast(char[])string` escapes a reference to local variable `string`
 fail_compilation/fail_scope.d(61): Error: returning `s.bar()` escapes a reference to local variable `s`
-fail_compilation/fail_scope.d(72): Error: `fail_scope.foo8` called with argument types `(int)` matches both:
+fail_compilation/fail_scope.d(72): Error: `fail_scope.foo8` called with argument types `(int)` matches multiple overloads exactly:
 fail_compilation/fail_scope.d(66):     `fail_scope.foo8(ref int x)`
 and:
 fail_compilation/fail_scope.d(67):     `fail_scope.foo8(return ref int x)`

--- a/compiler/test/fail_compilation/named_arguments_overload.d
+++ b/compiler/test/fail_compilation/named_arguments_overload.d
@@ -7,7 +7,7 @@ fail_compilation/named_arguments_overload.d(18):                        `named_a
 fail_compilation/named_arguments_overload.d(34): Error: none of the overloads of `snoopy` are callable using argument types `(immutable(T), immutable(S))`
 fail_compilation/named_arguments_overload.d(17):        Candidates are: `named_arguments_overload.snoopy(S s, int i = 0, T t = T())`
 fail_compilation/named_arguments_overload.d(18):                        `named_arguments_overload.snoopy(T t, int i, S s)`
-fail_compilation/named_arguments_overload.d(35): Error: `named_arguments_overload.snoopy` called with argument types `(immutable(S), immutable(T), immutable(int))` matches both:
+fail_compilation/named_arguments_overload.d(35): Error: `named_arguments_overload.snoopy` called with argument types `(immutable(S), immutable(T), immutable(int))` matches multiple overloads after qualifier conversion:
 fail_compilation/named_arguments_overload.d(17):     `named_arguments_overload.snoopy(S s, int i = 0, T t = T())`
 and:
 fail_compilation/named_arguments_overload.d(18):     `named_arguments_overload.snoopy(T t, int i, S s)`

--- a/compiler/test/fail_compilation/pull12941.d
+++ b/compiler/test/fail_compilation/pull12941.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/pull12941.d(110): Error: `pull12941.foo` called with argument types `(int*)` matches both:
+fail_compilation/pull12941.d(110): Error: `pull12941.foo` called with argument types `(int*)` matches multiple overloads exactly:
 fail_compilation/pull12941.d(101):     `pull12941.foo(return ref scope int* p)`
 and:
 fail_compilation/pull12941.d(102):     `pull12941.foo(return out scope int* p)`

--- a/compiler/test/fail_compilation/test18385b.d
+++ b/compiler/test/fail_compilation/test18385b.d
@@ -4,11 +4,11 @@ because they ignored the actual function name
 
 TEST_OUTPUT:
 ---
-fail_compilation/test18385b.d(13): Error: `test18385b.S.foo` called with argument types `(int)` matches both:
+fail_compilation/test18385b.d(13): Error: `test18385b.S.foo` called with argument types `(int)` matches multiple overloads exactly:
 fail_compilation/test18385b.d(8):     `test18385b.S.foo(int s)`
 and:
 fail_compilation/test18385b.d(3):     `test18385b.foo(int s)`
-fail_compilation/test18385b.d(102): Error: `test18385b.bar` called with argument types `(int)` matches both:
+fail_compilation/test18385b.d(102): Error: `test18385b.bar` called with argument types `(int)` matches multiple overloads exactly:
 fail_compilation/test18385b.d(2):     `test18385b.bar(int s)`
 and:
 fail_compilation/test18385b.d(3):     `test18385b.foo(int s)`

--- a/compiler/test/fail_compilation/testInference.d
+++ b/compiler/test/fail_compilation/testInference.d
@@ -222,7 +222,7 @@ void test13729b() pure
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/testInference.d(225): Error: `testInference.test17086` called with argument types `(bool)` matches both:
+fail_compilation/testInference.d(225): Error: `testInference.test17086` called with argument types `(bool)` matches multiple overloads exactly:
 fail_compilation/testInference.d(219):     `testInference.test17086!(bool, false).test17086(bool x)`
 and:
 fail_compilation/testInference.d(220):     `testInference.test17086!(bool, false).test17086(bool y)`

--- a/compiler/test/fail_compilation/testOpApply.d
+++ b/compiler/test/fail_compilation/testOpApply.d
@@ -1,7 +1,7 @@
 /+
 TEST_OUTPUT:
 ---
-fail_compilation/testOpApply.d(27): Error: `testOpApply.SameAttr.opApply` called with argument types `(int delegate(int i) pure nothrow @nogc @safe)` matches both:
+fail_compilation/testOpApply.d(27): Error: `testOpApply.SameAttr.opApply` called with argument types `(int delegate(int i) pure nothrow @nogc @safe)` matches multiple overloads after qualifier conversion:
 fail_compilation/testOpApply.d(13):     `testOpApply.SameAttr.opApply(int delegate(int) @system dg)`
 and:
 fail_compilation/testOpApply.d(18):     `testOpApply.SameAttr.opApply(int delegate(int) @system dg)`
@@ -30,7 +30,7 @@ void testSameAttr() @safe
 /+
 TEST_OUTPUT:
 ---
-fail_compilation/testOpApply.d(104): Error: `testOpApply.SameAttr.opApply` called with argument types `(int delegate(int i) pure nothrow @nogc @system)` matches both:
+fail_compilation/testOpApply.d(104): Error: `testOpApply.SameAttr.opApply` called with argument types `(int delegate(int i) pure nothrow @nogc @system)` matches multiple overloads after qualifier conversion:
 fail_compilation/testOpApply.d(13):     `testOpApply.SameAttr.opApply(int delegate(int) @system dg)`
 and:
 fail_compilation/testOpApply.d(18):     `testOpApply.SameAttr.opApply(int delegate(int) @system dg)`


### PR DESCRIPTION
Knowing the matching level is very useful when debugging ambiguous overloads (https://github.com/dlang/dmd/issues/20635 is what prompted me to add this). I just found it a bit awkward to fit it into the existing message. Suggestions for better wording are welcome.