### PR TITLE
Store messages directly in AttributeViolation

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2098,14 +2098,9 @@ public void errorSupplementalInferredAttr(FuncDeclaration fd, int maxDepth, bool
     if (!s)
         return;
 
-    if (s.format)
+    if (s.action.length > 0)
     {
-        OutBuffer buf;
-        buf.writestring("and ");
-        buf.printf(s.format, s.arg0 ? s.arg0.toChars() : "", s.arg1 ? s.arg1.toChars() : "", s.arg2 ? s.arg2.toChars() : "");
-        buf.printf(" makes it fail to infer `%.*s`", attr.fTuple.expand);
-
-        errorFunc(s.loc, "%s", buf.extractChars);
+        errorFunc(s.loc, "and %.*s makes it fail to infer `%.*s`", s.action.fTuple.expand, attr.fTuple.expand);
     }
     else if (s.fd)
     {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3653,17 +3653,11 @@ struct AttributeViolation final
 {
     Loc loc;
     FuncDeclaration* fd;
-    const char* format;
-    RootObject* arg0;
-    RootObject* arg1;
-    RootObject* arg2;
+    _d_dynamicArray< const char > action;
     AttributeViolation() :
         loc(),
         fd(),
-        format(),
-        arg0(),
-        arg1(),
-        arg2()
+        action()
     {
     }
 };

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -3043,7 +3043,11 @@ extern (D) bool setImpure(FuncDeclaration fd, Loc loc = Loc.init, const(char)* f
     {
         fd.purityInprocess = false;
         if (fmt)
-            fd.pureViolation = new AttributeViolation(loc, fmt, arg0); // impure action
+        {
+            OutBuffer buf;
+            buf.printf(fmt, arg0 ? arg0.toChars() : "");
+            fd.pureViolation = new AttributeViolation(loc, buf.extractSlice()); // impure action
+        }
         else if (arg0)
         {
             if (auto sa = arg0.isDsymbol())

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -18,6 +18,7 @@ import core.stdc.stdio;
 import dmd.aggregate;
 import dmd.astenums;
 import dmd.declaration;
+import dmd.common.outbuffer;
 import dmd.dmodule;
 import dmd.dscope;
 import dmd.dtemplate : isDsymbol;
@@ -301,7 +302,11 @@ extern (D) bool setGC(FuncDeclaration fd, Loc loc, const(char)* fmt, RootObject 
     {
         fd.nogcInprocess = false;
         if (fmt)
-            fd.nogcViolation = new AttributeViolation(loc, fmt, arg0); // action that requires GC
+        {
+            OutBuffer buf;
+            buf.printf(fmt, arg0 ? arg0.toChars() : "");
+            fd.nogcViolation = new AttributeViolation(loc, buf.extractSlice()); // action that requires GC
+        }
         else if (arg0)
         {
             if (auto sa = arg0.isDsymbol())

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -369,7 +369,11 @@ extern (D) void reportSafeError(FuncDeclaration fd, bool gag, Loc loc,
     if (fd.type.toTypeFunction().trust == TRUST.system) // function was just inferred to be @system
     {
         if (format)
-            fd.safetyViolation = new AttributeViolation(loc, format, arg0, arg1, arg2);
+        {
+            OutBuffer buf;
+            buf.printf(format, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+            fd.safetyViolation = new AttributeViolation(loc, buf.extractSlice());
+        }
         else if (arg0)
         {
             if (FuncDeclaration fd2 = (cast(Dsymbol) arg0).isFuncDeclaration())
@@ -560,8 +564,11 @@ bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, const(char)
         }
         else if (!sc.func.safetyViolation)
         {
+            OutBuffer buf;
+            buf.printf(format, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+
             import dmd.func : AttributeViolation;
-            sc.func.safetyViolation = new AttributeViolation(loc, format, arg0, arg1, arg2);
+            sc.func.safetyViolation = new AttributeViolation(loc, buf.extractSlice());
         }
         return false;
     }


### PR DESCRIPTION
Incrementally getting rid of those `RootObject arg0 = null` parameters by storing the message in the attribute violation directly, per Walter's suggestion: https://github.com/dlang/dmd/pull/17072#discussion_r1845805320