### PR TITLE
Revert "Enable -preview=fieldwise by default"

### DIFF
--- a/changelog/dmd.fieldwise.dd
+++ b/changelog/dmd.fieldwise.dd
@@ -1,8 +1,0 @@
-`-preview=fieldwise` is now enabled by default
-
-This fixes a bug that affected some struct comparisons using the `==` operator.
-For more information, see [the entry for `-preview=fieldwise` in the 2.085.0
-changelog](https://dlang.org/changelog/2.085.0.html#no-cmpsb).
-
-The new `-revert=fieldwise` switch can be used to disable the bug fix and
-restore the original behavior of the `==` operator.

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -944,8 +944,6 @@ dmd -cov -unittest myprog.d
                 "https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1000.md"),
         Feature("intpromote", "fix16997", "revert integral promotions for unary + - ~ operators"),
         Feature("dtorfields", "dtorFields", "don't destruct fields of partially constructed objects"),
-        Feature("fieldwise", "fieldwise", "don't use fieldwise comparisons for struct equality",
-            "https://dlang.org/changelog/2.085.0.html#no-cmpsb"),
     ];
 
     /// Returns all available previews
@@ -966,7 +964,7 @@ dmd -cov -unittest myprog.d
         Feature("bitfields", "bitfields", "add C-like bitfields",
             "https://github.com/dlang/dlang.org/pull/3190"),
         Feature("fieldwise", "fieldwise", "use fieldwise comparisons for struct equality",
-            "https://dlang.org/changelog/2.085.0.html#no-cmpsb", false, false),
+            "https://dlang.org/changelog/2.085.0.html#no-cmpsb"),
         Feature("fixAliasThis", "fixAliasThis",
             "when a symbol is resolved, check alias this scope before going to upper scopes",
             "https://github.com/dlang/dmd/pull/8885"),

--- a/compiler/test/compilable/previewhelp.d
+++ b/compiler/test/compilable/previewhelp.d
@@ -10,6 +10,7 @@ Upcoming language changes listed by -preview=name:
   =dip1008          implement @nogc Throwable DIP (https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1008.md)
   =dip1021          implement Mutable Function Arguments DIP (https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1021.md)
   =bitfields        add C-like bitfields (https://github.com/dlang/dlang.org/pull/3190)
+  =fieldwise        use fieldwise comparisons for struct equality (https://dlang.org/changelog/2.085.0.html#no-cmpsb)
   =fixAliasThis     when a symbol is resolved, check alias this scope before going to upper scopes (https://github.com/dlang/dmd/pull/8885)
   =rvaluerefparam   enable rvalue arguments to ref parameters (https://gist.github.com/andralex/e5405a5d773f07f73196c05f8339435a)
   =safer            more safety checks by default (https://github.com/WalterBright/documents/blob/38f0a846726b571f8108f6e63e5e217b91421c86/safer.md)

--- a/compiler/test/compilable/reverthelp.d
+++ b/compiler/test/compilable/reverthelp.d
@@ -9,6 +9,5 @@ Revertable language changes listed by -revert=name:
   =dip1000          revert DIP1000 changes (Scoped Pointers) (https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1000.md)
   =intpromote       revert integral promotions for unary + - ~ operators
   =dtorfields       don't destruct fields of partially constructed objects
-  =fieldwise        don't use fieldwise comparisons for struct equality (https://dlang.org/changelog/2.085.0.html#no-cmpsb)
 ----
 */


### PR DESCRIPTION
This reverts commit 6a7bd45a8e103fb84e3728b01e6db12b738e2d23.

PR #17495 was originally merged in an incomplete state. Since there are non-trivial obstacles to completing it, revert the incomplete changes instead.

See PR #20670 for more information.

CC @ibuclaw 