### PR TITLE
fix #20686 infer attributes for generated functions

### DIFF
--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -269,7 +269,7 @@ FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
         return null;
 
     //printf("StructDeclaration::buildOpAssign() %s\n", sd.toChars());
-    StorageClass stc = STC.safe | STC.nothrow_ | STC.pure_ | STC.nogc;
+    StorageClass stc = STC.safe;
     Loc declLoc = sd.loc;
     Loc loc; // internal code should have no loc to prevent coverage
 
@@ -1278,7 +1278,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
     const hasUserDefinedPosblit = sd.postblits.length && !sd.postblits[0].isDisabled ? true : false;
 
     // by default, the storage class of the created postblit
-    StorageClass stc = STC.safe | STC.nothrow_ | STC.pure_ | STC.nogc;
+    StorageClass stc = STC.safe;
     Loc declLoc = sd.postblits.length ? sd.postblits[0].loc : sd.loc;
     Loc loc; // internal code should have no loc to prevent coverage
 
@@ -1380,6 +1380,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         // perform semantic on the member postblit in order to
         // be able to aggregate it later on with the rest of the
         // postblits
+        sdv.postblit.isGenerated = true;
         functionSemantic(sdv.postblit);
 
         stc = mergeFuncAttrs(stc, sdv.postblit);
@@ -1445,6 +1446,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
          */
         if (sdv.dtor)
         {
+            sdv.dtor.isGenerated = true;
             functionSemantic(sdv.dtor);
 
             // keep a list of fields that need to be destroyed in case

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1562,7 +1562,7 @@ private CtorDeclaration generateCtorDeclaration(StructDeclaration sd, const Stor
     auto fparams = new Parameters();
     auto structType = sd.type;
     StorageClass stc = move ? 0 : STC.ref_;     // the only difference between copy or move
-    fparams.push(new Parameter(Loc.initial, paramStc | stc | STC.return_ | STC.scope_, structType, Id.p, null, null));
+    fparams.push(new Parameter(Loc.initial, paramStc | stc, structType, Id.p, null, null));
     ParameterList pList = ParameterList(fparams);
     auto tf = new TypeFunction(pList, structType, LINK.d, STC.ref_);
     auto ccd = new CtorDeclaration(sd.loc, Loc.initial, STC.ref_, tf);
@@ -1703,7 +1703,7 @@ void needCopyOrMoveCtor(StructDeclaration sd, out bool hasCopyCtor, out bool has
         hasCopyCtor = true;
 
     if (hasMoveCtor && hasCopyCtor)
-	return;
+        return;
 
     VarDeclaration fieldWithCpCtor;
     VarDeclaration fieldWithMoveCtor;
@@ -1737,9 +1737,9 @@ void needCopyOrMoveCtor(StructDeclaration sd, out bool hasCopyCtor, out bool has
     }
 
     if (fieldWithCpCtor && !hasCopyCtor)
-	needCopyCtor = true;
+        needCopyCtor = true;
     if (fieldWithMoveCtor && !hasMoveCtor)
-	needMoveCtor = true;
+        needMoveCtor = true;
 }
 
 /**

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2269,6 +2269,9 @@ int getLevelAndCheck(FuncDeclaration fd, const ref Loc loc, Scope* sc, FuncDecla
 /**********************************
  * Decide if attributes for this function can be inferred from examining
  * the function body.
+ * Params:
+ *      fd = function to infer attributes for
+ *      sc = context
  * Returns:
  *  true if can
  */
@@ -2290,7 +2293,8 @@ bool canInferAttributes(FuncDeclaration fd, Scope* sc)
         (!fd.isMember() || sc.func.isSafeBypassingInference() && !fd.isInstantiated()))
         return true;
     if (fd.isFuncLiteralDeclaration() ||               // externs are not possible with literals
-        (fd.storage_class & STC.inference) ||           // do attribute inference
+        (fd.storage_class & STC.inference) ||          // do attribute inference
+        fd.isGenerated ||                              // compiler generated function
         (fd.inferRetType && !fd.isCtorDeclaration()))
         return true;
     if (fd.isInstantiated())

--- a/compiler/test/compilable/cppmangle.d
+++ b/compiler/test/compilable/cppmangle.d
@@ -666,6 +666,8 @@ extern (C++) class C18890_2
     Agg s;
 }
 
+void test18890()
+{
 version (CppMangle_Itanium)
 {
     static assert(C18890.__dtor.mangleof == "_ZN6C18890D1Ev");
@@ -690,6 +692,7 @@ version (CppMangle_MSVC)
         static assert(C18890_2.__xdtor.mangleof == "??_GC18890_2@@UEAAPEAXI@Z");
     }
 }
+}
 
 /**************************************/
 // https://issues.dlang.org/show_bug.cgi?id=18891
@@ -704,6 +707,8 @@ extern (C++) class C18891
     Agg s;
 }
 
+void test18891()
+{
 version (CppMangle_Itanium)
 {
     static assert(C18891.__dtor.mangleof == "_ZN6C18891D1Ev");
@@ -721,6 +726,7 @@ version (CppMangle_MSVC)
         static assert(C18891.__dtor.mangleof == "??1C18891@@UEAA@XZ");
         static assert(C18891.__xdtor.mangleof == "??_GC18891@@UEAAPEAXI@Z");
     }
+}
 }
 
 /**************************************/

--- a/compiler/test/compilable/testInference.d
+++ b/compiler/test/compilable/testInference.d
@@ -817,4 +817,22 @@ void test13840() nothrow
     {}
 }
 
-// Add more tests regarding inferences later.
+/***************************************************/
+// https://github.com/dlang/dmd/pull/20685
+
+struct T1
+{
+    int a;
+    inout this(ref inout T1 t) @nogc nothrow pure { a = t.a; }
+}
+
+struct S1
+{
+    T1 t; // generate copy constructor, infer @nogc nothrow pure
+}
+
+void test1() @nogc nothrow pure
+{
+    S1 s;
+    S1 t = s;
+}


### PR DESCRIPTION
Instead of picking the most restrictive attributes, infer them.