### PR TITLE
Use selective imports when importing from `core.stdc` in `core`

### DIFF
--- a/druntime/src/core/gc/config.d
+++ b/druntime/src/core/gc/config.d
@@ -7,8 +7,8 @@
 
 module core.gc.config;
 
-import core.stdc.stdio;
 import core.internal.parseoptions;
+import core.stdc.stdio : printf;
 
 __gshared Config config;
 

--- a/druntime/src/core/int128.d
+++ b/druntime/src/core/int128.d
@@ -794,7 +794,7 @@ version (unittest)
 {
     version (none)
     {
-        import core.stdc.stdio;
+        import core.stdc.stdio : printf;
 
         @trusted
         void print(Cent c)

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -2348,7 +2348,7 @@ pure nothrow @nogc @system unittest
 
 debug(PRINTF)
 {
-    import core.stdc.stdio;
+    import core.stdc.stdio : printf;
 }
 
 /// Implementation of `_d_delstruct` and `_d_delstructTrace`

--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -1167,7 +1167,7 @@ extern (C) private @system @nogc nothrow
 {
     ref int fakePureErrnoImpl()
     {
-        import core.stdc.errno;
+        import core.stdc.errno : errno;
         return errno();
     }
 }

--- a/druntime/src/core/runtime.d
+++ b/druntime/src/core/runtime.d
@@ -624,7 +624,7 @@ extern (C) UnitTestResult runModuleUnitTests()
                 if (moduleName.length && e.file.length > moduleName.length
                     && e.file[0 .. moduleName.length] == moduleName)
                 {
-                    import core.stdc.stdio;
+                    import core.stdc.stdio : printf;
                     printf("%.*s(%llu): [unittest] %.*s\n",
                         cast(int) e.file.length, e.file.ptr, cast(ulong) e.line,
                         cast(int) e.message.length, e.message.ptr);
@@ -733,7 +733,7 @@ Throwable.TraceInfo defaultTraceHandler( void* ptr = null ) // @nogc
 unittest
 {
     import core.runtime;
-    import core.stdc.stdio;
+    import core.stdc.stdio : printf;
 
     void main()
     {

--- a/druntime/src/core/sync/condition.d
+++ b/druntime/src/core/sync/condition.d
@@ -35,7 +35,7 @@ version (Windows)
 }
 else version (Posix)
 {
-    import core.stdc.errno;
+    import core.stdc.errno : EAGAIN, ETIMEDOUT;
     import core.sync.config;
     import core.sys.posix.pthread : pthread_cond_broadcast, pthread_cond_destroy, pthread_cond_init,
         pthread_cond_signal, pthread_cond_t, pthread_cond_timedwait, pthread_cond_wait;

--- a/druntime/src/core/sync/semaphore.d
+++ b/druntime/src/core/sync/semaphore.d
@@ -37,7 +37,7 @@ version (Windows)
 }
 else version (Darwin)
 {
-    import core.stdc.errno;
+    import core.stdc.errno : EINTR, errno;
     import core.sync.config;
     import core.sys.darwin.mach.kern_return : KERN_ABORTED, KERN_OPERATION_TIMED_OUT;
     import core.sys.darwin.mach.semaphore : mach_task_self, mach_timespec_t, semaphore_create, semaphore_destroy,
@@ -45,7 +45,7 @@ else version (Darwin)
 }
 else version (Posix)
 {
-    import core.stdc.errno;
+    import core.stdc.errno : EAGAIN, EINTR, errno, ETIMEDOUT;
     import core.sync.config;
     import core.sys.posix.semaphore : sem_destroy, sem_init, sem_post, sem_t, sem_timedwait, sem_trywait, sem_wait;
     import core.sys.posix.time : clock_gettime, CLOCK_REALTIME, timespec;

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -56,7 +56,7 @@ else version (D_InlineAsm_X86_64)
 version (Windows)
 {
     import core.stdc.stdint : uintptr_t; // for _beginthreadex decl below
-    import core.stdc.stdlib;             // for malloc, atexit
+    import core.stdc.stdlib : free, malloc, realloc;
     import core.sys.windows.basetsd /+: HANDLE+/;
     import core.sys.windows.threadaux /+: getThreadStackBottom, impersonate_thread, OpenThreadHandle+/;
     import core.sys.windows.winbase /+: CloseHandle, CREATE_SUSPENDED, DuplicateHandle, GetCurrentThread,
@@ -74,7 +74,7 @@ else version (Posix)
 {
     static import core.sys.posix.pthread;
     static import core.sys.posix.signal;
-    import core.stdc.errno;
+    import core.stdc.errno : EINTR, errno;
     import core.sys.posix.pthread : pthread_atfork, pthread_attr_destroy, pthread_attr_getstack, pthread_attr_init,
         pthread_attr_setstacksize, pthread_create, pthread_detach, pthread_getschedparam, pthread_join, pthread_self,
         pthread_setschedparam, sched_get_priority_max, sched_get_priority_min, sched_param, sched_yield;

--- a/druntime/src/core/time.d
+++ b/druntime/src/core/time.d
@@ -67,8 +67,7 @@ module core.time;
 
 import core.exception;
 import core.internal.string;
-import core.stdc.stdio;
-import core.stdc.time;
+import core.stdc.time : time;
 
 version (OSX)
     version = Darwin;
@@ -93,6 +92,8 @@ else version (Posix)
     import core.sys.posix.sys.time : gettimeofday, timeval;
     import core.sys.posix.time : clock_getres, clock_gettime, CLOCK_MONOTONIC, timespec;
 }
+
+version (unittest) import core.stdc.stdio : printf;
 
 
 //This probably should be moved somewhere else in druntime which
@@ -2700,7 +2701,7 @@ unittest
 
     // It would be too expensive to cover a large range of possible values for
     // ticks, so we use random values in an attempt to get reasonable coverage.
-    import core.stdc.stdlib;
+    import core.stdc.stdlib : rand, srand;
     immutable seed = cast(int)time(null);
     srand(seed);
     scope(failure) printf("seed %d\n", seed);
@@ -2714,7 +2715,7 @@ unittest
     // than or equal to freq5, which at one point was considered for MonoTime's
     // ticksPerSecond rather than using the system's actual clock frequency, so
     // it seemed like a good test case to have.
-    import core.stdc.math;
+    import core.stdc.math : floor, log10, pow;
     immutable numDigitsMinus1 = cast(int)floor(log10(freq5));
     auto freq6 = cast(long)pow(10, numDigitsMinus1);
     if (freq5 > freq6)


### PR DESCRIPTION
Follows on #20723.
See #20632 for reasoning.