### PR TITLE
Fix -verrors=context handling of tabs

### DIFF
--- a/compiler/test/fail_compilation/fail_pretty_errors.d
+++ b/compiler/test/fail_compilation/fail_pretty_errors.d
@@ -2,20 +2,23 @@
 REQUIRED_ARGS: -verrors=context
 TEST_OUTPUT:
 ---
-fail_compilation/fail_pretty_errors.d(24): Error: undefined identifier `a`
+fail_compilation/fail_pretty_errors.d(27): Error: undefined identifier `a`
     a = 1;
     ^
-fail_compilation/fail_pretty_errors.d-mixin-29(29): Error: undefined identifier `b`
-fail_compilation/fail_pretty_errors.d(34): Error: cannot implicitly convert expression `5` of type `int` to `string`
+fail_compilation/fail_pretty_errors.d-mixin-32(32): Error: undefined identifier `b`
+fail_compilation/fail_pretty_errors.d(37): Error: cannot implicitly convert expression `5` of type `int` to `string`
     string x = 5;
                ^
-fail_compilation/fail_pretty_errors.d(39): Error: mixin `fail_pretty_errors.testMixin2.mixinTemplate!()` error instantiating
+fail_compilation/fail_pretty_errors.d(42): Error: mixin `fail_pretty_errors.testMixin2.mixinTemplate!()` error instantiating
     mixin mixinTemplate;
     ^
-fail_compilation/fail_pretty_errors.d(45): Error: invalid array operation `"" + ""` (possible missing [])
+fail_compilation/fail_pretty_errors.d(48): Error: invalid array operation `"" + ""` (possible missing [])
     auto x = ""+"";
              ^
-fail_compilation/fail_pretty_errors.d(45):        did you mean to concatenate (`"" ~ ""`) instead ?
+fail_compilation/fail_pretty_errors.d(48):        did you mean to concatenate (`"" ~ ""`) instead ?
+fail_compilation/fail_pretty_errors.d(51): Error: cannot implicitly convert expression `1111` of type `int` to `byte`
+        byte ɑ =    1111;
+                    ^
 ---
 */
 
@@ -43,4 +46,7 @@ void f()
 {
     // check supplemental error doesn't show context
     auto x = ""+"";
+
+    // Check correct spacing with the presence of unicode characters and tabs
+	 	byte ɑ = 	1111;
 }


### PR DESCRIPTION
Currently they're treated as if they have width 1, while terminals print them with width 8. This PR makes it so tab characters round the current column up to the next multiple of 4.