### PR TITLE
Move all array and finalizer functionality into the GC

### DIFF
--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -536,7 +536,7 @@ Tarr _d_newarraymTX(Tarr : U[], T, U)(size_t[] dims, bool isShared=false) @trust
         {
             (cast(void[]*)arr.ptr)[i] = __allocateInnerArray(dims[1..$]);
         }
-        return arr;
+        return arr.ptr[0 .. dim];
     }
 
     auto result = __allocateInnerArray(dims);
@@ -570,6 +570,21 @@ unittest
         assert(a[i].length == 3);
         for (size_t j = 0; j < a[i].length; j++)
             assert(a[i][j].x == 1);
+    }
+}
+
+// Test 3-level array allocation (this uses different code paths).
+unittest
+{
+    int[][][] a = _d_newarraymTX!(int[][][], int)([3, 4, 5]);
+    int[5] zeros = 0;
+
+    assert(a.length == 3);
+    foreach(l2; a)
+    {
+        assert(l2.length == 4);
+        foreach(l3; l2)
+            assert(l3 == zeros[]);
     }
 }
 

--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -349,7 +349,7 @@ T[] _d_newarrayU(T)(size_t length, bool isShared=false) @trusted
 {
     import core.exception : onOutOfMemoryError;
     import core.internal.traits : Unqual;
-    import core.internal.array.utils : __arrayStart, __setArrayAllocLength, __arrayAlloc;
+    import core.internal.array.utils : __arrayAlloc;
 
     alias UnqT = Unqual!T;
 
@@ -395,16 +395,11 @@ Loverflow:
     assert(0);
 
 Lcontinue:
-    auto info = __arrayAlloc!UnqT(arraySize);
-    if (!info.base)
+    auto arr = __arrayAlloc!UnqT(arraySize);
+    if (!arr.ptr)
         goto Loverflow;
-    debug(PRINTF) printf("p = %p\n", info.base);
-
-    auto arrstart = __arrayStart(info);
-
-    __setArrayAllocLength!UnqT(info, arraySize, isShared);
-
-    return (cast(T*) arrstart)[0 .. length];
+    debug(PRINTF) printf("p = %p\n", arr.ptr);
+    return (cast(T*) arr.ptr)[0 .. length];
 }
 
 /// ditto
@@ -522,7 +517,7 @@ Tarr _d_newarraymTX(Tarr : U[], T, U)(size_t[] dims, bool isShared=false) @trust
 
     void[] __allocateInnerArray(size_t[] dims)
     {
-        import core.internal.array.utils : __arrayStart, __setArrayAllocLength, __arrayAlloc;
+        import core.internal.array.utils : __arrayAlloc;
 
         auto dim = dims[0];
 
@@ -535,15 +530,13 @@ Tarr _d_newarraymTX(Tarr : U[], T, U)(size_t[] dims, bool isShared=false) @trust
 
         auto allocSize = (void[]).sizeof * dim;
         // the array-of-arrays holds pointers! Don't use UnqT here!
-        auto info = __arrayAlloc!(void[])(allocSize);
-        __setArrayAllocLength!(void[])(info, allocSize, isShared);
-        auto p = __arrayStart(info)[0 .. dim];
+        auto arr = __arrayAlloc!(void[])(allocSize);
 
         foreach (i; 0..dim)
         {
-            (cast(void[]*)p.ptr)[i] = __allocateInnerArray(dims[1..$]);
+            (cast(void[]*)arr.ptr)[i] = __allocateInnerArray(dims[1..$]);
         }
-        return p;
+        return arr;
     }
 
     auto result = __allocateInnerArray(dims);

--- a/druntime/src/core/internal/gc/blockmeta.d
+++ b/druntime/src/core/internal/gc/blockmeta.d
@@ -69,12 +69,11 @@ size_t structTypeInfoSize(const TypeInfo ti) pure nothrow @nogc
 
   where elem0 starts 16 bytes after the first byte.
   */
-bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, const TypeInfo tinext, size_t oldlength = ~0) pure nothrow
+bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, const TypeInfo tinext, size_t oldlength = size_t.max) pure nothrow
 {
-    size_t typeInfoSize = (info.attr & BlkAttr.STRUCTFINAL) ? size_t.sizeof : 0;
-    if (typeInfoSize)
-        __setBlockFinalizerInfo(info, tinext);
+    __setBlockFinalizerInfo(info, tinext);
 
+    size_t typeInfoSize = (info.attr & BlkAttr.STRUCTFINAL) ? size_t.sizeof : 0;
     return __setArrayAllocLengthImpl(info, newlength, isshared, oldlength, typeInfoSize);
 }
 
@@ -97,7 +96,7 @@ bool __setArrayAllocLengthImpl(ref BlkInfo info, size_t newlength, bool isshared
             return false;
 
         auto length = cast(ubyte *)(info.base + info.size - typeInfoSize - SMALLPAD);
-        if (oldlength != ~0)
+        if (oldlength != size_t.max)
         {
             if (isshared)
             {
@@ -123,7 +122,7 @@ bool __setArrayAllocLengthImpl(ref BlkInfo info, size_t newlength, bool isshared
             // new size does not fit inside block
             return false;
         auto length = cast(ushort *)(info.base + info.size - typeInfoSize - MEDPAD);
-        if (oldlength != ~0)
+        if (oldlength != size_t.max)
         {
             if (isshared)
             {
@@ -149,7 +148,7 @@ bool __setArrayAllocLengthImpl(ref BlkInfo info, size_t newlength, bool isshared
             // new size does not fit inside block
             return false;
         auto length = cast(size_t *)(info.base);
-        if (oldlength != ~0)
+        if (oldlength != size_t.max)
         {
             if (isshared)
             {
@@ -176,22 +175,42 @@ bool __setArrayAllocLengthImpl(ref BlkInfo info, size_t newlength, bool isshared
   The block finalizer info is set separately from the array length, as that is
   only needed on the initial setup of the block. No shared is needed, since
   this should only happen when the block is new.
+  If the STRUCTFINAL bit is not set, no finalizer is stored (but if needed the
+  slot is zeroed)
   */
 void __setBlockFinalizerInfo(ref BlkInfo info, const TypeInfo ti) pure nothrow
 {
     if ((info.attr & BlkAttr.APPENDABLE) && info.size >= PAGESIZE)
     {
+        // if the structfinal bit is not set, we don't have a finalizer. But we
+        // should still zero out the finalizer slot.
+        auto context = (info.attr & BlkAttr.STRUCTFINAL) ? cast(void*)ti : null;
+
         // array used size goes at the beginning. We can stuff the typeinfo
         // right after it, as we need to use 16 bytes anyway.
-        auto typeInfo = cast(TypeInfo*)(info.base + size_t.sizeof);
-        *typeInfo = cast() ti;
+        //
+        auto typeInfo = cast(void**)info.base + 1;
+        *typeInfo = context;
     }
-    else
+    else if(info.attr & BlkAttr.STRUCTFINAL)
     {
         // all other cases the typeinfo gets put at the end of the block
-        auto typeInfo = cast(TypeInfo*)(info.base + info.size - size_t.sizeof);
-        *typeInfo = cast() ti;
+        auto typeInfo = cast(void**)(info.base + info.size) - 1;
+        *typeInfo = cast(void*) ti;
     }
+}
+
+/**
+  Get the finalizer info from the block (typeinfo).
+  Must be called on a block with STRUCTFINAL set.
+  */
+const(TypeInfo) __getBlockFinalizerInfo(ref BlkInfo info) pure nothrow
+{
+    bool isLargeArray = (info.attr & BlkAttr.APPENDABLE) && info.size >= PAGESIZE;
+    auto typeInfo = isLargeArray ?
+        info.base + size_t.sizeof :
+        info.base + info.size - size_t.sizeof;
+    return *cast(TypeInfo*)typeInfo;
 }
 
 /**
@@ -263,8 +282,22 @@ size_t __allocPad(size_t size, uint bits) nothrow pure @trusted
     {
         if (size > MAXMEDSIZE - finalizerSize)
             return LARGEPAD;
-        return size > MAXSMALLSIZE - finalizerSize ? MEDPAD : SMALLPAD;
+        auto pad = (size > MAXSMALLSIZE - finalizerSize) ? MEDPAD : SMALLPAD;
+        return pad + finalizerSize;
     }
 
     return finalizerSize;
+}
+
+/**
+ * Get the start of the array for the given block.
+ *
+ * Params:
+ *  info = array metadata
+ * Returns:
+ *  pointer to the start of the array
+ */
+void *__arrayStart()(return scope BlkInfo info) nothrow pure
+{
+    return info.base + ((info.size & BIGLENGTHMASK) ? LARGEPREFIX : 0);
 }

--- a/druntime/src/core/internal/gc/blockmeta.d
+++ b/druntime/src/core/internal/gc/blockmeta.d
@@ -191,6 +191,11 @@ void __setBlockFinalizerInfo(ref BlkInfo info, const TypeInfo ti) pure nothrow
         //
         auto typeInfo = cast(void**)info.base + 1;
         *typeInfo = context;
+        version (D_LP64) {} else
+        {
+            // zero out the extra padding
+            (cast(size_t*)info.base)[2 .. 4] = 0;
+        }
     }
     else if(info.attr & BlkAttr.STRUCTFINAL)
     {

--- a/druntime/src/core/internal/gc/blockmeta.d
+++ b/druntime/src/core/internal/gc/blockmeta.d
@@ -251,3 +251,20 @@ size_t __arrayPad(size_t size, const TypeInfo tinext) nothrow pure @trusted
 {
     return size > MAXMEDSIZE ? LARGEPAD : ((size > MAXSMALLSIZE ? MEDPAD : SMALLPAD) + structTypeInfoSize(tinext));
 }
+
+/**
+  get the padding required to allocate size bytes, use the bits to determine
+  which metadata must be stored.
+  */
+size_t __allocPad(size_t size, uint bits) nothrow pure @trusted
+{
+    auto finalizerSize = (bits & BlkAttr.STRUCTFINAL) ? (void*).sizeof : 0;
+    if (bits & BlkAttr.APPENDABLE)
+    {
+        if (size > MAXMEDSIZE - finalizerSize)
+            return LARGEPAD;
+        return size > MAXSMALLSIZE - finalizerSize ? MEDPAD : SMALLPAD;
+    }
+
+    return finalizerSize;
+}

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -475,23 +475,32 @@ class ConservativeGC : GC
      */
     void *malloc(size_t size, uint bits = 0, const TypeInfo ti = null) nothrow
     {
-        if (!size)
+        import core.internal.gc.blockmeta;
+
+        if (size == 0)
         {
             return null;
         }
 
+        adjustAttrs(bits, ti);
+
+        immutable padding = __allocPad(size, bits);
+        immutable needed = size + padding;
+
         size_t localAllocSize = void;
 
-        auto p = runLocked!(mallocNoSync, mallocTime, numMallocs)(size, bits, localAllocSize, ti);
+        auto p = runLocked!(mallocNoSync, mallocTime, numMallocs)(needed, bits, localAllocSize, ti);
 
         invalidate(p[0 .. localAllocSize], 0xF0, true);
 
+        auto ret = setupMetadata(p[0 .. localAllocSize], bits, padding, size, ti);
+
         if (!(bits & BlkAttr.NO_SCAN))
         {
-            memset(p + size, 0, localAllocSize - size);
+            memset(ret.ptr + size, 0, ret.length - size);
         }
 
-        return p;
+        return ret.ptr;
     }
 
 
@@ -527,6 +536,8 @@ class ConservativeGC : GC
 
     BlkInfo qalloc( size_t size, uint bits, const scope TypeInfo ti) nothrow
     {
+        // qalloc should not be used for building metadata-containing blocks,
+        // so avoid all the checking for bits and array padding.
 
         if (!size)
         {
@@ -564,25 +575,38 @@ class ConservativeGC : GC
      */
     void *calloc(size_t size, uint bits = 0, const TypeInfo ti = null) nothrow
     {
+        import core.internal.gc.blockmeta;
+
         if (!size)
         {
             return null;
         }
 
+        adjustAttrs(bits, ti);
+
+        immutable padding = __allocPad(size, bits);
+        immutable needed = size + __allocPad(size, bits);
+
         size_t localAllocSize = void;
 
-        auto p = runLocked!(mallocNoSync, mallocTime, numMallocs)(size, bits, localAllocSize, ti);
+        auto p = runLocked!(mallocNoSync, mallocTime, numMallocs)(needed, bits, localAllocSize, ti);
 
         debug (VALGRIND) makeMemUndefined(p[0..size]);
-        invalidate((p + size)[0 .. localAllocSize - size], 0xF0, true);
 
-        memset(p, 0, size);
-        if (!(bits & BlkAttr.NO_SCAN))
+        auto ret = setupMetadata(p[0 .. localAllocSize], bits, padding, size, ti);
+
+        invalidate((ret.ptr + size)[0 .. ret.length - size], 0xF0, true);
+
+        if (bits & BlkAttr.NO_SCAN)
         {
-            memset(p + size, 0, localAllocSize - size);
+            memset(ret.ptr, 0, size);
+        }
+        else
+        {
+            memset(ret.ptr, 0, ret.length);
         }
 
-        return p;
+        return ret.ptr;
     }
 
     /**
@@ -595,7 +619,8 @@ class ConservativeGC : GC
      * Params:
      *  p = A pointer to the root of a valid memory block or to null.
      *  size = The desired allocation size in bytes.
-     *  bits = A bitmask of the attributes to set on this block.
+     *  bits = A bitmask of the attributes to set on this block. APPENDABLE and
+     *         FINALIZE are not allowed for realloc.
      *  ti = TypeInfo to describe the memory.
      *
      * Returns:
@@ -607,14 +632,28 @@ class ConservativeGC : GC
      */
     void *realloc(void *p, size_t size, uint bits = 0, const TypeInfo ti = null) nothrow
     {
+        if (bits & (BlkAttr.APPENDABLE | BlkAttr.FINALIZE))
+            // these bits are not allowed. We can't properly manage
+            // reallocation of such blocks.
+            onInvalidMemoryOperationError();
+
         size_t localAllocSize = void;
         auto oldp = p;
 
         p = runLocked!(reallocNoSync, mallocTime, numMallocs)(p, size, bits, localAllocSize, ti);
 
-        if (p && !(bits & BlkAttr.NO_SCAN))
+        if (p)
         {
-            memset(p + size, 0, localAllocSize - size);
+            // invalidate any block info cache we have for the old allocation.
+            import core.internal.gc.blkcache;
+            if (auto bic = __getBlkInfo(oldp)) {
+                *bic = BlkInfo.init;
+            }
+
+            if (!(bits & BlkAttr.NO_SCAN))
+            {
+                memset(p + size, 0, localAllocSize - size);
+            }
         }
 
         return p;
@@ -662,7 +701,8 @@ class ConservativeGC : GC
         void* doMalloc()
         {
             if (!bits)
-                bits = pool.getBits(biti);
+                bits = pool.getBits(biti) &
+                    ~(BlkAttr.APPENDABLE | BlkAttr.FINALIZE | BlkAttr.STRUCTFINAL);
 
             void* p2 = mallocNoSync(size, bits, alloc_size, ti);
             debug (SENTINEL)
@@ -759,7 +799,16 @@ class ConservativeGC : GC
 
     size_t extend(void* p, size_t minsize, size_t maxsize, const TypeInfo ti) nothrow
     {
-        return runLocked!(extendNoSync, extendTime, numExtends)(p, minsize, maxsize, ti);
+        auto result = runLocked!(extendNoSync, extendTime, numExtends)(p, minsize, maxsize, ti);
+        if (result != 0) {
+            // invalidate any block info cache we have for the old allocation.
+            import core.internal.gc.blkcache;
+            if (auto bic = __getBlkInfo(p)) {
+                *bic = BlkInfo.init;
+            }
+        }
+
+        return result;
     }
 
 
@@ -867,14 +916,22 @@ class ConservativeGC : GC
             return;
         }
 
-        return runLocked!(freeNoSync, freeTime, numFrees)(p);
+        auto didFree = runLocked!(freeNoSync, freeTime, numFrees)(p);
+
+        if (didFree) {
+            // invalidate any block info cache we have for the old allocation.
+            import core.internal.gc.blkcache;
+            if (auto bic = __getBlkInfo(p)) {
+                *bic = BlkInfo.init;
+            }
+        }
     }
 
 
     //
     // Implementation of free.
     //
-    private void freeNoSync(void *p) nothrow @nogc
+    private bool freeNoSync(void *p) nothrow @nogc
     {
         debug(PRINTF) printf("Freeing %p\n", cast(size_t) p);
         assert (p);
@@ -887,7 +944,7 @@ class ConservativeGC : GC
         // Find which page it is in
         pool = gcx.findPool(p);
         if (!pool)                              // if not one of ours
-            return;                             // ignore
+            return false;                       // ignore
 
         pagenum = pool.pagenumOf(p);
 
@@ -899,11 +956,11 @@ class ConservativeGC : GC
         // Verify that the pointer is at the beginning of a block,
         //  no action should be taken if p is an interior pointer
         if (bin > Bins.B_PAGE) // B_PAGEPLUS or B_FREE
-            return;
+            return false;
         size_t off = (sentinel_sub(p) - pool.baseAddr);
         size_t base = baseOffset(off, bin);
         if (off != base)
-            return;
+            return false;
 
         sentinel_Invariant(p);
         auto q = p;
@@ -928,7 +985,7 @@ class ConservativeGC : GC
         {
             biti = cast(size_t)(p - pool.baseAddr) >> pool.ShiftBy.Small;
             if (pool.freebits.test (biti))
-                return;
+                return false;
             // Add to free list
             List *list = cast(List*)p;
 
@@ -948,6 +1005,8 @@ class ConservativeGC : GC
         pool.clrBits(biti, ~BlkAttr.NONE);
 
         gcx.leakDetector.log_free(sentinel_add(p), ssize);
+
+        return true;
     }
 
 
@@ -5318,4 +5377,43 @@ void undefinedWrite(T)(ref T var, T value) nothrow
     }
     else
         var = value;
+}
+
+private void adjustAttrs(ref uint attrs, const TypeInfo ti) nothrow
+{
+    bool hasContext = ti !is null;
+    if((attrs & BlkAttr.FINALIZE) && hasContext && typeid(ti) is typeid(TypeInfo_Struct))
+        attrs |= BlkAttr.STRUCTFINAL;
+    else
+        // STRUCTFINAL now just means "has a context pointer added to the block"
+        attrs &= ~BlkAttr.STRUCTFINAL;
+}
+
+// sets up the array/context pointer metadata based on the block allocated.
+// This is called on any block *creation*, and not on updating the array
+// metadata.
+//
+// The return value is the true data that the user can use.
+private void[] setupMetadata(void[] block, uint bits, size_t padding, size_t used, const TypeInfo ti) nothrow
+{
+    import core.internal.gc.blockmeta;
+    import core.internal.array.utils;
+
+    BlkInfo info = BlkInfo(
+            base: block.ptr,
+            attr: bits,
+            size: block.length
+    );
+
+    auto typeInfoSize = (bits & BlkAttr.STRUCTFINAL) ? (void*).sizeof : 0;
+
+    if (typeInfoSize)
+        __setBlockFinalizerInfo(info, ti);
+
+    if (bits & BlkAttr.APPENDABLE) {
+        __setArrayAllocLengthImpl(info, used, false, ~0, typeInfoSize);
+        return __arrayStart(info)[0 .. block.length - padding];
+    }
+
+    return block.ptr[0 .. block.length - padding];
 }

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -13,10 +13,8 @@
 module rt.lifetime;
 
 import core.attribute : weak;
-import core.internal.array.utils : __arrayStart, __arrayClearPad;
 import core.memory;
-import core.internal.gc.blkcache;
-import core.internal.gc.blockmeta;
+import core.internal.gc.blockmeta : PAGESIZE;
 debug(PRINTF) import core.stdc.stdio;
 static import rt.tlsgc;
 
@@ -210,43 +208,22 @@ inout(TypeInfo) unqualify(return scope inout(TypeInfo) cti) pure nothrow @nogc
     return ti;
 }
 
-/**
-  allocate an array memory block by applying the proper padding and
-  assigning block attributes if not inherited from the existing block
-  */
-private BlkInfo __arrayAlloc(size_t arrsize, const scope TypeInfo ti, const TypeInfo tinext) nothrow pure
+private uint __typeAttrs(const scope TypeInfo ti, void *copyAttrsFrom = null) pure nothrow
 {
-    import core.checkedint;
-
-    return __arrayAlloc(arrsize, null, ti, tinext);
-}
-
-private BlkInfo __arrayAlloc(size_t arrsize, void* copyAttrsFrom, const scope TypeInfo ti, const TypeInfo tinext) nothrow pure
-{
-    import core.checkedint;
-
-    immutable padsize = __arrayPad(arrsize, tinext);
-    bool overflow;
-    auto padded_size = addu(arrsize, padsize, overflow);
-    if (overflow)
-    {
-        return BlkInfo();
-    }
-
-    uint attr = (!(tinext.flags & 1) ? BlkAttr.NO_SCAN : 0);
     if (copyAttrsFrom)
     {
         // try to copy attrs from the given block
         auto info = GC.query(copyAttrsFrom);
         if (info.base)
-            attr = info.attr;
+            return info.attr;
     }
-    // always make sure the appendable attr is set.
-    attr |= BlkAttr.APPENDABLE;
-
-    auto bi = GC.qalloc(padded_size, attr, tinext);
-    __arrayClearPad(bi, arrsize, padsize);
-    return bi;
+    uint attrs = !(ti.flags & 1) ? BlkAttr.NO_SCAN : 0;
+    if (typeid(ti) is typeid(TypeInfo_Struct)) {
+        auto sti = cast(TypeInfo_Struct)cast(void*)ti;
+        if (sti.xdtor)
+            attrs |= BlkAttr.STRUCTFINAL | BlkAttr.FINALIZE;
+    }
+    return attrs;
 }
 
 /**
@@ -417,37 +394,38 @@ Lcontinue:
 
     // step 2, if reserving in-place doesn't work, allocate a new array with at
     // least the requested allocated size.
-    auto info = __arrayAlloc(reqsize, (*p).ptr, ti, tinext);
-    if (info.base is null)
+    auto attrs = __typeAttrs(tinext, (*p).ptr) | BlkAttr.APPENDABLE;
+    auto ptr = GC.malloc(reqsize, attrs, tinext);
+    if (ptr is null)
         goto Loverflow;
+
     // copy the data over.
     // note that malloc will have initialized the data we did not request to 0.
-    auto tgt = __arrayStart(info);
-    memcpy(tgt, (*p).ptr, datasize);
+    memcpy(ptr, (*p).ptr, datasize);
 
     // handle postblit
-    __doPostblit(tgt, datasize, tinext);
+    __doPostblit(ptr, datasize, tinext);
 
-    if (!(info.attr & BlkAttr.NO_SCAN))
+    if (!(attrs & BlkAttr.NO_SCAN))
     {
         // need to memset the newly requested data, except for the data that
         // malloc returned that we didn't request.
-        void *endptr = tgt + reqsize;
-        void *begptr = tgt + datasize;
+        void *endptr = ptr + reqsize;
+        void *begptr = ptr + datasize;
 
         // sanity check
         assert(endptr >= begptr);
         memset(begptr, 0, endptr - begptr);
     }
 
-    // set up the correct length
-    __setArrayAllocLength(info, datasize, isshared, tinext);
-    if (!isshared)
-        __insertBlkInfoCache(info, null);
+    *p = ptr[0 .. (*p).length];
 
-    *p = (cast(void*)tgt)[0 .. (*p).length];
+    // set up the correct length. Note that we need to do this here, because
+    // the GC malloc will automatically set the used size to what we requested.
+    gc_shrinkArrayUsed(ptr[0 .. datasize], reqsize, isshared);
 
-    curCapacity = __arrayAllocCapacity(info);
+    curCapacity = gc_reserveArrayCapacity(ptr[0 .. datasize], 0, isshared);
+    assert(curCapacity);
     return curCapacity / size;
 }
 
@@ -509,15 +487,11 @@ Loverflow:
     assert(0);
 Lcontinue:
 
-    auto info = __arrayAlloc(size, ti, tinext);
-    if (!info.base)
+    auto ptr = GC.malloc(size, __typeAttrs(tinext) | BlkAttr.APPENDABLE, tinext);
+    if (!ptr)
         goto Loverflow;
-    debug(PRINTF) printf(" p = %p\n", info.base);
-    // update the length of the array
-    auto arrstart = __arrayStart(info);
-    auto isshared = typeid(ti) is typeid(TypeInfo_Shared);
-    __setArrayAllocLength(info, size, isshared, tinext);
-    return arrstart[0..length];
+    debug(PRINTF) printf(" p = %p\n", ptr);
+    return ptr[0 .. length];
 }
 
 /// ditto
@@ -580,24 +554,9 @@ Returns:
 extern (C) void* _d_newitemU(scope const TypeInfo _ti) pure nothrow @weak
 {
     auto ti = unqualify(_ti);
-    auto flags = !(ti.flags & 1) ? BlkAttr.NO_SCAN : 0;
-    immutable tiSize = structTypeInfoSize(ti);
-    immutable itemSize = ti.tsize;
-    immutable size = itemSize + tiSize;
-    if (tiSize)
-        flags |= BlkAttr.STRUCTFINAL | BlkAttr.FINALIZE;
+    auto flags = __typeAttrs(ti);
 
-    auto blkInf = GC.qalloc(size, flags, ti);
-    auto p = blkInf.base;
-
-    if (tiSize)
-    {
-        // the GC might not have cleared the padding area in the block
-        *cast(TypeInfo*)(p + (itemSize & ~(size_t.sizeof - 1))) = null;
-        __setBlockFinalizerInfo(blkInf, cast() ti);
-    }
-
-    return p;
+    return GC.malloc(ti.tsize, flags, ti);
 }
 
 /**
@@ -659,16 +618,25 @@ extern (C) CollectHandler rt_getCollectHandler()
  */
 extern (C) int rt_hasFinalizerInSegment(void* p, size_t size, uint attr, scope const(void)[] segment) nothrow
 {
+    if (!p)
+        return false;
+
     if (attr & BlkAttr.STRUCTFINAL)
     {
-        if (attr & BlkAttr.APPENDABLE)
-            return hasArrayFinalizerInSegment(p, size, segment);
-        return hasStructFinalizerInSegment(p, size, segment);
+        import core.internal.gc.blockmeta;
+        auto info = BlkInfo(
+            base: p,
+            size: size,
+            attr: attr
+        );
+
+        auto ti = cast(TypeInfo_Struct)cast(void*)__getBlockFinalizerInfo(info);
+        return cast(size_t)(cast(void*)ti.xdtor - segment.ptr) < segment.length;
     }
 
     // otherwise class
     auto ppv = cast(void**) p;
-    if (!p || !*ppv)
+    if (!*ppv)
         return false;
 
     auto c = *cast(ClassInfo*)*ppv;
@@ -682,67 +650,7 @@ extern (C) int rt_hasFinalizerInSegment(void* p, size_t size, uint attr, scope c
     return false;
 }
 
-int hasStructFinalizerInSegment(void* p, size_t size, in void[] segment) nothrow
-{
-    if (!p)
-        return false;
-
-    auto ti = *cast(TypeInfo_Struct*)(p + size - size_t.sizeof);
-    return cast(size_t)(cast(void*)ti.xdtor - segment.ptr) < segment.length;
-}
-
-int hasArrayFinalizerInSegment(void* p, size_t size, in void[] segment) nothrow
-{
-    if (!p)
-        return false;
-
-    TypeInfo_Struct si = void;
-    if (size < PAGESIZE)
-        si = *cast(TypeInfo_Struct*)(p + size - size_t.sizeof);
-    else
-        si = *cast(TypeInfo_Struct*)(p + size_t.sizeof);
-
-    return cast(size_t)(cast(void*)si.xdtor - segment.ptr) < segment.length;
-}
-
 debug (VALGRIND) import etc.valgrind.valgrind;
-
-// called by the GC
-void finalize_array2(void* p, size_t size) nothrow
-{
-    debug(PRINTF) printf("rt_finalize_array2(p = %p)\n", p);
-
-    // construct a BlkInfo to match the array API
-    auto info = BlkInfo(
-            base: p,
-            size: size,
-            attr: BlkAttr.APPENDABLE | BlkAttr.STRUCTFINAL
-    );
-    auto usedsize = __arrayAllocLength(info);
-    auto arrptr = __arrayStart(info);
-
-    debug (VALGRIND)
-    {
-        auto block = p[0..size];
-        disableAddrReportingInRange(block);
-    }
-
-    TypeInfo_Struct si = size < PAGESIZE ?
-        *cast(TypeInfo_Struct*)(p + size - size_t.sizeof) : // small
-        *cast(TypeInfo_Struct*)(p + size_t.sizeof); // large
-
-    debug (VALGRIND) enableAddrReportingInRange(block);
-
-    try
-    {
-        finalize_array(arrptr, usedsize, si);
-    }
-    catch (Exception e)
-    {
-        import core.exception : onFinalizeError;
-        onFinalizeError(si, e);
-    }
-}
 
 void finalize_array(void* p, size_t size, const TypeInfo_Struct si)
 {
@@ -758,11 +666,10 @@ void finalize_array(void* p, size_t size, const TypeInfo_Struct si)
 }
 
 // called by the GC
-void finalize_struct(void* p, size_t size) nothrow
+void finalize_struct(void* p, TypeInfo_Struct ti) nothrow
 {
     debug(PRINTF) printf("finalize_struct(p = %p)\n", p);
 
-    auto ti = *cast(TypeInfo_Struct*)(p + size - size_t.sizeof);
     try
     {
         ti.destroy(p); // call destructor
@@ -828,12 +735,37 @@ extern (C) void rt_finalize(void* p, bool det = true) nothrow
 extern (C) void rt_finalizeFromGC(void* p, size_t size, uint attr) nothrow
 {
     // to verify: reset memory necessary?
-    if (!(attr & BlkAttr.STRUCTFINAL))
+    if (!(attr & BlkAttr.STRUCTFINAL)) {
         rt_finalize2(p, false, false); // class
-    else if (attr & BlkAttr.APPENDABLE)
-        finalize_array2(p, size); // array of structs
+        return;
+    }
+
+    // get the struct typeinfo from the block, and the used size.
+    import core.internal.gc.blockmeta;
+    auto info = BlkInfo(
+            base: p,
+            size: size,
+            attr: attr
+    );
+
+    auto si = cast(TypeInfo_Struct)cast(void*)__getBlockFinalizerInfo(info);
+
+    if (attr & BlkAttr.APPENDABLE)
+    {
+        auto usedsize = __arrayAllocLength(info);
+        auto arrptr = __arrayStart(info);
+        try
+        {
+            finalize_array(arrptr, usedsize, si);
+        }
+        catch (Exception e)
+        {
+            import core.exception : onFinalizeError;
+            onFinalizeError(si, e);
+        }
+    }
     else
-        finalize_struct(p, size); // struct
+        finalize_struct(p, si); // struct
 }
 
 
@@ -927,28 +859,23 @@ do
 
     debug(PRINTF) printf("newsize = %x, newlength = %x\n", newsize, newlength);
 
-    const isshared = typeid(ti) is typeid(TypeInfo_Shared);
-
     if (!(*p).ptr)
     {
         assert((*p).length == 0);
         // pointer was null, need to allocate
-        auto info = __arrayAlloc(newsize, ti, tinext);
-        if (info.base is null)
+        auto ptr = GC.malloc(newsize, __typeAttrs(tinext) | BlkAttr.APPENDABLE, tinext);
+        if (ptr is null)
         {
             onOutOfMemoryError();
             assert(0);
         }
-        __setArrayAllocLength(info, newsize, isshared, tinext);
-        if (!isshared)
-            __insertBlkInfoCache(info, null);
-        void* newdata = cast(byte *)__arrayStart(info);
-        memset(newdata, 0, newsize);
-        *p = newdata[0 .. newlength];
+        memset(ptr, 0, newsize);
+        *p = ptr[0 .. newlength];
         return *p;
     }
 
     const size_t size = (*p).length * sizeelem;
+    const isshared = typeid(ti) is typeid(TypeInfo_Shared);
 
     /* Attempt to extend past the end of the existing array.
      * If not possible, allocate new space for entire array and copy.
@@ -956,24 +883,17 @@ do
     void* newdata = (*p).ptr;
     if (!gc_expandArrayUsed(newdata[0 .. size], newsize, isshared))
     {
-        auto info = __arrayAlloc(newsize, (*p).ptr, ti, tinext);
-        if (info.base is null)
+        newdata = GC.malloc(newsize, __typeAttrs(tinext, (*p).ptr) | BlkAttr.APPENDABLE, tinext);
+        if (newdata is null)
         {
             onOutOfMemoryError();
             assert(0);
         }
 
-        newdata = __arrayStart(info);
         newdata[0 .. size] = (*p).ptr[0 .. size];
-
-        __setArrayAllocLength(info, newsize, isshared, tinext);
 
         // Do postblit processing, as we are making a copy.
         __doPostblit(newdata, size, tinext);
-
-        // this hasn't been added to the cache yet.
-        if (!isshared)
-            __insertBlkInfoCache(info, null);
     }
 
     // Zero the unused portion of the newly allocated space
@@ -1049,8 +969,6 @@ do
 
     debug(PRINTF) printf("newsize = %x, newlength = %x\n", newsize, newlength);
 
-    const isshared = typeid(ti) is typeid(TypeInfo_Shared);
-
     static void doInitialize(void *start, void *end, const void[] initializer)
     {
         if (initializer.length == 1)
@@ -1072,22 +990,19 @@ do
     {
         assert((*p).length == 0);
         // pointer was null, need to allocate
-        auto info = __arrayAlloc(newsize, ti, tinext);
-        if (info.base is null)
+        auto ptr = GC.malloc(newsize, __typeAttrs(tinext) | BlkAttr.APPENDABLE, tinext);
+        if (ptr is null)
         {
             onOutOfMemoryError();
             assert(0);
         }
-        __setArrayAllocLength(info, newsize, isshared, tinext);
-        if (!isshared)
-            __insertBlkInfoCache(info, null);
-        void* newdata = cast(byte *)__arrayStart(info);
-        doInitialize(newdata, newdata + newsize, tinext.initializer);
-        *p = newdata[0 .. newlength];
+        doInitialize(ptr, ptr + newsize, tinext.initializer);
+        *p = ptr[0 .. newlength];
         return *p;
     }
 
     const size_t size = (*p).length * sizeelem;
+    const isshared = typeid(ti) is typeid(TypeInfo_Shared);
 
     /* Attempt to extend past the end of the existing array.
      * If not possible, allocate new space for entire array and copy.
@@ -1095,24 +1010,17 @@ do
     void* newdata = (*p).ptr;
     if (!gc_expandArrayUsed(newdata[0 .. size], newsize, isshared))
     {
-        auto info = __arrayAlloc(newsize, (*p).ptr, ti, tinext);
-        if (info.base is null)
+        newdata = GC.malloc(newsize, __typeAttrs(tinext, (*p).ptr) | BlkAttr.APPENDABLE, tinext);
+        if (newdata is null)
         {
             onOutOfMemoryError();
             assert(0);
         }
 
-        newdata = __arrayStart(info);
         newdata[0 .. size] = (*p).ptr[0 .. size];
-
-        __setArrayAllocLength(info, newsize, isshared, tinext);
 
         // Do postblit processing, as we are making a copy.
         __doPostblit(newdata, size, tinext);
-
-        // this hasn't been added to the cache yet.
-        if (!isshared)
-            __insertBlkInfoCache(info, null);
     }
 
     // Initialize the unused portion of the newly allocated space
@@ -1220,32 +1128,35 @@ byte[] _d_arrayappendcTX(const TypeInfo ti, return scope ref byte[] px, size_t n
     {
         // could not set the size, we must reallocate.
         auto newcap = newCapacity(newlength, sizeelem);
-        auto info = __arrayAlloc(newcap, px.ptr, ti, tinext);
-        if (info.base is null)
+        auto attrs = __typeAttrs(tinext, px.ptr) | BlkAttr.APPENDABLE;
+        auto ptr = cast(byte*) GC.malloc(newcap, attrs, tinext);
+        if (ptr is null)
         {
+            import core.stdc.stdio;
+            printf("here, ptr=%p, size=%lld, newcap=%lld, newsize=%lld, newlength=%lld, length=%lld, attrs=%02x\n", px.ptr, size, newcap, newsize, newlength, length, attrs);
             onOutOfMemoryError();
             assert(0);
         }
 
-        __setArrayAllocLength(info, newsize, isshared, tinext);
-        if (!isshared)
-            __insertBlkInfoCache(info, null);
+        if (newsize != newcap)
+        {
+            // For small blocks that are always fully scanned, if we allocated more
+            // capacity than was requested, we are responsible for zeroing that
+            // memory.
+            // TODO: should let the GC figure this out, as this property may
+            // not always hold.
+            if (!(attrs & BlkAttr.NO_SCAN) && newcap < PAGESIZE)
+                memset(ptr + newsize, 0, newcap - newsize);
 
-        auto newdata = cast(byte*)__arrayStart(info);
-        memcpy(newdata, px.ptr, size);
+            gc_shrinkArrayUsed(ptr[0 .. newsize], newcap, isshared);
+        }
 
-
-        // For small blocks that are always fully scanned, if we allocated more
-        // capacity than was requested, we are responsible for zeroing that
-        // memory.
-        // large blocks are only scanned up to the used size.
-        if (!(info.attr & BlkAttr.NO_SCAN) && newcap > newcap && info.size < PAGESIZE)
-            memset(newdata + newsize, 0, newcap - newsize);
+        memcpy(ptr, px.ptr, size);
 
         // do potsblit processing.
-        __doPostblit(newdata, size, tinext);
+        __doPostblit(ptr, size, tinext);
 
-        px = newdata[0 .. newlength];
+        px = ptr[0 .. newlength];
         return px;
     }
 
@@ -1428,16 +1339,12 @@ void* _d_arrayliteralTX(const TypeInfo ti, size_t length) @weak
 
     debug(PRINTF) printf("_d_arrayliteralTX(sizeelem = %d, length = %d)\n", sizeelem, length);
     if (length == 0 || sizeelem == 0)
-        result = null;
+        return null;
     else
     {
         auto allocsize = length * sizeelem;
-        auto info = __arrayAlloc(allocsize, ti, tinext);
-        auto isshared = typeid(ti) is typeid(TypeInfo_Shared);
-        __setArrayAllocLength(info, allocsize, isshared, tinext);
-        result = __arrayStart(info);
+        return GC.malloc(allocsize, __typeAttrs(tinext) | BlkAttr.APPENDABLE, tinext);
     }
-    return result;
 }
 
 
@@ -1804,6 +1711,7 @@ unittest
     GC.free(larr1);
 
     auto larr2 = new S[255];
+    import core.internal.gc.blockmeta : LARGEPREFIX;
     if (cast(void*)larr1 is cast(void*)larr2.ptr - LARGEPREFIX) // reusage not guaranteed
     {
         auto ptr = cast(S**)larr1;

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -1115,6 +1115,11 @@ byte[] _d_arrayappendcTX(const TypeInfo ti, return scope ref byte[] px, size_t n
     import core.exception : onOutOfMemoryError;
     // This is a cut&paste job from _d_arrayappendT(). Should be refactored.
 
+    // Short circuit if no data is being appended.
+    if (n == 0)
+        return px;
+
+
     // only optimize array append where ti is not a shared type
     auto tinext = unqualify(ti.next);
     auto sizeelem = tinext.tsize;              // array element size
@@ -1132,8 +1137,6 @@ byte[] _d_arrayappendcTX(const TypeInfo ti, return scope ref byte[] px, size_t n
         auto ptr = cast(byte*) GC.malloc(newcap, attrs, tinext);
         if (ptr is null)
         {
-            import core.stdc.stdio;
-            printf("here, ptr=%p, size=%lld, newcap=%lld, newsize=%lld, newlength=%lld, length=%lld, attrs=%02x\n", px.ptr, size, newcap, newsize, newlength, length, attrs);
             onOutOfMemoryError();
             assert(0);
         }

--- a/druntime/test/exceptions/src/assert_fail.d
+++ b/druntime/test/exceptions/src/assert_fail.d
@@ -523,8 +523,16 @@ void testDestruction()
         new long[100];
     }
 
+    static void clobberStack()
+    {
+        ubyte[1024] clobber;
+        clobber[] = 0xff;
+    }
+
     import core.memory : GC;
     createGarbage();
+    // ensure there are no stale references on the stack
+    clobberStack();
     GC.collect();
 
     assert(Test.run);


### PR DESCRIPTION
This also removes almost all dependency of the block metadata usage from rt.lifetime, and moves it into the GC. Now, instead of using the runtime to set up the metadata, the GC does it based on the attributes passed in.

Passing in APPENDABLE sets up the used data. Passing in FINALIZE + a typeinfo that is a struct typeinfo sets up the STRUCTFINAL bit and also stores the finalizer in the block.

There are a few remnants, such as the GC calling into the runtime to finalize where the typeinfo is extracted in the runtime instead of by the GC. This will be adjusted in a further PR.

This is split into 2 commits, the first commit adds the feature to set up the metadata in the GC allocation routines. The second commit migrates all calls to use the GC API.

The second commit is quite large, and if it needs further splitting, let me know.