### PR TITLE
Make safe error messages consistent

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -3261,7 +3261,7 @@ Expression scaleFactor(BinExp be, Scope* sc)
     if (eoff.op == EXP.int64 && eoff.toInteger() == 0)
     {
     }
-    else if (sc.setUnsafe(false, be.loc, "pointer arithmetic not allowed in @safe functions"))
+    else if (sc.setUnsafe(false, be.loc, "pointer arithmetic"))
     {
         return ErrorExp.get();
     }

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -717,7 +717,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         // Calculate type size + safety checks
         if (dsym.storage_class & STC.gshared && !dsym.isMember())
         {
-            sc.setUnsafe(false, dsym.loc, "__gshared not allowed in safe functions; use shared");
+            sc.setUnsafe(false, dsym.loc, "using `__gshared` instead of `shared`");
         }
 
         Dsymbol parent = dsym.toParent();
@@ -1146,22 +1146,22 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
                 if (dsym.type.hasPointers()) // also computes type size
                     sc.setUnsafe(false, dsym.loc,
-                        "`void` initializers for pointers not allowed in safe functions");
+                        "`void` initializing a pointer");
                 else if (dsym.type.hasInvariant())
                     sc.setUnsafe(false, dsym.loc,
-                        "`void` initializers for structs with invariants are not allowed in safe functions");
+                        "`void` initializing a struct with an invariant");
                 else if (dsym.type.toBasetype().ty == Tbool)
                     sc.setUnsafePreview(global.params.systemVariables, false, dsym.loc,
-                        "a `bool` must be 0 or 1, so void intializing it is not allowed in safe functions");
+                        "void intializing a bool (which must always be 0 or 1)");
                 else if (dsym.type.hasUnsafeBitpatterns())
                     sc.setUnsafePreview(global.params.systemVariables, false, dsym.loc,
-                        "`void` initializers for types with unsafe bit patterns are not allowed in safe functions");
+                        "`void` initializing a type with unsafe bit patterns");
             }
             else if (!dsym._init &&
                      !(dsym.storage_class & (STC.static_ | STC.extern_ | STC.gshared | STC.manifest | STC.field | STC.parameter)) &&
                      dsym.type.hasVoidInitPointers())
             {
-                sc.setUnsafe(false, dsym.loc, "`void` initializers for pointers not allowed in safe functions");
+                sc.setUnsafe(false, dsym.loc, "`void` initializers for pointers");
             }
         }
 
@@ -1323,7 +1323,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                                 {
                                     import dmd.escape : setUnsafeDIP1000;
                                     const inSafeFunc = sc.func && sc.func.isSafeBypassingInference();   // isSafeBypassingInference may call setUnsafe().
-                                    if (setUnsafeDIP1000(*sc, false, dsym.loc, "`scope` allocation of `%s` requires that constructor be annotated with `scope`", dsym))
+                                    if (setUnsafeDIP1000(*sc, false, dsym.loc, "`scope` allocation of `%s` with a non-`scope` constructor", dsym))
                                         errorSupplemental(ne.member.loc, "is the location of the constructor");
                                 }
                                 ne.onstack = 1;

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -354,7 +354,7 @@ bool checkParamArgumentEscape(ref Scope sc, FuncDeclaration fdc, Identifier parI
         if (assertmsg)
         {
             result |= sc.setUnsafeDIP1000(gag, arg.loc,
-                desc ~ " `%s` assigned to non-scope parameter calling `assert()`", v);
+                "assigning" ~ desc ~ " `%s` to non-scope parameter calling `assert()`", v);
             return;
         }
 
@@ -362,9 +362,9 @@ bool checkParamArgumentEscape(ref Scope sc, FuncDeclaration fdc, Identifier parI
 
         const(char)* msg =
             (isThis)        ? (desc ~ " `%s` calling non-scope member function `%s.%s()`") :
-            (fdc &&  parId) ? (desc ~ " `%s` assigned to non-scope parameter `%s` calling `%s`") :
-            (fdc && !parId) ? (desc ~ " `%s` assigned to non-scope anonymous parameter calling `%s`") :
-            (!fdc && parId) ? (desc ~ " `%s` assigned to non-scope parameter `%s`") :
+            (fdc &&  parId) ? ("assigning " ~ desc ~ " `%s` to non-scope parameter `%s` calling `%s`") :
+            (fdc && !parId) ? ("assigning " ~ desc ~ " `%s` to non-scope anonymous parameter calling `%s`") :
+            (!fdc && parId) ? ("assigning " ~ desc ~ " `%s` to non-scope parameter `%s`") :
             (desc ~ " `%s` assigned to non-scope anonymous parameter");
 
         if (isThis ?
@@ -440,8 +440,8 @@ bool checkParamArgumentEscape(ref Scope sc, FuncDeclaration fdc, Identifier parI
         if (parStc & STC.scope_)
             return;
         const(char)* msg = parId ?
-            "reference to stack allocated value returned by `%s` assigned to non-scope parameter `%s`" :
-            "reference to stack allocated value returned by `%s` assigned to non-scope anonymous parameter";
+            "assigning reference to stack allocated value returned by `%s` to non-scope parameter `%s`" :
+            "assigning reference to stack allocated value returned by `%s` to non-scope anonymous parameter";
 
         result |= sc.setUnsafeDIP1000(gag, ee.loc, msg, ee, parId);
     }
@@ -726,16 +726,16 @@ bool checkAssignEscape(ref Scope sc, Expression e, bool gag, bool byRef)
                 {
                     case EnclosedBy.none: assert(0);
                     case EnclosedBy.returnScope:
-                        msg = "scope variable `%s` assigned to return scope `%s`";
+                        msg = "assigning scope variable `%s` to return scope `%s`";
                         break;
                     case EnclosedBy.longerScope:
-                        msg = "scope variable `%s` assigned to `%s` with longer lifetime";
+                        msg = "assigning scope variable `%s` to `%s` with longer lifetime";
                         break;
                     case EnclosedBy.refVar:
-                        msg = "scope variable `%s` assigned to `ref` variable `%s` with longer lifetime";
+                        msg = "assigning scope variable `%s` to `ref` variable `%s` with longer lifetime";
                         break;
                     case EnclosedBy.global:
-                        msg = "scope variable `%s` assigned to global variable `%s`";
+                        msg = "assigning scope variable `%s` to global variable `%s`";
                         break;
                 }
 
@@ -762,7 +762,7 @@ bool checkAssignEscape(ref Scope sc, Expression e, bool gag, bool byRef)
                 }
                 return;
             }
-            result |= sc.setUnsafeDIP1000(gag, ae.loc, "scope variable `%s` assigned to non-scope `%s`", v, e1);
+            result |= sc.setUnsafeDIP1000(gag, ae.loc, "assigning scope variable `%s` to non-scope `%s`", v, e1);
         }
         else
         {
@@ -794,7 +794,7 @@ bool checkAssignEscape(ref Scope sc, Expression e, bool gag, bool byRef)
             else
             {
                 result |= sc.setUnsafeDIP1000(gag, ae.loc,
-                    "address of local variable `%s` assigned to return scope `%s`", v, va);
+                    "assigning address of local variable `%s` to return scope `%s`", v, va);
             }
         }
 
@@ -809,7 +809,7 @@ bool checkAssignEscape(ref Scope sc, Expression e, bool gag, bool byRef)
         // If va's lifetime encloses v's, then error
         if (va && !(vaIsFirstRef && v.isReturn()) && va.enclosesLifetimeOf(v))
         {
-            if (sc.setUnsafeDIP1000(gag, ae.loc, "address of variable `%s` assigned to `%s` with longer lifetime", v, va))
+            if (sc.setUnsafeDIP1000(gag, ae.loc, "assigning address of variable `%s` to `%s` with longer lifetime", v, va))
             {
                 result = true;
                 return;
@@ -829,7 +829,7 @@ bool checkAssignEscape(ref Scope sc, Expression e, bool gag, bool byRef)
             return;
         }
 
-        result |= sc.setUnsafeDIP1000(gag, ae.loc, "reference to local variable `%s` assigned to non-scope `%s`", v, e1);
+        result |= sc.setUnsafeDIP1000(gag, ae.loc, "assigning reference to local variable `%s` to non-scope `%s`", v, e1);
     }
 
     void onFunc(FuncDeclaration func, bool called)
@@ -869,7 +869,7 @@ bool checkAssignEscape(ref Scope sc, Expression e, bool gag, bool byRef)
                 return;
             }
             result |= sc.setUnsafeDIP1000(gag, ae.loc,
-                "reference to local `%s` assigned to non-scope `%s` in @safe code", v, e1);
+                "assigning reference to local `%s` to non-scope `%s`", v, e1);
         }
     }
 
@@ -889,8 +889,8 @@ bool checkAssignEscape(ref Scope sc, Expression e, bool gag, bool byRef)
         }
 
         const(char)* msg = (ee.op == EXP.structLiteral) ?
-            "address of struct literal `%s` assigned to `%s` with longer lifetime" :
-            "address of expression temporary returned by `%s` assigned to `%s` with longer lifetime";
+            "assigning address of struct literal `%s`  to `%s` with longer lifetime" :
+            "assigning address of expression temporary returned by `%s` to `%s` with longer lifetime";
 
         result |= sc.setUnsafeDIP1000(gag, ee.loc, msg, ee, e1);
     }
@@ -930,7 +930,7 @@ bool checkThrowEscape(ref Scope sc, Expression e, bool gag)
                                                 // despite being `scope`
         {
             // https://issues.dlang.org/show_bug.cgi?id=17029
-            result |= sc.setUnsafeDIP1000(gag, e.loc, "scope variable `%s` may not be thrown", v);
+            result |= sc.setUnsafeDIP1000(gag, e.loc, "throwing scope variable `%s`", v);
             return;
         }
         else
@@ -989,7 +989,7 @@ bool checkNewEscape(ref Scope sc, Expression e, bool gag)
                 !(p.parent == sc.func))
             {
                 // https://issues.dlang.org/show_bug.cgi?id=20868
-                result |= sc.setUnsafeDIP1000(gag, e.loc, "scope variable `%s` may not be copied into allocated memory", v);
+                result |= sc.setUnsafeDIP1000(gag, e.loc, "copying scope variable `%s` into allocated memory", v);
                 return;
             }
         }
@@ -1009,9 +1009,9 @@ bool checkNewEscape(ref Scope sc, Expression e, bool gag)
         bool escapingRef(VarDeclaration v, FeatureState fs)
         {
             const(char)* msg = v.isParameter() ?
-                "copying `%s` into allocated memory escapes a reference to parameter `%s`" :
-                "copying `%s` into allocated memory escapes a reference to local variable `%s`";
-            return setUnsafePreview(&sc, fs, gag, e.loc, msg, e, v);
+                "escaping a reference to parameter `%s` by copying `%s` into allocated memory" :
+                "escaping a reference to local variable `%s by copying `%s` into allocated memory";
+            return setUnsafePreview(&sc, fs, gag, e.loc, msg, v, e);
         }
 
         Dsymbol p = v.toParent2();
@@ -1064,14 +1064,14 @@ bool checkNewEscape(ref Scope sc, Expression e, bool gag)
     {
         if (called)
             result |= sc.setUnsafeDIP1000(gag, e.loc,
-                "nested function `%s` returns `scope` values and escapes them into allocated memory", fd);
+                "escaping a `scope` value returned from nested function `%s` into allocated memory", fd);
     }
 
     void onExp(Expression ee, bool retRefTransition)
     {
         if (log) printf("byexp %s\n", ee.toChars());
         if (!gag)
-            sc.eSink.error(ee.loc, "storing reference to stack allocated value returned by `%s` into allocated memory causes it to escape",
+            sc.eSink.error(ee.loc, "escaping reference to stack allocated value returned by `%s` into allocated memory",
                   ee.toChars());
         result = true;
     }
@@ -1210,7 +1210,7 @@ private bool checkReturnEscapeImpl(ref Scope sc, Expression e, bool refs, bool g
                 else
                 {
                     // https://issues.dlang.org/show_bug.cgi?id=17029
-                    result |= sc.setUnsafeDIP1000(gag, e.loc, "scope variable `%s` may not be returned", v);
+                    result |= sc.setUnsafeDIP1000(gag, e.loc, "returning scope variable `%s`", v);
                     return;
                 }
             }
@@ -1233,13 +1233,12 @@ private bool checkReturnEscapeImpl(ref Scope sc, Expression e, bool refs, bool g
         // depending on the flag passed to the CLI for DIP25
         void escapingRef(VarDeclaration v, FeatureState featureState)
         {
-            const(char)* msg = v.isParameter() ?
-                "returning `%s` escapes a reference to parameter `%s`" :
-                "returning `%s` escapes a reference to local variable `%s`";
-
+            const(char)* safeMsg = v.isParameter() ?
+                "escaping a reference to parameter `%s` by returning `%s`" :
+                "escaping a reference to local variable `%s` by returning `%s` ";
             if (v.isParameter() && v.isReference())
             {
-                if (setUnsafePreview(&sc, featureState, gag, e.loc, msg, e, v) ||
+                if (setUnsafePreview(&sc, featureState, gag, e.loc, safeMsg, v, e) ||
                     sc.func.isSafeBypassingInference())
                 {
                     result = true;
@@ -1260,10 +1259,13 @@ private bool checkReturnEscapeImpl(ref Scope sc, Expression e, bool refs, bool g
             {
                 if (retRefTransition)
                 {
-                    result |= sc.setUnsafeDIP1000(gag, e.loc, msg, e, v);
+                    result |= sc.setUnsafeDIP1000(gag, e.loc, safeMsg, v, e);
                 }
                 else
                 {
+                    const(char)* msg = v.isParameter() ?
+                        "returning `%s` escapes a reference to parameter `%s`" :
+                        "returning `%s` escapes a reference to local variable `%s`";
                     if (!gag)
                         previewErrorFunc(sc.isDeprecated(), featureState)(e.loc, msg, e.toChars(), v.toChars());
                     result = true;
@@ -2228,7 +2230,7 @@ private bool checkScopeVarAddr(VarDeclaration v, Expression e, ref Scope sc, boo
 
     // take address of `scope` variable not allowed, requires transitive scope
     return sc.setUnsafeDIP1000(gag, e.loc,
-        "cannot take address of `scope` variable `%s` since `scope` applies to first indirection only", v);
+        "taking address of `scope` variable `%s` with pointers", v);
 }
 
 /****************************

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1592,7 +1592,7 @@ Expressions* resolveStructLiteralNamedArgs(StructDeclaration sd, Type t, Scope* 
                     (vd.offset & (target.ptrsize - 1))))
             {
                 if (sc.setUnsafe(false, argLoc,
-                    "field `%s.%s` cannot assign to misaligned pointers in `@safe` code", sd, vd))
+                    "field `%s.%s` assigning to misaligned pointers", sd, vd))
                 {
                     errors = true;
                     elems[fieldi] = ErrorExp.get(); // for better diagnostics on multiple errors

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -17,6 +17,7 @@ import core.stdc.stdio;
 
 import dmd.aggregate;
 import dmd.astenums;
+import dmd.common.outbuffer;
 import dmd.dcast : implicitConvTo;
 import dmd.dclass;
 import dmd.declaration;
@@ -70,7 +71,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
     if (v.isSystem())
     {
         if (sc.setUnsafePreview(sc.previews.systemVariables, !printmsg, e.loc,
-            "cannot access `@system` field `%s.%s` in `@safe` code", ad, v))
+            "accessing `@system` field `%s.%s`", ad, v))
             return true;
     }
 
@@ -90,7 +91,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
         if (v.overlapped)
         {
             if (sc.func.isSafeBypassingInference() && sc.setUnsafe(!printmsg, e.loc,
-                "field `%s.%s` cannot access pointers in `@safe` code that overlap other fields", ad, v))
+                "accessing overlapped field `%s.%s` with pointers", ad, v))
             {
                 return true;
             }
@@ -103,7 +104,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
                 // To turn into an error, remove `isSafeBypassingInference` check in the
                 // above if statement and remove the else branch
                 sc.setUnsafePreview(FeatureState.default_, !printmsg, e.loc,
-                    "field `%s.%s` cannot access pointers in `@safe` code that overlap other fields", ad, v);
+                    "accessing overlapped field `%s.%s` with pointers", ad, v);
             }
         }
     }
@@ -113,7 +114,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
         if (v.overlapped)
         {
             if (sc.setUnsafe(!printmsg, e.loc,
-                "field `%s.%s` cannot access structs with invariants in `@safe` code that overlap other fields",
+                "accessing overlapped field `%s.%s` with a structs invariant",
                 ad, v))
                 return true;
         }
@@ -124,7 +125,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
     // Should probably be turned into an error in a new edition
     if (v.type.hasUnsafeBitpatterns() && v.overlapped && sc.setUnsafePreview(
         FeatureState.default_, !printmsg, e.loc,
-        "cannot access overlapped field `%s.%s` with unsafe bit patterns in `@safe` code", ad, v)
+        "accessing overlapped field `%s.%s` with unsafe bit patterns", ad, v)
     )
     {
         return true;
@@ -139,7 +140,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
              (v.offset & (target.ptrsize - 1)))
         {
             if (sc.setUnsafe(!printmsg, e.loc,
-                "field `%s.%s` cannot modify misaligned pointers in `@safe` code", ad, v))
+                "modifying misaligned pointers through field `%s.%s`", ad, v))
                 return true;
         }
     }
@@ -147,7 +148,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
     if (v.overlapUnsafe)
     {
         if (sc.setUnsafe(!printmsg, e.loc,
-            "field `%s.%s` cannot modify fields in `@safe` code that overlap fields with other storage classes",
+            "modifying field `%s.%s` which overlaps with fields with other storage classes",
             ad, v))
         {
             return true;
@@ -309,9 +310,9 @@ bool checkUnsafeDotExp(Scope* sc, Expression e, Identifier id, int flag)
     if (!(flag & DotExpFlag.noDeref)) // this use is attempting a dereference
     {
         if (id == Id.ptr)
-            return sc.setUnsafe(false, e.loc, "`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e, e);
+            return sc.setUnsafe(false, e.loc, "using `%s.ptr` (instead of `&%s[0])`", e, e);
         else
-            return sc.setUnsafe(false, e.loc, "`%s.%s` cannot be used in `@safe` code", e, id);
+            return sc.setUnsafe(false, e.loc, "using `%s.%s`", e, id);
     }
     return false;
 }
@@ -376,7 +377,15 @@ extern (D) void reportSafeError(FuncDeclaration fd, bool gag, Loc loc,
     else if (fd.isSafe() || fd.isSaferD())
     {
         if (!gag && format)
-            .error(loc, format, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+        {
+            OutBuffer buf;
+            buf.printf(format, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+            if (fd.isSafe())
+                buf.writestring(" is not allowed in a `@safe` function");
+            else
+                buf.writestring(" is not allowed in a function with default safety with `-preview=safer`");
+            .error(loc, buf.extractChars());
+        }
     }
 }
 
@@ -455,7 +464,11 @@ bool setUnsafe(Scope* sc,
         {
             if (sc.varDecl.storage_class & STC.safe)
             {
-                .error(loc, format, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+                OutBuffer buf;
+                buf.printf(format, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+                buf.printf(" can't initialize `@safe` variable `%s`", sc.varDecl.toChars());
+                .error(loc, buf.extractChars());
+
                 return true;
             }
             else if (!(sc.varDecl.storage_class & STC.trusted))
@@ -474,7 +487,10 @@ bool setUnsafe(Scope* sc,
         {
             // Message wil be gagged, but still call error() to update global.errors and for
             // -verrors=spec
-            .error(loc, format, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+            OutBuffer buf;
+            buf.printf(format, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+            buf.writestring(" is not allowed in a `@safe` function");
+            .error(loc, buf.extractChars());
             return true;
         }
         return false;
@@ -532,7 +548,10 @@ bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, const(char)
         {
             if (!gag && !sc.isDeprecated())
             {
-                deprecation(loc, format, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+                OutBuffer buf;
+                buf.printf(format, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+                buf.writestring(" will become `@system` in a future release");
+                deprecation(loc, buf.extractChars());
             }
         }
         else if (!sc.func.safetyViolation)

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3634,7 +3634,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             deprecation(cas.loc, "`asm` statement cannot be marked `@safe`, use `@system` or `@trusted` instead");
         if (!(cas.stc & (STC.trusted | STC.safe)))
         {
-            sc.setUnsafe(false, cas.loc, "`asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not");
+            sc.setUnsafe(false, cas.loc, "`asm` statement without `@trusted` annotation");
         }
 
         sc.pop();
@@ -4115,7 +4115,7 @@ void catchSemantic(Catch c, Scope* sc)
         }
         if (!c.internalCatch)
         {
-            if (sc.setUnsafe(false, c.loc, "cannot catch C++ class objects in `@safe` code"))
+            if (sc.setUnsafe(false, c.loc, "catching C++ class objects"))
                 c.errors = true;
         }
     }
@@ -4127,7 +4127,7 @@ void catchSemantic(Catch c, Scope* sc)
     else if (!c.internalCatch && ClassDeclaration.exception &&
             cd != ClassDeclaration.exception && !ClassDeclaration.exception.isBaseOf(cd, null) &&
             sc.setUnsafe(false, c.loc,
-                "can only catch class objects derived from `Exception` in `@safe` code, not `%s`", c.type))
+                "catching class objects derived from `%s` instead of `Exception`", c.type))
     {
         c.errors = true;
     }

--- a/compiler/test/fail_compilation/attributediagnostic.d
+++ b/compiler/test/fail_compilation/attributediagnostic.d
@@ -5,11 +5,11 @@ fail_compilation/attributediagnostic.d(24): Error: `@safe` function `attributedi
 fail_compilation/attributediagnostic.d(26):        which calls `attributediagnostic.layer0`
 fail_compilation/attributediagnostic.d(28):        which calls `attributediagnostic.system`
 fail_compilation/attributediagnostic.d(30):        which wasn't inferred `@safe` because of:
-fail_compilation/attributediagnostic.d(30):        `asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not
+fail_compilation/attributediagnostic.d(30):        `asm` statement without `@trusted` annotation
 fail_compilation/attributediagnostic.d(25):        `attributediagnostic.layer1` is declared here
 fail_compilation/attributediagnostic.d(46): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system1`
 fail_compilation/attributediagnostic.d(35):        which wasn't inferred `@safe` because of:
-fail_compilation/attributediagnostic.d(35):        cast from `uint` to `int*` not allowed in safe code
+fail_compilation/attributediagnostic.d(35):        cast from `uint` to `int*`
 fail_compilation/attributediagnostic.d(33):        `attributediagnostic.system1` is declared here
 fail_compilation/attributediagnostic.d(47): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system2`
 fail_compilation/attributediagnostic.d(41):        which wasn't inferred `@safe` because of:

--- a/compiler/test/fail_compilation/bool_cast.d
+++ b/compiler/test/fail_compilation/bool_cast.d
@@ -2,11 +2,11 @@
 REQUIRED_ARGS: -de -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/bool_cast.d(17): Deprecation: cast from `ubyte[]` to `bool[]` not allowed in safe code
+fail_compilation/bool_cast.d(17): Deprecation: cast from `ubyte[]` to `bool[]` will become `@system` in a future release
 fail_compilation/bool_cast.d(17):        Source element may have bytes which are not 0 or 1
-fail_compilation/bool_cast.d(22): Deprecation: cast from `int*` to `bool*` not allowed in safe code
+fail_compilation/bool_cast.d(22): Deprecation: cast from `int*` to `bool*` will become `@system` in a future release
 fail_compilation/bool_cast.d(22):        Source element may have bytes which are not 0 or 1
-fail_compilation/bool_cast.d(24): Deprecation: cast from `bool*` to `byte*` not allowed in safe code
+fail_compilation/bool_cast.d(24): Deprecation: cast from `bool*` to `byte*` will become `@system` in a future release
 fail_compilation/bool_cast.d(24):        Target element could be assigned a byte which is not 0 or 1
 ---
 */

--- a/compiler/test/fail_compilation/cast_qual.d
+++ b/compiler/test/fail_compilation/cast_qual.d
@@ -2,9 +2,9 @@
 REQUIRED_ARGS: -preview=dip1000 -de
 TEST_OUTPUT:
 ---
-fail_compilation/cast_qual.d(17): Deprecation: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
-fail_compilation/cast_qual.d(19): Deprecation: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
-fail_compilation/cast_qual.d(25): Error: cast from `const(Object)` to `object.Object` not allowed in safe code
+fail_compilation/cast_qual.d(17): Deprecation: using the result of a cast from `const(int)` to `int` as an lvalue will become `@system` in a future release
+fail_compilation/cast_qual.d(19): Deprecation: using the result of a cast from `const(int)` to `int` as an lvalue will become `@system` in a future release
+fail_compilation/cast_qual.d(25): Error: cast from `const(Object)` to `object.Object` is not allowed in a `@safe` function
 fail_compilation/cast_qual.d(25):        Incompatible type qualifier
 ---
 */

--- a/compiler/test/fail_compilation/cpp_cast.d
+++ b/compiler/test/fail_compilation/cpp_cast.d
@@ -3,9 +3,9 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/cpp_cast.d(19): Error: cast from `cpp_cast.I` to `cpp_cast.C` not allowed in safe code
+fail_compilation/cpp_cast.d(19): Error: cast from `cpp_cast.I` to `cpp_cast.C` is not allowed in a `@safe` function
 fail_compilation/cpp_cast.d(19):        No dynamic type information for extern(C++) classes
-fail_compilation/cpp_cast.d(21): Deprecation: cast from `cpp_cast.C` to `cpp_cast.D` not allowed in safe code
+fail_compilation/cpp_cast.d(21): Deprecation: cast from `cpp_cast.C` to `cpp_cast.D` will become `@system` in a future release
 fail_compilation/cpp_cast.d(21):        No dynamic type information for extern(C++) classes
 ---
 */

--- a/compiler/test/fail_compilation/cppeh1.d
+++ b/compiler/test/fail_compilation/cppeh1.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/cppeh1.d(26): Error: cannot catch C++ class objects in `@safe` code
+fail_compilation/cppeh1.d(26): Error: catching C++ class objects is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/deprecate12979d.d
+++ b/compiler/test/fail_compilation/deprecate12979d.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate12979d.d(11): Error: `asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not
+fail_compilation/deprecate12979d.d(11): Error: `asm` statement without `@trusted` annotation is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/diag10319.d
+++ b/compiler/test/fail_compilation/diag10319.d
@@ -9,7 +9,7 @@ fail_compilation/diag10319.d(26):        which wasn't inferred `pure` because of
 fail_compilation/diag10319.d(26):        `pure` function `diag10319.bar!int.bar` cannot access mutable static data `g`
 fail_compilation/diag10319.d(34): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
 fail_compilation/diag10319.d(27):        which wasn't inferred `@safe` because of:
-fail_compilation/diag10319.d(27):        cannot take address of local `x` in `@safe` function `bar`
+fail_compilation/diag10319.d(27):        taking the address of stack-allocated local variable `x`
 fail_compilation/diag10319.d(24):        `diag10319.bar!int.bar` is declared here
 fail_compilation/diag10319.d(33): Error: function `diag10319.foo` is not `nothrow`
 fail_compilation/diag10319.d(34): Error: function `diag10319.bar!int.bar` is not `nothrow`

--- a/compiler/test/fail_compilation/diag10359.d
+++ b/compiler/test/fail_compilation/diag10359.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10359.d(10): Error: pointer slicing not allowed in safe functions
+fail_compilation/diag10359.d(10): Error: pointer slicing is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/diag23295.d
+++ b/compiler/test/fail_compilation/diag23295.d
@@ -2,10 +2,10 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/diag23295.d(21): Error: scope variable `x` assigned to non-scope parameter `y` calling `foo`
+fail_compilation/diag23295.d(21): Error: assigning scope variable `x` to non-scope parameter `y` calling `foo` is not allowed in a `@safe` function
 fail_compilation/diag23295.d(32):        which is assigned to non-scope parameter `z`
 fail_compilation/diag23295.d(34):        which is not `scope` because of `f = & z`
-fail_compilation/diag23295.d(24): Error: scope variable `ex` assigned to non-scope parameter `e` calling `thro`
+fail_compilation/diag23295.d(24): Error: assigning scope variable `ex` to non-scope parameter `e` calling `thro` is not allowed in a `@safe` function
 fail_compilation/diag23295.d(39):        which is not `scope` because of `throw e`
 ---
 */

--- a/compiler/test/fail_compilation/dip25.d
+++ b/compiler/test/fail_compilation/dip25.d
@@ -2,10 +2,10 @@
 REQUIRED_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/dip25.d(17): Error: returning `this.buffer[]` escapes a reference to parameter `this`
+fail_compilation/dip25.d(17): Error: escaping a reference to parameter `this` by returning `this.buffer[]` is not allowed in a `@safe` function
 fail_compilation/dip25.d(15):        perhaps annotate the function with `return`
 fail_compilation/dip25.d(22): Error: returning `identity(x)` escapes a reference to parameter `x`
-fail_compilation/dip25.d(23): Error: returning `identity(x)` escapes a reference to parameter `x`
+fail_compilation/dip25.d(23): Error: escaping a reference to parameter `x` by returning `identity(x)` is not allowed in a `@safe` function
 fail_compilation/dip25.d(23):        perhaps annotate the parameter with `return`
 ---
 */

--- a/compiler/test/fail_compilation/fail17842.d
+++ b/compiler/test/fail_compilation/fail17842.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -preview=dip1000
  * TEST_OUTPUT:
 ---
-fail_compilation/fail17842.d(14): Error: scope variable `p` assigned to non-scope `*q`
-fail_compilation/fail17842.d(23): Error: scope variable `obj` may not be copied into allocated memory
+fail_compilation/fail17842.d(14): Error: assigning scope variable `p` to non-scope `*q` is not allowed in a `@safe` function
+fail_compilation/fail17842.d(23): Error: copying scope variable `obj` into allocated memory is not allowed in a `@safe` function
 ---
  */
 

--- a/compiler/test/fail_compilation/fail19881.d
+++ b/compiler/test/fail_compilation/fail19881.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -preview=dip1000
  * TEST_OUTPUT:
 ---
-fail_compilation/fail19881.d(13): Error: address of local variable `local` assigned to return scope `input`
-fail_compilation/fail19881.d(13): Error: address of variable `local` assigned to `input` with longer lifetime
+fail_compilation/fail19881.d(13): Error: assigning address of local variable `local` to return scope `input` is not allowed in a `@safe` function
+fail_compilation/fail19881.d(13): Error: assigning address of variable `local` to `input` with longer lifetime is not allowed in a `@safe` function
 ---
  */
 

--- a/compiler/test/fail_compilation/fail19965.d
+++ b/compiler/test/fail_compilation/fail19965.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail19965.d(36): Error: address of variable `f` assigned to `a` with longer lifetime
+fail_compilation/fail19965.d(36): Error: assigning address of variable `f` to `a` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/fail20000.d
+++ b/compiler/test/fail_compilation/fail20000.d
@@ -1,29 +1,29 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20000.d(37): Error: cast from `fail20000.DClass` to `fail20000.CppClass` not allowed in safe code
+fail_compilation/fail20000.d(37): Error: cast from `fail20000.DClass` to `fail20000.CppClass` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(37):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(38): Error: cast from `fail20000.DInterface` to `fail20000.CppClass` not allowed in safe code
+fail_compilation/fail20000.d(38): Error: cast from `fail20000.DInterface` to `fail20000.CppClass` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(38):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(39): Error: cast from `fail20000.CppClass2` to `fail20000.CppClass` not allowed in safe code
+fail_compilation/fail20000.d(39): Error: cast from `fail20000.CppClass2` to `fail20000.CppClass` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(39):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(40): Error: cast from `fail20000.CppInterface2` to `fail20000.CppClass` not allowed in safe code
+fail_compilation/fail20000.d(40): Error: cast from `fail20000.CppInterface2` to `fail20000.CppClass` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(40):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(42): Error: cast from `fail20000.DClass` to `fail20000.CppInterface` not allowed in safe code
+fail_compilation/fail20000.d(42): Error: cast from `fail20000.DClass` to `fail20000.CppInterface` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(42):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(43): Error: cast from `fail20000.DInterface` to `fail20000.CppInterface` not allowed in safe code
+fail_compilation/fail20000.d(43): Error: cast from `fail20000.DInterface` to `fail20000.CppInterface` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(43):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(44): Error: cast from `fail20000.CppClass2` to `fail20000.CppInterface` not allowed in safe code
+fail_compilation/fail20000.d(44): Error: cast from `fail20000.CppClass2` to `fail20000.CppInterface` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(44):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(45): Error: cast from `fail20000.CppInterface2` to `fail20000.CppInterface` not allowed in safe code
+fail_compilation/fail20000.d(45): Error: cast from `fail20000.CppInterface2` to `fail20000.CppInterface` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(45):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(47): Error: cast from `fail20000.CppClass` to `fail20000.DClass` not allowed in safe code
+fail_compilation/fail20000.d(47): Error: cast from `fail20000.CppClass` to `fail20000.DClass` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(47):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(48): Error: cast from `fail20000.CppInterface` to `fail20000.DClass` not allowed in safe code
+fail_compilation/fail20000.d(48): Error: cast from `fail20000.CppInterface` to `fail20000.DClass` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(48):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(50): Error: cast from `fail20000.CppClass` to `fail20000.DInterface` not allowed in safe code
+fail_compilation/fail20000.d(50): Error: cast from `fail20000.CppClass` to `fail20000.DInterface` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(50):        Source object type is incompatible with target type
-fail_compilation/fail20000.d(51): Error: cast from `fail20000.CppInterface` to `fail20000.DInterface` not allowed in safe code
+fail_compilation/fail20000.d(51): Error: cast from `fail20000.CppInterface` to `fail20000.DInterface` is not allowed in a `@safe` function
 fail_compilation/fail20000.d(51):        Source object type is incompatible with target type
 ---
 */

--- a/compiler/test/fail_compilation/fail20084.d
+++ b/compiler/test/fail_compilation/fail20084.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail20084.d(109): Error: returning `v.front()` escapes a reference to parameter `v`
+fail_compilation/fail20084.d(109): Error: escaping a reference to parameter `v` by returning `v.front()` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/fail20108.d
+++ b/compiler/test/fail_compilation/fail20108.d
@@ -2,10 +2,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20108.d(15): Error: address of variable `y` assigned to `x` with longer lifetime
+fail_compilation/fail20108.d(15): Error: assigning address of variable `y` to `x` with longer lifetime is not allowed in a `@safe` function
 fail_compilation/fail20108.d(16): Error: scope parameter `x` may not be returned
-fail_compilation/fail20108.d(23): Error: address of variable `y` assigned to `x` with longer lifetime
-fail_compilation/fail20108.d(24): Error: scope variable `x` may not be returned
+fail_compilation/fail20108.d(23): Error: assigning address of variable `y` to `x` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/fail20108.d(24): Error: returning scope variable `x` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/fail20183.d
+++ b/compiler/test/fail_compilation/fail20183.d
@@ -4,8 +4,6 @@ TEST_OUTPUT:
 fail_compilation/fail20183.d(1016): Error: function `addr` is not callable using argument types `(int)`
 fail_compilation/fail20183.d(1016):        cannot pass rvalue argument `S(0).i` of type `int` to parameter `return ref int b`
 fail_compilation/fail20183.d(1004):        `fail20183.addr(return ref int b)` declared here
-fail_compilation/fail20183.d(1017): Error: address of expression temporary returned by `s()` assigned to `q` with longer lifetime
-fail_compilation/fail20183.d(1018): Error: address of struct literal `S(0)` assigned to `r` with longer lifetime
 ---
  */
 
@@ -34,7 +32,9 @@ void test()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20183.d(1107): Error: address of expression temporary returned by `s()` assigned to `this.ptr` with longer lifetime
+fail_compilation/fail20183.d(1017): Error: assigning address of expression temporary returned by `s()` to `q` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/fail20183.d(1018): Error: assigning address of struct literal `S(0)`  to `r` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/fail20183.d(1107): Error: assigning address of expression temporary returned by `s()` to `this.ptr` with longer lifetime is not allowed in a `@safe` function
 ---
  */
 #line 1100

--- a/compiler/test/fail_compilation/fail20461.d
+++ b/compiler/test/fail_compilation/fail20461.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail20461.d(106): Error: reference to local variable `buffer` assigned to non-scope parameter calling `assert()`
+fail_compilation/fail20461.d(106): Error: assigningreference to local variable `buffer` to non-scope parameter calling `assert()` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/fail20551.d
+++ b/compiler/test/fail_compilation/fail20551.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20551.d(15): Error: cannot take address of lazy parameter `e` in `@safe` function `opAssign`
+fail_compilation/fail20551.d(15): Error: taking address of lazy parameter `e` is not allowed in a `@safe` function
 fail_compilation/fail20551.d(26): Error: template instance `fail20551.LazyStore!int.LazyStore.opAssign!int` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/fail20658.d
+++ b/compiler/test/fail_compilation/fail20658.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20658.d(14): Error: field `U.m` cannot modify fields in `@safe` code that overlap fields with other storage classes
+fail_compilation/fail20658.d(14): Error: modifying field `U.m` which overlaps with fields with other storage classes is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/fail20691.d
+++ b/compiler/test/fail_compilation/fail20691.d
@@ -1,9 +1,9 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail20691.d(106): Error: cannot take address of `scope` variable `sa` since `scope` applies to first indirection only
-fail_compilation/fail20691.d(107): Error: cannot take address of `scope` variable `sa` since `scope` applies to first indirection only
-fail_compilation/fail20691.d(108): Error: cannot take address of `scope` variable `sa` since `scope` applies to first indirection only
+fail_compilation/fail20691.d(106): Error: taking address of `scope` variable `sa` with pointers is not allowed in a `@safe` function
+fail_compilation/fail20691.d(107): Error: taking address of `scope` variable `sa` with pointers is not allowed in a `@safe` function
+fail_compilation/fail20691.d(108): Error: taking address of `scope` variable `sa` with pointers is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/fail21868b.d
+++ b/compiler/test/fail_compilation/fail21868b.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail21868b.d(19): Error: returning `&s.x` escapes a reference to parameter `s`
+fail_compilation/fail21868b.d(19): Error: escaping a reference to parameter `s` by returning `&s.x` is not allowed in a `@safe` function
 fail_compilation/fail21868b.d(17):        perhaps change the `return scope` into `scope return`
 ---
 */

--- a/compiler/test/fail_compilation/fail22138.d
+++ b/compiler/test/fail_compilation/fail22138.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail22138.d(107): Error: scope variable `e` may not be returned
+fail_compilation/fail22138.d(107): Error: returning scope variable `e` is not allowed in a `@safe` function
 ---
  */
 

--- a/compiler/test/fail_compilation/fail22366.d
+++ b/compiler/test/fail_compilation/fail22366.d
@@ -2,13 +2,13 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail22366.d(22): Error: scope variable `s` may not be copied into allocated memory
-fail_compilation/fail22366.d(25): Error: scope variable `s` may not be copied into allocated memory
-fail_compilation/fail22366.d(26): Error: scope variable `s` may not be copied into allocated memory
-fail_compilation/fail22366.d(27): Error: scope variable `s` may not be copied into allocated memory
-fail_compilation/fail22366.d(28): Error: scope variable `s` may not be copied into allocated memory
-fail_compilation/fail22366.d(31): Error: scope variable `s` may not be copied into allocated memory
-fail_compilation/fail22366.d(32): Error: scope variable `s` may not be copied into allocated memory
+fail_compilation/fail22366.d(22): Error: copying scope variable `s` into allocated memory is not allowed in a `@safe` function
+fail_compilation/fail22366.d(25): Error: copying scope variable `s` into allocated memory is not allowed in a `@safe` function
+fail_compilation/fail22366.d(26): Error: copying scope variable `s` into allocated memory is not allowed in a `@safe` function
+fail_compilation/fail22366.d(27): Error: copying scope variable `s` into allocated memory is not allowed in a `@safe` function
+fail_compilation/fail22366.d(28): Error: copying scope variable `s` into allocated memory is not allowed in a `@safe` function
+fail_compilation/fail22366.d(31): Error: copying scope variable `s` into allocated memory is not allowed in a `@safe` function
+fail_compilation/fail22366.d(32): Error: copying scope variable `s` into allocated memory is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/fail24208.d
+++ b/compiler/test/fail_compilation/fail24208.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail24208.d(19): Error: reference to local variable `n` assigned to non-scope parameter `p` calling `escape`
+fail_compilation/fail24208.d(19): Error: assigning reference to local variable `n` to non-scope parameter `p` calling `escape` is not allowed in a `@safe` function
 fail_compilation/fail24208.d(15):        which is not `scope` because of `escaped = p`
 ---
 +/

--- a/compiler/test/fail_compilation/fail24212.d
+++ b/compiler/test/fail_compilation/fail24212.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail24212.d(29): Error: reference to local variable `n` assigned to non-scope parameter `p` calling `fun`
+fail_compilation/fail24212.d(29): Error: assigning reference to local variable `n` to non-scope parameter `p` calling `fun` is not allowed in a `@safe` function
 ---
 +/
 class Base

--- a/compiler/test/fail_compilation/fail24213.d
+++ b/compiler/test/fail_compilation/fail24213.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail24213.d(16): Error: reference to local variable `n` assigned to non-scope parameter `p`
+fail_compilation/fail24213.d(16): Error: assigning reference to local variable `n` to non-scope parameter `p` is not allowed in a `@safe` function
 ---
 +/
 alias Dg = void delegate(int* p) @safe pure nothrow;

--- a/compiler/test/fail_compilation/fail327.d
+++ b/compiler/test/fail_compilation/fail327.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail327.d(11): Error: `asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not
+fail_compilation/fail327.d(11): Error: `asm` statement without `@trusted` annotation is not allowed in a `@safe` function
 fail_compilation/fail327.d(12): Deprecation: `asm` statement cannot be marked `@safe`, use `@system` or `@trusted` instead
 ---
 */

--- a/compiler/test/fail_compilation/fail6497.d
+++ b/compiler/test/fail_compilation/fail6497.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6497.d(12): Error: cannot take address of local `n` in `@safe` function `main`
-fail_compilation/fail6497.d(12): Error: cannot take address of local `n` in `@safe` function `main`
+fail_compilation/fail6497.d(12): Error: taking the address of stack-allocated local variable `n` is not allowed in a `@safe` function
+fail_compilation/fail6497.d(12): Error: taking the address of stack-allocated local variable `n` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/fix22108.d
+++ b/compiler/test/fail_compilation/fix22108.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fix22108.d(12): Error: scope variable `p` may not be returned
+fail_compilation/fix22108.d(12): Error: returning scope variable `p` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/fix5212.d
+++ b/compiler/test/fail_compilation/fix5212.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fix5212.d(14): Error: scope variable `args_` assigned to non-scope `this.args`
+fail_compilation/fix5212.d(14): Error: assigning scope variable `args_` to non-scope `this.args` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/previewin.d
+++ b/compiler/test/fail_compilation/previewin.d
@@ -11,11 +11,11 @@ fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(i
 fail_compilation/previewin.d(6): Error: function `takeFunction` is not callable using argument types `(void function(ref scope const(real) x) pure nothrow @nogc @safe)`
 fail_compilation/previewin.d(6):        cannot pass argument `__lambda_L6_C18` of type `void function(ref scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
 fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(in real) f)` declared here
-fail_compilation/previewin.d(15): Error: scope variable `arg` assigned to global variable `myGlobal`
-fail_compilation/previewin.d(16): Error: scope variable `arg` assigned to global variable `myGlobal`
+fail_compilation/previewin.d(15): Error: assigning scope variable `arg` to global variable `myGlobal` is not allowed in a `@safe` function
+fail_compilation/previewin.d(16): Error: assigning scope variable `arg` to global variable `myGlobal` is not allowed in a `@safe` function
 fail_compilation/previewin.d(17): Error: scope parameter `arg` may not be returned
-fail_compilation/previewin.d(18): Error: scope variable `arg` assigned to `ref` variable `escape` with longer lifetime
-fail_compilation/previewin.d(22): Error: returning `arg` escapes a reference to parameter `arg`
+fail_compilation/previewin.d(18): Error: assigning scope variable `arg` to `ref` variable `escape` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/previewin.d(22): Error: escaping a reference to parameter `arg` by returning `arg` is not allowed in a `@safe` function
 fail_compilation/previewin.d(22):        perhaps annotate the parameter with `return`
 ----
  */

--- a/compiler/test/fail_compilation/retscope.d
+++ b/compiler/test/fail_compilation/retscope.d
@@ -3,11 +3,11 @@ REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/retscope.d(22): Error: scope parameter `p` may not be returned
-fail_compilation/retscope.d(32): Error: returning `b ? nested1(& i) : nested2(& j)` escapes a reference to local variable `j`
-fail_compilation/retscope.d(45): Error: scope variable `p` assigned to global variable `q`
-fail_compilation/retscope.d(47): Error: address of variable `i` assigned to `q` with longer lifetime
-fail_compilation/retscope.d(48): Error: scope variable `a` assigned to global variable `b`
-fail_compilation/retscope.d(49): Error: address of expression temporary returned by `(*fp2)()` assigned to `q` with longer lifetime
+fail_compilation/retscope.d(32): Error: escaping a reference to local variable `j` by returning `b ? nested1(& i) : nested2(& j)`  is not allowed in a `@safe` function
+fail_compilation/retscope.d(45): Error: assigning scope variable `p` to global variable `q` is not allowed in a `@safe` function
+fail_compilation/retscope.d(47): Error: assigning address of variable `i` to `q` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope.d(48): Error: assigning scope variable `a` to global variable `b` is not allowed in a `@safe` function
+fail_compilation/retscope.d(49): Error: assigning address of expression temporary returned by `(*fp2)()` to `q` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 
@@ -85,7 +85,6 @@ struct HTTP
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(96): Error: reference to local variable `sa` assigned to non-scope parameter `a` calling `bar8`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=8838
@@ -107,7 +106,8 @@ int[] bar8(int[] a) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(123): Error: returning `foo9(cast(char[])tmp)` escapes a reference to local variable `tmp`
+fail_compilation/retscope.d(95): Error: assigning reference to local variable `sa` to non-scope parameter `a` calling `bar8` is not allowed in a `@safe` function
+fail_compilation/retscope.d(123): Error: escaping a reference to local variable `tmp` by returning `foo9(cast(char[])tmp)`  is not allowed in a `@safe` function
 ---
 */
 
@@ -164,7 +164,6 @@ class C11
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(177): Error: address of variable `i` assigned to `p` with longer lifetime
 ---
 */
 
@@ -181,7 +180,6 @@ void foo11() @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(197): Error: scope variable `e` may not be returned
 ---
 */
 
@@ -201,7 +199,9 @@ void* escapeDg1(scope void* d) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(212): Error: scope variable `p` assigned to non-scope `e.e`
+fail_compilation/retscope.d(176): Error: assigning address of variable `i` to `p` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope.d(195): Error: returning scope variable `e` is not allowed in a `@safe` function
+fail_compilation/retscope.d(212): Error: assigning scope variable `p` to non-scope `e.e` is not allowed in a `@safe` function
 ---
 */
 struct Escaper3 { void* e; }
@@ -254,7 +254,6 @@ void escape4() @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(266): Error: cannot take address of `scope` variable `p` since `scope` applies to first indirection only
 ---
 */
 
@@ -271,7 +270,8 @@ void escape5() @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(286): Error: returning `foo6(& b)` escapes a reference to local variable `b`
+fail_compilation/retscope.d(265): Error: taking address of `scope` variable `p` with pointers is not allowed in a `@safe` function
+fail_compilation/retscope.d(286): Error: escaping a reference to local variable `b` by returning `foo6(& b)`  is not allowed in a `@safe` function
 ---
 */
 
@@ -323,7 +323,6 @@ ref int[3] asStatic2(      scope int[] p) @safe { return p[0 .. 3]; }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(335): Error: reference to local variable `i` assigned to non-scope `f`
 ---
 */
 
@@ -347,7 +346,8 @@ int* bar10( scope int** ptr ) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(358): Error: cannot take address of `scope` variable `aa` since `scope` applies to first indirection only
+fail_compilation/retscope.d(334): Error: assigning reference to local variable `i` to non-scope `f` is not allowed in a `@safe` function
+fail_compilation/retscope.d(358): Error: taking address of `scope` variable `aa` with pointers is not allowed in a `@safe` function
 ---
 */
 
@@ -399,7 +399,6 @@ struct Foo12
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1103): Error: scope variable `f` may not be returned
 ---
 */
 
@@ -419,7 +418,6 @@ class Foo13
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1205): Error: scope variable `f14` calling non-scope member function `Foo14.foo()`
 ---
 */
 
@@ -442,7 +440,6 @@ struct Foo14
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1311): Error: scope variable `u2` assigned to `ek` with longer lifetime
 ---
 */
 
@@ -470,7 +467,6 @@ fail_compilation/retscope.d(1311): Error: scope variable `u2` assigned to `ek` w
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1405): Error: reference to local variable `buf` assigned to non-scope anonymous parameter calling `myprintf`
 ---
 */
 
@@ -488,7 +484,11 @@ fail_compilation/retscope.d(1405): Error: reference to local variable `buf` assi
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1509): Error: reference to stack allocated value returned by `(*fp15)()` assigned to non-scope anonymous parameter
+fail_compilation/retscope.d(1103): Error: returning scope variable `f` is not allowed in a `@safe` function
+fail_compilation/retscope.d(1205): Error: scope variable `f14` calling non-scope member function `Foo14.foo()` is not allowed in a `@safe` function
+fail_compilation/retscope.d(1311): Error: assigning scope variable `u2` to `ek` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope.d(1405): Error: assigning reference to local variable `buf` to non-scope anonymous parameter calling `myprintf` is not allowed in a `@safe` function
+fail_compilation/retscope.d(1509): Error: assigning reference to stack allocated value returned by `(*fp15)()` to non-scope anonymous parameter is not allowed in a `@safe` function
 ---
 */
 
@@ -678,8 +678,8 @@ int test21()
 /*********************************************
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1907): Error: scope variable `x` assigned to `ref` variable `this` with longer lifetime
-fail_compilation/retscope.d(1913): Error: scope variable `x` may not be returned
+fail_compilation/retscope.d(1907): Error: assigning scope variable `x` to `ref` variable `this` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope.d(1913): Error: returning scope variable `x` is not allowed in a `@safe` function
 ---
 */
 #line 1900

--- a/compiler/test/fail_compilation/retscope2.d
+++ b/compiler/test/fail_compilation/retscope2.d
@@ -2,8 +2,6 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(102): Error: scope variable `s` assigned to `ref` variable `p` with longer lifetime
-fail_compilation/retscope2.d(107): Error: address of variable `s` assigned to `p` with longer lifetime
 ---
 */
 
@@ -36,7 +34,6 @@ void test200()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(302): Error: scope variable `a` assigned to return scope `b`
 ---
 */
 
@@ -52,7 +49,6 @@ fail_compilation/retscope2.d(302): Error: scope variable `a` assigned to return 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(403): Error: scope variable `a` assigned to return scope `c`
 ---
 */
 
@@ -69,7 +65,6 @@ fail_compilation/retscope2.d(403): Error: scope variable `a` assigned to return 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(504): Error: scope variable `c` may not be returned
 ---
 */
 
@@ -86,8 +81,13 @@ fail_compilation/retscope2.d(504): Error: scope variable `c` may not be returned
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(604): Error: scope variable `__param_0` assigned to non-scope anonymous parameter calling `foo600`
-fail_compilation/retscope2.d(604): Error: scope variable `__param_1` assigned to non-scope anonymous parameter calling `foo600`
+fail_compilation/retscope2.d(102): Error: assigning scope variable `s` to `ref` variable `p` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope2.d(107): Error: assigning address of variable `s` to `p` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope2.d(302): Error: assigning scope variable `a` to return scope `b` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(403): Error: assigning scope variable `a` to return scope `c` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(504): Error: returning scope variable `c` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(604): Error: assigning scope variable `__param_0` to non-scope anonymous parameter calling `foo600` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(604): Error: assigning scope variable `__param_1` to non-scope anonymous parameter calling `foo600` is not allowed in a `@safe` function
 fail_compilation/retscope2.d(614): Error: template instance `retscope2.test600!(int*, int*)` error instantiating
 ---
 */
@@ -115,8 +115,6 @@ fail_compilation/retscope2.d(614): Error: template instance `retscope2.test600!(
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(719): Error: returning `get2(s)` escapes a reference to local variable `s`
-fail_compilation/retscope2.d(721): Error: returning `s.get1()` escapes a reference to local variable `s`
 ---
 */
 
@@ -150,7 +148,6 @@ S700* escape700(int i) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(804): Error: scope variable `e` may not be thrown
 ---
 */
 
@@ -167,7 +164,6 @@ void foo800() @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(907): Error: address of variable `this` assigned to `p17568` with longer lifetime
 ---
 */
 
@@ -188,9 +184,6 @@ struct T17568
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(1005): Error: scope variable `p` assigned to non-scope `this._p`
-fail_compilation/retscope2.d(1021): Error: scope variable `p` assigned to non-scope `c._p`
-fail_compilation/retscope2.d(1024): Error: scope variable `p` assigned to non-scope `d._p`
 ---
 */
 
@@ -229,7 +222,6 @@ void test17428() @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(1107): Error: scope variable `dg` may not be returned
 ---
 */
 
@@ -249,8 +241,6 @@ void delegate() test17430() @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(1216): Error: returning `s.foo()` escapes a reference to local variable `s`
-fail_compilation/retscope2.d(1233): Error: returning `t.foo()` escapes a reference to local variable `t`
 ---
 */
 
@@ -296,7 +286,17 @@ struct T17388
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(1306): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
+fail_compilation/retscope2.d(719): Error: returning `get2(s)` escapes a reference to local variable `s`
+fail_compilation/retscope2.d(721): Error: returning `s.get1()` escapes a reference to local variable `s`
+fail_compilation/retscope2.d(804): Error: throwing scope variable `e` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(907): Error: assigning address of variable `this` to `p17568` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope2.d(1005): Error: assigning scope variable `p` to non-scope `this._p` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(1021): Error: assigning scope variable `p` to non-scope `c._p` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(1024): Error: assigning scope variable `p` to non-scope `d._p` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(1107): Error: returning scope variable `dg` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(1216): Error: returning `s.foo()` escapes a reference to local variable `s`
+fail_compilation/retscope2.d(1233): Error: returning `t.foo()` escapes a reference to local variable `t`
+fail_compilation/retscope2.d(1306): Error: escaping a reference to local variable `i by copying `& i` into allocated memory is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/retscope3.d
+++ b/compiler/test/fail_compilation/retscope3.d
@@ -5,8 +5,6 @@ REQUIRED_ARGS: -preview=dip1000
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope3.d(2008): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
-fail_compilation/retscope3.d(2017): Error: copying `S2000(& i)` into allocated memory escapes a reference to local variable `i`
 ---
 */
 
@@ -53,9 +51,11 @@ void bar4()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope3.d(4003): Error: copying `u[]` into allocated memory escapes a reference to parameter `u`
+fail_compilation/retscope3.d(2008): Error: escaping a reference to local variable `i by copying `& i` into allocated memory is not allowed in a `@safe` function
+fail_compilation/retscope3.d(2017): Error: escaping a reference to local variable `i by copying `S2000(& i)` into allocated memory is not allowed in a `@safe` function
+fail_compilation/retscope3.d(4003): Error: escaping a reference to parameter `u` by copying `u[]` into allocated memory is not allowed in a `@safe` function
 fail_compilation/retscope3.d(4016): Error: storing reference to outer local variable `i` into allocated memory causes it to escape
-fail_compilation/retscope3.d(4025): Error: storing reference to stack allocated value returned by `makeSA()` into allocated memory causes it to escape
+fail_compilation/retscope3.d(4025): Error: escaping reference to stack allocated value returned by `makeSA()` into allocated memory
 ---
 */
 

--- a/compiler/test/fail_compilation/retscope5.d
+++ b/compiler/test/fail_compilation/retscope5.d
@@ -5,7 +5,7 @@ REQUIRED_ARGS: -preview=dip1000
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope5.d(5010): Error: address of variable `t` assigned to `p` with longer lifetime
+fail_compilation/retscope5.d(5010): Error: assigning address of variable `t` to `p` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/retscope6.d
+++ b/compiler/test/fail_compilation/retscope6.d
@@ -5,7 +5,7 @@ REQUIRED_ARGS: -preview=dip1000
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(6007): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
+fail_compilation/retscope6.d(6007): Error: escaping a reference to local variable `i by copying `& i` into allocated memory is not allowed in a `@safe` function
 ---
 */
 
@@ -23,11 +23,11 @@ int* test() @safe
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(7034): Error: address of variable `i` assigned to `s` with longer lifetime
-fail_compilation/retscope6.d(7035): Error: address of variable `i` assigned to `s` with longer lifetime
-fail_compilation/retscope6.d(7025): Error: scope variable `__param_2` assigned to `ref` variable `t` with longer lifetime
+fail_compilation/retscope6.d(7034): Error: assigning address of variable `i` to `s` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope6.d(7035): Error: assigning address of variable `i` to `s` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope6.d(7025): Error: assigning scope variable `__param_2` to `ref` variable `t` with longer lifetime is not allowed in a `@safe` function
 fail_compilation/retscope6.d(7037): Error: template instance `retscope6.S.emplace4!(int*)` error instantiating
-fail_compilation/retscope6.d(7037): Error: address of variable `i` assigned to `s` with longer lifetime
+fail_compilation/retscope6.d(7037): Error: assigning address of variable `i` to `s` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 
@@ -75,13 +75,13 @@ void foo() @safe
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(8016): Error: address of variable `i` assigned to `p` with longer lifetime
-fail_compilation/retscope6.d(8031): Error: reference to local variable `i` assigned to non-scope parameter `p` calling `betty`
-fail_compilation/retscope6.d(8031): Error: reference to local variable `j` assigned to non-scope parameter `q` calling `betty`
+fail_compilation/retscope6.d(8016): Error: assigning address of variable `i` to `p` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope6.d(8031): Error: assigning reference to local variable `i` to non-scope parameter `p` calling `betty` is not allowed in a `@safe` function
+fail_compilation/retscope6.d(8031): Error: assigning reference to local variable `j` to non-scope parameter `q` calling `betty` is not allowed in a `@safe` function
 fail_compilation/retscope6.d(8023):        which is not `scope` because of `p = q`
-fail_compilation/retscope6.d(8048): Error: reference to local variable `i` assigned to non-scope parameter `p` calling `archie`
+fail_compilation/retscope6.d(8048): Error: assigning reference to local variable `i` to non-scope parameter `p` calling `archie` is not allowed in a `@safe` function
 fail_compilation/retscope6.d(8039):        which is not `scope` because of `r = p`
-fail_compilation/retscope6.d(8048): Error: reference to local variable `j` assigned to non-scope parameter `q` calling `archie`
+fail_compilation/retscope6.d(8048): Error: assigning reference to local variable `j` to non-scope parameter `q` calling `archie` is not allowed in a `@safe` function
 fail_compilation/retscope6.d(8038):        which is not `scope` because of `p = q`
 ---
 */
@@ -144,7 +144,7 @@ void testarchie()
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(9023): Error: returning `fred(& i)` escapes a reference to local variable `i`
+fail_compilation/retscope6.d(9023): Error: escaping a reference to local variable `i` by returning `fred(& i)`  is not allowed in a `@safe` function
 ---
 */
 
@@ -177,7 +177,7 @@ T9 testfred()
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(10003): Error: scope variable `values` assigned to non-scope parameter `values` calling `escape`
+fail_compilation/retscope6.d(10003): Error: assigning scope variable `values` to non-scope parameter `values` calling `escape` is not allowed in a `@safe` function
 ---
 */
 
@@ -192,7 +192,7 @@ void escape(int[] values) {}
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(11004): Error: address of variable `buffer` assigned to `secret` with longer lifetime
+fail_compilation/retscope6.d(11004): Error: assigning address of variable `buffer` to `secret` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 
@@ -207,8 +207,8 @@ void hmac(scope ubyte[] secret)
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(12011): Error: returning `escape_m_20150(& x)` escapes a reference to local variable `x`
-fail_compilation/retscope6.d(12022): Error: returning `escape_c_20150(& x)` escapes a reference to local variable `x`
+fail_compilation/retscope6.d(12011): Error: escaping a reference to local variable `x` by returning `escape_m_20150(& x)`  is not allowed in a `@safe` function
+fail_compilation/retscope6.d(12022): Error: escaping a reference to local variable `x` by returning `escape_c_20150(& x)`  is not allowed in a `@safe` function
 ---
 */
 
@@ -240,7 +240,7 @@ const(int)* f_c_20150() @safe nothrow
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(13010): Error: reference to local variable `str` assigned to non-scope parameter `x` calling `f_throw`
+fail_compilation/retscope6.d(13010): Error: assigning reference to local variable `str` to non-scope parameter `x` calling `f_throw` is not allowed in a `@safe` function
 ---
 */
 
@@ -260,9 +260,9 @@ void escape_throw_20150() @safe
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(14019): Error: scope variable `scopePtr` assigned to non-scope parameter `x` calling `noInfer23021`
+fail_compilation/retscope6.d(14019): Error: assigning scope variable `scopePtr` to non-scope parameter `x` calling `noInfer23021` is not allowed in a `@safe` function
 fail_compilation/retscope6.d(14009):        which is not `scope` because of `*escapeHole = cast(const(int)*)x`
-fail_compilation/retscope6.d(14022): Error: scope variable `scopePtr` may not be returned
+fail_compilation/retscope6.d(14022): Error: returning scope variable `scopePtr` is not allowed in a `@safe` function
 ---
 */
 
@@ -299,7 +299,7 @@ ref int escape23021() @safe
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(14050): Error: scope variable `z` assigned to non-scope parameter `y` calling `f23294`
+fail_compilation/retscope6.d(14050): Error: assigning scope variable `z` to non-scope parameter `y` calling `f23294` is not allowed in a `@safe` function
 fail_compilation/retscope6.d(14044):        which is not `scope` because of `x = y`
 ---
 */

--- a/compiler/test/fail_compilation/safe_gshared.d
+++ b/compiler/test/fail_compilation/safe_gshared.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/safe_gshared.d(13): Error: `@safe` function `f` cannot access `__gshared` data `x`
-fail_compilation/safe_gshared.d(14): Error: `@safe` function `f` cannot access `__gshared` data `x`
+fail_compilation/safe_gshared.d(13): Error: accessing `__gshared` data `x` is not allowed in a `@safe` function
+fail_compilation/safe_gshared.d(14): Error: accessing `__gshared` data `x` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/safe_pointer_index.d
+++ b/compiler/test/fail_compilation/safe_pointer_index.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/safe_pointer_index.d(11): Error: `@safe` function `f` cannot index pointer `x`
+fail_compilation/safe_pointer_index.d(11): Error: indexing pointer `x` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/safer.d
+++ b/compiler/test/fail_compilation/safer.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=safer
 TEST_OUTPUT:
 ---
-fail_compilation/safer.d(10): Error: `void` initializers for pointers not allowed in safe functions
+fail_compilation/safer.d(10): Error: `void` initializing a pointer is not allowed in a function with default safety with `-preview=safer`
 ---
 */
 

--- a/compiler/test/fail_compilation/shared.d
+++ b/compiler/test/fail_compilation/shared.d
@@ -240,13 +240,13 @@ struct BitRange
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/shared.d(3004): Error: cast from `void*` to `shared(int*)` not allowed in safe code
+fail_compilation/shared.d(3004): Error: cast from `void*` to `shared(int*)` is not allowed in a `@safe` function
 fail_compilation/shared.d(3004):        `void` data may contain pointers and target element type is mutable
-fail_compilation/shared.d(3005): Error: cast from `void*` to `shared(const(int*))` not allowed in safe code
+fail_compilation/shared.d(3005): Error: cast from `void*` to `shared(const(int*))` is not allowed in a `@safe` function
 fail_compilation/shared.d(3005):        Source type is incompatible with target type containing a pointer
-fail_compilation/shared.d(3008): Error: cast from `shared(void*)` to `int*` not allowed in safe code
+fail_compilation/shared.d(3008): Error: cast from `shared(void*)` to `int*` is not allowed in a `@safe` function
 fail_compilation/shared.d(3008):        `void` data may contain pointers and target element type is mutable
-fail_compilation/shared.d(3009): Error: cast from `shared(void*)` to `shared(const(int*))` not allowed in safe code
+fail_compilation/shared.d(3009): Error: cast from `shared(void*)` to `shared(const(int*))` is not allowed in a `@safe` function
 fail_compilation/shared.d(3009):        Source type is incompatible with target type containing a pointer
 ---
 */

--- a/compiler/test/fail_compilation/system_ptr_cast.d
+++ b/compiler/test/fail_compilation/system_ptr_cast.d
@@ -2,9 +2,9 @@
 REQUIRED_ARGS: -preview=dip1000 -de
 TEST_OUTPUT:
 ---
-fail_compilation/system_ptr_cast.d(20): Deprecation: cast from `S*` to `int*` not allowed in safe code
+fail_compilation/system_ptr_cast.d(20): Deprecation: cast from `S*` to `int*` will become `@system` in a future release
 fail_compilation/system_ptr_cast.d(20):        Source element type has unsafe bit patterns and target element type is mutable
-fail_compilation/system_ptr_cast.d(24): Deprecation: cast from `int*` to `S*` not allowed in safe code
+fail_compilation/system_ptr_cast.d(24): Deprecation: cast from `int*` to `S*` will become `@system` in a future release
 fail_compilation/system_ptr_cast.d(24):        Target element type has unsafe bit patterns
 ---
 */

--- a/compiler/test/fail_compilation/systemvariables.d
+++ b/compiler/test/fail_compilation/systemvariables.d
@@ -2,23 +2,23 @@
 REQUIRED_ARGS: -preview=systemVariables
 TEST_OUTPUT:
 ---
-fail_compilation/systemvariables.d(39): Error: cannot access `@system` variable `gInt` in @safe code
+fail_compilation/systemvariables.d(39): Error: access `@system` variable `gInt` is not allowed in a `@safe` function
 fail_compilation/systemvariables.d(29):        `gInt` is declared here
-fail_compilation/systemvariables.d(40): Error: cannot access `@system` variable `gInt` in @safe code
+fail_compilation/systemvariables.d(40): Error: access `@system` variable `gInt` is not allowed in a `@safe` function
 fail_compilation/systemvariables.d(29):        `gInt` is declared here
-fail_compilation/systemvariables.d(41): Error: cannot access `@system` variable `gArr` in @safe code
+fail_compilation/systemvariables.d(41): Error: access `@system` variable `gArr` is not allowed in a `@safe` function
 fail_compilation/systemvariables.d(31):        `gArr` is declared here
-fail_compilation/systemvariables.d(42): Error: cannot access `@system` variable `gArr` in @safe code
+fail_compilation/systemvariables.d(42): Error: access `@system` variable `gArr` is not allowed in a `@safe` function
 fail_compilation/systemvariables.d(31):        `gArr` is declared here
-fail_compilation/systemvariables.d(43): Error: cannot access `@system` variable `gInt` in @safe code
+fail_compilation/systemvariables.d(43): Error: access `@system` variable `gInt` is not allowed in a `@safe` function
 fail_compilation/systemvariables.d(29):        `gInt` is declared here
-fail_compilation/systemvariables.d(46): Error: cannot access `@system` variable `lSys` in @safe code
+fail_compilation/systemvariables.d(46): Error: access `@system` variable `lSys` is not allowed in a `@safe` function
 fail_compilation/systemvariables.d(45):        `lSys` is declared here
-fail_compilation/systemvariables.d(47): Error: cannot access `@system` variable `lSys` in @safe code
+fail_compilation/systemvariables.d(47): Error: access `@system` variable `lSys` is not allowed in a `@safe` function
 fail_compilation/systemvariables.d(45):        `lSys` is declared here
-fail_compilation/systemvariables.d(48): Error: cannot access `@system` variable `lSys` in @safe code
+fail_compilation/systemvariables.d(48): Error: access `@system` variable `lSys` is not allowed in a `@safe` function
 fail_compilation/systemvariables.d(45):        `lSys` is declared here
-fail_compilation/systemvariables.d(50): Error: cannot access `@system` variable `eInt` in @safe code
+fail_compilation/systemvariables.d(50): Error: access `@system` variable `eInt` is not allowed in a `@safe` function
 fail_compilation/systemvariables.d(30):        `eInt` is declared here
 ---
 */

--- a/compiler/test/fail_compilation/systemvariables_bool_union.d
+++ b/compiler/test/fail_compilation/systemvariables_bool_union.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/systemvariables_bool_union.d(21): Deprecation: cannot access overlapped field `Box.b` with unsafe bit patterns in `@safe` code
+fail_compilation/systemvariables_bool_union.d(21): Deprecation: accessing overlapped field `Box.b` with unsafe bit patterns will become `@system` in a future release
 ---
 */
 

--- a/compiler/test/fail_compilation/systemvariables_deprecation.d
+++ b/compiler/test/fail_compilation/systemvariables_deprecation.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 fail_compilation/systemvariables_deprecation.d(16): Deprecation: `@safe` function `main` calling `middle`
 fail_compilation/systemvariables_deprecation.d(21):        which calls `systemvariables_deprecation.inferred`
 fail_compilation/systemvariables_deprecation.d(27):        which wouldn't be `@safe` because of:
-fail_compilation/systemvariables_deprecation.d(27):        cannot access `@system` variable `x0` in @safe code
+fail_compilation/systemvariables_deprecation.d(27):        access `@system` variable `x0`
 ---
 */
 

--- a/compiler/test/fail_compilation/systemvariables_struct.d
+++ b/compiler/test/fail_compilation/systemvariables_struct.d
@@ -2,16 +2,16 @@
 REQUIRED_ARGS: -preview=systemVariables
 TEST_OUTPUT:
 ---
-fail_compilation/systemvariables_struct.d(31): Error: cannot access `@system` field `S.syst` in `@safe` code
-fail_compilation/systemvariables_struct.d(32): Error: cannot access `@system` field `S.syst` in `@safe` code
-fail_compilation/systemvariables_struct.d(33): Error: cannot access `@system` field `S.syst` in `@safe` code
-fail_compilation/systemvariables_struct.d(36): Error: cannot access `@system` field `S.syst` in `@safe` code
-fail_compilation/systemvariables_struct.d(37): Error: cannot access `@system` field `S.syst` in `@safe` code
-fail_compilation/systemvariables_struct.d(38): Error: cannot access `@system` field `S.syst` in `@safe` code
-fail_compilation/systemvariables_struct.d(54): Error: cannot access `@system` field `S2.syst` in `@safe` code
-fail_compilation/systemvariables_struct.d(55): Error: cannot access `@system` field `S2.syst` in `@safe` code
-fail_compilation/systemvariables_struct.d(56): Error: cannot access `@system` field `S.syst` in `@safe` code
-fail_compilation/systemvariables_struct.d(57): Error: cannot access `@system` field `S.syst` in `@safe` code
+fail_compilation/systemvariables_struct.d(31): Error: accessing `@system` field `S.syst` is not allowed in a `@safe` function
+fail_compilation/systemvariables_struct.d(32): Error: accessing `@system` field `S.syst` is not allowed in a `@safe` function
+fail_compilation/systemvariables_struct.d(33): Error: accessing `@system` field `S.syst` is not allowed in a `@safe` function
+fail_compilation/systemvariables_struct.d(36): Error: accessing `@system` field `S.syst` is not allowed in a `@safe` function
+fail_compilation/systemvariables_struct.d(37): Error: accessing `@system` field `S.syst` is not allowed in a `@safe` function
+fail_compilation/systemvariables_struct.d(38): Error: accessing `@system` field `S.syst` is not allowed in a `@safe` function
+fail_compilation/systemvariables_struct.d(54): Error: accessing `@system` field `S2.syst` is not allowed in a `@safe` function
+fail_compilation/systemvariables_struct.d(55): Error: accessing `@system` field `S2.syst` is not allowed in a `@safe` function
+fail_compilation/systemvariables_struct.d(56): Error: accessing `@system` field `S.syst` is not allowed in a `@safe` function
+fail_compilation/systemvariables_struct.d(57): Error: accessing `@system` field `S.syst` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/systemvariables_var_init.d
+++ b/compiler/test/fail_compilation/systemvariables_var_init.d
@@ -2,11 +2,11 @@
 REQUIRED_ARGS: -preview=systemVariables
 TEST_OUTPUT:
 ---
-fail_compilation/systemvariables_var_init.d(24): Error: cannot access `@system` variable `ptrEnum` in @safe code
+fail_compilation/systemvariables_var_init.d(24): Error: access `@system` variable `ptrEnum` is not allowed in a `@safe` function
 fail_compilation/systemvariables_var_init.d(16):        `ptrEnum` is inferred to be `@system` from its initializer here
-fail_compilation/systemvariables_var_init.d(25): Error: cannot access `@system` variable `ptrConst` in @safe code
+fail_compilation/systemvariables_var_init.d(25): Error: access `@system` variable `ptrConst` is not allowed in a `@safe` function
 fail_compilation/systemvariables_var_init.d(17):        `ptrConst` is inferred to be `@system` from its initializer here
-fail_compilation/systemvariables_var_init.d(27): Error: cannot access `@system` variable `ptrVar` in @safe code
+fail_compilation/systemvariables_var_init.d(27): Error: access `@system` variable `ptrVar` is not allowed in a `@safe` function
 fail_compilation/systemvariables_var_init.d(19):        `ptrVar` is inferred to be `@system` from its initializer here
 ---
 */

--- a/compiler/test/fail_compilation/systemvariables_void_init.d
+++ b/compiler/test/fail_compilation/systemvariables_void_init.d
@@ -2,13 +2,13 @@
 REQUIRED_ARGS: -preview=systemVariables
 TEST_OUTPUT:
 ---
-fail_compilation/systemvariables_void_init.d(48): Error: `void` initializers for types with unsafe bit patterns are not allowed in safe functions
-fail_compilation/systemvariables_void_init.d(49): Error: `void` initializers for types with unsafe bit patterns are not allowed in safe functions
-fail_compilation/systemvariables_void_init.d(50): Error: `void` initializers for types with unsafe bit patterns are not allowed in safe functions
-fail_compilation/systemvariables_void_init.d(51): Error: a `bool` must be 0 or 1, so void intializing it is not allowed in safe functions
-fail_compilation/systemvariables_void_init.d(52): Error: a `bool` must be 0 or 1, so void intializing it is not allowed in safe functions
-fail_compilation/systemvariables_void_init.d(53): Error: `void` initializers for types with unsafe bit patterns are not allowed in safe functions
-fail_compilation/systemvariables_void_init.d(54): Error: `void` initializers for types with unsafe bit patterns are not allowed in safe functions
+fail_compilation/systemvariables_void_init.d(48): Error: `void` initializing a type with unsafe bit patterns is not allowed in a `@safe` function
+fail_compilation/systemvariables_void_init.d(49): Error: `void` initializing a type with unsafe bit patterns is not allowed in a `@safe` function
+fail_compilation/systemvariables_void_init.d(50): Error: `void` initializing a type with unsafe bit patterns is not allowed in a `@safe` function
+fail_compilation/systemvariables_void_init.d(51): Error: void intializing a bool (which must always be 0 or 1) is not allowed in a `@safe` function
+fail_compilation/systemvariables_void_init.d(52): Error: void intializing a bool (which must always be 0 or 1) is not allowed in a `@safe` function
+fail_compilation/systemvariables_void_init.d(53): Error: `void` initializing a type with unsafe bit patterns is not allowed in a `@safe` function
+fail_compilation/systemvariables_void_init.d(54): Error: `void` initializing a type with unsafe bit patterns is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test11176.d
+++ b/compiler/test/fail_compilation/test11176.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test11176.d(12): Error: `b.ptr` cannot be used in `@safe` code, use `&b[0]` instead
-fail_compilation/test11176.d(16): Error: `b.ptr` cannot be used in `@safe` code, use `&b[0]` instead
+fail_compilation/test11176.d(12): Error: using `b.ptr` (instead of `&b[0])` is not allowed in a `@safe` function
+fail_compilation/test11176.d(16): Error: using `b.ptr` (instead of `&b[0])` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test12822.d
+++ b/compiler/test/fail_compilation/test12822.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test12822.d(13): Error: cannot modify delegate pointer in `@safe` code `dg.ptr`
-fail_compilation/test12822.d(14): Error: `dg.funcptr` cannot be used in `@safe` code
+fail_compilation/test12822.d(13): Error: modifying delegate pointer `dg.ptr` is not allowed in a `@safe` function
+fail_compilation/test12822.d(14): Error: using `dg.funcptr` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test13536.d
+++ b/compiler/test/fail_compilation/test13536.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test13536.d(22): Error: field `U.sysDg` cannot access pointers in `@safe` code that overlap other fields
-fail_compilation/test13536.d(23): Error: field `U.safeDg` cannot access pointers in `@safe` code that overlap other fields
+fail_compilation/test13536.d(22): Error: accessing overlapped field `U.sysDg` with pointers is not allowed in a `@safe` function
+fail_compilation/test13536.d(23): Error: accessing overlapped field `U.safeDg` with pointers is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test13537.d
+++ b/compiler/test/fail_compilation/test13537.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test13537.d(31): Error: field `U.y` cannot modify fields in `@safe` code that overlap fields with other storage classes
-fail_compilation/test13537.d(32): Error: field `U.y` cannot modify fields in `@safe` code that overlap fields with other storage classes
-fail_compilation/test13537.d(33): Error: field `U.z` cannot access pointers in `@safe` code that overlap other fields
-fail_compilation/test13537.d(34): Error: field `U.y` cannot modify fields in `@safe` code that overlap fields with other storage classes
+fail_compilation/test13537.d(31): Error: modifying field `U.y` which overlaps with fields with other storage classes is not allowed in a `@safe` function
+fail_compilation/test13537.d(32): Error: modifying field `U.y` which overlaps with fields with other storage classes is not allowed in a `@safe` function
+fail_compilation/test13537.d(33): Error: accessing overlapped field `U.z` with pointers is not allowed in a `@safe` function
+fail_compilation/test13537.d(34): Error: modifying field `U.y` which overlaps with fields with other storage classes is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test14496.d
+++ b/compiler/test/fail_compilation/test14496.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test14496.d(21): Error: `void` initializers for pointers not allowed in safe functions
-fail_compilation/test14496.d(24): Error: `void` initializers for pointers not allowed in safe functions
-fail_compilation/test14496.d(28): Error: `void` initializers for pointers not allowed in safe functions
-fail_compilation/test14496.d(48): Error: `void` initializers for pointers not allowed in safe functions
-fail_compilation/test14496.d(49): Error: `void` initializers for pointers not allowed in safe functions
-fail_compilation/test14496.d(50): Error: `void` initializers for pointers not allowed in safe functions
+fail_compilation/test14496.d(21): Error: `void` initializing a pointer is not allowed in a `@safe` function
+fail_compilation/test14496.d(24): Error: `void` initializing a pointer is not allowed in a `@safe` function
+fail_compilation/test14496.d(28): Error: `void` initializing a pointer is not allowed in a `@safe` function
+fail_compilation/test14496.d(48): Error: `void` initializers for pointers is not allowed in a `@safe` function
+fail_compilation/test14496.d(49): Error: `void` initializers for pointers is not allowed in a `@safe` function
+fail_compilation/test14496.d(50): Error: `void` initializers for pointers is not allowed in a `@safe` function
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=14496

--- a/compiler/test/fail_compilation/test15191.d
+++ b/compiler/test/fail_compilation/test15191.d
@@ -4,8 +4,8 @@ REQUIRED_ARGS: -preview=dip1000
 fail_compilation/test15191.d(34): Error: returning `&identity(x)` escapes a reference to local variable `x`
 fail_compilation/test15191.d(40): Error: returning `&identityPtr(x)` escapes a reference to local variable `x`
 fail_compilation/test15191.d(46): Error: returning `&identityPtr(x)` escapes a reference to local variable `x`
-fail_compilation/test15191.d(67): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
-fail_compilation/test15191.d(69): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
+fail_compilation/test15191.d(67): Error: taking address of `scope` variable `x` with pointers is not allowed in a `@safe` function
+fail_compilation/test15191.d(69): Error: taking address of `scope` variable `x` with pointers is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test15399.d
+++ b/compiler/test/fail_compilation/test15399.d
@@ -1,14 +1,14 @@
 /* https://issues.dlang.org/show_bug.cgi?id=15399
 TEST_OUTPUT:
 ---
-fail_compilation/test15399.d(32): Error: field `S1.ptr` cannot modify misaligned pointers in `@safe` code
-fail_compilation/test15399.d(33): Error: field `S2.ptr` cannot modify misaligned pointers in `@safe` code
-fail_compilation/test15399.d(34): Error: field `S1.ptr` cannot modify misaligned pointers in `@safe` code
-fail_compilation/test15399.d(35): Error: field `S2.ptr` cannot modify misaligned pointers in `@safe` code
-fail_compilation/test15399.d(36): Error: field `S1.ptr` cannot modify misaligned pointers in `@safe` code
-fail_compilation/test15399.d(37): Error: field `S2.ptr` cannot modify misaligned pointers in `@safe` code
-fail_compilation/test15399.d(38): Error: field `S1.ptr` cannot modify misaligned pointers in `@safe` code
-fail_compilation/test15399.d(39): Error: field `S2.ptr` cannot modify misaligned pointers in `@safe` code
+fail_compilation/test15399.d(32): Error: modifying misaligned pointers through field `S1.ptr` is not allowed in a `@safe` function
+fail_compilation/test15399.d(33): Error: modifying misaligned pointers through field `S2.ptr` is not allowed in a `@safe` function
+fail_compilation/test15399.d(34): Error: modifying misaligned pointers through field `S1.ptr` is not allowed in a `@safe` function
+fail_compilation/test15399.d(35): Error: modifying misaligned pointers through field `S2.ptr` is not allowed in a `@safe` function
+fail_compilation/test15399.d(36): Error: modifying misaligned pointers through field `S1.ptr` is not allowed in a `@safe` function
+fail_compilation/test15399.d(37): Error: modifying misaligned pointers through field `S2.ptr` is not allowed in a `@safe` function
+fail_compilation/test15399.d(38): Error: modifying misaligned pointers through field `S1.ptr` is not allowed in a `@safe` function
+fail_compilation/test15399.d(39): Error: modifying misaligned pointers through field `S2.ptr` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test15544.d
+++ b/compiler/test/fail_compilation/test15544.d
@@ -2,8 +2,8 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test15544.d(20): Error: reference to local `this` assigned to non-scope `_del` in @safe code
-fail_compilation/test15544.d(22): Error: reference to local `this` assigned to non-scope `_del` in @safe code
+fail_compilation/test15544.d(20): Error: assigning reference to local `this` to non-scope `_del` is not allowed in a `@safe` function
+fail_compilation/test15544.d(22): Error: assigning reference to local `this` to non-scope `_del` is not allowed in a `@safe` function
 ---
 */
 
@@ -26,7 +26,7 @@ struct S {
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test15544.d(46): Error: reference to local `y` assigned to non-scope `dg` in @safe code
+fail_compilation/test15544.d(46): Error: assigning reference to local `y` to non-scope `dg` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test15672.d
+++ b/compiler/test/fail_compilation/test15672.d
@@ -1,9 +1,9 @@
 /*
  * TEST_OUTPUT:
 ---
-fail_compilation/test15672.d(17): Error: cast from `void[]` to `byte[]` not allowed in safe code
+fail_compilation/test15672.d(17): Error: cast from `void[]` to `byte[]` is not allowed in a `@safe` function
 fail_compilation/test15672.d(17):        `void` data may contain pointers and target element type is mutable
-fail_compilation/test15672.d(27): Error: cast from `void*` to `byte*` not allowed in safe code
+fail_compilation/test15672.d(27): Error: cast from `void*` to `byte*` is not allowed in a `@safe` function
 fail_compilation/test15672.d(27):        `void` data may contain pointers and target element type is mutable
 ---
 */

--- a/compiler/test/fail_compilation/test15703.d
+++ b/compiler/test/fail_compilation/test15703.d
@@ -2,15 +2,15 @@
 REQUIRED_ARGS: -m32
 TEST_OUTPUT:
 ---
-fail_compilation/test15703.d(23): Error: cast from `Object[]` to `uint[]` not allowed in safe code
+fail_compilation/test15703.d(23): Error: cast from `Object[]` to `uint[]` is not allowed in a `@safe` function
 fail_compilation/test15703.d(23):        Target element type is mutable and source element type contains a pointer
-fail_compilation/test15703.d(25): Error: cast from `object.Object` to `const(uint)*` not allowed in safe code
+fail_compilation/test15703.d(25): Error: cast from `object.Object` to `const(uint)*` is not allowed in a `@safe` function
 fail_compilation/test15703.d(25):        Source type is incompatible with target type containing a pointer
-fail_compilation/test15703.d(28): Error: cast from `uint[]` to `Object[]` not allowed in safe code
+fail_compilation/test15703.d(28): Error: cast from `uint[]` to `Object[]` is not allowed in a `@safe` function
 fail_compilation/test15703.d(28):        Target element type contains a pointer
-fail_compilation/test15703.d(44): Error: cast from `int[]` to `S[]` not allowed in safe code
+fail_compilation/test15703.d(44): Error: cast from `int[]` to `S[]` is not allowed in a `@safe` function
 fail_compilation/test15703.d(44):        Target element type is opaque
-fail_compilation/test15703.d(45): Error: cast from `S[]` to `int[]` not allowed in safe code
+fail_compilation/test15703.d(45): Error: cast from `S[]` to `int[]` is not allowed in a `@safe` function
 fail_compilation/test15703.d(45):        Source element type is opaque
 ---
 */

--- a/compiler/test/fail_compilation/test15704.d
+++ b/compiler/test/fail_compilation/test15704.d
@@ -1,9 +1,9 @@
 /*
  * TEST_OUTPUT:
 ---
-fail_compilation/test15704.d(17): Error: cannot copy `void[]` to `void[]` in `@safe` code
-fail_compilation/test15704.d(18): Error: cannot copy `const(void)[]` to `void[]` in `@safe` code
-fail_compilation/test15704.d(19): Deprecation: cannot copy `int[]` to `void[]` in `@safe` code
+fail_compilation/test15704.d(17): Error: copying `void[]` to `void[]` is not allowed in a `@safe` function
+fail_compilation/test15704.d(18): Error: copying `const(void)[]` to `void[]` is not allowed in a `@safe` function
+fail_compilation/test15704.d(19): Deprecation: copying `int[]` to `void[]` will become `@system` in a future release
 ---
  */
 

--- a/compiler/test/fail_compilation/test16365.d
+++ b/compiler/test/fail_compilation/test16365.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test16365.d(20): Error: `this` reference necessary to take address of member `f1` in `@safe` function `main`
+fail_compilation/test16365.d(20): Error: taking address of member `f1` without `this` reference is not allowed in a `@safe` function
 fail_compilation/test16365.d(22): Error: cannot implicitly convert expression `&f2` of type `void delegate() pure nothrow @nogc @safe` to `void function() @safe`
-fail_compilation/test16365.d(27): Error: `dg.funcptr` cannot be used in `@safe` code
+fail_compilation/test16365.d(27): Error: using `dg.funcptr` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test16589.d
+++ b/compiler/test/fail_compilation/test16589.d
@@ -2,13 +2,13 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test16589.d(26): Error: returning `&this.data` escapes a reference to parameter `this`
+fail_compilation/test16589.d(26): Error: escaping a reference to parameter `this` by returning `&this.data` is not allowed in a `@safe` function
 fail_compilation/test16589.d(24):        perhaps annotate the function with `return`
-fail_compilation/test16589.d(31): Error: returning `&this` escapes a reference to parameter `this`
+fail_compilation/test16589.d(31): Error: escaping a reference to parameter `this` by returning `&this` is not allowed in a `@safe` function
 fail_compilation/test16589.d(29):        perhaps annotate the function with `return`
-fail_compilation/test16589.d(37): Error: returning `&s.data` escapes a reference to parameter `s`
+fail_compilation/test16589.d(37): Error: escaping a reference to parameter `s` by returning `&s.data` is not allowed in a `@safe` function
 fail_compilation/test16589.d(35):        perhaps annotate the parameter with `return`
-fail_compilation/test16589.d(42): Error: returning `&s` escapes a reference to parameter `s`
+fail_compilation/test16589.d(42): Error: escaping a reference to parameter `s` by returning `&s` is not allowed in a `@safe` function
 fail_compilation/test16589.d(40):        perhaps annotate the parameter with `return`
 fail_compilation/test16589.d(47): Error: returning `&s.data` escapes a reference to parameter `s`
 fail_compilation/test16589.d(52): Error: returning `& s` escapes a reference to parameter `s`

--- a/compiler/test/fail_compilation/test17284.d
+++ b/compiler/test/fail_compilation/test17284.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test17284.d(17): Error: field `U.c` cannot access pointers in `@safe` code that overlap other fields
+fail_compilation/test17284.d(17): Error: accessing overlapped field `U.c` with pointers is not allowed in a `@safe` function
 pure nothrow @safe void(U t)
 ---
 REQUIRED_ARGS: -preview=bitfields

--- a/compiler/test/fail_compilation/test17422.d
+++ b/compiler/test/fail_compilation/test17422.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test17422.d(23): Error: scope variable `p` may not be returned
+fail_compilation/test17422.d(23): Error: returning scope variable `p` is not allowed in a `@safe` function
 ---
 */
 struct RC

--- a/compiler/test/fail_compilation/test17423.d
+++ b/compiler/test/fail_compilation/test17423.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test17423.d(27): Error: reference to local `this` assigned to non-scope parameter `dlg` calling `opApply`
+fail_compilation/test17423.d(27): Error: assigning reference to local `this` to non-scope parameter `dlg` calling `opApply` is not allowed in a `@safe` function
 fail_compilation/test17423.d(16):        which is not `scope` because of `this.myDlg = dlg`
 ---
 */

--- a/compiler/test/fail_compilation/test17450.d
+++ b/compiler/test/fail_compilation/test17450.d
@@ -2,9 +2,9 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test17450.d(17): Error: returning `&s.bar` escapes a reference to parameter `s`
+fail_compilation/test17450.d(17): Error: escaping a reference to parameter `s` by returning `&s.bar` is not allowed in a `@safe` function
 fail_compilation/test17450.d(16):        perhaps annotate the parameter with `return`
-fail_compilation/test17450.d(20): Error: returning `&this.bar` escapes a reference to parameter `this`
+fail_compilation/test17450.d(20): Error: escaping a reference to parameter `this` by returning `&this.bar` is not allowed in a `@safe` function
 fail_compilation/test17450.d(19):        perhaps annotate the function with `return`
 ---
 */

--- a/compiler/test/fail_compilation/test17764.d
+++ b/compiler/test/fail_compilation/test17764.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
  * TEST_OUTPUT:
 ---
-fail_compilation/test17764.d(109): Error: scope variable `c` assigned to global variable `global`
+fail_compilation/test17764.d(109): Error: assigning scope variable `c` to global variable `global` is not allowed in a `@safe` function
 ---
  */
 

--- a/compiler/test/fail_compilation/test17959.d
+++ b/compiler/test/fail_compilation/test17959.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test17959.d(18): Error: scope variable `this` assigned to non-scope `this.escape`
-fail_compilation/test17959.d(19): Error: scope variable `this` assigned to non-scope `this.f`
+fail_compilation/test17959.d(18): Error: assigning scope variable `this` to non-scope `this.escape` is not allowed in a `@safe` function
+fail_compilation/test17959.d(19): Error: assigning scope variable `this` to non-scope `this.f` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test17977.d
+++ b/compiler/test/fail_compilation/test17977.d
@@ -3,7 +3,7 @@ https://issues.dlang.org/show_bug.cgi?id=15399
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test17977.d(19): Error: address of variable `__slList3` assigned to `elem` with longer lifetime
+fail_compilation/test17977.d(19): Error: assigning address of variable `__slList3` to `elem` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test18282.d
+++ b/compiler/test/fail_compilation/test18282.d
@@ -1,13 +1,13 @@
 /* REQUIRED_ARGS: -preview=dip1000
    TEST_OUTPUT:
 ---
-fail_compilation/test18282.d(25): Error: scope variable `aa` may not be returned
-fail_compilation/test18282.d(34): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
-fail_compilation/test18282.d(35): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
-fail_compilation/test18282.d(36): Error: scope variable `staa` may not be returned
-fail_compilation/test18282.d(44): Error: copying `S2000(& i)` into allocated memory escapes a reference to local variable `i`
-fail_compilation/test18282.d(53): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
-fail_compilation/test18282.d(53): Error: copying `& c` into allocated memory escapes a reference to local variable `c`
+fail_compilation/test18282.d(25): Error: returning scope variable `aa` is not allowed in a `@safe` function
+fail_compilation/test18282.d(34): Error: escaping a reference to local variable `i by copying `& i` into allocated memory is not allowed in a `@safe` function
+fail_compilation/test18282.d(35): Error: escaping a reference to local variable `i by copying `& i` into allocated memory is not allowed in a `@safe` function
+fail_compilation/test18282.d(36): Error: returning scope variable `staa` is not allowed in a `@safe` function
+fail_compilation/test18282.d(44): Error: escaping a reference to local variable `i by copying `S2000(& i)` into allocated memory is not allowed in a `@safe` function
+fail_compilation/test18282.d(53): Error: escaping a reference to local variable `i by copying `& i` into allocated memory is not allowed in a `@safe` function
+fail_compilation/test18282.d(53): Error: escaping a reference to local variable `c by copying `& c` into allocated memory is not allowed in a `@safe` function
 ---
  */
 
@@ -57,10 +57,10 @@ void bar3()
 /******************************
 TEST_OUTPUT:
 ---
-fail_compilation/test18282.d(1007): Error: copying `& foo` into allocated memory escapes a reference to local variable `foo`
-fail_compilation/test18282.d(1008): Error: copying `& foo` into allocated memory escapes a reference to local variable `foo`
-fail_compilation/test18282.d(1009): Error: copying `& foo` into allocated memory escapes a reference to local variable `foo`
-fail_compilation/test18282.d(1016): Error: copying `&this` into allocated memory escapes a reference to parameter `this`
+fail_compilation/test18282.d(1007): Error: escaping a reference to local variable `foo by copying `& foo` into allocated memory is not allowed in a `@safe` function
+fail_compilation/test18282.d(1008): Error: escaping a reference to local variable `foo by copying `& foo` into allocated memory is not allowed in a `@safe` function
+fail_compilation/test18282.d(1009): Error: escaping a reference to local variable `foo by copying `& foo` into allocated memory is not allowed in a `@safe` function
+fail_compilation/test18282.d(1016): Error: escaping a reference to parameter `this` by copying `&this` into allocated memory is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test18597.d
+++ b/compiler/test/fail_compilation/test18597.d
@@ -1,8 +1,8 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test18597.d(24): Error: field `Unaligned.p` cannot modify misaligned pointers in `@safe` code
-fail_compilation/test18597.d(25): Error: field `Unaligned.p` cannot assign to misaligned pointers in `@safe` code
-fail_compilation/test18597.d(26): Error: field `Unaligned.p` cannot assign to misaligned pointers in `@safe` code
+fail_compilation/test18597.d(24): Error: modifying misaligned pointers through field `Unaligned.p` is not allowed in a `@safe` function
+fail_compilation/test18597.d(25): Error: field `Unaligned.p` assigning to misaligned pointers is not allowed in a `@safe` function
+fail_compilation/test18597.d(26): Error: field `Unaligned.p` assigning to misaligned pointers is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test18644.d
+++ b/compiler/test/fail_compilation/test18644.d
@@ -1,9 +1,9 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test18644.d(15): Error: nested function `foo` returns `scope` values and escapes them into allocated memory
-fail_compilation/test18644.d(16): Error: escaping local variable through nested function `foo`
-fail_compilation/test18644.d(22): Error: escaping local variable through nested function `foo`
+fail_compilation/test18644.d(15): Error: escaping a `scope` value returned from nested function `foo` into allocated memory is not allowed in a `@safe` function
+fail_compilation/test18644.d(16): Error: escaping local variable through nested function `foo` is not allowed in a `@safe` function
+fail_compilation/test18644.d(22): Error: escaping local variable through nested function `foo` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test19097.d
+++ b/compiler/test/fail_compilation/test19097.d
@@ -1,14 +1,14 @@
 /* REQUIRED_ARGS: -preview=dip1000
  * TEST_OUTPUT:
 ---
-fail_compilation/test19097.d(44): Error: scope variable `s` may not be returned
-fail_compilation/test19097.d(48): Error: scope variable `s1` may not be returned
-fail_compilation/test19097.d(77): Error: scope variable `z` assigned to `ref` variable `refPtr` with longer lifetime
-fail_compilation/test19097.d(108): Error: scope variable `s4` may not be returned
-fail_compilation/test19097.d(126): Error: scope variable `s5c` may not be returned
-fail_compilation/test19097.d(130): Error: scope variable `s5m` may not be returned
-fail_compilation/test19097.d(147): Error: scope variable `s6c` may not be returned
-fail_compilation/test19097.d(151): Error: scope variable `s6m` may not be returned
+fail_compilation/test19097.d(44): Error: returning scope variable `s` is not allowed in a `@safe` function
+fail_compilation/test19097.d(48): Error: returning scope variable `s1` is not allowed in a `@safe` function
+fail_compilation/test19097.d(77): Error: assigning scope variable `z` to `ref` variable `refPtr` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/test19097.d(108): Error: returning scope variable `s4` is not allowed in a `@safe` function
+fail_compilation/test19097.d(126): Error: returning scope variable `s5c` is not allowed in a `@safe` function
+fail_compilation/test19097.d(130): Error: returning scope variable `s5m` is not allowed in a `@safe` function
+fail_compilation/test19097.d(147): Error: returning scope variable `s6c` is not allowed in a `@safe` function
+fail_compilation/test19097.d(151): Error: returning scope variable `s6m` is not allowed in a `@safe` function
 ---
  */
 

--- a/compiler/test/fail_compilation/test19646.d
+++ b/compiler/test/fail_compilation/test19646.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test19646.d(12): Error: cast from `const(int)*` to `int*` not allowed in safe code
+fail_compilation/test19646.d(12): Error: cast from `const(int)*` to `int*` can't initialize `@safe` variable `y`
 fail_compilation/test19646.d(12):        Source type is incompatible with target type containing a pointer
 fail_compilation/test19646.d(18): Error: `@safe` variable `z` cannot be initialized by calling `@system` function `f`
 ---

--- a/compiler/test/fail_compilation/test20023.d
+++ b/compiler/test/fail_compilation/test20023.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/imports/test20023b.d(8): Error: scope variable `e` may not be returned
+fail_compilation/imports/test20023b.d(8): Error: returning scope variable `e` is not allowed in a `@safe` function
 fail_compilation/test20023.d(15): Error: template instance `imports.test20023b.threw!()` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/test20245.d
+++ b/compiler/test/fail_compilation/test20245.d
@@ -2,15 +2,15 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test20245.d(21): Error: reference to local variable `x` assigned to non-scope parameter `ptr` calling `escape`
-fail_compilation/test20245.d(22): Error: copying `&x` into allocated memory escapes a reference to parameter `x`
-fail_compilation/test20245.d(23): Error: scope variable `a` may not be returned
-fail_compilation/test20245.d(27): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
-fail_compilation/test20245.d(33): Error: reference to local variable `x` assigned to non-scope parameter `ptr` calling `escape`
-fail_compilation/test20245.d(34): Error: copying `&x` into allocated memory escapes a reference to parameter `x`
-fail_compilation/test20245.d(50): Error: reference to local variable `price` assigned to non-scope `this.minPrice`
-fail_compilation/test20245.d(69): Error: reference to local variable `this.content[]` calling non-scope member function `Exception.this()`
-fail_compilation/test20245.d(89): Error: reference to local variable `this` assigned to non-scope parameter `content` calling `listUp`
+fail_compilation/test20245.d(21): Error: assigning reference to local variable `x` to non-scope parameter `ptr` calling `escape` is not allowed in a `@safe` function
+fail_compilation/test20245.d(22): Error: escaping a reference to parameter `x` by copying `&x` into allocated memory is not allowed in a `@safe` function
+fail_compilation/test20245.d(23): Error: returning scope variable `a` is not allowed in a `@safe` function
+fail_compilation/test20245.d(27): Error: taking address of `scope` variable `x` with pointers is not allowed in a `@safe` function
+fail_compilation/test20245.d(33): Error: assigning reference to local variable `x` to non-scope parameter `ptr` calling `escape` is not allowed in a `@safe` function
+fail_compilation/test20245.d(34): Error: escaping a reference to parameter `x` by copying `&x` into allocated memory is not allowed in a `@safe` function
+fail_compilation/test20245.d(50): Error: assigning reference to local variable `price` to non-scope `this.minPrice` is not allowed in a `@safe` function
+fail_compilation/test20245.d(69): Error: reference to local variable `this.content[]` calling non-scope member function `Exception.this()` is not allowed in a `@safe` function
+fail_compilation/test20245.d(89): Error: assigning reference to local variable `this` to non-scope parameter `content` calling `listUp` is not allowed in a `@safe` function
 fail_compilation/test20245.d(82):        which is not `scope` because of `charPtr = content`
 ---
 */

--- a/compiler/test/fail_compilation/test20569.d
+++ b/compiler/test/fail_compilation/test20569.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -preview=dip1000
    TEST_OUTPUT:
 ---
-fail_compilation/test20569.d(19): Error: cannot take address of `scope` variable `s1` since `scope` applies to first indirection only
-fail_compilation/test20569.d(23): Error: cannot take address of `scope` variable `s2` since `scope` applies to first indirection only
+fail_compilation/test20569.d(19): Error: taking address of `scope` variable `s1` with pointers is not allowed in a `@safe` function
+fail_compilation/test20569.d(23): Error: taking address of `scope` variable `s2` with pointers is not allowed in a `@safe` function
 ---
  */
 

--- a/compiler/test/fail_compilation/test20655.d
+++ b/compiler/test/fail_compilation/test20655.d
@@ -4,13 +4,13 @@ TEST_OUTPUT:
 ---
 fail_compilation/test20655.d(29): Deprecation: `@safe` function `g` calling `f1`
 fail_compilation/test20655.d(24):        which wouldn't be `@safe` because of:
-fail_compilation/test20655.d(24):        field `U.s` cannot access pointers in `@safe` code that overlap other fields
+fail_compilation/test20655.d(24):        accessing overlapped field `U.s` with pointers
 fail_compilation/test20655.d(30): Deprecation: `@safe` function `g` calling `f2`
 fail_compilation/test20655.d(25):        which wouldn't be `@safe` because of:
-fail_compilation/test20655.d(25):        field `U.s` cannot access pointers in `@safe` code that overlap other fields
+fail_compilation/test20655.d(25):        accessing overlapped field `U.s` with pointers
 fail_compilation/test20655.d(31): Deprecation: `@safe` function `g` calling `f3`
 fail_compilation/test20655.d(28):        which wouldn't be `@safe` because of:
-fail_compilation/test20655.d(28):        field `U.s` cannot access pointers in `@safe` code that overlap other fields
+fail_compilation/test20655.d(28):        accessing overlapped field `U.s` with pointers
 ---
 */
 

--- a/compiler/test/fail_compilation/test20809.d
+++ b/compiler/test/fail_compilation/test20809.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/test20809.d(114): Error: returning `this.a` escapes a reference to parameter `this`
+fail_compilation/test20809.d(114): Error: escaping a reference to parameter `this` by returning `this.a` is not allowed in a `@safe` function
 fail_compilation/test20809.d(112):        perhaps annotate the function with `return`
 ---
  */

--- a/compiler/test/fail_compilation/test20881.d
+++ b/compiler/test/fail_compilation/test20881.d
@@ -2,10 +2,10 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test20881.d(20): Error: scope variable `this` may not be returned
-fail_compilation/test20881.d(27): Error: address of variable `s` assigned to `global` with longer lifetime
-fail_compilation/test20881.d(28): Error: address of variable `s` assigned to `global` with longer lifetime
-fail_compilation/test20881.d(29): Error: address of variable `s` assigned to `global` with longer lifetime
+fail_compilation/test20881.d(20): Error: returning scope variable `this` is not allowed in a `@safe` function
+fail_compilation/test20881.d(27): Error: assigning address of variable `s` to `global` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/test20881.d(28): Error: assigning address of variable `s` to `global` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/test20881.d(29): Error: assigning address of variable `s` to `global` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 @safe:

--- a/compiler/test/fail_compilation/test20998.d
+++ b/compiler/test/fail_compilation/test20998.d
@@ -30,7 +30,7 @@ X3 x3 = { ptr: null, "a", ptr: 2, 444 };
 fail_compilation/test20998.d(90): Error: too many initializers for `X3` with 3 fields
 X3 x3 = { ptr: null, "a", ptr: 2, 444 };
                                   ^
-fail_compilation/test20998.d(98): Error: field `X4.ptr` cannot assign to misaligned pointers in `@safe` code
+fail_compilation/test20998.d(98): Error: field `X4.ptr` assigning to misaligned pointers is not allowed in a `@safe` function
     X4 x4 = { ptr: null, "a", 444, ptr: 2, true };
                    ^
 fail_compilation/test20998.d(98): Error: cannot implicitly convert expression `"a"` of type `string` to `int`

--- a/compiler/test/fail_compilation/test21665.d
+++ b/compiler/test/fail_compilation/test21665.d
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test21665.d(18): Error: `void` initializers for structs with invariants are not allowed in safe functions
-fail_compilation/test21665.d(30): Error: field `U.s` cannot access structs with invariants in `@safe` code that overlap other fields
+fail_compilation/test21665.d(18): Error: `void` initializing a struct with an invariant is not allowed in a `@safe` function
+fail_compilation/test21665.d(30): Error: accessing overlapped field `U.s` with a structs invariant is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test22145.d
+++ b/compiler/test/fail_compilation/test22145.d
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 REQUIRED_ARGS: -preview=dip1000
 ---
-fail_compilation/test22145.d(115): Error: scope variable `x` assigned to global variable `global`
+fail_compilation/test22145.d(115): Error: assigning scope variable `x` to global variable `global` is not allowed in a `@safe` function
 ---
  */
 

--- a/compiler/test/fail_compilation/test22227.d
+++ b/compiler/test/fail_compilation/test22227.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test22227.d(12): Error: scope variable `foo` may not be returned
-fail_compilation/test22227.d(14): Error: scope variable `foo` may not be returned
+fail_compilation/test22227.d(12): Error: returning scope variable `foo` is not allowed in a `@safe` function
+fail_compilation/test22227.d(14): Error: returning scope variable `foo` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test22298.d
+++ b/compiler/test/fail_compilation/test22298.d
@@ -2,8 +2,8 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test22298.d(18): Error: scope variable `i` assigned to `p` with longer lifetime
-fail_compilation/test22298.d(29): Error: scope variable `y` assigned to `x` with longer lifetime
+fail_compilation/test22298.d(18): Error: assigning scope variable `i` to `p` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/test22298.d(29): Error: assigning scope variable `y` to `x` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test22541.d
+++ b/compiler/test/fail_compilation/test22541.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test22541.d(104): Error: returning `i` escapes a reference to parameter `i`
+fail_compilation/test22541.d(104): Error: escaping a reference to parameter `i` by returning `i` is not allowed in a `@safe` function
 fail_compilation/test22541.d(102):        perhaps annotate the parameter with `return`
 ---
  */

--- a/compiler/test/fail_compilation/test22680.d
+++ b/compiler/test/fail_compilation/test22680.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test22680.d(104): Error: scope variable `this` assigned to global variable `c`
+fail_compilation/test22680.d(104): Error: assigning scope variable `this` to global variable `c` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test22709.d
+++ b/compiler/test/fail_compilation/test22709.d
@@ -2,8 +2,8 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test22709.d(15): Error: address of variable `local` assigned to `arr` with longer lifetime
-fail_compilation/test22709.d(20): Error: address of variable `local` assigned to `arr` with longer lifetime
+fail_compilation/test22709.d(15): Error: assigning address of variable `local` to `arr` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/test22709.d(20): Error: assigning address of variable `local` to `arr` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test22910.d
+++ b/compiler/test/fail_compilation/test22910.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test22910.d(17): Error: returning `&this.val` escapes a reference to parameter `this`
+fail_compilation/test22910.d(17): Error: escaping a reference to parameter `this` by returning `&this.val` is not allowed in a `@safe` function
 fail_compilation/test22910.d(15):        perhaps change the `return scope` into `scope return`
 ---
 */

--- a/compiler/test/fail_compilation/test22977.d
+++ b/compiler/test/fail_compilation/test22977.d
@@ -2,8 +2,8 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test22977.d(16): Error: escaping local variable through nested function `scfunc`
-fail_compilation/test22977.d(22): Error: escaping local variable through nested function `scfunc2`
+fail_compilation/test22977.d(16): Error: escaping local variable through nested function `scfunc` is not allowed in a `@safe` function
+fail_compilation/test22977.d(22): Error: escaping local variable through nested function `scfunc2` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test23073.d
+++ b/compiler/test/fail_compilation/test23073.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test23073.d(28): Error: scope variable `c` assigned to non-scope parameter `c` calling `assignNext`
+fail_compilation/test23073.d(28): Error: assigning scope variable `c` to non-scope parameter `c` calling `assignNext` is not allowed in a `@safe` function
 fail_compilation/test23073.d(22):        which is not `scope` because of `c.next = c`
 ---
 */

--- a/compiler/test/fail_compilation/test23145.d
+++ b/compiler/test/fail_compilation/test23145.d
@@ -1,13 +1,13 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test23145.d(117): Error: `scope` allocation of `c` requires that constructor be annotated with `scope`
+fail_compilation/test23145.d(117): Error: `scope` allocation of `c` with a non-`scope` constructor is not allowed in a `@safe` function
 fail_compilation/test23145.d(111):        is the location of the constructor
-fail_compilation/test23145.d(124): Error: `scope` allocation of `c` requires that constructor be annotated with `scope`
+fail_compilation/test23145.d(124): Error: `scope` allocation of `c` with a non-`scope` constructor is not allowed in a `@safe` function
 fail_compilation/test23145.d(111):        is the location of the constructor
 fail_compilation/test23145.d(125): Error: `@safe` function `test23145.bax` cannot call `@system` function `test23145.inferred`
 fail_compilation/test23145.d(131):        which wasn't inferred `@safe` because of:
-fail_compilation/test23145.d(131):        `scope` allocation of `c` requires that constructor be annotated with `scope`
+fail_compilation/test23145.d(131):        `scope` allocation of `c` with a non-`scope` constructor
 fail_compilation/test23145.d(129):        `test23145.inferred` is declared here
 ---
 */

--- a/compiler/test/fail_compilation/test23491.d
+++ b/compiler/test/fail_compilation/test23491.d
@@ -2,9 +2,9 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test23491.d(16): Error: reference to local variable `buffer` assigned to non-scope anonymous parameter
-fail_compilation/test23491.d(17): Error: reference to local variable `buffer` assigned to non-scope anonymous parameter calling `sinkF`
-fail_compilation/test23491.d(18): Error: reference to local variable `buffer` assigned to non-scope parameter `buf`
+fail_compilation/test23491.d(16): Error: reference to local variable `buffer` assigned to non-scope anonymous parameter is not allowed in a `@safe` function
+fail_compilation/test23491.d(17): Error: assigning reference to local variable `buffer` to non-scope anonymous parameter calling `sinkF` is not allowed in a `@safe` function
+fail_compilation/test23491.d(18): Error: assigning reference to local variable `buffer` to non-scope parameter `buf` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test23982.d
+++ b/compiler/test/fail_compilation/test23982.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test23982.d(35): Error: scope variable `a` assigned to non-scope parameter `a` calling `foo2`
+fail_compilation/test23982.d(35): Error: assigning scope variable `a` to non-scope parameter `a` calling `foo2` is not allowed in a `@safe` function
 fail_compilation/test23982.d(26):        which is not `scope` because of `b = a`
 ---
 */

--- a/compiler/test/fail_compilation/test24015.d
+++ b/compiler/test/fail_compilation/test24015.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
  * TEST_OUTPUT:
 ---
-fail_compilation/test24015.d(19): Error: scope variable `v` assigned to non-scope parameter `...` calling `jer`
+fail_compilation/test24015.d(19): Error: assigning scope variable `v` to non-scope parameter `...` calling `jer` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test24680.d
+++ b/compiler/test/fail_compilation/test24680.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test24680.d(19): Error: returning `c.peek(buf[])` escapes a reference to local variable `buf`
+fail_compilation/test24680.d(19): Error: escaping a reference to local variable `buf` by returning `c.peek(buf[])`  is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test24694.d
+++ b/compiler/test/fail_compilation/test24694.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test24694.d(25): Error: reference to local variable `x` assigned to non-scope `b.c.p`
+fail_compilation/test24694.d(25): Error: assigning reference to local variable `x` to non-scope `b.c.p` is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/union_initialization.d
+++ b/compiler/test/fail_compilation/union_initialization.d
@@ -3,8 +3,8 @@ https://issues.dlang.org/show_bug.cgi?id=20068
 
 TEST_OUTPUT:
 ---
-fail_compilation/union_initialization.d(19): Error: field `B.p` cannot access pointers in `@safe` code that overlap other fields
-fail_compilation/union_initialization.d(25): Error: field `B.p` cannot access pointers in `@safe` code that overlap other fields
+fail_compilation/union_initialization.d(19): Error: accessing overlapped field `B.p` with pointers is not allowed in a `@safe` function
+fail_compilation/union_initialization.d(25): Error: accessing overlapped field `B.p` with pointers is not allowed in a `@safe` function
 ---
 */
 


### PR DESCRIPTION
There are quite a few safety error messages, and some tell they are related to 'safe code' or `@safe` functions, while others don't. This is not only inconsistent, it's also false with `-preview=safer`: some of these errors occur in functions without a `@safe` annotation. 

This PR rewrites all safety error messages so they either form a noun or gerund: "pointer arithmetic" or "void initializing a pointer". The error reporter will then surround that in context:

deprecations: "{action} will become `@system` in the future"
safe functions: "{action} is not allowed in a `@safe` function"
safer functions: "{action} is not allowed in a function with default safety with `-preview=safer`"
system variables: "{action} can't initialize `@safe` variable `%s`"
inferred supplemental error: "which wasn't safe because of: {action}"

Occasionally this requirement results in suggested fixes being phrased slightly awkwardly:

```
Error: using `b.ptr` (instead of `&b[0])` is not allowed in a `@safe` function
```

A future enhancement of adding supplemental errors to `setUnsafe` could improve this.