### PR TITLE
Use selective imports when importing from `core.stdc` in `core.internal`

### DIFF
--- a/druntime/src/core/internal/abort.d
+++ b/druntime/src/core/internal/abort.d
@@ -6,7 +6,7 @@ module core.internal.abort;
  */
 void abort(scope string msg, scope string filename = __FILE__, size_t line = __LINE__) @nogc nothrow @safe
 {
-    import core.stdc.stdlib: c_abort = abort;
+    import core.stdc.stdlib : c_abort = abort;
     // use available OS system calls to print the message to stderr
     version (Posix)
     {

--- a/druntime/src/core/internal/array/casting.d
+++ b/druntime/src/core/internal/array/casting.d
@@ -136,7 +136,7 @@ TTo[] __ArrayCast(TFrom, TTo)(return scope TFrom[] from) @nogc pure @trusted
 
     if (msg != expected)
     {
-        import core.stdc.stdio;
+        import core.stdc.stdio : printf;
         printf("Expected: |%.*s|\n", cast(int) expected.length, expected.ptr);
         printf("Actual  : |%.*s|\n", cast(int) msg.length, msg.ptr);
         assert(false);

--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -13,7 +13,7 @@ import core.internal.traits : Unqual;
 
 debug(PRINTF)
 {
-    import core.stdc.stdio;
+    import core.stdc.stdio : printf;
 }
 
 /**
@@ -46,7 +46,6 @@ Tarr _d_arrayctor(Tarr : T[], T)(return scope Tarr to, scope Tarr from, char* ma
     import core.lifetime : copyEmplace;
     import core.stdc.string : memcpy;
     import core.stdc.stdint : uintptr_t;
-    debug(PRINTF) import core.stdc.stdio : printf;
 
     debug(PRINTF) printf("_d_arrayctor(from = %p,%zd) size = %zd\n", from.ptr, from.length, T.sizeof);
 

--- a/druntime/src/core/internal/array/duplication.d
+++ b/druntime/src/core/internal/array/duplication.d
@@ -327,7 +327,7 @@ U[] _dup(T, U)(T[] a) if (!__traits(isPOD, T))
         {
             if (l != 0xDEADBEEF)
             {
-                import core.stdc.stdio;
+                import core.stdc.stdio : fflush, printf, stdout;
                 printf("Unexpected value: %lld\n", l);
                 fflush(stdout);
                 assert(false);

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -55,7 +55,7 @@ version (D_ProfileGC)
             // FIXME: use rt.tracegc.accumulator when it is accessable in the future.
             version (tracegc)
         } ~ "{\n" ~ q{
-                import core.stdc.stdio;
+                import core.stdc.stdio : printf;
 
                 printf("%sTrace file = '%.*s' line = %d function = '%.*s' type = %.*s\n",
                 } ~ "\"" ~ Hook ~ "\".ptr," ~ q{

--- a/druntime/src/core/internal/backtrace/dwarf.d
+++ b/druntime/src/core/internal/backtrace/dwarf.d
@@ -423,8 +423,6 @@ version (Darwin) {
  */
 void resolveAddresses(const(ubyte)[] debugLineSectionData, Location[] locations, size_t baseAddress) @nogc nothrow
 {
-    debug(DwarfDebugMachine) import core.stdc.stdio;
-
     size_t numberOfLocationsFound = 0;
 
     const(ubyte)[] dbg = debugLineSectionData;

--- a/druntime/src/core/internal/backtrace/handler.d
+++ b/druntime/src/core/internal/backtrace/handler.d
@@ -25,7 +25,7 @@ version (DRuntime_Use_Libunwind):
 
 import core.internal.backtrace.dwarf;
 import core.internal.backtrace.libunwind;
-import core.stdc.string;
+import core.stdc.string : strlen;
 import core.sys.posix.dlfcn : Dl_info, dladdr;
 
 /// Ditto
@@ -50,8 +50,6 @@ class LibunwindHandler : Throwable.TraceInfo
      */
     public this (size_t frames_to_skip = 1) nothrow @nogc
     {
-        import core.stdc.string : strlen;
-
         static assert(typeof(FrameInfo.address).sizeof == unw_word_t.sizeof,
                       "Mismatch in type size for call to unw_get_proc_name");
 

--- a/druntime/src/core/internal/backtrace/libunwind.d
+++ b/druntime/src/core/internal/backtrace/libunwind.d
@@ -33,7 +33,7 @@ version (DRuntime_Use_Libunwind):
 // mechanism for Windows, so the bindings haven't been brought in yet.
 version (Posix):
 
-import core.stdc.inttypes;
+import core.stdc.inttypes : uintptr_t;
 
 extern(C):
 @nogc:

--- a/druntime/src/core/internal/backtrace/unwind.d
+++ b/druntime/src/core/internal/backtrace/unwind.d
@@ -10,7 +10,7 @@
  */
 module core.internal.backtrace.unwind;
 
-import core.stdc.stdint;
+import core.stdc.stdint : intptr_t, uintptr_t;
 
 version (ARM)
 {

--- a/druntime/src/core/internal/elf/dl.d
+++ b/druntime/src/core/internal/elf/dl.d
@@ -146,8 +146,8 @@ struct SharedObject
     char[] getPath(size_t N)(ref char[N] buffer) const
     if (N > 1)
     {
-        import core.stdc.stdio;
-        import core.stdc.string;
+        import core.stdc.stdio : fclose, fgets, fopen, snprintf, sscanf;
+        import core.stdc.string : strlen;
         import core.sys.posix.unistd : getpid;
 
         char[N + 128] lineBuffer = void;
@@ -232,7 +232,7 @@ else // Bionic, BSDs
 
 unittest
 {
-    import core.stdc.stdio;
+    import core.stdc.stdio : printf;
 
     char[512] buffer = void;
     foreach (object; SharedObjects)

--- a/druntime/src/core/internal/gc/bits.d
+++ b/druntime/src/core/internal/gc/bits.d
@@ -10,9 +10,9 @@ module core.internal.gc.bits;
 import core.internal.gc.os : os_mem_map, os_mem_unmap, HaveFork;
 
 import core.bitop;
-import core.stdc.string;
-import core.stdc.stdlib;
 import core.exception : onOutOfMemoryError;
+import core.stdc.stdlib : calloc, free;
+import core.stdc.string : memcpy, memset;
 
 // use version gcbitsSingleBitOperation to disable optimizations that use
 //  word operands on bulk operation copyRange, setRange, clrRange, etc.

--- a/druntime/src/core/internal/gc/blkcache.d
+++ b/druntime/src/core/internal/gc/blkcache.d
@@ -44,8 +44,7 @@ else
 {
     if (!__blkcache_storage)
     {
-        import core.stdc.stdlib;
-        import core.stdc.string;
+        import core.stdc.stdlib : calloc;
         import core.thread.threadbase;
         auto tBase = ThreadBase.getThis();
         if (tBase is null)
@@ -68,7 +67,7 @@ else
 {
     if (__blkcache_storage)
     {
-        import core.stdc.stdlib;
+        import core.stdc.stdlib : free;
         import core.thread.threadbase;
         auto tBase = ThreadBase.getThis();
         if (tBase !is null)

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -15,7 +15,7 @@ module core.internal.gc.impl.conservative.gc;
 //debug = PARALLEL_PRINTF;      // turn on printf's
 //debug = COLLECT_PRINTF;       // turn on printf's
 //debug = MARK_PRINTF;          // turn on printf's
-//debug = PRINTF_TO_FILE;       // redirect printf's ouptut to file "gcx.log"
+//debug = PRINTF_TO_FILE;       // redirect printf's output to file "gcx.log"
 //debug = LOGGING;              // log allocations / frees
 //debug = MEMSTOMP;             // stomp on memory
 //debug = SENTINEL;             // add underrun/overrrun protection
@@ -43,7 +43,7 @@ import core.internal.spinlock;
 import core.internal.gc.pooltable;
 import core.internal.gc.blkcache;
 
-import cstdlib = core.stdc.stdlib : calloc, free, malloc, realloc;
+import cstdlib = core.stdc.stdlib;
 import core.stdc.string : memcpy, memset, memmove;
 import core.bitop;
 import core.thread;
@@ -4800,7 +4800,7 @@ debug(PRINTF_TO_FILE)
         }
         len += fprintf(gcx_fh, fmt, args);
         fflush(gcx_fh);
-        import core.stdc.string;
+        import core.stdc.string : strlen;
         hadNewline = fmt && fmt[0] && fmt[strlen(fmt) - 1] == '\n';
         return len;
     }
@@ -5266,8 +5266,8 @@ version (D_LP64) unittest
             catch (OutOfMemoryError)
             {
                 // ignore if the system still doesn't have enough virtual memory
-                import core.stdc.stdio;
-                printf("%s(%d): out-of-memory execption ignored, phys_mem = %zd",
+                import core.stdc.stdio : printf;
+                printf("%s(%d): out-of-memory exception ignored, phys_mem = %zd",
                        __FILE__.ptr, __LINE__, phys_mem);
             }
         }
@@ -5321,7 +5321,7 @@ unittest
 unittest
 {
     import core.memory;
-    import core.stdc.stdio;
+    import core.stdc.stdio : printf;
 
     // allocate from large pool
     auto o = GC.malloc(10);

--- a/druntime/src/core/internal/gc/os.d
+++ b/druntime/src/core/internal/gc/os.d
@@ -33,8 +33,10 @@ else version (Posix)
     else version (WatchOS)
         version = Darwin;
 
-    import core.stdc.stdlib;
+    public import core.sys.posix.unistd : fork, pid_t;
+    import core.stdc.errno : ECHILD, EINTR, errno;
     import core.sys.posix.sys.mman : MAP_ANON, MAP_FAILED, MAP_PRIVATE, MAP_SHARED, mmap, munmap, PROT_READ, PROT_WRITE;
+    import core.sys.posix.sys.wait : waitpid, WNOHANG;
 
 
     /// Possible results for the wait_pid() function.
@@ -74,15 +76,11 @@ else version (Posix)
         return ChildStatus.done;
     }
 
-    public import core.sys.posix.unistd : fork, pid_t;
-    import core.stdc.errno : ECHILD, EINTR, errno;
-    import core.sys.posix.sys.wait : waitpid, WNOHANG;
-
     //version = GC_Use_Alloc_MMap;
 }
 else
 {
-    import core.stdc.stdlib;
+    import core.stdc.stdlib : free, malloc;
 
     //version = GC_Use_Alloc_Malloc;
 }

--- a/druntime/src/core/internal/gc/pooltable.d
+++ b/druntime/src/core/internal/gc/pooltable.d
@@ -7,7 +7,7 @@
  */
 module core.internal.gc.pooltable;
 
-static import cstdlib=core.stdc.stdlib;
+static import cstdlib = core.stdc.stdlib;
 
 struct PoolTable(Pool)
 {

--- a/druntime/src/core/internal/parseoptions.d
+++ b/druntime/src/core/internal/parseoptions.d
@@ -9,12 +9,10 @@
 
 module core.internal.parseoptions;
 
-import core.stdc.stdlib;
-import core.stdc.stdio;
-import core.stdc.ctype;
-import core.stdc.string;
-import core.vararg;
 import core.internal.traits : externDFunc, hasUDA;
+import core.stdc.ctype : isdigit, isspace;
+import core.stdc.stdio : fprintf, snprintf, sscanf, stderr;
+import core.vararg;
 
 
 @nogc nothrow:

--- a/druntime/src/core/internal/qsort.d
+++ b/druntime/src/core/internal/qsort.d
@@ -10,8 +10,6 @@ module core.internal.qsort;
 
 //debug=qsort;
 
-import core.stdc.stdlib;
-
 debug (qsort) import core.stdc.stdio : printf;
 
 version (OSX)
@@ -150,6 +148,8 @@ else version (CRuntime_UClibc)
 }
 else
 {
+    import core.stdc.stdlib : qsort;
+
     private TypeInfo tiglobal;
 
     extern (C) void[] _adSort(return scope void[] a, TypeInfo ti)
@@ -166,7 +166,6 @@ else
 
 unittest
 {
-    debug(qsort) import core.stdc.stdio;
     debug(qsort) printf("array.sort.unittest()\n");
 
     int[] a = new int[10];

--- a/druntime/src/core/internal/util/array.d
+++ b/druntime/src/core/internal/util/array.d
@@ -10,7 +10,7 @@ module core.internal.util.array;
 
 
 import core.internal.string;
-import core.stdc.stdint;
+import core.stdc.stdint : uintptr_t;
 
 
 // TLS storage shared for all error messages.


### PR DESCRIPTION
A continuation of #20632 but for imports from `core.stdc`. See that pr for reasoning.
This pr only affects `core.internal`, I have more changes ready but would like to test, review and merge them in smaller bits.