### PR TITLE
Fix invalid "Source: " links in druntime module ddocs

### DIFF
--- a/druntime/src/__importc_builtins.di
+++ b/druntime/src/__importc_builtins.di
@@ -6,7 +6,7 @@
  * Copyright: Copyright D Language Foundation 2022-2024
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
- * Source: $(DRUNTIMESRC __importc_builtins.d)
+ * Source: $(DRUNTIMESRC __importc_builtins.di)
  */
 
 

--- a/druntime/src/core/internal/backtrace/dwarf.d
+++ b/druntime/src/core/internal/backtrace/dwarf.d
@@ -44,7 +44,7 @@
  * Copyright: Copyright Digital Mars 2015 - 2015.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Yazan Dabain, Sean Kelly
- * Source: $(DRUNTIMESRC rt/backtrace/dwarf.d)
+ * Source: $(DRUNTIMESRC core/internal/backtrace/dwarf.d)
  */
 
 module core.internal.backtrace.dwarf;

--- a/druntime/src/core/internal/backtrace/elf.d
+++ b/druntime/src/core/internal/backtrace/elf.d
@@ -6,7 +6,7 @@
  * Copyright: Copyright Digital Mars 2015 - 2018.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Yazan Dabain
- * Source: $(DRUNTIMESRC rt/backtrace/elf.d)
+ * Source: $(DRUNTIMESRC core/internal/backtrace/elf.d)
  */
 
 module core.internal.backtrace.elf;

--- a/druntime/src/core/internal/backtrace/macho.d
+++ b/druntime/src/core/internal/backtrace/macho.d
@@ -4,7 +4,7 @@
  * Copyright: Copyright Jacob Carlborg 2018.
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Authors:   Jacob Carlborg
- * Source:    $(DRUNTIMESRC rt/backtrace/macho.d)
+ * Source:    $(DRUNTIMESRC core/internal/backtrace/macho.d)
  */
 module core.internal.backtrace.macho;
 

--- a/druntime/src/core/internal/elf/io.d
+++ b/druntime/src/core/internal/elf/io.d
@@ -6,7 +6,7 @@
  * Copyright: Copyright Digital Mars 2015 - 2018.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Yazan Dabain, Martin Kinkelin
- * Source: $(DRUNTIMESRC core/elf/io.d)
+ * Source: $(DRUNTIMESRC core/internal/elf/io.d)
  */
 
 module core.internal.elf.io;

--- a/druntime/src/core/internal/postblit.d
+++ b/druntime/src/core/internal/postblit.d
@@ -5,7 +5,7 @@
   License: Distributed under the
        $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
      (See accompanying file LICENSE)
-  Source: $(DRUNTIMESRC core/_internal/_destruction.d)
+  Source: $(DRUNTIMESRC core/_internal/_postblit.d)
 */
 module core.internal.postblit;
 

--- a/druntime/src/core/internal/string.d
+++ b/druntime/src/core/internal/string.d
@@ -4,7 +4,7 @@
  * Copyright: Copyright Sean Kelly 2005 - 2009.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Walter Bright
- * Source: $(DRUNTIMESRC rt/util/_string.d)
+ * Source: $(DRUNTIMESRC core/internal/_string.d)
  */
 
 module core.internal.string;

--- a/druntime/src/core/sys/darwin/mach/stab.d
+++ b/druntime/src/core/sys/darwin/mach/stab.d
@@ -24,7 +24,7 @@
  *
  * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors: Mathias 'Geod24' Lang
- * Source: $(DRUNTIMESRC core/sys/darwin/mach/_nlist.d)
+ * Source: $(DRUNTIMESRC core/sys/darwin/mach/_stab.d)
  */
 module core.sys.darwin.mach.stab;
 

--- a/druntime/src/core/sys/posix/stdc/time.d
+++ b/druntime/src/core/sys/posix/stdc/time.d
@@ -9,7 +9,7 @@
  *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly,
  *            Alex Rønne Petersen
- * Source:    $(DRUNTIMESRC core/stdc/_time.d)
+ * Source:    $(DRUNTIMESRC core/sys/posix/stdc/_time.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 

--- a/druntime/src/core/sys/windows/dbghelp.d
+++ b/druntime/src/core/sys/windows/dbghelp.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Benjamin Thaut, Sean Kelly
- * Source:    $(DRUNTIMESRC core/sys/windows/_stacktrace.d)
+ * Source:    $(DRUNTIMESRC core/sys/windows/_dbghelp.d)
  */
 
 module core.sys.windows.dbghelp;

--- a/druntime/src/core/sys/windows/stdc/time.d
+++ b/druntime/src/core/sys/windows/stdc/time.d
@@ -9,7 +9,7 @@
  *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly,
  *            Alex Rønne Petersen
- * Source:    $(DRUNTIMESRC core/stdc/_time.d)
+ * Source:    $(DRUNTIMESRC core/sys/windows/stdc/_time.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -7,7 +7,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly, Walter Bright, Alex Rønne Petersen, Martin Nowak
- * Source:    $(DRUNTIMESRC core/thread/osthread.d)
+ * Source:    $(DRUNTIMESRC core/thread/threadbase.d)
  */
 
 module core.thread.threadbase;

--- a/druntime/src/core/thread/threadgroup.d
+++ b/druntime/src/core/thread/threadgroup.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly, Walter Bright, Alex Rønne Petersen, Martin Nowak
- * Source:    $(DRUNTIMESRC core/thread/osthread.d)
+ * Source:    $(DRUNTIMESRC core/thread/threadgroup.d)
  */
 
 module core.thread.threadgroup;

--- a/druntime/src/core/thread/types.d
+++ b/druntime/src/core/thread/types.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly, Walter Bright, Alex Rønne Petersen, Martin Nowak
- * Source:    $(DRUNTIMESRC core/thread/osthread.d)
+ * Source:    $(DRUNTIMESRC core/thread/types.d)
  */
 
 module core.thread.types;

--- a/druntime/src/etc/linux/memoryerror.d
+++ b/druntime/src/etc/linux/memoryerror.d
@@ -9,7 +9,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE_1_0.txt)
  * Authors:   Amaury SECHET, FeepingCreature, Vladimir Panteleev
- * Source: $(DRUNTIMESRC etc/linux/memory.d)
+ * Source: $(DRUNTIMESRC etc/linux/memoryerror.d)
  */
 
 module etc.linux.memoryerror;

--- a/druntime/src/rt/sections_elf_shared.d
+++ b/druntime/src/rt/sections_elf_shared.d
@@ -5,7 +5,7 @@
  * Copyright: Copyright Martin Nowak 2012-2013.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
- * Source: $(DRUNTIMESRC rt/_sections_linux.d)
+ * Source: $(DRUNTIMESRC rt/_sections_elf_shared.d)
  */
 
 module rt.sections_elf_shared;


### PR DESCRIPTION
Some "Source: " links in ddoc comments still pointed to an older name of the file.
This leads to incorrect links in documentation, e.g. on https://dlang.org/phobos/core_thread_threadbase.html.

This pr fixes 16 such cases in druntime.