### PR TITLE
Place the `version(linux):` in `core.sys.linux.sys.procfs` higher.

### DIFF
--- a/druntime/src/core/sys/linux/sys/procfs.d
+++ b/druntime/src/core/sys/linux/sys/procfs.d
@@ -7,9 +7,8 @@
 
 module core.sys.linux.sys.procfs;
 
+version (linux):
+
 import core.sys.posix.sys.types : pid_t;
 
-version (linux)
-{
-    alias lwpid_t = pid_t;
-}
+alias lwpid_t = pid_t;


### PR DESCRIPTION
A "`pid_t` not found" error occurs when you try to compile or import `core.sys.linux` on non-posix platforms.
The normal build system doesn't do this, but dub does.