### PR TITLE
Use Scope instead of dmd.globals for checking preview switch state

### DIFF
--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -632,6 +632,8 @@ public:
     bool nothrowInprocess(bool v);
     bool nogcInprocess() const;
     bool nogcInprocess(bool v);
+    bool saferD() const;
+    bool saferD(bool v);
     bool scopeInprocess() const;
     bool scopeInprocess(bool v);
     bool inlineScanned() const;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1577,7 +1577,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dsym.errors)
             return;
 
-        if (!(global.params.bitfields || sc.inCfile))
+        if (!(sc.previews.bitfields || sc.inCfile))
         {
             version (IN_GCC)
                 .error(dsym.loc, "%s `%s` use `-fpreview=bitfields` for bitfield support", dsym.kind, dsym.toPrettyChars);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -956,6 +956,102 @@ enum class Contract : uint8_t
     ensure = 3u,
 };
 
+enum class FeatureState : uint8_t
+{
+    default_ = 0u,
+    disabled = 1u,
+    enabled = 2u,
+};
+
+struct Previews final
+{
+private:
+    struct BitFields final
+    {
+        bool bitfields;
+        bool dip1000;
+        bool dip1008;
+        bool dip1021;
+        bool dip25;
+        bool fixAliasThis;
+        bool fixImmutableConv;
+        bool in_;
+        bool inclusiveInContracts;
+        bool noSharedAccess;
+        bool rvalueRefParam;
+        bool safer;
+        FeatureState systemVariables;
+        BitFields() :
+            bitfields(),
+            dip1000(),
+            dip1008(),
+            dip1021(),
+            dip25(),
+            fixAliasThis(),
+            fixImmutableConv(),
+            in_(),
+            inclusiveInContracts(),
+            noSharedAccess(),
+            rvalueRefParam(),
+            safer()
+        {
+        }
+        BitFields(bool bitfields, bool dip1000 = false, bool dip1008 = false, bool dip1021 = false, bool dip25 = false, bool fixAliasThis = false, bool fixImmutableConv = false, bool in_ = false, bool inclusiveInContracts = false, bool noSharedAccess = false, bool rvalueRefParam = false, bool safer = false, FeatureState systemVariables = (FeatureState)0u) :
+            bitfields(bitfields),
+            dip1000(dip1000),
+            dip1008(dip1008),
+            dip1021(dip1021),
+            dip25(dip25),
+            fixAliasThis(fixAliasThis),
+            fixImmutableConv(fixImmutableConv),
+            in_(in_),
+            inclusiveInContracts(inclusiveInContracts),
+            noSharedAccess(noSharedAccess),
+            rvalueRefParam(rvalueRefParam),
+            safer(safer),
+            systemVariables(systemVariables)
+            {}
+    };
+
+public:
+    bool bitfields() const;
+    bool bitfields(bool v);
+    bool dip1000() const;
+    bool dip1000(bool v);
+    bool dip1008() const;
+    bool dip1008(bool v);
+    bool dip1021() const;
+    bool dip1021(bool v);
+    bool dip25() const;
+    bool dip25(bool v);
+    bool fixAliasThis() const;
+    bool fixAliasThis(bool v);
+    bool fixImmutableConv() const;
+    bool fixImmutableConv(bool v);
+    bool in_() const;
+    bool in_(bool v);
+    bool inclusiveInContracts() const;
+    bool inclusiveInContracts(bool v);
+    bool noSharedAccess() const;
+    bool noSharedAccess(bool v);
+    bool rvalueRefParam() const;
+    bool rvalueRefParam(bool v);
+    bool safer() const;
+    bool safer(bool v);
+    FeatureState systemVariables() const;
+    FeatureState systemVariables(FeatureState v);
+private:
+    uint16_t bitFields;
+public:
+    Previews() :
+        bitFields(0u)
+    {
+    }
+    Previews(uint16_t bitFields) :
+        bitFields(bitFields)
+        {}
+};
+
 template <typename K, typename V>
 struct AssocArray final
 {
@@ -3681,6 +3777,8 @@ public:
     bool nothrowInprocess(bool v);
     bool nogcInprocess() const;
     bool nogcInprocess(bool v);
+    bool saferD() const;
+    bool saferD(bool v);
     bool scopeInprocess() const;
     bool scopeInprocess(bool v);
     bool inlineScanned() const;
@@ -6027,13 +6125,6 @@ enum class CppStdRevision : uint32_t
     cpp20 = 202002u,
 };
 
-enum class FeatureState : uint8_t
-{
-    default_ = 0u,
-    disabled = 1u,
-    enabled = 2u,
-};
-
 enum class CHECKENABLE : uint8_t
 {
     _default = 0u,
@@ -7127,13 +7218,10 @@ struct Scope final
     bool fullinst(bool v);
     bool ctfeBlock() const;
     bool ctfeBlock(bool v);
-    bool dip1000() const;
-    bool dip1000(bool v);
-    bool dip25() const;
-    bool dip25(bool v);
 private:
-    uint32_t bitFields;
+    uint16_t bitFields;
 public:
+    Previews previews;
     UserAttributeDeclaration* userAttribDecl;
     DocComment* lastdc;
     void* anchorCounts;
@@ -7177,6 +7265,7 @@ public:
         stc(),
         depdecl(),
         bitFields(0u),
+        previews(),
         userAttribDecl(),
         lastdc(),
         prevAnchor(),
@@ -7184,7 +7273,7 @@ public:
         argStruct()
     {
     }
-    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* sw = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tf = nullptr, ScopeGuardStatement* os = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, bool inDefaultArg = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, uint64_t stc = 0LLU, DeprecatedDeclaration* depdecl = nullptr, uint32_t bitFields = 0u, UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr, StructDeclaration* argStruct = nullptr) :
+    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* sw = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tf = nullptr, ScopeGuardStatement* os = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, bool inDefaultArg = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, uint64_t stc = 0LLU, DeprecatedDeclaration* depdecl = nullptr, uint16_t bitFields = 0u, Previews previews = Previews(), UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr, StructDeclaration* argStruct = nullptr) :
         enclosing(enclosing),
         _module(_module),
         scopesym(scopesym),
@@ -7220,6 +7309,7 @@ public:
         stc(stc),
         depdecl(depdecl),
         bitFields(bitFields),
+        previews(previews),
         userAttribDecl(userAttribDecl),
         lastdc(lastdc),
         anchorCounts(anchorCounts),
@@ -7431,6 +7521,7 @@ public:
     FuncDeclaration* f;
     bool checkOnly;
     bool err;
+    bool nogcExceptions;
     void doCond(Expression* exp);
     void visit(Expression* e) override;
     void visit(DeclarationExp* e) override;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -113,6 +113,7 @@ private struct FUNCFLAG
     bool safetyInprocess;    /// working on determining safety
     bool nothrowInprocess;   /// working on determining nothrow
     bool nogcInprocess;      /// working on determining @nogc
+    bool saferD;             /// do -preview=safer checks if this function has default safety
     bool scopeInprocess;     /// infer `return` and `scope` for parameters
     bool inlineScanned;      /// function has been scanned for inline possibilities
     bool hasCatches;         /// function has try-catch statements

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -46,6 +46,7 @@ public:
     FuncDeclaration f;
     bool checkOnly;     // don't print errors
     bool err;
+    bool nogcExceptions; // -preview=dip1008 enabled
 
     extern (D) this(FuncDeclaration f) scope @safe
     {
@@ -143,7 +144,7 @@ public:
         }
         if (e.onstack)
             return;
-        if (global.params.ehnogc && e.thrownew)
+        if (nogcExceptions && e.thrownew)
             return;                     // separate allocator is called for this, not the GC
 
         if (setGC(e, "cannot use `new` in `@nogc` %s `%s`"))
@@ -224,6 +225,7 @@ Expression checkGC(Scope* sc, Expression e)
     {
         scope NOGCVisitor gcv = new NOGCVisitor(f);
         gcv.checkOnly = betterC;
+        gcv.nogcExceptions = sc.previews.dip1008;
         walkPostorder(e, gcv);
         if (gcv.err)
         {

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -67,10 +67,9 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
     if (!ad)
         return false;
 
-    import dmd.globals : global;
     if (v.isSystem())
     {
-        if (sc.setUnsafePreview(global.params.systemVariables, !printmsg, e.loc,
+        if (sc.setUnsafePreview(sc.previews.systemVariables, !printmsg, e.loc,
             "cannot access `@system` field `%s.%s` in `@safe` code", ad, v))
             return true;
     }
@@ -323,8 +322,7 @@ bool checkUnsafeDotExp(Scope* sc, Expression e, Identifier id, int flag)
  */
 bool isSaferD(FuncDeclaration fd)
 {
-    return fd.type.toTypeFunction().trust == TRUST.default_ &&
-           global.params.safer == FeatureState.enabled;
+    return fd.type.toTypeFunction().trust == TRUST.default_ && fd.saferD;
 }
 
 bool isSafe(FuncDeclaration fd)

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -102,7 +102,8 @@ struct Scope final
 
     DeprecatedDeclaration *depdecl; // customized deprecation message
 
-    unsigned flags;
+    uint16_t flags;
+    uint16_t previews; // state of preview switches
 
     bool ctor() const;
     bool ctor(bool v);
@@ -130,10 +131,6 @@ struct Scope final
     bool fullinst(bool v);
     bool ctfeBlock() const;
     bool ctfeBlock(bool v);
-    bool dip1000() const;
-    bool dip1000(bool v);
-    bool dip25() const;
-    bool dip25(bool v);
 
     UserAttributeDeclaration *userAttribDecl;   // user defined attributes
 

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -298,6 +298,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             return;
         funcdecl.semanticRun = PASS.semantic3;
         funcdecl.hasSemantic3Errors = false;
+        funcdecl.saferD = sc.previews.safer;
 
         if (!funcdecl.type || funcdecl.type.ty != Tfunction)
             return;
@@ -975,7 +976,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 sc2 = sc2.pop();
             }
 
-            if (global.params.inclusiveInContracts)
+            if (sc.previews.inclusiveInContracts)
             {
                 funcdecl.frequire = funcdecl.mergeFrequireInclusivePreview(
                     funcdecl.frequire, funcdecl.fdrequireParams);
@@ -1393,7 +1394,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         }
 
         // Do live analysis
-        if (global.params.useDIP1021 && funcdecl.fbody && funcdecl.type.ty != Terror &&
+        if (sc.previews.dip1021 && funcdecl.fbody && funcdecl.type.ty != Terror &&
             funcdecl.type.isTypeFunction().isLive)
         {
             oblive(funcdecl);

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2677,7 +2677,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
                     // If we previously assumed the function could be ref when
                     // checking for `shared`, make sure we were right
-                    if (global.params.noSharedAccess == FeatureState.enabled && rs.exp.type.isShared())
+                    if (sc.previews.noSharedAccess && rs.exp.type.isShared())
                     {
                         .error(fd.loc, "%s `%s` function returns `shared` but cannot be inferred `ref`", fd.kind, fd.toPrettyChars);
                         supplemental();
@@ -4131,14 +4131,14 @@ void catchSemantic(Catch c, Scope* sc)
     {
         c.errors = true;
     }
-    else if (global.params.ehnogc)
+    else if (sc.previews.dip1008)
     {
         stc |= STC.scope_;
     }
 
     // DIP1008 requires destruction of the Throwable, even if the user didn't specify an identifier
     auto ident = c.ident;
-    if (!ident && global.params.ehnogc)
+    if (!ident && sc.previews.dip1008)
         ident = Identifier.generateAnonymousId("var");
 
     if (ident)
@@ -4148,7 +4148,7 @@ void catchSemantic(Catch c, Scope* sc)
         c.var.dsymbolSemantic(sc);
         sc.insert(c.var);
 
-        if (global.params.ehnogc && stc & STC.scope_)
+        if (sc.previews.dip1008 && stc & STC.scope_)
         {
             /* Add a destructor for c.var
              * try { handler } finally { if (!__ctfe) _d_delThrowable(var); }

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1362,7 +1362,7 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
                         {
                             // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
                         }
-                        else if (global.params.rvalueRefParam == FeatureState.enabled)
+                        else if (sc.previews.rvalueRefParam)
                         {
                             // Allow implicit conversion to ref
                         }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1122,7 +1122,7 @@ private extern(D) MATCH argumentMatchParameter (FuncDeclaration fd, TypeFunction
             // Need to make this a rvalue through a temporary
             m = MATCH.convert;
         }
-        else if (global.params.rvalueRefParam != FeatureState.enabled ||
+        else if (!(sc && sc.previews.rvalueRefParam) ||
                  p.storageClass & STC.out_ ||
                  !arg.type.isCopyable())  // can't copy to temp for ref parameter
         {
@@ -2335,8 +2335,7 @@ Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
             // default arg must be an lvalue
             if (isRefOrOut && !isAuto &&
-                !(fparam.storageClass & STC.constscoperef) &&
-                global.params.rvalueRefParam != FeatureState.enabled)
+                !(fparam.storageClass & STC.constscoperef) && !sc.previews.rvalueRefParam)
                 e = e.toLvalue(sc, "create default argument for `ref` / `out` parameter from");
 
             fparam.defaultArg = e;


### PR DESCRIPTION
This reduces reliance on dmd.globals, and enables adding module filters to preview switches, or enabling/disabling them per edition.

Note: there's still a use of `global.params.fixImmutableConv` because `implicitConvTo` doesn't get a Scope parameter, and passing the flag down through parameters requires fixing a lot of call sites, so I've put that off for now.