### PR TITLE
Disallow initializing fields with themself

### DIFF
--- a/changelog/dmd.deprecation-noop-assignment.dd
+++ b/changelog/dmd.deprecation-noop-assignment.dd
@@ -1,0 +1,15 @@
+Initializing a field with itself has been deprecated
+
+This is to prevent a common mistake when typing a simple constructor, where a parameter name is misspelled:
+
+---
+struct S
+{
+    int field;
+
+    this(int feild)
+    {
+        this.field = field; // equal to this.field = this.field
+    }
+}
+---

--- a/compiler/test/compilable/interpret3.d
+++ b/compiler/test/compilable/interpret3.d
@@ -6240,9 +6240,9 @@ struct Coord13831
 
 struct Chunk13831
 {
-    this(Coord13831)
+    this(Coord13831 coord)
     {
-        coord = coord;
+        this.coord = coord;
     }
 
     Coord13831 coord;

--- a/compiler/test/compilable/test22510.d
+++ b/compiler/test/compilable/test22510.d
@@ -7,7 +7,7 @@ struct S
     @disable this(this);
     this (scope ref inout S) inout
     {
-    	this.b = b;
+    	this.b = 0;
     }
 }
 

--- a/compiler/test/fail_compilation/ctor_self_assignment.d
+++ b/compiler/test/fail_compilation/ctor_self_assignment.d
@@ -1,0 +1,23 @@
+/**
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/ctor_self_assignment.d(17): Deprecation: cannot initialize field `location` with itself
+fail_compilation/ctor_self_assignment.d(15):        did you mean to use parameter `locaction`?
+---
+*/
+// https://forum.dlang.org/post/teghfhpmvkdcfwfeovua@forum.dlang.org
+
+alias Location = int;
+
+struct Node
+{
+    this(Location locaction, uint f)
+    {
+        this.location = location;
+        this.f = f;
+    }
+
+    Location location;
+    uint f;
+}


### PR DESCRIPTION
Trying to prevent a common user error: [Super easy struct construction question that I'm embarrassed to ask.](https://forum.dlang.org/post/teghfhpmvkdcfwfeovua@forum.dlang.org)

This might need a deprecation, but let's try errors first to see how buildkite responds.