### PR TITLE
core.builtins: Fix return value of likely/unlikely

### DIFF
--- a/druntime/src/core/builtins.d
+++ b/druntime/src/core/builtins.d
@@ -94,9 +94,9 @@ else version (DigitalMars)
 
 /// Provide static branch and value hints for the LDC/GDC compilers.
 /// DMD ignores these hints.
-pragma(inline, true) bool likely()(bool b)   { return expect(b, true);  }
+pragma(inline, true) bool likely()(bool b)   { return !!expect(b, true);  }
 /// ditto
-pragma(inline, true) bool unlikely()(bool b) { return expect(b, false); }
+pragma(inline, true) bool unlikely()(bool b) { return !!expect(b, false); }
 
 ///
 @nogc nothrow pure @safe unittest


### PR DESCRIPTION
For both GCC and LLVM, `__builtin_expect` and `llvm_expect` respectively return an integer, not a boolean. This triggers a compiler error as implicit narrow conversions are not allowed.