### PR TITLE
globals.h: Add missing C++ constructors for ImportPathInfo

### DIFF
--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -158,6 +158,9 @@ struct Verbose
 struct ImportPathInfo
 {
     const char* path;
+
+    ImportPathInfo() : path(NULL) { }
+    ImportPathInfo(const char* p) : path(p) { }
 };
 
 // Put command line switches in here

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1685,6 +1685,12 @@ void test_backend(FuncDeclaration *f, Type *t)
     f->fbody->accept(&v);
 }
 
+void test_import_paths(const char *path, const char *imppath)
+{
+  global.path.push(path);
+  global.params.imppath.shift(imppath);
+}
+
 /**********************************/
 
 int main(int argc, char **argv)


### PR DESCRIPTION
12d4f3e4d6 added the struct layout of ImportPathInfo, but non of the constructors.  This allows existing C++ code to continue working without modification.