### PR TITLE
Fix building druntime with all possible `-debug=` flags

### DIFF
--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -21,8 +21,12 @@ else version (TVOS)
 else version (WatchOS)
     version = Darwin;
 
-debug(trace) import core.stdc.stdio : printf;
-debug(info) import core.stdc.stdio : printf;
+debug (trace) debug = needPrintf;
+debug (info) debug = needPrintf;
+
+debug (needPrintf)
+private int printf(Args...)(scope const char* fmt, scope const Args args)
+    => __ctfe ? 0 : imported!"core.stdc.stdio".printf(fmt, args);
 
 extern (C) alias CXX_DEMANGLER = char* function (const char* mangled_name,
                                                 char* output_buffer,
@@ -2128,7 +2132,7 @@ pure @safe:
             }
             name = dst[beg .. nameEnd];
 
-            debug(info) printf( "name (%.*s)\n", cast(int) name.length, name.ptr );
+            debug(info) printf( "name (%.*s)\n", cast(int) name.length, name.getSlice.ptr );
             if ( 'M' == front )
                 popFront(); // has 'this' pointer
 

--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -48,7 +48,7 @@ Tarr _d_arrayctor(Tarr : T[], T)(return scope Tarr to, scope Tarr from, char* ma
     import core.stdc.stdint : uintptr_t;
     debug(PRINTF) import core.stdc.stdio : printf;
 
-    debug(PRINTF) printf("_d_arrayctor(from = %p,%d) size = %d\n", from.ptr, from.length, T.sizeof);
+    debug(PRINTF) printf("_d_arrayctor(from = %p,%zd) size = %zd\n", from.ptr, from.length, T.sizeof);
 
     void[] vFrom = (cast(void*) from.ptr)[0..from.length];
     void[] vTo = (cast(void*) to.ptr)[0..to.length];
@@ -513,7 +513,7 @@ version (D_ProfileGC)
  */
 Tarr _d_newarraymTX(Tarr : U[], T, U)(size_t[] dims, bool isShared=false) @trusted
 {
-    debug(PRINTF) printf("_d_newarraymTX(dims.length = %d)\n", dims.length);
+    debug(PRINTF) printf("_d_newarraymTX(dims.length = %zd)\n", dims.length);
 
     if (dims.length == 0)
         return null;
@@ -547,7 +547,7 @@ Tarr _d_newarraymTX(Tarr : U[], T, U)(size_t[] dims, bool isShared=false) @trust
     }
 
     auto result = __allocateInnerArray(dims);
-    debug(PRINTF) printf("result = %llx\n", result.ptr);
+    debug(PRINTF) printf("result = %p\n", result.ptr);
 
     return (cast(U*) result.ptr)[0 .. dims[0]];
 }

--- a/druntime/src/core/internal/backtrace/dwarf.d
+++ b/druntime/src/core/internal/backtrace/dwarf.d
@@ -1128,12 +1128,12 @@ LineNumberProgram readLineNumberProgram(ref const(ubyte)[] data) @nogc nothrow
         foreach (ref sf; lp.sourceFiles)
         {
             if (sf.dirIndex > lp.includeDirectories.length)
-                printf("\t- Out of bound directory! (%llu): %.*s\n",
+                printf("\t- Out of bound directory! (%zu): %.*s\n",
                        sf.dirIndex, cast(int) sf.file.length, sf.file.ptr);
             else if (sf.dirIndex > 0)
             {
                 const dir = lp.includeDirectories[sf.dirIndex - 1];
-                printf("\t- (Dir:%llu:%.*s/)%.*s\n", sf.dirIndex,
+                printf("\t- (Dir:%zu:%.*s/)%.*s\n", sf.dirIndex,
                        cast(int) dir.length, dir.ptr,
                        cast(int) sf.file.length, sf.file.ptr);
             }

--- a/druntime/src/core/internal/gc/blkcache.d
+++ b/druntime/src/core/internal/gc/blkcache.d
@@ -8,6 +8,8 @@ module core.internal.gc.blkcache;
 import core.memory;
 import core.attribute;
 
+debug (PRINTF) import core.stdc.stdio : printf;
+
 alias BlkInfo = GC.BlkInfo;
 alias BlkAttr = GC.BlkAttr;
 
@@ -98,17 +100,17 @@ void processGCMarks(void* data, scope IsMarkedDg isMarked) nothrow
     // called after the mark routine to eliminate block cache data when it
     // might be ready to sweep
 
-    debug(PRINTF) printf("processing GC Marks, %x\n", cache);
+    debug(PRINTF) printf("processing GC Marks, %p\n", cache);
     debug(PRINTF) foreach (i; 0 .. N_CACHE_BLOCKS)
     {
-        printf("cache entry %d has base ptr %x\tsize %d\tflags %x\n", i, cache[i].base, cache[i].size, cache[i].attr);
+        printf("cache entry %d has base ptr %p\tsize %zd\tflags %x\n", i, cache[i].base, cache[i].size, cache[i].attr);
     }
     auto cache_end = cache + N_CACHE_BLOCKS;
     for (;cache < cache_end; ++cache)
     {
         if (cache.base != null && isMarked(cache.base) == IsMarked.no)
         {
-            debug(PRINTF) printf("clearing cache entry at %x\n", cache.base);
+            debug(PRINTF) printf("clearing cache entry at %p\n", cache.base);
             cache.base = null; // clear that data.
         }
     }
@@ -250,7 +252,7 @@ debug(PRINTF)
         printf("CACHE: \n");
         foreach (i; 0 .. N_CACHE_BLOCKS)
         {
-            printf("  %d\taddr:% .8x\tsize:% .10d\tflags:% .8x\n", i, ptr[i].base, ptr[i].size, ptr[i].attr);
+            printf("  %d\taddr:% .8p\tsize:% .10zd\tflags:% .8x\n", i, ptr[i].base, ptr[i].size, ptr[i].attr);
         }
     }
 }

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -1763,7 +1763,7 @@ struct Gcx
 
                 long apiTime = mallocTime + reallocTime + freeTime + extendTime + otherTime + lockTime;
                 printf("\tGC API: %lld ms\n", toDuration(apiTime).total!"msecs");
-                sprintf(apitxt.ptr, " API%5ld ms", toDuration(apiTime).total!"msecs");
+                sprintf(apitxt.ptr, " API%5lld ms", toDuration(apiTime).total!"msecs");
             }
 
             printf("GC summary:%5lld MB,%5lld GC%5lld ms, Pauses%5lld ms <%5lld ms%s\n",
@@ -3680,13 +3680,16 @@ Lmark:
             busyThreads.atomicOp!"+="(1);
             if (toscan.popLocked(rng))
             {
-                debug(PARALLEL_PRINTF) printf("scanBackground thread %d scanning range [%p,%lld] from stack\n", threadId,
-                                              rng.pbot, cast(long) (rng.ptop - rng.pbot));
+                version (Posix) debug (PARALLEL_PRINTF)
+                {
+                    printf("scanBackground thread %d scanning range [%p,%lld] from stack\n",
+                        threadId, rng.pbot, cast(long) (rng.ptop - rng.pbot));
+                }
                 mark!(precise, true, true)(rng);
             }
             busyThreads.atomicOp!"-="(1);
         }
-        debug(PARALLEL_PRINTF) printf("scanBackground thread %d done\n", threadId);
+        version (Posix) debug (PARALLEL_PRINTF) printf("scanBackground thread %d done\n", threadId);
     }
 }
 

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -3659,9 +3659,12 @@ Lmark:
         if (atomicLoad(busyThreads) == 0)
             return;
 
-        debug(PARALLEL_PRINTF)
+        version (Posix) debug (PARALLEL_PRINTF)
+        {
+            import core.sys.posix.pthread : pthread_self, pthread_t;
             pthread_t threadId = pthread_self();
-        debug(PARALLEL_PRINTF) printf("scanBackground thread %d start\n", threadId);
+            printf("scanBackground thread %d start\n", threadId);
+        }
 
         ScanRange!precise rng;
         alias toscan = scanStack!precise;

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -503,7 +503,7 @@ class ConservativeGC : GC
         assert(size != 0);
 
         debug(PRINTF)
-            printf("GC::malloc(gcx = %p, size = %d bits = %x, ti = %s)\n", gcx, size, bits, debugTypeName(ti).ptr);
+            printf("GC::malloc(gcx = %p, size = %zd bits = %x, ti = %s)\n", gcx, size, bits, debugTypeName(ti).ptr);
 
         assert(gcx);
         //debug(PRINTF) printf("gcx.self = %x, pthread_self() = %x\n", gcx.self, pthread_self());
@@ -876,7 +876,7 @@ class ConservativeGC : GC
     //
     private void freeNoSync(void *p) nothrow @nogc
     {
-        debug(PRINTF) printf("Freeing %p\n", cast(size_t) p);
+        debug(PRINTF) printf("Freeing %#zx\n", cast(size_t) p);
         assert (p);
 
         Pool*  pool;
@@ -891,7 +891,7 @@ class ConservativeGC : GC
 
         pagenum = pool.pagenumOf(p);
 
-        debug(PRINTF) printf("pool base = %p, PAGENUM = %d of %d, bin = %d\n", pool.baseAddr, pagenum, pool.npages, pool.pagetable[pagenum]);
+        debug(PRINTF) printf("pool base = %p, PAGENUM = %zd of %zd, bin = %d\n", pool.baseAddr, pagenum, pool.npages, pool.pagetable[pagenum]);
         debug(PRINTF) if (pool.isLargeObject) printf("Block size = %d\n", pool.bPageOffsets[pagenum]);
 
         bin = pool.pagetable[pagenum];
@@ -2169,7 +2169,7 @@ struct Gcx
      */
     void* bigAlloc(size_t size, ref size_t alloc_size, uint bits, const TypeInfo ti = null) nothrow
     {
-        debug(PRINTF) printf("In bigAlloc.  Size:  %d\n", size);
+        debug(PRINTF) printf("In bigAlloc.  Size:  %zd\n", size);
 
         LargeObjectPool* pool;
         size_t pn;
@@ -2233,7 +2233,7 @@ struct Gcx
         debug(PRINTF) printFreeInfo(&pool.base);
 
         auto p = pool.baseAddr + pn * PAGESIZE;
-        debug(PRINTF) printf("Got large alloc:  %p, pt = %d, np = %d\n", p, pool.pagetable[pn], npages);
+        debug(PRINTF) printf("Got large alloc:  %p, pt = %d, np = %zd\n", p, pool.pagetable[pn], npages);
         invalidate(p[0 .. size], 0xF1, true);
         alloc_size = npages * PAGESIZE;
         //debug(PRINTF) printf("\tp = %p\n", p);
@@ -4203,12 +4203,12 @@ struct Pool
                                      debugTypeName(ti).ptr, p, bitmap, cast(ulong)element_size);
                 debug(PRINTF)
                     for (size_t i = 0; i < element_size/((void*).sizeof); i++)
-                        printf("%d", (bitmap[i/(8*size_t.sizeof)] >> (i%(8*size_t.sizeof))) & 1);
+                        printf("%zd", (bitmap[i/(8*size_t.sizeof)] >> (i%(8*size_t.sizeof))) & 1);
                 debug(PRINTF) printf("\n");
 
                 if (tocopy * (void*).sizeof < s) // better safe than sorry: if allocated more, assume pointers inside
                 {
-                    debug(PRINTF) printf("    Appending %d pointer bits\n", s/(void*).sizeof - tocopy);
+                    debug(PRINTF) printf("    Appending %zd pointer bits\n", s/(void*).sizeof - tocopy);
                     is_pointer.setRange(offset/(void*).sizeof + tocopy, s/(void*).sizeof - tocopy);
                 }
             }
@@ -4734,7 +4734,7 @@ debug(PRINTF) void printFreeInfo(Pool* pool) nothrow
         if (pool.pagetable[i] >= Bins.B_FREE) nReallyFree++;
     }
 
-    printf("Pool %p:  %d really free, %d supposedly free\n", pool, nReallyFree, pool.freepages);
+    printf("Pool %p:  %d really free, %zd supposedly free\n", pool, nReallyFree, pool.freepages);
 }
 
 debug(PRINTF)
@@ -4743,7 +4743,7 @@ void printGCBits(GCBits* bits)
     for (size_t i = 0; i < bits.nwords; i++)
     {
         if (i % 32 == 0) printf("\n\t");
-        printf("%x ", bits.data[i]);
+        printf("%zx ", bits.data[i]);
     }
     printf("\n");
 }

--- a/druntime/src/core/internal/qsort.d
+++ b/druntime/src/core/internal/qsort.d
@@ -12,6 +12,8 @@ module core.internal.qsort;
 
 import core.stdc.stdlib;
 
+debug (qsort) import core.stdc.stdio : printf;
+
 version (OSX)
     version = Darwin;
 else version (iOS)

--- a/druntime/src/core/internal/utf.d
+++ b/druntime/src/core/internal/utf.d
@@ -21,6 +21,8 @@
 
 module core.internal.utf;
 
+debug (utf) import core.stdc.stdio : printf;
+
 extern (C) void onUnicodeError( string msg, size_t idx, string file = __FILE__, size_t line = __LINE__ ) @safe pure;
 
 /*******************************

--- a/druntime/src/rt/aApply.d
+++ b/druntime/src/rt/aApply.d
@@ -10,6 +10,8 @@ module rt.aApply;
 
 import core.internal.utf : decode, toUTF8;
 
+debug (apply) import core.stdc.stdio : printf;
+
 /**********************************************/
 /* 1 argument versions */
 
@@ -76,7 +78,7 @@ extern (C) int _aApplycd1(scope const(char)[] aa, dg_t dg)
     int result;
     size_t len = aa.length;
 
-    debug(apply) printf("_aApplycd1(), len = %d\n", len);
+    debug(apply) printf("_aApplycd1(), len = %zd\n", len);
     for (size_t i = 0; i < len; )
     {
         dchar d = aa[i];
@@ -137,7 +139,7 @@ extern (C) int _aApplywd1(scope const(wchar)[] aa, dg_t dg)
     int result;
     size_t len = aa.length;
 
-    debug(apply) printf("_aApplywd1(), len = %d\n", len);
+    debug(apply) printf("_aApplywd1(), len = %zd\n", len);
     for (size_t i = 0; i < len; )
     {
         dchar d = aa[i];
@@ -198,7 +200,7 @@ extern (C) int _aApplycw1(scope const(char)[] aa, dg_t dg)
     int result;
     size_t len = aa.length;
 
-    debug(apply) printf("_aApplycw1(), len = %d\n", len);
+    debug(apply) printf("_aApplycw1(), len = %zd\n", len);
     for (size_t i = 0; i < len; )
     {
         wchar w = aa[i];
@@ -272,7 +274,7 @@ extern (C) int _aApplywc1(scope const(wchar)[] aa, dg_t dg)
     int result;
     size_t len = aa.length;
 
-    debug(apply) printf("_aApplywc1(), len = %d\n", len);
+    debug(apply) printf("_aApplywc1(), len = %zd\n", len);
     for (size_t i = 0; i < len; )
     {
         wchar w = aa[i];
@@ -351,7 +353,7 @@ extern (C) int _aApplydc1(scope const(dchar)[] aa, dg_t dg)
 {
     int result;
 
-    debug(apply) printf("_aApplydc1(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplydc1(), len = %zd\n", aa.length);
     foreach (dchar d; aa)
     {
         if (d & ~0x7F)
@@ -427,7 +429,7 @@ extern (C) int _aApplydw1(scope const(dchar)[] aa, dg_t dg)
 {
     int result;
 
-    debug(apply) printf("_aApplydw1(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplydw1(), len = %zd\n", aa.length);
     foreach (dchar d; aa)
     {
         wchar w;
@@ -513,7 +515,7 @@ extern (C) int _aApplycd2(scope const(char)[] aa, dg2_t dg)
     int result;
     size_t len = aa.length;
 
-    debug(apply) printf("_aApplycd2(), len = %d\n", len);
+    debug(apply) printf("_aApplycd2(), len = %zd\n", len);
     size_t n;
     for (size_t i = 0; i < len; i += n)
     {
@@ -581,7 +583,7 @@ extern (C) int _aApplywd2(scope const(wchar)[] aa, dg2_t dg)
     int result;
     size_t len = aa.length;
 
-    debug(apply) printf("_aApplywd2(), len = %d\n", len);
+    debug(apply) printf("_aApplywd2(), len = %zd\n", len);
     size_t n;
     for (size_t i = 0; i < len; i += n)
     {
@@ -649,7 +651,7 @@ extern (C) int _aApplycw2(scope const(char)[] aa, dg2_t dg)
     int result;
     size_t len = aa.length;
 
-    debug(apply) printf("_aApplycw2(), len = %d\n", len);
+    debug(apply) printf("_aApplycw2(), len = %zd\n", len);
     size_t n;
     for (size_t i = 0; i < len; i += n)
     {
@@ -728,7 +730,7 @@ extern (C) int _aApplywc2(scope const(wchar)[] aa, dg2_t dg)
     int result;
     size_t len = aa.length;
 
-    debug(apply) printf("_aApplywc2(), len = %d\n", len);
+    debug(apply) printf("_aApplywc2(), len = %zd\n", len);
     size_t n;
     for (size_t i = 0; i < len; i += n)
     {
@@ -813,7 +815,7 @@ extern (C) int _aApplydc2(scope const(dchar)[] aa, dg2_t dg)
     int result;
     size_t len = aa.length;
 
-    debug(apply) printf("_aApplydc2(), len = %d\n", len);
+    debug(apply) printf("_aApplydc2(), len = %zd\n", len);
     for (size_t i = 0; i < len; i++)
     {
         dchar d = aa[i];
@@ -891,7 +893,7 @@ unittest
 extern (C) int _aApplydw2(scope const(dchar)[] aa, dg2_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplydw2(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplydw2(), len = %zd\n", aa.length);
     foreach (size_t i, dchar d; aa)
     {
         wchar w;

--- a/druntime/src/rt/aApplyR.d
+++ b/druntime/src/rt/aApplyR.d
@@ -10,6 +10,8 @@ module rt.aApplyR;
 
 import core.internal.utf;
 
+debug (apply) import core.stdc.stdio : printf;
+
 /**********************************************/
 /* 1 argument versions */
 
@@ -37,7 +39,7 @@ Returns:
 extern (C) int _aApplyRcd1(scope const(char)[] aa, dg_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRcd1(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRcd1(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0; )
     {   dchar d;
 
@@ -110,7 +112,7 @@ unittest
 extern (C) int _aApplyRwd1(scope const(wchar)[] aa, dg_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRwd1(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRwd1(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0; )
     {   dchar d;
 
@@ -173,7 +175,7 @@ unittest
 extern (C) int _aApplyRcw1(scope const(char)[] aa, dg_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRcw1(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRcw1(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0; )
     {   dchar d;
         wchar w;
@@ -259,7 +261,7 @@ unittest
 extern (C) int _aApplyRwc1(scope const(wchar)[] aa, dg_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRwc1(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRwc1(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0; )
     {   dchar d;
         char c;
@@ -343,7 +345,7 @@ unittest
 extern (C) int _aApplyRdc1(scope const(dchar)[] aa, dg_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRdc1(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRdc1(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0;)
     {   dchar d = aa[--i];
         char c;
@@ -421,7 +423,7 @@ unittest
 extern (C) int _aApplyRdw1(scope const(dchar)[] aa, dg_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRdw1(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRdw1(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0; )
     {   dchar d = aa[--i];
         wchar w;
@@ -507,7 +509,7 @@ extern (C) int _aApplyRcd2(scope const(char)[] aa, dg2_t dg)
     size_t i;
     size_t len = aa.length;
 
-    debug(apply) printf("_aApplyRcd2(), len = %d\n", len);
+    debug(apply) printf("_aApplyRcd2(), len = %zd\n", len);
     for (i = len; i != 0; )
     {   dchar d;
 
@@ -581,7 +583,7 @@ unittest
 extern (C) int _aApplyRwd2(scope const(wchar)[] aa, dg2_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRwd2(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRwd2(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0; )
     {   dchar d;
 
@@ -646,7 +648,7 @@ unittest
 extern (C) int _aApplyRcw2(scope const(char)[] aa, dg2_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRcw2(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRcw2(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0; )
     {   dchar d;
         wchar w;
@@ -734,7 +736,7 @@ unittest
 extern (C) int _aApplyRwc2(scope const(wchar)[] aa, dg2_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRwc2(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRwc2(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0; )
     {   dchar d;
         char c;
@@ -820,7 +822,7 @@ unittest
 extern (C) int _aApplyRdc2(scope const(dchar)[] aa, dg2_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRdc2(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRdc2(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0; )
     {   dchar d = aa[--i];
         char c;
@@ -899,7 +901,7 @@ unittest
 extern (C) int _aApplyRdw2(scope const(dchar)[] aa, dg2_t dg)
 {   int result;
 
-    debug(apply) printf("_aApplyRdw2(), len = %d\n", aa.length);
+    debug(apply) printf("_aApplyRdw2(), len = %zd\n", aa.length);
     for (size_t i = aa.length; i != 0; )
     {   dchar d = aa[--i];
         wchar w;

--- a/druntime/src/rt/adi.d
+++ b/druntime/src/rt/adi.d
@@ -27,7 +27,7 @@ private
 
 extern (C) int _adEq2(void[] a1, void[] a2, TypeInfo ti)
 {
-    debug(adi) printf("_adEq2(a1.length = %d, a2.length = %d)\n", a1.length, a2.length);
+    debug(adi) printf("_adEq2(a1.length = %zd, a2.length = %zd)\n", a1.length, a2.length);
     if (a1.length != a2.length)
         return 0;               // not equal
     if (!ti.equals(&a1, &a2))

--- a/druntime/src/rt/arraycat.d
+++ b/druntime/src/rt/arraycat.d
@@ -21,7 +21,7 @@ extern (C) @trusted nothrow:
 
 void[] _d_arraycopy(size_t size, void[] from, void[] to)
 {
-    debug(PRINTF) printf("f = %p,%d, t = %p,%d, size = %d\n",
+    debug(PRINTF) printf("f = %p,%zd, t = %p,%zd, size = %zd\n",
                  from.ptr, from.length, to.ptr, to.length, size);
 
     enforceRawArraysConformable("copy", size, from, to);

--- a/druntime/src/rt/cast_.d
+++ b/druntime/src/rt/cast_.d
@@ -14,6 +14,8 @@
  */
 module rt.cast_;
 
+debug(cast_) import core.stdc.stdio : printf;
+
 extern (C):
 @nogc:
 nothrow:
@@ -60,7 +62,7 @@ Object _d_toObject(return scope void* p)
      */
     if (pi.offset < 0x10000)
     {
-        debug(cast_) printf("\tpi.offset = %d\n", pi.offset);
+        debug(cast_) printf("\tpi.offset = %zd\n", pi.offset);
         return cast(Object)(p - pi.offset);
     }
     return o;
@@ -72,19 +74,19 @@ Object _d_toObject(return scope void* p)
  */
 void* _d_interface_cast(void* p, ClassInfo c)
 {
-    debug(cast_) printf("_d_interface_cast(p = %p, c = '%.*s')\n", p, c.name);
+    debug(cast_) printf("_d_interface_cast(p = %p, c = '%.*s')\n", p, cast(int) c.name.length, c.name.ptr);
     if (!p)
         return null;
 
     Interface* pi = **cast(Interface***) p;
 
-    debug(cast_) printf("\tpi.offset = %d\n", pi.offset);
+    debug(cast_) printf("\tpi.offset = %zd\n", pi.offset);
     Object o2 = cast(Object)(p - pi.offset);
     void* res = null;
     size_t offset = 0;
     if (o2 && _d_isbaseof2(typeid(o2), c, offset))
     {
-        debug(cast_) printf("\toffset = %d\n", offset);
+        debug(cast_) printf("\toffset = %zd\n", offset);
         res = cast(void*) o2 + offset;
     }
     debug(cast_) printf("\tresult = %p\n", res);
@@ -101,13 +103,13 @@ void* _d_interface_cast(void* p, ClassInfo c)
  */
 void* _d_dynamic_cast(Object o, ClassInfo c)
 {
-    debug(cast_) printf("_d_dynamic_cast(o = %p, c = '%.*s')\n", o, c.name);
+    debug(cast_) printf("_d_dynamic_cast(o = %p, c = '%.*s')\n", o, cast(int) c.name.length, c.name.ptr);
 
     void* res = null;
     size_t offset = 0;
     if (o && _d_isbaseof2(typeid(o), c, offset))
     {
-        debug(cast_) printf("\toffset = %d\n", offset);
+        debug(cast_) printf("\toffset = %zd\n", offset);
         res = cast(void*) o + offset;
     }
     debug(cast_) printf("\tresult = %p\n", res);
@@ -124,7 +126,7 @@ void* _d_dynamic_cast(Object o, ClassInfo c)
  */
 void* _d_class_cast(Object o, ClassInfo c)
 {
-    debug(cast_) printf("_d_cast_cast(o = %p, c = '%.*s', level %d)\n", o, c.name, level);
+    debug(cast_) printf("_d_cast_cast(o = %p, c = '%.*s')\n", o, cast(int) c.name.length, c.name.ptr);
 
     if (!o)
         return null;

--- a/druntime/src/rt/deh_win64_posix.d
+++ b/druntime/src/rt/deh_win64_posix.d
@@ -138,7 +138,7 @@ immutable(FuncTable)* __eh_finddata(void *address)
 
 immutable(FuncTable)* __eh_finddata(void *address, immutable(FuncTable)* pstart, immutable(FuncTable)* pend)
 {
-    debug(PRINTF) printf("FuncTable.sizeof = %p\n", FuncTable.sizeof);
+    debug(PRINTF) printf("FuncTable.sizeof = %#zx\n", FuncTable.sizeof);
     debug(PRINTF) printf("__eh_finddata(address = %p)\n", address);
     debug(PRINTF) printf("_deh_beg = %p, _deh_end = %p\n", pstart, pend);
 
@@ -268,7 +268,7 @@ extern (C) void _d_throwc(Throwable h)
             break;
         }
 
-        debug(PRINTF) printf("found caller, EBP = %p, retaddr = %p\n", regebp, retaddr);
+        debug(PRINTF) printf("found caller, EBP = %#zx, retaddr = %#zx\n", regebp, retaddr);
 //if (++count == 12) *(char*)0=0;
         auto func_table = __eh_finddata(cast(void *)retaddr);   // find static data associated with function
         auto handler_table = func_table ? func_table.handlertable : null;
@@ -294,8 +294,8 @@ extern (C) void _d_throwc(Throwable h)
 
         debug(PRINTF)
         {
-            printf("retaddr = %p\n", retaddr);
-            printf("regebp=%p, funcoffset=%p, spoff=x%x, retoffset=x%x\n",
+            printf("retaddr = %#zx\n", retaddr);
+            printf("regebp=%#zx, funcoffset=%#zx, spoff=x%x, retoffset=x%x\n",
             regebp,funcoffset,spoff,retoffset);
         }
 
@@ -304,11 +304,11 @@ extern (C) void _d_throwc(Throwable h)
 
         debug(PRINTF)
         {
-            printf("handler_info[%d]:\n", dim);
+            printf("handler_info[%zd]:\n", dim);
             for (uint i = 0; i < dim; i++)
             {
                 auto phi = &handler_table.handler_info.ptr[i];
-                printf("\t[%d]: offset = x%04x, endoffset = x%04x, prev_index = %d, cioffset = x%04x, finally_offset = %x\n",
+                printf("\t[%d]: offset = x%04x, endoffset = x%04x, prev_index = %d, cioffset = x%04x, finally_offset = %zx\n",
                         i, phi.offset, phi.endoffset, phi.prev_index, phi.cioffset, phi.finally_offset);
             }
         }
@@ -318,7 +318,7 @@ extern (C) void _d_throwc(Throwable h)
         {
             auto phi = &handler_table.handler_info.ptr[i];
 
-            debug(PRINTF) printf("i = %d, phi.offset = %04x\n", i, funcoffset + phi.offset);
+            debug(PRINTF) printf("i = %d, phi.offset = %04zx\n", i, funcoffset + phi.offset);
             if (retaddr > funcoffset + phi.offset &&
                 retaddr <= funcoffset + phi.endoffset)
                 index = i;
@@ -328,7 +328,7 @@ extern (C) void _d_throwc(Throwable h)
         if (dim)
         {
             auto phi = &handler_table.handler_info.ptr[index+1];
-            debug(PRINTF) printf("next finally_offset %p\n", phi.finally_offset);
+            debug(PRINTF) printf("next finally_offset %#zx\n", phi.finally_offset);
             auto prev = cast(InFlight*) &__inflight;
             auto curr = prev.next;
 
@@ -418,7 +418,7 @@ extern (C) void _d_throwc(Throwable h)
                 // Call finally block
                 // Note that it is unnecessary to adjust the ESP, as the finally block
                 // accesses all items on the stack as relative to EBP.
-                debug(PRINTF) printf("calling finally_offset %p\n", phi.finally_offset);
+                debug(PRINTF) printf("calling finally_offset %#zx\n", phi.finally_offset);
 
                 auto     blockaddr = cast(void*)(funcoffset + phi.finally_offset);
                 InFlight inflight;

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -261,7 +261,7 @@ Params:
 */
 extern(C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow
 {
-    debug(PRINTF) printf("_d_arrayshrinkfit, elemsize = %d, arr.ptr = x%x arr.length = %d\n", ti.next.tsize, arr.ptr, arr.length);
+    debug(PRINTF) printf("_d_arrayshrinkfit, elemsize = %zd, arr.ptr = %p arr.length = %zd\n", ti.next.tsize, arr.ptr, arr.length);
     auto tinext = unqualify(ti.next);
     auto size = tinext.tsize;                  // array element size
     auto reqsize = arr.length * size;
@@ -471,7 +471,7 @@ extern (C) void[] _d_newarrayU(const scope TypeInfo ti, size_t length) pure noth
     auto tinext = unqualify(ti.next);
     auto size = tinext.tsize;
 
-    debug(PRINTF) printf("_d_newarrayU(length = x%x, size = %d)\n", length, size);
+    debug(PRINTF) printf("_d_newarrayU(length = x%zx, size = %zd)\n", length, size);
     if (length == 0 || size == 0)
         return null;
 
@@ -876,7 +876,7 @@ do
     {
         //printf("_d_arraysetlengthT(p = %p, sizeelem = %d, newlength = %d)\n", p, sizeelem, newlength);
         if (p)
-            printf("\tp.ptr = %p, p.length = %d\n", (*p).ptr, (*p).length);
+            printf("\tp.ptr = %p, p.length = %zd\n", (*p).ptr, (*p).length);
     }
 
     if (newlength <= (*p).length)
@@ -925,7 +925,7 @@ do
         assert(0);
     }
 
-    debug(PRINTF) printf("newsize = %x, newlength = %x\n", newsize, newlength);
+    debug(PRINTF) printf("newsize = %zx, newlength = %zx\n", newsize, newlength);
 
     const isshared = typeid(ti) is typeid(TypeInfo_Shared);
 
@@ -998,7 +998,7 @@ do
     {
         //printf("_d_arraysetlengthT(p = %p, sizeelem = %d, newlength = %d)\n", p, sizeelem, newlength);
         if (p)
-            printf("\tp.ptr = %p, p.length = %d\n", (*p).ptr, (*p).length);
+            printf("\tp.ptr = %p, p.length = %zd\n", (*p).ptr, (*p).length);
     }
 
     if (newlength <= (*p).length)
@@ -1047,7 +1047,7 @@ do
         assert(0);
     }
 
-    debug(PRINTF) printf("newsize = %x, newlength = %x\n", newsize, newlength);
+    debug(PRINTF) printf("newsize = %zx, newlength = %zx\n", newsize, newlength);
 
     const isshared = typeid(ti) is typeid(TypeInfo_Shared);
 
@@ -1184,7 +1184,7 @@ size_t newCapacity(size_t newlength, size_t elemsize)
     // ((newlength * mult + 99) / 100) * elemsize
     newcap = cast(size_t)((newlength * mult + 127) >> 7) * elemsize;
     debug(PRINTF) printf("mult: %2.2f, alloc: %2.2f\n",mult/128.0,newcap / cast(double)elemsize);
-    debug(PRINTF) printf("newcap = %d, newlength = %d, elemsize = %d\n", newcap, newlength, elemsize);
+    debug(PRINTF) printf("newcap = %zd, newlength = %zd, elemsize = %zd\n", newcap, newlength, elemsize);
     return newcap;
 }
 
@@ -1426,7 +1426,7 @@ void* _d_arrayliteralTX(const TypeInfo ti, size_t length) @weak
     auto sizeelem = tinext.tsize;              // array element size
     void* result;
 
-    debug(PRINTF) printf("_d_arrayliteralTX(sizeelem = %d, length = %d)\n", sizeelem, length);
+    debug(PRINTF) printf("_d_arrayliteralTX(sizeelem = %zd, length = %zd)\n", sizeelem, length);
     if (length == 0 || sizeelem == 0)
         result = null;
     else

--- a/druntime/src/rt/sections_win64.d
+++ b/druntime/src/rt/sections_win64.d
@@ -132,7 +132,7 @@ void initSections(void* handle) nothrow @nogc
         // consolidate GC ranges for pointers in the .data segment
         void[] dpSection = findImageSection(handle, ".dp");
         debug(PRINTF) printf("found .dp section: [%p,+%llx]\n", dpSection.ptr,
-                             cast(ulong)dpSsection.length);
+                             cast(ulong)dpSection.length);
         auto dp = cast(uint[]) dpSection;
         auto ranges = cast(void[]*) malloc(dp.length * (void[]).sizeof);
         size_t r = 0;


### PR DESCRIPTION
Many debug statements were broken, most often due to stricter checks `printf` from the compiler. Sometimes also due to missing imports or references to old symbols.
In the case of `core.demangle` the problem was that that module is heavily used with ctfe, which has no `printf`, so I added a wrapper that does nothing in ctfe.
This gets all of them to build again.