### PR TITLE
fix #20516 ImportC undefined identifier _Float16

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -173,6 +173,7 @@ typedef unsigned long long __uint64_t;
 #define __PRETTY_FUNCTION__ __func__
 
 #ifndef __aarch64__
+#define _Float16 float
 #define _Float32 float
 #define _Float32x double
 #define _Float64 double


### PR DESCRIPTION
The `_Float16` type is now in C23, and ImportC doesn't recognize it. But it will with this patch, even though DMD does not implement actual 16 bit floats.

This is necessary for the moment as `<math.h>` won't compile even if `_Float16` is not used.

Issue https://github.com/dlang/dmd/issues/20516