### PR TITLE
Fix "Casting class references to void* should be `@safe`"

### DIFF
--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -181,6 +181,10 @@ bool isSafeCast(Expression e, Type tfrom, Type tto, ref string msg)
     auto tfromb = tfrom.toBasetype();
     auto ttob = tto.toBasetype();
 
+    // Casting to void* is always safe, https://github.com/dlang/dmd/issues/20514
+    if (ttob.isTypePointer() && ttob.nextOf().toBasetype().ty == Tvoid)
+        return true;
+
     if (ttob.ty == Tclass && tfromb.ty == Tclass)
     {
         ClassDeclaration cdfrom = tfromb.isClassHandle();

--- a/compiler/test/runnable/testsafe.d
+++ b/compiler/test/runnable/testsafe.d
@@ -24,9 +24,9 @@ void pointercast2()
     int b;
     Object c;
 
-    static assert(!__traits(compiles, cast(void*)a));
-    static assert(!__traits(compiles, cast(void*)b));
-    static assert(!__traits(compiles, cast(void*)c));
+    static assert(__traits(compiles, cast(void*)a));
+    static assert(__traits(compiles, cast(void*)b));
+    static assert(__traits(compiles, cast(void*)c));
 }
 
 @safe
@@ -231,11 +231,11 @@ void multablecast()
     static assert( __traits(compiles, cast(const(void)*)mp));
     static assert( __traits(compiles, cast(const(void)*)ip));
 
-    static assert(!__traits(compiles, cast(immutable(void)*)mp));
-    static assert(!__traits(compiles, cast(immutable(void)*)cp));
+    static assert(__traits(compiles, cast(immutable(void)*)mp));
+    static assert(__traits(compiles, cast(immutable(void)*)cp));
 
-    static assert(!__traits(compiles, cast(void*)cp));
-    static assert(!__traits(compiles, cast(void*)ip));
+    static assert(__traits(compiles, cast(void*)cp));
+    static assert(__traits(compiles, cast(void*)ip));
 }
 
 @safe


### PR DESCRIPTION
Closes #20514

Reboot of https://github.com/dlang/dmd/pull/10672 

After a long discussion in the December DLF Monthly meeting, we concluded that casting to void* is not violating `@safe` since all usage of void* as a pointer is unsafe.