### PR TITLE
Add an assert-based segfault handler to `etc.linux.memoryerror`

### DIFF
--- a/changelog/druntime.segfault-message.dd
+++ b/changelog/druntime.segfault-message.dd
@@ -1,0 +1,65 @@
+New segfault handler showing backtraces for null access / call stack overflow on linux
+
+While buffer overflows are usually caught by array bounds checks, there are still other situations where a segmentation fault occurs in D programs:
+
+- `null` pointer dereference
+- Corrupted or dangling pointer dereference in `@system` code
+- Call stack overflow (infinite recursion)
+
+These result in an uninformative runtime error such as:
+
+$(CONSOLE
+[1]    37856 segmentation fault (core dumped)  ./app
+)
+
+In order to find the cause of the error, the program needs to be run again in a debugger like gdb.
+
+There is the `registerMemoryErrorHandler` function in `etc.linux.memoryerror`, which catches `SIGSEGV` signals and transforms them into a thrown `InvalidPointerError`, providing a better message.
+However, it doesn't work on call stack overflow, because it uses stack memory itself, so the segfault handler segfaults.
+It also relies on inline assembly, limiting it to the x86 architecture.
+
+A new function `registerMemoryAssertHandler` has been introduced, which does handle stack overflow by setting up an [altstack](https://man7.org/linux/man-pages/man2/sigaltstack.2.html).
+It uses `assert(0)` instead of throwing an `Error` object, so the result corresponds to the chosen `-checkaction=[D|C|halt|context]` setting.
+
+Example:
+
+---
+void main()
+{
+    version (linux)
+    {
+        import etc.linux.memoryerror;
+        registerMemoryAssertHandler();
+    }
+    int* p = null;
+    int* q = cast(int*) 0xDEADBEEF;
+
+    // int a = *p; // segmentation fault: null pointer read/write operation
+    // int b = *q; // segmentation fault: invalid pointer read/write operation
+    recurse();     // segmentation fault: call stack overflow
+}
+
+void recurse()
+{
+    recurse();
+}
+---
+
+Output with `dmd -g -run app.d`:
+
+$(CONSOLE
+core.exception.AssertError@src/etc/linux/memoryerror.d(82): segmentation fault: call stack overflow
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+src/core/exception.d:587 onAssertErrorMsg [0x58e270d2802d]
+src/core/exception.d:803 _d_assert_msg [0x58e270d1fb64]
+src/etc/linux/memoryerror.d:82 _d_handleSignalAssert [0x58e270d1f48d]
+??:? [0x7004139e876f]
+./app.d:16 void scratch.recurse() [0x58e270d1d757]
+./app.d:18 void scratch.recurse() [0x58e270d1d75c]
+./app.d:18 void scratch.recurse() [0x58e270d1d75c]
+./app.d:18 void scratch.recurse() [0x58e270d1d75c]
+./app.d:18 void scratch.recurse() [0x58e270d1d75c]
+...
+...
+...
+)

--- a/druntime/src/etc/linux/memoryerror.d
+++ b/druntime/src/etc/linux/memoryerror.d
@@ -43,6 +43,13 @@ version (linux)
 import core.sys.posix.signal : SA_SIGINFO, sigaction, sigaction_t, siginfo_t, SIGSEGV;
 import ucontext = core.sys.posix.ucontext;
 
+version (MemoryAssertSupported)
+{
+    import core.sys.posix.signal : SA_ONSTACK, sigaltstack, SIGSTKSZ, stack_t;
+}
+
+@system:
+
 // The first 64Kb are reserved for detecting null pointer dereferences.
 // TODO: this is a platform-specific assumption, can be made more robust
 private enum size_t MEMORY_RESERVED_FOR_NULL_DEREFERENCE = 4096 * 16;
@@ -382,9 +389,9 @@ version (MemoryAssertSupported)
 
             auto context = cast(ucontext.ucontext_t*) contextPtr;
             version (X86_64)
-                const stackPtr = cast(void*) context.uc_mcontext.gregs[REG_RSP];
+                const stackPtr = cast(void*) context.uc_mcontext.gregs[ucontext.REG_RSP];
             else version (X86)
-                const stackPtr = cast(void*) context.uc_mcontext.gregs[REG_ESP];
+                const stackPtr = cast(void*) context.uc_mcontext.gregs[ucontext.REG_ESP];
             else version (ARM)
                 const stackPtr = cast(void*) context.uc_mcontext.arm_sp;
             else version (AArch64)

--- a/druntime/src/etc/linux/memoryerror.d
+++ b/druntime/src/etc/linux/memoryerror.d
@@ -362,7 +362,7 @@ version (MemoryAssertSupported)
      * providing a more descriptive error message and stack trace if the program is
      * compiled with debug info and D assertions (as opposed to C assertions).
      *
-     * Differences with version 1 are:
+     * Differences with the `registerMemoryErrorHandler` version are:
      * - The handler is registered with SA_ONSTACK, so it can handle stack overflows.
      * - It uses `assert(0)` instead of `throw new Error` and doesn't support catching the error.
      * - This is a template so that the -check and -checkaction flags of the compiled program are used,

--- a/druntime/src/etc/linux/memoryerror.d
+++ b/druntime/src/etc/linux/memoryerror.d
@@ -443,4 +443,11 @@ version (MemoryAssertSupported)
     {
         return !sigaction(SIGSEGV, &oldSigactionMemoryAssert, null);
     }
+
+    unittest
+    {
+        // Testing actual memory errors is done in the test suite
+        assert(registerMemoryAssertHandler());
+        assert(deregisterMemoryAssertHandler());
+    }
 }

--- a/druntime/src/etc/linux/memoryerror.d
+++ b/druntime/src/etc/linux/memoryerror.d
@@ -380,7 +380,7 @@ version (MemoryAssertSupported)
 
             const void* segfaultingPtr = info.si_addr;
 
-            auto context = cast(ucontext_t*) contextPtr;
+            auto context = cast(ucontext.ucontext_t*) contextPtr;
             version (X86_64)
                 const stackPtr = cast(void*) context.uc_mcontext.gregs[REG_RSP];
             else version (X86)

--- a/druntime/src/etc/linux/memoryerror.d
+++ b/druntime/src/etc/linux/memoryerror.d
@@ -18,7 +18,7 @@ version (linux)
         {
             version (X86)
                 version = MemoryErrorSupported;
-            version (X86_64)
+            else version (X86_64)
                 version = MemoryErrorSupported;
         }
     }
@@ -28,19 +28,19 @@ version (linux)
 {
     version (X86)
         version = MemoryAssertSupported;
-    version (X86_64)
+    else version (X86_64)
         version = MemoryAssertSupported;
-    version (ARM)
+    else version (ARM)
         version = MemoryAssertSupported;
-    version (AArch64)
+    else version (AArch64)
         version = MemoryAssertSupported;
-    version (PPC64)
+    else version (PPC64)
         version = MemoryAssertSupported;
 }
 
 version (MemoryErrorSupported)
     version = AnySupported;
-version (MemoryErrorSupported)
+else version (MemoryErrorSupported)
     version = AnySupported;
 
 version (AnySupported):

--- a/druntime/src/etc/linux/memoryerror.d
+++ b/druntime/src/etc/linux/memoryerror.d
@@ -38,7 +38,12 @@ version (linux)
         version = MemoryAssertSupported;
 }
 
-@system:
+version (MemoryErrorSupported)
+    version = AnySupported;
+version (MemoryErrorSupported)
+    version = AnySupported;
+
+version (AnySupported):
 
 import core.sys.posix.signal : SA_SIGINFO, sigaction, sigaction_t, siginfo_t, SIGSEGV;
 import ucontext = core.sys.posix.ucontext;

--- a/druntime/src/rt/dmain2.d
+++ b/druntime/src/rt/dmain2.d
@@ -460,6 +460,13 @@ private extern (C) int _d_run_main2(char[][] args, size_t totalArgsLength, MainF
             useExceptionTrap = false;
     }
 
+    version (none)
+    {
+        // Causes test failures related to Fibers, not enabled by default yet
+        import etc.linux.memoryerror;
+        cast(void) registerMemoryAssertHandler();
+    }
+
     void tryExec(scope void delegate() dg)
     {
         if (useExceptionTrap)

--- a/druntime/test/exceptions/Makefile
+++ b/druntime/test/exceptions/Makefile
@@ -12,7 +12,8 @@ SED:=sed
 GDB:=gdb
 
 ifeq ($(OS),linux)
-    TESTS+=line_trace line_trace_21656 long_backtrace_trunc rt_trap_exceptions cpp_demangle
+    TESTS+=line_trace line_trace_21656 long_backtrace_trunc rt_trap_exceptions cpp_demangle \
+		   memoryerror_null_read memoryerror_null_write memoryerror_null_call memoryerror_stackoverflow
     line_trace_dflags:=-L--export-dynamic
 endif
 
@@ -88,6 +89,11 @@ $(ROOT)/rt_trap_exceptions.done: stderr_exp2="src/rt_trap_exceptions.d:8 main"
 $(ROOT)/assert_fail.done: stderr_exp="success."
 $(ROOT)/cpp_demangle.done: stderr_exp="thrower(int)"
 $(ROOT)/message_with_null.done: stderr_exp=" world"
+$(ROOT)/memoryerror_null_read.done: stderr_exp="segmentation fault: null pointer read/write operation"
+$(ROOT)/memoryerror_null_write.done: stderr_exp="segmentation fault: null pointer read/write operation"
+$(ROOT)/memoryerror_null_call.done: stderr_exp="segmentation fault: null pointer read/write operation"
+$(ROOT)/memoryerror_null_call.done: stderr_exp2="uncaught exception reached top of stack"
+$(ROOT)/memoryerror_stackoverflow.done: stderr_exp="segmentation fault: call stack overflow"
 
 $(ROOT)/%.done: $(ROOT)/%$(DOTEXE)
 	@echo Testing $*

--- a/druntime/test/exceptions/src/memoryerror_null_call.d
+++ b/druntime/test/exceptions/src/memoryerror_null_call.d
@@ -1,0 +1,9 @@
+import etc.linux.memoryerror;
+
+void function() foo = null;
+
+void main()
+{
+    registerMemoryAssertHandler;
+    foo();
+}

--- a/druntime/test/exceptions/src/memoryerror_null_read.d
+++ b/druntime/test/exceptions/src/memoryerror_null_read.d
@@ -1,0 +1,9 @@
+import etc.linux.memoryerror;
+
+int* x = null;
+
+void main()
+{
+    registerMemoryAssertHandler;
+    *x = 3;
+}

--- a/druntime/test/exceptions/src/memoryerror_null_write.d
+++ b/druntime/test/exceptions/src/memoryerror_null_write.d
@@ -1,0 +1,9 @@
+import etc.linux.memoryerror;
+
+int* x = null;
+
+int main()
+{
+    registerMemoryAssertHandler;
+    return *x;
+}

--- a/druntime/test/exceptions/src/memoryerror_stackoverflow.d
+++ b/druntime/test/exceptions/src/memoryerror_stackoverflow.d
@@ -1,0 +1,22 @@
+import etc.linux.memoryerror;
+
+pragma(inline, false):
+
+void f(ref ubyte[1024] buf)
+{
+    ubyte[1024] cpy = buf;
+    g(cpy);
+}
+
+void g(ref ubyte[1024] buf)
+{
+    ubyte[1024] cpy = buf;
+    f(cpy);
+}
+
+void main()
+{
+    registerMemoryAssertHandler;
+    ubyte[1024] buf;
+    f(buf);
+}


### PR DESCRIPTION
Continuation of #15331.

Implements `registerMemoryAssertHandler` and `deregisterMemoryAssertHandler`.
Has some advantages over the existing `registerMemoryErrorHandler`:
  - Doesn't use inline assembly.
  - Supports multiple architectures.
  - Usable by all compilers.
  - Properly handles segfaults caused by stack overflows.

Some thoughts from the previous pr summarized:
  - How does this work in multi-threaded programs? How do we want this to work? Write a test?
    Already determined that this breaks stack overflow detection.
  - Does this prevent core dumps from generating? Should it? Can we let the user decide?
  - Does this prevent debuggers from catching the segfault? (no)
  - Is `SEGFAULT` this the only signal we want to be able to handle? What about `SIGFPE`, `SIGILL`, `SIGBUS`...
    - If so, do we build a more generic and transparent api for this? This can also solve the awkward (re)storing of old signal handlers.
  - Can the dependency on the long deprecated `ucontext` be removed?
  - Could this be extended to more posix platforms beyond linux?