### PR TITLE
Make inferred attribute failure errors more compact and consistent

### DIFF
--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -478,7 +478,7 @@ int blockExit(Statement s, FuncDeclaration func, ErrorSink eSink)
             if (!(s.stc & STC.nothrow_))
             {
                 if(func)
-                    func.setThrow(s.loc, "`asm` statement is assumed to throw - mark it with `nothrow` if it does not");
+                    func.setThrow(s.loc, "executing an `asm` statement without a `nothrow` annotation");
                 if (eSink)
                     eSink.error(s.loc, "`asm` statement is assumed to throw - mark it with `nothrow` if it does not"); // TODO
                 else
@@ -523,7 +523,7 @@ BE checkThrow(ref const Loc loc, Expression exp, FuncDeclaration func, ErrorSink
     if (eSink)
         eSink.error(loc, "`%s` is thrown but not caught", exp.type.toChars());
     else if (func)
-        func.setThrow(loc, "`%s` is thrown but not caught", exp.type);
+        func.setThrow(loc, "`%s` being thrown but not caught", exp.type);
 
     return BE.throw_;
 }

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -3032,7 +3032,7 @@ extern (D) bool checkNRVO(FuncDeclaration fd)
  * Params:
  *     fd = function declaration to mark
  *     loc = location of impure action
- *     fmt = format string for error message. Must include "%s `%s`" for the function kind and name.
+ *     fmt = format string for error message
  *     arg0 = (optional) argument to format string
  *
  * Returns: `true` if there's a purity error
@@ -3043,7 +3043,7 @@ extern (D) bool setImpure(FuncDeclaration fd, Loc loc = Loc.init, const(char)* f
     {
         fd.purityInprocess = false;
         if (fmt)
-            fd.pureViolation = new AttributeViolation(loc, fmt, fd, arg0); // impure action
+            fd.pureViolation = new AttributeViolation(loc, fmt, arg0); // impure action
         else if (arg0)
         {
             if (auto sa = arg0.isDsymbol())

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -80,20 +80,19 @@ public:
      * Register that expression `e` requires the GC
      * Params:
      *   e = expression that uses GC
-     *   format = error message when `e` is used in a `@nogc` function.
-     *            Must contain format strings "`@nogc` %s `%s`" referring to the function.
+     *   msg = error message when `e` is used in a `@nogc` function.
      * Returns: `true` if `err` was set, `false` if it's not in a `@nogc` and not checkonly (-betterC)
      */
-    private bool setGC(Expression e, const(char)* format)
+    private bool setGC(Expression e, const(char)* msg)
     {
         if (checkOnly)
         {
             err = true;
             return true;
         }
-        if (f.setGC(e.loc, format))
+        if (f.setGC(e.loc, msg))
         {
-            error(e.loc, format, f.kind(), f.toPrettyChars());
+            error(e.loc, "%s causes a GC allocation in `@nogc` %s `%s`", msg, f.kind(), f.toChars());
             err = true;
             return true;
         }
@@ -111,7 +110,7 @@ public:
         auto fd = stripHookTraceImpl(e.f);
         if (fd.ident == Id._d_arraysetlengthT)
         {
-            if (setGC(e, "setting `length` in `@nogc` %s `%s` may cause a GC allocation"))
+            if (setGC(e, "setting this array's `length`"))
                 return;
             f.printGCUsage(e.loc, "setting `length` may cause a GC allocation");
         }
@@ -121,7 +120,7 @@ public:
     {
         if (e.type.ty != Tarray || !e.elements || !e.elements.length || e.onstack)
             return;
-        if (setGC(e, "array literal in `@nogc` %s `%s` may cause a GC allocation"))
+        if (setGC(e, "this array literal"))
             return;
         f.printGCUsage(e.loc, "array literal may cause a GC allocation");
     }
@@ -130,7 +129,7 @@ public:
     {
         if (!e.keys.length)
             return;
-        if (setGC(e, "associative array literal in `@nogc` %s `%s` may cause a GC allocation"))
+        if (setGC(e, "this associative array literal"))
             return;
         f.printGCUsage(e.loc, "associative array literal may cause a GC allocation");
     }
@@ -147,7 +146,7 @@ public:
         if (nogcExceptions && e.thrownew)
             return;                     // separate allocator is called for this, not the GC
 
-        if (setGC(e, "cannot use `new` in `@nogc` %s `%s`"))
+        if (setGC(e, "allocating with `new`"))
             return;
         f.printGCUsage(e.loc, "`new` causes a GC allocation");
     }
@@ -170,7 +169,7 @@ public:
         Type t1b = e.e1.type.toBasetype();
         if (e.modifiable && t1b.ty == Taarray)
         {
-            if (setGC(e, "assigning an associative array element in `@nogc` %s `%s` may cause a GC allocation"))
+            if (setGC(e, "assigning this associative array element"))
                 return;
             f.printGCUsage(e.loc, "assigning an associative array element may cause a GC allocation");
         }
@@ -180,7 +179,7 @@ public:
     {
         if (e.e1.op == EXP.arrayLength)
         {
-            if (setGC(e, "setting `length` in `@nogc` %s `%s` may cause a GC allocation"))
+            if (setGC(e, "setting this array's `length`"))
                 return;
             f.printGCUsage(e.loc, "setting `length` may cause a GC allocation");
         }
@@ -193,14 +192,14 @@ public:
             err = true;
             return;
         }
-        if (setGC(e, "cannot use operator `~=` in `@nogc` %s `%s`"))
+        if (setGC(e, "appending to this array with operator `~=`"))
             return;
         f.printGCUsage(e.loc, "operator `~=` may cause a GC allocation");
     }
 
     override void visit(CatExp e)
     {
-        if (setGC(e, "cannot use operator `~` in `@nogc` %s `%s`"))
+        if (setGC(e, "concatenating with operator `~`"))
             return;
         f.printGCUsage(e.loc, "operator `~` may cause a GC allocation");
     }
@@ -302,7 +301,7 @@ extern (D) bool setGC(FuncDeclaration fd, Loc loc, const(char)* fmt, RootObject 
     {
         fd.nogcInprocess = false;
         if (fmt)
-            fd.nogcViolation = new AttributeViolation(loc, fmt, fd, arg0); // action that requires GC
+            fd.nogcViolation = new AttributeViolation(loc, fmt, arg0); // action that requires GC
         else if (arg0)
         {
             if (auto sa = arg0.isDsymbol())

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1699,7 +1699,7 @@ extern (D) bool checkClosure(FuncDeclaration fd)
     if (!fd.needsClosure())
         return false;
 
-    if (fd.setGC(fd.loc, "%s `%s` is `@nogc` yet allocates closure for `%s()` with the GC", fd))
+    if (fd.setGC(fd.loc, "allocating a closure for `%s()`", fd))
     {
         .error(fd.loc, "%s `%s` is `@nogc` yet allocates closure for `%s()` with the GC", fd.kind, fd.toPrettyChars(), fd.toChars());
         if (global.gag)     // need not report supplemental errors

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3623,9 +3623,9 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         }
 
         assert(sc.func);
-        if (!(cas.stc & STC.pure_) && sc.func.setImpure(cas.loc, "`asm` statement is assumed to be impure - mark it with `pure` if it is not"))
+        if (!(cas.stc & STC.pure_) && sc.func.setImpure(cas.loc, "executing an `asm` statement without `pure` annotation"))
             error(cas.loc, "`asm` statement is assumed to be impure - mark it with `pure` if it is not");
-        if (!(cas.stc & STC.nogc) && sc.func.setGC(cas.loc, "`asm` statement in %s `%s` is assumed to use the GC - mark it with `@nogc` if it does not"))
+        if (!(cas.stc & STC.nogc) && sc.func.setGC(cas.loc, "executing an `asm` statement without `@nogc` annotation"))
             error(cas.loc, "`asm` statement is assumed to use the GC - mark it with `@nogc` if it does not");
         // @@@DEPRECATED_2.114@@@
         // change deprecation() to error(), add `else` and remove `| STC.safe`
@@ -3634,7 +3634,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             deprecation(cas.loc, "`asm` statement cannot be marked `@safe`, use `@system` or `@trusted` instead");
         if (!(cas.stc & (STC.trusted | STC.safe)))
         {
-            sc.setUnsafe(false, cas.loc, "`asm` statement without `@trusted` annotation");
+            sc.setUnsafe(false, cas.loc, "executing an `asm` statement without `@trusted` annotation");
         }
 
         sc.pop();

--- a/compiler/test/fail_compilation/attributediagnostic.d
+++ b/compiler/test/fail_compilation/attributediagnostic.d
@@ -1,20 +1,17 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/attributediagnostic.d(24): Error: `@safe` function `attributediagnostic.layer2` cannot call `@system` function `attributediagnostic.layer1`
-fail_compilation/attributediagnostic.d(26):        which calls `attributediagnostic.layer0`
-fail_compilation/attributediagnostic.d(28):        which calls `attributediagnostic.system`
-fail_compilation/attributediagnostic.d(30):        which wasn't inferred `@safe` because of:
-fail_compilation/attributediagnostic.d(30):        `asm` statement without `@trusted` annotation
-fail_compilation/attributediagnostic.d(25):        `attributediagnostic.layer1` is declared here
-fail_compilation/attributediagnostic.d(46): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system1`
-fail_compilation/attributediagnostic.d(35):        which wasn't inferred `@safe` because of:
-fail_compilation/attributediagnostic.d(35):        cast from `uint` to `int*`
-fail_compilation/attributediagnostic.d(33):        `attributediagnostic.system1` is declared here
-fail_compilation/attributediagnostic.d(47): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system2`
-fail_compilation/attributediagnostic.d(41):        which wasn't inferred `@safe` because of:
-fail_compilation/attributediagnostic.d(41):        `@safe` function `system2` cannot call `@system` `fsys`
-fail_compilation/attributediagnostic.d(39):        `attributediagnostic.system2` is declared here
+fail_compilation/attributediagnostic.d(21): Error: `@safe` function `attributediagnostic.layer2` cannot call `@system` function `attributediagnostic.layer1`
+fail_compilation/attributediagnostic.d(23):        which calls `attributediagnostic.layer0`
+fail_compilation/attributediagnostic.d(25):        which calls `attributediagnostic.system`
+fail_compilation/attributediagnostic.d(27):        and executing an `asm` statement without `@trusted` annotation makes it fail to infer `@safe`
+fail_compilation/attributediagnostic.d(22):        `attributediagnostic.layer1` is declared here
+fail_compilation/attributediagnostic.d(43): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system1`
+fail_compilation/attributediagnostic.d(32):        and cast from `uint` to `int*` makes it fail to infer `@safe`
+fail_compilation/attributediagnostic.d(30):        `attributediagnostic.system1` is declared here
+fail_compilation/attributediagnostic.d(44): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system2`
+fail_compilation/attributediagnostic.d(38):        and calling `@system` `fsys` makes it fail to infer `@safe`
+fail_compilation/attributediagnostic.d(36):        `attributediagnostic.system2` is declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/attributediagnostic_nogc.d
+++ b/compiler/test/fail_compilation/attributediagnostic_nogc.d
@@ -4,17 +4,13 @@ TEST_OUTPUT:
 fail_compilation/attributediagnostic_nogc.d(21): Error: `@nogc` function `attributediagnostic_nogc.layer2` cannot call non-@nogc function `attributediagnostic_nogc.layer1`
 fail_compilation/attributediagnostic_nogc.d(22):        which calls `attributediagnostic_nogc.layer0`
 fail_compilation/attributediagnostic_nogc.d(23):        which calls `attributediagnostic_nogc.gc`
-fail_compilation/attributediagnostic_nogc.d(27):        which wasn't inferred `@nogc` because of:
-fail_compilation/attributediagnostic_nogc.d(27):        `asm` statement in function `attributediagnostic_nogc.gc` is assumed to use the GC - mark it with `@nogc` if it does not
+fail_compilation/attributediagnostic_nogc.d(27):        and executing an `asm` statement without `@nogc` annotation makes it fail to infer `@nogc`
 fail_compilation/attributediagnostic_nogc.d(43): Error: `@nogc` function `D main` cannot call non-@nogc function `attributediagnostic_nogc.gc1`
-fail_compilation/attributediagnostic_nogc.d(32):        which wasn't inferred `@nogc` because of:
-fail_compilation/attributediagnostic_nogc.d(32):        cannot use `new` in `@nogc` function `attributediagnostic_nogc.gc1`
+fail_compilation/attributediagnostic_nogc.d(32):        and allocating with `new` makes it fail to infer `@nogc`
 fail_compilation/attributediagnostic_nogc.d(44): Error: `@nogc` function `D main` cannot call non-@nogc function `attributediagnostic_nogc.gc2`
-fail_compilation/attributediagnostic_nogc.d(38):        which wasn't inferred `@nogc` because of:
-fail_compilation/attributediagnostic_nogc.d(38):        `@nogc` function `attributediagnostic_nogc.gc2` cannot call non-@nogc `fgc`
+fail_compilation/attributediagnostic_nogc.d(38):        and calling non-@nogc `fgc` makes it fail to infer `@nogc`
 fail_compilation/attributediagnostic_nogc.d(45): Error: `@nogc` function `D main` cannot call non-@nogc function `attributediagnostic_nogc.gcClosure`
-fail_compilation/attributediagnostic_nogc.d(48):        which wasn't inferred `@nogc` because of:
-fail_compilation/attributediagnostic_nogc.d(48):        function `attributediagnostic_nogc.gcClosure` is `@nogc` yet allocates closure for `gcClosure()` with the GC
+fail_compilation/attributediagnostic_nogc.d(48):        and allocating a closure for `gcClosure()` makes it fail to infer `@nogc`
 ---
 */
 #line 18

--- a/compiler/test/fail_compilation/attributediagnostic_nothrow.d
+++ b/compiler/test/fail_compilation/attributediagnostic_nothrow.d
@@ -1,17 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/attributediagnostic_nothrow.d(21): Error: function `attributediagnostic_nothrow.layer1` is not `nothrow`
-fail_compilation/attributediagnostic_nothrow.d(22):        which calls `attributediagnostic_nothrow.layer0`
-fail_compilation/attributediagnostic_nothrow.d(23):        which calls `attributediagnostic_nothrow.gc`
-fail_compilation/attributediagnostic_nothrow.d(27):        which wasn't inferred `nothrow` because of:
-fail_compilation/attributediagnostic_nothrow.d(27):        `asm` statement is assumed to throw - mark it with `nothrow` if it does not
-fail_compilation/attributediagnostic_nothrow.d(21): Error: function `attributediagnostic_nothrow.layer2` may throw but is marked as `nothrow`
-fail_compilation/attributediagnostic_nothrow.d(43): Error: function `attributediagnostic_nothrow.gc1` is not `nothrow`
-fail_compilation/attributediagnostic_nothrow.d(32):        which wasn't inferred `nothrow` because of:
-fail_compilation/attributediagnostic_nothrow.d(32):        `object.Exception` is thrown but not caught
-fail_compilation/attributediagnostic_nothrow.d(44): Error: function `attributediagnostic_nothrow.gc2` is not `nothrow`
-fail_compilation/attributediagnostic_nothrow.d(41): Error: function `D main` may throw but is marked as `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(19): Error: function `attributediagnostic_nothrow.layer1` is not `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(20):        which calls `attributediagnostic_nothrow.layer0`
+fail_compilation/attributediagnostic_nothrow.d(21):        which calls `attributediagnostic_nothrow.gc`
+fail_compilation/attributediagnostic_nothrow.d(25):        and executing an `asm` statement without a `nothrow` annotation makes it fail to infer `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(19): Error: function `attributediagnostic_nothrow.layer2` may throw but is marked as `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(41): Error: function `attributediagnostic_nothrow.gc1` is not `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(30):        and `object.Exception` being thrown but not caught makes it fail to infer `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(42): Error: function `attributediagnostic_nothrow.gc2` is not `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(39): Error: function `D main` may throw but is marked as `nothrow`
 ---
 */
 

--- a/compiler/test/fail_compilation/attributediagnostic_pure.d
+++ b/compiler/test/fail_compilation/attributediagnostic_pure.d
@@ -1,9 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/attributediagnostic_pure.d(20): Error: `pure` function `D main` cannot call impure function `attributediagnostic_pure.gc`
-fail_compilation/attributediagnostic_pure.d(15):        which wasn't inferred `pure` because of:
-fail_compilation/attributediagnostic_pure.d(15):        `asm` statement is assumed to be impure - mark it with `pure` if it is not
+fail_compilation/attributediagnostic_pure.d(19): Error: `pure` function `D main` cannot call impure function `attributediagnostic_pure.gc`
+fail_compilation/attributediagnostic_pure.d(14):        and executing an `asm` statement without `pure` annotation makes it fail to infer `pure`
 ---
 */
 

--- a/compiler/test/fail_compilation/deprecate12979d.d
+++ b/compiler/test/fail_compilation/deprecate12979d.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate12979d.d(11): Error: `asm` statement without `@trusted` annotation is not allowed in a `@safe` function
+fail_compilation/deprecate12979d.d(11): Error: executing an `asm` statement without `@trusted` annotation is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/diag10319.d
+++ b/compiler/test/fail_compilation/diag10319.d
@@ -1,21 +1,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10319.d(33): Error: `pure` function `D main` cannot call impure function `diag10319.foo`
-fail_compilation/diag10319.d(33): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo`
-fail_compilation/diag10319.d(22):        `diag10319.foo` is declared here
-fail_compilation/diag10319.d(34): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
-fail_compilation/diag10319.d(26):        which wasn't inferred `pure` because of:
-fail_compilation/diag10319.d(26):        `pure` function `diag10319.bar!int.bar` cannot access mutable static data `g`
-fail_compilation/diag10319.d(34): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
-fail_compilation/diag10319.d(27):        which wasn't inferred `@safe` because of:
-fail_compilation/diag10319.d(27):        taking the address of stack-allocated local variable `x`
-fail_compilation/diag10319.d(24):        `diag10319.bar!int.bar` is declared here
-fail_compilation/diag10319.d(33): Error: function `diag10319.foo` is not `nothrow`
-fail_compilation/diag10319.d(34): Error: function `diag10319.bar!int.bar` is not `nothrow`
-fail_compilation/diag10319.d(28):        which wasn't inferred `nothrow` because of:
-fail_compilation/diag10319.d(28):        `object.Exception` is thrown but not caught
-fail_compilation/diag10319.d(31): Error: function `D main` may throw but is marked as `nothrow`
+fail_compilation/diag10319.d(30): Error: `pure` function `D main` cannot call impure function `diag10319.foo`
+fail_compilation/diag10319.d(30): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo`
+fail_compilation/diag10319.d(19):        `diag10319.foo` is declared here
+fail_compilation/diag10319.d(31): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(23):        and accessing mutable static data `g` makes it fail to infer `pure`
+fail_compilation/diag10319.d(31): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(24):        and taking the address of stack-allocated local variable `x` makes it fail to infer `@safe`
+fail_compilation/diag10319.d(21):        `diag10319.bar!int.bar` is declared here
+fail_compilation/diag10319.d(30): Error: function `diag10319.foo` is not `nothrow`
+fail_compilation/diag10319.d(31): Error: function `diag10319.bar!int.bar` is not `nothrow`
+fail_compilation/diag10319.d(25):        and `object.Exception` being thrown but not caught makes it fail to infer `nothrow`
+fail_compilation/diag10319.d(28): Error: function `D main` may throw but is marked as `nothrow`
 ---
 */
 

--- a/compiler/test/fail_compilation/diag9620.d
+++ b/compiler/test/fail_compilation/diag9620.d
@@ -1,10 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9620.d(20): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo1`
-fail_compilation/diag9620.d(21): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo2!().foo2`
-fail_compilation/diag9620.d(14):        which wasn't inferred `pure` because of:
-fail_compilation/diag9620.d(14):        `pure` function `diag9620.foo2!().foo2` cannot access mutable static data `x`
+fail_compilation/diag9620.d(19): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo1`
+fail_compilation/diag9620.d(20): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo2!().foo2`
+fail_compilation/diag9620.d(13):        and accessing mutable static data `x` makes it fail to infer `pure`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail12932.d
+++ b/compiler/test/fail_compilation/fail12932.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12932.d(11): Error: array literal in `@nogc` function `fail12932.foo` may cause a GC allocation
-fail_compilation/fail12932.d(15): Error: array literal in `@nogc` function `fail12932.foo` may cause a GC allocation
+fail_compilation/fail12932.d(11): Error: this array literal causes a GC allocation in `@nogc` function `foo`
+fail_compilation/fail12932.d(15): Error: this array literal causes a GC allocation in `@nogc` function `foo`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail21928.d
+++ b/compiler/test/fail_compilation/fail21928.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail21928.d(18): Error: array literal in `@nogc` function `D main` may cause a GC allocation
+fail_compilation/fail21928.d(18): Error: this array literal causes a GC allocation in `@nogc` function `main`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail21928b.d
+++ b/compiler/test/fail_compilation/fail21928b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail21928b.d(18): Error: array literal in `@nogc` function `D main` may cause a GC allocation
+fail_compilation/fail21928b.d(18): Error: this array literal causes a GC allocation in `@nogc` function `main`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail327.d
+++ b/compiler/test/fail_compilation/fail327.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail327.d(11): Error: `asm` statement without `@trusted` annotation is not allowed in a `@safe` function
+fail_compilation/fail327.d(11): Error: executing an `asm` statement without `@trusted` annotation is not allowed in a `@safe` function
 fail_compilation/fail327.d(12): Deprecation: `asm` statement cannot be marked `@safe`, use `@system` or `@trusted` instead
 ---
 */

--- a/compiler/test/fail_compilation/nogc1.d
+++ b/compiler/test/fail_compilation/nogc1.d
@@ -9,13 +9,13 @@ struct S3 { this(int) @nogc; }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(23): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(25): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(26): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(28): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(23): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
+fail_compilation/nogc1.d(25): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
+fail_compilation/nogc1.d(26): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
+fail_compilation/nogc1.d(28): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
 fail_compilation/nogc1.d(29): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
-fail_compilation/nogc1.d(30): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(32): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(30): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
+fail_compilation/nogc1.d(32): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
 ---
 */
 @nogc void testNew()
@@ -35,12 +35,12 @@ fail_compilation/nogc1.d(32): Error: cannot use `new` in `@nogc` function `nogc1
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(48): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(50): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(51): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(53): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(48): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
+fail_compilation/nogc1.d(50): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
+fail_compilation/nogc1.d(51): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
+fail_compilation/nogc1.d(53): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
 fail_compilation/nogc1.d(54): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc constructor `nogc1.S2.this`
-fail_compilation/nogc1.d(55): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(55): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
 ---
 */
 @nogc void testNewScope()

--- a/compiler/test/fail_compilation/nogc2.d
+++ b/compiler/test/fail_compilation/nogc2.d
@@ -5,14 +5,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc2.d(20): Error: cannot use operator `~` in `@nogc` function `nogc2.testCat`
-fail_compilation/nogc2.d(21): Error: cannot use operator `~` in `@nogc` function `nogc2.testCat`
-fail_compilation/nogc2.d(22): Error: cannot use operator `~` in `@nogc` function `nogc2.testCat`
-fail_compilation/nogc2.d(24): Error: cannot use operator `~` in `@nogc` function `nogc2.testCat`
-fail_compilation/nogc2.d(25): Error: cannot use operator `~` in `@nogc` function `nogc2.testCat`
-fail_compilation/nogc2.d(26): Error: cannot use operator `~` in `@nogc` function `nogc2.testCat`
-fail_compilation/nogc2.d(27): Error: cannot use operator `~` in `@nogc` function `nogc2.testCat`
-fail_compilation/nogc2.d(28): Error: cannot use operator `~` in `@nogc` function `nogc2.testCat`
+fail_compilation/nogc2.d(20): Error: concatenating with operator `~` causes a GC allocation in `@nogc` function `testCat`
+fail_compilation/nogc2.d(21): Error: concatenating with operator `~` causes a GC allocation in `@nogc` function `testCat`
+fail_compilation/nogc2.d(22): Error: concatenating with operator `~` causes a GC allocation in `@nogc` function `testCat`
+fail_compilation/nogc2.d(24): Error: concatenating with operator `~` causes a GC allocation in `@nogc` function `testCat`
+fail_compilation/nogc2.d(25): Error: concatenating with operator `~` causes a GC allocation in `@nogc` function `testCat`
+fail_compilation/nogc2.d(26): Error: concatenating with operator `~` causes a GC allocation in `@nogc` function `testCat`
+fail_compilation/nogc2.d(27): Error: concatenating with operator `~` causes a GC allocation in `@nogc` function `testCat`
+fail_compilation/nogc2.d(28): Error: concatenating with operator `~` causes a GC allocation in `@nogc` function `testCat`
 ---
 */
 @nogc void testCat(int[] a, string s)
@@ -37,9 +37,9 @@ fail_compilation/nogc2.d(28): Error: cannot use operator `~` in `@nogc` function
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc2.d(47): Error: cannot use operator `~=` in `@nogc` function `nogc2.testCatAssign`
-fail_compilation/nogc2.d(49): Error: cannot use operator `~=` in `@nogc` function `nogc2.testCatAssign`
-fail_compilation/nogc2.d(50): Error: cannot use operator `~=` in `@nogc` function `nogc2.testCatAssign`
+fail_compilation/nogc2.d(47): Error: appending to this array with operator `~=` causes a GC allocation in `@nogc` function `testCatAssign`
+fail_compilation/nogc2.d(49): Error: appending to this array with operator `~=` causes a GC allocation in `@nogc` function `testCatAssign`
+fail_compilation/nogc2.d(50): Error: appending to this array with operator `~=` causes a GC allocation in `@nogc` function `testCatAssign`
 ---
 */
 @nogc void testCatAssign(int[] a, string s)
@@ -57,8 +57,8 @@ fail_compilation/nogc2.d(50): Error: cannot use operator `~=` in `@nogc` functio
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc2.d(69): Error: array literal in `@nogc` function `nogc2.testArray` may cause a GC allocation
-fail_compilation/nogc2.d(70): Error: array literal in `@nogc` function `nogc2.testArray` may cause a GC allocation
+fail_compilation/nogc2.d(69): Error: this array literal causes a GC allocation in `@nogc` function `testArray`
+fail_compilation/nogc2.d(70): Error: this array literal causes a GC allocation in `@nogc` function `testArray`
 ---
 */
 @nogc void testArray()
@@ -75,8 +75,8 @@ fail_compilation/nogc2.d(70): Error: array literal in `@nogc` function `nogc2.te
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc2.d(86): Error: associative array literal in `@nogc` function `nogc2.testAssocArray` may cause a GC allocation
-fail_compilation/nogc2.d(87): Error: associative array literal in `@nogc` function `nogc2.testAssocArray` may cause a GC allocation
+fail_compilation/nogc2.d(86): Error: this associative array literal causes a GC allocation in `@nogc` function `testAssocArray`
+fail_compilation/nogc2.d(87): Error: this associative array literal causes a GC allocation in `@nogc` function `testAssocArray`
 ---
 */
 @nogc void testAssocArray()
@@ -92,7 +92,7 @@ fail_compilation/nogc2.d(87): Error: associative array literal in `@nogc` functi
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc2.d(100): Error: assigning an associative array element in `@nogc` function `nogc2.testIndex` may cause a GC allocation
+fail_compilation/nogc2.d(100): Error: assigning this associative array element causes a GC allocation in `@nogc` function `testIndex`
 ---
 */
 @nogc void testIndex(int[int] aa)

--- a/compiler/test/fail_compilation/nogc3.d
+++ b/compiler/test/fail_compilation/nogc3.d
@@ -5,9 +5,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc3.d(15): Error: setting `length` in `@nogc` function `nogc3.testArrayLength` may cause a GC allocation
-fail_compilation/nogc3.d(16): Error: setting `length` in `@nogc` function `nogc3.testArrayLength` may cause a GC allocation
-fail_compilation/nogc3.d(17): Error: setting `length` in `@nogc` function `nogc3.testArrayLength` may cause a GC allocation
+fail_compilation/nogc3.d(15): Error: setting this array's `length` causes a GC allocation in `@nogc` function `testArrayLength`
+fail_compilation/nogc3.d(16): Error: setting this array's `length` causes a GC allocation in `@nogc` function `testArrayLength`
+fail_compilation/nogc3.d(17): Error: setting this array's `length` causes a GC allocation in `@nogc` function `testArrayLength`
 ---
 */
 @nogc void testArrayLength(int[] a)
@@ -75,10 +75,10 @@ fail_compilation/nogc3.d(68):        `x` declared here
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc3.d(87): Error: array literal in `@nogc` function `nogc3.foo13702` may cause a GC allocation
-fail_compilation/nogc3.d(88): Error: array literal in `@nogc` function `nogc3.foo13702` may cause a GC allocation
-fail_compilation/nogc3.d(94): Error: array literal in `@nogc` function `nogc3.bar13702` may cause a GC allocation
-fail_compilation/nogc3.d(93): Error: array literal in `@nogc` function `nogc3.bar13702` may cause a GC allocation
+fail_compilation/nogc3.d(87): Error: this array literal causes a GC allocation in `@nogc` function `foo13702`
+fail_compilation/nogc3.d(88): Error: this array literal causes a GC allocation in `@nogc` function `foo13702`
+fail_compilation/nogc3.d(94): Error: this array literal causes a GC allocation in `@nogc` function `bar13702`
+fail_compilation/nogc3.d(93): Error: this array literal causes a GC allocation in `@nogc` function `bar13702`
 ---
 */
 int[] foo13702(bool b) @nogc

--- a/compiler/test/fail_compilation/systemvariables_deprecation.d
+++ b/compiler/test/fail_compilation/systemvariables_deprecation.d
@@ -2,10 +2,9 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/systemvariables_deprecation.d(16): Deprecation: `@safe` function `main` calling `middle`
-fail_compilation/systemvariables_deprecation.d(21):        which calls `systemvariables_deprecation.inferred`
-fail_compilation/systemvariables_deprecation.d(27):        which wouldn't be `@safe` because of:
-fail_compilation/systemvariables_deprecation.d(27):        access `@system` variable `x0`
+fail_compilation/systemvariables_deprecation.d(15): Deprecation: `@safe` function `main` calling `middle`
+fail_compilation/systemvariables_deprecation.d(20):        which calls `systemvariables_deprecation.inferred`
+fail_compilation/systemvariables_deprecation.d(26):        and access `@system` variable `x0` makes it fail to infer `@safe`
 ---
 */
 

--- a/compiler/test/fail_compilation/test20655.d
+++ b/compiler/test/fail_compilation/test20655.d
@@ -2,15 +2,12 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/test20655.d(29): Deprecation: `@safe` function `g` calling `f1`
-fail_compilation/test20655.d(24):        which wouldn't be `@safe` because of:
-fail_compilation/test20655.d(24):        accessing overlapped field `U.s` with pointers
-fail_compilation/test20655.d(30): Deprecation: `@safe` function `g` calling `f2`
-fail_compilation/test20655.d(25):        which wouldn't be `@safe` because of:
-fail_compilation/test20655.d(25):        accessing overlapped field `U.s` with pointers
-fail_compilation/test20655.d(31): Deprecation: `@safe` function `g` calling `f3`
-fail_compilation/test20655.d(28):        which wouldn't be `@safe` because of:
-fail_compilation/test20655.d(28):        accessing overlapped field `U.s` with pointers
+fail_compilation/test20655.d(26): Deprecation: `@safe` function `g` calling `f1`
+fail_compilation/test20655.d(21):        and accessing overlapped field `U.s` with pointers makes it fail to infer `@safe`
+fail_compilation/test20655.d(27): Deprecation: `@safe` function `g` calling `f2`
+fail_compilation/test20655.d(22):        and accessing overlapped field `U.s` with pointers makes it fail to infer `@safe`
+fail_compilation/test20655.d(28): Deprecation: `@safe` function `g` calling `f3`
+fail_compilation/test20655.d(25):        and accessing overlapped field `U.s` with pointers makes it fail to infer `@safe`
 ---
 */
 

--- a/compiler/test/fail_compilation/test23145.d
+++ b/compiler/test/fail_compilation/test23145.d
@@ -6,8 +6,7 @@ fail_compilation/test23145.d(111):        is the location of the constructor
 fail_compilation/test23145.d(124): Error: `scope` allocation of `c` with a non-`scope` constructor is not allowed in a `@safe` function
 fail_compilation/test23145.d(111):        is the location of the constructor
 fail_compilation/test23145.d(125): Error: `@safe` function `test23145.bax` cannot call `@system` function `test23145.inferred`
-fail_compilation/test23145.d(131):        which wasn't inferred `@safe` because of:
-fail_compilation/test23145.d(131):        `scope` allocation of `c` with a non-`scope` constructor
+fail_compilation/test23145.d(131):        and `scope` allocation of `c` with a non-`scope` constructor makes it fail to infer `@safe`
 fail_compilation/test23145.d(129):        `test23145.inferred` is declared here
 ---
 */

--- a/compiler/test/fail_compilation/test23170.d
+++ b/compiler/test/fail_compilation/test23170.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test23170.d(10): Error: array literal in `@nogc` delegate `test23170.__lambda_L10_C15` may cause a GC allocation
+fail_compilation/test23170.d(10): Error: this array literal causes a GC allocation in `@nogc` delegate `__lambda_L10_C15`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=23170

--- a/compiler/test/fail_compilation/testInference.d
+++ b/compiler/test/fail_compilation/testInference.d
@@ -140,8 +140,7 @@ TEST_OUTPUT:
 fail_compilation/testInference.d(154): Error: `pure` function `testInference.bar14049` cannot call impure function `testInference.foo14049!int.foo14049`
 fail_compilation/testInference.d(149):        which calls `testInference.foo14049!int.foo14049.__lambda_L147_C14`
 fail_compilation/testInference.d(148):        which calls `testInference.impure14049`
-fail_compilation/testInference.d(143):        which wasn't inferred `pure` because of:
-fail_compilation/testInference.d(143):        `pure` function `testInference.impure14049` cannot access mutable static data `i`
+fail_compilation/testInference.d(143):        and accessing mutable static data `i` makes it fail to infer `pure`
 ---
 */
 #line 143
@@ -191,11 +190,9 @@ void test12422() pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(198): Error: `pure` function `testInference.test13729a` cannot call impure function `testInference.test13729a.foo`
-fail_compilation/testInference.d(196):        which wasn't inferred `pure` because of:
-fail_compilation/testInference.d(196):        `pure` function `testInference.test13729a.foo` cannot access mutable static data `g13729`
+fail_compilation/testInference.d(196):        and accessing mutable static data `g13729` makes it fail to infer `pure`
 fail_compilation/testInference.d(206): Error: `pure` function `testInference.test13729b` cannot call impure function `testInference.test13729b.foo!().foo`
-fail_compilation/testInference.d(204):        which wasn't inferred `pure` because of:
-fail_compilation/testInference.d(204):        `pure` function `testInference.test13729b.foo!().foo` cannot access mutable static data `g13729`
+fail_compilation/testInference.d(204):        and accessing mutable static data `g13729` makes it fail to infer `pure`
 ---
 */
 


### PR DESCRIPTION
Currently, two supplemental errors are printed with the same location:

```
fail_compilation/testInference.d(143):        which wasn't inferred `pure` because of:
fail_compilation/testInference.d(143):        `pure` function `testInference.impure14049` cannot access mutable static data `i`
```

With -verrors=context, the context gets printed between those lines. This PR rewords error messages so they can be printed on one line.

As a bonus, this simplifies a lot of AttributeViolation logic, and makes the format strings simpler by removing the requirement "Must contain format strings `@nogc` %s `%s` referring to the function".
