### PR TITLE
Prevent `core.internal.traits.AliasSeq` from bleeding through `core.time`

### DIFF
--- a/druntime/src/core/time.d
+++ b/druntime/src/core/time.d
@@ -3925,7 +3925,14 @@ version (CoreUnittest) const(char)* numToStringz()(long value) @trusted pure not
 }
 
 
-import core.internal.traits : AliasSeq;
+/+
+    dmd @@@BUG18223@@@
+    A selective import of `AliasSeq` happens to bleed through and causes symbol clashes downstream.
+ +/
+version (none)
+    import core.internal.traits : AliasSeq;
+else
+    import core.internal.traits;
 
 
 /+ An adjusted copy of std.exception.assertThrown. +/


### PR DESCRIPTION
As outlined in #18223, the `AliasSeq` symbol imported by `core.time` can bleed through and lead to symbol clashes.
See also: <https://github.com/dlang/phobos/issues/10610#issuecomment-2571451921>

I’m aware this workaround ain’t pretty.