### PR TITLE
Fix "Compiler fills INIT_ARRAY/FINI_ARRAY with useless zeroes"

### DIFF
--- a/compiler/src/dmd/backend/dt.d
+++ b/compiler/src/dmd/backend/dt.d
@@ -258,6 +258,18 @@ nothrow:
         if (!size)
             return;
 
+        bool allZero = true;
+        foreach (i; 0 .. size)
+        {
+            if (ptr[i] != 0)
+            {
+                allZero = false;
+                break;
+            }
+        }
+        if (allZero)
+            return nzeros(size);
+
         dt_t *dt;
 
         if (size < dt_t.DTibytesMax)

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -306,11 +306,8 @@ void Expression_toDt(Expression e, ref DtBuilder dtb)
     void visitInteger(IntegerExp e)
     {
         //printf("IntegerExp.toDt() %d\n", e.op);
-        const sz = cast(uint)e.type.size();
-        if (auto value = e.getInteger())
-            dtb.nbytes(sz, cast(char*)&value);
-        else
-            dtb.nzeros(sz);
+        auto value = e.getInteger();
+        dtb.nbytes(cast(uint)e.type.size(), cast(char*) &value);
     }
 
     void visitReal(RealExp e)


### PR DESCRIPTION
Closes #20630
Makes the check for zeros done by `DtBuilder` instead of relying on the caller to check it every time. (This was done for IntegerExp but not RealExp).