### PR TITLE
Remove usage of obsolete `_fdToHandle` in rt/dmain2.d

### DIFF
--- a/druntime/src/rt/dmain2.d
+++ b/druntime/src/rt/dmain2.d
@@ -616,10 +616,7 @@ extern (C) void _d_print_throwable(Throwable t)
 
         HANDLE windowsHandle(int fd)
         {
-            version (CRuntime_Microsoft)
-                return cast(HANDLE)_get_osfhandle(fd);
-            else
-                return _fdToHandle(fd);
+            return cast(HANDLE)_get_osfhandle(fd);
         }
 
         // ensure the exception is shown at the beginning of the line, while also


### PR DESCRIPTION
This wasn't removed in f08bbff. The exact same change was made to `rt/cover.d` in that commit.