### PR TITLE
Fix build on i686, arm64 and x86_64+32b multilib for Darwin.

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -97,22 +97,22 @@ else version (Posix)
             import core.sys.darwin.mach.thread_act :
              x86_THREAD_STATE32, x86_THREAD_STATE32_COUNT, x86_thread_state32_t;
         }
-        version (X86_64)
+        else version (X86_64)
         {
             import core.sys.darwin.mach.thread_act :
              x86_THREAD_STATE64, x86_THREAD_STATE64_COUNT, x86_thread_state64_t;
         }
-        version (AArch64)
+        else version (AArch64)
         {
             import core.sys.darwin.mach.thread_act :
              ARM_THREAD_STATE64, ARM_THREAD_STATE64_COUNT, arm_thread_state64_t;
         }
-        version (PPC)
+        else version (PPC)
         {
             import core.sys.darwin.mach.thread_act :
              PPC_THREAD_STATE32, PPC_THREAD_STATE32_COUNT, ppc_thread_state32_t;
         }
-        version (PPC64)
+        else version (PPC64)
         {
             import core.sys.darwin.mach.thread_act :
              PPC_THREAD_STATE64, PPC_THREAD_STATE64_COUNT, ppc_thread_state64_t;

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -53,24 +53,6 @@ else version (D_InlineAsm_X86_64)
     }
 }
 
-version (Posix)
-{
-    version (AsmX86_Windows)    {} else
-    version (AsmX86_Posix)      {} else
-    version (AsmX86_64_Windows) {} else
-    version (AsmX86_64_Posix)   {} else
-    version (AsmExternal)       {} else
-    {
-        // NOTE: The ucontext implementation requires architecture specific
-        //       data definitions to operate so testing for it must be done
-        //       by checking for the existence of ucontext_t rather than by
-        //       a version identifier.  Please note that this is considered
-        //       an obsolescent feature according to the POSIX spec, so a
-        //       custom solution is still preferred.
-        static import core.sys.posix.ucontext;
-    }
-}
-
 version (Windows)
 {
     import core.stdc.stdint : uintptr_t; // for _beginthreadex decl below
@@ -107,9 +89,34 @@ else version (Posix)
     {
         import core.sys.darwin.mach.kern_return : KERN_SUCCESS;
         import core.sys.darwin.mach.port : mach_port_t;
-        import core.sys.darwin.mach.thread_act : mach_msg_type_number_t, thread_get_state, thread_resume,
-            thread_suspend, x86_THREAD_STATE64, x86_THREAD_STATE64_COUNT, x86_thread_state64_t;
+        import core.sys.darwin.mach.thread_act : mach_msg_type_number_t,
+            thread_get_state, thread_resume, thread_suspend;
         import core.sys.darwin.pthread : pthread_mach_thread_np;
+        version (X86)
+        {
+            import core.sys.darwin.mach.thread_act :
+             x86_THREAD_STATE32, x86_THREAD_STATE32_COUNT, x86_thread_state32_t;
+        }
+        version (X86_64)
+        {
+            import core.sys.darwin.mach.thread_act :
+             x86_THREAD_STATE64, x86_THREAD_STATE64_COUNT, x86_thread_state64_t;
+        }
+        version (AArch64)
+        {
+            import core.sys.darwin.mach.thread_act :
+             ARM_THREAD_STATE64, ARM_THREAD_STATE64_COUNT, arm_thread_state64_t;
+        }
+        version (PPC)
+        {
+            import core.sys.darwin.mach.thread_act :
+             PPC_THREAD_STATE32, PPC_THREAD_STATE32_COUNT, ppc_thread_state32_t;
+        }
+        version (PPC64)
+        {
+            import core.sys.darwin.mach.thread_act :
+             PPC_THREAD_STATE64, PPC_THREAD_STATE64_COUNT, ppc_thread_state64_t;
+        }
     }
 }
 


### PR DESCRIPTION
osthread.d needs to import the thread state definitions for each supported arch (but was only importing x86_64).

NOTE1: Iain Buclaw pointed out that the ucontext import was unused and do I have removed that too.

NOTE2: I did not add the data for 32bit Arm (as distinct from the possible use of AArch64/ILP32), because there is no way I know to test that - since there's no upstream 32b Arm implementation.

NOTE3: The earlier Darwin versions (equivalent to MacOSX 10.5) have quite limited D support - but both i686 and PowerPC should be able (at least) to build the druntime.

I tested on x86_64,i686-Darwin17 and aarch64-darwin23.