### PR TITLE
backend: Replace C pointer syntax with D

### DIFF
--- a/compiler/src/dmd/backend/aarray.d
+++ b/compiler/src/dmd/backend/aarray.d
@@ -30,7 +30,7 @@ nothrow:
  */
 private struct aaA
 {
-    aaA *next;
+    aaA* next;
     hash_t hash;        // hash of the key
     /* key   */         // key value goes here
     /* value */         // value value goes here
@@ -144,11 +144,11 @@ nothrow:
 
         // Not found, create new elem
         //printf("create new one\n");
-        e = cast(aaA *) malloc(aaA.sizeof + aligned_keysize + Value.sizeof);
+        e = cast(aaA*) malloc(aaA.sizeof + aligned_keysize + Value.sizeof);
         if (!e)
             err_nomem();
         memcpy(e + 1, &pkey, Key.sizeof);
-        memset(cast(void *)(e + 1) + aligned_keysize, 0, Value.sizeof);
+        memset(cast(void*)(e + 1) + aligned_keysize, 0, Value.sizeof);
         e.hash = key_hash;
         e.next = null;
         *pe = e;
@@ -248,7 +248,7 @@ nothrow:
 
         if (nodes >= size_t.max / Key.sizeof)
             err_nomem();
-        auto p = cast(Key *)malloc(nodes * Key.sizeof);
+        auto p = cast(Key*)malloc(nodes * Key.sizeof);
         if (!p)
             err_nomem();
         auto q = p;
@@ -279,7 +279,7 @@ nothrow:
         const aligned_keysize = aligntsize(Key.sizeof);
         if (nodes >= size_t.max / Key.sizeof)
             err_nomem();
-        auto p = cast(Value *)malloc(nodes * Value.sizeof);
+        auto p = cast(Value*)malloc(nodes * Value.sizeof);
         if (!p)
             err_nomem();
         auto q = p;
@@ -510,7 +510,7 @@ public alias AApair2 = AArray!(TinfoPair, Pair);
     aa.del(k);
     bool v = true;
     assert(!aa.isIn(k));
-    bool *pv = aa.get(k);
+    bool* pv = aa.get(k);
     *pv = true;
     int j = 9;
     pv = aa.get(j);

--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -163,7 +163,7 @@ void storeToEA(ref code cs, reg_t reg, uint sz)
  */
 
 @trusted
-int isscaledindex(tym_t ty, elem *e)
+int isscaledindex(tym_t ty, elem* e)
 {
     const size = tysize(ty);    // size of load
     if (size != 4 && size != 8)
@@ -228,7 +228,7 @@ int isscaledindex(tym_t ty, elem *e)
  */
 
 @trusted
-void logexp(ref CodeBuilder cdb, elem *e, uint jcond, FL fltarg, code *targ)
+void logexp(ref CodeBuilder cdb, elem* e, uint jcond, FL fltarg, code* targ)
 {
     //printf("logexp(e = %p, jcond = %d)\n", e, jcond); elem_print(e);
     if (tybasic(e.Ety) == TYnoreturn)
@@ -260,7 +260,7 @@ void logexp(ref CodeBuilder cdb, elem *e, uint jcond, FL fltarg, code *targ)
                 }
                 else
                 {
-                    code *cnop = gen1(null, INSTR.nop);
+                    code* cnop = gen1(null, INSTR.nop);
                     logexp(cdb, e.E1, jcond | 1, FL.code, cnop);
                     regconsave = cgstate.regcon;
                     logexp(cdb, e.E2, jcond, fltarg, targ);
@@ -277,7 +277,7 @@ void logexp(ref CodeBuilder cdb, elem *e, uint jcond, FL fltarg, code *targ)
                 con_t regconsave;
                 if (jcond & 1)
                 {
-                    code *cnop = gen1(null, INSTR.nop);    // a dummy target address
+                    code* cnop = gen1(null, INSTR.nop);    // a dummy target address
                     logexp(cdb, e.E1, jcond & ~1, FL.code, cnop);
                     regconsave = cgstate.regcon;
                     logexp(cdb, e.E2, jcond, fltarg, targ);
@@ -315,12 +315,12 @@ void logexp(ref CodeBuilder cdb, elem *e, uint jcond, FL fltarg, code *targ)
 
             case OPcond:
             {
-                code *cnop2 = gen1(null, INSTR.nop);   // addresses of start of leaves
-                code *cnop = gen1(null, INSTR.nop);
+                code* cnop2 = gen1(null, INSTR.nop);   // addresses of start of leaves
+                code* cnop = gen1(null, INSTR.nop);
                 logexp(cdb, e.E1, false, FL.code, cnop2);   // eval condition
                 con_t regconold = cgstate.regcon;
                 logexp(cdb, e.E2.E1, jcond, fltarg, targ);
-                genBranch(cdb, COND.al, FL.code, cast(block *) cnop); // skip second leaf
+                genBranch(cdb, COND.al, FL.code, cast(block*) cnop); // skip second leaf
 
                 con_t regconsave = cgstate.regcon;
                 cgstate.regcon = regconold;
@@ -363,7 +363,7 @@ void logexp(ref CodeBuilder cdb, elem *e, uint jcond, FL fltarg, code *targ)
     codelem(cgstate,cdb, e, retregs, true);         // evaluate elem
     if (no87)
         cse_flush(cdb,no87);              // flush CSE's to memory
-    genBranch(cdb, cond, fltarg, cast(block *) targ); // generate jmp instruction
+    genBranch(cdb, cond, fltarg, cast(block*) targ); // generate jmp instruction
     cgstate.stackclean--;
 }
 
@@ -384,7 +384,7 @@ void logexp(ref CodeBuilder cdb, elem *e, uint jcond, FL fltarg, code *targ)
  */
 
 @trusted
-void loadea(ref CodeBuilder cdb,elem *e,ref code cs,uint op,reg_t reg,targ_size_t offset,
+void loadea(ref CodeBuilder cdb,elem* e,ref code cs,uint op,reg_t reg,targ_size_t offset,
             regm_t keepmsk,regm_t desmsk, RM rmx = RM.rw)
 {
     code* c, cg, cd;
@@ -465,7 +465,7 @@ void loadea(ref CodeBuilder cdb,elem *e,ref code cs,uint op,reg_t reg,targ_size_
  */
 
 @trusted
-void getlvalue(ref CodeBuilder cdb,ref code pcs,elem *e,regm_t keepmsk,RM rm = RM.rw)
+void getlvalue(ref CodeBuilder cdb,ref code pcs,elem* e,regm_t keepmsk,RM rm = RM.rw)
 {
     FL fl;
     uint opsave;
@@ -861,7 +861,7 @@ void getlvalue(ref CodeBuilder cdb,ref code pcs,elem *e,regm_t keepmsk,RM rm = R
                 return Lptr();
             }
 
-            /* give up and replace *e1 with
+            /* give up and replace* e1 with
              *      MOV     idxreg,e
              *      EA =    0[idxreg]
              * pinholeopt() will usually correct the 0, we need it in case
@@ -1151,9 +1151,9 @@ static if (0)
         cdb.gen2(op | XORPS, modregrm(3, xreg-XMM0, xreg-XMM0));      // XORPS xreg,xreg
         cdb.gen2(op | UCOMISS, modregrm(3, xreg-XMM0, reg-XMM0));     // UCOMISS xreg,reg
         if (tym == TYcfloat || tym == TYcdouble)
-        {   code *cnop = gennop(null);
-            genjmp(cdb, JNE, FL.code, cast(block *) cnop); // JNE     L1
-            genjmp(cdb,  JP, FL.code, cast(block *) cnop); // JP      L1
+        {   code* cnop = gennop(null);
+            genjmp(cdb, JNE, FL.code, cast(block*) cnop); // JNE     L1
+            genjmp(cdb,  JP, FL.code, cast(block*) cnop); // JP      L1
             reg = findreg(regm & ~mask(reg));
             cdb.gen2(op | UCOMISS, modregrm(3, xreg-XMM0, reg-XMM0)); // UCOMISS xreg,reg
             cdb.append(cnop);
@@ -1265,7 +1265,7 @@ static if (0)
  * generate necessary code to return result in outretregs.
  */
 @trusted
-void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, ref regm_t outretregs)
+void fixresult(ref CodeBuilder cdb, elem* e, regm_t retregs, ref regm_t outretregs)
 {
     //printf("arm.fixresult(e = %p, retregs = %s, outretregs = %s)\n",e,regm_str(retregs),regm_str(outretregs));
     if (outretregs == 0) return;           // if don't want result
@@ -1398,7 +1398,7 @@ printf("stackpushsave: %d\n", stackpushsave);
 
     // Easier to deal with parameters as an array: parameters[0..np]
     int np = OTbinary(e.Eoper) ? el_nparams(e.E2) : 0;
-    Parameter *parameters = cast(Parameter *)alloca(np * Parameter.sizeof);
+    Parameter* parameters = cast(Parameter*)alloca(np * Parameter.sizeof);
 
     if (np)
     {
@@ -1407,7 +1407,7 @@ printf("stackpushsave: %d\n", stackpushsave);
         assert(n == np);
     }
 
-    Symbol *sf = null;                  // symbol of the function being called
+    Symbol* sf = null;                  // symbol of the function being called
     if (e.E1.Eoper == OPvar)
         sf = e.E1.Vsym;
 
@@ -1435,7 +1435,7 @@ printf("stackpushsave: %d\n", stackpushsave);
     FuncParamRegs fpr = FuncParamRegs_create(tyf);
     for (int i = np; --i >= 0;)
     {
-        elem *ep = parameters[i].e;
+        elem* ep = parameters[i].e;
         uint psize = cast(uint)_align(stackalign, paramsize(ep, tyf));     // align on stack boundary
         if (config.exe == EX_WIN64)
         {
@@ -1947,7 +1947,7 @@ private void funccall(ref CodeBuilder cdb, elem* e, uint numpara, uint numalign,
 
         if (e1.Eoper != OPind) { printf("e1.fl: %s, e1.Eoper: %s\n", fl_str(el_fl(e1)), oper_str(e1.Eoper)); }
         assert(e1.Eoper == OPind);
-        elem *e11 = e1.E1;
+        elem* e11 = e1.E1;
         tym_t e11ty = tybasic(e11.Ety);
         load_localgot(cdb);
         if (config.exe & (EX_LINUX | EX_FREEBSD | EX_OPENBSD | EX_SOLARIS)) // 32 bit only
@@ -2415,7 +2415,7 @@ static if (1)
             opcode_t opmv = xmmload(tym, xmmIsAligned(e));
             if (e.Eoper == OPvar)
             {
-                Symbol *s = e.Vsym;
+                Symbol* s = e.Vsym;
                 if (s.Sfl == FL.reg && !(mask(s.Sreglsw) & XMMREGS))
                 {   //opmv = LODD;          // MOVD/MOVQ
                     /* getlvalue() will unwind this and unregister s; could use a better solution */

--- a/compiler/src/dmd/backend/arm/cod2.d
+++ b/compiler/src/dmd/backend/arm/cod2.d
@@ -56,7 +56,7 @@ import dmd.backend.divcoeff : choose_multiplier, udiv_coefficients;
  */
 
 @trusted
-void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdorth(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
 
@@ -177,7 +177,7 @@ Extend tyToExtend(tym_t ty)
  */
 
 @trusted
-void cdmul(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdmul(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdmul(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
 
@@ -231,7 +231,7 @@ void cdmul(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cddiv(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cddiv(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cddiv(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
 
@@ -326,7 +326,7 @@ void cddiv(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdcom(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdcom(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdcom()\n");
     //elem_print(e);
@@ -369,7 +369,7 @@ void cdcom(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdbswap(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdbswap(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdbswap()\n");
     //elem_print(e);
@@ -415,15 +415,15 @@ void cdbswap(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdcond(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
     /* e1 ? e21 : e22
      */
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
-    elem *e21 = e2.E1;
-    elem *e22 = e2.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
+    elem* e21 = e2.E1;
+    elem* e22 = e2.E2;
     regm_t psw = pretregs & mPSW;               /* save PSW bit                 */
     const op1 = e1.Eoper;
     uint sz1 = tysize(e1.Ety);
@@ -439,12 +439,12 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         sz1 <= REGSIZE && !tyfloating(e1.Ety))
     {   // Recognize (e ? e : f)
 
-        code *cnop1 = gen1(null, INSTR.nop);
+        code* cnop1 = gen1(null, INSTR.nop);
         regm_t retregs = pretregs | mPSW;
         codelem(cgstate,cdb,e1,retregs,false);
 
         cse_flush(cdb,1);                // flush CSEs to memory
-        genBranch(cdb,jop,FL.code,cast(block *)cnop1);
+        genBranch(cdb,jop,FL.code,cast(block*)cnop1);
         freenode(e21);
 
         const regconsave = cgstate.regcon;
@@ -576,7 +576,7 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         tysize(e21.Ety) <= REGSIZE && !tyfloating(e21.Ety))
     {   // Recognize (e ? c : f)
 
-        code *cnop1 = gen1(null, INSTR.nop);
+        code* cnop1 = gen1(null, INSTR.nop);
         regm_t retregs = mPSW;
         jop = conditionCode(e1);            // get jmp condition
         codelem(cgstate,cdb,e1,retregs,false);
@@ -591,7 +591,7 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         retregs = mask(reg);
 
         cse_flush(cdb,1);                // flush CSE's to memory
-        genBranch(cdb,jop,FL.code,cast(block *)cnop1);
+        genBranch(cdb,jop,FL.code,cast(block*)cnop1);
         freenode(e21);
 
         const regconsave = cgstate.regcon;
@@ -609,8 +609,8 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         return;
     }
 
-    code *cnop1 = gen1(null, INSTR.nop);
-    code *cnop2 = gen1(null, INSTR.nop);         // dummy target addresses
+    code* cnop1 = gen1(null, INSTR.nop);
+    code* cnop2 = gen1(null, INSTR.nop);         // dummy target addresses
     logexp(cdb,e1,false,FL.code,cnop1);  // evaluate condition
     const regconold = cgstate.regcon;
     const stackpushold = cgstate.stackpush;
@@ -670,7 +670,7 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     andregcon(regconsave);
     assert(cgstate.stackpush == stackpushsave);
     freenode(e2);
-    genBranch(cdb,COND.al,FL.code,cast(block *) cnop2);
+    genBranch(cdb,COND.al,FL.code,cast(block*) cnop2);
     cdb.append(cnop1);
     cdb.append(cdb2);
     cdb.append(cnop2);
@@ -701,7 +701,7 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     /* We can trip the assert with the following:
      *    if ( (b<=a) ? (c<b || a<=c) : c>=a )
@@ -712,12 +712,12 @@ void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
 
     //printf("cdloglog() pretregs: %s\n", regm_str(pretregs));
     cgstate.stackclean++;
-    code *cnop1 = gen1(null, INSTR.nop);
+    code* cnop1 = gen1(null, INSTR.nop);
     CodeBuilder cdb1;
     cdb1.ctor();
     cdb1.append(cnop1);
-    code *cnop3 = gen1(null, INSTR.nop);
-    elem *e2 = e.E2;
+    code* cnop3 = gen1(null, INSTR.nop);
+    elem* e2 = e.E2;
     (e.Eoper == OPoror)
         ? logexp(cdb,e.E1,1,FL.code,cnop1)
         : logexp(cdb,e.E1,0,FL.code,cnop3);
@@ -764,7 +764,7 @@ void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         return;
     }
 
-    code *cnop2 = gen1(null, INSTR.nop);
+    code* cnop2 = gen1(null, INSTR.nop);
     uint sz = tysize(e.Ety);
     if (tybasic(e2.Ety) == TYbool &&
       sz == tysize(e2.Ety) &&
@@ -787,13 +787,13 @@ void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         if (e.Eoper == OPoror)
         {
             cdb.append(cnop3);
-            genBranch(cdb,COND.al,FL.code,cast(block *) cnop2);    // JMP cnop2
+            genBranch(cdb,COND.al,FL.code,cast(block*) cnop2);    // JMP cnop2
             cdb.append(cdb1);
             cdb.append(cnop2);
         }
         else
         {
-            genBranch(cdb,COND.al,FL.code,cast(block *) cnop2);    // JMP cnop2
+            genBranch(cdb,COND.al,FL.code,cast(block*) cnop2);    // JMP cnop2
             cdb.append(cnop3);
             cdb.append(cdb1);
             cdb.append(cnop2);
@@ -815,14 +815,14 @@ void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     CodeBuilder cdbcg;
     cdbcg.ctor();
     const reg = allocreg(cdbcg,retregs,TYint);               // allocate reg for result
-    code *cd = cdbcg.finish();
-    for (code *c1 = cd; c1; c1 = code_next(c1))              // for each instruction
+    code* cd = cdbcg.finish();
+    for (code* c1 = cd; c1; c1 = code_next(c1))              // for each instruction
         cdb1.gen(c1);                                        // duplicate it
     CodeBuilder cdbcg2;
     cdbcg2.ctor();
     movregconst(cdbcg2,reg,0,pretregs & mPSW);              // MOV reg,0
     cgstate.regcon.immed.mval &= ~mask(reg);                 // mark reg as unavail
-    genBranch(cdbcg2,COND.al,FL.code,cast(block *) cnop2);    // JMP cnop2
+    genBranch(cdbcg2,COND.al,FL.code,cast(block*) cnop2);    // JMP cnop2
     movregconst(cdb1,reg,1,pretregs & mPSW);                // reg = 1
     cgstate.regcon.immed.mval &= ~mask(reg);                 // mark reg as unavail
     pretregs = retregs;
@@ -841,7 +841,7 @@ void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdshift(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdshift(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdshift()\n");
 
@@ -904,7 +904,7 @@ void cdshift(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdind(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdind(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdind()\n");
     //elem_print(e);
@@ -1004,7 +1004,7 @@ void cdind(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void getoffset(ref CGstate cg, ref CodeBuilder cdb,elem *e,reg_t reg)
+void getoffset(ref CGstate cg, ref CodeBuilder cdb,elem* e,reg_t reg)
 {
     enum log = false;
     if (log) printf("getoffset(e = %p, reg = %s)\n", e, regm_str(mask(reg)));
@@ -1267,7 +1267,7 @@ static if (0)
  */
 
 @trusted
-void cdneg(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdneg(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdneg()\n");
     //elem_print(e);
@@ -1327,7 +1327,7 @@ void cdneg(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
 
 
 @trusted
-void cdabs(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
+void cdabs(ref CGstate cg, ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
 {
     //printf("cdabs(e = %p, pretregs = %s)\n", e, regm_str(pretregs));
     if (pretregs == 0)
@@ -1402,7 +1402,7 @@ void cdabs(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
  * OPpostinc, OPpostdec
  */
 @trusted
-void cdpost(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdpost(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdpost(pretregs = %s)\n", regm_str(pretregs));
     code cs = void;
@@ -1414,7 +1414,7 @@ void cdpost(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     }
     const tym_t tyml = tybasic(e.E1.Ety);
     const sz = _tysize[tyml];
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
 
     if (0 && tyfloating(tyml))
     {
@@ -1535,7 +1535,7 @@ void cdpost(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdhalt(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdhalt(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     assert(pretregs == 0);
 

--- a/compiler/src/dmd/backend/arm/cod4.d
+++ b/compiler/src/dmd/backend/arm/cod4.d
@@ -53,21 +53,21 @@ nothrow:
  * Generate code for an assignment, OPeq.
  */
 @trusted
-void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdeq(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
     elem_print(e);
 
     reg_t reg;
     code cs;
-    elem *e11;
+    elem* e11;
     bool regvar;                  // true means evaluate into register variable
     regm_t varregm = 0;
     reg_t varreg;
     targ_int postinc;
 
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     int e2oper = e2.Eoper;
     tym_t tyml = tybasic(e1.Ety);              // type of lvalue
     regm_t retregs = pretregs;
@@ -138,7 +138,7 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                 e11.E1.Vsym.Sfl == FL.reg
                )
             {
-                Symbol *s = e11.E1.Vsym;
+                Symbol* s = e11.E1.Vsym;
                 if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg)
                 {
                     cgstate.regcon.params &= ~s.Spregm();
@@ -159,7 +159,7 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
             if (cs.reg != NOREG)
             {
                 getregs(cdb, cs.reg);
-                const p = cast(targ_size_t *) &(e2.EV);
+                const p = cast(targ_size_t*) &(e2.EV);
                 movregconst(cdb,cs.reg,*p,sz == 8);
                 freenode(e2);
                 goto Lp;
@@ -206,7 +206,7 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         e11.E1.Eoper == OPvar &&
         e11.E1.Vsym.Sfl == FL.reg)
     {
-        Symbol *s = e11.E1.Vsym;
+        Symbol* s = e11.E1.Vsym;
         if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg)
         {
             cgstate.regcon.params &= ~s.Spregm();
@@ -267,12 +267,12 @@ Lp:
  */
 
 @trusted
-void cdaddass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdaddass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdaddass(e=%p, pretregs = %s)\n",e,regm_str(pretregs));
     OPER op = e.Eoper;
     regm_t retregs = 0;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     tym_t tyml = tybasic(e1.Ety);            // type of lvalue
     int sz = _tysize[tyml];
     int isbyte = (sz == 1);                     // 1 for byte operation, else 0
@@ -305,7 +305,7 @@ void cdaddass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
 
     reg_t reg;
     code cs;
-    elem *e2;
+    elem* e2;
     uint jop;
 
 
@@ -473,13 +473,13 @@ void cdaddass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdmulass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdmulass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     code cs;
 
     //printf("cdmulass(e=%p, pretregs = %s)\n",e,regm_str(pretregs));
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     OPER op = e.Eoper;                     // OPxxxx
 
     tym_t tyml = tybasic(e1.Ety);              // type of lvalue
@@ -552,10 +552,10 @@ void cdmulass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cddivass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cddivass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
 
     tym_t tyml = tybasic(e1.Ety);              // type of lvalue
     OPER op = e.Eoper;                     // OPxxxx
@@ -653,7 +653,7 @@ void cddivass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdshass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdshass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -662,8 +662,8 @@ void cdshass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     }
 
     //printf("cdshass(e=%p, pretregs = %s)\n",e,regm_str(pretregs));
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
 
     tym_t tyml = tybasic(e1.Ety);              // type of lvalue
 
@@ -746,7 +746,7 @@ void cdshass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdcmp(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
     //elem_print(e);
@@ -758,8 +758,8 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     int flag = cg.cmp_flag;
     cg.cmp_flag = 0;
 
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     if (pretregs == 0)                 // if don't want result
     {
         codelem(cgstate,cdb,e1,pretregs,false);
@@ -787,7 +787,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     uint grex = rex << 16;          // 64 bit operands
 
     code cs;
-    code *ce;
+    code* ce;
     if (tyfloating(tym))                  // if floating operation
     {
         if (config.fpxmmregs)
@@ -860,7 +860,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                 rreg = findregmsw(rretregs);
                 uint ins = INSTR.cmp_shift(1, rreg, 0, 0, reg); // CMP reg, rreg
                 cdb.gen1(ins);
-                genjmp(cdb,JNE,FL.code,cast(block *) ce);      // JNE nop
+                genjmp(cdb,JNE,FL.code,cast(block*) ce);      // JNE nop
 
                 reg = findreglsw(retregs);
                 rreg = findreglsw(rretregs);
@@ -991,7 +991,7 @@ printf("OPconst:\n");
                         cdb.gen(&cs);              // CMP EA+2,rreg
                         if (I64 && isbyte && rreg >= 4)
                             cdb.last().Irex |= REX;
-                        genjmp(cdb,JNE,FL.code,cast(block *) ce); // JNE nop
+                        genjmp(cdb,JNE,FL.code,cast(block*) ce); // JNE nop
                         rreg = findreglsw(rretregs);
                         NEWREG(cs.Irm,rreg);
                         getlvalue_lsw(cs);
@@ -1017,7 +1017,7 @@ printf("OPconst:\n");
                         }
                         getlvalue_msw(cs);
                         cdb.gen(&cs);              // CMP EA+2,const
-                        genjmp(cdb,JNE,FL.code, cast(block *) ce); // JNE nop
+                        genjmp(cdb,JNE,FL.code, cast(block*) ce); // JNE nop
                         if (e2.Eoper == OPconst)
                             cs.IEV2.Vint = cast(int)e2.Vllong;
                         else if (e2.Eoper == OPrelconst)
@@ -1136,7 +1136,7 @@ printf("OPconst:\n");
                 loadea(cdb,e2,cs,0x3B ^ reverse,reg,REGSIZE,retregs,0,RM.load);
                 if (I32 && sz == 6)
                     cdb.last().Iflags |= CFopsize;        // seg is only 16 bits
-                genjmp(cdb,JNE,FL.code, cast(block *) ce);  // JNE ce
+                genjmp(cdb,JNE,FL.code, cast(block*) ce);  // JNE ce
                 reg = findreglsw(retregs);
                 if (e2.Eoper == OPind)
                 {
@@ -1169,7 +1169,7 @@ L3:
         }
         else
         {
-            code *nop = null;
+            code* nop = null;
             regm_t save = cgstate.regcon.immed.mval;
             reg = allocreg(cdb,retregs,TYint);
             cgstate.regcon.immed.mval = save;
@@ -1203,7 +1203,7 @@ L3:
                 assert(!flag);
                 movregconst(cdb,reg,1,64|8);   // MOV reg,1
                 nop = gennop(nop);
-                genjmp(cdb,jop,FL.code,cast(block *) nop);  // Jtrue nop
+                genjmp(cdb,jop,FL.code,cast(block*) nop);  // Jtrue nop
                                                             // MOV reg,0
                 movregconst(cdb,reg,0,(pretregs & mPSW) ? 64|8 : 64);
                 cgstate.regcon.immed.mval &= ~mask(reg);
@@ -1213,7 +1213,7 @@ L3:
                 assert(!flag);
                 movregconst(cdb,reg,1,8);      // MOV reg,1
                 nop = gennop(nop);
-                genjmp(cdb,jop,FL.code,cast(block *) nop);  // Jtrue nop
+                genjmp(cdb,jop,FL.code,cast(block*) nop);  // Jtrue nop
                                                             // MOV reg,0
                 movregconst(cdb,reg,0,(pretregs & mPSW) ? 8 : 0);
                 cgstate.regcon.immed.mval &= ~mask(reg);
@@ -1249,7 +1249,7 @@ ret:
     OPld_d
  */
 @trusted
-void cdcnvt(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
+void cdcnvt(ref CGstate cg, ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
 {
     //printf("cdcnvt: %p pretregs = %s\n", e, regm_str(pretregs));
     //elem_print(e);
@@ -1474,7 +1474,7 @@ L1:
  */
 
 @trusted
-void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     reg_t reg;
     regm_t retregs;
@@ -1490,7 +1490,7 @@ void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
 
     if (op == OPu32_64)
     {
-        elem *e1 = e.E1;
+        elem* e1 = e.E1;
         retregs = pretregs;
         if (e1.Eoper == OPvar || (e1.Eoper == OPind && !e1.Ecount))
         {
@@ -1537,8 +1537,8 @@ void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     }
     else if (op == OPs16_32 || op == OPu16_32 || op == OPs32_64)
     {
-        elem *e11;
-        elem *e1 = e.E1;
+        elem* e11;
+        elem* e1 = e.E1;
 
         if (e1.Eoper == OPu8_16 && !e1.Ecount &&
             ((e11 = e1.E1).Eoper == OPvar || (e11.Eoper == OPind && !e11.Ecount))
@@ -1712,7 +1712,7 @@ void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdbyteint(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdbyteint(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     regm_t retregs;
     tym_t tyml = tybasic(e.Ety);              // type of lvalue
@@ -1726,7 +1726,7 @@ void cdbyteint(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
 
     //printf("cdbyteint(e = %p, pretregs = %s\n", e, regm_str(pretregs));
     char op = e.Eoper;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (e1.Eoper == OPcomma)
         docommas(cdb,e1);
 
@@ -1754,10 +1754,10 @@ void cdbyteint(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     CodeBuilder cdb1;
     cdb1.ctor();
     codelem(cgstate,cdb1,e1,retregs,false);
-    code *c1 = cdb1.finish();
+    code* c1 = cdb1.finish();
     cdb.append(cdb1);
     reg_t reg = findreg(retregs);
-    code *c;
+    code* c;
     if (!c1)
         goto L1;
 
@@ -1806,7 +1806,7 @@ void cdbyteint(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdlngsht(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdlngsht(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     debug
     {
@@ -1871,7 +1871,7 @@ void cdlngsht(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdmsw(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdmsw(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     assert(e.Eoper == OPmsw);
 
@@ -1912,7 +1912,7 @@ void cdmsw(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdpopcnt(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdpopcnt(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdpopcnt()\n");
     //elem_print(e);

--- a/compiler/src/dmd/backend/blockopt.d
+++ b/compiler/src/dmd/backend/blockopt.d
@@ -44,15 +44,15 @@ import dmd.backend.gflow : util_realloc;
 
 struct BlockOpt
 {
-    block *startblock;      // beginning block of function
+    block* startblock;      // beginning block of function
                             // (can have no predecessors)
 
     Barray!(block*) dfo;    // array of depth first order
 
-    block *curblock;        // current block being read in
-    block *block_last;      // last block read in
+    block* curblock;        // current block being read in
+    block* block_last;      // last block read in
 
-    block *block_freelist;
+    block* block_freelist;
 
     block blkzero;          // storage allocator
 }
@@ -60,9 +60,9 @@ struct BlockOpt
 __gshared BlockOpt bo;
 
 @trusted
-pragma(inline, true) block *block_calloc_i()
+pragma(inline, true) block* block_calloc_i()
 {
-    block *b;
+    block* b;
 
     if (bo.block_freelist)
     {
@@ -71,11 +71,11 @@ pragma(inline, true) block *block_calloc_i()
         *b = bo.blkzero;
     }
     else
-        b = cast(block *) mem_calloc(block.sizeof);
+        b = cast(block*) mem_calloc(block.sizeof);
     return b;
 }
 
-block *block_calloc()
+block* block_calloc()
 {
     return block_calloc_i();
 }
@@ -103,7 +103,7 @@ void block_term()
 {
     while (bo.block_freelist)
     {
-        block *b = bo.block_freelist.Bnext;
+        block* b = bo.block_freelist.Bnext;
         mem_free(bo.block_freelist);
         bo.block_freelist = b;
     }
@@ -132,7 +132,7 @@ void block_next(BlockState* bctx, BC bc, block* bn)
 
 block* block_goto(BlockState* bx, BC bc, block* bn)
 {
-    block *b;
+    block* b;
 
     b = bx.curblock;
     block_next(bx,bc,bn);
@@ -153,12 +153,12 @@ void block_goto()
     block_goto(block_calloc());
 }
 
-void block_goto(block *bn)
+void block_goto(block* bn)
 {
     block_goto(bn,bn);
 }
 
-void block_goto(block *bgoto,block *bnew)
+void block_goto(block* bgoto,block* bnew)
 {
     BC bc;
 
@@ -184,7 +184,7 @@ void block_ptr()
     //printf("block_ptr()\n");
 
     uint numblks = 0;
-    for (block *b = bo.startblock; b; b = b.Bnext)       /* for each block        */
+    for (block* b = bo.startblock; b; b = b.Bnext)       /* for each block        */
     {
         b.Bblknum = numblks;
         numblks++;
@@ -199,10 +199,10 @@ void block_ptr()
 void block_pred()
 {
     //printf("block_pred()\n");
-    for (block *b = bo.startblock; b; b = b.Bnext)       // for each block
+    for (block* b = bo.startblock; b; b = b.Bnext)       // for each block
         list_free(&b.Bpred,FPNULL);
 
-    for (block *b = bo.startblock; b; b = b.Bnext)       // for each block
+    for (block* b = bo.startblock; b; b = b.Bnext)       // for each block
     {
         //printf("b = %p, BC = %s\n", b, bc_str(b.bc));
         foreach (bp; ListRange(b.Bsucc))
@@ -222,7 +222,7 @@ void block_pred()
 @trusted
 void block_clearvisit()
 {
-    for (block *b = bo.startblock; b; b = b.Bnext)       // for each block
+    for (block* b = bo.startblock; b; b = b.Bnext)       // for each block
         b.Bflags = cast(BFL)(b.Bflags & ~cast(uint)BFL.visited); // mark as unvisited
 }
 
@@ -230,12 +230,12 @@ void block_clearvisit()
  * Visit block and each of its predecessors.
  */
 
-void block_visit(block *b)
+void block_visit(block* b)
 {
     b.Bflags |= BFL.visited;
     foreach (l; ListRange(b.Bsucc))
     {
-        block *bs = list_block(l);
+        block* bs = list_block(l);
         assert(bs);
         if ((bs.Bflags & BFL.visited) == 0)     // if not visited
             block_visit(bs);
@@ -257,10 +257,10 @@ void block_compbcount(ref GlobalOptimizer go)
  * Free list of blocks.
  */
 
-void blocklist_free(block **pb)
+void blocklist_free(block** pb)
 {
-    block *bn;
-    for (block *b = *pb; b; b = bn)
+    block* bn;
+    for (block* b = *pb; b; b = bn)
     {
         bn = b.Bnext;
         block_free(b);
@@ -273,7 +273,7 @@ void blocklist_free(block **pb)
  */
 
 @trusted
-void block_optimizer_free(block *b)
+void block_optimizer_free(block* b)
 {
     static void vfree(ref vec_t v) { vec_free(v); v = null; }
     vfree(b.Bdom);
@@ -297,7 +297,7 @@ void block_optimizer_free(block *b)
  */
 
 @trusted
-void block_free(block *b)
+void block_free(block* b)
 {
     assert(b);
     if (b.Belem)
@@ -343,17 +343,17 @@ void block_free(block *b)
  */
 
 @trusted
-void block_appendexp(block *b,elem *e)
+void block_appendexp(block* b,elem* e)
 {
     if (e)
     {
         assert(b);
         elem_debug(e);
-        elem **pe = &b.Belem;
-        elem *ec = *pe;
+        elem** pe = &b.Belem;
+        elem* ec = *pe;
         if (ec != null)
         {
-            type *t = e.ET;
+            type* t = e.ET;
 
             if (t)
                 type_debug(t);
@@ -385,7 +385,7 @@ version (COMPILE)
 
 //#undef block_initvar
 
-void block_initvar(Symbol *s)
+void block_initvar(Symbol* s)
 {
     symbol_debug(s);
     curblock.Binitvar = s;
@@ -448,7 +448,7 @@ void blockopt(ref GlobalOptimizer go, int iter)
         }
 
         /* canonicalize the trees        */
-        for (block *b = bo.startblock; b; b = b.Bnext)
+        for (block* b = bo.startblock; b; b = b.Bnext)
         {
             debug if (debugb)
             {
@@ -472,7 +472,7 @@ void blockopt(ref GlobalOptimizer go, int iter)
         if (localgot)
         {   // Initialize with:
             //  localgot = OPgot;
-            elem *e = el_long(TYnptr, 0);
+            elem* e = el_long(TYnptr, 0);
             e.Eoper = OPgot;
             e = el_bin(OPeq, TYnptr, el_var(localgot), e);
             bo.startblock.Belem = el_combine(e, bo.startblock.Belem);
@@ -509,15 +509,15 @@ void brcombine(ref GlobalOptimizer go)
     do
     {
         int anychanges = 0;
-        for (block *b = bo.startblock; b; b = b.Bnext)   // for each block
+        for (block* b = bo.startblock; b; b = b.Bnext)   // for each block
         {
             /* Look for [e1 IFFALSE L3,L2] L2: [e2 GOTO L3] L3: [e3]    */
             /* Replace with [(e1 && e2),e3]                             */
             const bc = b.bc;
             if (bc == BC.iftrue)
             {
-                block *b2 = b.nthSucc(0);
-                block *b3 = b.nthSucc(1);
+                block* b2 = b.nthSucc(0);
+                block* b3 = b.nthSucc(1);
 
                 if (list_next(b2.Bpred))       // if more than one predecessor
                     continue;
@@ -553,7 +553,7 @@ void brcombine(ref GlobalOptimizer go)
                     if (!OTleaf(b3.Belem.Eoper))
                         continue;
                     tym_t ty = (bc2 == BC.retexp) ? b2.Belem.Ety : cast(tym_t) TYvoid;
-                    elem *e = el_bin(OPcolon2,ty,b2.Belem,b3.Belem);
+                    elem* e = el_bin(OPcolon2,ty,b2.Belem,b3.Belem);
                     b.Belem = el_bin(OPcond,ty,b.Belem,e);
                     b.bc = bc2;
                     b.Belem.ET = b2.Belem.ET;
@@ -569,10 +569,10 @@ void brcombine(ref GlobalOptimizer go)
                          b3.bc == BC.goto_ &&
                          b2.nthSucc(0) == b3.nthSucc(0))
                 {
-                    block *bsucc = b2.nthSucc(0);
+                    block* bsucc = b2.nthSucc(0);
                     if (b2.Belem)
                     {
-                        elem *e;
+                        elem* e;
                         if (b3.Belem)
                         {
                             if (!OTleaf(b3.Belem.Eoper))
@@ -630,13 +630,13 @@ void brcombine(ref GlobalOptimizer go)
 private void bropt(ref GlobalOptimizer go)
 {
     debug if (debugc) printf("bropt()\n");
-    for (block *b = bo.startblock; b; b = b.Bnext)   // for each block
+    for (block* b = bo.startblock; b; b = b.Bnext)   // for each block
     {
-        elem **pn = &(b.Belem);
+        elem** pn = &(b.Belem);
         if (OPTIMIZER && *pn)
             pn = el_scancommas(pn);
 
-        elem *n = *pn;
+        elem* n = *pn;
 
         /* look for conditional that never returns */
         if (n && tybasic(n.Ety) == TYnoreturn && b.bc != BC.exit)
@@ -673,7 +673,7 @@ private void bropt(ref GlobalOptimizer go)
             }
 
             /* Take care of IF (constant)                   */
-            block *db;
+            block* db;
             if (iftrue(n))          /* if elem is true      */
             {
                 // select first succ
@@ -731,7 +731,7 @@ private void bropt(ref GlobalOptimizer go)
             {
                 if (i--)            // but not the db successor
                 {
-                    void *p = list_subtract(&(list_block(bl).Bpred),b);
+                    void* p = list_subtract(&(list_block(bl).Bpred),b);
                     assert(p == b);
                 }
             }
@@ -755,13 +755,13 @@ private void bropt(ref GlobalOptimizer go)
 private void brrear()
 {
     debug if (debugc) printf("brrear()\n");
-    for (block *b = bo.startblock; b; b = b.Bnext)   // for each block
+    for (block* b = bo.startblock; b; b = b.Bnext)   // for each block
     {
         foreach (bl; ListRange(b.Bsucc))
         {   /* For each transfer of control block pointer   */
             int iter = 0;
 
-            block *bt = list_block(bl);
+            block* bt = list_block(bl);
 
             /* If it is a transfer to a block that consists */
             /* of nothing but an unconditional transfer,    */
@@ -811,8 +811,8 @@ private void brrear()
 
             if (b.bc == BC.iftrue || b.bc == BC.iffalse)
             {
-                block *bif = b.nthSucc(0);
-                block *belse = b.nthSucc(1);
+                block* bif = b.nthSucc(0);
+                block* belse = b.nthSucc(1);
 
                 if (bif == b.Bnext)
                 {
@@ -845,14 +845,14 @@ void compdfo(ref Barray!(block*) dfo, block* startblock)
     /******************************
      * Add b's successors to dfo[], then b
      */
-    void walkDFO(block *b)
+    void walkDFO(block* b)
     {
         assert(b);
         b.Bflags |= BFL.visited;             // executed at least once
 
         foreach (bl; ListRange(b.Bsucc))   // for each successor
         {
-            block *bs = list_block(bl);
+            block* bs = list_block(bl);
             assert(bs);
             if ((bs.Bflags & BFL.visited) == 0) // if not visited
                 walkDFO(bs);
@@ -900,9 +900,9 @@ void compdfo(ref Barray!(block*) dfo, block* startblock)
 private void elimblks(ref GlobalOptimizer go)
 {
     debug if (debugc) printf("elimblks()\n");
-    block *bf = null;
-    block *b;
-    for (block **pb = &bo.startblock; (b = *pb) != null;)
+    block* bf = null;
+    block* b;
+    for (block** pb = &bo.startblock; (b = *pb) != null;)
     {
         if (((b.Bflags & BFL.visited) == 0)   // if block is not visited
             && ((b.Bflags & BFL.label) == 0)  // need label offset
@@ -962,7 +962,7 @@ private int mergeblks()
     foreach (b; bo.dfo[])
     {
         if (b.bc == BC.goto_)
-        {   block *bL2 = list_block(b.Bsucc);
+        {   block* bL2 = list_block(b.Bsucc);
 
             if (b == bL2)
             {
@@ -980,7 +980,7 @@ private int mergeblks()
                     continue;
 
                 /* JOIN the elems               */
-                elem *e = el_combine(b.Belem,bL2.Belem);
+                elem* e = el_combine(b.Belem,bL2.Belem);
                 if (b.Belem && bL2.Belem)
                     e = doptelem(e,bc_goal(bL2.bc) | Goal.again);
                 bL2.Belem = e;
@@ -998,7 +998,7 @@ private int mergeblks()
                 {
                     foreach (bs; ListRange(list_block(bl).Bsucc))
                         if (list_block(bs) == b)
-                            bs.ptr = cast(void *)bL2;
+                            bs.ptr = cast(void*)bL2;
                 }
 
                 merge++;
@@ -1008,7 +1008,7 @@ private int mergeblks()
                 {   /* bL2 is the new startblock */
                     debug if (debugc) printf("bL2 is new startblock\n");
                     /* Remove bL2 from list of blocks   */
-                    for (block **pb = &bo.startblock; 1; pb = &(*pb).Bnext)
+                    for (block** pb = &bo.startblock; 1; pb = &(*pb).Bnext)
                     {
                         assert(*pb);
                         if (*pb == bL2)
@@ -1041,14 +1041,14 @@ private void blident(ref GlobalOptimizer go)
     debug if (debugc) printf("blident()\n");
     assert(bo.startblock);
 
-    block *bnext;
-    for (block *bn = bo.startblock; bn; bn = bnext)
+    block* bnext;
+    for (block* bn = bo.startblock; bn; bn = bnext)
     {
         bnext = bn.Bnext;
         if (bn.Bflags & BFL.nomerg)
             continue;
 
-        for (block *b = bnext; b; b = b.Bnext)
+        for (block* b = bnext; b; b = b.Bnext)
         {
             /* Blocks are identical if:                 */
             /*  BC match                                */
@@ -1092,7 +1092,7 @@ private void blident(ref GlobalOptimizer go)
 
                 foreach (bl; ListRange(bn.Bpred))
                 {
-                    block *bp = list_block(bl);
+                    block* bp = list_block(bl);
                     if (bp.bc == BC.asm_)
                         // Can't do this because of jmp's and loop's
                         goto Lcontinue;
@@ -1103,7 +1103,7 @@ private void blident(ref GlobalOptimizer go)
                     // Predecessors must all be at the same btry level.
                     if (bn.Bpred)
                     {
-                        block *bp = list_block(bn.Bpred);
+                        block* bp = list_block(bn.Bpred);
                         btry = bp.Btry;
                         if (bp.bc == BC.try_)
                             btry = bp;
@@ -1113,7 +1113,7 @@ private void blident(ref GlobalOptimizer go)
 
                     foreach (bl; ListRange(b.Bpred))
                     {
-                        block *bp = list_block(bl);
+                        block* bp = list_block(bl);
                         if (bp.bc != BC.try_)
                             bp = bp.Btry;
                         if (btry != bp)
@@ -1134,10 +1134,10 @@ private void blident(ref GlobalOptimizer go)
                 /* b instead of bn                                      */
                 foreach (bl; ListRange(bn.Bpred))
                 {
-                    block *bp = list_block(bl);
+                    block* bp = list_block(bl);
                     foreach (bls; ListRange(bp.Bsucc))
                         if (list_block(bls) == bn)
-                        {   bls.ptr = cast(void *)b;
+                        {   bls.ptr = cast(void*)b;
                             list_prepend(&b.Bpred,bp);
                         }
                 }
@@ -1174,7 +1174,7 @@ private void blreturn(ref GlobalOptimizer go)
         int retcount = 0;               // number of return counts
 
         /* Find last return block       */
-        for (block *b = bo.startblock; b; b = b.Bnext)
+        for (block* b = bo.startblock; b; b = b.Bnext)
         {
             if (b.bc == BC.ret)
                 retcount++;
@@ -1186,7 +1186,7 @@ private void blreturn(ref GlobalOptimizer go)
             return;
 
         /* Split return blocks  */
-        for (block *b = bo.startblock; b; b = b.Bnext)
+        for (block* b = bo.startblock; b; b = b.Bnext)
         {
             if (b.bc != BC.ret)
                 continue;
@@ -1196,7 +1196,7 @@ private void blreturn(ref GlobalOptimizer go)
                 enum ifCondition = true;
                 if (ifCondition)
                 {
-                    for (block *b2 = bo.startblock; b2; b2 = b2.Bnext)
+                    for (block* b2 = bo.startblock; b2; b2 = b2.Bnext)
                     {
                         if (b2.bc == BC.ret && b != b2 && b.Btry == b2.Btry)
                             goto L1;
@@ -1210,7 +1210,7 @@ private void blreturn(ref GlobalOptimizer go)
                 debug if (debugc)
                     printf("blreturn: splitting block B%d\n",b.Bdfoidx);
 
-                block *bn = block_calloc();
+                block* bn = block_calloc();
                 bn.bc = BC.ret;
                 bn.Bnext = b.Bnext;
                 static if(SCPP_OR_NTEXCEPTIONS)
@@ -1254,7 +1254,7 @@ private void bl_enlist2(ref Barray!(elem*) elems, elem* e)
 }
 
 @trusted
-private list_t bl_enlist(elem *e)
+private list_t bl_enlist(elem* e)
 {
     list_t el = null;
 
@@ -1297,9 +1297,9 @@ private elem* bl_delist2(elem*[] elems)
 }
 
 @trusted
-private elem * bl_delist(list_t el)
+private elem* bl_delist(list_t el)
 {
-    elem *e = null;
+    elem* e = null;
     foreach (els; ListRange(el))
         e = el_combine(list_elem(els),e);
     list_free(&el,FPNULL);
@@ -1318,7 +1318,7 @@ private void bltailmerge(ref GlobalOptimizer go)
     if (!(go.mfoptim & MFtime))            /* if optimized for space       */
     {
         /* Split each block into a reversed linked list of elems        */
-        for (block *b = bo.startblock; b; b = b.Bnext)
+        for (block* b = bo.startblock; b; b = b.Bnext)
             b.Blist = bl_enlist(b.Belem);
 
         /* Search for two blocks that have the same successor list.
@@ -1329,15 +1329,15 @@ private void bltailmerge(ref GlobalOptimizer go)
             enum additionalAnd = "b.Btry == bn.Btry";
         else
             enum additionalAnd = "true";
-        for (block *b = bo.startblock; b; b = b.Bnext)
+        for (block* b = bo.startblock; b; b = b.Bnext)
         {
             if (!b.Blist)
                 continue;
-            elem *e = list_elem(b.Blist);
+            elem* e = list_elem(b.Blist);
             elem_debug(e);
-            for (block *bn = b.Bnext; bn; bn = bn.Bnext)
+            for (block* bn = b.Bnext; bn; bn = bn.Bnext)
             {
-                elem *en;
+                elem* en;
                 if (b.bc == bn.bc &&
                     list_equal(b.Bsucc,bn.Bsucc) &&
                     bn.Blist &&
@@ -1373,7 +1373,7 @@ private void bltailmerge(ref GlobalOptimizer go)
                     debug if (debugc)
                         printf("tail merging: %p and %p\n", b, bn);
 
-                    block *bnew = block_calloc();
+                    block* bnew = block_calloc();
                     bnew.Bnext = bn.Bnext;
                     bnew.bc = b.bc;
                     static if (SCPP_OR_NTEXCEPTIONS)
@@ -1435,7 +1435,7 @@ private void bltailmerge(ref GlobalOptimizer go)
         }
 
         /* Recombine elem lists into expression trees   */
-        for (block *b = bo.startblock; b; b = b.Bnext)
+        for (block* b = bo.startblock; b; b = b.Bnext)
             b.Belem = bl_delist(b.Blist);
     }
 }
@@ -1449,14 +1449,14 @@ private void brmin(ref GlobalOptimizer go)
 {
     debug if (debugc) printf("brmin()\n");
     debug assert(bo.startblock);
-    for (block *b = bo.startblock.Bnext; b; b = b.Bnext)
+    for (block* b = bo.startblock.Bnext; b; b = b.Bnext)
     {
-        block *bnext = b.Bnext;
+        block* bnext = b.Bnext;
         if (!bnext)
             break;
         foreach (bl; ListRange(b.Bsucc))
         {
-            block *bs = list_block(bl);
+            block* bs = list_block(bl);
             if (bs == bnext)
                 goto L1;
         }
@@ -1466,11 +1466,11 @@ private void brmin(ref GlobalOptimizer go)
 
         foreach (bl; ListRange(b.Bsucc))
         {
-            block *bs = list_block(bl);
-            block *bn;
+            block* bs = list_block(bl);
+            block* bn;
             foreach (blp; ListRange(bs.Bpred))
             {
-                block *bsp = list_block(blp);
+                block* bsp = list_block(blp);
                 if (bsp.Bnext == bs)
                     goto L2;
             }
@@ -1510,7 +1510,7 @@ static if(0)
 @trusted
 private void block_check()
 {
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block* b = startblock; b; b = b.Bnext)
     {
         int nsucc = list_nitems(b.Bsucc);
         int npred = list_nitems(b.Bpred);
@@ -1527,7 +1527,7 @@ private void block_check()
 
         foreach (bl; ListRange(b.Bsucc))
         {
-            block *bs = list_block(bl);
+            block* bs = list_block(bl);
 
             foreach (bls; ListRange(bs.Bpred))
             {
@@ -1566,12 +1566,12 @@ private void brtailrecursion(ref GlobalOptimizer go)
         return;
     }
 
-    for (block *b = bo.startblock; b; b = b.Bnext)
+    for (block* b = bo.startblock; b; b = b.Bnext)
     {
         if (b.bc == BC._try)
             return;
-        elem **pe = &b.Belem;
-        block *bn = null;
+        elem** pe = &b.Belem;
+        block* bn = null;
         if (*pe &&
             (b.bc == BC.ret ||
              b.bc == BC.retexp ||
@@ -1585,7 +1585,7 @@ private void brtailrecursion(ref GlobalOptimizer go)
 
             pe = el_scancommas(pe);
 
-            elem *e = *pe;
+            elem* e = *pe;
 
             static bool isCandidate(elem* e)
             {
@@ -1654,7 +1654,7 @@ private void brtailrecursion(ref GlobalOptimizer go)
                 else
                 {
                     int si = 0;
-                    elem *e2 = null;
+                    elem* e2 = null;
                     *pe = assignparams(&e.E2,&si,&e2);
                     *pe = el_combine(*pe,e2);
                 }
@@ -1673,7 +1673,7 @@ private void brtailrecursion(ref GlobalOptimizer go)
 
                 // Create a new startblock, bs, because startblock cannot
                 // have predecessors.
-                block *bs = block_calloc();
+                block* bs = block_calloc();
                 bs.bc = BC.goto_;
                 bs.Bnext = bo.startblock;
                 list_append(&bs.Bsucc,bo.startblock);
@@ -1692,16 +1692,16 @@ private void brtailrecursion(ref GlobalOptimizer go)
  */
 
 @trusted
-private elem * assignparams(elem **pe,int *psi,elem **pe2)
+private elem* assignparams(elem** pe,int* psi,elem** pe2)
 {
-    elem *e = *pe;
+    elem* e = *pe;
 
         if (e.Eoper == OPparam)
     {
-        elem *ea = null;
-        elem *eb = null;
-        elem *e2 = assignparams(&e.E2,psi,&eb);
-        elem *e1 = assignparams(&e.E1,psi,&ea);
+        elem* ea = null;
+        elem* eb = null;
+        elem* e2 = assignparams(&e.E2,psi,&eb);
+        elem* e1 = assignparams(&e.E1,psi,&ea);
         e.E1 = null;
         e.E2 = null;
         e = el_combine(e1,e2);
@@ -1710,23 +1710,23 @@ private elem * assignparams(elem **pe,int *psi,elem **pe2)
     else
     {
         int si = *psi;
-        type *t;
+        type* t;
 
         assert(si < globsym.length);
-        Symbol *sp = globsym[si];
-        Symbol *s = symbol_genauto(sp.Stype);
+        Symbol* sp = globsym[si];
+        Symbol* s = symbol_genauto(sp.Stype);
         s.Sfl = FL.auto_;
         int op = OPeq;
         if (e.Eoper == OPstrpar)
         {
             op = OPstreq;
             t = e.ET;
-            elem *ex = e;
+            elem* ex = e;
             e = e.E1;
             ex.E1 = null;
             el_free(ex);
         }
-        elem *es = el_var(s);
+        elem* es = el_var(s);
         es.Ety = e.Ety;
         e = el_bin(op,TYvoid,es,e);
         if (op == OPstreq)
@@ -1749,34 +1749,34 @@ private elem * assignparams(elem **pe,int *psi,elem **pe2)
 private void emptyloops(ref GlobalOptimizer go)
 {
     debug if (debugc) printf("emptyloops()\n");
-    for (block *b = bo.startblock; b; b = b.Bnext)
+    for (block* b = bo.startblock; b; b = b.Bnext)
     {
         if (b.bc == BC.iftrue &&
             list_block(b.Bsucc) == b &&
             list_nitems(b.Bpred) == 2)
         {
             // Find predecessor to b
-            block *bpred = list_block(b.Bpred);
+            block* bpred = list_block(b.Bpred);
             if (bpred == b)
                 bpred = list_block(list_next(b.Bpred));
             if (!bpred.Belem)
                 continue;
 
             // Find einit
-            elem *einit = *el_scancommas(&(bpred.Belem));
+            elem* einit = *el_scancommas(&(bpred.Belem));
             if (einit.Eoper != OPeq ||
                 einit.E2.Eoper != OPconst ||
                 einit.E1.Eoper != OPvar)
                 continue;
 
             // Look for ((i += 1) < limit)
-            elem *erel = b.Belem;
+            elem* erel = b.Belem;
             if (erel.Eoper != OPlt ||
                 erel.E2.Eoper != OPconst ||
                 erel.E1.Eoper != OPaddass)
                 continue;
 
-            elem *einc = erel.E1;
+            elem* einc = erel.E1;
             if (einc.E2.Eoper != OPconst ||
                 einc.E1.Eoper != OPvar ||
                 !el_match(einc.E1,einit.E1))
@@ -1820,7 +1820,7 @@ private void emptyloops(ref GlobalOptimizer go)
 private void funcsideeffects()
 {
     //printf("funcsideeffects('%s')\n",funcsym_p.Sident);
-    for (block *b = bo.startblock; b; b = b.Bnext)
+    for (block* b = bo.startblock; b; b = b.Bnext)
     {
         if (b.Belem && funcsideeffect_walk(b.Belem))
         {
@@ -1833,7 +1833,7 @@ private void funcsideeffects()
 }
 
 @trusted
-private int funcsideeffect_walk(elem *e)
+private int funcsideeffect_walk(elem* e)
 {
     assert(e);
     elem_debug(e);
@@ -1844,7 +1844,7 @@ private int funcsideeffect_walk(elem *e)
     {
         case OPcall:
         case OPucall:
-            Symbol *s;
+            Symbol* s;
             if (e.E1.Eoper == OPvar &&
                 tyfunc((s = e.E1.Vsym).Stype.Tty) &&
                 ((s.Sfunc && s.Sfunc.Fflags3 & Fnosideeff) || s == funcsym_p)
@@ -1873,7 +1873,7 @@ private int funcsideeffect_walk(elem *e)
  */
 
 @trusted
-private int el_anyframeptr(elem *e)
+private int el_anyframeptr(elem* e)
 {
     while (1)
     {
@@ -1905,7 +1905,7 @@ private void blassertsplit(ref GlobalOptimizer go)
 {
     debug if (debugc) printf("blassertsplit()\n");
     Barray!(elem*) elems;
-    for (block *b = bo.startblock; b; b = b.Bnext)
+    for (block* b = bo.startblock; b; b = b.Bnext)
     {
         /* Not sure of effect of jumping out of a try block
          */
@@ -1921,7 +1921,7 @@ private void blassertsplit(ref GlobalOptimizer go)
     L1:
         int dctor = 0;
 
-        int accumDctor(elem *e)
+        int accumDctor(elem* e)
         {
             while (1)
             {
@@ -1953,7 +1953,7 @@ private void blassertsplit(ref GlobalOptimizer go)
                 accumDctor(e);
                 continue;
             }
-            Symbol *f = e.E2.E1.Vsym;
+            Symbol* f = e.E2.E1.Vsym;
             if (!(f.Sflags & SFLexit))
             {
                 accumDctor(e);
@@ -1967,13 +1967,13 @@ private void blassertsplit(ref GlobalOptimizer go)
             }
 
             // Create exit block
-            block *bexit = block_calloc();
+            block* bexit = block_calloc();
             bexit.bc = BC.exit;
             bexit.Belem = e.E2;
 
             /* Append bexit to block list
              */
-            for (block *bx = b; 1; )
+            for (block* bx = b; 1; )
             {
                 block* bxn = bx.Bnext;
                 if (!bxn)
@@ -1991,7 +1991,7 @@ private void blassertsplit(ref GlobalOptimizer go)
 
             /* Split b into two blocks, [b,b2]
              */
-            block *b2 = block_calloc();
+            block* b2 = block_calloc();
             b2.Bnext = b.Bnext;
             b.Bnext = b2;
             b2.bc = b.bc;
@@ -2006,11 +2006,11 @@ private void blassertsplit(ref GlobalOptimizer go)
             b.Bsucc = null;
             foreach (b2sl; ListRange(b2.Bsucc))
             {
-                block *b2s = list_block(b2sl);
+                block* b2s = list_block(b2sl);
                 foreach (b2spl; ListRange(b2s.Bpred))
                 {
                     if (list_block(b2spl) == b)
-                        b2spl.ptr = cast(void *)b2;
+                        b2spl.ptr = cast(void*)b2;
                 }
             }
 
@@ -2048,7 +2048,7 @@ private void blexit(ref GlobalOptimizer go)
         printf("blexit()\n");
 
     Barray!(block*) bexits;
-    for (block *b = bo.startblock; b; b = b.Bnext)
+    for (block* b = bo.startblock; b; b = b.Bnext)
     {
         /* Not sure of effect of jumping out of a try block
          */
@@ -2072,7 +2072,7 @@ private void blexit(ref GlobalOptimizer go)
 
         foreach (bsl; ListRange(b.Bsucc))
         {
-            block *bs = list_block(bsl);
+            block* bs = list_block(bsl);
             list_subtract(&bs.Bpred, b);
         }
         list_free(&b.Bsucc, FPNULL);

--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -135,7 +135,7 @@ struct Pstate
                                 // prevent <array of> being converted to
                                 // <pointer to>.
 
-    Funcsym *STfuncsym_p;       // if inside a function, then this is the
+    Funcsym* STfuncsym_p;       // if inside a function, then this is the
                                 // function Symbol.
 
     stflags_t STflags;
@@ -171,7 +171,7 @@ enum
 // Determine if Symbol has a Ssymnum associated with it.
 // (That is, it is allocated on the stack or has live variable analysis
 //  done on it, so it is stack and register variables.)
-//char symbol_isintab(Symbol *s) { return sytab[s.Sclass] & SCSS; }
+//char symbol_isintab(Symbol* s) { return sytab[s.Sclass] & SCSS; }
 
 /******************************************
  * Basic blocks:
@@ -229,17 +229,17 @@ struct block
 nothrow:
     union
     {
-        elem *Belem;            // pointer to elem tree
+        elem* Belem;            // pointer to elem tree
         list_t  Blist;          // list of expressions
     }
 
-    block *Bnext;               // pointer to next block in list
+    block* Bnext;               // pointer to next block in list
     list_t Bsucc;               // linked list of pointers to successors
                                 //     of this block
     list_t Bpred;               // and the predecessor list
     int Bindex;                 // into created object stack
     int Bendindex;              // index at end of block
-    block *Btry;                // BC.try_,BC._try: enclosing try block, if any
+    block* Btry;                // BC.try_,BC._try: enclosing try block, if any
                                 // BC???: if in try-block, points to BC.try_ or BC._try
                                 // note that can't have a BC.try_ and BC._try in
                                 // the same function.
@@ -266,19 +266,19 @@ nothrow:
 
         struct
         {
-            Symbol *jcatchvar;      // __d_throw() fills in this
+            Symbol* jcatchvar;      // __d_throw() fills in this
             int Bscope_index;           // index into scope table
             int Blast_index;            // enclosing index into scope table
         }                               // BC._try
 
         struct
         {
-            Symbol *flag;               // EH_DWARF: set to 'flag' symbol that encloses finally
-            block *b_ret;               // EH_DWARF: associated BC._ret block
+            Symbol* flag;               // EH_DWARF: set to 'flag' symbol that encloses finally
+            block* b_ret;               // EH_DWARF: associated BC._ret block
         }                               // finally
 
         // add member mimicking the largest of the other elements of this union, so it can be copied
-        struct _BS { Symbol *jcvar; int Bscope_idx, Blast_idx; }
+        struct _BS { Symbol* jcvar; int Bscope_idx, Blast_idx; }
         _BS BS;
     }
     Srcpos      Bsrcpos;        // line number (0 if not known)
@@ -360,7 +360,7 @@ nothrow:
     block* nthSucc(int n)            { return cast(block*)list_ptr(list_nth(Bsucc, n)); }
 
     @trusted
-    void setNthSucc(int n, block *b) { list_nth(Bsucc, n).ptr = b; }
+    void setNthSucc(int n, block* b) { list_nth(Bsucc, n).ptr = b; }
 }
 
 @trusted
@@ -493,51 +493,51 @@ enum
 struct func_t
 {
     symlist_t Fsymtree;         // local Symbol table
-    block *Fstartblock;         // list of blocks comprising function
+    block* Fstartblock;         // list of blocks comprising function
     symtab_t Flocsym;           // local Symbol table
     Srcpos Fstartline;          // starting line # of function
     Srcpos Fendline;            // line # of closing brace of function
-    Symbol *F__func__;          // symbol for __func__[] string
+    Symbol* F__func__;          // symbol for __func__[] string
     func_flags_t Fflags;
     func_flags3_t Fflags3;
     ubyte Foper;                // operator number (OPxxxx) if Foperator
 
-    Symbol *Fparsescope;        // use this scope to parse friend functions
+    Symbol* Fparsescope;        // use this scope to parse friend functions
                                 // which are defined within a class, so the
                                 // class is in scope, but are not members
                                 // of the class
 
-    Classsym *Fclass;           // if member of a class, this is the class
+    Classsym* Fclass;           // if member of a class, this is the class
                                 // (I think this is redundant with Sscope)
-    Funcsym *Foversym;          // overloaded function at same scope
+    Funcsym* Foversym;          // overloaded function at same scope
     symlist_t Fclassfriends;    // Symbol list of classes of which this
                                 // function is a friend
-    block *Fbaseblock;          // block where base initializers get attached
-    block *Fbaseendblock;       // block where member destructors get attached
-    elem *Fbaseinit;            // list of member initializers (meminit_t)
+    block* Fbaseblock;          // block where base initializers get attached
+    block* Fbaseendblock;       // block where member destructors get attached
+    elem* Fbaseinit;            // list of member initializers (meminit_t)
                                 // this field has meaning only for
                                 // functions which are constructors
-    token_t *Fbody;             // if deferred parse, this is the list
+    token_t* Fbody;             // if deferred parse, this is the list
                                 // of tokens that make up the function
                                 // body
                                 // also used if SCfunctempl, SCftexpspec
     uint Fsequence;             // sequence number at point of definition
     Symbol* Ftempl;         // if Finstance this is the template that generated it
-    Funcsym *Falias;            // SCfuncalias: function Symbol referenced
+    Funcsym* Falias;            // SCfuncalias: function Symbol referenced
                                 // by using-declaration
     symlist_t Fthunks;          // list of thunks off of this function
-    param_t *Farglist;          // SCfunctempl: the template-parameter-list
-    param_t *Fptal;             // Finstance: this is the template-argument-list
+    param_t* Farglist;          // SCfunctempl: the template-parameter-list
+    param_t* Fptal;             // Finstance: this is the template-argument-list
                                 // SCftexpspec: for explicit specialization, this
                                 // is the template-argument-list
     list_t Ffwdrefinstances;    // SCfunctempl: list of forward referenced instances
     list_t Fexcspec;            // List of types in the exception-specification
                                 // (NULL if none or empty)
-    Funcsym *Fexplicitspec;     // SCfunctempl, SCftexpspec: threaded list
+    Funcsym* Fexplicitspec;     // SCfunctempl, SCftexpspec: threaded list
                                 // of SCftexpspec explicit specializations
-    Funcsym *Fsurrogatesym;     // Fsurrogate: surrogate cast function
+    Funcsym* Fsurrogatesym;     // Fsurrogate: surrogate cast function
 
-    char *Fredirect;            // redirect function name to this name in object
+    char* Fredirect;            // redirect function name to this name in object
 
     // Array of catch types for EH_DWARF Types Table generation
     Barray!(Symbol*) typesTable;
@@ -648,20 +648,20 @@ struct struct_t
 {
     targ_size_t Sstructsize;    // size of struct
     symlist_t Sfldlst;          // all members of struct (list freeable)
-    Symbol *Sroot;              // root of binary tree Symbol table
+    Symbol* Sroot;              // root of binary tree Symbol table
     uint Salignsize;            // size of struct for alignment purposes
     ubyte Sstructalign;         // struct member alignment in effect
     struct_flags_t Sflags;
     tym_t ptrtype;              // type of pointer to refer to classes by
-    baseclass_t *Sbase;         // list of direct base classes
-    Symbol *Svptr;              // Symbol of vptr
-    Symbol *Stempsym;           // if this struct is an instantiation
+    baseclass_t* Sbase;         // list of direct base classes
+    Symbol* Svptr;              // Symbol of vptr
+    Symbol* Stempsym;           // if this struct is an instantiation
                                 // of a template class, this is the
                                 // template class Symbol
 
     // For 64 bit Elf function ABI
-    type *Sarg1type;
-    type *Sarg2type;
+    type* Sarg1type;
+    type* Sarg2type;
 
     /* For:
      *  template<class T> struct A { };
@@ -678,7 +678,7 @@ struct struct_t
      *  Spr_arglist = <int*>;
      */
 
-    param_t *Sarglist;          // if this struct is an instantiation
+    param_t* Sarglist;          // if this struct is an instantiation
                                 // of a template class, this is the
                                 // actual arg list used
 }
@@ -825,7 +825,7 @@ struct Symbol
         return (1 << Spreg) | (Spreg2 == NOREG ? 0 : (1 << Spreg2));
     }
 
-    Symbol *Sscope;             // enclosing scope (could be struct tag,
+    Symbol* Sscope;             // enclosing scope (could be struct tag,
                                 // enclosing inline function for statics,
                                 // or namespace)
 
@@ -920,7 +920,7 @@ alias Aliassym = Symbol;
 //#endif
 
 /* Format the identifier for presentation to the user   */
-const(char)* prettyident(const Symbol *s) { return &s.Sident[0]; }
+const(char)* prettyident(const Symbol* s) { return &s.Sident[0]; }
 
 
 /**********************************
@@ -958,7 +958,7 @@ enum
  *      exception method for f
  */
 @trusted
-EHmethod ehmethod(Symbol *f)
+EHmethod ehmethod(Symbol* f)
 {
     return f.Sfunc.Fflags3 & Feh_none ? EHmethod.EH_NONE : config.ehmethod;
 }
@@ -1000,7 +1000,7 @@ nothrow:
 import dmd.backend.dtype : param_t_print, param_t_print_list, param_t_length, param_t_createTal,
     param_t_search, param_t_searchn;
 
-void param_debug(const param_t *p)
+void param_debug(const param_t* p)
 {
     debug assert(p.id == p.IDparam);
 }
@@ -1069,15 +1069,15 @@ enum FL : ubyte
 struct EEcontext
 {
     uint EElinnum;              // line number to insert expression
-    char *EEexpr;               // expression
-    char *EEtypedef;            // typedef identifier
+    char* EEexpr;               // expression
+    char* EEtypedef;            // typedef identifier
     byte EEpending;             // !=0 means we haven't compiled it yet
     byte EEimminent;            // we've installed it in the source text
     byte EEcompile;             // we're compiling for the EE expression
     byte EEin;                  // we are parsing an EE expression
-    elem *EEelem;               // compiled version of EEexpr
-    Symbol *EEfunc;             // function expression is in
-    code *EEcode;               // generated code
+    elem* EEelem;               // compiled version of EEexpr
+    Symbol* EEfunc;             // function expression is in
+    code* EEcode;               // generated code
 }
 
 public import dmd.backend.ee : eecontext;
@@ -1117,7 +1117,7 @@ enum Goal : uint
 
 struct dt_t
 {
-    dt_t *DTnext;                       // next in list
+    dt_t* DTnext;                       // next in list
     DT dt;                              // Tagged union tag, see above
     ubyte Dty;                          // pointer type
     ubyte DTn;                          // DTibytes: number of bytes
@@ -1139,7 +1139,7 @@ struct dt_t
         }
         struct                          // DTxoff
         {
-            Symbol *DTsym;              // symbol pointer
+            Symbol* DTsym;              // symbol pointer
             targ_size_t DToffset;       // offset from symbol
         }
     }

--- a/compiler/src/dmd/backend/cg.d
+++ b/compiler/src/dmd/backend/cg.d
@@ -44,8 +44,8 @@ regm_t  FLOATREGS = FLOATREGS_16;
 regm_t  FLOATREGS2 = FLOATREGS2_16;
 regm_t  DOUBLEREGS = DOUBLEREGS_16;
 
-Symbol *localgot;               // reference to GOT for this function
-Symbol *tls_get_addr_sym;       // function __tls_get_addr
+Symbol* localgot;               // reference to GOT for this function
+Symbol* tls_get_addr_sym;       // function __tls_get_addr
 
 int TARGET_STACKALIGN = 2;      // default for 16 bit code
 int STACKALIGN = 2;             // varies for each function

--- a/compiler/src/dmd/backend/cgcs.d
+++ b/compiler/src/dmd/backend/cgcs.d
@@ -187,7 +187,7 @@ struct CGCS
      * Add an elem to the common subexpression table.
      */
 
-    void push(elem *e, hash_t hash)
+    void push(elem* e, hash_t hash)
     {
         hcstab.push(HCS(e, hash));
     }
@@ -551,7 +551,7 @@ void ecom(ref CGCS cgcs, ref elem* pe)
  */
 
 @trusted
-hash_t cs_comphash(const elem *e)
+hash_t cs_comphash(const elem* e)
 {
     elem_debug(e);
     const op = e.Eoper;
@@ -724,7 +724,7 @@ void touchstar(ref CGCS cgcs)
  */
 
 @trusted
-void touchaccess(ref Barray!HCS hcstab, const elem *ev) pure nothrow
+void touchaccess(ref Barray!HCS hcstab, const elem* ev) pure nothrow
 {
     const ev1 = ev.E1;
     foreach (ref hcs; hcstab[])

--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -68,13 +68,13 @@ private bool cnst(const elem* e) { return e.Eoper == OPconst; }
  */
 
 @trusted
-private elem * cgel_lvalue(elem *e)
+private elem* cgel_lvalue(elem* e)
 {
     //printf("cgel_lvalue()\n"); elem_print(e);
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (e1.Eoper == OPbit)
     {
-        elem *e11 = e1.E1;
+        elem* e11 = e1.E1;
 
         if (e11.Eoper == OPcomma)
         {
@@ -125,7 +125,7 @@ private elem * cgel_lvalue(elem *e)
  */
 
 @trusted
-private elem * elscancommas(elem *e)
+private elem* elscancommas(elem* e)
 {
     while (e.Eoper == OPcomma
            || e.Eoper == OPinfo
@@ -139,7 +139,7 @@ private elem * elscancommas(elem *e)
  *    true if elem is the constant 1.
  */
 
-int elemisone(elem *e)
+int elemisone(elem* e)
 {
     if (e.Eoper == OPconst)
     {
@@ -204,7 +204,7 @@ nomatch:
  * Returns: true if elem is the constant -1.
  */
 
-int elemisnegone(elem *e)
+int elemisnegone(elem* e)
 {
     if (e.Eoper == OPconst)
     {
@@ -281,12 +281,12 @@ OPER swaprel(OPER op)
  * Replace e1 by t=e1, replace e2 by t.
  */
 
-private void fixside(elem **pe1,elem **pe2)
+private void fixside(elem** pe1,elem** pe2)
 {
     const tym = (*pe1).Ety;
-    elem *tmp = el_alloctmp(tym);
+    elem* tmp = el_alloctmp(tym);
     *pe1 = el_bin(OPeq,tym,tmp,*pe1);
-    elem *e2 = el_copytree(tmp);
+    elem* e2 = el_copytree(tmp);
     el_free(*pe2);
     *pe2 = e2;
 }
@@ -307,7 +307,7 @@ private int cost(const elem* n) { return opcost[n.Eoper]; }
  */
 
 @trusted
-private int fcost(const elem *e)
+private int fcost(const elem* e)
 {
     int cost;
 
@@ -358,7 +358,7 @@ private int fcost(const elem *e)
  */
 
 @trusted
-private elem *fixconvop(elem *e)
+private elem* fixconvop(elem* e)
 {
     static immutable ubyte[CNVOPMAX - CNVOPMIN + 1] invconvtab =
     [
@@ -410,7 +410,7 @@ private elem *fixconvop(elem *e)
     const cop = e.E1.Eoper;             /* the conversion operator      */
     assert(cop <= CNVOPMAX);
 
-    elem *econv = e.E1;
+    elem* econv = e.E1;
     while (OTconv(econv.Eoper))
     {
         if (econv.E1.Eoper != OPcomma)
@@ -422,7 +422,7 @@ private elem *fixconvop(elem *e)
          *   =>                 many:    =>
          * a, (conv(b) op= e2)         a, (conv(conv(b)) op= e2)
          */
-        elem *ecomma = econv.E1;
+        elem* ecomma = econv.E1;
         econv.E1 = ecomma.E2;
         econv.E1.Ety = ecomma.Ety;
         ecomma.E2 = e;
@@ -434,7 +434,7 @@ private elem *fixconvop(elem *e)
 
     if (e.E1.Eoper == OPd_f && OTconv(e.E1.E1.Eoper) && tyintegral(tyme))
     {
-        elem *e1 = e.E1;
+        elem* e1 = e.E1;
         e.E1 = e1.E1;
         e.E2 = el_una(OPf_d, e.E1.Ety, e.E2);
         e1.E1 = null;
@@ -445,9 +445,9 @@ private elem *fixconvop(elem *e)
     tym_t tycop = e.E1.Ety;
     tym_t tym = e.E1.E1.Ety;
     e.E1 = el_selecte1(e.E1);     /* dump it for now              */
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     e1.Ety = tym;
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     assert(e1 && e2);
     /* select inverse conversion operator   */
     const icop = invconvtab[convidx(cop)];
@@ -470,7 +470,7 @@ private elem *fixconvop(elem *e)
     /* Oh well, just split up the op and the =.                     */
     const op = opeqtoop(e.Eoper); // convert op= to op
     e.Eoper = OPeq;                  // just plain =
-    elem *ed = el_copytree(e1);       // duplicate e1
+    elem* ed = el_copytree(e1);       // duplicate e1
                                       // make: e1 = (icop) ((cop) ed op e2)
     e.E2 = el_una(icop,e1.Ety,
                              el_bin(op,tycop,el_una(cop,tycop,ed),
@@ -511,8 +511,8 @@ private elem *fixconvop(elem *e)
 
     // Handle case of multiple conversion operators on lvalue
     // (such as (intdbl 8int char += double))
-    elem *ex = e;
-    elem **pe = &e;
+    elem* ex = e;
+    elem** pe = &e;
     while (OTconv(ed.Eoper))
     {
         const uint copx = ed.Eoper;
@@ -551,7 +551,7 @@ private elem *fixconvop(elem *e)
      */
     if (ed.Eoper == OPind)
     {
-        elem *T = el_alloctmp(ed.E1.Ety);    // make temporary
+        elem* T = el_alloctmp(ed.E1.Ety);    // make temporary
         ed.E1 = el_bin(OPeq,T.Ety,T,ed.E1); // ed: *(T=e)
         el_free(e1.E1);
         e1.E1 = el_copytree(T);
@@ -561,7 +561,7 @@ private elem *fixconvop(elem *e)
     return e;
 }
 
-private elem * elerr(elem *e, Goal goal)
+private elem* elerr(elem* e, Goal goal)
 {
     debug elem_print(e);
     assert(0);
@@ -569,7 +569,7 @@ private elem * elerr(elem *e, Goal goal)
 
 /* For ops with no optimizations */
 
-private elem * elzot(elem *e, Goal goal)
+private elem* elzot(elem* e, Goal goal)
 {
     return e;
 }
@@ -577,7 +577,7 @@ private elem * elzot(elem *e, Goal goal)
 /****************************
  */
 
-private elem * elstring(elem *e, Goal goal)
+private elem* elstring(elem* e, Goal goal)
 {
     return e;
 }
@@ -591,7 +591,7 @@ private elem * elstring(elem *e, Goal goal)
 @trusted
 private void eltonear(ref elem* pe)
 {
-    elem *e = pe;
+    elem* e = pe;
     const tym_t ty = e.E1.Ety;
     e = el_selecte1(e);
     e.Ety = ty;
@@ -602,7 +602,7 @@ private void eltonear(ref elem* pe)
  */
 
 @trusted
-private elem * elstrcpy(elem *e, Goal goal)
+private elem* elstrcpy(elem* e, Goal goal)
 {
     elem_debug(e);
     switch (e.E2.Eoper)
@@ -619,7 +619,7 @@ private elem * elstrcpy(elem *e, Goal goal)
             /* Replace strcpy(e1,"string") with memcpy(e1,"string",sizeof("string")) */
             // As streq
             e.Eoper = OPstreq;
-            type *t = type_allocn(TYarray, tstypes[TYchar]);
+            type* t = type_allocn(TYarray, tstypes[TYchar]);
             t.Tdim = strlen(e.E2.Vstring) + 1;
             e.ET = t;
             t.Tcount++;
@@ -642,7 +642,7 @@ private elem * elstrcpy(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elstrcmp(elem *e, Goal goal)
+private elem* elstrcmp(elem* e, Goal goal)
 {
     elem_debug(e);
     if (OPTIMIZER)
@@ -675,7 +675,7 @@ private elem * elstrcmp(elem *e, Goal goal)
  */
 @trusted
 
-private elem * elmemcmp(elem *e, Goal goal)
+private elem* elmemcmp(elem* e, Goal goal)
 {
     elem_debug(e);
     if (!OPTIMIZER)
@@ -724,7 +724,7 @@ private elem * elmemcmp(elem *e, Goal goal)
         }
     }
 
-    elem *ex = e.E1;
+    elem* ex = e.E1;
     if (ex.E1.Eoper == OPnp_fp)
         eltonear(ex.E1);
     if (ex.E2.Eoper == OPnp_fp)
@@ -738,12 +738,12 @@ private elem * elmemcmp(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elmemset(elem *e, Goal goal)
+private elem* elmemset(elem* e, Goal goal)
 {
     //printf("elmemset()\n");
     elem_debug(e);
 
-    elem *ex = e.E1;
+    elem* ex = e.E1;
     if (ex.Eoper == OPnp_fp)
     {
         eltonear(ex);
@@ -751,13 +751,13 @@ private elem * elmemset(elem *e, Goal goal)
     }
 
     // lvalue OPmemset (nelems param value)
-    elem *enelems = e.E2.E1;
-    elem *evalue = e.E2.E2;
+    elem* enelems = e.E2.E1;
+    elem* evalue = e.E2.E2;
 
     if (!(enelems.Eoper == OPconst && evalue.Eoper == OPconst && REGSIZE >= 4))
         return e;
 
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
 
     if (e1.Eoper == OPcomma || OTassign(e1.Eoper))
         return cgel_lvalue(e);    // replace ((e,v) memset e2) with (e,(v memset e2))
@@ -841,12 +841,12 @@ private elem * elmemset(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elmemcpy(elem *e, Goal goal)
+private elem* elmemcpy(elem* e, Goal goal)
 {
     elem_debug(e);
     if (OPTIMIZER)
     {
-        elem *ex = e.E1;
+        elem* ex = e.E1;
         if (ex.Eoper == OPnp_fp)
             eltonear(e.E1);
         ex = e.E2;
@@ -865,7 +865,7 @@ private elem * elmemcpy(elem *e, Goal goal)
             }
             // Convert OPmemcpy to OPstreq
             e.Eoper = OPstreq;
-            type *t = type_allocn(TYarray, tstypes[TYchar]);
+            type* t = type_allocn(TYarray, tstypes[TYchar]);
             t.Tdim = cast(uint)el_tolong(ex.E2);
             e.ET = t;
             t.Tcount++;
@@ -907,15 +907,15 @@ private elem * elmemcpy(elem *e, Goal goal)
  */
 
 @trusted
-private elem * eladd(elem *e, Goal goal)
+private elem* eladd(elem* e, Goal goal)
 {
     //printf("eladd(%p)\n",e);
     targ_size_t ptrmask = ~cast(targ_size_t)0;
     if (_tysize[TYnptr] <= 4)
         ptrmask = 0xFFFFFFFF;
 L1:
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     if (e2.Eoper == OPconst)
     {
         if (e1.Eoper == OPrelconst && e1.Vsym.Sfl == FL.got)
@@ -1077,7 +1077,7 @@ L1:
  */
 
 @trusted
-private elem * elmul(elem *e, Goal goal)
+private elem* elmul(elem* e, Goal goal)
 {
     tym_t tym = e.Ety;
 
@@ -1092,12 +1092,12 @@ private elem * elmul(elem *e, Goal goal)
         }
     }
 
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     if (e2.Eoper == OPconst)           // try to replace multiplies with shifts
     {
         if (OPTIMIZER)
         {
-            elem *e1 = e.E1;
+            elem* e1 = e.E1;
             uint op1 = e1.Eoper;
 
             if (tyintegral(tym) &&              // skip floating types
@@ -1176,14 +1176,14 @@ Lneg:
  */
 
 @trusted
-private elem * elmin(elem *e, Goal goal)
+private elem* elmin(elem* e, Goal goal)
 {
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
 
     if (OPTIMIZER)
     {
         tym_t tym = e.Ety;
-        elem *e1 = e.E1;
+        elem* e1 = e.E1;
         if (e2.Eoper == OPrelconst)
         {
             if (e1.Eoper == OPrelconst && e1.Vsym == e2.Vsym)
@@ -1264,7 +1264,7 @@ private elem * elmin(elem *e, Goal goal)
             e.Eoper = OPadd;
             e1.Eoper = OPmin;
             e2.Eoper = OPmin;
-            elem *tmp = e1.E2;
+            elem* tmp = e1.E2;
             e1.E2 = e2.E1;
             e2.E1 = tmp;
             return optelem(e, Goal.value);
@@ -1303,10 +1303,10 @@ private elem * elmin(elem *e, Goal goal)
 
     if (I16 && tybasic(e2.Ety) == TYhptr && tybasic(e.E1.Ety) == TYhptr)
     {   // Convert to _aNahdiff(e1,e2)
-        __gshared Symbol *hdiff;
+        __gshared Symbol* hdiff;
         if (!hdiff)
         {
-            Symbol *s = symbol_calloc(LARGECODE ? "_aFahdiff" : "_aNahdiff");
+            Symbol* s = symbol_calloc(LARGECODE ? "_aFahdiff" : "_aNahdiff");
             s.Stype = tsclib;
             s.Sclass = SC.extern_;
             s.Sfl = FL.func;
@@ -1340,12 +1340,12 @@ private elem * elmin(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elbitwise(elem *e, Goal goal)
+private elem* elbitwise(elem* e, Goal goal)
 {
     //printf("elbitwise(e = %p, goal = x%x)\n", e, goal);
 
-    elem *e2 = e.E2;
-    elem *e1 = e.E1;
+    elem* e2 = e.E2;
+    elem* e1 = e.E1;
     const op = e1.Eoper;
     uint sz = tysize(e2.Ety);
 
@@ -1383,7 +1383,7 @@ private elem * elbitwise(elem *e, Goal goal)
                 if (ul == 0xFFFF && e.Eoper == OPand && (op == OPshr || op == OPashr) &&
                     e1.E2.Eoper == OPconst && el_tolong(e1.E2) == 16)
                 {
-                    elem *e11 = e1.E1;
+                    elem* e11 = e1.E1;
                     e11.Ety = touns(e11.Ety) | (e11.Ety & ~mTYbasic);
                     goto L1;
                 }
@@ -1423,7 +1423,7 @@ private elem * elbitwise(elem *e, Goal goal)
                 if (OPTIMIZER && i == 0xFF && e.Eoper == OPand &&
                     (op == OPshr || op == OPashr) && e1.E2.Eoper == OPconst && e1.E2.Vint == 8)
                 {
-                    elem *e11 = e1.E1;
+                    elem* e11 = e1.E1;
                     e11.Ety = touns(e11.Ety) | (e11.Ety & ~mTYbasic);
                     goto L1;
                 }
@@ -1566,9 +1566,9 @@ private elem * elbitwise(elem *e, Goal goal)
         (sz == 4 || sz == 8))
     {
         /* These should all compile to a BT instruction when -O, for -m32 and -m64
-         * int bt32(uint *p, uint b) { return ((p[b >> 5] & (1 << (b & 0x1F)))) != 0; }
-         * int bt64a(ulong *p, uint b) { return ((p[b >> 6] & (1L << (b & 63)))) != 0; }
-         * int bt64b(ulong *p, size_t b) { return ((p[b >> 6] & (1L << (b & 63)))) != 0; }
+         * int bt32(uint* p, uint b) { return ((p[b >> 5] & (1 << (b & 0x1F)))) != 0; }
+         * int bt64a(ulong* p, uint b) { return ((p[b >> 6] & (1L << (b & 63)))) != 0; }
+         * int bt64b(ulong* p, size_t b) { return ((p[b >> 6] & (1L << (b & 63)))) != 0; }
          */
 
         static bool ELCONST(elem* e, long c) { return e.Eoper == OPconst && el_tolong(e) == c; }
@@ -1585,8 +1585,8 @@ private elem * elbitwise(elem *e, Goal goal)
          * with:
          *  p bt b
          */
-        elem *e12;              // the (b & 31), which may be preceded by (64_32)
-        elem *e2111;            // the (b >>> 5), which may be preceded by (u32_64)
+        elem* e12;              // the (b & 31), which may be preceded by (64_32)
+        elem* e2111;            // the (b >>> 5), which may be preceded by (u32_64)
         if (e1.Eoper == OPshl &&
             ELCONST(e1.E1,1) &&
             (((e12 = e1.E2).Eoper == OP64_32 ? (e12 = e12.E1) : e12).Eoper == OPand) &&
@@ -1601,9 +1601,9 @@ private elem * elbitwise(elem *e, Goal goal)
             ELCONST(e2111.E2,pow2sz + 3)
            )
         {
-            elem **pb1 = &e12.E1;
-            elem **pb2 = &e2111.E1;
-            elem **pp  = &e2.E1.E2;
+            elem** pb1 = &e12.E1;
+            elem** pb2 = &e2111.E1;
+            elem** pp  = &e2.E1.E2;
 
             if (el_match(*pb1, *pb2) &&
                 !el_sideeffect(*pb1) &&
@@ -1705,14 +1705,14 @@ bool fillinops(elem*[] ops, ref size_t opsi, OPER oper, elem* e)
  */
 
 @trusted
-private elem *elor(elem *e, Goal goal)
+private elem* elor(elem* e, Goal goal)
 {
     //printf("elor()\n");
     /* ROL:     (a << shift) | (a >> (sizeof(a) * 8 - shift))
      * ROR:     (a >> shift) | (a << (sizeof(a) * 8 - shift))
      */
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     uint sz = tysize(e.Ety);
     if (sz <= REGSIZE)
     {
@@ -1865,13 +1865,13 @@ private elem *elor(elem *e, Goal goal)
         size_t opsi = 0;
         if (fillinops(ops, opsi, OPor, e) && opsi == ops.length)
         {
-            elem *ex = null;
+            elem* ex = null;
             uint bmask = 0;
             foreach (eo; ops)
             {
-                elem *eo2;
+                elem* eo2;
                 int shift;
-                elem *eo111;
+                elem* eo111;
                 if (eo.Eoper == OPu8_16 &&
                     eo.E1.Eoper == OPind)
                 {
@@ -1900,7 +1900,7 @@ private elem *elor(elem *e, Goal goal)
                     goto L1;
 
                 uint off;
-                elem *ed;
+                elem* ed;
                 if (eo111.Eoper == OPadd)
                 {
                     ed = eo111.E1;
@@ -1964,12 +1964,12 @@ private elem *elor(elem *e, Goal goal)
  */
 
 @trusted
-private elem *elxor(elem *e, Goal goal)
+private elem* elxor(elem* e, Goal goal)
 {
     if (OPTIMIZER)
     {
-        elem *e1 = e.E1;
-        elem *e2 = e.E2;
+        elem* e1 = e.E1;
+        elem* e2 = e.E2;
 
         /* Recognize:
          *    (a & c) ^ (b & c)  =>  (a ^ b) & c
@@ -2001,9 +2001,9 @@ private elem *elxor(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elnot(elem *e, Goal goal)
+private elem* elnot(elem* e, Goal goal)
 {
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     const op = e1.Eoper;
     switch (op)
     {
@@ -2078,9 +2078,9 @@ private elem * elnot(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elcom(elem *e, Goal goal)
+private elem* elcom(elem* e, Goal goal)
 {
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (e1.Eoper == OPcom)                       // ~ ~ e => e
         // Typing problem here
         e = el_selecte1(el_selecte1(e));
@@ -2095,11 +2095,11 @@ private elem * elcom(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elcond(elem *e, Goal goal)
+private elem* elcond(elem* e, Goal goal)
 {
     //printf("elcond() goal = %d\n", goal);
     //elem_print(e);
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     switch (e1.Eoper)
     {
         case OPconst:
@@ -2128,7 +2128,7 @@ private elem * elcond(elem *e, Goal goal)
         case OPnot:
         {
             // (!a ? b : c) => (a ? c : b)
-            elem *ex = e.E2.E1;
+            elem* ex = e.E2.E1;
             e.E2.E1 = e.E2.E2;
             e.E2.E2 = ex;
             goto L2;
@@ -2148,8 +2148,8 @@ private elem * elcond(elem *e, Goal goal)
 
         {
             tym_t ty = e.Ety;
-            elem *ec1 = e.E2.E1;
-            elem *ec2 = e.E2.E2;
+            elem* ec1 = e.E2.E1;
+            elem* ec2 = e.E2.E2;
 
             if (tyintegral(ty) && ec1.Eoper == OPconst && ec2.Eoper == OPconst)
             {
@@ -2426,16 +2426,16 @@ private elem* findPointer(elem* e)
  */
 
 @trusted
-private elem * elcomma(elem *e, Goal goal)
+private elem* elcomma(elem* e, Goal goal)
 {
     int changes = -1;
 L1:
     changes++;
 L2:
     //printf("elcomma()\n");
-    elem *e2 = e.E2;
-    elem **pe1 = &(e.E1);
-    elem *e1 = *pe1;
+    elem* e2 = e.E2;
+    elem** pe1 = &(e.E1);
+    elem* e1 = *pe1;
     int e1op = e1.Eoper;
 
   // c,e => e
@@ -2532,7 +2532,7 @@ L2:
             if ((OTopeq(e2.Eoper)) &&
                 el_match(e1.E1,e2.E1))
             {
-                elem *ex;
+                elem* ex;
                 e.E1 = el_long(TYint,0);
                 e1.Eoper = cast(ubyte)opeqtoop(e1op);
                 e2.E2 = el_bin(opeqtoop(e2.Eoper),e2.Ety,e1,e2.E2);
@@ -2550,7 +2550,7 @@ Lret:
 /********************************
  */
 
-private elem * elremquo(elem *e, Goal goal)
+private elem* elremquo(elem* e, Goal goal)
 {
     static if (0)
     if (cnst(e.E2) && !boolres(e.E2))
@@ -2563,7 +2563,7 @@ private elem * elremquo(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elmod(elem *e, Goal goal)
+private elem* elmod(elem* e, Goal goal)
 {
     tym_t tym = e.E1.Ety;
     if (!tyfloating(tym))
@@ -2577,10 +2577,10 @@ private elem * elmod(elem *e, Goal goal)
  */
 
 @trusted
-private elem * eldiv(elem *e, Goal goal)
+private elem* eldiv(elem* e, Goal goal)
 {
     //printf("eldiv()\n");
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     tym_t tym = e.E1.Ety;
     int uns = tyuns(tym) | tyuns(e2.Ety);
     if (cnst(e2))
@@ -2631,7 +2631,7 @@ private elem * eldiv(elem *e, Goal goal)
     {
         const int SQRT_INT_MAX = 0xB504;
         const uint SQRT_UINT_MAX = 0x10000;
-        elem *e1 = e.E1;
+        elem* e1 = e.E1;
         if (tyintegral(tym) && e.Eoper == OPdiv && e2.Eoper == OPconst &&
             e1.Eoper == OPdiv && e1.E2.Eoper == OPconst)
         {
@@ -2670,7 +2670,7 @@ private elem * eldiv(elem *e, Goal goal)
              * With:
              *   e / (c1 * c2)
              */
-            elem *erq = e1.E1;
+            elem* erq = e1.E1;
             targ_llong c1 = el_tolong(erq.E2);
             targ_llong c2 = el_tolong(e2);
             bool uns1 = tyuns(erq.E1.Ety) || tyuns(erq.E2.Ety);
@@ -2752,20 +2752,20 @@ private elem * eldiv(elem *e, Goal goal)
  */
 
 @trusted
-private elem * swaplog(elem *e, Goal goal)
+private elem* swaplog(elem* e, Goal goal)
 {
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     e.E1 = e1.E2;
     e1.E2 = e;
     return optelem(e1,goal);
 }
 
 @trusted
-private elem * eloror(elem *e, Goal goal)
+private elem* eloror(elem* e, Goal goal)
 {
     tym_t ty1,ty2;
 
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (OTboolnop(e1.Eoper))
     {
         e.E1 = e1.E1;
@@ -2774,7 +2774,7 @@ private elem * eloror(elem *e, Goal goal)
         return eloror(e, goal);
     }
 
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     if (OTboolnop(e2.Eoper))
     {
         e.E2 = e2.E1;
@@ -2890,7 +2890,7 @@ private bool optim_loglog(ref elem* pe)
 {
     if (I16 || config.target_cpu == TARGET_AArch64)
         return false;
-    elem *e = pe;
+    elem* e = pe;
     const op = e.Eoper;
     assert(op == OPandand || op == OPoror);
     size_t n = el_opN(e, op);
@@ -2903,7 +2903,7 @@ private bool optim_loglog(ref elem* pe)
     auto sb = SmallBuffer!(elem*)(n, tmp[]);
     elem*[] array = sb[];
 
-    elem **p = array.ptr;
+    elem** p = array.ptr;
     el_opArray(&p, e, op);
 
     bool any = false;
@@ -2912,7 +2912,7 @@ private bool optim_loglog(ref elem* pe)
     int cmpop = op == OPandand ? OPne : OPeqeq;
     for (size_t i = 0; i < n; ++i)
     {
-        elem *eq = array[i];
+        elem* eq = array[i];
         if (eq.Eoper == cmpop &&
             eq.E2.Eoper == OPconst &&
             tyintegral(eq.E2.Ety) &&
@@ -2987,7 +2987,7 @@ private bool optim_loglog(ref elem* pe)
         targ_ullong bits = 0;
         for (size_t i = first; i <= last; ++i)
         {
-            elem *eq = array[i];
+            elem* eq = array[i];
             if (0 && eq.E2.Eoper != OPconst)
             {
                 printf("eq = %p, eq.E2 = %p\n", eq, eq.E2);
@@ -3005,9 +3005,9 @@ private bool optim_loglog(ref elem* pe)
 
         uint tyc = array[first].E1.Ety;
 
-        elem *ex = el_bin(OPmin, tyc, array[first].E1, el_long(tyc,emin));
+        elem* ex = el_bin(OPmin, tyc, array[first].E1, el_long(tyc,emin));
         ex = el_bin(op == OPandand ? OPgt : OPle, TYbool, ex, el_long(touns(tyc), emax - emin));
-        elem *ey = el_bin(OPmin, tyc, array[first + 1].E1, el_long(tyc,emin));
+        elem* ey = el_bin(OPmin, tyc, array[first + 1].E1, el_long(tyc,emin));
 
         tym_t tybits = TYuint;
         if ((emax - emin) >= 32)
@@ -3063,9 +3063,9 @@ private bool optim_loglog(ref elem* pe)
 }
 
 @trusted
-private elem * elandand(elem *e, Goal goal)
+private elem* elandand(elem* e, Goal goal)
 {
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (OTboolnop(e1.Eoper))
     {
         e.E1 = e1.E1;
@@ -3073,7 +3073,7 @@ private elem * elandand(elem *e, Goal goal)
         el_free(e1);
         return elandand(e, goal);
     }
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     if (OTboolnop(e2.Eoper))
     {
         e.E2 = e2.E1;
@@ -3116,7 +3116,7 @@ private elem * elandand(elem *e, Goal goal)
             e1.E1.E2.Eoper == OPconst)
         {
             // Replace (e >>> c) with (e & x)
-            elem *e11 = e1.E1;
+            elem* e11 = e1.E1;
 
             targ_ullong shift = el_tolong(e11.E2);
             if (shift < _tysize[TYint] * 8)
@@ -3215,11 +3215,11 @@ L1:
  */
 
 @trusted
-private elem * elbit(elem *e, Goal goal)
+private elem* elbit(elem* e, Goal goal)
 {
     tym_t tym1 = e.E1.Ety;
     uint sz = tysize(tym1) * 8;
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     uint wb = e2.Vuns;
 
     uint w = (wb >> 8) & 0xFF;               // width in bits of field
@@ -3279,10 +3279,10 @@ private elem * elbit(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elind(elem *e, Goal goal)
+private elem* elind(elem* e, Goal goal)
 {
     tym_t tym = e.Ety;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     switch (e1.Eoper)
     {
         case OPrelconst:
@@ -3295,7 +3295,7 @@ private elem * elind(elem *e, Goal goal)
         case OPadd:
             if (OPTIMIZER)
             {   /* Try to convert far pointer to stack pointer  */
-                elem *e12 = e1.E2;
+                elem* e12 = e1.E2;
 
                 if (e12.Eoper == OPrelconst &&
                     tybasic(e12.Ety) == TYfptr &&
@@ -3310,7 +3310,7 @@ private elem * elind(elem *e, Goal goal)
         case OPcomma:
             // Replace (*(ea,eb)) with (ea,*eb)
             e.E1.ET = e.ET;
-            type *t = e.ET;
+            type* t = e.ET;
             e = el_selecte1(e);
             e.Ety = tym;
             e.E2 = el_una(OPind,tym,e.E2);
@@ -3333,10 +3333,10 @@ private elem * elind(elem *e, Goal goal)
  */
 
 @trusted
-private elem * eladdr(elem *e, Goal goal)
+private elem* eladdr(elem* e, Goal goal)
 {
     tym_t tym = e.Ety;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     elem_debug(e1);
     switch (e1.Eoper)
     {
@@ -3397,7 +3397,7 @@ private elem * eladdr(elem *e, Goal goal)
                 else if (e1.E1.Eoper == OPind)
                 {
                     const tym_t tym111 = e1.E1.E1.Ety;
-                    elem *tmp = el_alloctmp(tym111);
+                    elem* tmp = el_alloctmp(tym111);
                     e1.E1.E1 = el_bin(OPeq,tym111,tmp,e1.E1.E1);
                     e.Eoper = OPcomma;
                     e.E2 = el_copytree(tmp);
@@ -3408,7 +3408,7 @@ private elem * eladdr(elem *e, Goal goal)
 
         case OPcond:
         {   // Replace &(x ? y : z) with (x ? &y : &z)
-            elem *ecolon = e1.E2;
+            elem* ecolon = e1.E2;
             ecolon.Ety = tym;
             ecolon.E1 = el_una(OPaddr,tym,ecolon.E1);
             ecolon.E2 = el_una(OPaddr,tym,ecolon.E2);
@@ -3431,7 +3431,7 @@ private elem * eladdr(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elneg(elem *e, Goal goal)
+private elem* elneg(elem* e, Goal goal)
 {
     if (e.E1.Eoper == OPneg)
     {
@@ -3454,7 +3454,7 @@ private elem * elneg(elem *e, Goal goal)
 }
 
 @trusted
-private elem * elcall(elem *e, Goal goal)
+private elem* elcall(elem* e, Goal goal)
 {
     if (e.E1.Eoper == OPcomma || OTassign(e.E1.Eoper))
         e = cgel_lvalue(e);
@@ -3466,7 +3466,7 @@ private elem * elcall(elem *e, Goal goal)
  */
 
 @trusted
-private void elstructwalk(elem *e,tym_t tym)
+private void elstructwalk(elem* e,tym_t tym)
 {
     tym_t ety;
 
@@ -3500,7 +3500,7 @@ private void elstructwalk(elem *e,tym_t tym)
  */
 
 @trusted
-elem * elstruct(elem *e, Goal goal)
+elem* elstruct(elem* e, Goal goal)
 {
     //printf("elstruct(%p)\n", e);
     //elem_print(e);
@@ -3515,7 +3515,7 @@ elem * elstruct(elem *e, Goal goal)
         e.E2.Ety = e.Ety;
         e.E2.ET = e.ET;
         e.Eoper = OPcomma;
-        elem *etmp = e.E1;
+        elem* etmp = e.E1;
         e.E1 = e.E2.E1;
         e.E2.E1 = etmp;
         return optelem(e, goal);
@@ -3532,15 +3532,15 @@ elem * elstruct(elem *e, Goal goal)
         return e;
     //printf("\tnumbytes = %d\n", cast(int)type_size(e.ET));
 
-    type *t = e.ET;
+    type* t = e.ET;
     tym_t tym = ~0;
     tym_t ty = tybasic(t.Tty);
 
     uint sz = (e.Eoper == OPstrpar && type_zeroSize(t, global_tyf)) ? 0 : cast(uint)type_size(t);
     //printf("\tsz = %d\n", cast(int)sz);
 
-    type *targ1 = null;
-    type *targ2 = null;
+    type* targ1 = null;
+    type* targ2 = null;
     if (ty == TYstruct)
     {   // If a struct is a wrapper for another type, prefer that other type
         targ1 = t.Ttag.Sstruct.Sarg1type;
@@ -3660,7 +3660,7 @@ elem * elstruct(elem *e, Goal goal)
                     {
                         // we can't optimize OPstreq in this case,
                         // there will be memory corruption in the assignment
-                        elem *e2 = e.E2;
+                        elem* e2 = e.E2;
                         if (e2.Eoper != OPvar && e2.Eoper != OPind)
                         {
                             // the source may come in registers. ex: returned from a function.
@@ -3722,7 +3722,7 @@ elem * elstruct(elem *e, Goal goal)
                 e = en;
                 break;
             }
-            elem **pe2;
+            elem** pe2;
             if (e.Eoper == OPstreq)
                 pe2 = &e.E2;
             else if (e.Eoper == OPstrpar)
@@ -3730,7 +3730,7 @@ elem * elstruct(elem *e, Goal goal)
             else
                 break;
             pe2 = el_scancommas(pe2);
-            elem *e2 = *pe2;
+            elem* e2 = *pe2;
 
             if (e2.Eoper == OPvar)
                 e2.Vsym.Sflags &= ~GTregcand;
@@ -3785,10 +3785,10 @@ elem * elstruct(elem *e, Goal goal)
  */
 
 @trusted
-private elem * eleq(elem *e, Goal goal)
+private elem* eleq(elem* e, Goal goal)
 {
     Goal wantres = goal;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
 
     if (e1.Eoper == OPcomma || OTassign(e1.Eoper))
         return cgel_lvalue(e);
@@ -3809,11 +3809,11 @@ static if (0)  // Doesn't work too well, removed
 
     if (OPTIMIZER)
     {
-        elem *e2 = e.E2;
+        elem* e2 = e.E2;
         int op2 = e2.Eoper;
 
         // Replace (e1 = *p++) with (e1 = *p, p++, e1)
-        elem *ei = e2;
+        elem* ei = e2;
         if (e1.Eoper == OPvar &&
             (op2 == OPind || (OTunary(op2) && (ei = e2.E1).Eoper == OPind)) &&
             (ei.E1.Eoper == OPpostinc || ei.E1.Eoper == OPpostdec) &&
@@ -3903,7 +3903,7 @@ static if (0)  // Doesn't work too well, removed
         // Replace (x = (y ? z : x)) with ((y && (x = z)),x)
         if (op2 == OPcond && el_match(e1,e2.E2.E2))
         {
-            elem *e22 = e2.E2;         // e22 is the OPcond
+            elem* e22 = e2.E2;         // e22 is the OPcond
             e.Eoper = OPcomma;
             e.E2 = e1;
             e.E1 = e2;
@@ -3920,7 +3920,7 @@ static if (0)  // Doesn't work too well, removed
         // Replace (x = (y ? x : z)) with ((y || (x = z)),x)
         if (op2 == OPcond && el_match(e1,e2.E2.E1))
         {
-            elem *e22 = e2.E2;         // e22 is the OPcond
+            elem* e22 = e2.E2;         // e22 is the OPcond
             e.Eoper = OPcomma;
             e.E2 = e1;
             e.E1 = e2;
@@ -3997,7 +3997,7 @@ static if (0)  // Doesn't work too well, removed
             e2.Ety = ty;
             e.Ety = ty;
             e1.Ety = ty;
-            elem *eb = el_copytree(e1);
+            elem* eb = el_copytree(e1);
             eb.Voffset += REGSIZE;
 
             if (e2.Eoper == OPpair)
@@ -4034,7 +4034,7 @@ static if (0)  // Doesn't work too well, removed
             e.Ety = ty;
             e1.Ety = ty;
 
-            elem *eb = el_copytree(e);
+            elem* eb = el_copytree(e);
             eb.E1.Voffset += REGSIZE;
             eb.E2.Voffset += REGSIZE;
 
@@ -4051,17 +4051,17 @@ static if (0)  // Doesn't work too well, removed
         return cgel_lvalue(e);
 
     uint t = e.Ety;
-    elem *l = e1.E1;                           // lvalue
-    elem *r = e.E2;
+    elem* l = e1.E1;                           // lvalue
+    elem* r = e.E2;
     tym_t tyl = l.Ety;
     uint sz = tysize(tyl) * 8;
     uint w = (e1.E2.Vuns >> 8);        // width in bits of field
     targ_ullong m = (cast(targ_ullong)1 << w) - 1;  // mask w bits wide
     uint b = e1.E2.Vuns & 0xFF;        // bits to shift
 
-    elem *l2;
-    elem *r2;
-    elem *eres =  el_bin(OPeq,t,
+    elem* l2;
+    elem* r2;
+    elem* eres =  el_bin(OPeq,t,
                 l,
                 el_bin(OPor,t,
                         el_bin(OPshl,t,
@@ -4080,8 +4080,8 @@ static if (0)  // Doesn't work too well, removed
     if (wantres)
     {
         uint c;
-        elem **pe;
-        elem *e2;
+        elem** pe;
+        elem* e2;
 
         r = el_copytree(r);
         if (tyuns(tyl))                 /* uint bit field           */
@@ -4112,7 +4112,7 @@ static if (0)  // Doesn't work too well, removed
 /**********************************
  */
 
-private elem * elnegass(elem *e, Goal goal)
+private elem* elnegass(elem* e, Goal goal)
 {
     e = cgel_lvalue(e);
     return e;
@@ -4147,9 +4147,9 @@ private elem * elnegass(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elopass(elem *e, Goal goal)
+private elem* elopass(elem* e, Goal goal)
 {
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (OTconv(e1.Eoper))
     {   e = fixconvop(e);
         return optelem(e, Goal.value);
@@ -4165,9 +4165,9 @@ private elem * elopass(elem *e, Goal goal)
         tym_t t = touns(e.Ety);
 
         assert(tyintegral(t));
-        elem *l = e1.E1;                       // lvalue
+        elem* l = e1.E1;                       // lvalue
         tym_t tyl = l.Ety;
-        elem *r = e.E2;
+        elem* r = e.E2;
         uint w = (e1.E2.Vuns >> 8) & 0xFF; // width in bits of field
         targ_llong m = (cast(targ_llong)1 << w) - 1;    // mask w bits wide
         uint b = e1.E2.Vuns & 0xFF;        // bits to shift
@@ -4249,12 +4249,12 @@ private elem * elopass(elem *e, Goal goal)
                     // Replace r/=c with r=r/c
                     if (tycomplex(e.E2.Ety) && !tycomplex(e1.Ety))
                     {
-                        elem *ed;
+                        elem* ed;
                         e.Eoper = OPeq;
                         if (e1.Eoper == OPind)
                         {   // ed: *(tmp=e1.E1)
                             // e1: *tmp
-                            elem *tmp = el_alloctmp(e1.E1.Ety);
+                            elem* tmp = el_alloctmp(e1.E1.Ety);
                             ed = el_bin(OPeq, tmp.Ety, tmp, e1.E1);
                             e1.E1 = el_copytree(tmp);
                             ed = el_una(OPind, e1.Ety, ed);
@@ -4312,9 +4312,9 @@ private elem * elopass(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elpost(elem *e, Goal goal)
+private elem* elpost(elem* e, Goal goal)
 {
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (e1.Eoper != OPbit)
     {
         if (e1.Eoper == OPcomma || OTassign(e1.Eoper))
@@ -4345,10 +4345,10 @@ private elem * elpost(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elcmp(elem *e, Goal goal)
+private elem* elcmp(elem* e, Goal goal)
 {
-    elem *e2 = e.E2;
-    elem *e1 = e.E1;
+    elem* e2 = e.E2;
+    elem* e1 = e.E1;
 
     //printf("elcmp(%p)\n",e); elem_print(e);
 
@@ -4383,7 +4383,7 @@ private elem * elcmp(elem *e, Goal goal)
         // Convert ((e & 1) == 1) => (e & 1)
         if (op == OPeqeq && e2.Eoper == OPconst && e1.Eoper == OPand)
         {
-            elem *e12 = e1.E2;
+            elem* e12 = e1.E2;
 
             if (e12.Eoper == OPconst && el_tolong(e2) == 1 && el_tolong(e12) == 1)
             {
@@ -4611,7 +4611,7 @@ private elem * elcmp(elem *e, Goal goal)
         else if (OPTIMIZER && e1.Eoper == OPeq &&
                  e1.E2.Eoper == OPconst)
         {    // Convert ((x = c1) rel c2) to ((x = c1),(c1 rel c2)
-             elem *ec = el_copytree(e1.E2);
+             elem* ec = el_copytree(e1.E2);
              ec.Ety = e1.Ety;
              e.E1 = ec;
              e = el_bin(OPcomma,e.Ety,e1,e);
@@ -4647,7 +4647,7 @@ ret:
  */
 
 @trusted
-private elem * elbool(elem *e, Goal goal)
+private elem* elbool(elem* e, Goal goal)
 {
     //printf("elbool()\n");
     elem* e1 = e.E1;
@@ -4787,7 +4787,7 @@ private elem * elbool(elem *e, Goal goal)
                 )
         {
             tym_t ty = e.Ety;
-            elem *ex = e.E1.E1;
+            elem* ex = e.E1.E1;
             ex.Eoper = OPbtst;
             e.E1.E1 = null;
             ex.E1 = e.E1.E2;
@@ -4818,7 +4818,7 @@ private elem * elbool(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elptrlptr(elem *e, Goal goal)
+private elem* elptrlptr(elem* e, Goal goal)
 {
     if (e.E1.Eoper == OPrelconst || e.E1.Eoper == OPstring)
     {
@@ -4833,12 +4833,12 @@ private elem * elptrlptr(elem *e, Goal goal)
  * Conversions of handle pointers to far pointers.
  */
 @trusted
-private elem * elvptrfptr(elem *e, Goal goal)
+private elem* elvptrfptr(elem* e, Goal goal)
 {
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (e1.Eoper == OPadd || e1.Eoper == OPmin)
     {
-        elem *e12 = e1.E2;
+        elem* e12 = e1.E2;
         if (tybasic(e12.Ety) != TYvptr)
         {
             /* Rewrite (vtof(e11 + e12)) to (vtof(e11) + e12)   */
@@ -4862,11 +4862,11 @@ private elem * elvptrfptr(elem *e, Goal goal)
  */
 
 @trusted
-private elem * ellngsht(elem *e, Goal goal)
+private elem* ellngsht(elem* e, Goal goal)
 {
     //printf("ellngsht()\n");
     tym_t ty = e.Ety;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     switch (e1.Eoper)
     {
     case OPs16_32:
@@ -5010,10 +5010,10 @@ private elem * ellngsht(elem *e, Goal goal)
  */
 
 @trusted
-private elem * el64_32(elem *e, Goal goal)
+private elem* el64_32(elem* e, Goal goal)
 {
     tym_t ty = e.Ety;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     switch (e1.Eoper)
     {
     case OPs32_64:
@@ -5032,9 +5032,9 @@ private elem * el64_32(elem *e, Goal goal)
         if (el_sideeffect(e1.E2))
         {
             // Rewrite (OP64_32(a pair b)) as ((t=a),(b,t))
-            elem *a = e1.E1;
-            elem *b = e1.E2;
-            elem *t = el_alloctmp(a.Ety);
+            elem* a = e1.E1;
+            elem* b = e1.E2;
+            elem* t = el_alloctmp(a.Ety);
 
             e.Eoper = OPcomma;
             e.E1 = el_bin(OPeq,a.Ety,t,a);
@@ -5105,9 +5105,9 @@ private elem * el64_32(elem *e, Goal goal)
  */
 
 @trusted
-private elem *elc_r(elem *e, Goal goal)
+private elem* elc_r(elem* e, Goal goal)
 {
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
 
     if (e1.Eoper == OPvar || e1.Eoper == OPind)
     {
@@ -5122,9 +5122,9 @@ private elem *elc_r(elem *e, Goal goal)
  */
 
 @trusted
-private elem *elc_i(elem *e, Goal goal)
+private elem* elc_i(elem* e, Goal goal)
 {
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
 
     if (e1.Eoper == OPvar)
     {
@@ -5148,7 +5148,7 @@ private elem *elc_i(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elbyteint(elem *e, Goal goal)
+private elem* elbyteint(elem* e, Goal goal)
 {
     if (OTlogical(e.E1.Eoper) || e.E1.Eoper == OPbtst)
     {
@@ -5164,7 +5164,7 @@ private elem * elbyteint(elem *e, Goal goal)
  * OPu32_64
  */
 @trusted
-private elem * el32_64(elem *e, Goal goal)
+private elem* el32_64(elem* e, Goal goal)
 {
     if (REGSIZE == 8 && e.E1.Eoper == OPbtst)
     {
@@ -5182,7 +5182,7 @@ private elem * el32_64(elem *e, Goal goal)
  */
 
 @trusted
-private elem *elu64_d(elem *e, Goal goal)
+private elem* elu64_d(elem* e, Goal goal)
 {
     tym_t ty;
     elem** pu;
@@ -5214,10 +5214,10 @@ private elem *elu64_d(elem *e, Goal goal)
          *    u >= 0 ? OPs64_d(u) : OPs64_d((u >> 1) | (u & 1)) * 2
          */
         u.Ety = TYllong;
-        elem *u1 = el_copytree(u);
+        elem* u1 = el_copytree(u);
         if (!OTleaf(u.Eoper))
             fixside(&u, &u1);
-        elem *u2 = el_copytree(u1);
+        elem* u2 = el_copytree(u1);
 
         u = el_bin(OPge, TYint, u, el_long(TYllong, 0));
 
@@ -5247,7 +5247,7 @@ private elem *elu64_d(elem *e, Goal goal)
          *  u < 0 ? OPs64_d(u) : OPs64_d(u) + 0x1p+64
          */
         u.Ety = TYllong;
-        elem *u1 = el_copytree(u);
+        elem* u1 = el_copytree(u);
         if (!OTleaf(u.Eoper))
             fixside(&u, &u1);
 
@@ -5287,11 +5287,11 @@ private elem *elu64_d(elem *e, Goal goal)
  */
 
 @trusted
-private elem *elshl(elem *e, Goal goal)
+private elem* elshl(elem* e, Goal goal)
 {
     tym_t ty = e.Ety;
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
 
     if (e1.Eoper == OPconst && !boolres(e1))             // if e1 is 0
     {
@@ -5323,11 +5323,11 @@ private elem *elshl(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elshr(elem *e, Goal goal)
+private elem* elshr(elem* e, Goal goal)
 {
     tym_t ty = e.Ety;
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
 
     // (x >> 16) replaced with ((shtlng) x+2)
     if (OPTIMIZER &&
@@ -5336,7 +5336,7 @@ private elem * elshr(elem *e, Goal goal)
     {
         if (e1.Eoper == OPvar)
         {
-            Symbol *s = e1.Vsym;
+            Symbol* s = e1.Vsym;
 
             if (s.Sclass != SC.fastpar && s.Sclass != SC.shadowreg)
             {
@@ -5398,10 +5398,10 @@ private elem * elshr(elem *e, Goal goal)
  */
 
 @trusted
-elem *elmsw(elem *e, Goal goal)
+elem* elmsw(elem* e, Goal goal)
 {
     tym_t ty = e.Ety;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
 
     if (OPTIMIZER &&
         tysize(e1.Ety) == LLONGSIZE &&
@@ -5469,10 +5469,10 @@ elem *elmsw(elem *e, Goal goal)
  */
 
 @trusted
-elem *elpair(elem *e, Goal goal)
+elem* elpair(elem* e, Goal goal)
 {
     //printf("elpair()\n");
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (e1.Eoper == OPconst)
     {
         e.E1 = e.E2;
@@ -5486,7 +5486,7 @@ elem *elpair(elem *e, Goal goal)
  * Handle OPddtor
  */
 
-elem *elddtor(elem *e, Goal goal)
+elem* elddtor(elem* e, Goal goal)
 {
     return e;
 }
@@ -5495,7 +5495,7 @@ elem *elddtor(elem *e, Goal goal)
  * Handle OPinfo, OPmark, OPctor, OPdtor
  */
 
-private elem * elinfo(elem *e, Goal goal)
+private elem* elinfo(elem* e, Goal goal)
 {
     //printf("elinfo()\n");
     return e;
@@ -5504,7 +5504,7 @@ private elem * elinfo(elem *e, Goal goal)
 /********************************************
  */
 
-private elem * elclassinit(elem *e, Goal goal)
+private elem* elclassinit(elem* e, Goal goal)
 {
     return e;
 }
@@ -5513,7 +5513,7 @@ private elem * elclassinit(elem *e, Goal goal)
  */
 
 @trusted
-private elem * elvalist(elem *e, Goal goal)
+private elem* elvalist(elem* e, Goal goal)
 {
     assert(e.Eoper == OPva_start);
 
@@ -5534,8 +5534,8 @@ private elem * elvalist(elem *e, Goal goal)
         //elem_print(e);
 
         // Find last named parameter
-        Symbol *lastNamed = null;
-        Symbol *arguments_typeinfo = null;
+        Symbol* lastNamed = null;
+        Symbol* arguments_typeinfo = null;
         foreach (s; globsym[])
         {
             if (s.Sclass == SC.parameter || s.Sclass == SC.regpar)
@@ -5570,7 +5570,7 @@ if (config.exe & EX_windos)
     //elem_print(e);
 
     // Find last named parameter
-    Symbol *lastNamed = null;
+    Symbol* lastNamed = null;
     foreach (s; globsym[])
     {
         if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg || s.Sclass == SC.parameter)
@@ -5598,7 +5598,7 @@ if (config.exe & EX_posix)
     //elem_print(e);
 
     // Find __va_argsave
-    Symbol *va_argsave = null;
+    Symbol* va_argsave = null;
     foreach (s; globsym[])
     {
         if (s.Sident[0] == '_' && strcmp(s.Sident.ptr, "__va_argsave") == 0)
@@ -5629,7 +5629,7 @@ if (config.exe & EX_posix)
  */
 
 @trusted
-private void elparamx(elem *e)
+private void elparamx(elem* e)
 {
     //printf("elparam()\n");
     if (e.E1.Eoper == OPrpair)
@@ -5639,7 +5639,7 @@ private void elparamx(elem *e)
     else if (e.E1.Eoper == OPpair && !el_sideeffect(e.E1))
     {
         e.E1.Eoper = OPparam;
-        elem *ex = e.E1.E2;
+        elem* ex = e.E1.E2;
         e.E1.E2 = e.E1.E1;
         e.E1.E1 = ex;
     }
@@ -5657,7 +5657,7 @@ private void elparamx(elem *e)
             else if (e.E2.Eoper == OPpair)
             {
                 e.E2.Eoper = OPparam;
-                elem *ex = e.E2.E2;
+                elem* ex = e.E2.E2;
                 e.E2.E2 = e.E2.E1;
                 e.E2.E1 = ex;
             }
@@ -5666,7 +5666,7 @@ private void elparamx(elem *e)
 }
 
 @trusted
-private elem * elparam(elem *e, Goal goal)
+private elem* elparam(elem* e, Goal goal)
 {
     if (!OPTIMIZER)
     {
@@ -5686,7 +5686,7 @@ private elem * elparam(elem *e, Goal goal)
  */
 
 @trusted
-private elem * optelem(elem *e, Goal goal)
+private elem* optelem(elem* e, Goal goal)
 {
 beg:
     //__gshared uint count;
@@ -5727,10 +5727,10 @@ beg:
         {
             case OPcomma:
             {
-                elem *e1 = e.E1 = optelem(e.E1, Goal.none);
+                elem* e1 = e.E1 = optelem(e.E1, Goal.none);
 //              if (e1 && !OTsideff(e1.Eoper))
 //                  e1 = e.E1 = optelem(e1, Goal.none);
-                elem *e2 = e.E2 = optelem(e.E2,goal);
+                elem* e2 = e.E2 = optelem(e.E2,goal);
                 if (!e1)
                 {
                     if (!e2)
@@ -5753,7 +5753,7 @@ beg:
             case OPcond:
                 if (!goal)
                 {   // Transform x?y:z into x&&y or x||z
-                    elem *e2 = e.E2;
+                    elem* e2 = e.E2;
                     if (!el_sideeffect(e2.E1))
                     {
                         e.Eoper = OPoror;
@@ -5769,8 +5769,8 @@ beg:
                         goto beg;
                     }
                     assert(e2.Eoper == OPcolon || e2.Eoper == OPcolon2);
-                    elem *e21 = e2.E1 = optelem(e2.E1, goal);
-                    elem *e22 = e2.E2 = optelem(e2.E2, goal);
+                    elem* e21 = e2.E1 = optelem(e2.E1, goal);
+                    elem* e22 = e2.E2 = optelem(e2.E2, goal);
                     if (!e21)
                     {
                         if (!e22)
@@ -5839,12 +5839,12 @@ beg:
             {
                 const tyf = tybasic(e.E1.Ety);
                 leftgoal = rightgoal;
-                elem *e1 = e.E1 = optelem(e.E1, leftgoal);
+                elem* e1 = e.E1 = optelem(e.E1, leftgoal);
 
                 // Need argument to type_zeroSize()
                 const tyf_save = global_tyf;
                 global_tyf = tyf;
-                elem *e2 = e.E2 = optelem(e.E2, rightgoal);
+                elem* e2 = e.E2 = optelem(e.E2, rightgoal);
                 global_tyf = tyf_save;
 
                 if (!e1)
@@ -5863,10 +5863,10 @@ beg:
             }
         }
 
-        elem *e1 = e.E1;
+        elem* e1 = e.E1;
         if (OTassign(op))
         {
-            elem *ex = e1;
+            elem* ex = e1;
             while (OTconv(ex.Eoper))
                 ex = ex.E1;
             if (ex.Eoper == OPbit)
@@ -5931,7 +5931,7 @@ beg:
             }
         }
 
-        elem *e2 = e.E2 = optelem(e.E2,rightgoal);
+        elem* e2 = e.E2 = optelem(e.E2,rightgoal);
         if (!e1)
         {
             if (!e2)
@@ -6211,7 +6211,7 @@ beg:
  */
 
 @trusted
-elem *doptelem(elem *e, Goal goal)
+elem* doptelem(elem* e, Goal goal)
 {
     //printf("doptelem(e = %p, goal = x%x)\n", e, goal);
     do
@@ -6236,7 +6236,7 @@ elem *doptelem(elem *e, Goal goal)
  */
 
 @trusted
-void postoptelem(elem *e)
+void postoptelem(elem* e)
 {
     Srcpos pos = {0};
 
@@ -6294,7 +6294,7 @@ void postoptelem(elem *e)
  * Rewrite rvalues of complex numbers to pairs of floating point numbers.
  */
 @trusted
-private elem *elToPair(elem *e)
+private elem* elToPair(elem* e)
 {
     switch (e.Eoper)
     {
@@ -6315,7 +6315,7 @@ private elem *elToPair(elem *e)
                     if (_tysize[tybasic(ty0)] < REGSIZE)
                         break;                          // func parameters, for example, can't handle this
                     e.Ety = ty0;
-                    elem *e2 = el_copytree(e);
+                    elem* e2 = el_copytree(e);
                     e2.Voffset += _tysize[tybasic(ty0)];
                     return el_bin(OPpair, ty, e, e2);
 
@@ -6343,7 +6343,7 @@ private elem *elToPair(elem *e)
                     if (_tysize[tybasic(ty0)] < REGSIZE)
                         break;                          // func parameters, for example, can't handle this
                     e.Ety = ty0;
-                    elem *e2 = el_copytree(e.E1);
+                    elem* e2 = el_copytree(e.E1);
                     if (el_sideeffect(e2))
                         fixside(&e.E1, &e2);
                     e2 = el_bin(OPadd,e2.Ety,e2,el_long(TYsize, _tysize[tybasic(ty0)]));
@@ -6408,7 +6408,7 @@ private bool canHappenAfter(elem* a, elem* b)
  * Call table, index is OPER
  */
 
-private alias elfp_t = elem *function(elem *, Goal) nothrow;
+private alias elfp_t = elem* function(elem *, Goal) nothrow;
 
 private immutable elfp_t[OPMAX] elxxx =
 [

--- a/compiler/src/dmd/backend/cgen.d
+++ b/compiler/src/dmd/backend/cgen.d
@@ -40,7 +40,7 @@ public import dmd.backend.x86.cgcod : cgstate;
  * Find last code in list.
  */
 
-code *code_last(code *c)
+code* code_last(code* c)
 {
     if (c)
     {   while (c.next)
@@ -53,7 +53,7 @@ code *code_last(code *c)
  * Set flag bits on last code in list.
  */
 
-void code_orflag(code *c,uint flag)
+void code_orflag(code* c,uint flag)
 {
     if (flag && c)
     {   while (c.next)
@@ -66,7 +66,7 @@ void code_orflag(code *c,uint flag)
  * Set rex bits on last code in list.
  */
 
-void code_orrex(code *c,uint rex)
+void code_orrex(code* c,uint rex)
 {
     if (rex && c)
     {   while (c.next)
@@ -80,8 +80,8 @@ void code_orrex(code *c,uint rex)
  * Concatenate two code lists together. Return pointer to result.
  */
 
-code *cat(code *c1,code *c2)
-{   code **pc;
+code* cat(code* c1,code* c2)
+{   code** pc;
 
     if (!c1)
         return c2;
@@ -103,7 +103,7 @@ code *cat(code *c1,code *c2)
  *      pointer to start of code list
  */
 private
-code *gen(code *c, ref code cs)
+code* gen(code* c, ref code cs)
 {
     assert(I64 || cs.Irex == 0);
     code* ce = code_malloc();
@@ -121,7 +121,7 @@ code *gen(code *c, ref code cs)
     return ce;
 }
 
-code *gen1(code *c,opcode_t op)
+code* gen1(code* c,opcode_t op)
 {
     code* ce;
     code* cstart;
@@ -139,7 +139,7 @@ code *gen1(code *c,opcode_t op)
   return ce;
 }
 
-code *gen2(code *c,opcode_t op,uint rm)
+code* gen2(code* c,opcode_t op,uint rm)
 {
     code* ce;
     code* cstart;
@@ -158,7 +158,7 @@ code *gen2(code *c,opcode_t op,uint rm)
 }
 
 
-code *genc2(code *c,opcode_t op,uint ea,targ_size_t EV2)
+code* genc2(code* c,opcode_t op,uint ea,targ_size_t EV2)
 {   code cs;
 
     cs.Iop = op;
@@ -175,7 +175,7 @@ code *genc2(code *c,opcode_t op,uint ea,targ_size_t EV2)
  * Generate 'nop'
  */
 
-code *gennop(code *c)
+code* gennop(code* c)
 {
     return gen1(c,NOP);
 }
@@ -186,7 +186,7 @@ code *gennop(code *c)
  */
 
 @trusted
-void gencodelem(ref CodeBuilder cdb,elem *e,ref regm_t pretregs,bool constflag)
+void gencodelem(ref CodeBuilder cdb,elem* e,ref regm_t pretregs,bool constflag)
 {
     if (e)
     {
@@ -266,7 +266,7 @@ private __gshared Barray!Fixup fixups;
  * Add to the fix list.
  */
 @trusted
-size_t addtofixlist(Symbol *s,targ_size_t offset,int seg,targ_size_t val,int flags)
+size_t addtofixlist(Symbol* s,targ_size_t offset,int seg,targ_size_t val,int flags)
 {
         static immutable ubyte[8] zeros = 0;
 
@@ -336,7 +336,7 @@ static if (TARGET_SEGMENTED)
         {
             // OBJ_OMF does not set Sxtrnnum for static Symbols, so check
             // whether the Symbol was assigned to a segment instead, compare
-            // outdata(Symbol *s)
+            // outdata(Symbol* s)
             if (f.sym.Sseg == UNKNOWN)
             {
                 error(Srcpos.init, "no definition found for static `%s` in this module, statics defined in one module cannot be referenced from another",
@@ -363,7 +363,7 @@ static if (TARGET_SEGMENTED)
 
 if (config.exe & (EX_OSX | EX_OSX64))
 {
-    Symbol *funcsymsave = funcsym_p;
+    Symbol* funcsymsave = funcsym_p;
     funcsym_p = f.funcsym;
     objmod.reftoident(f.seg, f.offset, f.sym, f.val, f.flags);
     funcsym_p = funcsymsave;

--- a/compiler/src/dmd/backend/cgsched.d
+++ b/compiler/src/dmd/backend/cgsched.d
@@ -64,7 +64,7 @@ private enum CIFL : ubyte
 // Struct where we gather information about an instruction
 struct Cinfo
 {
-    code *c;            // the instruction
+    code* c;            // the instruction
     ubyte pair;         // pairing information
     ubyte sz;           // operand size
     ubyte isz;          // instruction size
@@ -90,7 +90,7 @@ struct Cinfo
     @trusted
     nothrow void print()        // pretty-printer
     {
-        Cinfo *ci = &this;
+        Cinfo* ci = &this;
 
         if (ci == null)
         {
@@ -131,7 +131,7 @@ struct Cinfo
  */
 
 @trusted
-private void cgsched_pentium(code **pc,regm_t scratch)
+private void cgsched_pentium(code** pc,regm_t scratch)
 {
     //printf("scratch = x%02x\n",scratch);
     if (config.target_scheduler >= TARGET_80486)
@@ -864,7 +864,7 @@ extern (D) private immutable ubyte[8] uopsx = [ 1,1,2,5,1,1,1,5 ];
  *      prefix bytes
  */
 
-private ubyte uops(code *c)
+private ubyte uops(code* c)
 {
     ubyte n;
     int op;
@@ -1119,13 +1119,13 @@ private ubyte uops(code *c)
  *      NP,UV,PU,PV optionally OR'd with PE
  */
 
-private int pair_class(code *c)
+private int pair_class(code* c)
 {   ubyte op;
     ubyte irm,mod,reg,rm;
     uint a32;
     int pc;
 
-    // Of course, with Intel this is *never* simple, and Intel's
+    // Of course, with Intel this is* never* simple, and Intel's
     // documentation is vague about the specifics.
 
     op = c.Iop & 0xFF;
@@ -1275,7 +1275,7 @@ private int pair_class(code *c)
  * Returns:
  *     CInfo struct containing info about c
  */
-private Cinfo getinfo(code *c)
+private Cinfo getinfo(code* c)
 {
     if (!c)
         return Cinfo.init;
@@ -1859,7 +1859,7 @@ private int pair_agi(const ref Cinfo c1, const ref Cinfo c2) pure
  *      true if they can decode simultaneously
  */
 
-private bool triple_test(const ref Cinfo c0, const ref Cinfo c1, Cinfo *c2)
+private bool triple_test(const ref Cinfo c0, const ref Cinfo c1, Cinfo* c2)
 {
     const c2isz = c2 ? c2.isz : 0;
     if (c0.isz > 7 || c1.isz > 7 || c2isz > 7 ||
@@ -1880,7 +1880,7 @@ private bool triple_test(const ref Cinfo c0, const ref Cinfo c1, Cinfo *c2)
  *      null    no more instructions
  */
 
-private code * cnext(code *c)
+private code* cnext(code* c)
 {
     while (1)
     {
@@ -1918,10 +1918,10 @@ private code * cnext(code *c)
 //                      if 2, then adjust ci1 as well as ci2
 
 @trusted
-private int conflict(Cinfo *ci1,Cinfo *ci2,int fpsched)
+private int conflict(Cinfo* ci1,Cinfo* ci2,int fpsched)
 {
-    code *c1;
-    code *c2;
+    code* c1;
+    code* c2;
     uint r1,w1,a1;
     uint r2,w2,a2;
     int sz1,sz2;
@@ -2246,9 +2246,9 @@ nothrow:
         stagelist.dtor();
     }
 
-code **assemble(code **pc)  // reassemble scheduled instructions
+code** assemble(code** pc)  // reassemble scheduled instructions
 {
-    code *c;
+    code* c;
 
     debug
     if (debugs) printf("assemble:\n");
@@ -2305,7 +2305,7 @@ code **assemble(code **pc)  // reassemble scheduled instructions
 
         // Put in any FXCH prefix
         if (ci.fxch_pre)
-        {   code *cf;
+        {   code* cf;
             assert(i);
             cf = gen2(null,0xD9,0xC8 + ci.fxch_pre);
             *pc = cf;
@@ -2332,7 +2332,7 @@ code **assemble(code **pc)  // reassemble scheduled instructions
                     break;
                 }
             }
-            {   code *cf;
+            {   code* cf;
                 cf = gen2(null,0xD9,0xC8 + ci.fxch_post);
                 *pc = cf;
                 pc = &cf.next;
@@ -2370,8 +2370,8 @@ code **assemble(code **pc)  // reassemble scheduled instructions
  *      0       could not be scheduled; have to start a new one
  */
 
-int insert(Cinfo *ci)
-{   code *c;
+int insert(Cinfo* ci)
+{   code* c;
     int clocks;
     int i;
     int ic = 0;
@@ -2502,7 +2502,7 @@ int insert(Cinfo *ci)
         {
             if (PRO)
             {   int i0 = (i / 3) * 3;           // index of decode unit 0
-                Cinfo *ci0;
+                Cinfo* ci0;
 
                 assert(((TBLMAX / 3) * 3) == TBLMAX);
                 switch (i - i0)
@@ -2675,7 +2675,7 @@ Linsert:
  */
 
 @trusted
-bool stage(code *c)
+bool stage(code* c)
 {
     //printf("stage: "); c.print();
     if (cinfomax == TBLMAX)             // if out of space
@@ -2768,12 +2768,12 @@ Lnostage:
  *      null for no more instructions
  */
 
-private code * csnip(code *c)
+private code* csnip(code* c)
 {
     if (c)
     {
         uint iflags = c.Iflags & CFclassinit;
-        code **pc;
+        code** pc;
         while (1)
         {
             pc = &c.next;
@@ -2799,10 +2799,10 @@ private code * csnip(code *c)
  */
 
 @trusted
-private code *schedule(code *c,regm_t scratch)
+private code* schedule(code* c,regm_t scratch)
 {
-    code *cresult = null;
-    code **pctail = &cresult;
+    code* cresult = null;
+    code** pctail = &cresult;
     Schedule sch = void;
 
     sch.initialize(0);                  // initialize scheduling table
@@ -2812,7 +2812,7 @@ private code *schedule(code *c,regm_t scratch)
              ((c.Iop & PSOP.mask) == PSOP.root && c.Iop != PSOP.adjfpu) ||
              c.Iflags & CFclassinit) &&
             !(c.Iflags & (CFtarg | CFtarg2)))
-        {   code *cn;
+        {   code* cn;
 
             // Just append this instruction to pctail and go to the next one
             *pctail = c;
@@ -2848,7 +2848,7 @@ private code *schedule(code *c,regm_t scratch)
  * Replace any occurrence of r1 in EA with r2.
  */
 
-private void repEA(code *c,uint r1,uint r2)
+private void repEA(code* c,uint r1,uint r2)
 {
     uint mod,reg,rm;
     uint rmn;
@@ -2916,7 +2916,7 @@ private void repEA(code *c,uint r1,uint r2)
  * Swap in place to not disturb addresses of jmp targets
  */
 
-private void code_swap(code *c1,code *c2)
+private void code_swap(code* c1,code* c2)
 {   code cs;
 
     // Special case of:
@@ -2945,7 +2945,7 @@ private void code_swap(code *c1,code *c2)
     c2.next = cs.next;
 }
 
-private code *peephole(code *cstart,regm_t scratch)
+private code* peephole(code* cstart,regm_t scratch)
 {
     // Look for cases of:
     //  MOV r1,r2
@@ -2954,12 +2954,12 @@ private code *peephole(code *cstart,regm_t scratch)
     //  MOV r1,r2
     //  OP ?,r2
     // to improve pairing
-    code *c1;
+    code* c1;
     uint r1,r2;
     uint mod,reg,rm;
 
     //printf("peephole\n");
-    for (code *c = cstart; c; c = c1)
+    for (code* c = cstart; c; c = c1)
     {
         ubyte rmn;
 
@@ -3188,10 +3188,10 @@ Lnop:
  */
 
 @trusted
-code *simpleops(code *c,regm_t scratch)
-{   code *cstart;
+code* simpleops(code* c,regm_t scratch)
+{   code* cstart;
     uint reg;
-    code *c2;
+    code* c2;
 
     // Worry about using registers not saved yet by prolog
     scratch &= ~fregsaved;

--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -66,19 +66,19 @@ union evc
     struct
     {
         targ_size_t Vdoffset;   /// offset from symbol
-        _Declaration *Vdsym;    /// pointer to D symbol table
+        _Declaration* Vdsym;    /// pointer to D symbol table
     }
 
     struct
     {
         targ_size_t Vloffset;   /// offset from symbol
-        _LabelDsymbol *Vlsym;   /// pointer to D Label
+        _LabelDsymbol* Vlsym;   /// pointer to D Label
     }
 
     struct
     {
         size_t len;
-        char *bytes;
+        char* bytes;
     }                           // asm node (FL.asm)
 }
 
@@ -86,13 +86,13 @@ union evc
 
 public import dmd.backend.dcode : code_calloc, code_free, code_term, code_chunk_alloc, code_list;
 
-code *code_next(code *c) { return c.next; }
+code* code_next(code* c) { return c.next; }
 
 @trusted
-code *code_malloc()
+code* code_malloc()
 {
     //printf("code %d\n", sizeof(code));
-    code *c = code_list ? code_list : code_chunk_alloc();
+    code* c = code_list ? code_list : code_chunk_alloc();
     code_list = code_next(c);
     //printf("code_malloc: %p\n",c);
     return c;
@@ -193,7 +193,7 @@ struct CGstate
     LocalSection EEStack;       // offset of SCstack variables from ESP
     LocalSection Alloca;        // data for alloca() temporary
 
-    Symbol *retsym;             // symbol that should be placed in AX
+    Symbol* retsym;             // symbol that should be placed in AX
 
     uint stackpush;             // # of bytes that SP is beyond BP.
 
@@ -334,7 +334,7 @@ struct FuncParamRegs
     //this(tym_t tyf);
     static FuncParamRegs create(tym_t tyf) { return FuncParamRegs_create(tyf); }
 
-    bool alloc(type *t, tym_t ty, out reg_t reg1, out reg_t reg2)
+    bool alloc(type* t, tym_t ty, out reg_t reg1, out reg_t reg2)
     { return FuncParamRegs_alloc(this, t, ty, reg1, reg2); }
 
   private:
@@ -381,7 +381,7 @@ public import dmd.backend.x86.cg87;
  * Returns: mask of registers used by block bp.
  */
 @system
-regm_t iasm_regs(block *bp)
+regm_t iasm_regs(block* bp)
 {
     debug (debuga)
         printf("Block iasm regs = 0x%X\n", bp.usIasmregs);

--- a/compiler/src/dmd/backend/codebuilder.d
+++ b/compiler/src/dmd/backend/codebuilder.d
@@ -31,8 +31,8 @@ struct CodeBuilder
 {
   private:
 
-    code *head;
-    code **pTail;
+    code* head;
+    code** pTail;
 
     enum BADINS = 0x1234_5678;
 //    enum BADINS = 0xF940_03A8;
@@ -40,7 +40,7 @@ struct CodeBuilder
   nothrow:
   public:
     //this() { pTail = &head; }
-    //this(code *c);
+    //this(code* c);
 
     @trusted
     void ctor()
@@ -55,12 +55,12 @@ struct CodeBuilder
         pTail = c ? &code_last(c).next : &head;
     }
 
-    code *finish()
+    code* finish()
     {
         return head;
     }
 
-    code *peek() { return head; }       // non-destructively look at the list
+    code* peek() { return head; }       // non-destructively look at the list
 
     @trusted
     void reset() { head = null; pTail = &head; }
@@ -105,7 +105,7 @@ struct CodeBuilder
     }
 
     @trusted
-    void append(code *c)
+    void append(code* c)
     {
         if (c)
         {
@@ -115,7 +115,7 @@ struct CodeBuilder
         }
     }
 
-    void gen(code *cs)
+    void gen(code* cs)
     {
         /* this is a high usage routine */
         debug assert(cs);
@@ -137,7 +137,7 @@ assert(cs.Iop != BADINS);
     {
         //debug printf("gen1(%08x)\n", op);
 assert(op != BADINS);
-        code *ce = code_calloc();
+        code* ce = code_calloc();
         ce.Iop = op;
         ccheck(ce);
         assert(op != LEA);
@@ -149,7 +149,7 @@ assert(op != BADINS);
     void gen2(opcode_t op, uint rm)
     {
 assert(op != BADINS);
-        code *ce = code_calloc();
+        code* ce = code_calloc();
         ce.Iop = op;
         ce.Iea = rm;
         ccheck(ce);
@@ -170,7 +170,7 @@ assert(op != BADINS);
 
     void gen2sib(opcode_t op, uint rm, uint sib)
     {
-        code *ce = code_calloc();
+        code* ce = code_calloc();
         ce.Iop = op;
         ce.Irm = cast(ubyte)rm;
         ce.Isib = cast(ubyte)sib;
@@ -189,11 +189,11 @@ assert(op != BADINS);
     @trusted
     void genasm(const ubyte[] bytes)
     {
-        code *ce = code_calloc();
+        code* ce = code_calloc();
         ce.Iop = ASM;
         ce.IFL1 = FL.asm_;
         ce.IEV1.len = bytes.length;
-        ce.IEV1.bytes = cast(char *) mem_malloc(bytes.length);
+        ce.IEV1.bytes = cast(char*) mem_malloc(bytes.length);
         memcpy(ce.IEV1.bytes,bytes.ptr,bytes.length);
 
         *pTail = ce;
@@ -201,9 +201,9 @@ assert(op != BADINS);
     }
 
     @trusted
-    void genasm(_LabelDsymbol *label)
+    void genasm(_LabelDsymbol* label)
     {
-        code *ce = code_calloc();
+        code* ce = code_calloc();
         ce.Iop = ASM;
         ce.Iflags = CFaddrsize;
         ce.IFL1 = FL.blockoff;
@@ -214,9 +214,9 @@ assert(op != BADINS);
     }
 
     @trusted
-    void genasm(block *label)
+    void genasm(block* label)
     {
-        code *ce = code_calloc();
+        code* ce = code_calloc();
         ce.Iop = ASM;
         ce.Iflags = CFaddrsize;
         ce.IFL1 = FL.blockoff;
@@ -228,7 +228,7 @@ assert(op != BADINS);
     }
 
     @trusted
-    void gencs1(opcode_t op, uint ea, FL FL1, Symbol *s)
+    void gencs1(opcode_t op, uint ea, FL FL1, Symbol* s)
     {
 assert(op != BADINS);
         code cs;
@@ -244,7 +244,7 @@ assert(op != BADINS);
     }
 
     @trusted
-    void gencs(opcode_t op, uint ea, FL FL2, Symbol *s)
+    void gencs(opcode_t op, uint ea, FL FL2, Symbol* s)
     {
 assert(op != BADINS);
         code cs;
@@ -394,18 +394,18 @@ assert(op != BADINS);
      *  code that pTail points to
      */
     @trusted
-    code *last()
+    code* last()
     {
         // g++ and clang++ complain about offsetof() because of the code::code() constructor.
         // return (code *)((char *)pTail - offsetof(code, next));
         // So do our own.
-        return cast(code *)(cast(void *)pTail - (cast(void*)&(*pTail).next - cast(void*)*pTail));
+        return cast(code*)(cast(void*)pTail - (cast(void*)&(*pTail).next - cast(void*)*pTail));
     }
 
     /*************************************
      * Handy function to answer the question: who the heck is generating this piece of code?
      */
-    static void ccheck(code *cs)
+    static void ccheck(code* cs)
     {
     //    if (cs.Iop == LEA && (cs.Irm & 0x3F) == 0x34 && cs.Isib == 7) *(char*)0=0;
     //    if (cs.Iop == 0x31) *(char*)0=0;
@@ -420,7 +420,7 @@ assert(op != BADINS);
     void print()
     {
         printf("---\n");
-        for (code *c = head; c; c = c.next)
+        for (code* c = head; c; c = c.next)
             printf("%02x\n", c.Iop);
     }
 }

--- a/compiler/src/dmd/backend/cv8.d
+++ b/compiler/src/dmd/backend/cv8.d
@@ -63,52 +63,52 @@ private bool symbol_iscomdat4(Symbol* s)
 enum CV8_MAX_SYMBOL_LENGTH = 0xffd8;
 
 // The "F1" section, which is the symbols
-private __gshared OutBuffer *F1_buf;
+private __gshared OutBuffer* F1_buf;
 
 // The "F2" section, which is the line numbers
-private __gshared OutBuffer *F2_buf;
+private __gshared OutBuffer* F2_buf;
 
 // The "F3" section, which is global and a string table of source file names.
-private __gshared OutBuffer *F3_buf;
+private __gshared OutBuffer* F3_buf;
 
 // The "F4" section, which is global and a lists info about source files.
-private __gshared OutBuffer *F4_buf;
+private __gshared OutBuffer* F4_buf;
 
 /* Fixups that go into F1 section
  */
 struct F1_Fixups
 {
-    Symbol *s;
+    Symbol* s;
     uint offset;
     uint value;
 }
 
-private __gshared OutBuffer *F1fixup;      // array of F1_Fixups
+private __gshared OutBuffer* F1fixup;      // array of F1_Fixups
 
 /* Struct in which to collect per-function data, for later emission
  * into .debug$S.
  */
 struct FuncData
 {
-    Symbol *sfunc;
+    Symbol* sfunc;
     uint section_length;
     const(char)* srcfilename;
     uint srcfileoff;
     uint linepairstart;     // starting byte index of offset/line pairs in linebuf[]
     uint linepairbytes;     // number of bytes for offset/line pairs
     uint linepairsegment;   // starting byte index of filename segment for offset/line pairs
-    OutBuffer *f1buf;
-    OutBuffer *f1fixup;
+    OutBuffer* f1buf;
+    OutBuffer* f1fixup;
 }
 
 __gshared FuncData currentfuncdata;
 
-private __gshared OutBuffer *funcdata;     // array of FuncData's
+private __gshared OutBuffer* funcdata;     // array of FuncData's
 
-private __gshared OutBuffer *linepair;     // array of offset/line pairs
+private __gshared OutBuffer* linepair;     // array of offset/line pairs
 
 private @trusted
-void cv8_writename(OutBuffer *buf, const(char)* name, size_t len)
+void cv8_writename(OutBuffer* buf, const(char)* name, size_t len)
 {
     if(config.flags2 & CFG2gms)
     {
@@ -248,9 +248,9 @@ void cv8_termfile(const(char)[] objfilename)
 
     // Write out "F2" sections
     uint length = cast(uint)funcdata.length();
-    ubyte *p = funcdata.buf;
+    ubyte* p = funcdata.buf;
     for (uint u = 0; u < length; u += FuncData.sizeof)
-    {   FuncData *fd = cast(FuncData *)(p + u);
+    {   FuncData* fd = cast(FuncData*)(p + u);
 
         F2_buf.reset();
 
@@ -278,9 +278,9 @@ void cv8_termfile(const(char)[] objfilename)
 
             // Fixups for "F1" section
             const uint fixupLength = cast(uint)fd.f1fixup.length();
-            ubyte *pfixup = fd.f1fixup.buf;
+            ubyte* pfixup = fd.f1fixup.buf;
             for (uint v = 0; v < fixupLength; v += F1_Fixups.sizeof)
-            {   F1_Fixups *f = cast(F1_Fixups *)(pfixup + v);
+            {   F1_Fixups* f = cast(F1_Fixups*)(pfixup + v);
 
                 objmod.reftoident(f2seg, f1offset + 8 + f.offset, f.s, f.value, CFseg | CFoff);
             }
@@ -305,7 +305,7 @@ void cv8_termfile(const(char)[] objfilename)
         length = cast(uint)F1fixup.length();
         p = F1fixup.buf;
         for (uint u = 0; u < length; u += F1_Fixups.sizeof)
-        {   F1_Fixups *f = cast(F1_Fixups *)(p + u);
+        {   F1_Fixups* f = cast(F1_Fixups*)(p + u);
 
             objmod.reftoident(seg, f1offset + 8 + f.offset, f.s, f.value, CFseg | CFoff);
         }
@@ -336,7 +336,7 @@ void cv8_termmodule()
  * Called at the start of a function.
  */
 @trusted
-void cv8_func_start(Symbol *sfunc)
+void cv8_func_start(Symbol* sfunc)
 {
     //printf("cv8_func_start(%s)\n", sfunc.Sident);
     currentfuncdata.sfunc = sfunc;
@@ -359,7 +359,7 @@ void cv8_func_start(Symbol *sfunc)
 }
 
 @trusted
-void cv8_func_term(Symbol *sfunc)
+void cv8_func_term(Symbol* sfunc)
 {
     //printf("cv8_func_term(%s)\n", sfunc.Sident);
 
@@ -383,9 +383,9 @@ void cv8_func_term(Symbol *sfunc)
 
         type* classtype = cast(type*)fn.Fclass;
         uint classidx = cv4_typidx(classtype);
-        type *tp = type_allocn(TYnptr, classtype);
+        type* tp = type_allocn(TYnptr, classtype);
         uint thisidx = cv4_typidx(tp);  // TODO
-        debtyp_t *d = debtyp_alloc(2 + 4 + 4 + 4 + 1 + 1 + 2 + 4 + 4);
+        debtyp_t* d = debtyp_alloc(2 + 4 + 4 + 4 + 1 + 1 + 2 + 4 + 4);
         TOWORD(d.data.ptr,LF_MFUNCTION_V2);
         TOLONG(d.data.ptr + 2,next);       // return type
         TOLONG(d.data.ptr + 6,classidx);   // class type
@@ -565,7 +565,7 @@ uint cv8_addfile(const(char)* filename)
      */
 
     uint length = cast(uint)F3_buf.length();
-    ubyte *p = F3_buf.buf;
+    ubyte* p = F3_buf.buf;
     size_t len = strlen(filename);
 
     // ensure the filename is absolute to help the debugger to find the source
@@ -617,14 +617,14 @@ L1:
     uint u = 0;
     while (u + 8 <= length)
     {
-        //printf("\t%x\n", *cast(uint *)(p + u));
-        if (off == *cast(uint *)(p + u))
+        //printf("\t%x\n", *cast(uint*)(p + u));
+        if (off == *cast(uint*)(p + u))
         {
             //printf("\tfound %x\n", u);
             return u;
         }
         u += 4;
-        ushort type = *cast(ushort *)(p + u);
+        ushort type = *cast(ushort*)(p + u);
         u += 2;
         if (type == 0x0110)
             u += 16;            // truncated blake3 hash
@@ -648,7 +648,7 @@ L1:
 }
 
 private @trusted
-void cv8_writesection(int seg, uint type, OutBuffer *buf)
+void cv8_writesection(int seg, uint type, OutBuffer* buf)
 {
     /* Write out as:
      *  bytes   desc
@@ -669,7 +669,7 @@ void cv8_writesection(int seg, uint type, OutBuffer *buf)
 }
 
 @trusted
-void cv8_outsym(Symbol *s)
+void cv8_outsym(Symbol* s)
 {
     //printf("cv8_outsym(s = '%s')\n", s.Sident);
     //type_print(s.Stype);
@@ -837,7 +837,7 @@ void cv8_udt(const(char)* id, idx_t typidx)
 /*********************************************
  * Get Codeview register number for symbol s.
  */
-int cv8_regnum(Symbol *s)
+int cv8_regnum(Symbol* s)
 {
     int reg = s.Sreglsw;
     assert(s.Sfl == FL.reg);
@@ -884,12 +884,12 @@ int cv8_regnum(Symbol *s)
  * Only put out the real definitions with toDebug().
  */
 @trusted
-idx_t cv8_fwdref(Symbol *s)
+idx_t cv8_fwdref(Symbol* s)
 {
     assert(config.fulltypes == CV8);
 //    if (s.Stypidx && !global.params.multiobj)
 //      return s.Stypidx;
-    struct_t *st = s.Sstruct;
+    struct_t* st = s.Sstruct;
     uint leaf;
     uint numidx;
     if (st.Sflags & STRunion)
@@ -913,7 +913,7 @@ idx_t cv8_fwdref(Symbol *s)
     if (idlen > CV8_MAX_SYMBOL_LENGTH)
         idlen = CV8_MAX_SYMBOL_LENGTH;
 
-    debtyp_t *d = debtyp_alloc(len + idlen + 1);
+    debtyp_t* d = debtyp_alloc(len + idlen + 1);
     TOWORD(d.data.ptr, leaf);
     TOWORD(d.data.ptr + 2, 0);     // number of fields
     TOWORD(d.data.ptr + 4, 0x80);  // property
@@ -939,7 +939,7 @@ idx_t cv8_fwdref(Symbol *s)
  *      etypidx type index for E
  */
 @trusted
-idx_t cv8_darray(type *t, idx_t etypidx)
+idx_t cv8_darray(type* t, idx_t etypidx)
 {
     //printf("cv8_darray(etypidx = %x)\n", etypidx);
     /* Put out a struct:
@@ -961,7 +961,7 @@ static if (0)
     return cv_debtyp(d);
 }
 
-    type *tp = type_pointer(t.Tnext);
+    type* tp = type_pointer(t.Tnext);
     idx_t ptridx = cv4_typidx(tp);
     type_free(tp);
 
@@ -982,7 +982,7 @@ static if (0)
         0xf2, 0xf1,
     ];
 
-    debtyp_t *f = debtyp_alloc(fl.sizeof);
+    debtyp_t* f = debtyp_alloc(fl.sizeof);
     memcpy(f.data.ptr,fl.ptr,fl.sizeof);
     TOLONG(f.data.ptr + 6, I64 ? 0x23 : 0x22); // size_t
     TOLONG(f.data.ptr + 26, ptridx);
@@ -1014,7 +1014,7 @@ static if (0)
     if (idlen > CV8_MAX_SYMBOL_LENGTH)
         idlen = CV8_MAX_SYMBOL_LENGTH;
 
-    debtyp_t *d = debtyp_alloc(20 + idlen + 1);
+    debtyp_t* d = debtyp_alloc(20 + idlen + 1);
     TOWORD(d.data.ptr, LF_STRUCTURE_V3);
     TOWORD(d.data.ptr + 2, 2);     // count
     TOWORD(d.data.ptr + 4, 0);     // property
@@ -1040,7 +1040,7 @@ static if (0)
  *      functypidx type index for pointer to function
  */
 @trusted
-idx_t cv8_ddelegate(type *t, idx_t functypidx)
+idx_t cv8_ddelegate(type* t, idx_t functypidx)
 {
     //printf("cv8_ddelegate(functypidx = %x)\n", functypidx);
     /* Put out a struct:
@@ -1050,18 +1050,18 @@ idx_t cv8_ddelegate(type *t, idx_t functypidx)
      *    }
      */
 
-    type *tv = type_fake(TYnptr);
+    type* tv = type_fake(TYnptr);
     tv.Tcount++;
     idx_t pvidx = cv4_typidx(tv);
     type_free(tv);
 
-    type *tp = type_pointer(t.Tnext);
+    type* tp = type_pointer(t.Tnext);
     idx_t ptridx = cv4_typidx(tp);
     type_free(tp);
 
 static if (0)
 {
-    debtyp_t *d = debtyp_alloc(18);
+    debtyp_t* d = debtyp_alloc(18);
     TOWORD(d.data.ptr, 0x100F);
     TOWORD(d.data.ptr + 2, OEM);
     TOWORD(d.data.ptr + 4, 3);     // 3 = delegate
@@ -1088,7 +1088,7 @@ else
         0xf2, 0xf1,
     ];
 
-    debtyp_t *f = debtyp_alloc(fl.sizeof);
+    debtyp_t* f = debtyp_alloc(fl.sizeof);
     memcpy(f.data.ptr,fl.ptr,fl.sizeof);
     TOLONG(f.data.ptr + 6, pvidx);
     TOLONG(f.data.ptr + 22, ptridx);
@@ -1100,7 +1100,7 @@ else
     if (idlen > CV8_MAX_SYMBOL_LENGTH)
         idlen = CV8_MAX_SYMBOL_LENGTH;
 
-    debtyp_t *d = debtyp_alloc(20 + idlen + 1);
+    debtyp_t* d = debtyp_alloc(20 + idlen + 1);
     TOWORD(d.data.ptr, LF_STRUCTURE_V3);
     TOWORD(d.data.ptr + 2, 2);     // count
     TOWORD(d.data.ptr + 4, 0);     // property
@@ -1122,7 +1122,7 @@ else
  *      validx     value type
  */
 @trusted
-idx_t cv8_daarray(type *t, idx_t keyidx, idx_t validx)
+idx_t cv8_daarray(type* t, idx_t keyidx, idx_t validx)
 {
     //printf("cv8_daarray(keyidx = %x, validx = %x)\n", keyidx, validx);
     /* Put out a struct:
@@ -1135,7 +1135,7 @@ idx_t cv8_daarray(type *t, idx_t keyidx, idx_t validx)
 
 static if (0)
 {
-    debtyp_t *d = debtyp_alloc(18);
+    debtyp_t* d = debtyp_alloc(18);
     TOWORD(d.data.ptr, 0x100F);
     TOWORD(d.data.ptr + 2, OEM);
     TOWORD(d.data.ptr + 4, 2);     // 2 = associative array
@@ -1145,7 +1145,7 @@ static if (0)
 }
 else
 {
-    type *tv = type_fake(TYnptr);
+    type* tv = type_fake(TYnptr);
     tv.Tcount++;
     idx_t pvidx = cv4_typidx(tv);
     type_free(tv);
@@ -1171,7 +1171,7 @@ else
         '_','_','v','a','l','_','t',0,  // "__val_t"
     ];
 
-    debtyp_t *f = debtyp_alloc(fl.sizeof);
+    debtyp_t* f = debtyp_alloc(fl.sizeof);
     memcpy(f.data.ptr,fl.ptr,fl.sizeof);
     TOLONG(f.data.ptr + 6, pvidx);
     TOLONG(f.data.ptr + 22, keyidx);
@@ -1183,7 +1183,7 @@ else
     if (idlen > CV8_MAX_SYMBOL_LENGTH)
         idlen = CV8_MAX_SYMBOL_LENGTH;
 
-    debtyp_t *d = debtyp_alloc(20 + idlen + 1);
+    debtyp_t* d = debtyp_alloc(20 + idlen + 1);
     TOWORD(d.data.ptr, LF_STRUCTURE_V3);
     TOWORD(d.data.ptr + 2, 1);     // count
     TOWORD(d.data.ptr + 4, 0);     // property

--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -74,7 +74,7 @@ enum DEBTYPVECDIM = 16_001;   //8009 //3001     // dimension of debtypvec (shoul
 enum DEBTYPHASHDIM = 1009;
 private uint[DEBTYPHASHDIM] debtyphash;
 
-private OutBuffer *reset_symbuf; // Keep pointers to reset symbols
+private OutBuffer* reset_symbuf; // Keep pointers to reset symbols
 
 @trusted
 idx_t DEB_NULL() { return cgcv.deb_offset; }        // index of null debug type record
@@ -119,7 +119,7 @@ int cv_stringbytes(const(char)* name)
  */
 
 @trusted
-int cv_namestring(ubyte *p, const(char)* name, int length = -1)
+int cv_namestring(ubyte* p, const(char)* name, int length = -1)
 {
     size_t len = (length >= 0) ? length : strlen(name);
     if (config.fulltypes == CV8)
@@ -162,7 +162,7 @@ int cv_namestring(ubyte *p, const(char)* name, int length = -1)
  */
 
 @trusted
-private int cv_regnum(Symbol *s)
+private int cv_regnum(Symbol* s)
 {
     uint reg = s.Sreglsw;
     if (s.Sclass == SC.pseudo)
@@ -208,9 +208,9 @@ static if (0)
  * Allocate a debtyp_t.
  */
 @trusted
-debtyp_t * debtyp_alloc(uint length)
+debtyp_t* debtyp_alloc(uint length)
 {
-    debtyp_t *d;
+    debtyp_t* d;
     uint pad = 0;
 
     //printf("len = %u, x%x\n", length, length);
@@ -226,13 +226,13 @@ debtyp_t * debtyp_alloc(uint length)
     const len = debtyp_t.sizeof - (d.data).sizeof + length;
 debug
 {
-    d = cast(debtyp_t *) mem_malloc(len /*+ 1*/);
+    d = cast(debtyp_t*) mem_malloc(len /*+ 1*/);
     memset(d, 0xAA, len);
 //    (cast(char*)d)[len] = 0x2E;
 }
 else
 {
-    d = cast(debtyp_t *) malloc(debtyp_t.sizeof - (d.data).sizeof + length);
+    d = cast(debtyp_t*) malloc(debtyp_t.sizeof - (d.data).sizeof + length);
     if (!d)
         err_nomem();
 }
@@ -251,7 +251,7 @@ else
  */
 
 @trusted
-private void debtyp_free(debtyp_t *d)
+private void debtyp_free(debtyp_t* d)
 {
     //printf("debtyp_free(length = %d, %p)\n", d.length, d);
     //fflush(stdout);
@@ -271,7 +271,7 @@ else
 
 static if (0)
 {
-void debtyp_check(debtyp_t *d,int linnum)
+void debtyp_check(debtyp_t* d,int linnum)
 {   int i;
     __gshared char c;
 
@@ -296,7 +296,7 @@ void debtyp_check(debtyp_t* d) { }
  */
 
 @trusted
-idx_t cv_debtyp(debtyp_t *d)
+idx_t cv_debtyp(debtyp_t* d)
 {
     uint hashi;
 
@@ -362,14 +362,14 @@ idx_t cv_numdebtypes()
 
 @trusted
 void cv_init()
-{   debtyp_t *d;
+{   debtyp_t* d;
 
     //printf("cv_init()\n");
 
     // Initialize statics
     debtyp.setLength(0);
     if (!ftdbname)
-        ftdbname = cast(char *)"symc.tdb".ptr;
+        ftdbname = cast(char*)"symc.tdb".ptr;
 
     memset(&cgcv,0,cgcv.sizeof);
     cgcv.sz_idx = 2;
@@ -381,8 +381,8 @@ void cv_init()
 
     if (reset_symbuf)
     {
-        Symbol **p = cast(Symbol **)reset_symbuf.buf;
-        const size_t n = reset_symbuf.length() / (Symbol *).sizeof;
+        Symbol** p = cast(Symbol**)reset_symbuf.buf;
+        const size_t n = reset_symbuf.length() / (Symbol*).sizeof;
         for (size_t i = 0; i < n; ++i)
             symbol_reset(*p[i]);
         reset_symbuf.reset();
@@ -461,7 +461,7 @@ void cv_init()
 
             default:
             {   const(char)* x = "1MYS";
-                cgcv.signature = *cast(int *) x;
+                cgcv.signature = *cast(int*) x;
                 break;
             }
         }
@@ -560,7 +560,7 @@ uint cv4_numericbytes(uint value)
  */
 
 @trusted
-void cv4_storenumeric(ubyte *p, uint value)
+void cv4_storenumeric(ubyte* p, uint value)
 {
     if (value < 0x8000)
         TOWORD(p,value);
@@ -571,7 +571,7 @@ void cv4_storenumeric(ubyte *p, uint value)
     }
     else
     {   TOWORD(p,LF_ULONG);
-        *cast(targ_ulong *)(p + 2) = cast(uint) value;
+        *cast(targ_ulong*)(p + 2) = cast(uint) value;
     }
 }
 
@@ -602,7 +602,7 @@ uint cv4_signednumericbytes(int value)
  *   value = value to store
  */
 @trusted
-void cv4_storesignednumeric(ubyte *p, int value)
+void cv4_storesignednumeric(ubyte* p, int value)
 {
     if (value >= 0 && value < 0x8000)
         TOWORD(p, value);
@@ -623,12 +623,12 @@ void cv4_storesignednumeric(ubyte *p, int value)
  */
 
 @trusted
-idx_t cv4_arglist(type *t,uint *pnparam)
+idx_t cv4_arglist(type* t,uint* pnparam)
 {   uint u;
     uint nparam;
     idx_t paramidx;
-    debtyp_t *d;
-    param_t *p;
+    debtyp_t* d;
+    param_t* p;
 
     // Compute nparam, number of parameters
     nparam = 0;
@@ -707,20 +707,20 @@ idx_t cv4_arglist(type *t,uint *pnparam)
  */
 
 @trusted
-idx_t cv4_struct(Classsym *s,int flags)
+idx_t cv4_struct(Classsym* s,int flags)
 {   targ_size_t size;
     debtyp_t* d,dt;
     uint len;
     uint nfields,fnamelen;
     idx_t typidx;
-    type *t;
-    struct_t *st;
+    type* t;
+    struct_t* st;
     const(char)* id;
     uint numidx;
     uint leaf;
     uint property;
     uint attribute;
-    ubyte *p;
+    ubyte* p;
     int refonly;
     int i;
     int count;                  // COUNT field in LF_CLASS
@@ -857,7 +857,7 @@ idx_t cv4_struct(Classsym *s,int flags)
     fnamelen = 2;
     count = nfields;
     foreach (sl; ListRange(st.Sfldlst))
-    {   Symbol *sf = list_symbol(sl);
+    {   Symbol* sf = list_symbol(sl);
         targ_size_t offset;
 
         symbol_debug(sf);
@@ -896,7 +896,7 @@ idx_t cv4_struct(Classsym *s,int flags)
     // And fill it in
     p += 2;
     foreach (sl; ListRange(s.Sstruct.Sfldlst))
-    {   Symbol *sf = list_symbol(sl);
+    {   Symbol* sf = list_symbol(sl);
         targ_size_t offset;
 
         symbol_debug(sf);
@@ -904,7 +904,7 @@ idx_t cv4_struct(Classsym *s,int flags)
         switch (sf.Sclass)
         {
             case SC.field:
-            {   debtyp_t *db;
+            {   debtyp_t* db;
 
                 if (config.fulltypes == CV4)
                 {   db = debtyp_alloc(6);
@@ -1000,7 +1000,7 @@ private uint cv4_fwdenum(type* t)
  * Return 'calling convention' type of function.
  */
 
-ubyte cv4_callconv(type *t)
+ubyte cv4_callconv(type* t)
 {   ubyte call;
 
     switch (tybasic(t.Tty))
@@ -1026,7 +1026,7 @@ ubyte cv4_callconv(type *t)
 /**********************************************
  * Return type index for the type of a symbol.
  */
-private uint cv4_symtypidx(Symbol *s)
+private uint cv4_symtypidx(Symbol* s)
 {
     return cv4_typidx(s.Stype);
 }
@@ -1036,17 +1036,17 @@ private uint cv4_symtypidx(Symbol *s)
  */
 
 @trusted
-uint cv4_typidx(type *t)
+uint cv4_typidx(type* t)
 {   uint typidx;
     uint u;
     uint next;
     uint key;
-    debtyp_t *d;
+    debtyp_t* d;
     targ_size_t size;
     tym_t tym;
     tym_t tycv;
     tym_t tymnext;
-    type *tv;
+    type* tv;
     uint dt;
     uint attribute;
     ubyte call;
@@ -1360,7 +1360,7 @@ else
         case TYjfunc:
         case TYifunc:
         {
-            param_t *p;
+            param_t* p;
             uint nparam;
             idx_t paramidx;
 
@@ -1522,15 +1522,15 @@ else
  */
 
 @trusted
-private void cv4_outsym(Symbol *s)
+private void cv4_outsym(Symbol* s)
 {
     uint len;
-    type *t;
+    type* t;
     uint length;
     uint u;
     tym_t tym;
     const(char)* id;
-    ubyte *debsym = null;
+    ubyte* debsym = null;
     ubyte[64] buf = void;
 
     //printf("cv4_outsym(%s)\n",s.Sident.ptr);
@@ -1552,7 +1552,7 @@ private void cv4_outsym(Symbol *s)
 
         // Length of record
         length = 2 + 2 + 4 * 3 + _tysize[TYint] * 4 + 2 + cgcv.sz_idx + 1;
-        debsym = (length + len <= (buf).sizeof) ? buf.ptr : cast(ubyte *) malloc(length + len);
+        debsym = (length + len <= (buf).sizeof) ? buf.ptr : cast(ubyte*) malloc(length + len);
         if (!debsym)
             err_nomem();
         memset(debsym,0,length + len);
@@ -1625,7 +1625,7 @@ private void cv4_outsym(Symbol *s)
         typidx = cv4_typidx(t);
         id = s.prettyIdent ? s.prettyIdent : prettyident(s);
         len = cast(uint)strlen(id);
-        debsym = (39 + IDOHD + len <= (buf).sizeof) ? buf.ptr : cast(ubyte *) malloc(39 + IDOHD + len);
+        debsym = (39 + IDOHD + len <= (buf).sizeof) ? buf.ptr : cast(ubyte*) malloc(39 + IDOHD + len);
         if (!debsym)
             err_nomem();
         switch (s.Sclass)
@@ -1821,7 +1821,7 @@ Lret:
 private void cv_outlist()
 {
     while (cgcv.list)
-        cv_outsym(cast(Symbol *) list_pop(&cgcv.list));
+        cv_outsym(cast(Symbol*) list_pop(&cgcv.list));
 }
 
 /******************************************
@@ -1829,7 +1829,7 @@ private void cv_outlist()
  */
 
 @trusted
-private void cv4_func(Funcsym *s, ref symtab_t symtab)
+private void cv4_func(Funcsym* s, ref symtab_t symtab)
 {
     int endarg;
 
@@ -2085,9 +2085,9 @@ void cv_term()
             if (debtyp.length != 1 || config.fulltypes == CV8)
             {
                 for (uint u = 0; u < debtyp.length; u++)
-                {   debtyp_t *d = debtyp[u];
+                {   debtyp_t* d = debtyp[u];
 
-                    objmod.write_bytes(SegData[typeseg],(cast(void *)d)[uint.sizeof .. uint.sizeof + 2 + d.length]);
+                    objmod.write_bytes(SegData[typeseg],(cast(void*)d)[uint.sizeof .. uint.sizeof + 2 + d.length]);
                     debtyp_free(d);
                 }
             }
@@ -2112,7 +2112,7 @@ void cv_term()
  */
 
 @trusted
-void cv_func(Funcsym *s)
+void cv_func(Funcsym* s)
 {
 
     //printf("cv_func('%s')\n",s.Sident.ptr);
@@ -2137,7 +2137,7 @@ void cv_func(Funcsym *s)
  */
 
 @trusted
-void cv_outsym(Symbol *s)
+void cv_outsym(Symbol* s)
 {
     //printf("cv_outsym('%s')\n",s.Sident.ptr);
     symbol_debug(s);
@@ -2165,7 +2165,7 @@ void cv_outsym(Symbol *s)
  */
 
 @trusted
-uint cv_typidx(type *t)
+uint cv_typidx(type* t)
 {   uint ti;
 
     //printf("cv_typidx(%p)\n",t);

--- a/compiler/src/dmd/backend/dcode.d
+++ b/compiler/src/dmd/backend/dcode.d
@@ -29,18 +29,18 @@ nothrow:
 @safe:
 
 __gshared
-code *code_list = null;
+code* code_list = null;
 
 /************************************
  * Allocate a chunk of code's and add them to
  * code_list.
  */
 @trusted
-code *code_chunk_alloc()
+code* code_chunk_alloc()
 {
     const size_t n = 4096 / code.sizeof;
     //printf("code_chunk_alloc() n = %d\n", n);
-    code *chunk = cast(code *)mem_fmalloc(n * code.sizeof);
+    code* chunk = cast(code*)mem_fmalloc(n * code.sizeof);
     for (size_t i = 0; i < n - 1; ++i)
     {
         chunk[i].next = &chunk[i + 1];
@@ -55,10 +55,10 @@ code *code_chunk_alloc()
  */
 
 @trusted
-code *code_calloc()
+code* code_calloc()
 {
     //printf("code %d\n", code.sizeof);
-    code *c = code_list ? code_list : code_chunk_alloc();
+    code* c = code_list ? code_list : code_chunk_alloc();
     code_list = code_next(c);
     memset(c, 0, code.sizeof);
 
@@ -72,18 +72,18 @@ code *code_calloc()
  */
 
 @trusted
-void code_free(code *cstart)
+void code_free(code* cstart)
 {
     if (cstart)
     {
-        code *c = cstart;
+        code* c = cstart;
         while (1)
         {
             if (c.Iop == ASM)
             {
                 mem_free(c.IEV1.bytes);
             }
-            code *cnext = code_next(c);
+            code* cnext = code_next(c);
             if (!cnext)
                 break;
             c = cnext;
@@ -100,7 +100,7 @@ void code_term()
 {
 static if (TERMCODE)
 {
-    code *cn;
+    code* cn;
     int count = 0;
 
     while (code_list)
@@ -117,7 +117,7 @@ debug
 {
     int count = 0;
 
-    for (code *cn = code_list; cn; cn = code_next(cn))
+    for (code* cn = code_list; cn; cn = code_next(cn))
         count++;
     printf("Max # of codes = %d\n",count);
 }

--- a/compiler/src/dmd/backend/debugprint.d
+++ b/compiler/src/dmd/backend/debugprint.d
@@ -205,7 +205,7 @@ void WRarglst(list_t a)
  */
 
 @trusted
-void WReqn(elem *e)
+void WReqn(elem* e)
 { __gshared int nest;
 
   if (!e)
@@ -307,7 +307,7 @@ void WRblocklist(list_t bl)
 {
     foreach (bl2; ListRange(bl))
     {
-        block *b = list_block(bl2);
+        block* b = list_block(bl2);
 
         if (b && b.Bweight)
             printf("B%d (%p) ",b.Bdfoidx,b);
@@ -377,7 +377,7 @@ const(char)* fl_str(FL fl)
  */
 
 @trusted
-void WRblock(block *b)
+void WRblock(block* b)
 {
     if (OPTIMIZER)
     {
@@ -492,10 +492,10 @@ void WRblock(block *b)
  * Number the blocks starting at 1.
  * So much more convenient than pointer values.
  */
-void numberBlocks(block *startblock)
+void numberBlocks(block* startblock)
 {
     uint number = 0;
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block* b = startblock; b; b = b.Bnext)
         b.Bnumber = ++number;
 }
 
@@ -511,6 +511,6 @@ void WRfunc(const char* msg, Symbol* sfunc, block* startblock)
 {
     printf("............%s...%s()\n", msg, sfunc.Sident.ptr);
     numberBlocks(startblock);
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block* b = startblock; b; b = b.Bnext)
         WRblock(b);
 }

--- a/compiler/src/dmd/backend/divcoeff.d
+++ b/compiler/src/dmd/backend/divcoeff.d
@@ -45,7 +45,7 @@ bool XltY128(ullong xh, ullong xl, ullong yh, ullong yl)
     return xh < yh || (xh == yh && xl < yl);
 }
 
-void u128Div(ullong xh, ullong xl, ullong yh, ullong yl, ullong *pqh, ullong *pql)
+void u128Div(ullong xh, ullong xl, ullong yh, ullong yl, ullong* pqh, ullong* pql)
 {
     /* Use auld skool shift & subtract algorithm.
      * Not very efficient.
@@ -117,7 +117,7 @@ void u128Div(ullong xh, ullong xl, ullong yh, ullong yl, ullong *pqh, ullong *pq
  */
 
 @trusted
-bool choose_multiplier(int N, ullong d, int prec, ullong *pm, int *pshpost)
+bool choose_multiplier(int N, ullong d, int prec, ullong* pm, int* pshpost)
 {
     assert(N == 32 || N == 64);
     assert(prec <= N);
@@ -233,7 +233,7 @@ bool choose_multiplier(int N, ullong d, int prec, ullong *pm, int *pshpost)
  *              q = SRL(MULUH(m, SRL(n, shpre)), shpost)
  */
 
-bool udiv_coefficients(int N, ullong d, int *pshpre, ullong *pm, int *pshpost)
+bool udiv_coefficients(int N, ullong d, int* pshpre, ullong* pm, int* pshpost)
 {
     bool mhighbit = choose_multiplier(N, d, N, pm, pshpost);
     if (mhighbit && (d & 1) == 0)

--- a/compiler/src/dmd/backend/dlist.d
+++ b/compiler/src/dmd/backend/dlist.d
@@ -80,7 +80,7 @@ int list_data(list_t list) { return list.data; }
  * Prepend integer item to list.
  */
 
-void list_prependdata(list_t *plist,int d)
+void list_prependdata(list_t* plist,int d)
 {
     list_prepend(plist, null).data = d;
 }
@@ -136,7 +136,7 @@ void list_free(list_t* plist, list_free_fp freeptr)
     }
 }
 
-void list_free(list_t *l)
+void list_free(list_t* l)
 {
      list_free(l, FPNULL);
 }
@@ -174,9 +174,9 @@ void* list_subtract(list_t* plist, void* ptr)
 }
 
 /***************************
- * Remove first element in list pointed to by *plist.
+ * Remove first element in list pointed to by* plist.
  * Returns:
- *      First element, null if *plist is null
+ *      First element, null if* plist is null
  */
 
 void* list_pop(list_t* plist)
@@ -185,7 +185,7 @@ void* list_pop(list_t* plist)
 }
 
 /*************************
- * Append ptr to *plist.
+ * Append ptr to* plist.
  * Returns:
  *      pointer to list item created.
  *      null if out of memory
@@ -209,14 +209,14 @@ list_t list_append(list_t* plist, void* ptr)
 }
 
 /*************************
- * Prepend ptr to *plist.
+ * Prepend ptr to* plist.
  * Returns:
  *      pointer to list item created (which is also the start of the list).
  *      null if out of memory
  */
 
 @trusted
-list_t list_prepend(list_t *plist, void *ptr)
+list_t list_prepend(list_t* plist, void* ptr)
 {
     list_t list = list_alloc();
     if (list)

--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -68,7 +68,7 @@ void outthunk(Symbol* sthunk, Symbol* sfunc, uint p, tym_t thisty,
  *      s               symbol to be initialized
  */
 @trusted
-void outdata(Symbol *s)
+void outdata(Symbol* s)
 {
     int seg;
     targ_size_t offset;
@@ -86,13 +86,13 @@ void outdata(Symbol *s)
     // Data segment variables are always live on exit from a function
     s.Sflags |= SFLlivexit;
 
-    dt_t *dtstart = s.Sdt;
+    dt_t* dtstart = s.Sdt;
     s.Sdt = null;                      // it will be free'd
     targ_size_t datasize = 0;
     tym_t ty = s.ty();
     if (ty & mTYexport && config.wflags & WFexpdef && s.Sclass != SC.static_)
         objmod.export_symbol(s,0);        // export data definition
-    for (dt_t *dt = dtstart; dt; dt = dt.DTnext)
+    for (dt_t* dt = dtstart; dt; dt = dt.DTnext)
     {
         //printf("\tdt = %p, dt = %d\n",dt,dt.dt);
         switch (dt.dt)
@@ -152,7 +152,7 @@ void outdata(Symbol *s)
                             assert(config.objfmt == OBJ_MACH && I64);
                             goto case;
                         case mTYthread:
-                        {   seg_data *pseg = objmod.tlsseg_bss();
+                        {   seg_data* pseg = objmod.tlsseg_bss();
                             s.Sseg = pseg.SDseg;
                             objmod.data_start(s, datasize, pseg.SDseg);
                             if (config.objfmt == OBJ_OMF)
@@ -191,7 +191,7 @@ void outdata(Symbol *s)
                 goto Lret;
 
             case DT.xoff:
-            {   Symbol *sb = dt.DTsym;
+            {   Symbol* sb = dt.DTsym;
 
                 if (tyfunc(sb.ty()))
                 {
@@ -257,7 +257,7 @@ void outdata(Symbol *s)
         {
             assert(config.objfmt == OBJ_MACH && I64);
 
-            seg_data *pseg = objmod.tlsseg_data();
+            seg_data* pseg = objmod.tlsseg_data();
             s.Sseg = pseg.SDseg;
             objmod.data_start(s, datasize, s.Sseg);
             seg = pseg.SDseg;
@@ -266,7 +266,7 @@ void outdata(Symbol *s)
         }
         case mTYthread:
         {
-            seg_data *pseg = objmod.tlsseg();
+            seg_data* pseg = objmod.tlsseg();
             s.Sseg = pseg.SDseg;
             objmod.data_start(s, datasize, s.Sseg);
             seg = pseg.SDseg;
@@ -329,7 +329,7 @@ Lret:
  */
 
 @trusted
-void dt_writeToObj(Obj objmod, dt_t *dt, int seg, ref targ_size_t offset)
+void dt_writeToObj(Obj objmod, dt_t* dt, int seg, ref targ_size_t offset)
 {
     for (; dt; dt = dt.DTnext)
     {
@@ -388,7 +388,7 @@ else
 
             case DT.xoff:
             {
-                Symbol *sb = dt.DTsym;          // get external symbol pointer
+                Symbol* sb = dt.DTsym;          // get external symbol pointer
                 targ_size_t a = dt.DToffset;    // offset from it
                 int flags;
                 if (tyreg(dt.Dty))
@@ -419,7 +419,7 @@ else
  */
 
 @trusted
-void outcommon(Symbol *s,targ_size_t n)
+void outcommon(Symbol* s,targ_size_t n)
 {
     //printf("outcommon('%s',%d)\n",s.Sident.ptr,n);
     if (n != 0)
@@ -485,7 +485,7 @@ void outcommon(Symbol *s,targ_size_t n)
  */
 
 @trusted
-void out_readonly(Symbol *s)
+void out_readonly(Symbol* s)
 {
     if (config.flags2 & CFG2noreadonly)
         return;
@@ -517,7 +517,7 @@ void out_readonly(Symbol *s)
  * Returns: a Symbol pointing to it.
  */
 @trusted
-Symbol *out_string_literal(const(char)* str, uint len, uint sz)
+Symbol* out_string_literal(const(char)* str, uint len, uint sz)
 {
     tym_t ty = TYchar;
     if (sz == 2)
@@ -527,7 +527,7 @@ Symbol *out_string_literal(const(char)* str, uint len, uint sz)
     else if (sz == 8)
         ty = TYulong;
 
-    Symbol *s = symbol_generate(SC.static_,type_static_array(len, tstypes[ty]));
+    Symbol* s = symbol_generate(SC.static_,type_static_array(len, tstypes[ty]));
     switch (config.objfmt)
     {
         case OBJ_ELF:
@@ -608,11 +608,11 @@ Symbol *out_string_literal(const(char)* str, uint len, uint sz)
  */
 
 @trusted
-/*private*/ void outelem(elem *e, ref bool addressOfParam)
+/*private*/ void outelem(elem* e, ref bool addressOfParam)
 {
-    Symbol *s;
+    Symbol* s;
     tym_t tym;
-    elem *e1;
+    elem* e1;
 
 again:
     assert(e);
@@ -721,12 +721,12 @@ debug
  */
 
 @trusted
-void out_regcand(symtab_t *psymtab)
+void out_regcand(symtab_t* psymtab)
 {
     //printf("out_regcand()\n");
     const bool ifunc = (tybasic(funcsym_p.ty()) == TYifunc);
     for (SYMIDX si = 0; si < psymtab.length; si++)
-    {   Symbol *s = (*psymtab)[si];
+    {   Symbol* s = (*psymtab)[si];
 
         symbol_debug(s);
         //assert(sytab[s.Sclass] & SCSS);      // only stack variables
@@ -740,7 +740,7 @@ void out_regcand(symtab_t *psymtab)
     }
 
     bool addressOfParam = false;                  // haven't taken addr of param yet
-    for (block *b = bo.startblock; b; b = b.Bnext)
+    for (block* b = bo.startblock; b; b = b.Bnext)
     {
         if (b.Belem)
             out_regcand_walk(b.Belem, addressOfParam);
@@ -763,7 +763,7 @@ void out_regcand(symtab_t *psymtab)
 }
 
 @trusted
-private void out_regcand_walk(elem *e, ref bool addressOfParam)
+private void out_regcand_walk(elem* e, ref bool addressOfParam)
 {
     while (1)
     {   elem_debug(e);
@@ -772,12 +772,12 @@ private void out_regcand_walk(elem *e, ref bool addressOfParam)
         {   if (e.Eoper == OPstreq)
             {   if (e.E1.Eoper == OPvar)
                 {
-                    Symbol *s = e.E1.Vsym;
+                    Symbol* s = e.E1.Vsym;
                     s.Sflags &= ~(SFLunambig | GTregcand);
                 }
                 if (e.E2.Eoper == OPvar)
                 {
-                    Symbol *s = e.E2.Vsym;
+                    Symbol* s = e.E2.Vsym;
                     s.Sflags &= ~(SFLunambig | GTregcand);
                 }
             }
@@ -789,7 +789,7 @@ private void out_regcand_walk(elem *e, ref bool addressOfParam)
             // Don't put 'this' pointers in registers if we need
             // them for EH stack cleanup.
             if (e.Eoper == OPctor)
-            {   elem *e1 = e.E1;
+            {   elem* e1 = e.E1;
 
                 if (e1.Eoper == OPadd)
                     e1 = e1.E1;
@@ -801,7 +801,7 @@ private void out_regcand_walk(elem *e, ref bool addressOfParam)
         else
         {   if (e.Eoper == OPrelconst)
             {
-                Symbol *s = e.Vsym;
+                Symbol* s = e.Vsym;
                 assert(s);
                 symbol_debug(s);
                 switch (s.Sclass)
@@ -849,7 +849,7 @@ private void out_regcand_walk(elem *e, ref bool addressOfParam)
  */
 
 @trusted
-void writefunc(Symbol *sfunc)
+void writefunc(Symbol* sfunc)
 {
     import dmd.backend.var : go;
     cstate.CSpsymtab = &globsym;
@@ -858,9 +858,9 @@ void writefunc(Symbol *sfunc)
 }
 
 @trusted
-private void writefunc2(Symbol *sfunc, ref GlobalOptimizer go)
+private void writefunc2(Symbol* sfunc, ref GlobalOptimizer go)
 {
-    func_t *f = sfunc.Sfunc;
+    func_t* f = sfunc.Sfunc;
 
     debugb && printf("=========== writefunc %s ==================\n",sfunc.Sident.ptr);
     //symbol_print(sfunc);
@@ -951,7 +951,7 @@ private void writefunc2(Symbol *sfunc, ref GlobalOptimizer go)
 
     bool addressOfParam = false;  // see if any parameters get their address taken
     bool anyasm = false;
-    for (block *b = bo.startblock; b; b = b.Bnext)
+    for (block* b = bo.startblock; b; b = b.Bnext)
     {
         memset(&b._BLU,0,block.sizeof - block._BLU.offsetof);
         if (b.Belem)
@@ -1107,13 +1107,13 @@ private void writefunc2(Symbol *sfunc, ref GlobalOptimizer go)
     {
 version (LittleEndian)
 {
-        short *p = cast(short *) sfunc.Sident.ptr;
+        short* p = cast(short*) sfunc.Sident.ptr;
         if (p[0] == (('S' << 8) | '_') && (p[1] == (('I' << 8) | 'T') || p[1] == (('D' << 8) | 'T')))
             objmod.setModuleCtorDtor(sfunc, sfunc.Sident.ptr[3] == 'I');
 }
 else
 {
-        char *p = sfunc.Sident.ptr;
+        char* p = sfunc.Sident.ptr;
         if (p[0] == '_' && p[1] == 'S' && p[2] == 'T' &&
             (p[3] == 'I' || p[3] == 'D'))
             objmod.setModuleCtorDtor(sfunc, sfunc.Sident.ptr[3] == 'I');
@@ -1163,7 +1163,7 @@ void alignOffset(int seg,targ_size_t datasize)
 enum ROMAX = 32;
 struct Readonly
 {
-    Symbol *sym;
+    Symbol* sym;
     size_t length;
     ubyte[ROMAX] p;
 }
@@ -1184,7 +1184,7 @@ void out_reset()
 }
 
 @trusted
-Symbol *out_readonly_sym(tym_t ty, void *p, int len)
+Symbol* out_readonly_sym(tym_t ty, void* p, int len)
 {
 static if (0)
 {
@@ -1195,12 +1195,12 @@ static if (0)
     // Look for previous symbol we can reuse
     for (int i = 0; i < readonly_length; i++)
     {
-        Readonly *r = &readonly[i];
+        Readonly* r = &readonly[i];
         if (r.length == len && memcmp(p, r.p.ptr, len) == 0)
             return r.sym;
     }
 
-    Symbol *s;
+    Symbol* s;
 
     bool cdata = config.objfmt == OBJ_ELF ||
                  config.objfmt == OBJ_OMF ||
@@ -1210,7 +1210,7 @@ static if (0)
         /* MACHOBJ can't go here, because the const data segment goes into
          * the _TEXT segment, and one cannot have a fixup from _TEXT to _TEXT.
          */
-        s = objmod.sym_cdata(ty, cast(char *)p, len);
+        s = objmod.sym_cdata(ty, cast(char*)p, len);
     }
     else
     {
@@ -1224,7 +1224,7 @@ static if (0)
     }
 
     if (len <= ROMAX)
-    {   Readonly *r;
+    {   Readonly* r;
 
         if (readonly_length < RMAX)
         {
@@ -1253,7 +1253,7 @@ static if (0)
  *      nzeros = number of trailing zeros to append
  */
 @trusted
-void out_readonly_comdat(Symbol *s, const(void)* p, uint len, uint nzeros)
+void out_readonly_comdat(Symbol* s, const(void)* p, uint len, uint nzeros)
 {
     objmod.readonly_comdat(s);         // create comdat segment
     objmod.write_bytes(SegData[s.Sseg], p[0 .. len]);

--- a/compiler/src/dmd/backend/drtlsym.d
+++ b/compiler/src/dmd/backend/drtlsym.d
@@ -50,11 +50,11 @@ Symbol* getRtlsymPersonality() { return getRtlsym(RTLSYM.PERSONALITY); }
  * Returns:
  *      runtime library Symbol
  */
-Symbol *getRtlsym(RTLSYM i) @trusted
+Symbol* getRtlsym(RTLSYM i) @trusted
 {
      Symbol** ps = &rtlsym[i];
      if (*ps)
-        return *ps;
+        return* ps;
 
     __gshared type* t;
     __gshared type* tv;
@@ -203,7 +203,7 @@ Symbol *getRtlsym(RTLSYM i) @trusted
         default:
             assert(0);
     }
-    return *ps;
+    return* ps;
 }
 
 
@@ -217,9 +217,9 @@ Symbol *getRtlsym(RTLSYM i) @trusted
  *    flags = value for Sflags
  *    t = type of function
  */
-private void symbolz(Symbol** ps, FL fl, regm_t regsaved, const(char)* name, SYMFLGS flags, type *t)
+private void symbolz(Symbol** ps, FL fl, regm_t regsaved, const(char)* name, SYMFLGS flags, type* t)
 {
-    Symbol *s = symbol_calloc(name[0 .. strlen(name)]);
+    Symbol* s = symbol_calloc(name[0 .. strlen(name)]);
     s.Stype = t;
     s.Ssymnum = SYMIDX.max;
     s.Sclass = SC.extern_;

--- a/compiler/src/dmd/backend/dt.d
+++ b/compiler/src/dmd/backend/dt.d
@@ -35,11 +35,11 @@ nothrow:
  */
 
 @trusted
-void dt_free(dt_t *dt)
+void dt_free(dt_t* dt)
 {
     if (dt)
     {
-        dt_t *dtn = dt;
+        dt_t* dtn = dt;
         while (1)
         {
             switch (dtn.dt)
@@ -52,7 +52,7 @@ void dt_free(dt_t *dt)
                 default:
                     break;
             }
-            dt_t *dtnext = dtn.DTnext;
+            dt_t* dtnext = dtn.DTnext;
             if (!dtnext)
                 break;
             dtn = dtnext;
@@ -70,7 +70,7 @@ void dt_term()
 {
 static if (0 && TERMCODE)
 {
-    dt_t *dtn;
+    dt_t* dtn;
 
     while (dt_freelist)
     {   dtn = dt_freelist.DTnext;
@@ -80,7 +80,7 @@ static if (0 && TERMCODE)
 }
 }
 
-dt_t **dtend(dt_t **pdtend)
+dt_t** dtend(dt_t** pdtend)
 {
     while (*pdtend)
         pdtend = &((*pdtend).DTnext);
@@ -90,7 +90,7 @@ dt_t **dtend(dt_t **pdtend)
 
 /*********************************
  */
-void dtpatchoffset(dt_t *dt, uint offset)
+void dtpatchoffset(dt_t* dt, uint offset)
 {
     dt.DToffset = offset;
 }
@@ -98,14 +98,14 @@ void dtpatchoffset(dt_t *dt, uint offset)
 /**************************
  * Make a common block for s.
  */
-void init_common(Symbol *s)
+void init_common(Symbol* s)
 {
     //printf("init_common('%s')\n", s.Sident);
 
     uint size = cast(uint)type_size(s.Stype);
     if (size)
     {
-        dt_t *dt = dt_calloc(DT.common);
+        dt_t* dt = dt_calloc(DT.common);
         dt.DTazeros = size;
         s.Sdt = dt;
     }
@@ -182,7 +182,7 @@ bool dtpointers(const(dt_t)* dtstart)
  * Turn DT.azeros into DTcommon
  */
 
-void dt2common(dt_t **pdt)
+void dt2common(dt_t** pdt)
 {
     assert((*pdt).dt == DT.azeros);
     (*pdt).dt = DT.common;
@@ -225,7 +225,7 @@ nothrow:
     /*************************
      * Finish and return completed data structure.
      */
-    dt_t *finish()
+    dt_t* finish()
     {
         /* Merge all the 0s at the start of the list
          * so we can later check for dtallzeros()
@@ -234,7 +234,7 @@ nothrow:
         {
             while (1)
             {
-                dt_t *dtn = head.DTnext;
+                dt_t* dtn = head.DTnext;
                 if (!(dtn && dtn.dt == DT.azeros))
                     break;
 
@@ -276,7 +276,7 @@ nothrow:
         if (allZero)
             return nzeros(data.length);
 
-        dt_t *dt;
+        dt_t* dt;
 
         if (data.length < dt_t.DTibytesMax)
         {
@@ -310,11 +310,11 @@ nothrow:
     @trusted
     void abytes(tym_t ty, uint offset, const(char)[] data, uint nzeros, ubyte _align)
     {
-        dt_t *dt = dt_calloc(DT.abytes);
+        dt_t* dt = dt_calloc(DT.abytes);
         const n = data.length + nzeros;
         assert(n >= data.length);      // overflow check
         dt.DTnbytes = n;
-        dt.DTpbytes = cast(byte *) mem_malloc(n);
+        dt.DTpbytes = cast(byte*) mem_malloc(n);
         dt.Dty = cast(ubyte)ty;
         dt.DTalign = _align;
         dt.DTabytes = offset;
@@ -346,7 +346,7 @@ nothrow:
             return;
         }
 
-        dt_t *dt = dt_calloc(DT.ibytes);
+        dt_t* dt = dt_calloc(DT.ibytes);
         dt.DTn = 4;
 
         union U { char* cp; int* lp; }
@@ -371,7 +371,7 @@ nothrow:
             nzeros(_tysize[TYnptr]);
             return;
         }
-        dt_t *dt = dt_calloc(DT.ibytes);
+        dt_t* dt = dt_calloc(DT.ibytes);
         dt.DTn = _tysize[TYnptr];
 
         union U { char* cp; int* lp; }
@@ -396,7 +396,7 @@ nothrow:
             return;
         assert(cast(int) size > 0);
 
-        dt_t *dt = dt_calloc(DT.azeros);
+        dt_t* dt = dt_calloc(DT.azeros);
         dt.DTazeros = size;
 
         assert(!*pTail);
@@ -409,9 +409,9 @@ nothrow:
      * Write a reference to s+offset
      */
     @trusted
-    void xoff(Symbol *s, uint offset, tym_t ty)
+    void xoff(Symbol* s, uint offset, tym_t ty)
     {
-        dt_t *dt = dt_calloc(DT.xoff);
+        dt_t* dt = dt_calloc(DT.xoff);
         dt.DTsym = s;
         dt.DToffset = offset;
         dt.Dty = cast(ubyte)ty;
@@ -425,7 +425,7 @@ nothrow:
     /******************************
      * Create reference to s+offset
      */
-    void xoff(Symbol *s, uint offset)
+    void xoff(Symbol* s, uint offset)
     {
         xoff(s, offset, TYnptr);
     }
@@ -434,32 +434,32 @@ nothrow:
      * Like xoff(), but returns handle with which to patch 'offset' value.
      */
     @trusted
-    dt_t *xoffpatch(Symbol *s, uint offset, tym_t ty)
+    dt_t* xoffpatch(Symbol* s, uint offset, tym_t ty)
     {
-        dt_t *dt = dt_calloc(DT.xoff);
+        dt_t* dt = dt_calloc(DT.xoff);
         dt.DTsym = s;
         dt.DToffset = offset;
         dt.Dty = cast(ubyte)ty;
 
-        dt_t **pxoff = pTail;
+        dt_t** pxoff = pTail;
 
         assert(!*pTail);
         *pTail = dt;
         pTail = &dt.DTnext;
         assert(!*pTail);
 
-        return *pxoff;
+        return* pxoff;
     }
 
     /*************************************
      * Create a reference to another dt.
      * Returns: the internal symbol used for the other dt
      */
-    Symbol *dtoff(dt_t *dt, uint offset)
+    Symbol* dtoff(dt_t* dt, uint offset)
     {
-        type *t = type_alloc(TYint);
+        type* t = type_alloc(TYint);
         t.Tcount++;
-        Symbol *s = symbol_calloc("internal");
+        Symbol* s = symbol_calloc("internal");
         s.Sclass = SC.static_;
         s.Sfl = FL.extern_;
         s.Sflags |= SFLnodebug;
@@ -477,7 +477,7 @@ nothrow:
     @trusted
     void coff(uint offset)
     {
-        dt_t *dt = dt_calloc(DT.coff);
+        dt_t* dt = dt_calloc(DT.coff);
 
         if (config.exe & EX_segmented)
             dt.Dty = TYcptr;
@@ -496,7 +496,7 @@ nothrow:
     /**********************
      * Append dt to data.
      */
-    void cat(dt_t *dt)
+    void cat(dt_t* dt)
     {
         assert(!*pTail);
         *pTail = dt;
@@ -524,7 +524,7 @@ nothrow:
      * Repeat a list of dt_t's count times.
      */
     @trusted
-    void repeat(dt_t *dt, size_t count)
+    void repeat(dt_t* dt, size_t count)
     {
         if (!count)
             return;
@@ -544,20 +544,20 @@ nothrow:
 
         if (dtpointers(dt))
         {
-            dt_t *dtp = null;
-            dt_t **pdt = &dtp;
+            dt_t* dtp = null;
+            dt_t** pdt = &dtp;
             for (size_t i = 0; i < count; ++i)
             {
-                for (dt_t *dtn = dt; dtn; dtn = dtn.DTnext)
+                for (dt_t* dtn = dt; dtn; dtn = dtn.DTnext)
                 {
-                    dt_t *dtx = dt_calloc(dtn.dt);
+                    dt_t* dtx = dt_calloc(dtn.dt);
                     *dtx = *dtn;
                     dtx.DTnext = null;
                     switch (dtx.dt)
                     {
                         case DT.abytes:
                         case DT.nbytes:
-                            dtx.DTpbytes = cast(byte *) mem_malloc(dtx.DTnbytes);
+                            dtx.DTpbytes = cast(byte*) mem_malloc(dtx.DTnbytes);
                             memcpy(dtx.DTpbytes, dtn.DTpbytes, dtx.DTnbytes);
                             break;
 
@@ -578,10 +578,10 @@ nothrow:
 
         const n = size * count;
         assert(n >= size);
-        char *p = cast(char *)mem_malloc(n);
+        char* p = cast(char*)mem_malloc(n);
         size_t offset = 0;
 
-        for (dt_t *dtn = dt; dtn; dtn = dtn.DTnext)
+        for (dt_t* dtn = dt; dtn; dtn = dtn.DTnext)
         {
             switch (dtn.dt)
             {
@@ -610,7 +610,7 @@ nothrow:
             offset += size;
         }
 
-        dt_t *dtx = dt_calloc(DT.nbytes);
+        dt_t* dtx = dt_calloc(DT.nbytes);
         dtx.DTnbytes = cast(uint)(size * count);
         dtx.DTpbytes = cast(byte*)p;
 
@@ -638,20 +638,20 @@ nothrow:
     }
 }
 
-private __gshared dt_t *dt_freelist;
+private __gshared dt_t* dt_freelist;
 
 /**********************************************
  * Allocate a data definition struct.
  */
 
 @trusted
-private dt_t *dt_calloc(DT dtx)
+private dt_t* dt_calloc(DT dtx)
 {
-    dt_t *dt = dt_freelist;
+    dt_t* dt = dt_freelist;
     if (!dt)
     {
         const size_t n = 4096 / dt_t.sizeof;
-        dt_t *chunk = cast(dt_t *)mem_fmalloc(n * dt_t.sizeof);
+        dt_t* chunk = cast(dt_t*)mem_fmalloc(n * dt_t.sizeof);
         for (size_t i = 0; i < n - 1; ++i)
         {
             chunk[i].DTnext = &chunk[i + 1];
@@ -675,7 +675,7 @@ private dt_t *dt_calloc(DT dtx)
 
 dt_t* dt_get_nzeros(uint n)
 {
-    dt_t *dt = dt_calloc(DT.azeros);
+    dt_t* dt = dt_calloc(DT.azeros);
     dt.DTazeros = n;
     return dt;
 }

--- a/compiler/src/dmd/backend/dtype.d
+++ b/compiler/src/dmd/backend/dtype.d
@@ -34,8 +34,8 @@ struct_t* struct_calloc() { return cast(struct_t*) mem_calloc(struct_t.sizeof); 
 
 private __gshared
 {
-    type *type_list;          // free list of types
-    param_t *param_list;      // free list of params
+    type* type_list;          // free list of types
+    param_t* param_list;      // free list of params
 
     int type_num,type_max;   /* gather statistics on # of types      */
 }
@@ -61,7 +61,7 @@ __gshared
  *      size
  */
 @trusted @nogc
-targ_size_t type_size(const type *t)
+targ_size_t type_size(const type* t)
 {   targ_size_t s;
     tym_t tyb;
 
@@ -137,7 +137,7 @@ targ_size_t type_size(const type *t)
  */
 
 @trusted
-uint type_alignsize(type *t)
+uint type_alignsize(type* t)
 {   targ_size_t sz;
 
 L1:
@@ -190,7 +190,7 @@ L1:
  *      true if it is
  */
 @trusted
-bool type_zeroSize(type *t, tym_t tyf)
+bool type_zeroSize(type* t, tym_t tyf)
 {
     if (tyf != TYjfunc && config.exe & (EX_FREEBSD | EX_OPENBSD | EX_OSX))
     {
@@ -198,7 +198,7 @@ bool type_zeroSize(type *t, tym_t tyf)
          */
         if (t && tybasic(t.Tty) == TYstruct)
         {
-            type *ts = t.Ttag.Stype;     // find main instance
+            type* ts = t.Ttag.Stype;     // find main instance
                                            // (for const struct X)
             if (ts.Tflags & TFsizeunknown)
             {
@@ -220,7 +220,7 @@ bool type_zeroSize(type *t, tym_t tyf)
  * Returns:
  *      size in bytes
  */
-uint type_parameterSize(type *t, tym_t tyf)
+uint type_parameterSize(type* t, tym_t tyf)
 {
     if (type_zeroSize(t, tyf))
         return 0;
@@ -238,12 +238,12 @@ uint type_parameterSize(type *t, tym_t tyf)
  */
 
 @trusted
-uint type_paramsize(type *t)
+uint type_paramsize(type* t)
 {
     targ_size_t sz = 0;
     if (tyfunc(t.Tty))
     {
-        for (param_t *p = t.Tparamtypes; p; p = p.Pnext)
+        for (param_t* p = t.Tparamtypes; p; p = p.Pnext)
         {
             const size_t n = type_parameterSize(p.Ptype, tybasic(t.Tty));
             sz += _align(REGSIZE,n);       // align to REGSIZE boundary
@@ -261,8 +261,8 @@ uint type_paramsize(type *t)
  */
 
 @trusted @nogc
-type *type_alloc(tym_t ty)
-{   type *t;
+type* type_alloc(tym_t ty)
+{   type* t;
 
     assert(tybasic(ty) != TYtemplate);
     if (type_list)
@@ -270,7 +270,7 @@ type *type_alloc(tym_t ty)
         type_list = t.Tnext;
     }
     else
-        t = cast(type *) mem_fmalloc(type.sizeof);
+        t = cast(type*) mem_fmalloc(type.sizeof);
     *t = type();
     t.Tty = ty;
 version (SRCPOS_4TYPES)
@@ -298,8 +298,8 @@ debug
  *      pointer to newly created type.
  */
 @nogc
-type *type_fake(tym_t ty)
-{   type *t;
+type* type_fake(tym_t ty)
+{   type* t;
 
     assert(ty != TYstruct);
 
@@ -315,8 +315,8 @@ type *type_fake(tym_t ty)
  * Allocate a type of ty with a Tnext of tn.
  */
 
-type *type_allocn(tym_t ty,type *tn)
-{   type *t;
+type* type_allocn(tym_t ty,type* tn)
+{   type* t;
 
     //printf("type_allocn(ty = x%x, tn = %p)\n", ty, tn);
     assert(tn);
@@ -334,9 +334,9 @@ type *type_allocn(tym_t ty,type *tn)
  *      Tcount already incremented
  */
 
-type *type_pointer(type *tnext)
+type* type_pointer(type* tnext)
 {
-    type *t = type_allocn(TYnptr, tnext);
+    type* t = type_allocn(TYnptr, tnext);
     t.Tcount++;
     return t;
 }
@@ -347,9 +347,9 @@ type *type_pointer(type *tnext)
  *      Tcount already incremented
  */
 @trusted
-type *type_dyn_array(type *tnext)
+type* type_dyn_array(type* tnext)
 {
-    type *t = type_allocn(TYdarray, tnext);
+    type* t = type_allocn(TYdarray, tnext);
     t.Tcount++;
     return t;
 }
@@ -360,9 +360,9 @@ type *type_dyn_array(type *tnext)
  *      Tcount already incremented
  */
 
-type* type_static_array(targ_size_t dim, type *tnext)
+type* type_static_array(targ_size_t dim, type* tnext)
 {
-    type *t = type_allocn(TYarray, tnext);
+    type* t = type_allocn(TYarray, tnext);
     t.Tdim = dim;
     t.Tcount++;
     return t;
@@ -376,9 +376,9 @@ type* type_static_array(targ_size_t dim, type *tnext)
  */
 
 @trusted
-type *type_assoc_array(type *tkey, type *tvalue)
+type* type_assoc_array(type* tkey, type* tvalue)
 {
-    type *t = type_allocn(TYaarray, tvalue);
+    type* t = type_allocn(TYaarray, tvalue);
     t.Tkey = tkey;
     tkey.Tcount++;
     t.Tcount++;
@@ -392,9 +392,9 @@ type *type_assoc_array(type *tkey, type *tvalue)
  */
 
 @trusted
-type *type_delegate(type *tnext)
+type* type_delegate(type* tnext)
 {
-    type *t = type_allocn(TYdelegate, tnext);
+    type* t = type_allocn(TYdelegate, tnext);
     t.Tcount++;
     return t;
 }
@@ -410,14 +410,14 @@ type *type_delegate(type *tnext)
  *      Tcount already incremented
  */
 @trusted
-type *type_function(tym_t tyf, type*[] ptypes, bool variadic, type *tret)
+type* type_function(tym_t tyf, type*[] ptypes, bool variadic, type* tret)
 {
-    param_t *paramtypes = null;
+    param_t* paramtypes = null;
     foreach (p; ptypes)
     {
         param_append_type(&paramtypes, p);
     }
-    type *t = type_allocn(tyf, tret);
+    type* t = type_allocn(tyf, tret);
     t.Tflags |= TFprototype;
     if (!variadic)
         t.Tflags |= TFfixed;
@@ -435,15 +435,15 @@ type *type_function(tym_t tyf, type*[] ptypes, bool variadic, type *tret)
  *      Tcount already incremented
  */
 @trusted
-type *type_enum(const(char)* name, type *tbase)
+type* type_enum(const(char)* name, type* tbase)
 {
-    Symbol *s = symbol_calloc(name[0 .. strlen(name)]);
+    Symbol* s = symbol_calloc(name[0 .. strlen(name)]);
     s.Sclass = SC.enum_;
-    s.Senum = cast(enum_t *) mem_calloc(enum_t.sizeof);
+    s.Senum = cast(enum_t*) mem_calloc(enum_t.sizeof);
     s.Senum.SEflags |= SENforward;        // forward reference
 
-    type *t = type_allocn(TYenum, tbase);
-    t.Ttag = cast(Classsym *)s;            // enum tag name
+    type* t = type_allocn(TYenum, tbase);
+    t.Ttag = cast(Classsym*)s;            // enum tag name
     t.Tcount++;
     s.Stype = t;
     t.Tcount++;
@@ -459,8 +459,8 @@ type *type_enum(const(char)* name, type *tbase)
  *      Tcount already incremented
  */
 @trusted
-type *type_struct_class(const(char)* name, uint alignsize, uint structsize,
-        type *arg1type, type *arg2type, bool isUnion, bool isClass, bool isPOD, bool is0size)
+type* type_struct_class(const(char)* name, uint alignsize, uint structsize,
+        type* arg1type, type* arg2type, bool isUnion, bool isClass, bool isPOD, bool is0size)
 {
     static if (0)
     {
@@ -476,7 +476,7 @@ type *type_struct_class(const(char)* name, uint alignsize, uint structsize,
             type_print(arg2type);
         }
     }
-    Symbol *s = symbol_calloc(name[0 .. strlen(name)]);
+    Symbol* s = symbol_calloc(name[0 .. strlen(name)]);
     s.Sclass = SC.struct_;
     s.Sstruct = struct_calloc();
     s.Sstruct.Salignsize = alignsize;
@@ -496,8 +496,8 @@ type *type_struct_class(const(char)* name, uint alignsize, uint structsize,
     if (is0size)
         s.Sstruct.Sflags |= STR0size;
 
-    type *t = type_alloc(TYstruct);
-    t.Ttag = cast(Classsym *)s;            // structure tag name
+    type* t = type_alloc(TYstruct);
+    t.Ttag = cast(Classsym*)s;            // structure tag name
     t.Tcount++;
     s.Stype = t;
     t.Tcount++;
@@ -509,8 +509,8 @@ type *type_struct_class(const(char)* name, uint alignsize, uint structsize,
  */
 
 @trusted
-void type_free(type *t)
-{   type *tn;
+void type_free(type* t)
+{   type* tn;
     tym_t ty;
 
     while (t)
@@ -554,7 +554,7 @@ version (STATS)
 /* count number of free types available on type list */
 void type_count_free()
     {
-    type *t;
+    type* t;
     int count;
 
     for(t=type_list;t;t=t.Tnext)
@@ -568,7 +568,7 @@ void type_count_free()
  */
 
 private type * type_allocbasic(tym_t ty)
-{   type *t;
+{   type* t;
 
     t = type_alloc(ty);
     t.Tmangle = Mangle.c;
@@ -665,12 +665,12 @@ void type_term()
 {
 static if (TERMCODE)
 {
-    type *tn;
-    param_t *pn;
+    type* tn;
+    param_t* pn;
     int i;
 
     for (i = 0; i < tstypes.length; i++)
-    {   type *t = tsptr2types[i];
+    {   type* t = tsptr2types[i];
 
         if (t)
         {   assert(!(t.Tty & (mTYconst | mTYvolatile | mTYimmutable | mTYshared)));
@@ -719,9 +719,9 @@ debug
  */
 
 @trusted
-type *type_copy(type *t)
-{   type *tn;
-    param_t *p;
+type* type_copy(type* t)
+{   type* tn;
+    param_t* p;
 
     type_debug(t);
     tn = type_alloc(t.Tty);
@@ -739,12 +739,12 @@ type *type_copy(type *t)
                 {
                     tn.Tparamtypes = null;
                     for (p = t.Tparamtypes; p; p = p.Pnext)
-                    {   param_t *pn;
+                    {   param_t* pn;
 
                         pn = param_append_type(&tn.Tparamtypes,p.Ptype);
                         if (p.Pident)
                         {
-                            pn.Pident = cast(char *)mem_strdup(p.Pident);
+                            pn.Pident = cast(char*)mem_strdup(p.Pident);
                         }
                         assert(!p.Pelem);
                     }
@@ -768,14 +768,14 @@ type *type_copy(type *t)
  * Modify the tym_t field of a type.
  */
 
-type *type_setty(type **pt,uint newty)
-{   type *t;
+type* type_setty(type** pt,uint newty)
+{   type* t;
 
     t = *pt;
     type_debug(t);
     if (cast(tym_t)newty != t.Tty)
     {   if (t.Tcount > 1)              /* if other people pointing at t */
-        {   type *tn;
+        {   type* tn;
 
             tn = type_copy(t);
             tn.Tcount++;
@@ -792,29 +792,29 @@ type *type_setty(type **pt,uint newty)
  * Set type field of some object to t.
  */
 
-type *type_settype(type **pt, type *t)
+type* type_settype(type** pt, type* t)
 {
     if (t)
     {   type_debug(t);
         t.Tcount++;
     }
     type_free(*pt);
-    return *pt = t;
+    return* pt = t;
 }
 
 /****************************
  * Modify the Tmangle field of a type.
  */
 
-type *type_setmangle(type **pt, Mangle mangle)
-{   type *t;
+type* type_setmangle(type** pt, Mangle mangle)
+{   type* t;
 
     t = *pt;
     type_debug(t);
     if (mangle != type_mangle(t))
     {
         if (t.Tcount > 1)              // if other people pointing at t
-        {   type *tn;
+        {   type* tn;
 
             tn = type_copy(t);
             tn.Tcount++;
@@ -828,11 +828,11 @@ type *type_setmangle(type **pt, Mangle mangle)
 }
 
 /******************************
- * Set/clear const and volatile bits in *pt according to the settings
+ * Set/clear const and volatile bits in* pt according to the settings
  * in cv.
  */
 
-type *type_setcv(type **pt,tym_t cv)
+type* type_setcv(type** pt,tym_t cv)
 {   uint ty;
 
     type_debug(*pt);
@@ -844,12 +844,12 @@ type *type_setcv(type **pt,tym_t cv)
  * Set dimension of array.
  */
 
-type *type_setdim(type **pt,targ_size_t dim)
-{   type *t = *pt;
+type* type_setdim(type** pt,targ_size_t dim)
+{   type* t = *pt;
 
     type_debug(t);
     if (t.Tcount > 1)                  /* if other people pointing at t */
-    {   type *tn;
+    {   type* tn;
 
         tn = type_copy(t);
         tn.Tcount++;
@@ -858,7 +858,7 @@ type *type_setdim(type **pt,targ_size_t dim)
     }
     t.Tflags &= ~TFsizeunknown; /* we have determined its size */
     t.Tdim = dim;              /* index of array               */
-    return *pt = t;
+    return* pt = t;
 }
 
 
@@ -866,7 +866,7 @@ type *type_setdim(type **pt,targ_size_t dim)
  * Create a 'dependent' version of type t.
  */
 
-type *type_setdependent(type *t)
+type* type_setdependent(type* t)
 {
     type_debug(t);
     if (t.Tcount > 0 &&                        /* if other people pointing at t */
@@ -883,10 +883,10 @@ type *type_setdependent(type *t)
  */
 
 @trusted
-int type_isdependent(type *t)
+int type_isdependent(type* t)
 {
-    Symbol *stempl;
-    type *tstart;
+    Symbol* stempl;
+    type* tstart;
 
     //printf("type_isdependent(%p)\n", t);
     //type_print(t);
@@ -899,7 +899,7 @@ int type_isdependent(type *t)
                 || tybasic(t.Tty) == TYtemplate
                 )
         {
-            for (param_t *p = t.Tparamtypes; p; p = p.Pnext)
+            for (param_t* p = t.Tparamtypes; p; p = p.Pnext)
             {
                 if (p.Ptype && type_isdependent(p.Ptype))
                     goto Lisdependent;
@@ -910,7 +910,7 @@ int type_isdependent(type *t)
         else if (type_struct(t) &&
                  (stempl = t.Ttag.Sstruct.Stempsym) != null)
         {
-            for (param_t *p = t.Ttag.Sstruct.Sarglist; p; p = p.Pnext)
+            for (param_t* p = t.Ttag.Sstruct.Sarglist; p; p = p.Pnext)
             {
                 if (p.Ptype && type_isdependent(p.Ptype))
                     goto Lisdependent;
@@ -937,8 +937,8 @@ Lisdependent:
  */
 
 @trusted
-int type_embed(type *t,type *u)
-{   param_t *p;
+int type_embed(type* t,type* u)
+{   param_t* p;
 
     for (; t; t = t.Tnext)
     {
@@ -960,7 +960,7 @@ int type_embed(type *t,type *u)
  * Determine if type is a VLA.
  */
 
-int type_isvla(type *t)
+int type_isvla(type* t)
 {
     while (t)
     {
@@ -979,7 +979,7 @@ int type_isvla(type *t)
  */
 
 @trusted
-void type_print(const type *t)
+void type_print(const type* t)
 {
   type_debug(t);
   printf("Tty=%s", tym_str(t.Tty));
@@ -1009,7 +1009,7 @@ void type_print(const type *t)
             printf(" Tident='%s'",t.Tident);
             break;
         case TYtemplate:
-            printf(" Tsym='%s'",(cast(typetemp_t *)t).Tsym.Sident.ptr);
+            printf(" Tsym='%s'",(cast(typetemp_t*)t).Tsym.Sident.ptr);
             {
                 int i;
 
@@ -1095,10 +1095,10 @@ void param_t_print_list(scope param_t* p)
  */
 
 @trusted
-param_t *param_calloc()
+param_t* param_calloc()
 {
     static param_t pzero;
-    param_t *p;
+    param_t* p;
 
     if (param_list)
     {
@@ -1107,7 +1107,7 @@ param_t *param_calloc()
     }
     else
     {
-        p = cast(param_t *) mem_fmalloc(param_t.sizeof);
+        p = cast(param_t*) mem_fmalloc(param_t.sizeof);
     }
     *p = pzero;
 
@@ -1120,8 +1120,8 @@ param_t *param_calloc()
  * Allocate a param_t of type t, and append it to parameter list.
  */
 
-param_t *param_append_type(param_t **pp,type *t)
-{   param_t *p;
+param_t* param_append_type(param_t** pp,type* t)
+{   param_t* p;
 
     p = param_calloc();
     while (*pp)
@@ -1140,7 +1140,7 @@ param_t *param_append_type(param_t **pp,type *t)
  */
 
 @trusted
-void param_free_l(param_t *p)
+void param_free_l(param_t* p)
 {
     param_free(&p);
 }
@@ -1152,7 +1152,7 @@ void param_free_l(param_t *p)
  */
 
 @trusted
-void param_free(param_t **pparamlst)
+void param_free(param_t** pparamlst)
 {   param_t* p,pn;
 
     //debug_assert(PARSER);
@@ -1195,10 +1195,10 @@ uint param_t_length(scope param_t* p)
  */
 
 @trusted
-param_t* param_t_createTal(scope param_t* p, param_t *ptali)
+param_t* param_t_createTal(scope param_t* p, param_t* ptali)
 {
-    param_t *ptal = null;
-    param_t **pp = &ptal;
+    param_t* ptal = null;
+    param_t** pp = &ptal;
 
     for (; p; p = p.Pnext)
     {
@@ -1206,7 +1206,7 @@ param_t* param_t_createTal(scope param_t* p, param_t *ptali)
         if (p.Pident)
         {
             // Should find a way to just point rather than dup
-            (*pp).Pident = cast(char *)mem_strdup(p.Pident);
+            (*pp).Pident = cast(char*)mem_strdup(p.Pident);
         }
         if (ptali)
         {
@@ -1216,7 +1216,7 @@ param_t* param_t_createTal(scope param_t* p, param_t *ptali)
             }
             if (ptali.Pelem)
             {
-                elem *e = el_copytree(ptali.Pelem);
+                elem* e = el_copytree(ptali.Pelem);
                 (*pp).Pelem = e;
             }
             (*pp).Psym = ptali.Psym;
@@ -1249,7 +1249,7 @@ param_t* param_t_search(return scope param_t* p, const(char)* id)
  */
 
 @trusted
-int param_t_searchn(param_t* p, char *id)
+int param_t_searchn(param_t* p, char* id)
 {
     int n = 0;
 
@@ -1269,11 +1269,11 @@ int param_t_searchn(param_t* p, char *id)
  */
 
 @trusted
-Symbol *param_search(const(char)* name, param_t **pp)
-{   Symbol *s = null;
-    param_t *p;
+Symbol* param_search(const(char)* name, param_t** pp)
+{   Symbol* s = null;
+    param_t* p;
 
-    p = (*pp).search(cast(char *)name);
+    p = (*pp).search(cast(char*)name);
     if (p)
     {
         s = p.Psym;
@@ -1290,7 +1290,7 @@ Symbol *param_search(const(char)* name, param_t **pp)
 }
 
 // Return TRUE if type lists match.
-private int paramlstmatch(param_t *p1,param_t *p2)
+private int paramlstmatch(param_t* p1,param_t* p2)
 {
         return p1 == p2 ||
             p1 && p2 && typematch(p1.Ptype,p2.Ptype,0) &&
@@ -1308,7 +1308,7 @@ private int paramlstmatch(param_t *p1,param_t *p2)
  */
 
 @trusted
-int typematch(type *t1,type *t2,int relax)
+int typematch(type* t1,type* t2,int relax)
 { tym_t t1ty, t2ty;
   tym_t tym;
 

--- a/compiler/src/dmd/backend/dvarstats.d
+++ b/compiler/src/dmd/backend/dvarstats.d
@@ -278,7 +278,7 @@ public void writeSymbolTable(ref symtab_t symtab,
     bool endarg = false;
     for (SYMIDX si = 0; si < symtab2.length; si++)
     {
-        Symbol *sa = (*symtab2)[si];
+        Symbol* sa = (*symtab2)[si];
         if (endarg == false &&
             sa.Sclass != SC.parameter &&
             sa.Sclass != SC.fastpar &&

--- a/compiler/src/dmd/backend/dvec.d
+++ b/compiler/src/dmd/backend/dvec.d
@@ -68,10 +68,10 @@ struct VecGlobal
 
             foreach (size_t i; 0 .. freelist.length)
             {
-                void **vn;
-                for (void** v = cast(void **)freelist[i]; v; v = vn)
+                void** vn;
+                for (void** v = cast(void**)freelist[i]; v; v = vn)
                 {
-                    vn = cast(void **)(*v);
+                    vn = cast(void**)(*v);
                     //mem_free(v);
                     .free(v);
                 }
@@ -89,7 +89,7 @@ struct VecGlobal
         vec_t v;
         if (dim < freelist.length && (v = freelist[dim]) != null)
         {
-            freelist[dim] = *cast(vec_t *)v;
+            freelist[dim] = *cast(vec_t*)v;
             v += 2;
             switch (dim)
             {
@@ -138,7 +138,7 @@ struct VecGlobal
         vec_t result;
         if (dim < freelist.length && (vc = freelist[dim]) != null)
         {
-            freelist[dim] = *cast(vec_t *)vc;
+            freelist[dim] = *cast(vec_t*)vc;
             goto L1;
         }
         else
@@ -169,7 +169,7 @@ struct VecGlobal
             v -= 2;
             if (dim < freelist.length)
             {
-                *cast(vec_t *)v = freelist[dim];
+                *cast(vec_t*)v = freelist[dim];
                 freelist[dim] = v;
             }
             else

--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -91,7 +91,7 @@ static if (1)
             int except_table_seg = UNKNOWN; // __gcc_except_tab segment
             int except_table_num = 0;       // sequence number for GCC_except_table%d symbols
             int eh_frame_seg = UNKNOWN;     // __eh_frame segment
-            Symbol *eh_frame_sym = null;    // past end of __eh_frame
+            Symbol* eh_frame_sym = null;    // past end of __eh_frame
 
         uint CIE_offset_unwind;     // CIE offset for unwind data
         uint CIE_offset_no_unwind;  // CIE offset for no unwind data
@@ -142,7 +142,7 @@ static if (1)
         return Obj.getsegment(name, suffix, SHT_PROGBITS, SHF_ALLOC, align_ * 4);
     }
 
-    int dwarf_except_table_alloc(Symbol *s)
+    int dwarf_except_table_alloc(Symbol* s)
     {
         //printf("dwarf_except_table_alloc('%s')\n", s.Sident.ptr);
         if (config.objfmt == OBJ_ELF)
@@ -151,7 +151,7 @@ static if (1)
              * a unique section, which then gets added to the COMDAT group
              * associated with `s`.
              */
-            seg_data *pseg = SegData[s.Sseg];
+            seg_data* pseg = SegData[s.Sseg];
             if (pseg.SDassocseg)
             {
                 const(char)* suffix = s.Sident.ptr; // cpp_mangle(s);
@@ -182,7 +182,7 @@ static if (1)
              */
             if (!eh_frame_sym)
             {
-                type *t = tspvoid;
+                type* t = tspvoid;
                 t.Tcount++;
                 type_setmangle(&t, Mangle.syscall);         // no leading '_' for mangled name
                 eh_frame_sym = symbol_name("EH_frame0", SC.static_, t);
@@ -218,7 +218,7 @@ static if (1)
             assert(0);
     }
 
-    void dwarf_appreladdr(int seg, OutBuffer *buf, int targseg, targ_size_t val)
+    void dwarf_appreladdr(int seg, OutBuffer* buf, int targseg, targ_size_t val)
     {
         if (I64)
         {
@@ -242,13 +242,13 @@ static if (1)
         }
     }
 
-    void dwarf_apprel32(int seg, OutBuffer *buf, int targseg, targ_size_t val)
+    void dwarf_apprel32(int seg, OutBuffer* buf, int targseg, targ_size_t val)
     {
         dwarf_addrel(seg, buf.length(), targseg, I64 ? val : 0);
         buf.write32(I64 ? 0 : cast(uint)val);
     }
 
-    void append_addr(OutBuffer *buf, targ_size_t addr)
+    void append_addr(OutBuffer* buf, targ_size_t addr)
     {
         if (I64)
             buf.write64(addr);
@@ -476,7 +476,7 @@ static if (1)
     {
         segidx_t seg = 0;
         IDXSEC secidx = 0;
-        OutBuffer *buf = null;
+        OutBuffer* buf = null;
         const(char)* name;
         int flags = 0;
 
@@ -527,15 +527,15 @@ static if (1)
          * representing the abbreviation code itself."
          */
         uint abbrevcode = 1;
-        AApair *abbrev_table;
+        AApair* abbrev_table;
         int hasModname;    // 1 if has DW_TAG_module
 
         // .debug_info
-        AAchars *infoFileName_table;
+        AAchars* infoFileName_table;
 
-        AApair *type_table;
-        AApair *functype_table;  // not sure why this cannot be combined with type_table
-        OutBuffer *functypebuf;
+        AApair* type_table;
+        AApair* functype_table;  // not sure why this cannot be combined with type_table
+        OutBuffer* functypebuf;
 
         // .debug_line
         size_t linebuf_filetab_end;
@@ -593,7 +593,7 @@ static if (1)
      * Params:
      *      buf = write raw data here
      */
-    void writeDebugFrameHeader(OutBuffer *buf)
+    void writeDebugFrameHeader(OutBuffer* buf)
     {
         void writeDebugFrameHeader(ubyte dversion)()
         {
@@ -666,7 +666,7 @@ static if (1)
      * See_Also:
      *      https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA/ehframechpt.html
      */
-    private uint writeEhFrameHeader(IDXSEC dfseg, OutBuffer *buf, Symbol *personality, bool ehunwind)
+    private uint writeEhFrameHeader(IDXSEC dfseg, OutBuffer* buf, Symbol* personality, bool ehunwind)
     {
         /* Augmentation string:
          *  z = first character, means Augmentation Data field is present
@@ -799,7 +799,7 @@ static if (1)
      *      dfseg = SegData[] index for .debug_frame
      *      sfunc = the function
      */
-    void writeDebugFrameFDE(IDXSEC dfseg, Symbol *sfunc)
+    void writeDebugFrameFDE(IDXSEC dfseg, Symbol* sfunc)
     {
         if (I64)
         {
@@ -830,7 +830,7 @@ static if (1)
             // Do we need this?
             //debugFrameFDE64.initial_location = sfunc.Soffset;
 
-            OutBuffer *debug_frame_buf = SegData[dfseg].SDbuf;
+            OutBuffer* debug_frame_buf = SegData[dfseg].SDbuf;
             uint debug_frame_buf_offset = cast(uint)debug_frame_buf.length();
             debug_frame_buf.reserve(1000);
             debug_frame_buf.writen(&debugFrameFDE64,debugFrameFDE64.sizeof);
@@ -871,7 +871,7 @@ static if (1)
             // Do we need this?
             //debugFrameFDE32.initial_location = sfunc.Soffset;
 
-            OutBuffer *debug_frame_buf = SegData[dfseg].SDbuf;
+            OutBuffer* debug_frame_buf = SegData[dfseg].SDbuf;
             uint debug_frame_buf_offset = cast(uint)debug_frame_buf.length();
             debug_frame_buf.reserve(1000);
             debug_frame_buf.writen(&debugFrameFDE32,debugFrameFDE32.sizeof);
@@ -893,18 +893,18 @@ static if (1)
      *      ehunwind = will have EH unwind table
      *      CIE_offset = offset of enclosing CIE
      */
-    void writeEhFrameFDE(IDXSEC dfseg, Symbol *sfunc, bool ehunwind, uint CIE_offset)
+    void writeEhFrameFDE(IDXSEC dfseg, Symbol* sfunc, bool ehunwind, uint CIE_offset)
     {
-        OutBuffer *buf = SegData[dfseg].SDbuf;
+        OutBuffer* buf = SegData[dfseg].SDbuf;
         const uint startsize = cast(uint)buf.length();
 
-        Symbol *fdesym;
+        Symbol* fdesym;
         if (config.objfmt == OBJ_MACH)
         {
             /* Create symbol named "funcname.eh" for the start of the FDE
              */
             const size_t len = strlen(getSymName(sfunc));
-            char *name = cast(char *)malloc(len + 3 + 1);
+            char* name = cast(char*)malloc(len + 3 + 1);
             if (!name)
                 err_nomem();
             memcpy(name, getSymName(sfunc), len);
@@ -1034,7 +1034,7 @@ static if (1)
                 flags = SHT_PROGBITS;
 
             int seg = dwarf_getsegment(debug_frame_name, 1, flags);
-            OutBuffer *buf = SegData[seg].SDbuf;
+            OutBuffer* buf = SegData[seg].SDbuf;
             buf.reserve(1000);
             writeDebugFrameHeader(buf);
         }
@@ -1050,7 +1050,7 @@ static if (1)
          ******************************************************************** */
         {
             debug_str.initialize();
-            //OutBuffer *debug_str_buf = debug_str.buf;
+            //OutBuffer* debug_str_buf = debug_str.buf;
         }
 
         /* *********************************************************************
@@ -1384,12 +1384,12 @@ static if (1)
             aachars = AAchars.create();
         }
 
-        uint *pidx = aachars.get(str);
+        uint* pidx = aachars.get(str);
         if (!*pidx)                 // if no idx assigned yet
         {
             *pidx = cast(uint) aachars.length(); // assign newly computed idx
         }
-        return *pidx;
+        return* pidx;
     }
 
     /**
@@ -1464,7 +1464,7 @@ static if (1)
             {
                 for (uint i = 0; i < SegData[seg].SDlinnum_data.length; i++)
                 {
-                    linnum_data *ld = &SegData[seg].SDlinnum_data[i];
+                    linnum_data* ld = &SegData[seg].SDlinnum_data[i];
                     const(char)* filename;
 
                     filename = ld.filename;
@@ -1577,7 +1577,7 @@ static if (1)
 
         for (uint seg = 1; seg < SegData.length; seg++)
         {
-            seg_data *sd = SegData[seg];
+            seg_data* sd = SegData[seg];
             uint addressmax = 0;
             uint linestart = ~0;
 
@@ -1586,7 +1586,7 @@ static if (1)
 
             //printf("sd = %x, SDlinnum_count = %d\n", sd, sd.SDlinnum_count);
             for (int i = 0; i < sd.SDlinnum_data.length; i++)
-            {   linnum_data *ld = &sd.SDlinnum_data[i];
+            {   linnum_data* ld = &sd.SDlinnum_data[i];
 
                 // Set address to start of segment with DW_LNE_set_address
                 debug_line.buf.writeByte(0);
@@ -1681,8 +1681,8 @@ static if (1)
         debug_pubnames.buf.write32(0);
 
         // Plug final sizes into header
-        *cast(uint *)debug_pubnames.buf.buf = cast(uint)debug_pubnames.buf.length() - 4;
-        *cast(uint *)(debug_pubnames.buf.buf + 10) = cast(uint)debug_info.buf.length();
+        *cast(uint*)debug_pubnames.buf.buf = cast(uint)debug_pubnames.buf.length() - 4;
+        *cast(uint*)(debug_pubnames.buf.buf + 10) = cast(uint)debug_info.buf.length();
 
         /* ================================================= */
 
@@ -1691,7 +1691,7 @@ static if (1)
         append_addr(debug_aranges.buf, 0);
 
         // Plug final sizes into header
-        *cast(uint *)debug_aranges.buf.buf = cast(uint)debug_aranges.buf.length() - 4;
+        *cast(uint*)debug_aranges.buf.buf = cast(uint)debug_aranges.buf.length() - 4;
 
         /* ================================================= */
 
@@ -1719,7 +1719,7 @@ static if (1)
     /*****************************************
      * Start of code gen for function.
      */
-    void dwarf_func_start(Symbol *sfunc)
+    void dwarf_func_start(Symbol* sfunc)
     {
         //printf("dwarf_func_start(%s)\n", sfunc.Sident.ptr);
         if (config.target_cpu == TARGET_AArch64)
@@ -1746,7 +1746,7 @@ static if (1)
     /*****************************************
      * End of code gen for function.
      */
-    void dwarf_func_term(Symbol *sfunc)
+    void dwarf_func_term(Symbol* sfunc)
     {
         //printf("dwarf_func_term(sfunc = '%s')\n", sfunc.Sident.ptr);
 
@@ -1756,10 +1756,10 @@ static if (1)
 
             IDXSEC dfseg = dwarf_eh_frame_alloc();
 
-            OutBuffer *buf = SegData[dfseg].SDbuf;
+            OutBuffer* buf = SegData[dfseg].SDbuf;
             buf.reserve(1000);
 
-            uint *poffset = ehunwind ? &CIE_offset_unwind : &CIE_offset_no_unwind;
+            uint* poffset = ehunwind ? &CIE_offset_unwind : &CIE_offset_no_unwind;
             if (*poffset == ~0)
                 *poffset = writeEhFrameHeader(dfseg, buf, getRtlsymPersonality(), ehunwind);
 
@@ -1789,7 +1789,7 @@ static if (1)
         }
 
         IDXSEC seg = sfunc.Sseg;
-        seg_data *sd = SegData[seg];
+        seg_data* sd = SegData[seg];
 
         int filenum = dwarf_line_addfile(filename);
 
@@ -1992,10 +1992,10 @@ static if (1)
 
                             /* find member offset in closure */
                             targ_size_t memb_off = 0;
-                            struct_t *st = sa.Sscope.Stype.Tnext.Ttag.Sstruct; // Sscope is __closptr
+                            struct_t* st = sa.Sscope.Stype.Tnext.Ttag.Sstruct; // Sscope is __closptr
                             foreach (sl; ListRange(st.Sfldlst))
                             {
-                                Symbol *sf = list_symbol(sl);
+                                Symbol* sf = list_symbol(sl);
                                 if (sf.Sclass == SC.member)
                                 {
                                     if(strcmp(sa.Sident.ptr, sf.Sident.ptr) == 0)
@@ -2039,7 +2039,7 @@ static if (1)
             debug_info.buf.writeByte(0);              // end of parameter children
 
             idxsibling = cast(uint)debug_info.buf.length();
-            *cast(uint *)(debug_info.buf.buf + siblingoffset) = idxsibling;
+            *cast(uint*)(debug_info.buf.buf + siblingoffset) = idxsibling;
         }
 
         /* ============= debug_pubnames =========================== */
@@ -2051,7 +2051,7 @@ static if (1)
 
         if (sd.SDaranges_offset)
             // Extend existing entry size
-            *cast(ulong *)(debug_aranges.buf.buf + sd.SDaranges_offset + _tysize[TYnptr]) = cgstate.funcoffset + sfunc.Ssize;
+            *cast(ulong*)(debug_aranges.buf.buf + sd.SDaranges_offset + _tysize[TYnptr]) = cgstate.funcoffset + sfunc.Ssize;
         else
         {   // Add entry
             sd.SDaranges_offset = cast(uint)debug_aranges.buf.length();
@@ -2109,7 +2109,7 @@ static if (1)
      * Write out symbol table for current function.
      */
 
-    void dwarf_outsym(Symbol *s)
+    void dwarf_outsym(Symbol* s)
     {
         //printf("dwarf_outsym('%s')\n",s.Sident.ptr);
         //symbol_print(s);
@@ -2119,7 +2119,7 @@ static if (1)
         if (s.Sflags & SFLnodebug)
             return;
 
-        type *t = s.Stype;
+        type* t = s.Stype;
         type_debug(t);
         tym_t tym = tybasic(t.Tty);
         if (tyfunc(tym) && s.Sclass != SC.typedef_)
@@ -2214,15 +2214,15 @@ static if (1)
 
     /* ======================= Type Index ============================== */
 
-    uint dwarf_typidx(type *t)
+    uint dwarf_typidx(type* t)
     {
         uint idx = 0;
         uint nextidx;
         uint keyidx;
         uint pvoididx;
         uint code;
-        type *tnext;
-        type *tbase;
+        type* tnext;
+        type* tbase;
         const(char)* p;
 
         static immutable ubyte[8] abbrevTypeBasic =
@@ -2396,7 +2396,7 @@ static if (1)
                     uint lenidx = I64 ? dwarf_typidx(tstypes[TYullong]) : dwarf_typidx(tstypes[TYuint]);
 
                     {
-                        type *tdata = type_alloc(TYnptr);
+                        type* tdata = type_alloc(TYnptr);
                         tdata.Tnext = t.Tnext;
                         t.Tnext.Tcount++;
                         tdata.Tcount++;
@@ -2447,7 +2447,7 @@ static if (1)
                  * function type
                  */
                 {
-                    type *tp = type_fake(TYnptr);
+                    type* tp = type_fake(TYnptr);
                     tp.Tcount++;
                     pvoididx = dwarf_typidx(tp);    // void*
 
@@ -2503,7 +2503,7 @@ static if (1)
                  * element type, Tkey is the key type
                  */
                 {
-                    type *tp = type_fake(TYnptr);
+                    type* tp = type_fake(TYnptr);
                     tp.Tcount++;
                     pvoididx = dwarf_typidx(tp);    // void*
                 }
@@ -2598,7 +2598,7 @@ static if (1)
                 nextidx = dwarf_typidx(t.Tnext);                   // function return type
                 tmpbuf.write32(nextidx);
                 uint params = 0;
-                for (param_t *p2 = t.Tparamtypes; p2; p2 = p2.Pnext)
+                for (param_t* p2 = t.Tparamtypes; p2; p2 = p2.Pnext)
                 {
                     params = 1;
                     uint paramidx = dwarf_typidx(p2.Ptype);
@@ -2624,12 +2624,12 @@ static if (1)
                  */
                 if (!functype_table)
                     functype_table = AApair.create(functypebuf.bufptr);
-                uint *pidx = cast(uint *)functype_table.get(Pair(functypebufidx, cast(uint)functypebuf.length()));
+                uint* pidx = cast(uint*)functype_table.get(Pair(functypebufidx, cast(uint)functypebuf.length()));
                 if (*pidx)
                 {
                     // Reuse existing typidx
                     functypebuf.setsize(functypebufidx);
-                    return *pidx;
+                    return* pidx;
                 }
 
                 /* Not in the cache, create a new typidx
@@ -2662,9 +2662,9 @@ static if (1)
                             DW_AT_type,              DW_FORM_ref4
                     ]);
 
-                    uint *pparamidx = cast(uint *)(functypebuf.buf + functypebufidx);
+                    uint* pparamidx = cast(uint*)(functypebuf.buf + functypebufidx);
                     //printf("2: functypebufidx = %x, pparamidx = %p, size = %x\n", functypebufidx, pparamidx, functypebuf.length());
-                    for (param_t *p2 = t.Tparamtypes; p2; p2 = p2.Pnext)
+                    for (param_t* p2 = t.Tparamtypes; p2; p2 = p2.Pnext)
                     {
                         debug_info.buf.writeuLEB128(paramcode);
                         //uint x = dwarf_typidx(p2.Ptype);
@@ -2798,8 +2798,8 @@ static if (1)
 
             case TYstruct:
             {
-                Classsym *s = t.Ttag;
-                struct_t *st = s.Sstruct;
+                Classsym* s = t.Ttag;
+                struct_t* st = s.Sstruct;
 
                 if (s.Stypidx)
                     return s.Stypidx;
@@ -2837,7 +2837,7 @@ static if (1)
                 t.Tflags |= TFforward;
                 foreach (sl; ListRange(st.Sfldlst))
                 {
-                    Symbol *sf = list_symbol(sl);
+                    Symbol* sf = list_symbol(sl);
                     switch (sf.Sclass)
                     {
                         case SC.member:
@@ -2914,7 +2914,7 @@ static if (1)
                     for (auto bc = st.Sbase; bc; bc = bc.BCnext, n++)
                     {
                         debug_info.buf.writeuLEB128(baseclasscode);
-                        uint bci = (cast(uint *)baseclassidx.buf)[n];
+                        uint bci = (cast(uint*)baseclassidx.buf)[n];
                         debug_info.buf.write32(bci);
                         const soffset = debug_info.buf.length();
                         debug_info.buf.writeByte(2);
@@ -2927,7 +2927,7 @@ static if (1)
                     n = 0;
                     foreach (sl; ListRange(st.Sfldlst))
                     {
-                        Symbol *sf = list_symbol(sl);
+                        Symbol* sf = list_symbol(sl);
                         size_t soffset;
 
                         switch (sf.Sclass)
@@ -2936,7 +2936,7 @@ static if (1)
                                 debug_info.buf.writeuLEB128(membercode);
                                 debug_info.buf.writeStringz(getSymName(sf));      // DW_AT_name
                                 //debug_info.buf.write32(dwarf_typidx(sf.Stype));
-                                uint fi = (cast(uint *)fieldidx.buf)[n];
+                                uint fi = (cast(uint*)fieldidx.buf)[n];
                                 debug_info.buf.write32(fi);
                                 n++;
                                 soffset = debug_info.buf.length();
@@ -2960,9 +2960,9 @@ static if (1)
 
             case TYenum:
             {
-                Symbol *s = t.Ttag;
-                enum_t *se = s.Senum;
-                type *tbase2 = s.Stype.Tnext;
+                Symbol* s = t.Ttag;
+                enum_t* se = s.Senum;
+                type* tbase2 = s.Stype.Tnext;
                 uint sz = cast(uint)type_size(tbase2);
                 symlist_t sl;
 
@@ -3011,7 +3011,7 @@ static if (1)
 
                 foreach (sl2; ListRange(s.Senum.SEenumlist))
                 {
-                    Symbol *sf = cast(Symbol *)list_ptr(sl2);
+                    Symbol* sf = cast(Symbol*)list_ptr(sl2);
                     const value = cast(uint)el_tolong(sf.Svalue);
 
                     debug_info.buf.writeuLEB128(membercode);
@@ -3042,7 +3042,7 @@ static if (1)
              */
             type_table = AApair.create(debug_info.buf.bufptr);
 
-        uint *pidx = type_table.get(Pair(idx, cast(uint)debug_info.buf.length()));
+        uint* pidx = type_table.get(Pair(idx, cast(uint)debug_info.buf.length()));
         if (!*pidx)                 // if no idx assigned yet
         {
             *pidx = idx;            // assign newly computed idx
@@ -3172,7 +3172,7 @@ static if (1)
          * discard this one and use the previous one.
          */
 
-        uint *pcode = abbrev_table.get(Pair(cast(uint) start, cast(uint) end));
+        uint* pcode = abbrev_table.get(Pair(cast(uint) start, cast(uint) end));
         if (!*pcode)
         {
             // if no code assigned yet, assign newly computed code
@@ -3184,7 +3184,7 @@ static if (1)
             debug_abbrev.buf.setsize(idx);
             --abbrevcode;
         }
-        return *pcode;
+        return* pcode;
     }
 
     /*****************************************************
@@ -3194,13 +3194,13 @@ static if (1)
      *      startoffset = size of function prolog
      *      retoffset = offset from start of function to epilog
      */
-    void dwarf_except_gentables(Funcsym *sfunc, uint startoffset, uint retoffset)
+    void dwarf_except_gentables(Funcsym* sfunc, uint startoffset, uint retoffset)
     {
         if (!doUnwindEhFrame())
             return;
 
         int seg = dwarf_except_table_alloc(sfunc);
-        OutBuffer *buf = SegData[seg].SDbuf;
+        OutBuffer* buf = SegData[seg].SDbuf;
         buf.reserve(100);
 
         if (config.objfmt == OBJ_ELF)
@@ -3210,10 +3210,10 @@ static if (1)
         {
             char[16 + (except_table_num).sizeof * 3 + 1] name = void;
             const length = snprintf(name.ptr, name.length, "GCC_except_table%d", ++except_table_num);
-            type *t = tspvoid;
+            type* t = tspvoid;
             t.Tcount++;
             type_setmangle(&t, Mangle.syscall);         // no leading '_' for mangled name
-            Symbol *s = symbol_name(name[0 .. length], SC.static_, t);
+            Symbol* s = symbol_name(name[0 .. length], SC.static_, t);
             Obj.pubdef(seg, s, cast(uint)buf.length());
             symbol_keep(s);
 
@@ -3230,7 +3230,7 @@ else
     void dwarf_CFA_set_loc(uint location) { }
     void dwarf_CFA_set_reg_offset(int reg, int offset) { }
     void dwarf_CFA_offset(int reg, int offset) { }
-    void dwarf_except_gentables(Funcsym *sfunc, uint startoffset, uint retoffset) { }
+    void dwarf_except_gentables(Funcsym* sfunc, uint startoffset, uint retoffset) { }
 }
 
 version (Windows)
@@ -3263,5 +3263,5 @@ private char* filespecname(const(char)* filespec) nothrow
          p--
         )
     { }
-    return cast(char *)p;
+    return cast(char*)p;
 }

--- a/compiler/src/dmd/backend/dwarfeh.d
+++ b/compiler/src/dmd/backend/dwarfeh.d
@@ -34,7 +34,7 @@ struct DwEhTableEntry
     uint end;           // 1 past end
     uint lpad;          // landing pad
     uint action;        // index into Action Table
-    block *bcatch;      // catch block data
+    block* bcatch;      // catch block data
     int prev;           // index to enclosing entry (-1 for none)
 }
 
@@ -53,7 +53,7 @@ package __gshared DwEhTable dwehtable;
  *      retoffset = offset from start of function to epilog
  */
 
-void genDwarfEh(Funcsym *sfunc, int seg, OutBuffer *et, bool scancode, uint startoffset, uint retoffset, ref DwEhTable deh)
+void genDwarfEh(Funcsym* sfunc, int seg, OutBuffer* et, bool scancode, uint startoffset, uint retoffset, ref DwEhTable deh)
 {
     /* LPstart = encoding of LPbase
      * LPbase = landing pad base (normally omitted)
@@ -73,7 +73,7 @@ void genDwarfEh(Funcsym *sfunc, int seg, OutBuffer *et, bool scancode, uint star
      */
 
     et.reserve(100);
-    block *startblock = sfunc.Sfunc.Fstartblock;
+    block* startblock = sfunc.Sfunc.Fstartblock;
     //printf("genDwarfEh: func = %s, offset = x%x, startblock.Boffset = x%x, scancode = %d startoffset=x%x, retoffset=x%x\n",
       //sfunc.Sident.ptr, cast(int)sfunc.Soffset, cast(int)startblock.Boffset, scancode, startoffset, retoffset);
 
@@ -93,21 +93,21 @@ static if (0)
     /* Build deh table, and Action Table
      */
     int index = -1;
-    block *bprev = null;
+    block* bprev = null;
     // The first entry encompasses the entire function
     {
         uint i = cast(uint) deh.length;
-        DwEhTableEntry *d = deh.push();
+        DwEhTableEntry* d = deh.push();
         d.start = cast(uint)(startblock.Boffset + startoffset);
         d.end = cast(uint)(startblock.Boffset + retoffset);
         d.lpad = 0;                    // no cleanup, no catches
         index = i;
     }
-    for (block *b = startblock; b; b = b.Bnext)
+    for (block* b = startblock; b; b = b.Bnext)
     {
         if (index > 0 && b.Btry == bprev)
         {
-            DwEhTableEntry *d = &deh[index];
+            DwEhTableEntry* d = &deh[index];
             d.end = cast(uint)b.Boffset;
             index = d.prev;
             if (bprev)
@@ -116,10 +116,10 @@ static if (0)
         if (b.bc == BC._try)
         {
             uint i = cast(uint) deh.length;
-            DwEhTableEntry *d = deh.push();
+            DwEhTableEntry* d = deh.push();
             d.start = cast(uint)b.Boffset;
 
-            block *bf = b.nthSucc(1);
+            block* bf = b.nthSucc(1);
             if (bf.bc == BC.jcatch)
             {
                 d.lpad = cast(uint)bf.Boffset;
@@ -147,12 +147,12 @@ static if (0)
         {
             uint coffset = cast(uint)b.Boffset;
             int n = 0;
-            for (code *c = b.Bcode; c; c = code_next(c))
+            for (code* c = b.Bcode; c; c = code_next(c))
             {
                 if (c.Iop == PSOP.dctor)
                 {
                     uint i = cast(uint) deh.length;
-                    DwEhTableEntry *d = deh.push();
+                    DwEhTableEntry* d = deh.push();
                     d.start = coffset;
                     d.prev = index;
                     index = i;
@@ -163,7 +163,7 @@ static if (0)
                 {
                     assert(n > 0);
                     --n;
-                    DwEhTableEntry *d = &deh[index];
+                    DwEhTableEntry* d = &deh[index];
                     d.end = coffset;
                     d.lpad = coffset;
                     index = d.prev;
@@ -223,7 +223,7 @@ else
         uint j = i;
         do
         {
-            DwEhTableEntry *d = deh.index(j);
+            DwEhTableEntry* d = deh.index(j);
             //printf(" [%d] start=%x end=%x lpad=%x action=%x bcatch=%p prev=%d\n",
             //  j, d.start, d.end, d.lpad, d.action, d.bcatch, d.prev);
             if (d.start <= end && end < d.end)
@@ -232,7 +232,7 @@ else
                 uint dend = d.end;
                 if (i + 1 < deh.dim)
                 {
-                    DwEhTableEntry *dnext = deh.index(i + 1);
+                    DwEhTableEntry* dnext = deh.index(i + 1);
                     if (dnext.start < dend)
                         dend = dnext.start;
                 }
@@ -331,7 +331,7 @@ else
     auto typesTable = sfunc.Sfunc.typesTable[];
     for (int i = cast(int)typesTable.length; i--; )
     {
-        Symbol *s = typesTable[i];
+        Symbol* s = typesTable[i];
         /* MACHOBJ 64: pcrel 1 length 1 extern 1 RELOC_GOT
          *         32: [0] address x004c pcrel 0 length 2 value x224 type 4 RELOC_LOCAL_SECTDIFF
          *             [1] address x0000 pcrel 0 length 2 value x160 type 1 RELOC_PAIR
@@ -356,7 +356,7 @@ else
  * Returns:
  *      offset of inserted action
  */
-int actionTableInsert(OutBuffer *atbuf, int ttindex, int nextoffset)
+int actionTableInsert(OutBuffer* atbuf, int ttindex, int nextoffset)
 {
     //printf("actionTableInsert(%d, %d)\n", ttindex, nextoffset);
     auto p = cast(const(ubyte)[]) (*atbuf)[];

--- a/compiler/src/dmd/backend/ee.d
+++ b/compiler/src/dmd/backend/ee.d
@@ -38,7 +38,7 @@ __gshared EEcontext eecontext;
 @trusted
 void eecontext_convs(SYMIDX marksi)
 {
-    symtab_t *ps;
+    symtab_t* ps;
 
     // Change all generated SC.auto's to SC.stack's
     ps = cstate.CSpsymtab;

--- a/compiler/src/dmd/backend/eh.d
+++ b/compiler/src/dmd/backend/eh.d
@@ -39,7 +39,7 @@ package(dmd) @property @nogc nothrow auto @trusted NPTRSIZE() { return _tysize[T
  */
 
 @trusted
-Symbol *except_gentables()
+Symbol* except_gentables()
 {
     //printf("except_gentables()\n");
     if (config.ehmethod == EHmethod.EH_DM && !(funcsym_p.Sfunc.Fflags3 & Feh_none))
@@ -53,7 +53,7 @@ Symbol *except_gentables()
         __gshared int tmpnum;
         const len = snprintf(name.ptr, name.length, "_HandlerTable%d", tmpnum++);
 
-        Symbol *s = symbol_name(name[0 .. len],SC.static_,tstypes[TYint]);
+        Symbol* s = symbol_name(name[0 .. len],SC.static_,tstypes[TYint]);
         symbol_keep(s);
         //symbol_debug(s);
 
@@ -81,11 +81,11 @@ Symbol *except_gentables()
  *    }
  *    int last_index;             // previous index (enclosing guarded section)
  *    uint catchoffset;           // offset to catch block from Symbol
- *    void *finally;              // finally code to execute
+ *    void* finally;              // finally code to execute
  * }
  */
 @trusted
-void except_fillInEHTable(Symbol *s)
+void except_fillInEHTable(Symbol* s)
 {
     uint fsize = NPTRSIZE;             // target size of function pointer
     auto dtb = DtBuilder(0);
@@ -98,9 +98,9 @@ void except_fillInEHTable(Symbol *s)
         Guard guard[];          // sorted such that the enclosing guarded sections come first
       catchoffset:
         uint ncatches;          // number of catch blocks
-        {   void *type;         // Symbol representing type
+        {   void* type;         // Symbol representing type
             uint bpoffset;      // EBP offset of catch variable
-            void *handler;      // catch handler code
+            void* handler;      // catch handler code
         } catch[];
      */
 
@@ -146,7 +146,7 @@ void except_fillInEHTable(Symbol *s)
 //      printf("b.bc = %2d, Bscope_index = %2d, last_index = %2d, offset = x%x\n",
 //              b.bc, b.Bscope_index, b.Blast_index, b.Boffset);
         if (cgstate.usednteh & EHcleanup)
-            for (code *c = b.Bcode; c; c = code_next(c))
+            for (code* c = b.Bcode; c; c = code_next(c))
             {
                 if (c.Iop == PSOP.ddtor)
                     ndctors++;
@@ -186,7 +186,7 @@ void except_fillInEHTable(Symbol *s)
 
             // Compute ending offset
             uint endoffset;
-            for (block *bn = b.Bnext; 1; bn = bn.Bnext)
+            for (block* bn = b.Bnext; 1; bn = bn.Bnext)
             {
                 //printf("\tbn = %p, bn.Btry = %p, bn.offset = %x\n", bn, bn.Btry, bn.Boffset);
                 assert(bn);
@@ -213,7 +213,7 @@ void except_fillInEHTable(Symbol *s)
             {
                 assert(nsucc == 2);
                 dtb.dword(0);           // no catch offset
-                block *bhandler = b.nthSucc(1);
+                block* bhandler = b.nthSucc(1);
                 assert(bhandler.bc == BC._finally);
                 // To successor of BC._finally block
                 bhandler = bhandler.nthSucc(0);
@@ -246,11 +246,11 @@ void except_fillInEHTable(Symbol *s)
         stack.push(b.Btry ? b.Btry.Bscope_index : -1);
 
         uint boffset = cast(uint)b.Boffset;
-        for (code *c = b.Bcode; c; c = code_next(c))
+        for (code* c = b.Bcode; c; c = code_next(c))
         {
             if (c.Iop == PSOP.dctor)
             {
-                code *c2 = code_next(c);
+                code* c2 = code_next(c);
                 if (config.ehmethod == EHmethod.EH_WIN32)
                     nteh_patchindex(c2, scopeindex);
                 if (config.ehmethod == EHmethod.EH_DM)
@@ -273,7 +273,7 @@ void except_fillInEHTable(Symbol *s)
                         else
                         {
                             foffset = eoffset;
-                            code *cf = code_next(c2);
+                            code* cf = code_next(c2);
                             if (config.ehmethod == EHmethod.EH_WIN32)
                             {
                                 nteh_patchindex(cf, stack[stack.length - 1]);
@@ -338,7 +338,7 @@ void except_fillInEHTable(Symbol *s)
 
             for (int j = 1; j < nsucc; ++j)
             {
-                block *bcatch = b.nthSucc(j);
+                block* bcatch = b.nthSucc(j);
 
                 dtb.xoff(bcatch.Bcatchtype,0,TYnptr);
 

--- a/compiler/src/dmd/backend/el.d
+++ b/compiler/src/dmd/backend/el.d
@@ -98,7 +98,7 @@ struct elem
         struct
         {
             targ_size_t Voffset;// offset from symbol
-            Symbol *Vsym;       // pointer to symbol table
+            Symbol* Vsym;       // pointer to symbol table
             union
             {
                 param_t* Vtal;  // template-argument-list for SCfunctempl,
@@ -157,7 +157,7 @@ struct elem
         }
     }
 
-    type *ET;            // pointer to type of elem if TYstruct | TYarray
+    type* ET;            // pointer to type of elem if TYstruct | TYarray
     Srcpos Esrcpos;      // source file position
 }
 
@@ -181,7 +181,7 @@ FL el_fl(const elem* e) { return e.Vsym.Sfl; }
 inout(elem)* list_elem(inout list_t list) { return cast(inout(elem)*)list_ptr(list); }
 
 @trusted
-void list_setelem(list_t list, void* ptr) { list.ptr = cast(elem *)ptr; }
+void list_setelem(list_t list, void* ptr) { list.ptr = cast(elem*)ptr; }
 
 public import dmd.backend.elem;
 public import dmd.backend.elpicpie : el_var, el_ptr;

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -70,7 +70,7 @@ private __gshared
 
 private __gshared
 {
-    elem *nextfree = null;           /* pointer to next free elem    */
+    elem* nextfree = null;           /* pointer to next free elem    */
 
     int elcount = 0;                 /* number of allocated elems    */
     int elem_size = elem.sizeof;
@@ -84,7 +84,7 @@ private __gshared
 
 struct STAB
 {
-    Symbol *sym;        // symbol that refers to the string
+    Symbol* sym;        // symbol that refers to the string
     char[] str;         // the string
 }
 
@@ -136,7 +136,7 @@ void el_term()
             printf("unfreed elems = %d\n",elcount);
         while (nextfree)
         {
-            elem *e;
+            elem* e;
             e = nextfree.E1;
             mem_ffree(nextfree);
             nextfree = e;
@@ -153,9 +153,9 @@ void el_term()
  */
 
 @trusted
-elem *el_calloc()
+elem* el_calloc()
 {
-    elem *e;
+    elem* e;
 
     elcount++;
     if (nextfree)
@@ -164,7 +164,7 @@ elem *el_calloc()
         nextfree = e.E1;
     }
     else
-        e = cast(elem *) mem_fmalloc(elem.sizeof);
+        e = cast(elem*) mem_fmalloc(elem.sizeof);
 
     version (STATS)
         eprm_cnt++;
@@ -187,7 +187,7 @@ elem *el_calloc()
  * Free element
  */
 @trusted
-void el_free(elem *e)
+void el_free(elem* e)
 {
 L1:
     if (!e) return;
@@ -246,7 +246,7 @@ version (STATS)
     /* count number of elems available on free list */
     void el_count_free()
     {
-        elem *e;
+        elem* e;
         int count;
 
         for(e=nextfree;e;e=e.E1)
@@ -263,7 +263,7 @@ version (STATS)
  * Be careful about either or both being null.
  */
 
-elem * el_combine(elem *e1,elem *e2)
+elem* el_combine(elem* e1,elem* e2)
 {
     if (e1)
     {
@@ -282,7 +282,7 @@ elem * el_combine(elem *e1,elem *e2)
  * Be careful about either or both being null.
  */
 
-elem * el_param(elem *e1,elem *e2)
+elem* el_param(elem* e1,elem* e2)
 {
     //printf("el_param(%p, %p)\n", e1, e2);
     if (e1)
@@ -302,9 +302,9 @@ elem * el_param(elem *e1,elem *e2)
  */
 
 @trusted
-elem *el_params(elem *e1, ...)
+elem* el_params(elem* e1, ...)
 {
-    elem *e;
+    elem* e;
     va_list ap;
 
     e = null;
@@ -323,12 +323,12 @@ elem *el_params(elem *e1, ...)
  */
 
 @trusted
-elem *el_params(void **args, int length)
+elem* el_params(void** args, int length)
 {
     if (length == 0)
         return null;
     if (length == 1)
-        return cast(elem *)args[0];
+        return cast(elem*)args[0];
     int mid = length >> 1;
     return el_param(el_params(args, mid),
                     el_params(args + mid, length - mid));
@@ -340,12 +340,12 @@ elem *el_params(void **args, int length)
  */
 
 @trusted
-elem *el_combines(void **args, int length)
+elem* el_combines(void** args, int length)
 {
     if (length == 0)
         return null;
     if (length == 1)
-        return cast(elem *)args[0];
+        return cast(elem*)args[0];
     int mid = length >> 1;
     return el_combine(el_combines(args, mid),
                     el_combines(args + mid, length - mid));
@@ -356,7 +356,7 @@ elem *el_combines(void **args, int length)
  */
 
 @trusted
-size_t el_opN(const elem *e, OPER op)
+size_t el_opN(const elem* e, OPER op)
 {
     if (e.Eoper == op)
         return el_opN(e.E1, op) + el_opN(e.E2, op);
@@ -369,7 +369,7 @@ size_t el_opN(const elem *e, OPER op)
  */
 
 @trusted
-void el_opArray(elem ***parray, elem *e, OPER op)
+void el_opArray(elem ***parray, elem* e, OPER op)
 {
     if (e.Eoper == op)
     {
@@ -384,7 +384,7 @@ void el_opArray(elem ***parray, elem *e, OPER op)
 }
 
 @trusted
-void el_opFree(elem *e, OPER op)
+void el_opFree(elem* e, OPER op)
 {
     if (e.Eoper == op)
     {
@@ -401,7 +401,7 @@ void el_opFree(elem *e, OPER op)
  */
 
 @trusted
-elem *el_opCombine(elem **args, size_t length, OPER op, tym_t ty)
+elem* el_opCombine(elem** args, size_t length, OPER op, tym_t ty)
 {
     if (length == 0)
         return null;
@@ -414,7 +414,7 @@ elem *el_opCombine(elem **args, size_t length, OPER op, tym_t ty)
  * Return a list of the parameters.
  */
 
-int el_nparams(const elem *e)
+int el_nparams(const elem* e)
 {
     return cast(int)el_opN(e, OPparam);
 }
@@ -424,7 +424,7 @@ int el_nparams(const elem *e)
  */
 
 @trusted
-void el_paramArray(elem ***parray, elem *e)
+void el_paramArray(elem ***parray, elem* e)
 {
     if (e.Eoper == OPparam)
     {
@@ -443,7 +443,7 @@ void el_paramArray(elem ***parray, elem *e)
  * Create a quad word out of two dwords.
  */
 
-elem *el_pair(tym_t tym, elem *lo, elem *hi)
+elem* el_pair(tym_t tym, elem* lo, elem* hi)
 {
     static if (0)
     {
@@ -464,7 +464,7 @@ elem *el_pair(tym_t tym, elem *lo, elem *hi)
  */
 
 @trusted
-void el_copy(elem *to, const elem *from)
+void el_copy(elem* to, const elem* from)
 {
     assert(to && from);
     elem_debug(from);
@@ -476,9 +476,9 @@ void el_copy(elem *to, const elem *from)
 /***********************************
  * Allocate a temporary, and return temporary elem.
  */
-elem * el_alloctmp(tym_t ty)
+elem* el_alloctmp(tym_t ty)
 {
-    Symbol *s;
+    Symbol* s;
     s = symbol_generate(SC.auto_,type_fake(ty));
     symbol_add(s);
     s.Sfl = FL.auto_;
@@ -491,9 +491,9 @@ elem * el_alloctmp(tym_t ty)
  */
 
 @trusted
-elem * el_selecte1(elem *e)
+elem* el_selecte1(elem* e)
 {
-    elem *e1;
+    elem* e1;
     elem_debug(e);
     assert(!OTleaf(e.Eoper));
     e1 = e.E1;
@@ -519,9 +519,9 @@ elem * el_selecte1(elem *e)
  */
 
 @trusted
-elem * el_selecte2(elem *e)
+elem* el_selecte2(elem* e)
 {
-    elem *e2;
+    elem* e2;
     //printf("el_selecte2(%p)\n",e);
     elem_debug(e);
     assert(OTbinary(e.Eoper));
@@ -548,9 +548,9 @@ elem * el_selecte2(elem *e)
  */
 
 @trusted
-elem * el_copytree(elem *e)
+elem* el_copytree(elem* e)
 {
-    elem *d;
+    elem* d;
     if (!e)
         return e;
     elem_debug(e);
@@ -590,7 +590,7 @@ static if (0)
                 break;
 }
             case OPasm:
-                d.Vstring = cast(char *) mem_malloc(d.Vstrlen);
+                d.Vstring = cast(char*) mem_malloc(d.Vstrlen);
                 memcpy(d.Vstring,e.Vstring,e.Vstrlen);
                 break;
 
@@ -605,20 +605,20 @@ static if (0)
  * Replace (e) with ((stmp = e),stmp)
  */
 @trusted
-elem *exp2_copytotemp(elem *e)
+elem* exp2_copytotemp(elem* e)
 {
     //printf("exp2_copytotemp()\n");
     elem_debug(e);
     tym_t ty = tybasic(e.Ety);
-    type *t;
+    type* t;
     if ((ty == TYstruct || ty == TYarray) && e.ET)
         t = e.ET;
     else
         t = type_fake(ty);
 
-    Symbol *stmp = symbol_genauto(t);
-    elem *eeq = el_bin(OPeq,e.Ety,el_var(stmp),e);
-    elem *er = el_bin(OPcomma,e.Ety,eeq,el_var(stmp));
+    Symbol* stmp = symbol_genauto(t);
+    elem* eeq = el_bin(OPeq,e.Ety,el_var(stmp),e);
+    elem* er = el_bin(OPcomma,e.Ety,eeq,el_var(stmp));
     if (ty == TYstruct || ty == TYarray)
     {
         eeq.Eoper = OPstreq;
@@ -636,9 +636,9 @@ elem *exp2_copytotemp(elem *e)
  */
 
 @trusted
-elem * el_same(ref elem* pe)
+elem* el_same(ref elem* pe)
 {
-    elem *e = pe;
+    elem* e = pe;
     if (e && el_sideeffect(e))
     {
         pe = exp2_copytotemp(e);       /* convert to ((tmp=e),tmp)     */
@@ -652,10 +652,10 @@ elem * el_same(ref elem* pe)
  * always makes a temporary.
  */
 @trusted
-elem *el_copytotmp(ref elem* pe)
+elem* el_copytotmp(ref elem* pe)
 {
     //printf("copytotemp()\n");
-    elem *e = pe;
+    elem* e = pe;
     if (e)
     {
         pe = exp2_copytotemp(e);
@@ -672,7 +672,7 @@ elem *el_copytotmp(ref elem* pe)
  */
 
 @trusted
-int el_appears(const(elem)* e, const Symbol *s)
+int el_appears(const(elem)* e, const Symbol* s)
 {
     symbol_debug(s);
     while (1)
@@ -712,9 +712,9 @@ int el_appears(const(elem)* e, const Symbol *s)
 
 static if (0)
 {
-Symbol *el_basesym(elem *e)
+Symbol* el_basesym(elem* e)
 {
-    Symbol *s;
+    Symbol* s;
     s = null;
     while (1)
     {
@@ -752,7 +752,7 @@ Symbol *el_basesym(elem *e)
  */
 
 @trusted
-bool el_anydef(const elem *ed, const(elem)* e)
+bool el_anydef(const elem* ed, const(elem)* e)
 {
     const edop = ed.Eoper;
     const s = (edop == OPvar) ? ed.Vsym : null;
@@ -787,12 +787,12 @@ bool el_anydef(const elem *ed, const(elem)* e)
 
 
 @trusted
-elem* el_bin(OPER op,tym_t ty,elem *e1,elem *e2)
+elem* el_bin(OPER op,tym_t ty,elem* e1,elem* e2)
 {
 static if (0)
 {
     if (!(op < OPMAX && OTbinary(op) && e1 && e2))
-        *cast(char *)0=0;
+        *cast(char*)0=0;
 }
     assert(op < OPMAX && OTbinary(op) && e1 && e2);
     elem_debug(e1);
@@ -811,7 +811,7 @@ static if (0)
  * Make a unary operator node.
  */
 @trusted
-elem* el_una(OPER op,tym_t ty,elem *e1)
+elem* el_una(OPER op,tym_t ty,elem* e1)
 {
     debug if (!(op < OPMAX && OTunary(op) && e1))
         printf("op = x%x, e1 = %p\n",op,e1);
@@ -934,7 +934,7 @@ elem* el_vectorConst(tym_t ty, ulong val)
  * Set new type for elem.
  */
 
-elem * el_settype(elem *e,type *t)
+elem* el_settype(elem* e,type* t)
 {
     assert(0);
 }
@@ -943,7 +943,7 @@ elem * el_settype(elem *e,type *t)
  * Create elem that is the size of a type.
  */
 
-elem * el_typesize(type *t)
+elem* el_typesize(type* t)
 {
     assert(0);
 }
@@ -953,7 +953,7 @@ elem * el_typesize(type *t)
  */
 
 @trusted
-bool el_funcsideeff(const elem *e)
+bool el_funcsideeff(const elem* e)
 {
     const(Symbol)* s;
     if (e.Eoper == OPvar &&
@@ -969,7 +969,7 @@ bool el_funcsideeff(const elem *e)
  */
 
 @trusted
-bool el_sideeffect(const elem *e)
+bool el_sideeffect(const elem* e)
 {
     assert(e);
     const op = e.Eoper;
@@ -992,7 +992,7 @@ bool el_sideeffect(const elem *e)
  */
 
 @trusted
-int el_depends(const(elem)* ea, const elem *eb)
+int el_depends(const(elem)* ea, const elem* eb)
 {
  L1:
     elem_debug(ea);
@@ -1039,7 +1039,7 @@ Lnodep:
  */
 
 @trusted
-bool ERTOL(const elem *e)
+bool ERTOL(const elem* e)
 {
     elem_debug(e);
     return OTrtol(e.Eoper) &&
@@ -1109,7 +1109,7 @@ bool el_returns(const(elem)* e)
  */
 
 @trusted
-elem **el_scancommas(elem **pe)
+elem** el_scancommas(elem** pe)
 {
     while ((*pe).Eoper == OPcomma)
         pe = &(*pe).E2;
@@ -1164,7 +1164,7 @@ elem* el_convfloat(ref GlobalOptimizer go, elem* e)
     tym_t ty = e.Ety;
     int sz = tysize(ty);
     assert(sz <= buffer.length);
-    void *p;
+    void* p;
     switch (tybasic(ty))
     {
         case TYfloat:
@@ -1216,12 +1216,12 @@ elem* el_convfloat(ref GlobalOptimizer go, elem* e)
         printf("%gL+%gLi\n", cast(double)e.Vcldouble.re, cast(double)e.Vcldouble.im);
         printf("el_convfloat() %g %g sz=%d\n", e.Vcdouble.re, e.Vcdouble.im, sz);
         printf("el_convfloat(): sz = %d\n", sz);
-        ushort *p = cast(ushort *)&e.Vcldouble;
+        ushort* p = cast(ushort*)&e.Vcldouble;
         for (int i = 0; i < sz/2; i++) printf("%04x ", p[i]);
         printf("\n");
     }
 
-    Symbol *s  = out_readonly_sym(ty, p, sz);
+    Symbol* s  = out_readonly_sym(ty, p, sz);
     el_free(e);
     e = el_var(s);
     e.Ety = ty;
@@ -1249,16 +1249,16 @@ elem* el_convxmm(ref GlobalOptimizer go, elem* e)
     tym_t ty = e.Ety;
     int sz = tysize(ty);
     assert(sz <= buffer.length);
-    void *p = &e.EV;
+    void* p = &e.EV;
 
     static if (0)
     {
         printf("el_convxmm(): sz = %d\n", sz);
-        for (size i = 0; i < sz; i++) printf("%02x ", (cast(ubyte *)p)[i]);
+        for (size i = 0; i < sz; i++) printf("%02x ", (cast(ubyte*)p)[i]);
         printf("\n");
     }
 
-    Symbol *s  = out_readonly_sym(ty, p, sz);
+    Symbol* s  = out_readonly_sym(ty, p, sz);
     el_free(e);
     e = el_var(s);
     e.Ety = ty;
@@ -1274,12 +1274,12 @@ elem* el_convxmm(ref GlobalOptimizer go, elem* e)
  */
 
 @trusted
-elem *el_convstring(elem *e)
+elem* el_convstring(elem* e)
 {
     //printf("el_convstring()\n");
     int i;
-    Symbol *s;
-    char *p;
+    Symbol* s;
+    char* p;
 
     elem_debug(e);
     assert(e.Eoper == OPstring);
@@ -1327,7 +1327,7 @@ elem *el_convstring(elem *e)
 
 L1:
     // Refer e to the symbol generated
-    elem *ex = el_ptr(s);
+    elem* ex = el_ptr(s);
     ex.Ety = e.Ety;
     if (e.Voffset)
     {
@@ -1350,7 +1350,7 @@ L1:
 static if (1)
 {
 @trusted
-void shrinkLongDoubleConstantIfPossible(elem *e)
+void shrinkLongDoubleConstantIfPossible(elem* e)
 {
     if (e.Eoper == OPconst && e.Ety == TYldouble)
     {
@@ -1462,7 +1462,7 @@ elem* el_convert(ref GlobalOptimizer go, elem* e)
  */
 
 @safe
-elem * el_const(tym_t ty, ref Vconst pconst)
+elem* el_const(tym_t ty, ref Vconst pconst)
 {
     elem* e = el_calloc();
     e.Eoper = OPconst;
@@ -1482,9 +1482,9 @@ elem * el_const(tym_t ty, ref Vconst pconst)
 
 static if (0)
 {
-elem *el_dctor(elem *e,void *decl)
+elem* el_dctor(elem* e,void* decl)
 {
-    elem *ector = el_calloc();
+    elem* ector = el_calloc();
     ector.Eoper = OPdctor;
     ector.Ety = TYvoid;
     ector.ed.Edecl = decl;
@@ -1508,13 +1508,13 @@ elem *el_dctor(elem *e,void *decl)
 
 static if (0)
 {
-elem *el_ddtor(elem *e,void *decl)
+elem* el_ddtor(elem* e,void* decl)
 {
     /* A destructor always executes code, or we wouldn't need
      * eh for it.
      * An OPddtor must match 1:1 with an OPdctor
      */
-    elem *edtor = el_calloc();
+    elem* edtor = el_calloc();
     edtor.Eoper = OPddtor;
     edtor.Ety = TYvoid;
     edtor.ed.Edecl = decl;
@@ -1535,9 +1535,9 @@ elem *el_ddtor(elem *e,void *decl)
  */
 
 @trusted
-elem *el_ctor_dtor(elem *ec, elem *ed, out elem* pedtor)
+elem* el_ctor_dtor(elem* ec, elem* ed, out elem* pedtor)
 {
-    elem *er;
+    elem* er;
     if (config.ehmethod == EHmethod.EH_DWARF)
     {
         /* Construct (note that OPinfo is evaluated RTOL):
@@ -1549,39 +1549,39 @@ elem *el_ctor_dtor(elem *ec, elem *ed, out elem* pedtor)
          * Use volatile to prevent optimizer from messing them up, since optimizer doesn't know about
          * landing pads (the landing pad will be on the OPddtor's EV.ed.Eleft)
          */
-        Symbol *sflag = symbol_name("__flag", SC.auto_, type_fake(mTYvolatile | TYbool));
-        Symbol *sreg = symbol_name("__EAX", SC.pseudo, type_fake(mTYvolatile | TYnptr));
+        Symbol* sflag = symbol_name("__flag", SC.auto_, type_fake(mTYvolatile | TYbool));
+        Symbol* sreg = symbol_name("__EAX", SC.pseudo, type_fake(mTYvolatile | TYnptr));
         sreg.Sreglsw = 0;          // EAX, RAX, whatevs
-        Symbol *seo = symbol_name("__exception_object", SC.auto_, tspvoid);
+        Symbol* seo = symbol_name("__exception_object", SC.auto_, tspvoid);
 
         symbol_add(sflag);
         symbol_add(sreg);
         symbol_add(seo);
 
-        elem *ector = el_calloc();
+        elem* ector = el_calloc();
         ector.Eoper = OPdctor;
         ector.Ety = TYvoid;
 //      ector.ed.Edecl = decl;
 
         Vconst c = void;
         memset(&c, 0, c.sizeof);
-        elem *e_flag_0 = el_bin(OPeq, TYvoid, el_var(sflag), el_const(TYbool, c));  // __flag = 0
+        elem* e_flag_0 = el_bin(OPeq, TYvoid, el_var(sflag), el_const(TYbool, c));  // __flag = 0
         er = el_bin(OPinfo, ec ? ec.Ety : TYvoid, ector, el_combine(e_flag_0, ec));
 
         /* A destructor always executes code, or we wouldn't need
          * eh for it.
          * An OPddtor must match 1:1 with an OPdctor
          */
-        elem *edtor = el_calloc();
+        elem* edtor = el_calloc();
         edtor.Eoper = OPddtor;
         edtor.Ety = TYvoid;
 //      edtor.Edecl = decl;
 //      edtor.E1 = e;
 
         c.Vint = 1;
-        elem *e_flag_1 = el_bin(OPeq, TYvoid, el_var(sflag), el_const(TYbool, c));  // __flag = 1
-        elem *e_eax = el_bin(OPeq, TYvoid, el_var(seo), el_var(sreg));              // __exception_object = __EAX
-        elem *eu = el_bin(OPcall, TYvoid, el_var(getRtlsym(RTLSYM.UNWIND_RESUME)), el_var(seo));
+        elem* e_flag_1 = el_bin(OPeq, TYvoid, el_var(sflag), el_const(TYbool, c));  // __flag = 1
+        elem* e_eax = el_bin(OPeq, TYvoid, el_var(seo), el_var(sreg));              // __exception_object = __EAX
+        elem* eu = el_bin(OPcall, TYvoid, el_var(getRtlsym(RTLSYM.UNWIND_RESUME)), el_var(seo));
         eu = el_bin(OPandand, TYvoid, el_una(OPnot, TYbool, el_var(sflag)), eu);
 
         edtor.E1 = el_combine(el_combine(e_eax, ed), eu);
@@ -1594,7 +1594,7 @@ elem *el_ctor_dtor(elem *ec, elem *ed, out elem* pedtor)
          *  er = (OPdctor OPinfo ec)
          *  edtor = (OPddtor ed)
          */
-        elem *ector = el_calloc();
+        elem* ector = el_calloc();
         ector.Eoper = OPdctor;
         ector.Ety = TYvoid;
 //      ector.ed.Edecl = decl;
@@ -1610,7 +1610,7 @@ elem *el_ctor_dtor(elem *ec, elem *ed, out elem* pedtor)
          * eh for it.
          * An OPddtor must match 1:1 with an OPdctor
          */
-        elem *edtor = el_calloc();
+        elem* edtor = el_calloc();
         edtor.Eoper = OPddtor;
         edtor.Ety = TYvoid;
 //      edtor.Edecl = decl;
@@ -1627,7 +1627,7 @@ elem *el_ctor_dtor(elem *ec, elem *ed, out elem* pedtor)
  */
 
 @trusted
-elem ** el_parent(elem *e, return ref elem* pe)
+elem ** el_parent(elem* e, return ref elem* pe)
 {
     assert(e && pe);
     elem_debug(e);
@@ -1984,7 +1984,7 @@ bool el_match5(const elem* n1, const elem* n2)
  */
 
 @trusted
-targ_llong el_tolong(elem *e)
+targ_llong el_tolong(elem* e)
 {
     elem_debug(e);
     if (e.Eoper != OPconst)
@@ -2156,7 +2156,7 @@ bool el_signx32(const elem* e)
 
 version (CRuntime_Microsoft)
 {
-longdouble_soft el_toldouble(elem *e)
+longdouble_soft el_toldouble(elem* e)
 {
     longdouble_soft result;
     elem_debug(e);
@@ -2191,7 +2191,7 @@ longdouble_soft el_toldouble(elem *e)
 }
 else
 {
-targ_ldouble el_toldouble(elem *e)
+targ_ldouble el_toldouble(elem* e)
 {
     targ_ldouble result;
     elem_debug(e);
@@ -2253,7 +2253,7 @@ bool el_isdependent(elem* e)
 /****************************************
  * Returns: alignment size of elem e
  */
-uint el_alignsize(elem *e)
+uint el_alignsize(elem* e)
 {
     const tym = tybasic(e.Ety);
     uint alignsize = tyalignsize(tym);

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -101,7 +101,7 @@ alias reltype_t = uint;
 /******************************************
  */
 
-Symbol *ElfObj_getGOTsym()
+Symbol* ElfObj_getGOTsym()
 {
     if (!elfobj.GOTsym)
     {
@@ -114,12 +114,12 @@ void ElfObj_refGOTsym()
 {
     if (!elfobj.GOTsym)
     {
-        Symbol *s = ElfObj_getGOTsym();
+        Symbol* s = ElfObj_getGOTsym();
         ElfObj_external(s);
     }
 }
 
-//private void objfile_write(FILE *fd, void *buffer, uint len);
+//private void objfile_write(FILE* fd, void* buffer, uint len);
 
 // The object file is built is several separate pieces
 
@@ -268,7 +268,7 @@ import dmd.backend.code: SegData;
  * Returns index into the specified string table.
  */
 
-IDXSTR ElfObj_addstr(OutBuffer *strtab, const(char)* str)
+IDXSTR ElfObj_addstr(OutBuffer* strtab, const(char)* str)
 {
     //dbg_printf("ElfObj_addstr(strtab = x%x str = '%s')\n",strtab,str);
     IDXSTR idx = cast(IDXSTR)strtab.length();        // remember starting offset
@@ -285,7 +285,7 @@ IDXSTR ElfObj_addstr(OutBuffer *strtab, const(char)* str)
  * Returns index into the table.
  */
 
-private IDXSTR elf_addmangled(Symbol *s)
+private IDXSTR elf_addmangled(Symbol* s)
 {
     //printf("elf_addmangled(%s)\n", s.Sident.ptr);
     char[DEST_LEN] buf = void;
@@ -472,7 +472,7 @@ Returns:
     pointer to Pair, where the first field is the string index of the new or existing section name,
     and the second field is its segment index
  */
-private Pair* elf_addsectionname(const(char)* name, const(char)* suffix = null, bool *padded = null)
+private Pair* elf_addsectionname(const(char)* name, const(char)* suffix = null, bool* padded = null)
 {
     IDXSTR namidx = cast(IDXSTR)elfobj.section_names.length();
     elfobj.section_names.writeStringz(name);
@@ -511,9 +511,9 @@ private IDXSEC elf_newsection(const(char)* name, const(char)* suffix,
  *
  */
 
-Symbol *ElfObj_sym_cdata(tym_t ty,char *p,int len)
+Symbol* ElfObj_sym_cdata(tym_t ty,char* p,int len)
 {
-    Symbol *s;
+    Symbol* s;
 
 static if (0)
 {
@@ -548,7 +548,7 @@ static if (0)
  *      offset of that data
  */
 
-int ElfObj_data_readonly(char *p, int len, int *pseg)
+int ElfObj_data_readonly(char* p, int len, int* pseg)
 {
     int oldoff = cast(int)Offset(CDATA);
     SegData[CDATA].SDbuf.reserve(len);
@@ -558,7 +558,7 @@ int ElfObj_data_readonly(char *p, int len, int *pseg)
     return oldoff;
 }
 
-int ElfObj_data_readonly(char *p, int len)
+int ElfObj_data_readonly(char* p, int len)
 {
     int pseg;
 
@@ -600,7 +600,7 @@ int ElfObj_string_literal_segment(uint sz)
  *      csegname = name for code segment
  */
 
-Obj ElfObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
+Obj ElfObj_init(OutBuffer* objbuf, const(char)* filename, const(char)* csegname)
 {
     //printf("ElfObj_init(filename = %s, csegname = %s)\n",filename,csegname);
     Obj obj = cast(Obj)mem_calloc(__traits(classInstanceSize, Obj));
@@ -817,25 +817,25 @@ static if (0)
  *      sorted symbol table, caller must free with util_free()
  */
 
-void *elf_renumbersyms()
-{   void *symtab;
+void* elf_renumbersyms()
+{   void* symtab;
     int nextlocal = 0;
     int nextglobal = elfobj.local_cnt;
 
-    SYMIDX *sym_map = cast(SYMIDX *)util_malloc(SYMIDX.sizeof,elfobj.symbol_idx);
+    SYMIDX* sym_map = cast(SYMIDX*)util_malloc(SYMIDX.sizeof,elfobj.symbol_idx);
 
     if (I64)
     {
-        Elf64_Sym *oldsymtab = &elfobj.SymbolTable64[0];
-        Elf64_Sym *symtabend = oldsymtab+elfobj.symbol_idx;
+        Elf64_Sym* oldsymtab = &elfobj.SymbolTable64[0];
+        Elf64_Sym* symtabend = oldsymtab+elfobj.symbol_idx;
 
         symtab = util_malloc(Elf64_Sym.sizeof,elfobj.symbol_idx);
 
-        Elf64_Sym *sl = cast(Elf64_Sym *)symtab;
-        Elf64_Sym *sg = sl + elfobj.local_cnt;
+        Elf64_Sym* sl = cast(Elf64_Sym*)symtab;
+        Elf64_Sym* sg = sl + elfobj.local_cnt;
 
         int old_idx = 0;
-        for(Elf64_Sym *s = oldsymtab; s != symtabend; s++)
+        for(Elf64_Sym* s = oldsymtab; s != symtabend; s++)
         {   // reorder symbol and map new #s to old
             int bind = ELF64_ST_BIND(s.st_info);
             if (bind == STB_LOCAL)
@@ -853,16 +853,16 @@ void *elf_renumbersyms()
     }
     else
     {
-        Elf32_Sym *oldsymtab = &elfobj.SymbolTable[0];
-        Elf32_Sym *symtabend = oldsymtab+elfobj.symbol_idx;
+        Elf32_Sym* oldsymtab = &elfobj.SymbolTable[0];
+        Elf32_Sym* symtabend = oldsymtab+elfobj.symbol_idx;
 
         symtab = util_malloc(Elf32_Sym.sizeof,elfobj.symbol_idx);
 
-        Elf32_Sym *sl = cast(Elf32_Sym *)symtab;
-        Elf32_Sym *sg = sl + elfobj.local_cnt;
+        Elf32_Sym* sl = cast(Elf32_Sym*)symtab;
+        Elf32_Sym* sg = sl + elfobj.local_cnt;
 
         int old_idx = 0;
-        for(Elf32_Sym *s = oldsymtab; s != symtabend; s++)
+        for(Elf32_Sym* s = oldsymtab; s != symtabend; s++)
         {   // reorder symbol and map new #s to old
             int bind = ELF32_ST_BIND(s.st_info);
             if (bind == STB_LOCAL)
@@ -886,8 +886,8 @@ void *elf_renumbersyms()
         const size_t shndx_idx = elfobj.shndx_data.length() / Elf64_Word.sizeof;
         elfobj.shndx_data.writezeros(cast(uint)((elfobj.symbol_idx - shndx_idx) * Elf64_Word.sizeof));
 
-        Elf64_Word *old_buf = cast(Elf64_Word *)elfobj.shndx_data.buf;
-        Elf64_Word *tmp_buf = cast(Elf64_Word *)util_malloc(Elf64_Word.sizeof, elfobj.symbol_idx);
+        Elf64_Word* old_buf = cast(Elf64_Word*)elfobj.shndx_data.buf;
+        Elf64_Word* tmp_buf = cast(Elf64_Word*)util_malloc(Elf64_Word.sizeof, elfobj.symbol_idx);
         for (SYMIDX old_idx = 0; old_idx < elfobj.symbol_idx; ++old_idx)
         {
             const SYMIDX new_idx = sym_map[old_idx];
@@ -900,7 +900,7 @@ void *elf_renumbersyms()
     // Renumber the relocations
     for (int i = 1; i < SegData.length; i++)
     {                           // Map indicies in the segment table
-        seg_data *pseg = SegData[i];
+        seg_data* pseg = SegData[i];
         pseg.SDsymidx = cast(uint) sym_map[pseg.SDsymidx];
 
         if (elfobj.SecHdrTab[pseg.SDshtidx].sh_type == SHT_GROUP)
@@ -916,7 +916,7 @@ void *elf_renumbersyms()
         {
             if (I64)
             {
-                Elf64_Rela *rel = cast(Elf64_Rela *) pseg.SDrel.buf;
+                Elf64_Rela* rel = cast(Elf64_Rela*) pseg.SDrel.buf;
                 for (int r = 0; r < pseg.SDrelcnt; r++)
                 {
                     uint t = ELF64_R_TYPE(rel.r_info);
@@ -928,7 +928,7 @@ void *elf_renumbersyms()
             }
             else
             {
-                Elf32_Rel *rel = cast(Elf32_Rel *) pseg.SDrel.buf;
+                Elf32_Rel* rel = cast(Elf32_Rel*) pseg.SDrel.buf;
                 assert(pseg.SDrelcnt == pseg.SDrel.length() / Elf32_Rel.sizeof);
                 for (int r = 0; r < pseg.SDrelcnt; r++)
                 {
@@ -980,10 +980,10 @@ void ElfObj_term(const(char)[] objfilename)
         obj_rtinit();
 
     int foffset;
-    Elf32_Shdr *sechdr;
-    seg_data *seg;
-    void *symtab = elf_renumbersyms();
-    FILE *fd = null;
+    Elf32_Shdr* sechdr;
+    seg_data* seg;
+    void* symtab = elf_renumbersyms();
+    FILE* fd = null;
 
     int hdrsize = (I64 ? Elf64_Ehdr.sizeof : Elf32_Ehdr.sizeof);
 
@@ -1020,8 +1020,8 @@ void ElfObj_term(const(char)[] objfilename)
     //printf("Setup offsets and sizes foffset %d\n\tSecHdrTab.length %d, SegData.length %d\n",foffset,cast(int)elfobj.SecHdrTab.length,SegData.length);
     foreach (int i; 1 .. cast(int)SegData.length)
     {
-        seg_data *pseg = SegData[i];
-        Elf32_Shdr *sechdr2 = MAP_SEG2SEC(i);        // corresponding section
+        seg_data* pseg = SegData[i];
+        Elf32_Shdr* sechdr2 = MAP_SEG2SEC(i);        // corresponding section
         if (sechdr2.sh_addralign < pseg.SDalignment)
             sechdr2.sh_addralign = pseg.SDalignment;
         foffset = elf_align(sechdr2.sh_addralign,foffset);
@@ -1146,8 +1146,8 @@ void ElfObj_term(const(char)[] objfilename)
                     static int elf64_rel_fp(scope const(void*) e1,
                                             scope const(void*) e2)
                     {
-                        Elf64_Rela *r1 = cast(Elf64_Rela *)e1;
-                        Elf64_Rela *r2 = cast(Elf64_Rela *)e2;
+                        Elf64_Rela* r1 = cast(Elf64_Rela*)e1;
+                        Elf64_Rela* r2 = cast(Elf64_Rela*)e2;
 
                         return (r1.r_offset > r2.r_offset)
                              - (r1.r_offset < r2.r_offset);
@@ -1166,8 +1166,8 @@ void ElfObj_term(const(char)[] objfilename)
                     static int elf32_rel_fp(scope const(void*) e1,
                                             scope const(void*) e2)
                     {
-                        Elf32_Rel *r1 = cast(Elf32_Rel *)e1;
-                        Elf32_Rel *r2 = cast(Elf32_Rel *)e2;
+                        Elf32_Rel* r1 = cast(Elf32_Rel*)e1;
+                        Elf32_Rel* r2 = cast(Elf32_Rel*)e2;
 
                         return (r1.r_offset > r2.r_offset)
                              - (r1.r_offset < r2.r_offset);
@@ -1347,7 +1347,7 @@ static if (0)
         return;
 
     size_t i;
-    seg_data *pseg = SegData[seg];
+    seg_data* pseg = SegData[seg];
 
     // Find entry i in SDlinnum_data[] that corresponds to srcpos filename
     for (i = 0; 1; i++)
@@ -1361,7 +1361,7 @@ static if (0)
             break;
     }
 
-    linnum_data *ld = &pseg.SDlinnum_data[i];
+    linnum_data* ld = &pseg.SDlinnum_data[i];
 //    printf("i = %d, ld = x%x\n", i, ld);
     ld.linoff.push(LinOff(srcpos.Slinnum, cast(uint)offset));
 }
@@ -1371,7 +1371,7 @@ static if (0)
  * Set start address
  */
 
-void ElfObj_startaddress(Symbol *s)
+void ElfObj_startaddress(Symbol* s)
 {
     //dbg_printf("ElfObj_startaddress(Symbol *%s)\n",s.Sident.ptr);
     //obj.startaddress = s;
@@ -1431,9 +1431,9 @@ void ElfObj_user(const(char)* p)
  * Output a weak extern record.
  */
 
-void ElfObj_wkext(Symbol *s1,Symbol *s2)
+void ElfObj_wkext(Symbol* s1,Symbol* s2)
 {
-    //dbg_printf("ElfObj_wkext(Symbol *%s,Symbol *s2)\n",s1.Sident.ptr,s2.Sident.ptr);
+    //dbg_printf("ElfObj_wkext(Symbol *%s,Symbol* s2)\n",s1.Sident.ptr,s2.Sident.ptr);
 }
 
 /*******************************
@@ -1473,7 +1473,7 @@ void ElfObj_compiler(const(char)* p)
  *              3:      compiler
  */
 
-void ElfObj_staticctor(Symbol *s, int, int)
+void ElfObj_staticctor(Symbol* s, int, int)
 {
     ElfObj_setModuleCtorDtor(s, true);
 }
@@ -1486,7 +1486,7 @@ void ElfObj_staticctor(Symbol *s, int, int)
  *      s       static destructor function
  */
 
-void ElfObj_staticdtor(Symbol *s)
+void ElfObj_staticdtor(Symbol* s)
 {
     ElfObj_setModuleCtorDtor(s, false);
 }
@@ -1496,7 +1496,7 @@ void ElfObj_staticdtor(Symbol *s)
  * Used for static ctor and dtor lists.
  */
 
-void ElfObj_setModuleCtorDtor(Symbol *sfunc, bool isCtor)
+void ElfObj_setModuleCtorDtor(Symbol* sfunc, bool isCtor)
 {
     IDXSEC seg;
     if (USE_INIT_ARRAY())
@@ -1517,7 +1517,7 @@ void ElfObj_setModuleCtorDtor(Symbol *sfunc, bool isCtor)
  *      length of function
  */
 
-void ElfObj_ehtables(Symbol *sfunc,uint size,Symbol *ehsym)
+void ElfObj_ehtables(Symbol* sfunc,uint size,Symbol* ehsym)
 {
     assert(0);                  // converted to Dwarf EH debug format
 }
@@ -1568,7 +1568,7 @@ private void obj_tlssections()
  *      COMDAT section groups https://www.airs.com/blog/archives/52
  */
 
-private void setup_comdat(Symbol *s)
+private void setup_comdat(Symbol* s)
 {
     const(char)* prefix;
     int type;
@@ -1682,7 +1682,7 @@ else
     SegData[s.Sseg].SDsym = s;
 }
 
-int ElfObj_comdat(Symbol *s)
+int ElfObj_comdat(Symbol* s)
 {
     setup_comdat(s);
     if (s.Sfl == FL.data || s.Sfl == FL.tlsdata)
@@ -1692,7 +1692,7 @@ int ElfObj_comdat(Symbol *s)
     return s.Sseg;
 }
 
-int ElfObj_comdatsize(Symbol *s, targ_size_t symsize)
+int ElfObj_comdatsize(Symbol* s, targ_size_t symsize)
 {
     setup_comdat(s);
     if (s.Sfl == FL.data || s.Sfl == FL.tlsdata)
@@ -1703,12 +1703,12 @@ int ElfObj_comdatsize(Symbol *s, targ_size_t symsize)
     return s.Sseg;
 }
 
-int ElfObj_readonly_comdat(Symbol *s)
+int ElfObj_readonly_comdat(Symbol* s)
 {
     assert(0);
 }
 
-int ElfObj_jmpTableSegment(Symbol *s)
+int ElfObj_jmpTableSegment(Symbol* s)
 {
     segidx_t seg = elfobj.jmpseg;
     if (seg)                            // memoize the elfobj.jmpseg on a per-function basis
@@ -1718,7 +1718,7 @@ int ElfObj_jmpTableSegment(Symbol *s)
         seg = cseg;
     else
     {
-        seg_data *pseg = SegData[s.Sseg];
+        seg_data* pseg = SegData[s.Sseg];
         if (pseg.SDassocseg)
         {
             /* `s` is in a COMDAT, so the jmp table segment must also
@@ -1743,14 +1743,14 @@ int ElfObj_jmpTableSegment(Symbol *s)
 
 private void addSectionToComdat(IDXSEC secidx, segidx_t comdatseg)
 {
-    seg_data *pseg = SegData[comdatseg];
+    seg_data* pseg = SegData[comdatseg];
     if (segidx_t groupseg = pseg.SDassocseg)
     {
-        seg_data *pgroupseg = SegData[groupseg];
+        seg_data* pgroupseg = SegData[groupseg];
 
         /* Don't write it if it is already there
          */
-        OutBuffer *buf = pgroupseg.SDbuf;
+        OutBuffer* buf = pgroupseg.SDbuf;
         assert(int.sizeof == 4);               // loop depends on this
         for (size_t i = buf.length(); i > 4;)
         {
@@ -1783,7 +1783,7 @@ private segidx_t elf_addsegment2(IDXSEC shtidx, IDXSYM symidx, IDXSEC relidx)
     seg_data* pseg = *ppseg;
     if (!pseg)
     {
-        pseg = cast(seg_data *)mem_calloc(seg_data.sizeof);
+        pseg = cast(seg_data*)mem_calloc(seg_data.sizeof);
         //printf("test2: SegData[%d] = %p\n", seg, SegData[seg]);
         SegData[seg] = pseg;
     }
@@ -1913,7 +1913,7 @@ void ElfObj_setcodeseg(int seg)
  *      segment index of newly created code segment
  */
 
-int ElfObj_codeseg(const char *name,int suffix)
+int ElfObj_codeseg(const char* name,int suffix)
 {
     int seg;
     const(char)* sfx;
@@ -1975,7 +1975,7 @@ int ElfObj_codeseg(const char *name,int suffix)
  *      segment for TLS segment
  */
 
-seg_data *ElfObj_tlsseg()
+seg_data* ElfObj_tlsseg()
 {
     /* Ensure that ".tdata" precedes any other .tdata. section, as the ld
      * linker script fails to work right.
@@ -2002,7 +2002,7 @@ seg_data *ElfObj_tlsseg()
  *      segment for TLS segment
  */
 
-seg_data *ElfObj_tlsseg_bss()
+seg_data* ElfObj_tlsseg_bss()
 {
     static immutable char[6] tlssegname = ".tbss";
     //dbg_printf("ElfObj_tlsseg_bss(\n");
@@ -2015,7 +2015,7 @@ seg_data *ElfObj_tlsseg_bss()
     return SegData[elfobj.seg_tlsseg_bss];
 }
 
-seg_data *ElfObj_tlsseg_data()
+seg_data* ElfObj_tlsseg_data()
 {
     // specific for Mach-O
     assert(0);
@@ -2032,7 +2032,7 @@ void ElfObj_alias(const(char)* n1,const(char)* n2)
     assert(0);
 static if (0)
 {
-    char *buffer = cast(char *) alloca(strlen(n1) + strlen(n2) + 2 * ONS_OHD);
+    char* buffer = cast(char*) alloca(strlen(n1) + strlen(n2) + 2 * ONS_OHD);
     uint len = obj_namestring(buffer,n1);
     len += obj_namestring(buffer + len,n2);
     objrecord(ALIAS,buffer,len);
@@ -2074,7 +2074,7 @@ char[] obj_mangle2(ref Symbol s, char[] dest)
             dest = dest[0 .. len];
         else
         {
-            char* p = cast(char *)mem_malloc(len + 1);
+            char* p = cast(char*)mem_malloc(len + 1);
             dest = p[0 .. len];
         }
     }
@@ -2098,7 +2098,7 @@ char[] obj_mangle2(ref Symbol s, char[] dest)
             bool cond = tyfunc(s.ty()) && !variadic(s.Stype);
             if (cond)
             {
-                char *pstr = unsstr(type_paramsize(s.Stype));
+                char* pstr = unsstr(type_paramsize(s.Stype));
                 size_t pstrlen = strlen(pstr);
                 size_t dlen = len + 1 + pstrlen;
 
@@ -2138,7 +2138,7 @@ debug
  * Export a function name.
  */
 
-void ElfObj_export_symbol(Symbol *s,uint argsize)
+void ElfObj_export_symbol(Symbol* s,uint argsize)
 {
     //dbg_printf("ElfObj_export_symbol(%s,%d)\n",s.Sident.ptr,argsize);
 }
@@ -2156,7 +2156,7 @@ void ElfObj_export_symbol(Symbol *s,uint argsize)
  *      actual seg
  */
 
-int ElfObj_data_start(Symbol *sdata, targ_size_t datasize, int seg)
+int ElfObj_data_start(Symbol* sdata, targ_size_t datasize, int seg)
 {
     targ_size_t alignbytes;
     //printf("ElfObj_data_start(%s,size %llx,seg %d)\n",sdata.Sident.ptr,datasize,seg);
@@ -2187,7 +2187,7 @@ int ElfObj_data_start(Symbol *sdata, targ_size_t datasize, int seg)
  * than the current default in cseg, switch cseg to new segment.
  */
 
-void ElfObj_func_start(Symbol *sfunc)
+void ElfObj_func_start(Symbol* sfunc)
 {
     //dbg_printf("ElfObj_func_start(%s)\n",sfunc.Sident.ptr);
     symbol_debug(sfunc);
@@ -2224,7 +2224,7 @@ else
  * Update function info after codgen
  */
 
-void ElfObj_func_term(Symbol *sfunc)
+void ElfObj_func_term(Symbol* sfunc)
 {
     //dbg_printf("ElfObj_func_term(%s) offset %x, Coffset %x symidx %d\n",
 //          sfunc.Sident.ptr, sfunc.Soffset,Offset(cseg),sfunc.Sxtrnnum);
@@ -2245,7 +2245,7 @@ void ElfObj_func_term(Symbol *sfunc)
  *      offset =        offset of name within segment
  */
 
-void ElfObj_pubdef(int seg, Symbol *s, targ_size_t offset)
+void ElfObj_pubdef(int seg, Symbol* s, targ_size_t offset)
 {
     const targ_size_t symsize=
         tyfunc(s.ty()) ? Offset(s.Sseg) - offset : type_size(s.Stype);
@@ -2261,7 +2261,7 @@ void ElfObj_pubdef(int seg, Symbol *s, targ_size_t offset)
  *      symsize         size of symbol
  */
 
-void ElfObj_pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize)
+void ElfObj_pubdefsize(int seg, Symbol* s, targ_size_t offset, targ_size_t symsize)
 {
     int bind;
     ubyte visibility = STV_DEFAULT;
@@ -2339,7 +2339,7 @@ int ElfObj_external_def(const(char)* name)
  *      NOTE: Numbers will not be linear.
  */
 
-int ElfObj_external(Symbol *s)
+int ElfObj_external(Symbol* s)
 {
     int symtype,sectype;
     uint size;
@@ -2374,7 +2374,7 @@ int ElfObj_external(Symbol *s)
  *      Symbol table index for symbol
  */
 
-int ElfObj_common_block(Symbol *s,targ_size_t size,targ_size_t count)
+int ElfObj_common_block(Symbol* s,targ_size_t size,targ_size_t count)
 {
     //printf("ElfObj_common_block('%s',%d,%d)\n",s.Sident.ptr,size,count);
     symbol_debug(s);
@@ -2416,7 +2416,7 @@ static if (0)
 }
 }
 
-int ElfObj_common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count)
+int ElfObj_common_block(Symbol* s, int flag, targ_size_t size, targ_size_t count)
 {
     return ElfObj_common_block(s, size, count);
 }
@@ -2426,7 +2426,7 @@ int ElfObj_common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count
  * (uninitialized data only)
  */
 
-void ElfObj_write_zeros(seg_data *pseg, targ_size_t count)
+void ElfObj_write_zeros(seg_data* pseg, targ_size_t count)
 {
     ElfObj_lidata(pseg.SDseg, pseg.SDoffset, count);
 }
@@ -2458,7 +2458,7 @@ void ElfObj_lidata(int seg,targ_size_t offset,targ_size_t count)
  * Append byte to segment.
  */
 
-void ElfObj_write_byte(seg_data *pseg, uint byte_)
+void ElfObj_write_byte(seg_data* pseg, uint byte_)
 {
     ElfObj_byte(pseg.SDseg, pseg.SDoffset, byte_);
 }
@@ -2469,7 +2469,7 @@ void ElfObj_write_byte(seg_data *pseg, uint byte_)
 
 void ElfObj_byte(int seg,targ_size_t offset,uint byte_)
 {
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     int save = cast(int)buf.length();
     //dbg_printf("ElfObj_byte(seg=%d, offset=x%lx, byte_=x%x)\n",seg,offset,byte_);
     buf.setsize(cast(uint)offset);
@@ -2485,7 +2485,7 @@ void ElfObj_byte(int seg,targ_size_t offset,uint byte_)
  * Append bytes to segment.
  */
 
-void ElfObj_write_bytes(seg_data *pseg, const(void[]) a)
+void ElfObj_write_bytes(seg_data* pseg, const(void[]) a)
 {
     ElfObj_bytes(pseg.SDseg, pseg.SDoffset, a.length, a.ptr);
 }
@@ -2506,7 +2506,7 @@ static if (0)
     }
 }
     assert(seg >= 0 && seg < SegData.length);
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     if (buf == null)
     {
         //dbg_printf("ElfObj_bytes(seg=%d, offset=x%lx, nbytes=%d, p=x%x)\n", seg, offset, nbytes, p);
@@ -2544,8 +2544,8 @@ __gshared int relcnt=0;
 void ElfObj_addrel(int seg, targ_size_t offset, uint type,
                     IDXSYM symidx, targ_size_t val)
 {
-    seg_data *segdata;
-    OutBuffer *buf;
+    seg_data* segdata;
+    OutBuffer* buf;
     IDXSEC secidx;
 
     //assert(val == 0);
@@ -2577,11 +2577,11 @@ void ElfObj_addrel(int seg, targ_size_t offset, uint type,
             import dmd.common.smallbuffer : SmallBuffer;
             // Get the section name, and make a copy because
             // elf_newsection() may reallocate the string buffer.
-            char *section_name = cast(char *)GET_SECTION_NAME(secidx);
+            char* section_name = cast(char*)GET_SECTION_NAME(secidx);
             size_t len = strlen(section_name) + 1;
             char[20] buf2 = void;
             auto sb = SmallBuffer!char(len, buf2[]);
-            char *p = sb.ptr;
+            char* p = sb.ptr;
             memcpy(p, section_name, len);
 
             relidx = elf_newsection(I64 ? ".rela" : ".rel", p, I64 ? SHT_RELA : SHT_REL, 0);
@@ -2595,7 +2595,7 @@ void ElfObj_addrel(int seg, targ_size_t offset, uint type,
              * the code a bit simpler. In ElfObj_term(), we translate the Elf32_Shdr into the proper
              * Elf64_Shdr.
              */
-            Elf32_Shdr *relsec = &elfobj.SecHdrTab[relidx];
+            Elf32_Shdr* relsec = &elfobj.SecHdrTab[relidx];
             relsec.sh_link = SHN_SYMTAB;
             relsec.sh_info = secidx;
             relsec.sh_entsize = Elf64_Rela.sizeof;
@@ -2603,7 +2603,7 @@ void ElfObj_addrel(int seg, targ_size_t offset, uint type,
         }
         else
         {
-            Elf32_Shdr *relsec = &elfobj.SecHdrTab[relidx];
+            Elf32_Shdr* relsec = &elfobj.SecHdrTab[relidx];
             relsec.sh_link = SHN_SYMTAB;
             relsec.sh_info = secidx;
             relsec.sh_entsize = Elf32_Rel.sizeof;
@@ -2731,7 +2731,7 @@ private size_t writeaddrval(int targseg, size_t offset, targ_size_t val, size_t 
 {
     assert(targseg >= 0 && targseg < SegData.length);
 
-    OutBuffer *buf = SegData[targseg].SDbuf;
+    OutBuffer* buf = SegData[targseg].SDbuf;
     const save = buf.length();
     buf.setsize(cast(uint)offset);
     buf.write(&val, cast(uint)size);
@@ -2784,7 +2784,7 @@ size_t ElfObj_writerel(int targseg, size_t offset, reltype_t reltype,
  *      targetdatum =   DATA, CDATA or UDATA, depending where the address is
  *      flags =         CFoff, CFseg, CFoffset64, CFswitch
  * Example:
- *      int *abc = &def[3];
+ *      int* abc = &def[3];
  *      to allocate storage:
  *              ElfObj_reftodatseg(DATA,offset,3 * (int *).sizeof,UDATA);
  * Note:
@@ -2901,7 +2901,7 @@ static if (0)
  *      number of bytes in reference (4 or 8)
  */
 
-int ElfObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
+int ElfObj_reftoident(int seg, targ_size_t offset, Symbol* s, targ_size_t val,
         int flags)
 {
     if (elfobj.AArch64)
@@ -3174,7 +3174,7 @@ static if (0)
     return refSize;
 }
 
-int ElfObj_reftoidentAArch64(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
+int ElfObj_reftoidentAArch64(int seg, targ_size_t offset, Symbol* s, targ_size_t val,
         int flags)
 {
     bool external = true;
@@ -3374,7 +3374,7 @@ static if (0)
  *      s       Symbol to generate a thunk for
  */
 
-void ElfObj_far16thunk(Symbol *s)
+void ElfObj_far16thunk(Symbol* s)
 {
     //dbg_printf("ElfObj_far16thunk('%s')\n", s.Sident.ptr);
     assert(0);
@@ -3414,7 +3414,7 @@ static if (TERMCODE)
 /**********************************
   * Write to the object file
   */
-/+void objfile_write(FILE *fd, void *buffer, uint len)
+/+void objfile_write(FILE* fd, void* buffer, uint len)
 {
     elfobj.fobjbuf.write(buffer[0 .. len]);
 }
@@ -3435,7 +3435,7 @@ int elf_align(targ_size_t size,int foffset)
  * Stuff pointer to ModuleInfo into its own section (minfo).
  */
 
-void ElfObj_moduleinfo(Symbol *scc)
+void ElfObj_moduleinfo(Symbol* scc)
 {
     const CFflags = I64 ? (CFoffset64 | CFoff) : CFoff;
 
@@ -3449,7 +3449,7 @@ void ElfObj_moduleinfo(Symbol *scc)
 /***************************************
  * Stuff pointer to DEH into its own section (deh).
  */
-void ElfObj_dehinfo(Symbol *scc)
+void ElfObj_dehinfo(Symbol* scc)
 {
     const CFflags = I64 ? (CFoffset64 | CFoff) : CFoff;
 
@@ -3567,7 +3567,7 @@ private void obj_rtinit()
             elf_addsym(namidx, 0, 0, STT_FUNC, STB_LOCAL, MAP_SEG2SECIDX(codseg));
         }
 
-        OutBuffer *buf = SegData[codseg].SDbuf;
+        OutBuffer* buf = SegData[codseg].SDbuf;
         assert(!buf.length());
         size_t off = 0;
 
@@ -3824,7 +3824,7 @@ else
     }
     // set group section infos
     Offset(groupseg) = SegData[groupseg].SDbuf.length();
-    Elf32_Shdr *p = MAP_SEG2SEC(groupseg);
+    Elf32_Shdr* p = MAP_SEG2SEC(groupseg);
     p.sh_link    = SHN_SYMTAB;
     p.sh_info    = dso_rec; // set the dso_rec as group symbol
     p.sh_entsize = IDXSYM.sizeof;
@@ -3834,7 +3834,7 @@ else
 /*************************************
  */
 
-void ElfObj_gotref(Symbol *s)
+void ElfObj_gotref(Symbol* s)
 {
     //printf("ElfObj_gotref(%x '%s', %d)\n",s,s.Sident.ptr, s.Sclass);
     switch(s.Sclass)
@@ -3856,7 +3856,7 @@ void ElfObj_gotref(Symbol *s)
     }
 }
 
-Symbol *ElfObj_tlv_bootstrap()
+Symbol* ElfObj_tlv_bootstrap()
 {
     // specific for Mach-O
     assert(0);
@@ -3876,7 +3876,7 @@ void ElfObj_write_pointerRef(Symbol* s, uint off)
  * Returns:
  *      number of bytes written at seg:offset
  */
-int elf_dwarf_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val)
+int elf_dwarf_reftoident(int seg, targ_size_t offset, Symbol* s, targ_size_t val)
 {
     //printf("elf_dwarf_reftoident()\n");
     if (config.flags3 & CFG3pic)
@@ -3891,7 +3891,7 @@ int elf_dwarf_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val
         if (!s.Sdw_ref_idx)
         {
             const dataDWref_seg = ElfObj_getsegment(".data.DW.ref.", s.Sident.ptr, SHT_PROGBITS, SHF_ALLOC|SHF_WRITE, I64 ? 8 : 4);
-            OutBuffer *buf = SegData[dataDWref_seg].SDbuf;
+            OutBuffer* buf = SegData[dataDWref_seg].SDbuf;
             assert(buf.length() == 0);
             ElfObj_reftoident(dataDWref_seg, 0, s, 0, I64 ? CFoffset64 : CFoff);
 

--- a/compiler/src/dmd/backend/elpicpie.d
+++ b/compiler/src/dmd/backend/elpicpie.d
@@ -40,9 +40,9 @@ enum log = false;
  * Make an elem out of a symbol.
  */
 @trusted
-elem * el_var(Symbol *s)
+elem* el_var(Symbol* s)
 {
-    elem *e;
+    elem* e;
     if (log) printf("el_var(s = '%s')\n", s.Sident.ptr);
     //printf("%x\n", s.Stype.Tty);
     if (config.exe & EX_posix)
@@ -151,7 +151,7 @@ elem * el_var(Symbol *s)
          */
         if (I64)
             Obj.refGOTsym();
-        elem *e1 = el_calloc();
+        elem* e1 = el_calloc();
         e1.Vsym = s;
         if (s.Sclass == SC.global ||
             s.Sclass == SC.static_ ||
@@ -238,7 +238,7 @@ elem * el_var(Symbol *s)
  */
 
 @trusted
-elem * el_ptr(Symbol *s)
+elem* el_ptr(Symbol* s)
 {
     if (log) printf("el_ptr(s = '%s')\n", s.Sident.ptr);
     symbol_debug(s);
@@ -255,7 +255,7 @@ elem * el_ptr(Symbol *s)
              * code in that data variable, and return the elem for
              * that data variable.
              */
-            Symbol *sd = symboldata(Offset(DATA), typtr);
+            Symbol* sd = symboldata(Offset(DATA), typtr);
             sd.Sseg = DATA;
             Obj.data_start(sd, _tysize[TYnptr], DATA);
             Offset(DATA) += Obj.reftoident(DATA, Offset(DATA), s, 0, CFoff);
@@ -298,7 +298,7 @@ elem * el_ptr(Symbol *s)
         }
     }
 
-    elem *e;
+    elem* e;
 
     if (config.exe & EX_windos)
     {
@@ -344,7 +344,7 @@ elem * el_ptr(Symbol *s)
  */
 
 @trusted
-private Symbol *el_alloc_localgot()
+private Symbol* el_alloc_localgot()
 {
     if (log) printf("el_alloc_localgot()\n");
     if (config.exe & EX_windos)
@@ -360,7 +360,7 @@ private Symbol *el_alloc_localgot()
         char[15] name = void;
         __gshared int tmpnum;
         const length = snprintf(name.ptr, name.length, "_LOCALGOT%d".ptr, tmpnum++);
-        type *t = type_fake(TYnptr);
+        type* t = type_fake(TYnptr);
         /* Make it volatile because we need it for calling functions, but that isn't
          * noticed by the data flow analysis. Hence, it may get deleted if we don't
          * make it volatile.
@@ -380,7 +380,7 @@ private Symbol *el_alloc_localgot()
  */
 
 @trusted
-private elem *el_picvar(Symbol *s)
+private elem* el_picvar(Symbol* s)
 {
     if (config.exe & (EX_OSX | EX_OSX64))
         return el_picvar_OSX(s);
@@ -390,9 +390,9 @@ private elem *el_picvar(Symbol *s)
 }
 
 @trusted
-private elem *el_picvar_OSX(Symbol *s)
+private elem* el_picvar_OSX(Symbol* s)
 {
-    elem *e;
+    elem* e;
     int x;
 
     if (log) printf("el_picvar(s = '%s') Sclass = %s\n", s.Sident.ptr, class_str(s.Sclass));
@@ -449,7 +449,7 @@ static if (1)
             {
                 if (!tls_get_addr_sym)
                 {
-                    /* void *___tls_get_addr(void *ptr);
+                    /* void* ___tls_get_addr(void* ptr);
                      * Parameter ptr is passed in RDI, matching TYnfunc calling convention.
                      */
                     tls_get_addr_sym = symbol_name("___tls_get_addr",SC.global,type_fake(TYnfunc));
@@ -515,7 +515,7 @@ static if (1)
                 e = el_una(OPind, TYnptr, e);
                 e = el_una(OPind, TYnfunc, e);
 
-                elem *e2 = el_calloc();
+                elem* e2 = el_calloc();
                 e2.Eoper = OPvar;
                 e2.Vsym = s;
                 e2.Ety = s.ty();
@@ -542,7 +542,7 @@ static if (1)
 }
 
 @trusted
-private elem *el_picvar_posix(Symbol *s)
+private elem* el_picvar_posix(Symbol* s)
 {
     if (log) printf("el_picvar(s = '%s')\n", s.Sident.ptr);
     symbol_debug(s);
@@ -629,7 +629,7 @@ private elem *el_picvar_posix(Symbol *s)
                     e.Ety |= mTYvolatile;
                     if (!tls_get_addr_sym)
                     {
-                        /* void *__tls_get_addr(void *ptr);
+                        /* void* __tls_get_addr(void* ptr);
                          * Parameter ptr is passed in RDI, matching TYnfunc calling convention.
                          */
                         tls_get_addr_sym = symbol_name("__tls_get_addr",SC.global,type_fake(TYnfunc));
@@ -711,7 +711,7 @@ private elem *el_picvar_posix(Symbol *s)
                     e.Ety |= mTYvolatile;
                     if (!tls_get_addr_sym)
                     {
-                        /* void *___tls_get_addr(void *ptr);
+                        /* void* ___tls_get_addr(void* ptr);
                          * Parameter ptr is passed in EAX, matching TYjfunc calling convention.
                          */
                         tls_get_addr_sym = symbol_name("___tls_get_addr",SC.global,type_fake(TYjfunc));
@@ -759,7 +759,7 @@ private elem *el_picvar_posix(Symbol *s)
  * Returns: elem created
  */
 @trusted
-private elem *el_pievar(Symbol *s)
+private elem* el_pievar(Symbol* s)
 {
     if (config.exe & (EX_OSX | EX_OSX64))
         assert(0);
@@ -840,7 +840,7 @@ private elem *el_pievar(Symbol *s)
  * Returns: elem created
  */
 @trusted
-private elem *el_pieptr(Symbol *s)
+private elem* el_pieptr(Symbol* s)
 {
     if (config.exe & (EX_OSX | EX_OSX64))
         assert(0);

--- a/compiler/src/dmd/backend/evalu8.d
+++ b/compiler/src/dmd/backend/evalu8.d
@@ -44,7 +44,7 @@ import dmd.backend.fp : testFE, clearFE, statusFE, have_float_except;
  * Return boolean result of constant elem.
  */
 
-int boolres(elem *e)
+int boolres(elem* e)
 {   int b;
 
     //printf("boolres()\n");
@@ -210,7 +210,7 @@ int boolres(elem *e)
  */
 
 @trusted
-int iftrue(elem *e)
+int iftrue(elem* e)
 {
     while (1)
     {
@@ -242,7 +242,7 @@ int iftrue(elem *e)
  */
 
 @trusted
-int iffalse(elem *e)
+int iffalse(elem* e)
 {
     while (1)
     {
@@ -274,7 +274,7 @@ int iffalse(elem *e)
  */
 
 @trusted
-elem * evalu8(elem *e, Goal goal)
+elem* evalu8(elem* e, Goal goal)
 {
     elem* e1;
     elem* e2;
@@ -1941,7 +1941,7 @@ static if (0) // && MARS
  * instead of the soft long double ones.
  */
 
-extern (D) targ_ldouble el_toldoubled(elem *e)
+extern (D) targ_ldouble el_toldoubled(elem* e)
 {
     targ_ldouble result;
 

--- a/compiler/src/dmd/backend/gdag.d
+++ b/compiler/src/dmd/backend/gdag.d
@@ -47,7 +47,7 @@ bool Eunambig(elem* e) { return OTassign(e.Eoper) && e.E1.Eoper == OPvar; }
  */
 
 @trusted
-private bool cse_float(elem *e)
+private bool cse_float(elem* e)
 {
     // Don't CSE floating stuff if generating
     // inline 8087 code, the code generator
@@ -166,14 +166,14 @@ void builddags(ref GlobalOptimizer go)
 
 
 /****************************
- * Walk tree, rewriting *pn into a DAG as we go.
+ * Walk tree, rewriting* pn into a DAG as we go.
  * Params:
  *      go = GlobalOptimizer
  *      pn = pointer to expression tree to convert to DAG
  *      ae = vector of available expressions
  */
 @trusted
-private void aewalk(ref GlobalOptimizer go, elem **pn, vec_t ae)
+private void aewalk(ref GlobalOptimizer go, elem** pn, vec_t ae)
 {
     elem* n = *pn;
     assert(n && ae);
@@ -186,7 +186,7 @@ private void aewalk(ref GlobalOptimizer go, elem **pn, vec_t ae)
         if (aetype == Aetype.cse)
         {
             for (uint i = 0; (i = cast(uint) vec_index(i, ae)) < go.exptop; ++i)
-            {   elem *e = go.expnod[i];
+            {   elem* e = go.expnod[i];
 
                 // Attempt to replace n with e
                 if (e == null)              // if elem no longer exists
@@ -202,7 +202,7 @@ private void aewalk(ref GlobalOptimizer go, elem **pn, vec_t ae)
                     e.Ecount++;
                     debug assert(e.Ecount != 0);
 
-                    void aeclear(elem *n)
+                    void aeclear(elem* n)
                     {
                         while (1)
                         {
@@ -236,7 +236,7 @@ private void aewalk(ref GlobalOptimizer go, elem **pn, vec_t ae)
         }
     }
 
-    elem *t;
+    elem* t;
     switch (op)
     {
         case OPcolon:
@@ -327,7 +327,7 @@ private void aewalk(ref GlobalOptimizer go, elem **pn, vec_t ae)
                 vec_subass(ae,go.starkill);
             for (uint i = 0; (i = cast(uint) vec_index(i, ae)) < go.exptop; ++i) // for each ae elem
             {
-                elem *e = go.expnod[i];
+                elem* e = go.expnod[i];
 
                 if (!e) continue;
                 if (OTunary(e.Eoper))
@@ -385,9 +385,9 @@ private void aewalk(ref GlobalOptimizer go, elem **pn, vec_t ae)
  *      *pe
  */
 @trusted
-private elem * delcse(elem **pe)
+private elem* delcse(elem** pe)
 {
-    elem *e;
+    elem* e;
 
     e = el_calloc();
     el_copy(e,*pe);
@@ -404,7 +404,7 @@ private elem * delcse(elem **pe)
     {
         if (e.E1.Ecount == 0xFF-1)
         {
-            elem *ereplace;
+            elem* ereplace;
             ereplace = el_calloc();
             el_copy(ereplace,e.E1);
             e.E1 = ereplace;
@@ -419,7 +419,7 @@ private elem * delcse(elem **pe)
         {
             if (e.E2.Ecount == 0xFF-1)
             {
-                elem *ereplace;
+                elem* ereplace;
                 ereplace = el_calloc();
                 el_copy(ereplace,e.E2);
                 e.E2 = ereplace;
@@ -437,7 +437,7 @@ private elem * delcse(elem **pe)
     (*pe).Nflags |= NFLdelcse;     // not generating node
     e.Ecount = 0;
     *pe = e;
-    return *pe;
+    return* pe;
 }
 
 
@@ -447,7 +447,7 @@ private elem * delcse(elem **pe)
  */
 
 @trusted
-private void removecses(elem **pe)
+private void removecses(elem** pe)
 {
 L1:
     elem* e = *pe;
@@ -465,7 +465,7 @@ L1:
         if (op == OPind)
         {
             bool scaledIndex = I32 || I64;      // if scaled index addressing mode support
-            elem *e1 = e.E1;
+            elem* e1 = e.E1;
             if (e1.Eoper == OPadd &&
                 e1.Ecount
                )
@@ -528,7 +528,7 @@ L1:
                 delcse(&e1.E1);              // the <<. operator
             }
 
-            // Remove *e1 where it's a double
+            // Remove* e1 where it's a double
             if (e.Ecount && tyfloating(e.Ety))
                 e = delcse(pe);
         }
@@ -544,7 +544,7 @@ L1:
                  (op == OP64_32 || op == OP128_64 || op == OPmsw) &&
                  e.E1.Ecount == 0)
         {   // Convert back to OPdiv or OPmod
-            elem *e1 = e.E1;
+            elem* e1 = e.E1;
             e.Eoper = (op == OPmsw) ? OPmod : OPdiv;
             e.E1 = e1.E1;
             e.E2 = e1.E2;
@@ -621,7 +621,7 @@ void boolopt(ref GlobalOptimizer go)
     // Mark each expression that we know starts off with a non-zero value
     foreach (const i; 0 .. go.exptop)
     {
-        elem *e = go.expnod[i];
+        elem* e = go.expnod[i];
         if (e)
         {
             elem_debug(e);
@@ -665,9 +665,9 @@ void boolopt(ref GlobalOptimizer go)
  */
 
 @trusted
-private void abewalk(ref GlobalOptimizer go, elem *n, vec_t ae, vec_t aeval)
+private void abewalk(ref GlobalOptimizer go, elem* n, vec_t ae, vec_t aeval)
 {
-    elem *t;
+    elem* t;
 
     assert(n && ae);
     elem_debug(n);
@@ -808,7 +808,7 @@ private void abewalk(ref GlobalOptimizer go, elem *n, vec_t ae, vec_t aeval)
         /* remove all AEs that could be affected by this def    */
         if (Eunambig(n))        /* if unambiguous definition    */
         {
-            Symbol *s;
+            Symbol* s;
 
             assert(t.Eoper == OPvar);
             s = t.Vsym;
@@ -816,7 +816,7 @@ private void abewalk(ref GlobalOptimizer go, elem *n, vec_t ae, vec_t aeval)
                 vec_subass(ae,go.starkill);
             for (uint i = 0; (i = cast(uint) vec_index(i, ae)) < go.exptop; ++i) // for each ae elem
             {
-                elem *e = go.expnod[i];
+                elem* e = go.expnod[i];
 
                 if (!e) continue;
                 if (el_appears(e,s))
@@ -861,7 +861,7 @@ private void abewalk(ref GlobalOptimizer go, elem *n, vec_t ae, vec_t aeval)
  */
 
 @trusted
-private void abeboolres(ref GlobalOptimizer go, elem *n,vec_t ae,vec_t aeval)
+private void abeboolres(ref GlobalOptimizer go, elem* n,vec_t ae,vec_t aeval)
 {
     //printf("abeboolres()[%d %p] ", n.Eexp, go.expnod[n.Eexp]); WReqn(n); printf("\n");
     elem_debug(n);
@@ -870,7 +870,7 @@ private void abeboolres(ref GlobalOptimizer go, elem *n,vec_t ae,vec_t aeval)
         assert(go.expnod[n.Eexp] == n);
         uint i;
         for (i = 0; (i = cast(uint) vec_index(i, ae)) < go.exptop; ++i) // for each ae elem
-        {   elem *e = go.expnod[i];
+        {   elem* e = go.expnod[i];
 
             // Attempt to replace n with the boolean result of e
             //printf("Looking at go.expnod[%d] = %p\n",i,e);
@@ -900,7 +900,7 @@ private void abeboolres(ref GlobalOptimizer go, elem *n,vec_t ae,vec_t aeval)
  */
 
 @trusted
-private void abefree(ref GlobalOptimizer go, elem *e,vec_t ae)
+private void abefree(ref GlobalOptimizer go, elem* e,vec_t ae)
 {
     //printf("abefree [%d %p]: ", e.Eexp, e); WReqn(e); printf("\n");
     assert(e.Eexp);
@@ -926,7 +926,7 @@ private void abefree(ref GlobalOptimizer go, elem *e,vec_t ae)
  */
 
 @trusted
-private void abeset(ref GlobalOptimizer go, elem *e, vec_t ae, vec_t aeval, int flag)
+private void abeset(ref GlobalOptimizer go, elem* e, vec_t ae, vec_t aeval, int flag)
 {
     while (1)
     {

--- a/compiler/src/dmd/backend/gflow.d
+++ b/compiler/src/dmd/backend/gflow.d
@@ -44,7 +44,7 @@ char symbol_isintab(const Symbol* s) { return sytab[s.Sclass] & SCSS; }
 void util_free(void* p) { if (p) free(p); }
 
 @trusted
-void *util_calloc(uint n, uint size)
+void* util_calloc(uint n, uint size)
 {
     void* p = calloc(n, size);
     if (n * size && !p)
@@ -53,7 +53,7 @@ void *util_calloc(uint n, uint size)
 }
 
 @trusted
-void *util_realloc(void* p, size_t n, size_t size)
+void* util_realloc(void* p, size_t n, size_t size)
 {
     void* q = realloc(p, n * size);
     if (n * size && !q)
@@ -254,7 +254,7 @@ private uint numdefelems(const(elem)* e, ref uint num_unambig_def)
  */
 
 @trusted
-private void asgdefelems(block *b,elem *n, DefNode[] defnod, ref size_t i)
+private void asgdefelems(block* b,elem* n, DefNode[] defnod, ref size_t i)
 {
     assert(b && n);
     while (1)
@@ -308,7 +308,7 @@ private void initDNunambigVectors(ref GlobalOptimizer go, DefNode[] defnod)
     size_t j = 0;
     foreach (const i; 0 .. defnod.length)
     {
-        elem *e = defnod[i].DNelem;
+        elem* e = defnod[i].DNelem;
         if (OTassign(e.Eoper) && e.E1.Eoper == OPvar)
         {
             vec_t v = &go.dnunambig[j] + 2;
@@ -325,7 +325,7 @@ private void initDNunambigVectors(ref GlobalOptimizer go, DefNode[] defnod)
     {
         if (vec_t v = defnod[i].DNunambig)
         {
-            elem *e = defnod[i].DNelem;
+            elem* e = defnod[i].DNelem;
             vec_setbit(i, v);        // of course it modifies itself
             fillInDNunambig(v, e, i, defnod[]);
         }
@@ -347,12 +347,12 @@ private void initDNunambigVectors(ref GlobalOptimizer go, DefNode[] defnod)
  */
 
 @trusted
-private void fillInDNunambig(vec_t v, elem *e, size_t start, DefNode[] defnod)
+private void fillInDNunambig(vec_t v, elem* e, size_t start, DefNode[] defnod)
 {
     assert(OTassign(e.Eoper));
-    elem *t = e.E1;
+    elem* t = e.E1;
     assert(t.Eoper == OPvar);
-    Symbol *d = t.Vsym;
+    Symbol* d = t.Vsym;
 
     targ_size_t toff = t.Voffset;
     targ_size_t tsize = (e.Eoper == OPstreq) ? type_size(e.ET) : tysize(t.Ety);
@@ -365,8 +365,8 @@ private void fillInDNunambig(vec_t v, elem *e, size_t start, DefNode[] defnod)
         if (!v2)
             continue;
 
-        elem *tn = defnod[i].DNelem;
-        elem *tn1;
+        elem* tn = defnod[i].DNelem;
+        elem* tn1;
         targ_size_t tn1size;
 
         // If not same variable then no overlap
@@ -397,7 +397,7 @@ private void fillInDNunambig(vec_t v, elem *e, size_t start, DefNode[] defnod)
  *      n = elem tree to evaluate for GEN and KILL
  *      deftop = number of bits in vectors
  */
-private void rdelem(ref GlobalOptimizer go, out vec_t GEN, out vec_t KILL, elem *n, uint deftop)
+private void rdelem(ref GlobalOptimizer go, out vec_t GEN, out vec_t KILL, elem* n, uint deftop)
 {
     GEN  = vec_calloc(deftop);
     KILL = vec_calloc(deftop);
@@ -410,7 +410,7 @@ private void rdelem(ref GlobalOptimizer go, out vec_t GEN, out vec_t KILL, elem 
  */
 
 @trusted
-private void accumrd(ref GlobalOptimizer go, vec_t GEN,vec_t KILL,elem *n,uint deftop)
+private void accumrd(ref GlobalOptimizer go, vec_t GEN,vec_t KILL,elem* n,uint deftop)
 {
     assert(GEN && KILL && n);
     const op = n.Eoper;
@@ -678,7 +678,7 @@ private void aecpgenkill(ref GlobalOptimizer go, int flowxx)
     /********************************
      * Assign cp elems to go.expnod[] (in order of evaluation).
      */
-    void asgcpelems(elem *n)
+    void asgcpelems(elem* n)
     {
         while (1)
         {
@@ -731,7 +731,7 @@ private void aecpgenkill(ref GlobalOptimizer go, int flowxx)
     /********************************
      * Assign ae and vbe elems to go.expnod[] (in order of evaluation).
      */
-    bool asgaeelems(elem *n)
+    bool asgaeelems(elem* n)
     {
         bool ae;
 
@@ -1051,7 +1051,7 @@ void genkillae(ref GlobalOptimizer go)
  */
 
 @trusted
-private void aecpelem(ref GlobalOptimizer go, out vec_t gen, out vec_t kill, elem *n, uint exptop)
+private void aecpelem(ref GlobalOptimizer go, out vec_t gen, out vec_t kill, elem* n, uint exptop)
 {
     gen = vec_calloc(exptop);
     kill = vec_calloc(exptop);
@@ -1075,7 +1075,7 @@ private __gshared
 }
 
 @trusted
-private void accumaecp(ref GlobalOptimizer go, vec_t g,vec_t k,elem *n)
+private void accumaecp(ref GlobalOptimizer go, vec_t g,vec_t k,elem* n)
 {   vec_t GENsave,KILLsave;
 
     assert(g && k);
@@ -1089,9 +1089,9 @@ private void accumaecp(ref GlobalOptimizer go, vec_t g,vec_t k,elem *n)
 }
 
 @trusted
-private void accumaecpx(ref GlobalOptimizer go, elem *n)
+private void accumaecpx(ref GlobalOptimizer go, elem* n)
 {
-    elem *t;
+    elem* t;
 
     assert(n);
     elem_debug(n);
@@ -1230,7 +1230,7 @@ private void accumaecpx(ref GlobalOptimizer go, elem *n)
             Symbol* s = t.Vsym;                  // ptr to var being def'd
             foreach (uint i; 1 .. go.exptop)        // for each ae elem
             {
-                elem *e = go.expnod[i];
+                elem* e = go.expnod[i];
 
                 /* If it could be changed by the definition,     */
                 /* set bit in KILL.                              */
@@ -1281,7 +1281,7 @@ private void accumaecpx(ref GlobalOptimizer go, elem *n)
             }
             foreach (uint i; 1 .. go.exptop)        // for each ae elem
             {
-                elem *e = go.expnod[i];
+                elem* e = go.expnod[i];
                 const int eop = e.Eoper;
 
                 /* If it could be changed by the definition,     */
@@ -1426,7 +1426,7 @@ void flowlv()
 private void lvgenkill()
 {
     /* Compute ambigsym, a vector of all variables that could be    */
-    /* referenced by a *e or a call.                                */
+    /* referenced by a* e or a call.                                */
     Symbol*[] gsym = globsym[];
     const length = gsym.length;
     vec_t ambigsym = vec_calloc(length);
@@ -1621,7 +1621,7 @@ private void accumlv(vec_t GEN, vec_t KILL, const(elem)* n, const vec_t ambigsym
             case OPstrlen:
                 accumlv(GEN,KILL,n.E1,ambigsym);
 
-                /* If it was a *p elem, set bits in GEN for all symbols */
+                /* If it was a* p elem, set bits in GEN for all symbols */
                 /* it could have referenced, but only if bits in KILL   */
                 /* are not already set.                                 */
 
@@ -1749,9 +1749,9 @@ void flowvbe(ref GlobalOptimizer go)
  */
 
 @trusted
-private void accumvbe(ref GlobalOptimizer go, vec_t GEN,vec_t KILL,elem *n)
+private void accumvbe(ref GlobalOptimizer go, vec_t GEN,vec_t KILL,elem* n)
 {
-    elem *t;
+    elem* t;
 
     assert(GEN && KILL && n);
     const op = n.Eoper;
@@ -1924,7 +1924,7 @@ private void accumvbe(ref GlobalOptimizer go, vec_t GEN,vec_t KILL,elem *n)
                 vec_orass(KILL,go.starkill);/* kill all 'starred' refs */
             foreach (uint i; 1 .. go.exptop)        // for each vbe elem
             {
-                elem *e = go.expnod[i];
+                elem* e = go.expnod[i];
                 uint eop = e.Eoper;
 
                 /* If it could be changed by the definition,     */

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -96,9 +96,9 @@ targ_size_t size(tym_t ty)
 /****************************
  * Generate symbol of type ty at DATA:offset
  */
-Symbol *symboldata(targ_size_t offset, tym_t ty)
+Symbol* symboldata(targ_size_t offset, tym_t ty)
 {
-    Symbol *s = symbol_generate(SC.locstat, type_fake(ty));
+    Symbol* s = symbol_generate(SC.locstat, type_fake(ty));
     s.Sfl = FL.data;
     s.Soffset = offset;
     s.Stype.Tmangle = Mangle.syscall; // writes symbol unmodified in Obj::mangle
@@ -126,8 +126,8 @@ public import dmd.backend.util2 : err_exit, ispow2;
 
 void* util_malloc(uint n,uint size) { return mem_malloc(n * size); }
 void* util_calloc(uint n,uint size) { return mem_calloc(n * size); }
-void util_free(void *p) { mem_free(p); }
-void *util_realloc(void *oldp,size_t n,size_t size) { return mem_realloc(oldp, n * size); }
+void util_free(void* p) { mem_free(p); }
+void* util_realloc(void* oldp,size_t n,size_t size) { return mem_realloc(oldp, n * size); }
 
 public import dmd.backend.cgcs : comsubs, cgcs_term;
 public import dmd.backend.evalu8;
@@ -138,7 +138,7 @@ void err_nomem() @nogc nothrow @trusted
     err_exit();
 }
 
-void symbol_keep(Symbol *s) { }
+void symbol_keep(Symbol* s) { }
 public import dmd.backend.symbol : symbol_print, symbol_term, symbol_ident, symbol_calloc,
     symbol_name, symbol_generate, symbol_genauto, symbol_genauto, symbol_genauto,
     symbol_func, symbol_funcalias, baseclass_find, baseclass_find_nest,

--- a/compiler/src/dmd/backend/glocal.d
+++ b/compiler/src/dmd/backend/glocal.d
@@ -55,7 +55,7 @@ enum
 
 struct loc_t
 {
-    elem *e;
+    elem* e;
     int flags;  // LFxxxxx
 }
 
@@ -106,9 +106,9 @@ void localize(ref GlobalOptimizer go)
 //
 
 @trusted
-private void local_exp(ref GlobalOptimizer go, ref Barray!loc_t lt, elem *e, int goal)
+private void local_exp(ref GlobalOptimizer go, ref Barray!loc_t lt, elem* e, int goal)
 {
-    elem *e1;
+    elem* e1;
     OPER op1;
 
 Loop:
@@ -477,7 +477,7 @@ private bool local_chkrem(const elem* e, const(elem)* eu)
 // Add entry e to lt[]
 
 @trusted
-private void local_ins(ref Barray!loc_t lt, elem *e)
+private void local_ins(ref Barray!loc_t lt, elem* e)
 {
     elem_debug(e);
     if (e.E1.Eoper == OPvar)

--- a/compiler/src/dmd/backend/gloop.d
+++ b/compiler/src/dmd/backend/gloop.d
@@ -38,7 +38,7 @@ nothrow:
 @safe:
 
 @trusted
-char symbol_isintab(const Symbol *s) { return sytab[s.Sclass] & SCSS; }
+char symbol_isintab(const Symbol* s) { return sytab[s.Sclass] & SCSS; }
 
 
 import dmd.backend.gother : findloopparameters;
@@ -55,9 +55,9 @@ struct Loop
 nothrow:
     vec_t Lloop;        // Vector of blocks in this loop
     vec_t Lexit;        // Vector of exit blocks of loop
-    block *Lhead;       // Pointer to header of loop
-    block *Ltail;       // Pointer to tail
-    block *Lpreheader;  // Pointer to preheader (if any)
+    block* Lhead;       // Pointer to header of loop
+    block* Ltail;       // Pointer to tail
+    block* Lpreheader;  // Pointer to preheader (if any)
     Barray!(elem*) Llis; // loop invariant elems moved to Lpreheader, so
                         // redundant temporaries aren't created
     Rarray!Iv Livlist;        // basic induction variables
@@ -88,7 +88,7 @@ nothrow:
     {
         debug
         {
-            Loop *l = &this;
+            Loop* l = &this;
             printf("loop %p\n", l);
             printf("\thead: B%d, tail: B%d, prehead: B%d\n",l.Lhead.Bdfoidx,
                 l.Ltail.Bdfoidx,(l.Lpreheader ) ? l.Lpreheader.Bdfoidx
@@ -102,10 +102,10 @@ nothrow:
 struct famlist
 {
 nothrow:
-    elem **FLpelem;         /* parent of elem in the family         */
-    elem *c1;
-    elem *c2;               // c1*(basic IV) + c2
-    Symbol *FLtemp;         // symbol index of temporary (FLELIM if */
+    elem** FLpelem;         /* parent of elem in the family         */
+    elem* c1;
+    elem* c2;               // c1*(basic IV) + c2
+    Symbol* FLtemp;         // symbol index of temporary (FLELIM if */
                             /* this entry has no temporary)         */
     tym_t FLty;             /* type of this induction variable      */
     tym_t FLivty;           /* type of the basic IV elem (which is  */
@@ -136,13 +136,13 @@ nothrow:
 }
 
 @system
-enum FLELIM = cast(Symbol *)-1;
+enum FLELIM = cast(Symbol*)-1;
 
 struct Iv
 {
 nothrow:
-    Symbol *IVbasic;        // symbol of basic IV
-    elem **IVincr;          // pointer to parent of IV increment elem
+    Symbol* IVbasic;        // symbol of basic IV
+    elem** IVincr;          // pointer to parent of IV increment elem
     Barray!famlist IVfamily;      // variables in this family
 
     void reset()
@@ -335,7 +335,7 @@ private extern (D) void findloops(block*[] dfo, ref Loops loops)
         assert(b);
         foreach (bl; ListRange(b.Bsucc))
         {
-            block *s = list_block(bl);      // each successor s to b
+            block* s = list_block(bl);      // each successor s to b
             assert(s);
             if (dom(s,b))                   // if s dominates b
                 buildloop(loops, s, b);     // we found a loop
@@ -382,13 +382,13 @@ private uint loop_weight(uint weight, int factor) pure
  */
 
 @trusted
-private void buildloop(ref Loops ploops,block *head,block *tail)
+private void buildloop(ref Loops ploops,block* head,block* tail)
 {
     //printf("buildloop()\n");
 
      /* Add a block b and all its predecessors to vector v.
       */
-    static void insert(block *b, vec_t v)
+    static void insert(block* b, vec_t v)
     {
         assert(b && v);
         if (!vec_testbit(b.Bdfoidx,v))      // if block is not in loop
@@ -464,7 +464,7 @@ L1:
     l.Lpreheader = null;
     foreach (bl; ListRange(head.Bpred))
     {
-        block *b = list_block(bl);
+        block* b = list_block(bl);
 
         if (!vec_testbit(b.Bdfoidx,l.Lloop))  /* if not in loop       */
         {
@@ -545,8 +545,8 @@ L1:
 @trusted
 private bool looprotate(ref GlobalOptimizer go, ref Loop l)
 {
-    block *tail = l.Ltail;
-    block *head = l.Lhead;
+    block* tail = l.Ltail;
+    block* head = l.Lhead;
 
     //printf("looprotate(%p)\n",l);
 
@@ -590,9 +590,9 @@ private bool looprotate(ref GlobalOptimizer go, ref Loop l)
 
         // pred(head1) = pred(head) outside loop
         // pred(head2) = pred(head) inside loop
-        list_t *pbln;
+        list_t* pbln;
         auto pbl2 = &(head2.Bpred);
-        for (list_t *pbl = &(head.Bpred); *pbl; pbl = pbln)
+        for (list_t* pbl = &(head.Bpred); *pbl; pbl = pbln)
         {
             if (vec_testbit(list_block(*pbl).Bdfoidx, l.Lloop))
             {   // if this predecessor is inside the loop
@@ -606,7 +606,7 @@ private bool looprotate(ref GlobalOptimizer go, ref Loop l)
                 foreach (bl; ListRange(bsucc))
                     if (list_block(bl) == head)
                     {
-                        bl.ptr = cast(void *)head2;
+                        bl.ptr = cast(void*)head2;
                         goto L2;
                     }
                 assert(0);
@@ -754,7 +754,7 @@ restart:
             // Move preds of h that aren't in the loop to preds of p
             for (list_t bl = h.Bpred; bl;)
             {
-                block *b = list_block(bl);
+                block* b = list_block(bl);
 
                 if (!vec_testbit (b.Bdfoidx, l.Lloop))
                 {
@@ -765,7 +765,7 @@ restart:
                     /* Fix up successors of predecessors        */
                     foreach (bls; ListRange(b.Bsucc))
                         if (list_block(bls) == h)
-                                bls.ptr = cast(void *)p;
+                                bls.ptr = cast(void*)p;
                 }
                 else
                     bl = list_next(bl);
@@ -842,7 +842,7 @@ restart:
         vec_t rd = vec_calloc(go.defnod.length);        /* allocate our running RD vector */
         for (uint i = 0; (i = cast(uint) vec_index(i, lv)) < bo.dfo.length; ++i) // for each block in loop
         {
-            block *b = bo.dfo[i];
+            block* b = bo.dfo[i];
 
             if (debugc) printf("B%d\n",i);
             if (b.Belem)
@@ -934,15 +934,15 @@ restart:
  */
 
 @trusted
-private void markInvariants(ref GlobalOptimizer go, int gref, block* gblock, vec_t lv, vec_t gin, elem *n, vec_t rd)
+private void markInvariants(ref GlobalOptimizer go, int gref, block* gblock, vec_t lv, vec_t gin, elem* n, vec_t rd)
 {
 
-    void markinvar(elem *n,vec_t rd)
+    void markinvar(elem* n,vec_t rd)
     {
         vec_t tmp;
         uint i;
-        Symbol *v;
-        elem *n1;
+        Symbol* v;
+        elem* n1;
 
         assert(n && rd);
         assert(vec_numbits(rd) == go.defnod.length);
@@ -1217,7 +1217,7 @@ private void markInvariants(ref GlobalOptimizer go, int gref, block* gblock, vec
                                 //printf("\tn is: "); WReqn(n); printf("\n");
                                 for (j = 0; (j = cast(uint) vec_index(j, gin)) < go.exptop; ++j)
                                 {
-                                    elem *e = go.expnod[j];
+                                    elem* e = go.expnod[j];
 
                                     //printf("\t\tgo.expnod[%d] = %p\n",j,e);
                                     //printf("\t\tAE is: "); WReqn(e); printf("\n");
@@ -1309,10 +1309,10 @@ private void markInvariants(ref GlobalOptimizer go, int gref, block* gblock, vec
  */
 
 @trusted
-void updaterd(ref GlobalOptimizer go, elem *n,vec_t GEN,vec_t KILL)
+void updaterd(ref GlobalOptimizer go, elem* n,vec_t GEN,vec_t KILL)
 {
     const op = n.Eoper;
-    elem *t;
+    elem* t;
 
     assert(OTdef(op));
     assert(GEN);
@@ -1339,8 +1339,8 @@ void updaterd(ref GlobalOptimizer go, elem *n,vec_t GEN,vec_t KILL)
                 // for all unambig defs in go.defnod[]
                 foreach (uint i; 0 .. go.defnod.length)
                 {
-                    elem *tn = go.defnod[i].DNelem;
-                    elem *tn1;
+                    elem* tn = go.defnod[i].DNelem;
+                    elem* tn1;
 
                     if (tn == n)
                         ni = i;
@@ -1369,7 +1369,7 @@ void updaterd(ref GlobalOptimizer go, elem *n,vec_t GEN,vec_t KILL)
  */
 
 @trusted
-private void unmarkall(elem *e)
+private void unmarkall(elem* e)
 {
     for (; 1; e = e.E1)
     {
@@ -1398,7 +1398,7 @@ private void unmarkall(elem *e)
  */
 
 @trusted
-private bool refs(Symbol *v,elem *n,elem *nstop)
+private bool refs(Symbol* v,elem* n,elem* nstop)
 {
     symbol_debug(v);
     assert(symbol_isintab(v));
@@ -1489,10 +1489,10 @@ private bool refs(Symbol *v,elem *n,elem *nstop)
 private void movelis(ref GlobalOptimizer go, elem* n, block* b, ref Loop l, ref uint pdomexit)
 {
     vec_t tmp;
-    elem *ne;
-    elem *t;
-    elem *n2;
-    Symbol *v;
+    elem* ne;
+    elem* t;
+    elem* n2;
+    Symbol* v;
     tym_t ty;
 
 Lnextlis:
@@ -1549,7 +1549,7 @@ Lnextlis:
                     {
                         foreach (bl; ListRange(bo.dfo[i].Bsucc))
                         {
-                            block *s;           // successor to exit block
+                            block* s;           // successor to exit block
 
                             s = list_block(bl);
                             if (!vec_testbit(s.Bdfoidx,l.Lloop) &&
@@ -1579,7 +1579,7 @@ Lnextlis:
                         if (go.defnod[j].DNelem == n)
                             continue;
                         if (bo.dfo[i].Belem &&
-                            refs(v,bo.dfo[i].Belem,cast(elem *)null)) //if refs of v
+                            refs(v,bo.dfo[i].Belem,cast(elem*)null)) //if refs of v
                         {
                             vec_free(tmp);
                             goto L3;
@@ -1675,8 +1675,8 @@ L3:
     {
         if (OTassign(op))
         {
-            elem *n1 = n.E1;
-            elem *n11;
+            elem* n1 = n.E1;
+            elem* n11;
 
             if (OTbinary(op))
                 movelis(go, n.E2, b, l, pdomexit);
@@ -1711,7 +1711,7 @@ L3:
         }
         else if (OTunary(op))
         {
-            elem *e1 = n.E1;
+            elem* e1 = n.E1;
 
             // If *(x + c), just make x the LI, not the (x + c).
             // The +c comes free with the addressing mode.
@@ -1746,7 +1746,7 @@ L3:
 
             // If this operand has already been indirected, we can let
             // it pass.
-            Symbol *s;
+            Symbol* s;
 
             printf("looking at:\n");
             elem_print(n);
@@ -1875,7 +1875,7 @@ Lret:
  */
 
 @trusted
-private void appendelem(elem *n,elem **pn)
+private void appendelem(elem* n,elem** pn)
 {
     assert(n && pn);
     if (*pn)                                    /* if this elem exists  */
@@ -2030,7 +2030,7 @@ private void loopiv(ref GlobalOptimizer go, ref Loop l)
 private void findbasivs(ref GlobalOptimizer go, ref Loop l)
 {
     vec_t poss,notposs;
-    elem *n;
+    elem* n;
     bool ambdone;
 
     ambdone = false;
@@ -2049,7 +2049,7 @@ private void findbasivs(ref GlobalOptimizer go, ref Loop l)
         elem_debug(n);
         if (OTassign(n.Eoper) && n.E1.Eoper == OPvar)
         {
-            Symbol *s;                  /* if unambiguous def           */
+            Symbol* s;                  /* if unambiguous def           */
 
             s = n.E1.Vsym;
             if (symbol_isintab(s))
@@ -2102,7 +2102,7 @@ private void findbasivs(ref GlobalOptimizer go, ref Loop l)
     uint i;
     for (i = 0; (i = cast(uint) vec_index(i, poss)) < globsym.length; ++i)  // for each basic IV
     {
-        Symbol *s;
+        Symbol* s;
 
         /* Skip if we don't want it to be a basic IV (see funcprev())   */
         s = globsym[i];
@@ -2170,7 +2170,7 @@ private void findbasivs(ref GlobalOptimizer go, ref Loop l)
 private void findopeqs(ref GlobalOptimizer go, ref Loop l)
 {
     vec_t poss,notposs;
-    elem *n;
+    elem* n;
     bool ambdone;
 
     ambdone = false;
@@ -2189,7 +2189,7 @@ private void findopeqs(ref GlobalOptimizer go, ref Loop l)
         elem_debug(n);
         if (OTopeq(n.Eoper) && n.E1.Eoper == OPvar)
         {
-            Symbol *s;                  // if unambiguous def
+            Symbol* s;                  // if unambiguous def
 
             s = n.E1.Vsym;
             if (symbol_isintab(s))
@@ -2245,7 +2245,7 @@ private void findopeqs(ref GlobalOptimizer go, ref Loop l)
     uint i;
     for (i = 0; (i = cast(uint) vec_index(i, poss)) < globsym.length; ++i)  // for each opeq IV
     {
-        Symbol *s;
+        Symbol* s;
 
         s = globsym[i];
         assert(symbol_isintab(s));
@@ -2326,11 +2326,11 @@ private void findivfams(ref Loop l)
  */
 
 @trusted
-private void ivfamelems(Iv *biv,elem **pn)
+private void ivfamelems(Iv* biv,elem** pn)
 {
     tym_t ty,c2ty;
-    elem *n1;
-    elem *n2;
+    elem* n1;
+    elem* n2;
 
     assert(pn);
     elem* n = *pn;
@@ -2534,7 +2534,7 @@ private void elimfrivivs(ref Loop l)
             /* from biv                                                 */
             foreach (ref fl; biv.IVfamily)
             {
-                elem *ec1 = fl.c1;
+                elem* ec1 = fl.c1;
                 targ_llong c;
 
                 if (elemisone(ec1) ||
@@ -2568,17 +2568,17 @@ private void elimfrivivs(ref Loop l)
 @trusted
 private void intronvars(ref GlobalOptimizer go, ref Loop l)
 {
-    elem *T;
-    elem *ne;
-    elem *t2;
-    elem *C2;
-    elem *cmul;
+    elem* T;
+    elem* ne;
+    elem* t2;
+    elem* C2;
+    elem* cmul;
     tym_t ty,tyr;
 
     if (debugc) printf("intronvars(%p)\n", &l);
     foreach (ref biv; l.Livlist)
     {
-        elem *bivinc = *biv.IVincr;   /* ptr to increment elem */
+        elem* bivinc = *biv.IVincr;   /* ptr to increment elem */
 
         foreach (ref fl; biv.IVfamily)
         {                               /* for each IV in family of biv  */
@@ -2667,9 +2667,9 @@ private bool funcprev(ref GlobalOptimizer go, ref Iv biv, ref famlist fl)
 {
     tym_t tymin;
     int sz;
-    elem *e1;
-    elem *e2;
-    elem *flse1;
+    elem* e1;
+    elem* e2;
+    elem* flse1;
 
     debug if (debugc)
         printf("funcprev\n");
@@ -2905,7 +2905,7 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
                     continue;
             }
 
-            elem *refE2 = el_copytree(ref_.E2);
+            elem* refE2 = el_copytree(ref_.E2);
             int refEoper = ref_.Eoper;
 
             /* if c1 < 0 and relop is < <= > >=
@@ -3009,8 +3009,8 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
 
             for (uint i = 0; (i = cast(uint) vec_index(i, l.Lexit)) < bo.dfo.length; ++i)  // for each exit block
             {
-                elem *ne;
-                block *b;
+                elem* ne;
+                block* b;
 
                 foreach (bl; ListRange(bo.dfo[i].Bsucc))
                 {   /* for each successor   */
@@ -3050,18 +3050,18 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
                     /* more than one predecessor to b.      */
                     if (list_next(b.Bpred))
                     {
-                        block *bn = block_calloc();
+                        block* bn = block_calloc();
                         bn.Btry = b.Btry;
                         bn.bc = BC.goto_;
                         bn.Bnext = bo.dfo[i].Bnext;
                         bo.dfo[i].Bnext = bn;
                         list_append(&(bn.Bsucc),b);
                         list_append(&(bn.Bpred),bo.dfo[i]);
-                        bl.ptr = cast(void *)bn;
+                        bl.ptr = cast(void*)bn;
                         foreach (bl2; ListRange(b.Bpred))
                             if (list_block(bl2) == bo.dfo[i])
                             {
-                                bl2.ptr = cast(void *)bn;
+                                bl2.ptr = cast(void*)bn;
                                 goto L2;
                             }
                         assert(0);
@@ -3090,7 +3090,7 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
             {
                 foreach (bl; ListRange(bo.dfo[i].Bsucc))
                 {   /* for each successor   */
-                    block *b = list_block(bl);
+                    block* b = list_block(bl);
                     if (vec_testbit(b.Bdfoidx,l.Lloop))
                         continue;       /* inside loop  */
                     if (vec_testbit(X.Ssymnum,b.Binlv))
@@ -3126,8 +3126,8 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
 @trusted
 private void elimopeqs(ref GlobalOptimizer go, ref Loop l)
 {
-    elem **pref;
-    Symbol *X;
+    elem** pref;
+    Symbol* X;
     int refcount;
 
     if (debugc) printf("elimopeqs(%p)\n", &l);
@@ -3155,7 +3155,7 @@ private void elimopeqs(ref GlobalOptimizer go, ref Loop l)
             {
                 foreach (bl; ListRange(bo.dfo[i].Bsucc))
                 {   // for each successor
-                    block *b = list_block(bl);
+                    block* b = list_block(bl);
                     if (vec_testbit(b.Bdfoidx,l.Lloop))
                         continue;       // inside loop
                     if (vec_testbit(X.Ssymnum,b.Binlv))
@@ -3372,13 +3372,13 @@ private bool catchRef(Symbol* x, ref Loop l)
 
 private __gshared
 {
-    elem **nd;
-    elem *sincn;
-    Symbol *X;
+    elem** nd;
+    elem* sincn;
+    Symbol* X;
 }
 
 @trusted
-private elem ** onlyref(Symbol *x, ref Loop l,elem *incn, out int refcount)
+private elem ** onlyref(Symbol* x, ref Loop l,elem* incn, out int refcount)
 {
     uint i;
 
@@ -3426,9 +3426,9 @@ private elem ** onlyref(Symbol *x, ref Loop l,elem *incn, out int refcount)
  */
 
 @trusted
-private int countrefs(elem **pn,bool flag)
+private int countrefs(elem** pn,bool flag)
 {
-    elem *n = *pn;
+    elem* n = *pn;
 
     assert(n);
     if (n == sincn)                       /* if it is the increment elem  */
@@ -3443,7 +3443,7 @@ private int countrefs(elem **pn,bool flag)
     {
         if (OTrel(n.Eoper))
         {
-            elem *e1 = n.E1;
+            elem* e1 = n.E1;
 
             assert(e1.Eoper != OPcomma);
             if (e1 == sincn &&
@@ -3508,9 +3508,9 @@ extern(D) void elimspec(ref GlobalOptimizer go, const ref Loop loop, block*[] df
  */
 
 @trusted
-private void elimspecwalk(ref GlobalOptimizer go, elem **pn)
+private void elimspecwalk(ref GlobalOptimizer go, elem** pn)
 {
-    elem *n;
+    elem* n;
 
     n = *pn;
     assert(n);
@@ -3522,7 +3522,7 @@ private void elimspecwalk(ref GlobalOptimizer go, elem **pn)
         elimspecwalk(go, &n.E2);
         if (OTrel(n.Eoper))
         {
-            elem *e1 = n.E1;
+            elem* e1 = n.E1;
 
             /* Replace ((e1,e2) rel e3) with (e1,(e2 rel e3).
              * This will reduce the number of cases for elimbasivs().
@@ -3531,7 +3531,7 @@ private void elimspecwalk(ref GlobalOptimizer go, elem **pn)
              */
             if (e1.Eoper == OPcomma)
             {
-                elem *e;
+                elem* e;
 
                 debug if (debugc)
                 {   printf("3rewriting ("); WReqn(n); printf(")\n"); }
@@ -3562,7 +3562,7 @@ private void elimspecwalk(ref GlobalOptimizer go, elem **pn)
                 ) &&
                 !el_sideeffect(e1.E1))
             {
-                elem *e;
+                elem* e;
                 OPER op;
 
                 debug if (debugc)
@@ -3627,7 +3627,7 @@ private void unrollWalker(elem* e, uint defnum, Symbol* v, targ_llong increment,
      * state == unrolls: done
      */
 
-    void walker(elem *e) @trusted
+    void walker(elem* e) @trusted
     {
         assert(e);
         const op = e.Eoper;
@@ -3657,7 +3657,7 @@ private void unrollWalker(elem* e, uint defnum, Symbol* v, targ_llong increment,
                  e.Vsym == v)
         {
             // overwrite e with (v+increment)
-            elem *e1 = el_calloc();
+            elem* e1 = el_calloc();
             el_copy(e1,e);
             e.Eoper = OPadd;
             e.E1 = e1;
@@ -3735,8 +3735,8 @@ bool loopunroll(ref GlobalOptimizer go, ref Loop l)
         return false;
     }
 
-    elem *ehead = l.Lhead.Belem;
-    elem *etail = l.Ltail.Belem;
+    elem* ehead = l.Lhead.Belem;
+    elem* etail = l.Ltail.Belem;
 
     if (log)
     {
@@ -3755,8 +3755,8 @@ bool loopunroll(ref GlobalOptimizer go, ref Loop l)
         return false;
     }
 
-    elem *e1 = etail.E1;
-    elem *e2 = etail.E2;
+    elem* e1 = etail.E1;
+    elem* e2 = etail.E2;
 
     if (!tyintegral(e1.Ety) ||
         tysize(e1.Ety) > targ_llong.sizeof ||
@@ -3787,8 +3787,8 @@ bool loopunroll(ref GlobalOptimizer go, ref Loop l)
 
     /* Find the initial, increment elem, and final value of s
      */
-    elem *einitial;
-    elem *eincrement;
+    elem* einitial;
+    elem* eincrement;
     if (!findloopparameters(go, etail, einitial, eincrement))
     {
         if (log) printf("\tnot findloopparameters()\n");
@@ -3880,7 +3880,7 @@ bool loopunroll(ref GlobalOptimizer go, ref Loop l)
  *  number of elems in tree
  */
 @trusted
-private int el_length(elem *e)
+private int el_length(elem* e)
 {
     int n = 0;
     while (e)

--- a/compiler/src/dmd/backend/go.d
+++ b/compiler/src/dmd/backend/go.d
@@ -89,7 +89,7 @@ else
  *      !=0     recognized
  */
 @trusted
-int go_flag(ref GlobalOptimizer go, char *cp)
+int go_flag(ref GlobalOptimizer go, char* cp)
 {
     enum GL     // indices of various flags in flagtab[]
     {
@@ -197,9 +197,9 @@ badflag:
 
 debug (DEBUG_TREES)
 {
-void dbg_optprint(char *title)
+void dbg_optprint(char* title)
 {
-    block *b;
+    block* b;
     for (b = startblock; b; b = b.Bnext)
         if (b.Belem)
         {
@@ -227,7 +227,7 @@ void optfunc(ref GlobalOptimizer go)
     if (localgot)
     {   // Initialize with:
         //      localgot = OPgot;
-        elem *e = el_long(TYnptr, 0);
+        elem* e = el_long(TYnptr, 0);
         e.Eoper = OPgot;
         e = el_bin(OPeq, TYnptr, el_var(localgot), e);
         bo.startblock.Belem = el_combine(e, bo.startblock.Belem);
@@ -317,7 +317,7 @@ void optfunc(ref GlobalOptimizer go)
          * replaced with loads from variables in read-only data.
          * This can result in localgot getting needed.
          */
-        Symbol *localgotsave = localgot;
+        Symbol* localgotsave = localgot;
         for (block* b = bo.startblock; b; b = b.Bnext)
         {
             if (b.Belem)
@@ -331,7 +331,7 @@ void optfunc(ref GlobalOptimizer go)
         {   /* Looks like we did need localgot, initialize with:
              *  localgot = OPgot;
              */
-            elem *e = el_long(TYnptr, 0);
+            elem* e = el_long(TYnptr, 0);
             e.Eoper = OPgot;
             e = el_bin(OPeq, TYnptr, el_var(localgot), e);
             bo.startblock.Belem = el_combine(e, bo.startblock.Belem);

--- a/compiler/src/dmd/backend/gother.d
+++ b/compiler/src/dmd/backend/gother.d
@@ -35,7 +35,7 @@ nothrow:
 @safe:
 
 @trusted
-char symbol_isintab(const Symbol *s) { return sytab[s.Sclass] & SCSS; }
+char symbol_isintab(const Symbol* s) { return sytab[s.Sclass] & SCSS; }
 
 
 /**********************************************************************/
@@ -46,9 +46,9 @@ alias Elemdatas = Rarray!(Elemdata);
 struct Elemdata
 {
 nothrow:
-    elem *pelem;            // the elem in question
-    block *pblock;          // which block it's in
-    Barray!(elem*) rdlist;  // list of definition elems for *pelem
+    elem* pelem;            // the elem in question
+    block* pblock;          // which block it's in
+    Barray!(elem*) rdlist;  // list of definition elems for* pelem
 
     /***************************
      * Reset memory so this allocation can be re-used.
@@ -61,7 +61,7 @@ nothrow:
     /******************
      * Initialize instance at ed.
      */
-    void emplace(elem *e,block *b)
+    void emplace(elem* e,block* b)
     {
         this.pelem = e;
         this.pblock = b;
@@ -77,7 +77,7 @@ nothrow:
  *      null if not
  */
 @trusted
-Elemdata* find(ref Elemdatas eds, elem *e)
+Elemdata* find(ref Elemdatas eds, elem* e)
 {
     foreach (ref edl; eds)
     {
@@ -220,10 +220,10 @@ private void rd_compute(ref GlobalOptimizer go, ref EqRelInc eqrelinc)
 @trusted
 private void constantPropagation(ref GlobalOptimizer go, block* thisblock, ref EqRelInc eqrelinc)
 {
-    void conpropwalk(elem *n,vec_t IN)
+    void conpropwalk(elem* n,vec_t IN)
     {
         vec_t L,R;
-        elem *t;
+        elem* t;
 
         assert(n && IN);
         //printf("conpropwalk()\n"),elem_print(n);
@@ -383,7 +383,7 @@ private void constantPropagation(ref GlobalOptimizer go, block* thisblock, ref E
 
             if (!(config.flags & CFGnowarning))     // if warnings are enabled
                 chkrd(n,rdl);
-            elem *e = chkprop(go, n, rdl);
+            elem* e = chkprop(go, n, rdl);
             if (e)
             {   tym_t nty;
 
@@ -403,9 +403,9 @@ private void constantPropagation(ref GlobalOptimizer go, block* thisblock, ref E
  */
 
 @trusted
-private void chkrd(elem *n, Barray!(elem*) rdlist)
+private void chkrd(elem* n, Barray!(elem*) rdlist)
 {
-    Symbol *sv;
+    Symbol* sv;
     int unambig;
 
     sv = n.Vsym;
@@ -500,11 +500,11 @@ private void chkrd(elem *n, Barray!(elem*) rdlist)
  */
 
 @trusted
-private elem* chkprop(ref GlobalOptimizer go, elem *n, Barray!(elem*) rdlist)
+private elem* chkprop(ref GlobalOptimizer go, elem* n, Barray!(elem*) rdlist)
 {
-    elem *foundelem = null;
+    elem* foundelem = null;
     int unambig;
-    Symbol *sv;
+    Symbol* sv;
     tym_t nty;
     uint nsize;
     targ_size_t noff;
@@ -533,7 +533,7 @@ private elem* chkprop(ref GlobalOptimizer go, elem *n, Barray!(elem*) rdlist)
 
         if (OTassign(d.Eoper))      // if assignment elem
         {
-            elem *t = d.E1;
+            elem* t = d.E1;
 
             if (t.Eoper == OPvar)
             {
@@ -611,10 +611,10 @@ noprop:
  */
 
 @trusted
-void listrds(ref GlobalOptimizer go, vec_t IN, elem *e, vec_t f, Barray!(elem*)* rdlist)
+void listrds(ref GlobalOptimizer go, vec_t IN, elem* e, vec_t f, Barray!(elem*)* rdlist)
 {
     uint unambig;
-    Symbol *s;
+    Symbol* s;
     uint nsize;
     targ_size_t noff;
     tym_t ty;
@@ -632,13 +632,13 @@ void listrds(ref GlobalOptimizer go, vec_t IN, elem *e, vec_t f, Barray!(elem*)*
         vec_clear(f);
     for (size_t i = 0; (i = vec_index(i, IN)) < go.defnod.length; ++i)
     {
-        elem *d = go.defnod[i].DNelem;
+        elem* d = go.defnod[i].DNelem;
         //printf("\tlooking at "); WReqn(d); printf("\n");
         const op = d.Eoper;
         if (op == OPasm)                // assume ASM elems define everything
             goto listit;
         if (OTassign(op))
-        {   elem *t = d.E1;
+        {   elem* t = d.E1;
 
             if (t.Eoper == OPvar && t.Vsym == s)
             {   if (op == OPstreq)
@@ -677,9 +677,9 @@ void listrds(ref GlobalOptimizer go, vec_t IN, elem *e, vec_t f, Barray!(elem*)*
 @trusted
 private void eqeqranges(ref Elemdatas eqeqlist)
 {
-    Symbol *v;
+    Symbol* v;
     int sz;
-    elem *e;
+    elem* e;
     targ_llong c;
     int result;
 
@@ -695,7 +695,7 @@ private void eqeqranges(ref Elemdatas eqeqlist)
         result = -1;                    // result not known yet
         foreach (erd; rel.rdlist)
         {
-            elem *erd1;
+            elem* erd1;
             int szrd;
             int tmp;
 
@@ -741,11 +741,11 @@ private void eqeqranges(ref Elemdatas eqeqlist)
 @trusted
 private void intranges(ref GlobalOptimizer go, ref Elemdatas rellist, ref Elemdatas inclist)
 {
-    block *rb;
-    block *ib;
-    Symbol *v;
-    elem *rdeq;
-    elem *rdinc;
+    block* rb;
+    block* ib;
+    Symbol* v;
+    elem* rdeq;
+    elem* rdinc;
     uint incop,relatop;
     targ_llong initial,increment,final_;
 
@@ -804,8 +804,8 @@ private void intranges(ref GlobalOptimizer go, ref Elemdatas rellist, ref Elemda
         /* are rdeq and rdinc.                                          */
         foreach (ref iel; inclist)
         {
-            elem *rd1;
-            elem *rd2;
+            elem* rd1;
+            elem* rd2;
 
             ib = iel.pblock;
             if (iel.pelem != rdinc)
@@ -1005,8 +1005,8 @@ public bool findloopparameters(ref GlobalOptimizer go, elem* erel, ref elem* rde
         if (log) printf("nitems != 2\n");
         return returnResult(false);
     }
-    elem *rd1 = iel.rdlist[0];
-    elem *rd2 = iel.rdlist[1];
+    elem* rd1 = iel.rdlist[0];
+    elem* rd2 = iel.rdlist[1];
     if (rd1 == rdinc)
         rdeq = rd2;
     else if (rd2 == rdinc)
@@ -1052,13 +1052,13 @@ public bool findloopparameters(ref GlobalOptimizer go, elem* erel, ref elem* rde
  */
 
 @trusted
-private int loopcheck(block *start,block *inc,block *rel)
+private int loopcheck(block* start,block* inc,block* rel)
 {
     if (!(start.Bflags & BFL.visited))
     {   start.Bflags |= BFL.visited;    /* guarantee eventual termination */
         foreach (list; ListRange(start.Bsucc))
         {
-            block *b = cast(block *) list_ptr(list);
+            block* b = cast(block*) list_ptr(list);
             if (b != rel && (b == inc || loopcheck(b,inc,rel)))
                 return true;
         }
@@ -1143,7 +1143,7 @@ Louter:
  */
 
 @trusted
-private bool copyPropWalk(ref GlobalOptimizer go, elem *n, vec_t IN)
+private bool copyPropWalk(ref GlobalOptimizer go, elem* n, vec_t IN)
 {
     bool recalc = false;
     int nocp = 0;
@@ -1155,7 +1155,7 @@ private bool copyPropWalk(ref GlobalOptimizer go, elem *n, vec_t IN)
         if (recalc)
             return;
 
-        elem *t;
+        elem* t;
         const op = n.Eoper;
         if (op == OPcolon || op == OPcolon2)
         {
@@ -1226,7 +1226,7 @@ private bool copyPropWalk(ref GlobalOptimizer go, elem *n, vec_t IN)
             ambig = !OTassign(op) || t.Eoper == OPind;
             for (size_t i = 0; (i = vec_index(i, IN)) < go.exptop; ++i) // for each active copy elem
             {
-                Symbol *v;
+                Symbol* v;
 
                 if (op == OPasm)
                     goto clr;
@@ -1270,7 +1270,7 @@ private bool copyPropWalk(ref GlobalOptimizer go, elem *n, vec_t IN)
         }
         else if (op == OPvar && !nocp)  // if reference to variable v
         {
-            Symbol *v = n.Vsym;
+            Symbol* v = n.Vsym;
 
             //printf("Checking copyprop for '%s', ty=x%x\n", v.Sident.ptr,n.Ety);
             symbol_debug(v);
@@ -1279,8 +1279,8 @@ private bool copyPropWalk(ref GlobalOptimizer go, elem *n, vec_t IN)
             if (sz == -1 && !tyfunc(n.Ety))
                 sz = cast(uint)type_size(v.Stype);
 
-            elem *foundelem = null;
-            Symbol *f;
+            elem* foundelem = null;
+            Symbol* f;
             for (size_t i = 0; (i = vec_index(i, IN)) < go.exptop; ++i) // for all active copy elems
             {
                 elem* c = go.expnod[i];
@@ -1316,11 +1316,11 @@ private bool copyPropWalk(ref GlobalOptimizer go, elem *n, vec_t IN)
                 debug if (debugc)
                 {
                     printf("Copyprop, '%s'(%d) replaced with '%s'(%d)\n",
-                        (v.Sident[0]) ? cast(char *)v.Sident.ptr : "temp".ptr, cast(int) v.Ssymnum,
-                        (f.Sident[0]) ? cast(char *)f.Sident.ptr : "temp".ptr, cast(int) f.Ssymnum);
+                        (v.Sident[0]) ? cast(char*)v.Sident.ptr : "temp".ptr, cast(int) v.Ssymnum,
+                        (f.Sident[0]) ? cast(char*)f.Sident.ptr : "temp".ptr, cast(int) f.Ssymnum);
                 }
 
-                type *nt = n.ET;
+                type* nt = n.ET;
                 targ_size_t noffset = n.Voffset;
                 el_copy(n,foundelem.E2);
                 n.Ety = ty;    // retain original type
@@ -1366,7 +1366,7 @@ private __gshared
     Barray!(elem*) assnod;      /* array of pointers to asg elems       */
     vec_t ambigref;             /* vector of assignment elems that      */
                                 /* are referenced when an ambiguous     */
-                                /* reference is done (as in *p or call) */
+                                /* reference is done (as in* p or call) */
 }
 
 @trusted
@@ -1397,9 +1397,9 @@ public void rmdeadass(ref GlobalOptimizer go)
         vec_orass(POSS,DEAD);   /* POSS |= DEAD                 */
         for (uint j = 0; (j = cast(uint) vec_index(j, POSS)) < assnum; ++j) // for each possible dead asg.
         {
-            Symbol *v;      /* v = target of assignment     */
-            elem *n;
-            elem *nv;
+            Symbol* v;      /* v = target of assignment     */
+            elem* n;
+            elem* nv;
 
             n = assnod[j];
             nv = n.E1;
@@ -1452,8 +1452,8 @@ public void rmdeadass(ref GlobalOptimizer go)
  */
 
 @trusted
-public void elimass(elem *n)
-{   elem *e1;
+public void elimass(elem* n)
+{   elem* e1;
 
     switch (n.Eoper)
     {
@@ -1523,7 +1523,7 @@ public void elimass(elem *n)
  */
 
 @trusted
-private uint numasg(elem *e)
+private uint numasg(elem* e)
 {
     assert(e);
     if (OTassign(e.Eoper) && e.E1.Eoper == OPvar)
@@ -1550,7 +1550,7 @@ private uint numasg(elem *e)
  */
 
 @trusted
-private void accumda(elem *n,vec_t DEAD, vec_t POSS)
+private void accumda(elem* n,vec_t DEAD, vec_t POSS)
 {
   LtailRecurse:
     assert(n && DEAD && POSS);
@@ -1600,7 +1600,7 @@ private void accumda(elem *n,vec_t DEAD, vec_t POSS)
 
         case OPvar:
         {
-            Symbol *v = n.Vsym;
+            Symbol* v = n.Vsym;
             targ_size_t voff = n.Voffset;
             uint vsize = tysize(n.Ety);
 
@@ -1609,7 +1609,7 @@ private void accumda(elem *n,vec_t DEAD, vec_t POSS)
 
             foreach (const i; 0 .. assnod.length)
             {
-                elem *ti = assnod[i].E1;
+                elem* ti = assnod[i].E1;
                 if (v == ti.Vsym &&
                     ((vsize == -1 || tysize(ti.Ety) == -1) ||
                      // If symbol references overlap
@@ -1676,7 +1676,7 @@ private void accumda(elem *n,vec_t DEAD, vec_t POSS)
         default:
             if (OTassign(op))
             {
-                elem *t;
+                elem* t;
 
                 if (ERTOL(n))
                     accumda(n.E2,DEAD,POSS);
@@ -1703,7 +1703,7 @@ private void accumda(elem *n,vec_t DEAD, vec_t POSS)
                         tsz = cast(uint)type_size(n.ET);
                     foreach (const i; 0 .. assnod.length)
                     {
-                        elem *ti = assnod[i].E1;
+                        elem* ti = assnod[i].E1;
 
                         uint tisz = tysize(ti.Ety);
                         if (assnod[i].Eoper == OPstreq)
@@ -1817,7 +1817,7 @@ public void deadvar()
                 s.Sflags &= ~GTregcand;    // do not put dead variables in registers
             debug
             {
-                auto p = cast(char *) s.Sident.ptr ;
+                auto p = cast(char*) s.Sident.ptr ;
                 if (s.Sflags & SFLdead)
                     if (debugc) printf("Symbol %d '%s' is dead\n",cast(int) i,p);
                 if (debugc && s.Srange /*&& s.Sclass != CLMOS*/)
@@ -1837,14 +1837,14 @@ public void deadvar()
  *      i = block index
  */
 @trusted
-private void dvwalk(elem *n,uint i)
+private void dvwalk(elem* n,uint i)
 {
     for (; true; n = n.E1)
     {
         assert(n);
         if (n.Eoper == OPvar || n.Eoper == OPrelconst)
         {
-            Symbol *s = n.Vsym;
+            Symbol* s = n.Vsym;
 
             s.Sflags &= ~SFLdead;
             if (s.Srange)
@@ -1869,7 +1869,7 @@ private __gshared vec_t blockseen; /* which blocks we have visited         */
 @trusted
 public void verybusyexp(ref GlobalOptimizer go)
 {
-    elem **pn;
+    elem** pn;
 
     if (debugc) printf("verybusyexp()\n");
     flowvbe(go);                      /* compute VBEs                 */
@@ -2046,7 +2046,7 @@ public void verybusyexp(ref GlobalOptimizer go)
  */
 
 @trusted
-private int killed(uint j,block *bp,block *b)
+private int killed(uint j,block* bp,block* b)
 {
     if (bp == b || vec_testbit(bp.Bdfoidx,blockseen))
         return false;

--- a/compiler/src/dmd/backend/gsroa.d
+++ b/compiler/src/dmd/backend/gsroa.d
@@ -225,7 +225,7 @@ extern (D) private void sliceStructs_Gather(ref const symtab_t symtab, SymInfo[]
  *      e = expression tree to rewrite in place
  */
 @trusted
-extern (D) private void sliceStructs_Replace(ref symtab_t symtab, const SymInfo[] sia, elem *e)
+extern (D) private void sliceStructs_Replace(ref symtab_t symtab, const SymInfo[] sia, elem* e)
 {
     while (1)
     {
@@ -233,7 +233,7 @@ extern (D) private void sliceStructs_Replace(ref symtab_t symtab, const SymInfo[
         {
             case OPvar:
             {
-                Symbol *s = e.Vsym;
+                Symbol* s = e.Vsym;
                 const si = s.Ssymnum;
                 //printf("e: %d %d\n", si, sia[si].canSlice);
                 //elem_print(e);
@@ -244,13 +244,13 @@ extern (D) private void sliceStructs_Replace(ref symtab_t symtab, const SymInfo[
                     {
                         if (log) { printf("slicing struct before "); elem_print(e); }
                         // Rewrite e as (si0 OPpair si0+1)
-                        elem *e1 = el_calloc();
+                        elem* e1 = el_calloc();
                         el_copy(e1, e);
                         e1.Ety = sia[si].ty[0];
 
-                        elem *e2 = el_calloc();
+                        elem* e2 = el_calloc();
                         el_copy(e2, e);
-                        Symbol *s1 = symtab[sia[si].si0 + 1]; // +1 for second slice
+                        Symbol* s1 = symtab[sia[si].si0 + 1]; // +1 for second slice
                         e2.Ety = sia[si].ty[1];
                         e2.Vsym = s1;
                         e2.Voffset = 0;
@@ -299,7 +299,7 @@ extern (D) private void sliceStructs_Replace(ref symtab_t symtab, const SymInfo[
 
             case OPrelconst:
             {
-                Symbol *s = e.Vsym;
+                Symbol* s = e.Vsym;
                 const si = s.Ssymnum;
                 //printf("e: %d %d\n", si, sia[si].canSlice);
                 //elem_print(e);
@@ -353,14 +353,14 @@ if (enable) // disable while we test the inliner
 
     if (log) foreach (si; 0 .. symtab.length)
     {
-        Symbol *s = symtab[si];
+        Symbol* s = symtab[si];
         printf("[%d]: %p %d %s %s\n", cast(int)si, s, cast(int)type_size(s.Stype), s.Sident.ptr, tym_str(s.Stype.Tty));
     }
 
     bool anySlice = false;
     foreach (si; 0 .. symtab.length)
     {
-        Symbol *s = symtab[si];
+        Symbol* s = symtab[si];
         if (log) printf("slice1 [%d]: %s\n", cast(int)si, s.Sident.ptr);
 
         //if (strcmp(s.Sident.ptr, "__inlineretval3".ptr) == 0) { printf("can't\n"); sia[si].canSlice = false; continue; }
@@ -454,17 +454,17 @@ if (enable) // disable while we test the inliner
                 /* Split slice-able symbol sold into two symbols,
                  * (sold,snew) in adjacent slots in the symbol table.
                  */
-                Symbol *sold = symtab[si + n];
+                Symbol* sold = symtab[si + n];
 
                 const idlen = 2 + strlen(sold.Sident.ptr) + 2;
-                char *id = cast(char *)malloc(idlen + 1);
+                char* id = cast(char*)malloc(idlen + 1);
                 if (!id)
                     err_nomem();
                 const len = snprintf(id, idlen + 1, "__%s_%d", sold.Sident.ptr, SLICESIZE);
                 assert(len == idlen);
                 if (log) printf("retyping slice symbol %s %s\n", sold.Sident.ptr, tym_str(sia[si].ty[0]));
                 if (log) printf("creating slice symbol %s %s\n", id, tym_str(sia[si].ty[1]));
-                Symbol *snew = symbol_calloc(id[0 .. idlen]);
+                Symbol* snew = symbol_calloc(id[0 .. idlen]);
                 free(id);
                 snew.Sclass = sold.Sclass;
                 snew.Sfl = sold.Sfl;
@@ -497,7 +497,7 @@ if (enable) // disable while we test the inliner
 
     foreach (si; 0 .. symtab.length)
     {
-        Symbol *s = symtab[si];
+        Symbol* s = symtab[si];
         assert(s.Ssymnum == si);
     }
 

--- a/compiler/src/dmd/backend/inliner.d
+++ b/compiler/src/dmd/backend/inliner.d
@@ -59,7 +59,7 @@ private enum log2 = false;
  */
 
 @trusted
-bool canInlineFunction(Symbol *sfunc)
+bool canInlineFunction(Symbol* sfunc)
 {
     auto f = sfunc.Sfunc;
 
@@ -152,7 +152,7 @@ bool canInlineFunction(Symbol *sfunc)
  */
 
 @trusted
-void scanForInlines(Symbol *sfunc)
+void scanForInlines(Symbol* sfunc)
 {
     if (log) debug printf("scanForInlines(%s)\n",prettyident(sfunc));
     //symbol_debug(sfunc);
@@ -237,7 +237,7 @@ bool canInlineExpression(elem* e)
  *      replacement tree
  */
 @trusted
-elem* scanExpressionForInlines(elem *e)
+elem* scanExpressionForInlines(elem* e)
 {
     //printf("scanExpressionForInlines(%p)\n",e);
     const op = e.Eoper;
@@ -272,7 +272,7 @@ elem* scanExpressionForInlines(elem *e)
  */
 
 @trusted
-private elem* tryInliningCall(elem *e)
+private elem* tryInliningCall(elem* e)
 {
     //elem_debug(e);
     assert(e && (e.Eoper == OPcall || e.Eoper == OPucall));
@@ -297,7 +297,7 @@ private elem* tryInliningCall(elem *e)
     else if (sfunc.Sfunc.Fstartblock == null)
         {   } //nwc_mustwrite(sfunc);
     else
-    {   func_t *f = sfunc.Sfunc;
+    {   func_t* f = sfunc.Sfunc;
 
         /* Check to see if we inline expand the function, or queue  */
         /* it to be output.                                         */
@@ -319,7 +319,7 @@ private elem* tryInliningCall(elem *e)
  *      the expression replacing the function call
  */
 @trusted
-private elem* inlineCall(elem *e,Symbol *sfunc)
+private elem* inlineCall(elem* e,Symbol* sfunc)
 {
     if (debugc)
         printf("inline %s\n", prettyident(sfunc));
@@ -450,9 +450,9 @@ private elem* initializeParamsWithArgs(elem* eargs, SYMIDX sistart, SYMIDX siend
     /* Create args[] and fill it with the arguments
      */
     const nargs = el_nparams(eargs);
-    assert(nargs < size_t.max / (2 * (elem *).sizeof));   // conservative overflow check
-    elem*[] args = (cast(elem **)malloc(nargs * (elem *).sizeof))[0 .. nargs];
-    elem **tmp = args.ptr;
+    assert(nargs < size_t.max / (2 * (elem*).sizeof));   // conservative overflow check
+    elem*[] args = (cast(elem**)malloc(nargs * (elem*).sizeof))[0 .. nargs];
+    elem** tmp = args.ptr;
     el_paramArray(&tmp, eargs);
 
     elem* ecopy;
@@ -482,7 +482,7 @@ private elem* initializeParamsWithArgs(elem* eargs, SYMIDX sistart, SYMIDX siend
             }
         }
 
-        Symbol *s = nextSymbol(si);
+        Symbol* s = nextSymbol(si);
         if (!s)
         {
             ecopy = el_combine(el_copytree(e), ecopy); // for ... arguments
@@ -617,7 +617,7 @@ private elem* initializeParamsWithArgs(elem* eargs, SYMIDX sistart, SYMIDX siend
  * Replace references to old symbols with references to copied symbols.
  */
 @trusted
-private void adjustExpression(elem *e)
+private void adjustExpression(elem* e)
 {
     while (1)
     {
@@ -639,7 +639,7 @@ private void adjustExpression(elem *e)
         {
             if (e.Eoper == OPvar || e.Eoper == OPrelconst)
             {
-                Symbol *s = e.Vsym;
+                Symbol* s = e.Vsym;
 
                 if (s.Sflags & SFLreplace)
                 {

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -56,20 +56,20 @@ alias nlist = dmd.backend.mach.nlist;   // avoid conflict with dmd.backend.dlist
 extern (C) {
 @trusted
 private int mach_rel_fp(scope const(void*) e1, scope const(void*) e2)
-{   Relocation *r1 = cast(Relocation *)e1;
-    Relocation *r2 = cast(Relocation *)e2;
+{   Relocation* r1 = cast(Relocation*)e1;
+    Relocation* r2 = cast(Relocation*)e2;
 
     return cast(int)(r1.offset - r2.offset);
 }
 }
 
 @trusted
-void mach_relsort(OutBuffer *buf)
+void mach_relsort(OutBuffer* buf)
 {
     qsort(buf.buf, buf.length() / Relocation.sizeof, Relocation.sizeof, &mach_rel_fp);
 }
 
-private extern (D) __gshared OutBuffer *fobjbuf;
+private extern (D) __gshared OutBuffer* fobjbuf;
 
 enum DEST_LEN = (IDMAX + IDOHD + 1);
 
@@ -82,7 +82,7 @@ public import dmd.backend.dwarfdbginf : except_table_seg, eh_frame_seg;
 @trusted
 Symbol* MachObj_getGOTsym()
 {
-    __gshared Symbol *GOTsym;
+    __gshared Symbol* GOTsym;
     if (!GOTsym)
     {
         GOTsym = symbol_name("_GLOBAL_OFFSET_TABLE_",SC.global,tspvoid);
@@ -99,14 +99,14 @@ void MachObj_refGOTsym()
 
 
 // String Table  - String table for all other names
-private extern (D) __gshared OutBuffer *symtab_strings;
+private extern (D) __gshared OutBuffer* symtab_strings;
 
 // Section Headers
 __gshared OutBuffer  *SECbuf;             // Buffer to build section table in
 @trusted
-section* SecHdrTab() { return cast(section *)SECbuf.buf; }
+section* SecHdrTab() { return cast(section*)SECbuf.buf; }
 @trusted
-section_64* SecHdrTab64() { return cast(section_64 *)SECbuf.buf; }
+section_64* SecHdrTab64() { return cast(section_64*)SECbuf.buf; }
 
 __gshared
 {
@@ -126,16 +126,16 @@ enum SYM_TAB_INC  = 50;          // Number of symbols to increment buffer by
  * are grouped into 3 different types (and a 4th for comdef's).
  */
 
-private OutBuffer *local_symbuf;
-private OutBuffer *public_symbuf;
-private OutBuffer *extern_symbuf;
+private OutBuffer* local_symbuf;
+private OutBuffer* public_symbuf;
+private OutBuffer* extern_symbuf;
 }
 
 @trusted
-private void reset_symbols(OutBuffer *buf)
+private void reset_symbols(OutBuffer* buf)
 {
-    Symbol **p = cast(Symbol **)buf.buf;
-    const size_t n = buf.length() / (Symbol *).sizeof;
+    Symbol** p = cast(Symbol**)buf.buf;
+    const size_t n = buf.length() / (Symbol*).sizeof;
     for (size_t i = 0; i < n; ++i)
         symbol_reset(*p[i]);
 }
@@ -143,13 +143,13 @@ private void reset_symbols(OutBuffer *buf)
 __gshared
 {
 
-struct Comdef { Symbol *sym; targ_size_t size; int count; }
-private OutBuffer *comdef_symbuf;        // Comdef's are stored here
+struct Comdef { Symbol* sym; targ_size_t size; int count; }
+private OutBuffer* comdef_symbuf;        // Comdef's are stored here
 
-private OutBuffer *indirectsymbuf1;      // indirect symbol table of Symbol*'s
+private OutBuffer* indirectsymbuf1;      // indirect symbol table of Symbol*'s
 private int jumpTableSeg;                // segment index for __jump_table
 
-private OutBuffer *indirectsymbuf2;      // indirect symbol table of Symbol*'s
+private OutBuffer* indirectsymbuf2;      // indirect symbol table of Symbol*'s
 private int pointersSeg;                 // segment index for __pointers
 
 /* If an MachObj_external_def() happens, set this to the string index,
@@ -241,8 +241,8 @@ enum
 struct Relocation
 {   // Relocations are attached to the struct seg_data they refer to
     targ_size_t offset; // location in segment to be fixed up
-    Symbol *funcsym;    // function in which offset lies, if any
-    Symbol *targsym;    // if !=null, then location is to be fixed up
+    Symbol* funcsym;    // function in which offset lies, if any
+    Symbol* targsym;    // if !=null, then location is to be fixed up
                         // to address of this symbol
     uint targseg;       // if !=0, then location is to be fixed up
                         // to address of start of this segment
@@ -261,7 +261,7 @@ struct Relocation
  * Returns index into the specified string table.
  */
 @trusted
-IDXSTR MachObj_addstr(OutBuffer *strtab, const(char)* str)
+IDXSTR MachObj_addstr(OutBuffer* strtab, const(char)* str)
 {
     //printf("MachObj_addstr(strtab = %p str = '%s')\n",strtab,str);
     IDXSTR idx = cast(IDXSTR)strtab.length();        // remember starting offset
@@ -278,11 +278,11 @@ IDXSTR MachObj_addstr(OutBuffer *strtab, const(char)* str)
  * Returns index into the table.
  */
 @trusted
-private IDXSTR mach_addmangled(Symbol *s)
+private IDXSTR mach_addmangled(Symbol* s)
 {
     //printf("mach_addmangled(%s)\n", s.Sident);
     char[DEST_LEN] dest = void;
-    char *destr;
+    char* destr;
     const(char)* name;
     IDXSTR namidx;
 
@@ -308,9 +308,9 @@ private IDXSTR mach_addmangled(Symbol *s)
  *
  */
 
-Symbol * MachObj_sym_cdata(tym_t ty,char *p,int len)
+Symbol* MachObj_sym_cdata(tym_t ty,char* p,int len)
 {
-    Symbol *s;
+    Symbol* s;
 
     //printf("MachObj_sym_cdata(ty = %x, p = %x, len = %d, Offset(CDATA) = %x)\n", ty, p, len, Offset(CDATA));
     alignOffset(CDATA, tysize(ty));
@@ -328,7 +328,7 @@ Symbol * MachObj_sym_cdata(tym_t ty,char *p,int len)
  *
  */
 @trusted
-int MachObj_data_readonly(char *p, int len, int *pseg)
+int MachObj_data_readonly(char* p, int len, int* pseg)
 {
     int oldoff = cast(int)Offset(CDATA);
     SegData[CDATA].SDbuf.reserve(len);
@@ -339,7 +339,7 @@ int MachObj_data_readonly(char *p, int len, int *pseg)
 }
 
 @trusted
-int MachObj_data_readonly(char *p, int len)
+int MachObj_data_readonly(char* p, int len)
 {
     int pseg;
 
@@ -368,7 +368,7 @@ int MachObj_string_literal_segment(uint sz)
  *      Called before any other obj_xxx routines
  */
 @system
-Obj MachObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
+Obj MachObj_init(OutBuffer* objbuf, const(char)* filename, const(char)* csegname)
 {
     //printf("MachObj_init()\n");
     Obj obj = cast(Obj)mem_calloc(__traits(classInstanceSize, Obj));
@@ -405,7 +405,7 @@ Obj MachObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname
         local_symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
         if (!local_symbuf)
             err_nomem();
-        local_symbuf.reserve((Symbol *).sizeof * SYM_TAB_INIT);
+        local_symbuf.reserve((Symbol*).sizeof * SYM_TAB_INIT);
     }
     local_symbuf.reset();
 
@@ -419,7 +419,7 @@ Obj MachObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname
         public_symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
         if (!public_symbuf)
             err_nomem();
-        public_symbuf.reserve((Symbol *).sizeof * SYM_TAB_INIT);
+        public_symbuf.reserve((Symbol*).sizeof * SYM_TAB_INIT);
     }
 
     if (extern_symbuf)
@@ -432,7 +432,7 @@ Obj MachObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname
         extern_symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
         if (!extern_symbuf)
             err_nomem();
-        extern_symbuf.reserve((Symbol *).sizeof * SYM_TAB_INIT);
+        extern_symbuf.reserve((Symbol*).sizeof * SYM_TAB_INIT);
     }
 
     if (!comdef_symbuf)
@@ -440,7 +440,7 @@ Obj MachObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname
         comdef_symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
         if (!comdef_symbuf)
             err_nomem();
-        comdef_symbuf.reserve((Symbol *).sizeof * SYM_TAB_INIT);
+        comdef_symbuf.reserve((Symbol*).sizeof * SYM_TAB_INIT);
     }
     comdef_symbuf.reset();
 
@@ -506,24 +506,24 @@ void MachObj_initfile(const(char)* filename, const(char)* csegname, const(char)*
  */
 
 @trusted
-int32_t *patchAddr(int seg, targ_size_t offset)
+int32_t* patchAddr(int seg, targ_size_t offset)
 {
-    return cast(int32_t *)(fobjbuf.buf + SecHdrTab[SegData[seg].SDshtidx].offset + offset);
+    return cast(int32_t*)(fobjbuf.buf + SecHdrTab[SegData[seg].SDshtidx].offset + offset);
 }
 
 @trusted
-int32_t *patchAddr64(int seg, targ_size_t offset)
+int32_t* patchAddr64(int seg, targ_size_t offset)
 {
-    return cast(int32_t *)(fobjbuf.buf + SecHdrTab64[SegData[seg].SDshtidx].offset + offset);
+    return cast(int32_t*)(fobjbuf.buf + SecHdrTab64[SegData[seg].SDshtidx].offset + offset);
 }
 
 @trusted
-void patch(seg_data *pseg, targ_size_t offset, int seg, targ_size_t value)
+void patch(seg_data* pseg, targ_size_t offset, int seg, targ_size_t value)
 {
     //printf("patch(offset = x%04x, seg = %d, value = x%llx)\n", cast(uint)offset, seg, value);
     if (I64)
     {
-        int32_t *p = cast(int32_t *)(fobjbuf.buf + SecHdrTab64[pseg.SDshtidx].offset + offset);
+        int32_t* p = cast(int32_t*)(fobjbuf.buf + SecHdrTab64[pseg.SDshtidx].offset + offset);
         if (log)
             debug printf("\taddr1 = x%llx\n\taddr2 = x%llx\n\t*p = x%x\n\tdelta = x%llx\n",
                          SecHdrTab64[pseg.SDshtidx].addr,
@@ -536,7 +536,7 @@ void patch(seg_data *pseg, targ_size_t offset, int seg, targ_size_t value)
     }
     else
     {
-        int32_t *p = cast(int32_t *)(fobjbuf.buf + SecHdrTab[pseg.SDshtidx].offset + offset);
+        int32_t* p = cast(int32_t*)(fobjbuf.buf + SecHdrTab[pseg.SDshtidx].offset + offset);
         if (log)
             debug printf("\taddr1 = x%x\n\taddr2 = x%x\n\t*p = x%x\n\tdelta = x%llx\n",
                          SecHdrTab[pseg.SDshtidx].addr,
@@ -560,30 +560,30 @@ void mach_numbersyms()
     int n = 0;
 
     int dim;
-    dim = cast(int)(local_symbuf.length() / (Symbol *).sizeof);
+    dim = cast(int)(local_symbuf.length() / (Symbol*).sizeof);
     for (int i = 0; i < dim; i++)
-    {   Symbol *s = (cast(Symbol **)local_symbuf.buf)[i];
+    {   Symbol* s = (cast(Symbol**)local_symbuf.buf)[i];
         s.Sxtrnnum = n;
         n++;
     }
 
-    dim = cast(int)(public_symbuf.length() / (Symbol *).sizeof);
+    dim = cast(int)(public_symbuf.length() / (Symbol*).sizeof);
     for (int i = 0; i < dim; i++)
-    {   Symbol *s = (cast(Symbol **)public_symbuf.buf)[i];
+    {   Symbol* s = (cast(Symbol**)public_symbuf.buf)[i];
         s.Sxtrnnum = n;
         n++;
     }
 
-    dim = cast(int)(extern_symbuf.length() / (Symbol *).sizeof);
+    dim = cast(int)(extern_symbuf.length() / (Symbol*).sizeof);
     for (int i = 0; i < dim; i++)
-    {   Symbol *s = (cast(Symbol **)extern_symbuf.buf)[i];
+    {   Symbol* s = (cast(Symbol**)extern_symbuf.buf)[i];
         s.Sxtrnnum = n;
         n++;
     }
 
     dim = cast(int)(comdef_symbuf.length() / Comdef.sizeof);
     for (int i = 0; i < dim; i++)
-    {   Comdef *c = (cast(Comdef *)comdef_symbuf.buf) + i;
+    {   Comdef* c = (cast(Comdef*)comdef_symbuf.buf) + i;
         c.sym.Sxtrnnum = n;
         n++;
     }
@@ -730,19 +730,19 @@ void MachObj_term(const(char)[] objfilename)
      */
     if (pointersSeg)
     {
-        seg_data *pseg = SegData[pointersSeg];
+        seg_data* pseg = SegData[pointersSeg];
         if (I64)
         {
-            section_64 *psechdr = &SecHdrTab64[pseg.SDshtidx]; // corresponding section
+            section_64* psechdr = &SecHdrTab64[pseg.SDshtidx]; // corresponding section
             psechdr.reserved1 = cast(uint)(indirectsymbuf1
-                ? indirectsymbuf1.length() / (Symbol *).sizeof
+                ? indirectsymbuf1.length() / (Symbol*).sizeof
                 : 0);
         }
         else
         {
-            section *psechdr = &SecHdrTab[pseg.SDshtidx]; // corresponding section
+            section* psechdr = &SecHdrTab[pseg.SDshtidx]; // corresponding section
             psechdr.reserved1 = cast(uint)(indirectsymbuf1
-                ? indirectsymbuf1.length() / (Symbol *).sizeof
+                ? indirectsymbuf1.length() / (Symbol*).sizeof
                 : 0);
         }
     }
@@ -766,10 +766,10 @@ void MachObj_term(const(char)[] objfilename)
     {
         for (int seg = 1; seg < SegData.length; seg++)
         {
-            seg_data *pseg = SegData[seg];
+            seg_data* pseg = SegData[seg];
             if (I64)
             {
-                section_64 *psechdr = &SecHdrTab64[pseg.SDshtidx]; // corresponding section
+                section_64* psechdr = &SecHdrTab64[pseg.SDshtidx]; // corresponding section
 
                 // Do zero-fill the second time through this loop
                 if (i ^ (psechdr.flags == S_ZEROFILL || psechdr.flags == S_THREAD_LOCAL_ZEROFILL))
@@ -807,7 +807,7 @@ void MachObj_term(const(char)[] objfilename)
             }
             else
             {
-                section *psechdr = &SecHdrTab[pseg.SDshtidx]; // corresponding section
+                section* psechdr = &SecHdrTab[pseg.SDshtidx]; // corresponding section
 
                 // Do zero-fill the second time through this loop
                 if (i ^ (psechdr.flags == S_ZEROFILL || psechdr.flags == S_THREAD_LOCAL_ZEROFILL))
@@ -873,9 +873,9 @@ void MachObj_term(const(char)[] objfilename)
     mach_numbersyms();
     for (int seg = 1; seg < SegData.length; seg++)
     {
-        seg_data *pseg = SegData[seg];
-        section *psechdr = null;
-        section_64 *psechdr64 = null;
+        seg_data* pseg = SegData[seg];
+        section* psechdr = null;
+        section_64* psechdr64 = null;
         if (I64)
         {
             psechdr64 = &SecHdrTab64[pseg.SDshtidx];   // corresponding section
@@ -890,10 +890,10 @@ void MachObj_term(const(char)[] objfilename)
         uint reloff = foffset;
         uint nreloc = 0;
         if (pseg.SDrel)
-        {   Relocation *r = cast(Relocation *)pseg.SDrel.buf;
-            Relocation *rend = cast(Relocation *)(pseg.SDrel.buf + pseg.SDrel.length());
+        {   Relocation* r = cast(Relocation*)pseg.SDrel.buf;
+            Relocation* rend = cast(Relocation*)(pseg.SDrel.buf + pseg.SDrel.length());
             for (; r != rend; r++)
-            {   Symbol *s = r.targsym;
+            {   Symbol* s = r.targsym;
                 const(char)* rs = r.rtype == RELaddr ? "addr" : "rel";
                 //printf("%d:x%04llx : tseg %d tsym %s REL%s\n", seg, r.offset, r.targseg, s ? s.Sident.ptr : "0", rs);
                 relocation_info rel;
@@ -923,7 +923,7 @@ void MachObj_term(const(char)[] objfilename)
                             ++nreloc;
 
                             // patch with fdesym.Soffset - offset
-                            long *p = cast(long *)patchAddr64(seg, r.offset);
+                            long* p = cast(long*)patchAddr64(seg, r.offset);
                             *p += r.funcsym.Soffset - r.offset;
                             continue;
                         }
@@ -950,7 +950,7 @@ void MachObj_term(const(char)[] objfilename)
                             foffset += srel.sizeof;
                             ++nreloc;
 
-                            int32_t *p = patchAddr(seg, r.offset);
+                            int32_t* p = patchAddr(seg, r.offset);
                             *p += targ_address - fixup_address;
                             continue;
                         }
@@ -1004,7 +1004,7 @@ void MachObj_term(const(char)[] objfilename)
                                 foffset += rel.sizeof;
                                 nreloc++;
 
-                                int32_t *p = patchAddr64(seg, r.offset);
+                                int32_t* p = patchAddr64(seg, r.offset);
                                 // Absolute address; add in addr of start of targ seg
 //printf("*p = x%x, .addr = x%x, Soffset = x%x\n", *p, cast(int)SecHdrTab64[SegData[s.Sseg].SDshtidx].addr, cast(int)s.Soffset);
 //printf("pseg = x%x, r.offset = x%x\n", cast(int)SecHdrTab64[pseg.SDshtidx].addr, cast(int)r.offset);
@@ -1059,14 +1059,14 @@ void MachObj_term(const(char)[] objfilename)
                             if (I64)
                             {
                                 rel.r_length = 3;
-                                int32_t *p = patchAddr64(seg, r.offset);
+                                int32_t* p = patchAddr64(seg, r.offset);
                                 // Absolute address; add in addr of start of targ seg
                                 *p += SecHdrTab64[SegData[s.Sseg].SDshtidx].addr + s.Soffset;
                                 //patch(pseg, r.offset, s.Sseg, s.Soffset);
                             }
                             else
                             {
-                                int32_t *p = patchAddr(seg, r.offset);
+                                int32_t* p = patchAddr(seg, r.offset);
                                 // Absolute address; add in addr of start of targ seg
                                 *p += SecHdrTab[SegData[s.Sseg].SDshtidx].addr + s.Soffset;
                                 //patch(pseg, r.offset, s.Sseg, s.Soffset);
@@ -1083,14 +1083,14 @@ void MachObj_term(const(char)[] objfilename)
                     srel.r_length = 2;
                     if (I64)
                     {
-                        int32_t *p64 = patchAddr64(seg, r.offset);
+                        int32_t* p64 = patchAddr64(seg, r.offset);
                         srel.r_type = X86_64_RELOC_GOT;
                         srel.r_value = cast(int)(SecHdrTab64[SegData[r.targseg].SDshtidx].addr + *p64);
                         //printf("SECTDIFF: x%llx + x%llx = x%x\n", SecHdrTab[SegData[r.targseg].SDshtidx].addr, *p, srel.r_value);
                     }
                     else
                     {
-                        int32_t *p = patchAddr(seg, r.offset);
+                        int32_t* p = patchAddr(seg, r.offset);
                         srel.r_type = GENERIC_RELOC_LOCAL_SECTDIFF;
                         srel.r_value = SecHdrTab[SegData[r.targseg].SDshtidx].addr + *p;
                         //printf("SECTDIFF: x%x + x%x = x%x\n", SecHdrTab[SegData[r.targseg].SDshtidx].addr, *p, srel.r_value);
@@ -1127,15 +1127,15 @@ void MachObj_term(const(char)[] objfilename)
                     // Recalc due to possible realloc of fobjbuf.buf
                     if (I64)
                     {
-                        int32_t *p64 = patchAddr64(seg, r.offset);
-                        //printf("address = x%x, p64 = %p *p64 = x%llx\n", r.offset, p64, *p64);
+                        int32_t* p64 = patchAddr64(seg, r.offset);
+                        //printf("address = x%x, p64 = %p* p64 = x%llx\n", r.offset, p64, *p64);
                         *p64 += SecHdrTab64[SegData[r.targseg].SDshtidx].addr -
                               (SecHdrTab64[pseg.SDshtidx].addr + r.funcsym.Slocalgotoffset + _tysize[TYnptr]);
                     }
                     else
                     {
-                        int32_t *p = patchAddr(seg, r.offset);
-                        //printf("address = x%x, p = %p *p = x%x\n", r.offset, p, *p);
+                        int32_t* p = patchAddr(seg, r.offset);
+                        //printf("address = x%x, p = %p* p = x%x\n", r.offset, p, *p);
                         if (r.funcsym)
                             *p += SecHdrTab[SegData[r.targseg].SDshtidx].addr -
                                   (SecHdrTab[pseg.SDshtidx].addr + r.funcsym.Slocalgotoffset + _tysize[TYnptr]);
@@ -1166,7 +1166,7 @@ void MachObj_term(const(char)[] objfilename)
                     nreloc++;
                     if (I64)
                     {
-                        int32_t *p64 = patchAddr64(seg, r.offset);
+                        int32_t* p64 = patchAddr64(seg, r.offset);
                         //long before = *p64;
                         if (rel.r_pcrel)
                             // Relative address
@@ -1182,7 +1182,7 @@ void MachObj_term(const(char)[] objfilename)
                     }
                     else
                     {
-                        int32_t *p = patchAddr(seg, r.offset);
+                        int32_t* p = patchAddr(seg, r.offset);
                         //int32_t before = *p;
                         if (rel.r_pcrel)
                             // Relative address
@@ -1215,11 +1215,11 @@ void MachObj_term(const(char)[] objfilename)
     foffset = elf_align(I64 ? 8 : 4, foffset);
     symtab_cmd.symoff = foffset;
     dysymtab_cmd.ilocalsym = 0;
-    dysymtab_cmd.nlocalsym  = cast(uint)(local_symbuf.length() / (Symbol *).sizeof);
+    dysymtab_cmd.nlocalsym  = cast(uint)(local_symbuf.length() / (Symbol*).sizeof);
     dysymtab_cmd.iextdefsym = dysymtab_cmd.nlocalsym;
-    dysymtab_cmd.nextdefsym = cast(uint)(public_symbuf.length() / (Symbol *).sizeof);
+    dysymtab_cmd.nextdefsym = cast(uint)(public_symbuf.length() / (Symbol*).sizeof);
     dysymtab_cmd.iundefsym = dysymtab_cmd.iextdefsym + dysymtab_cmd.nextdefsym;
-    int nexterns = cast(int)(extern_symbuf.length() / (Symbol *).sizeof);
+    int nexterns = cast(int)(extern_symbuf.length() / (Symbol*).sizeof);
     int ncomdefs = cast(int)(comdef_symbuf.length() / Comdef.sizeof);
     dysymtab_cmd.nundefsym  = nexterns + ncomdefs;
     symtab_cmd.nsyms =  dysymtab_cmd.nlocalsym +
@@ -1227,7 +1227,7 @@ void MachObj_term(const(char)[] objfilename)
                         dysymtab_cmd.nundefsym;
     fobjbuf.reserve(cast(uint)(symtab_cmd.nsyms * (I64 ? nlist_64.sizeof : nlist.sizeof)));
     for (int i = 0; i < dysymtab_cmd.nlocalsym; i++)
-    {   Symbol *s = (cast(Symbol **)local_symbuf.buf)[i];
+    {   Symbol* s = (cast(Symbol**)local_symbuf.buf)[i];
         nlist_64 sym = void;
         sym.n_strx = mach_addmangled(s);
         sym.n_type = N_SECT;
@@ -1252,7 +1252,7 @@ void MachObj_term(const(char)[] objfilename)
         }
     }
     for (int i = 0; i < dysymtab_cmd.nextdefsym; i++)
-    {   Symbol *s = (cast(Symbol **)public_symbuf.buf)[i];
+    {   Symbol* s = (cast(Symbol**)public_symbuf.buf)[i];
 
         //printf("Writing public symbol %d:x%x %s\n", s.Sseg, s.Soffset, s.Sident);
         nlist_64 sym = void;
@@ -1281,7 +1281,7 @@ void MachObj_term(const(char)[] objfilename)
         }
     }
     for (int i = 0; i < nexterns; i++)
-    {   Symbol *s = (cast(Symbol **)extern_symbuf.buf)[i];
+    {   Symbol* s = (cast(Symbol**)extern_symbuf.buf)[i];
         nlist_64 sym = void;
         sym.n_strx = mach_addmangled(s);
         sym.n_value = s.Soffset;
@@ -1303,7 +1303,7 @@ void MachObj_term(const(char)[] objfilename)
         }
     }
     for (int i = 0; i < ncomdefs; i++)
-    {   Comdef *c = (cast(Comdef *)comdef_symbuf.buf) + i;
+    {   Comdef* c = (cast(Comdef*)comdef_symbuf.buf) + i;
         nlist_64 sym = void;
         sym.n_strx = mach_addmangled(c.sym);
         sym.n_value = c.size * c.count;
@@ -1371,18 +1371,18 @@ void MachObj_term(const(char)[] objfilename)
     dysymtab_cmd.indirectsymoff = foffset;
     if (indirectsymbuf1)
     {
-        dysymtab_cmd.nindirectsyms += indirectsymbuf1.length() / (Symbol *).sizeof;
+        dysymtab_cmd.nindirectsyms += indirectsymbuf1.length() / (Symbol*).sizeof;
         for (int i = 0; i < dysymtab_cmd.nindirectsyms; i++)
-        {   Symbol *s = (cast(Symbol **)indirectsymbuf1.buf)[i];
+        {   Symbol* s = (cast(Symbol**)indirectsymbuf1.buf)[i];
             fobjbuf.write32(s.Sxtrnnum);
         }
     }
     if (indirectsymbuf2)
     {
-        int n = cast(int)(indirectsymbuf2.length() / (Symbol *).sizeof);
+        int n = cast(int)(indirectsymbuf2.length() / (Symbol*).sizeof);
         dysymtab_cmd.nindirectsyms += n;
         for (int i = 0; i < n; i++)
-        {   Symbol *s = (cast(Symbol **)indirectsymbuf2.buf)[i];
+        {   Symbol* s = (cast(Symbol**)indirectsymbuf2.buf)[i];
             fobjbuf.write32(s.Sxtrnnum);
         }
     }
@@ -1436,7 +1436,7 @@ void MachObj_linnum(Srcpos srcpos, int seg, targ_size_t offset)
         return;
 
     size_t i;
-    seg_data *pseg = SegData[seg];
+    seg_data* pseg = SegData[seg];
 
     // Find entry i in SDlinnum_data[] that corresponds to srcpos filename
     for (i = 0; 1; i++)
@@ -1450,7 +1450,7 @@ void MachObj_linnum(Srcpos srcpos, int seg, targ_size_t offset)
             break;
     }
 
-    linnum_data *ld = &pseg.SDlinnum_data[i];
+    linnum_data* ld = &pseg.SDlinnum_data[i];
 //    printf("i = %d, ld = x%x\n", i, ld);
     ld.linoff.push(LinOff(srcpos.Slinnum, cast(uint)offset));
 }
@@ -1460,7 +1460,7 @@ void MachObj_linnum(Srcpos srcpos, int seg, targ_size_t offset)
  * Set start address
  */
 
-void MachObj_startaddress(Symbol *s)
+void MachObj_startaddress(Symbol* s)
 {
     //dbg_printf("MachObj_startaddress(Symbol *%s)\n",s.Sident);
     //obj.startaddress = s;
@@ -1516,9 +1516,9 @@ void MachObj_user(const(char)* p)
  * Output a weak extern record.
  */
 
-void MachObj_wkext(Symbol *s1,Symbol *s2)
+void MachObj_wkext(Symbol* s1,Symbol* s2)
 {
-    //dbg_printf("MachObj_wkext(Symbol *%s,Symbol *s2)\n",s1.Sident.ptr,s2.Sident.ptr);
+    //dbg_printf("MachObj_wkext(Symbol *%s,Symbol* s2)\n",s1.Sident.ptr,s2.Sident.ptr);
 }
 
 /*******************************
@@ -1557,7 +1557,7 @@ void MachObj_compiler(const(char)* p)
  *              3:      compiler
  */
 
-void MachObj_staticctor(Symbol *s, int, int)
+void MachObj_staticctor(Symbol* s, int, int)
 {
     MachObj_setModuleCtorDtor(s, true);
 }
@@ -1570,7 +1570,7 @@ void MachObj_staticctor(Symbol *s, int, int)
  *      s       static destructor function
  */
 
-void MachObj_staticdtor(Symbol *s)
+void MachObj_staticdtor(Symbol* s)
 {
     MachObj_setModuleCtorDtor(s, false);
 }
@@ -1581,7 +1581,7 @@ void MachObj_staticdtor(Symbol *s)
  * Used for static ctor and dtor lists.
  */
 @trusted
-void MachObj_setModuleCtorDtor(Symbol *sfunc, bool isCtor)
+void MachObj_setModuleCtorDtor(Symbol* sfunc, bool isCtor)
 {
     const align_ = I64 ? 3 : 2; // align to _tysize[TYnptr]
 
@@ -1602,7 +1602,7 @@ void MachObj_setModuleCtorDtor(Symbol *sfunc, bool isCtor)
  *      length of function
  */
 @trusted
-void MachObj_ehtables(Symbol *sfunc,uint size,Symbol *ehsym)
+void MachObj_ehtables(Symbol* sfunc,uint size,Symbol* ehsym)
 {
     //dbg_printf("MachObj_ehtables(%s) \n",sfunc.Sident.ptr);
 
@@ -1614,7 +1614,7 @@ void MachObj_ehtables(Symbol *sfunc,uint size,Symbol *ehsym)
     // The size is (FuncTable).sizeof in deh2.d
     int seg = getsegment2(seg_deh_eh, "__deh_eh", "__DATA", align_, S_REGULAR);
 
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     if (I64)
     {
         MachObj_reftoident(seg, buf.length(), sfunc, 0, CFoff | CFoffset64);
@@ -1648,13 +1648,13 @@ void MachObj_ehsections()
  *      "segment index" of COMDAT
  */
 
-int MachObj_comdatsize(Symbol *s, targ_size_t symsize)
+int MachObj_comdatsize(Symbol* s, targ_size_t symsize)
 {
     return MachObj_comdat(s);
 }
 
 @trusted
-int MachObj_comdat(Symbol *s)
+int MachObj_comdat(Symbol* s)
 {
     const(char)* sectname;
     const(char)* segname;
@@ -1710,7 +1710,7 @@ int MachObj_comdat(Symbol *s)
     return s.Sseg;
 }
 
-int MachObj_readonly_comdat(Symbol *s)
+int MachObj_readonly_comdat(Symbol* s)
 {
     assert(0);
 }
@@ -1720,7 +1720,7 @@ int MachObj_readonly_comdat(Symbol *s)
  *      jump table segment for function s
  */
 @trusted
-int MachObj_jmpTableSegment(Symbol *s)
+int MachObj_jmpTableSegment(Symbol* s)
 {
     return (config.flags & CFGromable) ? cseg : CDATA;
 }
@@ -1739,7 +1739,7 @@ int MachObj_getsegment(const(char)* sectname, const(char)* segname,
     assert(strlen(sectname) <= 16);
     assert(strlen(segname)  <= 16);
     for (int seg = 1; seg < cast(int)SegData.length; seg++)
-    {   seg_data *pseg = SegData[seg];
+    {   seg_data* pseg = SegData[seg];
         if (I64)
         {
             if (strncmp(SecHdrTab64[pseg.SDshtidx].sectname.ptr, sectname, 16) == 0 &&
@@ -1761,8 +1761,8 @@ int MachObj_getsegment(const(char)* sectname, const(char)* segname,
 
     if (pseg)
     {
-        OutBuffer *b1 = pseg.SDbuf;
-        OutBuffer *b2 = pseg.SDrel;
+        OutBuffer* b1 = pseg.SDbuf;
+        OutBuffer* b2 = pseg.SDrel;
         memset(pseg, 0, seg_data.sizeof);
         if (b1)
             b1.reset();
@@ -1773,7 +1773,7 @@ int MachObj_getsegment(const(char)* sectname, const(char)* segname,
     }
     else
     {
-        pseg = cast(seg_data *)mem_calloc(seg_data.sizeof);
+        pseg = cast(seg_data*)mem_calloc(seg_data.sizeof);
         SegData[seg] = pseg;
     }
 
@@ -1795,7 +1795,7 @@ int MachObj_getsegment(const(char)* sectname, const(char)* segname,
 
     if (I64)
     {
-        section_64 *sec = cast(section_64 *)
+        section_64* sec = cast(section_64*)
             SECbuf.writezeros(section_64.sizeof);
         strncpy(sec.sectname.ptr, sectname, 16);
         strncpy(sec.segname.ptr, segname, 16);
@@ -1804,7 +1804,7 @@ int MachObj_getsegment(const(char)* sectname, const(char)* segname,
     }
     else
     {
-        section *sec = cast(section *)
+        section* sec = cast(section*)
             SECbuf.writezeros(section.sizeof);
         strncpy(sec.sectname.ptr, sectname, 16);
         strncpy(sec.segname.ptr, segname, 16);
@@ -1862,7 +1862,7 @@ void MachObj_setcodeseg(int seg)
  *      segment index of newly created code segment
  */
 
-int MachObj_codeseg(const char *name,int suffix)
+int MachObj_codeseg(const char* name,int suffix)
 {
     //dbg_printf("MachObj_codeseg(%s,%x)\n",name,suffix);
     return 0;
@@ -1876,7 +1876,7 @@ int MachObj_codeseg(const char *name,int suffix)
  *      segment for TLS segment
  */
 @trusted
-seg_data *MachObj_tlsseg()
+seg_data* MachObj_tlsseg()
 {
     //printf("MachObj_tlsseg(\n");
     int seg = I32 ? getsegment2(seg_tlsseg, "__tls_data", "__DATA", 2, S_REGULAR)
@@ -1893,7 +1893,7 @@ seg_data *MachObj_tlsseg()
  *      segment for TLS segment
  */
 @trusted
-seg_data *MachObj_tlsseg_bss()
+seg_data* MachObj_tlsseg_bss()
 {
 
     if (I32)
@@ -1920,7 +1920,7 @@ seg_data *MachObj_tlsseg_bss()
  *      segment for TLS data segment
  */
 @trusted
-seg_data *MachObj_tlsseg_data()
+seg_data* MachObj_tlsseg_data()
 {
     //printf("MachObj_tlsseg_data(\n");
     assert(I64);
@@ -1958,7 +1958,7 @@ private extern (D) char* unsstr (uint value)
 
 @trusted
 private extern (D)
-char *obj_mangle2(Symbol *s,char *dest)
+char* obj_mangle2(Symbol* s,char* dest)
 {
     size_t len;
     const(char)* name;
@@ -1975,9 +1975,9 @@ char *obj_mangle2(Symbol *s,char *dest)
         case Mangle.pascal:             // if upper case
         case Mangle.fortran:
             if (len >= DEST_LEN)
-                dest = cast(char *)mem_malloc(len + 1);
+                dest = cast(char*)mem_malloc(len + 1);
             memcpy(dest,name,len + 1);  // copy in name and ending 0
-            for (char *p = dest; *p; p++)
+            for (char* p = dest; *p; p++)
                 *p = cast(char)toupper(*p);
             break;
         case Mangle.stdcall:
@@ -1985,12 +1985,12 @@ char *obj_mangle2(Symbol *s,char *dest)
             bool cond = (tyfunc(s.ty()) && !variadic(s.Stype));
             if (cond)
             {
-                char *pstr = unsstr(type_paramsize(s.Stype));
+                char* pstr = unsstr(type_paramsize(s.Stype));
                 size_t pstrlen = strlen(pstr);
                 size_t destlen = len + 1 + pstrlen + 1;
 
                 if (destlen > DEST_LEN)
-                    dest = cast(char *)mem_malloc(destlen);
+                    dest = cast(char*)mem_malloc(destlen);
                 memcpy(dest,name,len);
                 dest[len] = '@';
                 memcpy(dest + 1 + len, pstr, pstrlen + 1);
@@ -2001,7 +2001,7 @@ char *obj_mangle2(Symbol *s,char *dest)
         case Mangle.syscall:
         case 0:
             if (len >= DEST_LEN)
-                dest = cast(char *)mem_malloc(len + 1);
+                dest = cast(char*)mem_malloc(len + 1);
             memcpy(dest,name,len+1);// copy in name and trailing 0
             break;
 
@@ -2012,7 +2012,7 @@ char *obj_mangle2(Symbol *s,char *dest)
         case Mangle.cpp:
         case Mangle.d:
             if (len >= DEST_LEN - 1)
-                dest = cast(char *)mem_malloc(1 + len + 1);
+                dest = cast(char*)mem_malloc(1 + len + 1);
             dest[0] = '_';
             memcpy(dest + 1,name,len+1);// copy in name and trailing 0
             break;
@@ -2035,7 +2035,7 @@ debug
  * Export a function name.
  */
 
-void MachObj_export_symbol(Symbol *s,uint argsize)
+void MachObj_export_symbol(Symbol* s,uint argsize)
 {
     //dbg_printf("MachObj_export_symbol(%s,%d)\n",s.Sident.ptr,argsize);
 }
@@ -2053,7 +2053,7 @@ void MachObj_export_symbol(Symbol *s,uint argsize)
  *      actual seg
  */
 @trusted
-int MachObj_data_start(Symbol *sdata, targ_size_t datasize, int seg)
+int MachObj_data_start(Symbol* sdata, targ_size_t datasize, int seg)
 {
     targ_size_t alignbytes;
 
@@ -2086,7 +2086,7 @@ int MachObj_data_start(Symbol *sdata, targ_size_t datasize, int seg)
  * than the current default in cseg, switch cseg to new segment.
  */
 @trusted
-void MachObj_func_start(Symbol *sfunc)
+void MachObj_func_start(Symbol* sfunc)
 {
     //printf("MachObj_func_start(%s)\n",sfunc.Sident.ptr);
     symbol_debug(sfunc);
@@ -2107,7 +2107,7 @@ void MachObj_func_start(Symbol *sfunc)
  * Update function info after codgen
  */
 @trusted
-void MachObj_func_term(Symbol *sfunc)
+void MachObj_func_term(Symbol* sfunc)
 {
     //dbg_printf("MachObj_func_term(%s) offset %x, Coffset %x symidx %d\n",
     //           sfunc.Sident.ptr, sfunc.Soffset,Offset(cseg),sfunc.Sxtrnnum);
@@ -2122,13 +2122,13 @@ void MachObj_func_term(Symbol *sfunc)
  *      offset =        offset of name within segment
  */
 
-void MachObj_pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize)
+void MachObj_pubdefsize(int seg, Symbol* s, targ_size_t offset, targ_size_t symsize)
 {
     return MachObj_pubdef(seg, s, offset);
 }
 
 @trusted
-void MachObj_pubdef(int seg, Symbol *s, targ_size_t offset)
+void MachObj_pubdef(int seg, Symbol* s, targ_size_t offset)
 {
     //printf("MachObj_pubdef(%d:x%x s=%p, %s)\n", seg, offset, s, s.Sident.ptr);
     //symbol_print(s);
@@ -2193,7 +2193,7 @@ int MachObj_external_def(const(char)* name)
  */
 
 @trusted
-int MachObj_external(Symbol *s)
+int MachObj_external(Symbol* s)
 {
     //printf("MachObj_external('%s') %x\n",s.Sident.ptr,s.Svalue);
     symbol_debug(s);
@@ -2212,7 +2212,7 @@ int MachObj_external(Symbol *s)
  *      Symbol table index for symbol
  */
 @trusted
-int MachObj_common_block(Symbol *s,targ_size_t size,targ_size_t count)
+int MachObj_common_block(Symbol* s,targ_size_t size,targ_size_t count)
 {
     //printf("MachObj_common_block('%s', size=%d, count=%d)\n",s.Sident.ptr,size,count);
     symbol_debug(s);
@@ -2233,7 +2233,7 @@ int MachObj_common_block(Symbol *s,targ_size_t size,targ_size_t count)
     return 0;           // should return void
 }
 
-int MachObj_common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count)
+int MachObj_common_block(Symbol* s, int flag, targ_size_t size, targ_size_t count)
 {
     return MachObj_common_block(s, size, count);
 }
@@ -2243,7 +2243,7 @@ int MachObj_common_block(Symbol *s, int flag, targ_size_t size, targ_size_t coun
  * (uninitialized data only)
  */
 
-void MachObj_write_zeros(seg_data *pseg, targ_size_t count)
+void MachObj_write_zeros(seg_data* pseg, targ_size_t count)
 {
     MachObj_lidata(pseg.SDseg, pseg.SDoffset, count);
 }
@@ -2274,7 +2274,7 @@ void MachObj_lidata(int seg,targ_size_t offset,targ_size_t count)
  * Append byte to segment.
  */
 
-void MachObj_write_byte(seg_data *pseg, uint byte_)
+void MachObj_write_byte(seg_data* pseg, uint byte_)
 {
     MachObj_byte(pseg.SDseg, pseg.SDoffset, byte_);
 }
@@ -2285,7 +2285,7 @@ void MachObj_write_byte(seg_data *pseg, uint byte_)
 @trusted
 void MachObj_byte(int seg,targ_size_t offset,uint byte_)
 {
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     int save = cast(int)buf.length();
     //dbg_printf("MachObj_byte(seg=%d, offset=x%lx, byte_=x%x)\n",seg,offset,byte_);
     buf.setsize(cast(uint)offset);
@@ -2301,7 +2301,7 @@ void MachObj_byte(int seg,targ_size_t offset,uint byte_)
  * Append bytes to segment.
  */
 
-void MachObj_write_bytes(seg_data *pseg, const(void[]) a)
+void MachObj_write_bytes(seg_data* pseg, const(void[]) a)
 {
     MachObj_bytes(pseg.SDseg, pseg.SDoffset, a.length, &a[0]);
 }
@@ -2323,7 +2323,7 @@ size_t MachObj_bytes(int seg, targ_size_t offset, size_t nbytes, const(void)* p)
         }
     }
     assert(seg >= 0 && seg < SegData.length);
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     if (buf == null)
     {
         //dbg_printf("MachObj_bytes(seg=%d, offset=x%llx, nbytes=%d, p=%p)\n", seg, offset, nbytes, p);
@@ -2350,7 +2350,7 @@ size_t MachObj_bytes(int seg, targ_size_t offset, size_t nbytes, const(void)* p)
  * Add a relocation entry for seg/offset.
  */
 @trusted
-void MachObj_addrel(int seg, targ_size_t offset, Symbol *targsym,
+void MachObj_addrel(int seg, targ_size_t offset, Symbol* targsym,
         uint targseg, int rtype, int val = 0)
 {
     Relocation rel = void;
@@ -2361,7 +2361,7 @@ void MachObj_addrel(int seg, targ_size_t offset, Symbol *targsym,
     rel.flag = 0;
     rel.funcsym = funcsym_p;
     rel.val = cast(short)val;
-    seg_data *pseg = SegData[seg];
+    seg_data* pseg = SegData[seg];
     if (!pseg.SDrel)
     {
         pseg.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
@@ -2379,7 +2379,7 @@ void MachObj_addrel(int seg, targ_size_t offset, Symbol *targsym,
  *      targetdatum =   target segment number (DATA, CDATA or UDATA, etc.)
  *      flags =         CFoff, CFseg
  * Example:
- *      int *abc = &def[3];
+ *      int* abc = &def[3];
  *      to allocate storage:
  *              MachObj_reftodatseg(DATA,offset,3 * (int *).sizeof,UDATA);
  */
@@ -2387,7 +2387,7 @@ void MachObj_addrel(int seg, targ_size_t offset, Symbol *targsym,
 void MachObj_reftodatseg(int seg,targ_size_t offset,targ_size_t val,
         uint targetdatum,int flags)
 {
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     int save = cast(int)buf.length();
     buf.setsize(cast(uint)offset);
     if (log)
@@ -2428,7 +2428,7 @@ void MachObj_reftocodeseg(int seg,targ_size_t offset,targ_size_t val)
 {
     //printf("MachObj_reftocodeseg(seg=%d, offset=x%x, val=x%x )\n",seg,cast(uint)offset,cast(uint)val);
     assert(seg > 0);
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     int save = cast(int)buf.length();
     buf.setsize(cast(uint)offset);
     val -= funcsym_p.Soffset;
@@ -2457,7 +2457,7 @@ void MachObj_reftocodeseg(int seg,targ_size_t offset,targ_size_t val)
  *      number of bytes in reference (4 or 8)
  */
 @trusted
-int MachObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
+int MachObj_reftoident(int seg, targ_size_t offset, Symbol* s, targ_size_t val,
         int flags)
 {
     int retsize = (flags & CFoffset64) ? 8 : 4;
@@ -2503,7 +2503,7 @@ int MachObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                     jumpTableSeg =
                         MachObj_getsegment("__jump_table", "__IMPORT",  0, S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS | S_ATTR_SELF_MODIFYING_CODE);
                 }
-                seg_data *pseg = SegData[jumpTableSeg];
+                seg_data* pseg = SegData[jumpTableSeg];
                 if (I64)
                     SecHdrTab64[pseg.SDshtidx].reserved2 = 5;
                 else
@@ -2517,8 +2517,8 @@ int MachObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                 }
                 else
                 {   // Look through indirectsym to see if it is already there
-                    int n = cast(int)(indirectsymbuf1.length() / (Symbol *).sizeof);
-                    Symbol **psym = cast(Symbol **)indirectsymbuf1.buf;
+                    int n = cast(int)(indirectsymbuf1.length() / (Symbol*).sizeof);
+                    Symbol** psym = cast(Symbol**)indirectsymbuf1.buf;
                     for (int i = 0; i < n; i++)
                     {   // Linear search, pretty pathetic
                         if (s == psym[i])
@@ -2554,7 +2554,7 @@ int MachObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                     pointersSeg =
                         MachObj_getsegment("__pointers", "__IMPORT",  0, S_NON_LAZY_SYMBOL_POINTERS);
                 }
-                seg_data *pseg = SegData[pointersSeg];
+                seg_data* pseg = SegData[pointersSeg];
 
                 if (!indirectsymbuf2)
                 {
@@ -2564,8 +2564,8 @@ int MachObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                 }
                 else
                 {   // Look through indirectsym to see if it is already there
-                    int n = cast(int)(indirectsymbuf2.length() / (Symbol *).sizeof);
-                    Symbol **psym = cast(Symbol **)indirectsymbuf2.buf;
+                    int n = cast(int)(indirectsymbuf2.length() / (Symbol*).sizeof);
+                    Symbol** psym = cast(Symbol**)indirectsymbuf2.buf;
                     for (int i = 0; i < n; i++)
                     {   // Linear search, pretty pathetic
                         if (s == psym[i])
@@ -2593,7 +2593,7 @@ int MachObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                     rel.flag = 0;
                     rel.funcsym = null;
                     rel.val = 0;
-                    seg_data *pseg2 = SegData[seg];
+                    seg_data* pseg2 = SegData[seg];
                     if (!pseg2.SDrel)
                     {
                         pseg2.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
@@ -2611,7 +2611,7 @@ int MachObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
             }
         }
 
-        OutBuffer *buf = SegData[seg].SDbuf;
+        OutBuffer* buf = SegData[seg].SDbuf;
         int save = cast(int)buf.length();
         buf.position(cast(size_t)offset, retsize);
         //printf("offset = x%llx, val = x%llx\n", offset, val);
@@ -2631,7 +2631,7 @@ int MachObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
  *      s       Symbol to generate a thunk for
  */
 
-void MachObj_far16thunk(Symbol *s)
+void MachObj_far16thunk(Symbol* s)
 {
     //dbg_printf("MachObj_far16thunk('%s')\n", s.Sident.ptr);
     assert(0);
@@ -2671,7 +2671,7 @@ static if(TERMCODE)
 /**********************************
   * Write to the object file
   */
-/+void objfile_write(FILE *fd, void *buffer, uint len)
+/+void objfile_write(FILE* fd, void* buffer, uint len)
 {
     fobjbuf.write(buffer, len);
 }+/
@@ -2692,7 +2692,7 @@ int elf_align(targ_size_t size, int foffset)
  * Stuff pointer to ModuleInfo in its own segment.
  */
 @trusted
-void MachObj_moduleinfo(Symbol *scc)
+void MachObj_moduleinfo(Symbol* scc)
 {
     int align_ = I64 ? 3 : 2; // align to _tysize[TYnptr]
 
@@ -2707,7 +2707,7 @@ void MachObj_moduleinfo(Symbol *scc)
 
 /*************************************
  */
-void MachObj_gotref(Symbol *s)
+void MachObj_gotref(Symbol* s)
 {
     //printf("MachObj_gotref(%x '%s', %d)\n",s,s.Sident.ptr, s.Sclass);
     switch(s.Sclass)
@@ -2760,7 +2760,7 @@ void MachObj_write_pointerRef(Symbol* s, uint off)
  * Returns:
  *      number of bytes written at seg:offset
  */
-int mach_dwarf_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val)
+int mach_dwarf_reftoident(int seg, targ_size_t offset, Symbol* s, targ_size_t val)
 {
     //printf("dwarf_reftoident(seg=%d offset=x%x s=%s val=x%x\n", seg, cast(int)offset, s.Sident.ptr, cast(int)val);
     MachObj_reftoident(seg, offset, s, val + 4, I64 ? CFoff : CFindirect);
@@ -2797,9 +2797,9 @@ int mach_dwarf_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t va
  *      number of bytes written at seg:offset
  */
 @trusted
-int dwarf_eh_frame_fixup(int dfseg, targ_size_t offset, Symbol *s, targ_size_t val, Symbol *fdesym)
+int dwarf_eh_frame_fixup(int dfseg, targ_size_t offset, Symbol* s, targ_size_t val, Symbol* fdesym)
 {
-    OutBuffer *buf = SegData[dfseg].SDbuf;
+    OutBuffer* buf = SegData[dfseg].SDbuf;
     assert(offset == buf.length());
     assert(fdesym.Sseg == dfseg);
     if (I64)
@@ -2815,7 +2815,7 @@ int dwarf_eh_frame_fixup(int dfseg, targ_size_t offset, Symbol *s, targ_size_t v
     rel.flag = 1;
     rel.funcsym = fdesym;
     rel.val = 0;
-    seg_data *pseg = SegData[dfseg];
+    seg_data* pseg = SegData[dfseg];
     if (!pseg.SDrel)
     {
         pseg.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -62,7 +62,7 @@ char* strupr(char* s)
     return s;
 }
 
-private extern (D) __gshared OutBuffer *fobjbuf;
+private extern (D) __gshared OutBuffer* fobjbuf;
 
 enum DEST_LEN = (IDMAX + IDOHD + 1);
 
@@ -76,14 +76,14 @@ __gshared private
 {
 
 // String Table  - String table for all other names
-    OutBuffer *string_table;
+    OutBuffer* string_table;
 
 // Section Headers
     public OutBuffer  *ScnhdrBuf;             // Buffer to build section table in
 
 // The -1 is because it is 1 based indexing
     @trusted
-IMAGE_SECTION_HEADER* ScnhdrTab() { return cast(IMAGE_SECTION_HEADER *)ScnhdrBuf.buf - 1; }
+IMAGE_SECTION_HEADER* ScnhdrTab() { return cast(IMAGE_SECTION_HEADER*)ScnhdrBuf.buf - 1; }
 
     int scnhdr_cnt;          // Number of sections in table
     enum SCNHDR_TAB_INITSIZE = 16;  // Initial number of sections in buffer
@@ -93,9 +93,9 @@ IMAGE_SECTION_HEADER* ScnhdrTab() { return cast(IMAGE_SECTION_HEADER *)ScnhdrBuf
     enum SYM_TAB_INC  = 50;         // Number of symbols to increment buffer by
 
 // The symbol table
-    OutBuffer *symbuf;
+    OutBuffer* symbuf;
 
-    OutBuffer *syment_buf;   // array of struct syment
+    OutBuffer* syment_buf;   // array of struct syment
 
     segidx_t segidx_drectve = UNKNOWN;         // contents of ".drectve" section
     segidx_t segidx_debugS = UNKNOWN;
@@ -104,11 +104,11 @@ IMAGE_SECTION_HEADER* ScnhdrTab() { return cast(IMAGE_SECTION_HEADER *)ScnhdrBuf
 
     extern (D) int jumpTableSeg;     // segment index for __jump_table
 
-    extern (D) OutBuffer *indirectsymbuf2;      // indirect symbol table of Symbol*'s
+    extern (D) OutBuffer* indirectsymbuf2;      // indirect symbol table of Symbol*'s
     extern (D) int pointersSeg;      // segment index for __pointers
 
-    OutBuffer *ptrref_buf;           // buffer for pointer references
-    OutBuffer *impref_buf;           // buffer for import table references
+    OutBuffer* ptrref_buf;           // buffer for pointer references
+    OutBuffer* impref_buf;           // buffer for import table references
 
     int floatused;
 
@@ -160,8 +160,8 @@ enum
 struct Relocation
 {   // Relocations are attached to the struct seg_data they refer to
     targ_size_t offset; // location in segment to be fixed up
-    Symbol *funcsym;    // function in which offset lies, if any
-    Symbol *targsym;    // if !=null, then location is to be fixed up
+    Symbol* funcsym;    // function in which offset lies, if any
+    Symbol* targsym;    // if !=null, then location is to be fixed up
                         // to address of this symbol
     uint targseg;   // if !=0, then location is to be fixed up
                         // to address of start of this segment
@@ -179,7 +179,7 @@ struct Relocation
  * Returns offset into the specified string table.
  */
 
-IDXSTR MsCoffObj_addstr(OutBuffer *strtab, const char[] str) @system
+IDXSTR MsCoffObj_addstr(OutBuffer* strtab, const char[] str) @system
 {
     //printf("MsCoffObj_addstr(strtab = %p str = '%s')\n",strtab,str);
     IDXSTR idx = cast(IDXSTR)strtab.length();        // remember starting offset
@@ -193,11 +193,11 @@ IDXSTR MsCoffObj_addstr(OutBuffer *strtab, const char[] str) @system
  *
  */
 
-Symbol * MsCoffObj_sym_cdata(tym_t ty,char *p,int len)
+Symbol* MsCoffObj_sym_cdata(tym_t ty,char* p,int len)
 {
     //printf("MsCoffObj_sym_cdata(ty = %x, p = %x, len = %d, Offset(CDATA) = %x)\n", ty, p, len, Offset(CDATA));
     alignOffset(CDATA, tysize(ty));
-    Symbol *s = symboldata(Offset(CDATA), ty);
+    Symbol* s = symboldata(Offset(CDATA), ty);
     s.Sseg = CDATA;
     MsCoffObj_pubdef(CDATA, s, Offset(CDATA));
     MsCoffObj_bytes(CDATA, Offset(CDATA), len, p);
@@ -212,7 +212,7 @@ Symbol * MsCoffObj_sym_cdata(tym_t ty,char *p,int len)
  */
 
 @trusted
-int MsCoffObj_data_readonly(char *p, int len, segidx_t *pseg)
+int MsCoffObj_data_readonly(char* p, int len, segidx_t* pseg)
 {
     int oldoff;
     oldoff = cast(int)Offset(CDATA);
@@ -224,7 +224,7 @@ int MsCoffObj_data_readonly(char *p, int len, segidx_t *pseg)
 }
 
 @trusted
-int MsCoffObj_data_readonly(char *p, int len)
+int MsCoffObj_data_readonly(char* p, int len)
 {
     segidx_t pseg;
 
@@ -251,7 +251,7 @@ int MsCoffObj_string_literal_segment(uint sz)
  */
 
 @system
-Obj MsCoffObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
+Obj MsCoffObj_init(OutBuffer* objbuf, const(char)* filename, const(char)* csegname)
 {
     //printf("MsCoffObj_init()\n");
     Obj obj = cast(Obj)mem_calloc(__traits(classInstanceSize, Obj));
@@ -284,8 +284,8 @@ Obj MsCoffObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegna
 
     if (symbuf)
     {
-        Symbol **p = cast(Symbol **)symbuf.buf;
-        const size_t n = symbuf.length() / (Symbol *).sizeof;
+        Symbol** p = cast(Symbol**)symbuf.buf;
+        const size_t n = symbuf.length() / (Symbol*).sizeof;
         for (size_t i = 0; i < n; ++i)
             symbol_reset(*p[i]);
         symbuf.reset();
@@ -295,7 +295,7 @@ Obj MsCoffObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegna
         symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
         if (!symbuf)
             err_nomem();
-        symbuf.reserve((Symbol *).sizeof * SYM_TAB_INIT);
+        symbuf.reserve((Symbol*).sizeof * SYM_TAB_INIT);
     }
 
     if (!syment_buf)
@@ -396,28 +396,28 @@ void MsCoffObj_initfile(const(char)* filename, const(char)* csegname, const(char
 
 @trusted
 private extern (D)
-int32_t *MsCoffObj_patchAddr(int seg, targ_size_t offset)
+int32_t* MsCoffObj_patchAddr(int seg, targ_size_t offset)
 {
-    return cast(int32_t *)(fobjbuf.buf + ScnhdrTab[SegData[seg].SDshtidx].PointerToRawData + offset);
+    return cast(int32_t*)(fobjbuf.buf + ScnhdrTab[SegData[seg].SDshtidx].PointerToRawData + offset);
 }
 
 @trusted
 private extern (D)
-int32_t *MsCoffObj_patchAddr64(int seg, targ_size_t offset)
+int32_t* MsCoffObj_patchAddr64(int seg, targ_size_t offset)
 {
-    return cast(int32_t *)(fobjbuf.buf + ScnhdrTab[SegData[seg].SDshtidx].PointerToRawData + offset);
+    return cast(int32_t*)(fobjbuf.buf + ScnhdrTab[SegData[seg].SDshtidx].PointerToRawData + offset);
 }
 
 private extern (D)
 static if (0)
 {
 @trusted
-void patch(seg_data *pseg, targ_size_t offset, int seg, targ_size_t value)
+void patch(seg_data* pseg, targ_size_t offset, int seg, targ_size_t value)
 {
     //printf("patch(offset = x%04x, seg = %d, value = x%llx)\n", cast(uint)offset, seg, value);
     if (I64)
     {
-        int32_t *p = cast(int32_t *)(fobjbuf.buf + ScnhdrTab[pseg.SDshtidx].PointerToRawData  + offset);
+        int32_t* p = cast(int32_t*)(fobjbuf.buf + ScnhdrTab[pseg.SDshtidx].PointerToRawData  + offset);
 
 static if (0)
         printf("\taddr1 = x%llx\n\taddr2 = x%llx\n\t*p = x%llx\n\tdelta = x%llx\n",
@@ -432,7 +432,7 @@ static if (0)
     }
     else
     {
-        int32_t *p = cast(int32_t *)(fobjbuf.buf + ScnhdrTab[pseg.SDshtidx].PointerToRawData + offset);
+        int32_t* p = cast(int32_t*)(fobjbuf.buf + ScnhdrTab[pseg.SDshtidx].PointerToRawData + offset);
 
 static if (0)
         printf("\taddr1 = x%x\n\taddr2 = x%x\n\t*p = x%x\n\tdelta = x%x\n",
@@ -454,7 +454,7 @@ static if (0)
  */
 
 @trusted
-private void syment_set_name(SymbolTable32 *sym, const(char)* name)
+private void syment_set_name(SymbolTable32* sym, const(char)* name)
 {
     size_t len = strlen(name);
     if (len > 8)
@@ -500,8 +500,8 @@ void build_syment_table(bool bigobj)
      */
     for (segidx_t seg = 1; seg < SegData.length; seg++)
     {
-        seg_data *pseg = SegData[seg];
-        IMAGE_SECTION_HEADER *psechdr = &ScnhdrTab[pseg.SDshtidx];   // corresponding section
+        seg_data* pseg = SegData[seg];
+        IMAGE_SECTION_HEADER* psechdr = &ScnhdrTab[pseg.SDshtidx];   // corresponding section
 
         SymbolTable32 sym;
         memcpy(sym.Name.ptr, psechdr.Name.ptr, 8);
@@ -547,16 +547,16 @@ void build_syment_table(bool bigobj)
      */
 
     int n = cast(int)SegData.length;
-    size_t dim = symbuf.length() / (Symbol *).sizeof;
+    size_t dim = symbuf.length() / (Symbol*).sizeof;
     for (size_t i = 0; i < dim; i++)
-    {   Symbol *s = (cast(Symbol **)symbuf.buf)[i];
+    {   Symbol* s = (cast(Symbol**)symbuf.buf)[i];
         s.Sxtrnnum = cast(uint)(syment_buf.length() / symsize);
         n++;
 
         SymbolTable32 sym;
 
         char[DEST_LEN+1] dest = void;
-        char *destr = obj_mangle2(s, dest.ptr);
+        char* destr = obj_mangle2(s, dest.ptr);
         syment_set_name(&sym, destr);
 
         sym.Value = 0;
@@ -696,8 +696,8 @@ void MsCoffObj_term(const(char)[] objfilename)
 
     for (segidx_t seg = 1; seg < SegData.length; seg++)
     {
-        seg_data *pseg = SegData[seg];
-        IMAGE_SECTION_HEADER *psechdr = &ScnhdrTab[pseg.SDshtidx];   // corresponding section
+        seg_data* pseg = SegData[seg];
+        IMAGE_SECTION_HEADER* psechdr = &ScnhdrTab[pseg.SDshtidx];   // corresponding section
 
         int align_ = pseg.SDalignment;
         if (align_ > 1)
@@ -717,8 +717,8 @@ void MsCoffObj_term(const(char)[] objfilename)
     // Compute file offsets of the relocation data
     for (segidx_t seg = 1; seg < SegData.length; seg++)
     {
-        seg_data *pseg = SegData[seg];
-        IMAGE_SECTION_HEADER *psechdr = &ScnhdrTab[pseg.SDshtidx];   // corresponding section
+        seg_data* pseg = SegData[seg];
+        IMAGE_SECTION_HEADER* psechdr = &ScnhdrTab[pseg.SDshtidx];   // corresponding section
         if (pseg.SDrel)
         {
             foffset = (foffset + 3) & ~3;
@@ -767,15 +767,15 @@ void MsCoffObj_term(const(char)[] objfilename)
 
     // Write the string table
     assert(foffset == string_table_offset);
-    *cast(uint *)(string_table.buf) = cast(uint)string_table.length();
+    *cast(uint*)(string_table.buf) = cast(uint)string_table.length();
     fobjbuf.write((*string_table)[]);
     foffset += string_table.length();
 
     // Write the section data
     for (segidx_t seg = 1; seg < SegData.length; seg++)
     {
-        seg_data *pseg = SegData[seg];
-        IMAGE_SECTION_HEADER *psechdr = &ScnhdrTab[pseg.SDshtidx];   // corresponding section
+        seg_data* pseg = SegData[seg];
+        IMAGE_SECTION_HEADER* psechdr = &ScnhdrTab[pseg.SDshtidx];   // corresponding section
         foffset = elf_align(pseg.SDalignment, foffset);
         if (pseg.SDbuf && pseg.SDbuf.length())
         {
@@ -791,14 +791,14 @@ void MsCoffObj_term(const(char)[] objfilename)
     assert((reloc).sizeof == 10);
     for (segidx_t seg = 1; seg < SegData.length; seg++)
     {
-        seg_data *pseg = SegData[seg];
-        IMAGE_SECTION_HEADER *psechdr = &ScnhdrTab[pseg.SDshtidx];   // corresponding section
+        seg_data* pseg = SegData[seg];
+        IMAGE_SECTION_HEADER* psechdr = &ScnhdrTab[pseg.SDshtidx];   // corresponding section
         if (pseg.SDrel)
         {
-            Relocation *r = cast(Relocation *)pseg.SDrel.buf;
+            Relocation* r = cast(Relocation*)pseg.SDrel.buf;
             size_t sz = pseg.SDrel.length();
             bool pdata = (strcmp(cast(const(char)* )psechdr.Name, ".pdata") == 0);
-            Relocation *rend = cast(Relocation *)(pseg.SDrel.buf + sz);
+            Relocation* rend = cast(Relocation*)(pseg.SDrel.buf + sz);
             foffset = elf_align(4, foffset);
 
             debug
@@ -818,7 +818,7 @@ void MsCoffObj_term(const(char)[] objfilename)
                 rel.r_symndx = 0;
                 rel.r_type = 0;
 
-                Symbol *s = r.targsym;
+                Symbol* s = r.targsym;
                 const(char)* rs = r.rtype == RELaddr ? "addr" : "rel";
                 //printf("%d:x%04lx : tseg %d tsym %s REL%s\n", seg, cast(int)r.offset, r.targseg, s ? s.Sident.ptr : "0", rs);
                 if (s)
@@ -922,7 +922,7 @@ void MsCoffObj_term(const(char)[] objfilename)
                 }
                 else if (r.rtype == RELaddr && pseg.isCode())
                 {
-                    int32_t *p = null;
+                    int32_t* p = null;
                     p = MsCoffObj_patchAddr(seg, r.offset);
 
                     rel.r_vaddr = cast(uint)r.offset;
@@ -985,7 +985,7 @@ void MsCoffObj_linnum(Srcpos srcpos, int seg, targ_size_t offset)
  * Set start address
  */
 
-void MsCoffObj_startaddress(Symbol *s)
+void MsCoffObj_startaddress(Symbol* s)
 {
     //dbg_printf("MsCoffObj_startaddress(Symbol *%s)\n",s.Sident.ptr);
     //obj.startaddress = s;
@@ -1052,9 +1052,9 @@ void MsCoffObj_user(const(char)* p)
  * Output a weak extern record.
  */
 
-void MsCoffObj_wkext(Symbol *s1,Symbol *s2)
+void MsCoffObj_wkext(Symbol* s1,Symbol* s2)
 {
-    //dbg_printf("MsCoffObj_wkext(Symbol *%s,Symbol *s2)\n",s1.Sident.ptr,s2.Sident.ptr);
+    //dbg_printf("MsCoffObj_wkext(Symbol *%s,Symbol* s2)\n",s1.Sident.ptr,s2.Sident.ptr);
 }
 
 /*******************************
@@ -1092,7 +1092,7 @@ void MsCoffObj_compiler(const(char)* p)
  *              3:      compiler
  */
 
-void MsCoffObj_staticctor(Symbol *s,int dtor,int none)
+void MsCoffObj_staticctor(Symbol* s,int dtor,int none)
 {
     MsCoffObj_setModuleCtorDtor(s, true);
 }
@@ -1105,7 +1105,7 @@ void MsCoffObj_staticctor(Symbol *s,int dtor,int none)
  *      s       static destructor function
  */
 
-void MsCoffObj_staticdtor(Symbol *s)
+void MsCoffObj_staticdtor(Symbol* s)
 {
     MsCoffObj_setModuleCtorDtor(s, false);
 }
@@ -1117,7 +1117,7 @@ void MsCoffObj_staticdtor(Symbol *s)
  */
 
 @trusted
-void MsCoffObj_setModuleCtorDtor(Symbol *sfunc, bool isCtor)
+void MsCoffObj_setModuleCtorDtor(Symbol* sfunc, bool isCtor)
 {
     // Also see https://blogs.msdn.microsoft.com/vcblog/2006/10/20/crt-initialization/
     // and https://www.codeguru.com/cplusplus/running-code-before-and-after-main/
@@ -1139,7 +1139,7 @@ void MsCoffObj_setModuleCtorDtor(Symbol *sfunc, bool isCtor)
  */
 
 @trusted
-void MsCoffObj_ehtables(Symbol *sfunc,uint size,Symbol *ehsym)
+void MsCoffObj_ehtables(Symbol* sfunc,uint size,Symbol* ehsym)
 {
     //printf("MsCoffObj_ehtables(func = %s, handler table = %s) \n",sfunc.Sident.ptr, ehsym.Sident.ptr);
 
@@ -1155,7 +1155,7 @@ void MsCoffObj_ehtables(Symbol *sfunc,uint size,Symbol *ehsym)
                                       align_ |
                                       IMAGE_SCN_MEM_READ);
 
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     if (I64)
     {   MsCoffObj_reftoident(seg, buf.length(), sfunc, 0, CFoff | CFoffset64);
         MsCoffObj_reftoident(seg, buf.length(), ehsym, 0, CFoff | CFoffset64);
@@ -1186,7 +1186,7 @@ private void emitSectionBrace(const(char)* segname, const(char)* symname, int at
     /* Create symbol sym_beg that sits just before the .seg$B section
      */
     strcat(strcpy(name.ptr, symname), "_beg");
-    Symbol *beg = symbol_name(name[0 .. strlen(name.ptr)], SC.global, tspvoid);
+    Symbol* beg = symbol_name(name[0 .. strlen(name.ptr)], SC.global, tspvoid);
     beg.Sseg = seg_bg;
     beg.Soffset = 0;
     symbuf.write((&beg)[0 .. 1]);
@@ -1196,7 +1196,7 @@ private void emitSectionBrace(const(char)* segname, const(char)* symname, int at
     /* Create symbol sym_end that sits just after the .seg$B section
      */
     strcat(strcpy(name.ptr, symname), "_end");
-    Symbol *end = symbol_name(name[0 .. strlen(name.ptr)], SC.global, tspvoid);
+    Symbol* end = symbol_name(name[0 .. strlen(name.ptr)], SC.global, tspvoid);
     end.Sseg = seg_en;
     end.Soffset = 0;
     symbuf.write((&end)[0 .. 1]);
@@ -1244,7 +1244,7 @@ static if (0)
 
     /* Create symbol _minfo_beg that sits just before the .tls$AAB section
      */
-    Symbol *minfo_beg = symbol_name("_tlsstart", SC.global, tspvoid);
+    Symbol* minfo_beg = symbol_name("_tlsstart", SC.global, tspvoid);
     minfo_beg.Sseg = segbg;
     minfo_beg.Soffset = 0;
     symbuf.write((&minfo_beg)[0 .. 1]);
@@ -1252,7 +1252,7 @@ static if (0)
 
     /* Create symbol _minfo_end that sits just after the .tls$AAB section
      */
-    Symbol *minfo_end = symbol_name("_tlsend", SC.global, tspvoid);
+    Symbol* minfo_end = symbol_name("_tlsend", SC.global, tspvoid);
     minfo_end.Sseg = segen;
     minfo_end.Soffset = 0;
     symbuf.write((&minfo_end)[0 .. 1]);
@@ -1270,13 +1270,13 @@ static if (0)
  *      "segment index" of COMDAT
  */
 
-int MsCoffObj_comdatsize(Symbol *s, targ_size_t symsize)
+int MsCoffObj_comdatsize(Symbol* s, targ_size_t symsize)
 {
     return MsCoffObj_comdat(s);
 }
 
 @trusted
-int MsCoffObj_comdat(Symbol *s)
+int MsCoffObj_comdat(Symbol* s)
 {
     uint align_;
 
@@ -1329,7 +1329,7 @@ int MsCoffObj_comdat(Symbol *s)
 }
 
 @trusted
-int MsCoffObj_readonly_comdat(Symbol *s)
+int MsCoffObj_readonly_comdat(Symbol* s)
 {
     //printf("MsCoffObj_readonly_comdat(Symbol* %s)\n",s.Sident.ptr);
     //symbol_print(s);
@@ -1358,7 +1358,7 @@ int MsCoffObj_readonly_comdat(Symbol *s)
  *      jump table segment for function s
  */
 @trusted
-int MsCoffObj_jmpTableSegment(Symbol *s)
+int MsCoffObj_jmpTableSegment(Symbol* s)
 {
     return (config.flags & CFGromable) ? cseg : DATA;
 }
@@ -1380,7 +1380,7 @@ segidx_t MsCoffObj_getsegment(const(char)* sectname, uint flags)
     if (!(flags & IMAGE_SCN_LNK_COMDAT))
     {
         for (segidx_t seg = 1; seg < SegData.length; seg++)
-        {   seg_data *pseg = SegData[seg];
+        {   seg_data* pseg = SegData[seg];
             if (!(ScnhdrTab[pseg.SDshtidx].Characteristics & IMAGE_SCN_LNK_COMDAT) &&
                 strncmp(cast(const(char)* )ScnhdrTab[pseg.SDshtidx].Name, sectname, 8) == 0)
             {
@@ -1410,8 +1410,8 @@ segidx_t MsCoffObj_getsegment2(IDXSEC shtidx)
     seg_data* pseg = *ppseg;
     if (pseg)
     {
-        OutBuffer *b1 = pseg.SDbuf;
-        OutBuffer *b2 = pseg.SDrel;
+        OutBuffer* b1 = pseg.SDbuf;
+        OutBuffer* b2 = pseg.SDrel;
         memset(pseg, 0, (seg_data).sizeof);
         if (b1)
             b1.reset();
@@ -1429,7 +1429,7 @@ segidx_t MsCoffObj_getsegment2(IDXSEC shtidx)
     }
     else
     {
-        pseg = cast(seg_data *)mem_calloc((seg_data).sizeof);
+        pseg = cast(seg_data*)mem_calloc((seg_data).sizeof);
         SegData[seg] = pseg;
         if (!(ScnhdrTab[shtidx].Characteristics & IMAGE_SCN_CNT_UNINITIALIZED_DATA))
 
@@ -1469,12 +1469,12 @@ IDXSEC MsCoffObj_addScnhdr(const(char)* scnhdr_name, uint flags)
     if (len > 8)
     {   // Use /nnnn form
         IDXSTR idx = MsCoffObj_addstr(string_table, scnhdr_name[0 .. len]);
-        snprintf(cast(char *)sec.Name, IMAGE_SIZEOF_SHORT_NAME, "/%d", idx);
+        snprintf(cast(char*)sec.Name, IMAGE_SIZEOF_SHORT_NAME, "/%d", idx);
     }
     else
         memcpy(sec.Name.ptr, scnhdr_name, len);
     sec.Characteristics = flags;
-    ScnhdrBuf.write(cast(void *)&sec, (sec).sizeof);
+    ScnhdrBuf.write(cast(void*)&sec, (sec).sizeof);
     return ++scnhdr_cnt;
 }
 
@@ -1491,7 +1491,7 @@ IDXSEC MsCoffObj_addScnhdr(const(char)* scnhdr_name, uint flags)
  *      segment index of newly created code segment
  */
 
-int MsCoffObj_codeseg(const char *name,int suffix)
+int MsCoffObj_codeseg(const char* name,int suffix)
 {
     //dbg_printf("MsCoffObj_codeseg(%s,%x)\n",name,suffix);
     return 0;
@@ -1506,7 +1506,7 @@ int MsCoffObj_codeseg(const char *name,int suffix)
  */
 
 @trusted
-seg_data *MsCoffObj_tlsseg()
+seg_data* MsCoffObj_tlsseg()
 {
     //printf("MsCoffObj_tlsseg\n");
 
@@ -1530,14 +1530,14 @@ seg_data *MsCoffObj_tlsseg()
  *      segment for TLS segment
  */
 
-seg_data *MsCoffObj_tlsseg_bss()
+seg_data* MsCoffObj_tlsseg_bss()
 {
     /* No thread local bss for MS-COFF
      */
     return MsCoffObj_tlsseg();
 }
 
-seg_data *MsCoffObj_tlsseg_data()
+seg_data* MsCoffObj_tlsseg_data()
 {
     // specific for Mach-O
     assert(0);
@@ -1572,7 +1572,7 @@ segidx_t MsCoffObj_seg_xdata()
 }
 
 @trusted
-segidx_t MsCoffObj_seg_pdata_comdat(Symbol *sfunc)
+segidx_t MsCoffObj_seg_pdata_comdat(Symbol* sfunc)
 {
     segidx_t seg = MsCoffObj_getsegment(".pdata", IMAGE_SCN_CNT_INITIALIZED_DATA |
                                           IMAGE_SCN_ALIGN_4BYTES |
@@ -1583,7 +1583,7 @@ segidx_t MsCoffObj_seg_pdata_comdat(Symbol *sfunc)
 }
 
 @trusted
-segidx_t MsCoffObj_seg_xdata_comdat(Symbol *sfunc)
+segidx_t MsCoffObj_seg_xdata_comdat(Symbol* sfunc)
 {
     segidx_t seg = MsCoffObj_getsegment(".xdata", IMAGE_SCN_CNT_INITIALIZED_DATA |
                                           IMAGE_SCN_ALIGN_4BYTES |
@@ -1608,7 +1608,7 @@ segidx_t MsCoffObj_seg_debugS()
 
 
 @trusted
-segidx_t MsCoffObj_seg_debugS_comdat(Symbol *sfunc)
+segidx_t MsCoffObj_seg_debugS_comdat(Symbol* sfunc)
 {
     //printf("associated with seg %d\n", sfunc.Sseg);
     segidx_t seg = MsCoffObj_getsegment(".debug$S", IMAGE_SCN_CNT_INITIALIZED_DATA |
@@ -1653,9 +1653,9 @@ void MsCoffObj_alias(const(char)* n1,const(char)* n2)
 static if (0) // NOT_DONE
 {
     uint len;
-    char *buffer;
+    char* buffer;
 
-    buffer = cast(char *) alloca(strlen(n1) + strlen(n2) + 2 * ONS_OHD);
+    buffer = cast(char*) alloca(strlen(n1) + strlen(n2) + 2 * ONS_OHD);
     len = obj_namestring(buffer,n1);
     len += obj_namestring(buffer + len,n2);
     objrecord(ALIAS,buffer,len);
@@ -1679,7 +1679,7 @@ private extern (D) char* unsstr(uint value)
 
 @trusted
 private extern (D)
-char *obj_mangle2(Symbol *s,char *dest)
+char* obj_mangle2(Symbol* s,char* dest)
 {
     size_t len;
     const(char)* name;
@@ -1698,7 +1698,7 @@ char *obj_mangle2(Symbol *s,char *dest)
         case Mangle.pascal:             // if upper case
         case Mangle.fortran:
             if (len >= DEST_LEN)
-                dest = cast(char *)mem_malloc(len + 1);
+                dest = cast(char*)mem_malloc(len + 1);
             memcpy(dest,name,len + 1);  // copy in name and ending 0
             strupr(dest);               // to upper case
             break;
@@ -1707,13 +1707,13 @@ char *obj_mangle2(Symbol *s,char *dest)
                 config.exe == EX_WIN32 && tyfunc(s.ty()) &&
                 !variadic(s.Stype))
             {
-                char *pstr = unsstr(type_paramsize(s.Stype));
+                char* pstr = unsstr(type_paramsize(s.Stype));
                 size_t pstrlen = strlen(pstr);
                 size_t prelen = I32 ? 1 : 0;
                 size_t destlen = prelen + len + 1 + pstrlen + 1;
 
                 if (destlen > DEST_LEN)
-                    dest = cast(char *)mem_malloc(destlen);
+                    dest = cast(char*)mem_malloc(destlen);
                 dest[0] = '_';
                 memcpy(dest + prelen,name,len);
                 dest[prelen + len] = '@';
@@ -1727,7 +1727,7 @@ char *obj_mangle2(Symbol *s,char *dest)
         case_mTYman_c64:
         case 0:
             if (len >= DEST_LEN)
-                dest = cast(char *)mem_malloc(len + 1);
+                dest = cast(char*)mem_malloc(len + 1);
             memcpy(dest,name,len+1);// copy in name and trailing 0
             break;
 
@@ -1737,7 +1737,7 @@ char *obj_mangle2(Symbol *s,char *dest)
                 goto case_mTYman_c64;
             // Prepend _ to identifier
             if (len >= DEST_LEN - 1)
-                dest = cast(char *)mem_malloc(1 + len + 1);
+                dest = cast(char*)mem_malloc(1 + len + 1);
             dest[0] = '_';
             memcpy(dest + 1,name,len+1);// copy in name and trailing 0
             break;
@@ -1760,10 +1760,10 @@ debug
  */
 
 @trusted
-void MsCoffObj_export_symbol(Symbol *s,uint argsize)
+void MsCoffObj_export_symbol(Symbol* s,uint argsize)
 {
     char[DEST_LEN+1] dest = void;
-    char *destr = obj_mangle2(s, dest.ptr);
+    char* destr = obj_mangle2(s, dest.ptr);
 
     int seg = MsCoffObj_seg_drectve();
     //printf("MsCoffObj_export_symbol(%s,%d)\n",s.Sident.ptr,argsize);
@@ -1787,7 +1787,7 @@ void MsCoffObj_export_symbol(Symbol *s,uint argsize)
  */
 
 @trusted
-segidx_t MsCoffObj_data_start(Symbol *sdata, targ_size_t datasize, segidx_t seg)
+segidx_t MsCoffObj_data_start(Symbol* sdata, targ_size_t datasize, segidx_t seg)
 {
     targ_size_t alignbytes;
 
@@ -1821,7 +1821,7 @@ segidx_t MsCoffObj_data_start(Symbol *sdata, targ_size_t datasize, segidx_t seg)
  */
 
 @trusted
-void MsCoffObj_func_start(Symbol *sfunc)
+void MsCoffObj_func_start(Symbol* sfunc)
 {
     //printf("MsCoffObj_func_start(%s)\n",sfunc.Sident.ptr);
     symbol_debug(sfunc);
@@ -1844,7 +1844,7 @@ void MsCoffObj_func_start(Symbol *sfunc)
  */
 
 @trusted
-void MsCoffObj_func_term(Symbol *sfunc)
+void MsCoffObj_func_term(Symbol* sfunc)
 {
     //dbg_printf("MsCoffObj_func_term(%s) offset %x, Coffset %x symidx %d\n",
 //          sfunc.Sident.ptr, sfunc.Soffset,Offset(cseg),sfunc.Sxtrnnum);
@@ -1862,7 +1862,7 @@ void MsCoffObj_func_term(Symbol *sfunc)
  */
 
 @trusted
-void MsCoffObj_pubdef(segidx_t seg, Symbol *s, targ_size_t offset)
+void MsCoffObj_pubdef(segidx_t seg, Symbol* s, targ_size_t offset)
 {
     //printf("MsCoffObj_pubdef(%d:x%x s=%p, %s)\n", seg, cast(int)offset, s, s.Sident.ptr);
     //symbol_print(s);
@@ -1889,7 +1889,7 @@ void MsCoffObj_pubdef(segidx_t seg, Symbol *s, targ_size_t offset)
     s.Sxtrnnum = 1;
 }
 
-void MsCoffObj_pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize)
+void MsCoffObj_pubdefsize(int seg, Symbol* s, targ_size_t offset, targ_size_t symsize)
 {
     MsCoffObj_pubdef(seg, s, offset);
 }
@@ -1909,7 +1909,7 @@ int MsCoffObj_external_def(const(char)* name)
 {
     //printf("MsCoffObj_external_def('%s')\n",name);
     assert(name);
-    Symbol *s = symbol_name(name[0 .. strlen(name)], SC.extern_, tspvoid);
+    Symbol* s = symbol_name(name[0 .. strlen(name)], SC.extern_, tspvoid);
     symbuf.write((&s)[0 .. 1]);
     return 0;
 }
@@ -1926,7 +1926,7 @@ int MsCoffObj_external_def(const(char)* name)
  */
 
 @trusted
-int MsCoffObj_external(Symbol *s)
+int MsCoffObj_external(Symbol* s)
 {
     //printf("MsCoffObj_external('%s') %x\n",s.Sident.ptr,s.Svalue);
     symbol_debug(s);
@@ -1946,7 +1946,7 @@ int MsCoffObj_external(Symbol *s)
  */
 
 @trusted
-int MsCoffObj_common_block(Symbol *s,targ_size_t size,targ_size_t count)
+int MsCoffObj_common_block(Symbol* s,targ_size_t size,targ_size_t count)
 {
     //printf("MsCoffObj_common_block('%s', size=%d, count=%d)\n",s.Sident.ptr,size,count);
     symbol_debug(s);
@@ -1975,7 +1975,7 @@ int MsCoffObj_common_block(Symbol *s,targ_size_t size,targ_size_t count)
     return 1;           // should return void
 }
 
-int MsCoffObj_common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count)
+int MsCoffObj_common_block(Symbol* s, int flag, targ_size_t size, targ_size_t count)
 {
     return MsCoffObj_common_block(s, size, count);
 }
@@ -1985,7 +1985,7 @@ int MsCoffObj_common_block(Symbol *s, int flag, targ_size_t size, targ_size_t co
  * (uninitialized data only)
  */
 
-void MsCoffObj_write_zeros(seg_data *pseg, targ_size_t count)
+void MsCoffObj_write_zeros(seg_data* pseg, targ_size_t count)
 {
     MsCoffObj_lidata(pseg.SDseg, pseg.SDoffset, count);
 }
@@ -2015,7 +2015,7 @@ void MsCoffObj_lidata(segidx_t seg,targ_size_t offset,targ_size_t count)
  * Append byte to segment.
  */
 
-void MsCoffObj_write_byte(seg_data *pseg, uint byte_)
+void MsCoffObj_write_byte(seg_data* pseg, uint byte_)
 {
     MsCoffObj_byte(pseg.SDseg, pseg.SDoffset, byte_);
 }
@@ -2027,7 +2027,7 @@ void MsCoffObj_write_byte(seg_data *pseg, uint byte_)
 @trusted
 void MsCoffObj_byte(segidx_t seg,targ_size_t offset,uint byte_)
 {
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     int save = cast(int)buf.length();
     //dbg_printf("MsCoffObj_byte(seg=%d, offset=x%lx, byte=x%x)\n",seg,offset,byte_);
     buf.setsize(cast(uint)offset);
@@ -2044,7 +2044,7 @@ void MsCoffObj_byte(segidx_t seg,targ_size_t offset,uint byte_)
  */
 
 @trusted
-void MsCoffObj_write_bytes(seg_data *pseg, const(void[]) a)
+void MsCoffObj_write_bytes(seg_data* pseg, const(void[]) a)
 {
     MsCoffObj_bytes(pseg.SDseg, pseg.SDoffset, a.length, a.ptr);
 }
@@ -2066,7 +2066,7 @@ static if (0)
     }
 }
     assert(seg >= 0 && seg < SegData.length);
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     if (buf == null)
     {
         //printf("MsCoffObj_bytes(seg=%d, offset=x%llx, nbytes=%d, p=x%x)\n", seg, offset, nbytes, p);
@@ -2094,7 +2094,7 @@ static if (0)
  */
 
 @trusted
-void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol *targsym,
+void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol* targsym,
         uint targseg, int rtype, int val)
 {
     if (targsym && targsym.Sflags & SFLimported && !SegData[seg].isCode())
@@ -2119,7 +2119,7 @@ void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol *targsym,
     rel.rtype = cast(ubyte)rtype;
     rel.funcsym = funcsym_p;
     rel.val = cast(short)val;
-    seg_data *pseg = SegData[seg];
+    seg_data* pseg = SegData[seg];
     if (!pseg.SDrel)
     {
         pseg.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
@@ -2136,8 +2136,8 @@ void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol *targsym,
 extern (C) {
 @trusted
 private int mscoff_rel_fp(scope const(void*) e1, scope const(void*) e2)
-{   Relocation *r1 = cast(Relocation *)e1;
-    Relocation *r2 = cast(Relocation *)e2;
+{   Relocation* r1 = cast(Relocation*)e1;
+    Relocation* r2 = cast(Relocation*)e2;
 
     return cast(int)(r1.offset - r2.offset);
 }
@@ -2151,7 +2151,7 @@ private int mscoff_rel_fp(scope const(void*) e1, scope const(void*) e2)
  *      targetdatum =   target segment number (DATA, CDATA or UDATA, etc.)
  *      flags =         CFoff, CFseg
  * Example:
- *      int *abc = &def[3];
+ *      int* abc = &def[3];
  *      to allocate storage:
  *              MsCoffObj_reftodatseg(DATA,offset,3 * (int *).sizeof,UDATA);
  */
@@ -2160,7 +2160,7 @@ private int mscoff_rel_fp(scope const(void*) e1, scope const(void*) e2)
 void MsCoffObj_reftodatseg(segidx_t seg,targ_size_t offset,targ_size_t val,
         uint targetdatum,int flags)
 {
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     int save = cast(int)buf.length();
     buf.setsize(cast(uint)offset);
 static if (0)
@@ -2204,7 +2204,7 @@ void MsCoffObj_reftocodeseg(segidx_t seg,targ_size_t offset,targ_size_t val)
 {
     //printf("MsCoffObj_reftocodeseg(seg=%d, offset=x%lx, val=x%lx )\n",seg,cast(uint)offset,cast(uint)val);
     assert(seg > 0);
-    OutBuffer *buf = SegData[seg].SDbuf;
+    OutBuffer* buf = SegData[seg].SDbuf;
     int save = cast(int)buf.length();
     buf.setsize(cast(uint)offset);
     val -= funcsym_p.Soffset;
@@ -2236,7 +2236,7 @@ void MsCoffObj_reftocodeseg(segidx_t seg,targ_size_t offset,targ_size_t val)
  */
 
 @trusted
-int MsCoffObj_reftoident(segidx_t seg, targ_size_t offset, Symbol *s, targ_size_t val,
+int MsCoffObj_reftoident(segidx_t seg, targ_size_t offset, Symbol* s, targ_size_t val,
         int flags)
 {
     int refsize = (flags & CFoffset64) ? 8 : 4;
@@ -2291,7 +2291,7 @@ static if (0)
         {
             if (SegData[seg].isCode() && flags & CFselfrel)
             {
-                seg_data *pseg = SegData[jumpTableSeg];
+                seg_data* pseg = SegData[jumpTableSeg];
                 val -= offset + 4;
                 MsCoffObj_addrel(seg, offset, null, jumpTableSeg, RELrel, 0);
             }
@@ -2304,7 +2304,7 @@ static if (0)
             }
             else if (SegData[seg].isCode() && !tyfunc(s.ty()))
             {
-                seg_data *pseg = SegData[pointersSeg];
+                seg_data* pseg = SegData[pointersSeg];
 
                 if (!indirectsymbuf2)
                 {
@@ -2314,8 +2314,8 @@ static if (0)
                 }
                 else
                 {   // Look through indirectsym to see if it is already there
-                    int n = cast(int)(indirectsymbuf2.length() / (Symbol *).sizeof);
-                    Symbol **psym = cast(Symbol **)indirectsymbuf2.buf;
+                    int n = cast(int)(indirectsymbuf2.length() / (Symbol*).sizeof);
+                    Symbol** psym = cast(Symbol**)indirectsymbuf2.buf;
                     for (int i = 0; i < n; i++)
                     {   // Linear search, pretty pathetic
                         if (s == psym[i])
@@ -2341,7 +2341,7 @@ static if (0)
             }
         }
 
-        OutBuffer *buf = SegData[seg].SDbuf;
+        OutBuffer* buf = SegData[seg].SDbuf;
         int save = cast(int)buf.length();
         buf.setsize(cast(uint)offset);
         //printf("offset = x%llx, val = x%llx\n", offset, val);
@@ -2368,7 +2368,7 @@ static if (0)
  *      s       Symbol to generate a thunk for
  */
 
-void MsCoffObj_far16thunk(Symbol *s)
+void MsCoffObj_far16thunk(Symbol* s)
 {
     //dbg_printf("MsCoffObj_far16thunk('%s')\n", s.Sident.ptr);
     assert(0);
@@ -2411,7 +2411,7 @@ int elf_align(int size, int foffset)
  *      scc     symbol for ModuleInfo
  */
 @trusted
-void MsCoffObj_moduleinfo(Symbol *scc)
+void MsCoffObj_moduleinfo(Symbol* scc)
 {
     int align_ = I64 ? IMAGE_SCN_ALIGN_8BYTES : IMAGE_SCN_ALIGN_4BYTES;
 
@@ -2441,7 +2441,7 @@ void MsCoffObj_setcodeseg(int seg)
     cseg = seg;
 }
 
-Symbol *MsCoffObj_tlv_bootstrap()
+Symbol* MsCoffObj_tlv_bootstrap()
 {
     // specific for Mach-O
     assert(0);
@@ -2507,8 +2507,8 @@ extern (D) private void objflush_pointerRefs()
     if (!ptrref_buf)
         return;
 
-    ubyte *p = ptrref_buf.buf;
-    ubyte *end = ptrref_buf.buf + ptrref_buf.length();
+    ubyte* p = ptrref_buf.buf;
+    ubyte* end = ptrref_buf.buf + ptrref_buf.length();
     segidx_t[2] segments = UNKNOWN;
     while (p < end)
     {
@@ -2568,8 +2568,8 @@ extern (D) private void objflush_importTableRefs()
     OutBuffer* buf = SegData[seg].SDbuf;
     buf.setsize(cast(uint)offset);
 
-    ubyte *p = impref_buf.buf;
-    ubyte *end = impref_buf.buf + impref_buf.length();
+    ubyte* p = impref_buf.buf;
+    ubyte* end = impref_buf.buf + impref_buf.length();
     while (p < end)
     {
         int sseg = *cast(int*)p;

--- a/compiler/src/dmd/backend/obj.d
+++ b/compiler/src/dmd/backend/obj.d
@@ -89,12 +89,12 @@ else
             mixin(genRetVal("linnum(srcpos, seg, offset)"));
         }
 
-        int codeseg(const char *name,int suffix)
+        int codeseg(const char* name,int suffix)
         {
             mixin(genRetVal("codeseg(name, suffix)"));
         }
 
-        void startaddress(Symbol *s)
+        void startaddress(Symbol* s)
         {
             mixin(genRetVal("startaddress(s)"));
         }
@@ -139,22 +139,22 @@ else
             mixin(genRetVal("alias(n1, n2)"));
         }
 
-        void staticctor(Symbol *s,int dtor,int seg)
+        void staticctor(Symbol* s,int dtor,int seg)
         {
             mixin(genRetVal("staticctor(s, dtor, seg)"));
         }
 
-        void staticdtor(Symbol *s)
+        void staticdtor(Symbol* s)
         {
             mixin(genRetVal("staticdtor(s)"));
         }
 
-        void setModuleCtorDtor(Symbol *s, bool isCtor)
+        void setModuleCtorDtor(Symbol* s, bool isCtor)
         {
             mixin(genRetVal("setModuleCtorDtor(s, isCtor)"));
         }
 
-        void ehtables(Symbol *sfunc,uint size,Symbol *ehsym)
+        void ehtables(Symbol* sfunc,uint size,Symbol* ehsym)
         {
             mixin(genRetVal("ehtables(sfunc, size, ehsym)"));
         }
@@ -164,22 +164,22 @@ else
             mixin(genRetVal("ehsections()"));
         }
 
-        void moduleinfo(Symbol *scc)
+        void moduleinfo(Symbol* scc)
         {
             mixin(genRetVal("moduleinfo(scc)"));
         }
 
-        int comdat(Symbol *s)
+        int comdat(Symbol* s)
         {
             mixin(genRetVal("comdat(s)"));
         }
 
-        int comdatsize(Symbol *s, targ_size_t symsize)
+        int comdatsize(Symbol* s, targ_size_t symsize)
         {
             mixin(genRetVal("comdatsize(s, symsize)"));
         }
 
-        int readonly_comdat(Symbol *s)
+        int readonly_comdat(Symbol* s)
         {
             mixin(genRetVal("comdat(s)"));
         }
@@ -189,32 +189,32 @@ else
             mixin(genRetVal("setcodeseg(seg)"));
         }
 
-        seg_data *tlsseg()
+        seg_data* tlsseg()
         {
             mixin(genRetVal("tlsseg()"));
         }
 
-        seg_data *tlsseg_bss()
+        seg_data* tlsseg_bss()
         {
             mixin(genRetVal("tlsseg_bss()"));
         }
 
-        seg_data *tlsseg_data()
+        seg_data* tlsseg_data()
         {
             mixin(genRetVal("tlsseg_data()"));
         }
 
-        void export_symbol(Symbol *s, uint argsize)
+        void export_symbol(Symbol* s, uint argsize)
         {
             mixin(genRetVal("export_symbol(s, argsize)"));
         }
 
-        void pubdef(int seg, Symbol *s, targ_size_t offset)
+        void pubdef(int seg, Symbol* s, targ_size_t offset)
         {
             mixin(genRetVal("pubdef(seg, s, offset)"));
         }
 
-        void pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize)
+        void pubdefsize(int seg, Symbol* s, targ_size_t offset, targ_size_t symsize)
         {
             mixin(genRetVal("pubdefsize(seg, s, offset, symsize)"));
         }
@@ -224,22 +224,22 @@ else
             mixin(genRetVal("external_def(name)"));
         }
 
-        int data_start(Symbol *sdata, targ_size_t datasize, int seg)
+        int data_start(Symbol* sdata, targ_size_t datasize, int seg)
         {
             mixin(genRetVal("data_start(sdata, datasize, seg)"));
         }
 
-        int external(Symbol *s)
+        int external(Symbol* s)
         {
             mixin(genRetVal("external(s)"));
         }
 
-        int common_block(Symbol *s, targ_size_t size, targ_size_t count)
+        int common_block(Symbol* s, targ_size_t size, targ_size_t count)
         {
             mixin(genRetVal("common_block(s, size, count)"));
         }
 
-        int common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count)
+        int common_block(Symbol* s, int flag, targ_size_t size, targ_size_t count)
         {
             mixin(genRetVal("common_block(s, flag, size, count)"));
         }
@@ -249,17 +249,17 @@ else
             mixin(genRetVal("lidata(seg, offset, count)"));
         }
 
-        void write_zeros(seg_data *pseg, targ_size_t count)
+        void write_zeros(seg_data* pseg, targ_size_t count)
         {
             mixin(genRetVal("write_zeros(pseg, count)"));
         }
 
-        void write_byte(seg_data *pseg, uint _byte)
+        void write_byte(seg_data* pseg, uint _byte)
         {
             mixin(genRetVal("write_byte(pseg, _byte)"));
         }
 
-        void write_bytes(seg_data *pseg, const(void[]) a)
+        void write_bytes(seg_data* pseg, const(void[]) a)
         {
             mixin(genRetVal("write_bytes(pseg, a)"));
         }
@@ -284,12 +284,12 @@ else
             mixin(genRetVal("reftocodeseg(seg, offset, val)"));
         }
 
-        int reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val, int flags)
+        int reftoident(int seg, targ_size_t offset, Symbol* s, targ_size_t val, int flags)
         {
             mixin(genRetVal("reftoident(seg, offset, s, val, flags)"));
         }
 
-        void far16thunk(Symbol *s)
+        void far16thunk(Symbol* s)
         {
             mixin(genRetVal("far16thunk(s)"));
         }
@@ -299,12 +299,12 @@ else
             mixin(genRetVal("fltused()"));
         }
 
-        int data_readonly(char *p, int len, int *pseg)
+        int data_readonly(char* p, int len, int* pseg)
         {
             mixin(genRetVal("data_readonly(p, len, pseg)"));
         }
 
-        int data_readonly(char *p, int len)
+        int data_readonly(char* p, int len)
         {
             mixin(genRetVal("data_readonly(p, len)"));
         }
@@ -314,17 +314,17 @@ else
             mixin(genRetVal("string_literal_segment(sz)"));
         }
 
-        Symbol *sym_cdata(tym_t ty, char *p, int len)
+        Symbol* sym_cdata(tym_t ty, char* p, int len)
         {
             mixin(genRetVal("sym_cdata(ty, p, len)"));
         }
 
-        void func_start(Symbol *sfunc)
+        void func_start(Symbol* sfunc)
         {
             mixin(genRetVal("func_start(sfunc)"));
         }
 
-        void func_term(Symbol *sfunc)
+        void func_term(Symbol* sfunc)
         {
             mixin(genRetVal("func_term(sfunc)"));
         }
@@ -339,12 +339,12 @@ else
             mixin(genRetVal("jmpTableSegment(s)"));
         }
 
-        Symbol *tlv_bootstrap()
+        Symbol* tlv_bootstrap()
         {
             mixin(genRetVal("tlv_bootstrap()"));
         }
 
-        void gotref(Symbol *s)
+        void gotref(Symbol* s)
         {
             switch (config.objfmt)
             {
@@ -354,7 +354,7 @@ else
             }
         }
 
-        Symbol *getGOTsym()
+        Symbol* getGOTsym()
         {
             switch (config.objfmt)
             {
@@ -383,7 +383,7 @@ else
             }
         }
 
-        uint addstr(OutBuffer *strtab, const(char)* p)
+        uint addstr(OutBuffer* strtab, const(char)* p)
         {
             switch (config.objfmt)
             {
@@ -411,7 +411,7 @@ else
             return MsCoffObj_getsegment(sectname, flags);
         }
 
-        void addrel(int seg, targ_size_t offset, Symbol *targsym, uint targseg, int rtype, int val = 0)
+        void addrel(int seg, targ_size_t offset, Symbol* targsym, uint targseg, int rtype, int val = 0)
         {
             switch (config.objfmt)
             {
@@ -463,13 +463,13 @@ else
             return MsCoffObj_seg_xdata();
         }
 
-        int  seg_pdata_comdat(Symbol *sfunc)
+        int  seg_pdata_comdat(Symbol* sfunc)
         {
             assert(config.objfmt == OBJ_MSCOFF);
             return MsCoffObj_seg_pdata_comdat(sfunc);
         }
 
-        int  seg_xdata_comdat(Symbol *sfunc)
+        int  seg_xdata_comdat(Symbol* sfunc)
         {
             assert(config.objfmt == OBJ_MSCOFF);
             return MsCoffObj_seg_xdata_comdat(sfunc);
@@ -481,7 +481,7 @@ else
             return MsCoffObj_seg_debugS();
         }
 
-        int  seg_debugS_comdat(Symbol *sfunc)
+        int  seg_debugS_comdat(Symbol* sfunc)
         {
             assert(config.objfmt == OBJ_MSCOFF);
             return MsCoffObj_seg_debugS_comdat(sfunc);

--- a/compiler/src/dmd/backend/pdata.d
+++ b/compiler/src/dmd/backend/pdata.d
@@ -56,23 +56,23 @@ enum ALLOCA_LIMIT = 0x10000;
  *      localsize = offset to symbols on stack
  */
 @trusted
-public void win64_pdata(Symbol *sf, targ_size_t localsize)
+public void win64_pdata(Symbol* sf, targ_size_t localsize)
 {
     //printf("win64_pdata()\n");
     assert(config.exe == EX_WIN64);
 
     // Generate the pdata name, which is $pdata$funcname
     size_t sflen = strlen(sf.Sident.ptr);
-    char *pdata_name = cast(char *)(sflen < ALLOCA_LIMIT ? alloca(7 + sflen + 1) : malloc(7 + sflen + 1));
+    char* pdata_name = cast(char*)(sflen < ALLOCA_LIMIT ? alloca(7 + sflen + 1) : malloc(7 + sflen + 1));
     assert(pdata_name);
     memcpy(pdata_name, "$pdata$".ptr, 7);
     memcpy(pdata_name + 7, sf.Sident.ptr, sflen + 1);      // include terminating 0
 
-    Symbol *spdata = symbol_name(pdata_name[0 .. 7 + sflen],SC.static_,tstypes[TYint]);
+    Symbol* spdata = symbol_name(pdata_name[0 .. 7 + sflen],SC.static_,tstypes[TYint]);
     symbol_keep(spdata);
     symbol_debug(spdata);
 
-    Symbol *sunwind = win64_unwind(sf, localsize);
+    Symbol* sunwind = win64_unwind(sf, localsize);
 
     /* 3 pointers are emitted:
      *  1. pointer to start of function sf
@@ -104,16 +104,16 @@ private:
  *      generated symbol referring to unwind data
  */
 @trusted
-private Symbol *win64_unwind(Symbol *sf, targ_size_t localsize)
+private Symbol* win64_unwind(Symbol* sf, targ_size_t localsize)
 {
     // Generate the unwind name, which is $unwind$funcname
     size_t sflen = strlen(sf.Sident.ptr);
-    char *unwind_name = cast(char *)(sflen < ALLOCA_LIMIT ? alloca(8 + sflen + 1) : malloc(8 + sflen + 1));
+    char* unwind_name = cast(char*)(sflen < ALLOCA_LIMIT ? alloca(8 + sflen + 1) : malloc(8 + sflen + 1));
     assert(unwind_name);
     memcpy(unwind_name, "$unwind$".ptr, 8);
     memcpy(unwind_name + 8, sf.Sident.ptr, sflen + 1);     // include terminating 0
 
-    Symbol *sunwind = symbol_name(unwind_name[0 .. 8 + sflen],SC.static_,tstypes[TYint]);
+    Symbol* sunwind = symbol_name(unwind_name[0 .. 8 + sflen],SC.static_,tstypes[TYint]);
     symbol_keep(sunwind);
     symbol_debug(sunwind);
 
@@ -201,7 +201,7 @@ static if (0)
 
 
 @trusted
-private dt_t *unwind_data(targ_size_t localsize)
+private dt_t* unwind_data(targ_size_t localsize)
 {
     UNWIND_INFO ui;
 

--- a/compiler/src/dmd/backend/ptrntab.d
+++ b/compiler/src/dmd/backend/ptrntab.d
@@ -5798,7 +5798,7 @@ unittest
 /*******************************
  */
 
-const(char)* asm_opstr(OP *pop)
+const(char)* asm_opstr(OP* pop)
 {
     return pop ? &(*pop).str[0] : null;
 }
@@ -5807,7 +5807,7 @@ const(char)* asm_opstr(OP *pop)
  */
 
 @trusted
-OP *asm_op_lookup(const(char)* s)
+OP* asm_op_lookup(const(char)* s)
 {
     int i;
     char[20] szBuf = void;

--- a/compiler/src/dmd/backend/symbol.d
+++ b/compiler/src/dmd/backend/symbol.d
@@ -37,12 +37,12 @@ nothrow:
 
 import dmd.backend.x86.code_x86;
 
-void struct_free(struct_t *st) { }
+void struct_free(struct_t* st) { }
 
 @trusted @nogc
 func_t* func_calloc()
 {
-    func_t* f = cast(func_t *) calloc(1, func_t.sizeof);
+    func_t* f = cast(func_t*) calloc(1, func_t.sizeof);
     if (!f)
         err_nomem();
     return f;
@@ -89,7 +89,7 @@ debug
  * Terminate use of symbol table.
  */
 
-private __gshared Symbol *keep;
+private __gshared Symbol* keep;
 
 @trusted
 void symbol_term()
@@ -104,7 +104,7 @@ void symbol_term()
 static if (TERMCODE)
 {
 
-void symbol_keep(Symbol *s)
+void symbol_keep(Symbol* s)
 {
     symbol_debug(s);
     s.Sr = keep;       // use Sr so symbol_free() doesn't nest
@@ -240,10 +240,10 @@ const(char)* symbol_ident(return ref const Symbol s)
  */
 
 @trusted @nogc
-Symbol * symbol_calloc(const(char)[] id)
+Symbol* symbol_calloc(const(char)[] id)
 {
     //printf("sizeof(symbol)=%d, sizeof(s.Sident)=%d, len=%d\n", symbol.sizeof, s.Sident.sizeof, cast(int)id.length);
-    Symbol* s = cast(Symbol *) mem_fmalloc(Symbol.sizeof - Symbol.Sident.length + id.length + 1 + 5);
+    Symbol* s = cast(Symbol*) mem_fmalloc(Symbol.sizeof - Symbol.Sident.length + id.length + 1 + 5);
     memset(s,0,Symbol.sizeof - s.Sident.length);
     memcpy(s.Sident.ptr,id.ptr,id.length);
     s.Sident.ptr[id.length] = 0;
@@ -264,10 +264,10 @@ Symbol * symbol_calloc(const(char)[] id)
  */
 
 @nogc
-Symbol * symbol_name(const(char)[] name, SC sclass, type *t)
+Symbol* symbol_name(const(char)[] name, SC sclass, type* t)
 {
     type_debug(t);
-    Symbol *s = symbol_calloc(name);
+    Symbol* s = symbol_calloc(name);
     s.Sclass = sclass;
     s.Stype = t;
     s.Stype.Tcount++;
@@ -282,13 +282,13 @@ Symbol * symbol_name(const(char)[] name, SC sclass, type *t)
  */
 
 @trusted
-Funcsym *symbol_funcalias(Funcsym *sf)
+Funcsym* symbol_funcalias(Funcsym* sf)
 {
     symbol_debug(sf);
     assert(tyfunc(sf.Stype.Tty));
     if (sf.Sclass == SC.funcalias)
         sf = sf.Sfunc.Falias;
-    auto s = cast(Funcsym *)symbol_name(sf.Sident.ptr[0 .. strlen(sf.Sident.ptr)],SC.funcalias,sf.Stype);
+    auto s = cast(Funcsym*)symbol_name(sf.Sident.ptr[0 .. strlen(sf.Sident.ptr)],SC.funcalias,sf.Stype);
     s.Sfunc.Falias = sf;
 
     return s;
@@ -299,14 +299,14 @@ Funcsym *symbol_funcalias(Funcsym *sf)
  */
 
 @trusted @nogc
-Symbol * symbol_generate(SC sclass,type *t)
+Symbol* symbol_generate(SC sclass,type* t)
 {
     __gshared int tmpnum;
     char[4 + tmpnum.sizeof * 3 + 1] name = void;
 
     //printf("symbol_generate(_TMP%d)\n", tmpnum);
     const length = snprintf(name.ptr,name.length,"_TMP%d",tmpnum++);
-    Symbol *s = symbol_name(name.ptr[0 .. length],sclass,t);
+    Symbol* s = symbol_name(name.ptr[0 .. length],sclass,t);
     //symbol_print(s);
 
     s.Sflags |= SFLnodebug | SFLartifical;
@@ -330,7 +330,7 @@ Symbol* symbol_genauto(type* t)
  * Generate symbol into which we can copy the contents of expression e.
  */
 
-Symbol *symbol_genauto(elem *e)
+Symbol* symbol_genauto(elem* e)
 {
     return symbol_genauto(type_fake(e.Ety));
 }
@@ -339,7 +339,7 @@ Symbol *symbol_genauto(elem *e)
  * Generate symbol into which we can copy the contents of expression e.
  */
 
-Symbol *symbol_genauto(tym_t ty)
+Symbol* symbol_genauto(tym_t ty)
 {
     return symbol_genauto(type_fake(ty));
 }
@@ -373,9 +373,9 @@ void symbol_func(ref Symbol s)
  */
 
 @trusted
-void symbol_struct_addField(ref Symbol s, const(char)* name, type *t, uint offset)
+void symbol_struct_addField(ref Symbol s, const(char)* name, type* t, uint offset)
 {
-    Symbol *s2 = symbol_name(name[0 .. strlen(name)], SC.member, t);
+    Symbol* s2 = symbol_name(name[0 .. strlen(name)], SC.member, t);
     s2.Smemoff = offset;
     list_append(&s.Sstruct.Sfldlst, s2);
 }
@@ -392,10 +392,10 @@ void symbol_struct_addField(ref Symbol s, const(char)* name, type *t, uint offse
  */
 
 @trusted
-void symbol_struct_addBitField(ref Symbol s, const(char)* name, type *t, uint offset, uint fieldWidth, uint bitOffset)
+void symbol_struct_addBitField(ref Symbol s, const(char)* name, type* t, uint offset, uint fieldWidth, uint bitOffset)
 {
     //printf("symbol_struct_addBitField() s: %s\n", s.Sident.ptr);
-    Symbol *s2 = symbol_name(name[0 .. strlen(name)], SC.field, t);
+    Symbol* s2 = symbol_name(name[0 .. strlen(name)], SC.field, t);
     s2.Smemoff = offset;
     s2.Swidth = cast(ubyte)fieldWidth;
     s2.Sbit = cast(ubyte)bitOffset;
@@ -423,7 +423,7 @@ void symbol_struct_hasBitFields(ref Symbol s)
  */
 
 @trusted
-void symbol_struct_addBaseClass(ref Symbol s, type *t, uint offset)
+void symbol_struct_addBaseClass(ref Symbol s, type* t, uint offset)
 {
     assert(t && t.Tty == TYstruct);
     auto bc = cast(baseclass_t*)mem_fmalloc(baseclass_t.sizeof);
@@ -471,17 +471,17 @@ void symbol_tree_check(const(Symbol)* s)
 
 static if (0)
 {
-Symbol * lookupsym(const(char)* p)
+Symbol* lookupsym(const(char)* p)
 {
     return scope_search(p,SCTglobal | SCTlocal);
 }
 }
 
 @trusted
-void symbol_free(Symbol *s)
+void symbol_free(Symbol* s)
 {
     while (s)                           /* if symbol exists             */
-    {   Symbol *sr;
+    {   Symbol* sr;
 
 debug
 {
@@ -490,13 +490,13 @@ debug
         symbol_debug(s);
         assert(/*s.Sclass != SC.unde &&*/ cast(int) s.Sclass < cast(int) SCMAX);
 }
-        {   type *t = s.Stype;
+        {   type* t = s.Stype;
 
             if (t)
                 type_debug(t);
             if (t && tyfunc(t.Tty) && s.Sfunc)
             {
-                func_t *f = s.Sfunc;
+                func_t* f = s.Sfunc;
 
                 debug assert(f);
                 blocklist_free(&f.Fstartblock);
@@ -636,7 +636,7 @@ private void symbol_undef(ref Symbol s)
  */
 
 @trusted
-SYMIDX symbol_add(Symbol *s)
+SYMIDX symbol_add(Symbol* s)
 {
     return symbol_add(*cstate.CSpsymtab, s);
 }
@@ -696,7 +696,7 @@ SYMIDX symbol_insert(ref symtab_t symtab, Symbol* s, SYMIDX n)
  */
 
 @trusted
-void freesymtab(Symbol **stab,SYMIDX n1,SYMIDX n2)
+void freesymtab(Symbol** stab,SYMIDX n1,SYMIDX n2)
 {
     if (!stab)
         return;
@@ -729,9 +729,9 @@ void freesymtab(Symbol **stab,SYMIDX n1,SYMIDX n2)
  */
 
 @trusted
-Symbol * symbol_copy(ref Symbol s)
-{   Symbol *scopy;
-    type *t;
+Symbol* symbol_copy(ref Symbol s)
+{   Symbol* scopy;
+    type* t;
 
     symbol_debug(&s);
     /*printf("symbol_copy(%s)\n",s.Sident.ptr);*/
@@ -762,7 +762,7 @@ Symbol * symbol_copy(ref Symbol s)
  *      pointer to baseclass
  */
 
-baseclass_t *baseclass_find(baseclass_t *bm,Classsym *sbase)
+baseclass_t* baseclass_find(baseclass_t* bm,Classsym* sbase)
 {
     symbol_debug(sbase);
     for (; bm; bm = bm.BCnext)
@@ -772,7 +772,7 @@ baseclass_t *baseclass_find(baseclass_t *bm,Classsym *sbase)
 }
 
 @trusted
-baseclass_t *baseclass_find_nest(baseclass_t *bm,Classsym *sbase)
+baseclass_t* baseclass_find_nest(baseclass_t* bm,Classsym* sbase)
 {
     symbol_debug(sbase);
     for (; bm; bm = bm.BCnext)
@@ -788,7 +788,7 @@ baseclass_t *baseclass_find_nest(baseclass_t *bm,Classsym *sbase)
  * Calculate number of baseclasses in list.
  */
 
-int baseclass_nitems(baseclass_t *b)
+int baseclass_nitems(baseclass_t* b)
 {   int i;
 
     for (i = 0; b; b = b.BCnext)

--- a/compiler/src/dmd/backend/type.d
+++ b/compiler/src/dmd/backend/type.d
@@ -91,7 +91,7 @@ struct TYPE
     }
 
     list_t Texcspec;        // tyfunc(): list of types of exception specification
-    Symbol *Ttypedef;       // if this type came from a typedef, this is
+    Symbol* Ttypedef;       // if this type came from a typedef, this is
                             // the typedef symbol
 }
 
@@ -102,7 +102,7 @@ struct typetemp_t
     /* Tsym should really be part of a derived class, as we only
         allocate room for it if TYtemplate
      */
-    Symbol *Tsym;               // primary class template symbol
+    Symbol* Tsym;               // primary class template symbol
 }
 
 void type_debug(const type* t)
@@ -111,10 +111,10 @@ void type_debug(const type* t)
 }
 
 // Return name mangling of type
-Mangle type_mangle(const type *t) { return t.Tmangle; }
+Mangle type_mangle(const type* t) { return t.Tmangle; }
 
 // Return true if function type has a variable number of arguments
-bool variadic(const type *t) { return (t.Tflags & (TFprototype | TFfixed)) == TFprototype; }
+bool variadic(const type* t) { return (t.Tflags & (TFprototype | TFfixed)) == TFprototype; }
 
 public import dmd.backend.var : chartype;
 

--- a/compiler/src/dmd/backend/util2.d
+++ b/compiler/src/dmd/backend/util2.d
@@ -198,7 +198,7 @@ int ispow2(ulong c)
 
 /*****************************
  */
-void *mem_malloc2(uint size)
+void* mem_malloc2(uint size)
 {
     return mem_malloc(size);
 }

--- a/compiler/src/dmd/backend/var.d
+++ b/compiler/src/dmd/backend/var.d
@@ -65,13 +65,13 @@ char debugy = 0; /// watch output to il buffer
 
 /* File variables: */
 
-char *argv0;                    // argv[0] (program name)
+char* argv0;                    // argv[0] (program name)
 FILE* fdep = null;              // dependency file stream pointer
 FILE* flst = null;              // list file stream pointer
 FILE* fin = null;               // input file
 
 // htod
-char *fdmodulename = null;
+char* fdmodulename = null;
 FILE* fdmodule = null;
 
 char*   foutdir = null,       // directory to place output files in
@@ -104,7 +104,7 @@ int level = 0;                  /* declaration level                    */
                                 /* 2: function local declarations       */
                                 /* 3+: compound statement decls         */
 
-param_t *paramlst = null;       /* function parameter list              */
+param_t* paramlst = null;       /* function parameter list              */
 tym_t pointertype = TYnptr;     /* default data pointer type            */
 
 /* From util.c */
@@ -177,7 +177,7 @@ const(char)*[32] regstring = ["AX","CX","DX","BX","SP","BP","SI","DI",
 
 /* From nwc.c */
 
-type *chartype;                 /* default 'char' type                  */
+type* chartype;                 /* default 'char' type                  */
 
 Obj objmod = null;
 

--- a/compiler/src/dmd/backend/x86/cg87.d
+++ b/compiler/src/dmd/backend/x86/cg87.d
@@ -70,8 +70,8 @@ enum
 struct Dconst
 {
     int round;
-    Symbol *roundto0;
-    Symbol *roundtonearest;
+    Symbol* roundto0;
+    Symbol* roundtonearest;
 }
 
 private __gshared Dconst oldd;
@@ -94,7 +94,7 @@ enum CW : ushort
  */
 
 @trusted
-private void getlvalue87(ref CodeBuilder cdb, ref code pcs,elem *e,regm_t keepmsk)
+private void getlvalue87(ref CodeBuilder cdb, ref code pcs,elem* e,regm_t keepmsk)
 {
     // the x87 instructions cannot read XMM registers
     if (e.Eoper == OPvar || e.Eoper == OPrelconst)
@@ -251,13 +251,13 @@ void push87(ref CodeBuilder cdb, int line, const(char)* file)
  * Note elem e as being in ST(i) as being a value we want to keep.
  */
 
-void note87(elem *e, uint offset, int i)
+void note87(elem* e, uint offset, int i)
 {
     note87(e, offset, i, __LINE__);
 }
 
 @trusted
-void note87(elem *e, uint offset, int i, int linnum)
+void note87(elem* e, uint offset, int i, int linnum)
 {
     if (NDPP)
         printf("note87(e = %p.%d, i = %d, stackused = %d, line = %d)\n",e,offset,i,global87.stackused,linnum);
@@ -301,13 +301,13 @@ void xchg87(int i, int j)
  *      flag    1       don't bother with FXCH
  */
 
-private void makesure87(ref CodeBuilder cdb,elem *e,uint offset,int i,uint flag)
+private void makesure87(ref CodeBuilder cdb,elem* e,uint offset,int i,uint flag)
 {
     makesure87(cdb,e,offset,i,flag,__LINE__);
 }
 
 @trusted
-private void makesure87(ref CodeBuilder cdb,elem *e,uint offset,int i,uint flag,int linnum)
+private void makesure87(ref CodeBuilder cdb,elem* e,uint offset,int i,uint flag,int linnum)
 {
     debug if (NDPP) printf("makesure87(e=%p, offset=%d, i=%d, flag=%d, line=%d)\n",e,offset,i,flag,linnum);
 
@@ -447,7 +447,7 @@ void gensaverestore87(regm_t regm, ref CodeBuilder cdbsave, ref CodeBuilder cdbr
  */
 
 @trusted
-private int cse_get(elem *e, uint offset)
+private int cse_get(elem* e, uint offset)
 {
     int i;
 
@@ -473,7 +473,7 @@ private int cse_get(elem *e, uint offset)
 /*************************************
  * Reload common subexpression.
  */
-void comsub87(ref CodeBuilder cdb,elem *e, ref regm_t outretregs)
+void comsub87(ref CodeBuilder cdb,elem* e, ref regm_t outretregs)
 {
     //printf("comsub87(e = %p, outretregs = %s)\n", e, regm_str(outretregs));
     // Look on 8087 stack
@@ -553,19 +553,19 @@ private void cg87_87topsw(ref CodeBuilder cdb)
  */
 
 @trusted
-private void genjmpifC2(ref CodeBuilder cdb, code *ctarget)
+private void genjmpifC2(ref CodeBuilder cdb, code* ctarget)
 {
     if (NOSAHF)
     {
         getregs(cdb,mAX);
         cdb.genf2(0xDF,0xE0);                                    // FSTSW AX
         cdb.genc2(0xF6,modregrm(3,0,4),4);                       // TEST AH,4
-        genjmp(cdb, JNE, FL.code, cast(block *)ctarget); // JNE ctarget
+        genjmp(cdb, JNE, FL.code, cast(block*)ctarget); // JNE ctarget
     }
     else
     {
         cg87_87topsw(cdb);
-        genjmp(cdb, JP, FL.code, cast(block *)ctarget);  // JP ctarget
+        genjmp(cdb, JP, FL.code, cast(block*)ctarget);  // JP ctarget
     }
 }
 
@@ -578,7 +578,7 @@ private void genjmpifC2(ref CodeBuilder cdb, code *ctarget)
  */
 
 @trusted
-private void genftst(ref CodeBuilder cdb,elem *e,int pop)
+private void genftst(ref CodeBuilder cdb,elem* e,int pop)
 {
     if (NOSAHF)
     {
@@ -639,7 +639,7 @@ private void genftst(ref CodeBuilder cdb,elem *e,int pop)
  */
 
 @trusted
-ubyte loadconst(elem *e, int im)
+ubyte loadconst(elem* e, int im)
 {
     elem_debug(e);
     assert(im == 0 || im == 1);
@@ -676,7 +676,7 @@ ubyte loadconst(elem *e, int im)
     targ_ldouble ld;
     int sz;
     int zero;
-    void *p;
+    void* p;
     immutable ubyte[16] zeros;
 
     if (im == 0)
@@ -783,7 +783,7 @@ ubyte loadconst(elem *e, int im)
  */
 
 @trusted
-void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs, ref regm_t outretregs, bool isReturnValue = false)
+void fixresult87(ref CodeBuilder cdb,elem* e,regm_t retregs, ref regm_t outretregs, bool isReturnValue = false)
 {
     //printf("fixresult87(e = %p, retregs = x%x, outretregs = x%x)\n", e,retregs,outretregs);
     //printf("fixresult87(e = %p, retregs = %s, outretregs = %s)\n", e,regm_str(retregs),regm_str(outretregs));
@@ -941,14 +941,14 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs, ref regm_t outretre
 __gshared const ubyte[9] oprev = [ cast(ubyte)-1,0,1,2,3,5,4,7,6 ];
 
 @trusted
-void orth87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void orth87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("orth87(+e = %p, pretregs = %s)\n", e, regm_str(pretregs));
     // we could be evaluating / for side effects only
     assert(pretregs != 0);
 
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     uint sz2 = tysize(e1.Ety);
     if (tycomplex(e1.Ety))
         sz2 /= 2;
@@ -1456,12 +1456,12 @@ void orth87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
             cdb.genf2(0xD9, 0xC8 + 1);             // FXCH ST(1)
 
             cdb.gen2(0xD9, 0xF8);                  // FPREM
-            code *cfm1 = cdb.last();
+            code* cfm1 = cdb.last();
             genjmpifC2(cdb, cfm1);                 // JC2 FM1
             cdb.genf2(0xD9, 0xC8 + 2);             // FXCH ST(2)
 
             cdb.gen2(0xD9, 0xF8);                  // FPREM
-            code *cfm2 = cdb.last();
+            code* cfm2 = cdb.last();
 
             genjmpifC2(cdb, cfm2);                 // JC2 FM2
             cdb.genf2(0xDD,0xD8 + 1);              // FSTP ST(1)
@@ -1548,7 +1548,7 @@ void orth87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
             cdb.genf2(0xD9,0xC8 + 1);           // FXCH ST(1)
 
         cdb.gen2(0xD9, 0xF8);                   // FM1: FPREM
-        code *cfm1 = cdb.last();
+        code* cfm1 = cdb.last();
         genjmpifC2(cdb, cfm1);                  // JC2 FM1
         cdb.genf2(0xDD,0xD8 + 1);               // FSTP ST(1)
 
@@ -1571,7 +1571,7 @@ void orth87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-private void loadComplex(ref CodeBuilder cdb,elem *e)
+private void loadComplex(ref CodeBuilder cdb,elem* e)
 {
     regm_t retregs;
 
@@ -1620,7 +1620,7 @@ private void loadComplex(ref CodeBuilder cdb,elem *e)
  */
 
 @trusted
-void load87(ref CodeBuilder cdb,elem *e,uint eoffset,ref regm_t outretregs,elem *eleft,OPER op)
+void load87(ref CodeBuilder cdb,elem* e,uint eoffset,ref regm_t outretregs,elem* eleft,OPER op)
 {
     code cs;
     regm_t retregs;
@@ -1885,7 +1885,7 @@ L5:
                 pop87();
                 if (op == 4 || op == 6)     // sub or div
                 {
-                    code *cl = cdb.last();
+                    code* cl = cdb.last();
                     if (cl && cl.Iop == 0xD9 && cl.Irm == 0xC9)   // FXCH ST(1)
                     {   cl.Iop = NOP;
                         opr = op;           // reverse operands
@@ -1911,7 +1911,7 @@ L5:
  */
 
 @trusted
-int cmporder87(elem *e)
+int cmporder87(elem* e)
 {
     //printf("cmporder87(%p)\n",e);
   L1:
@@ -1969,7 +1969,7 @@ ret0:
  */
 
 @trusted
-void eq87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void eq87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     code cs;
     opcode_t op1;
@@ -2023,7 +2023,7 @@ void eq87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         cs.Iop = op1;
         if (pretregs & (mST0 | ALLREGS | mBP | XMMREGS)) // if want result on stack too
         {   // Make sure it's still there
-            elem *e2 = e.E2;
+            elem* e2 = e.E2;
             e2 = *el_scancommas(&e2);
             note87(e2,0,0);
             getlvalue87(cdb, cs, e.E1, 0);
@@ -2083,7 +2083,7 @@ void eq87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void complex_eq87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void complex_eq87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     code cs;
     opcode_t op1;
@@ -2203,7 +2203,7 @@ void complex_eq87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-private void cnvteq87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+private void cnvteq87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     code cs;
     opcode_t op1;
@@ -2254,7 +2254,7 @@ private void cnvteq87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-public void opass87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+public void opass87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     code cs;
     uint op;
@@ -2327,7 +2327,7 @@ public void opass87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
          *          jp      FM1                     // continue till ST < ST1
          *          fstp    ST(1)                   // leave remainder on stack
          */
-        code *c1;
+        code* c1;
 
         push87(cdb);
         cs.Iop = op1;
@@ -2336,7 +2336,7 @@ public void opass87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         cdb.gen(&cs);                       // FLD   e.E1
 
         cdb.gen2(0xD9, 0xF8);               // FPREM
-        code *cfm1 = cdb.last();
+        code* cfm1 = cdb.last();
         genjmpifC2(cdb, cfm1);              // JC2 FM1
         cdb.genf2(0xDD,0xD8 + 1);           // FSTP ST(1)
 
@@ -2388,7 +2388,7 @@ public void opass87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-private void opmod_complex87(ref CodeBuilder cdb, elem *e,ref regm_t pretregs)
+private void opmod_complex87(ref CodeBuilder cdb, elem* e,ref regm_t pretregs)
 {
 
     /*          fld     E2
@@ -2431,7 +2431,7 @@ private void opmod_complex87(ref CodeBuilder cdb, elem *e,ref regm_t pretregs)
     cdb.gen(&cs);                               // FLD E1.re
 
     cdb.gen2(0xD9, 0xF8);                       // FPREM
-    code *cfm1 = cdb.last();
+    code* cfm1 = cdb.last();
     genjmpifC2(cdb, cfm1);                      // JC2 FM1
     cdb.genf2(0xD9, 0xC8 + 1);                  // FXCH ST(1)
 
@@ -2440,7 +2440,7 @@ private void opmod_complex87(ref CodeBuilder cdb, elem *e,ref regm_t pretregs)
     cdb.gen(&cs);                               // FLD E1.im
 
     cdb.gen2(0xD9, 0xF8);                       // FPREM
-    code *cfm2 = cdb.last();
+    code* cfm2 = cdb.last();
     genjmpifC2(cdb, cfm2);                      // JC2 FM2
     cdb.genf2(0xDD,0xD8 + 1);                   // FSTP ST(1)
 
@@ -2474,7 +2474,7 @@ private void opmod_complex87(ref CodeBuilder cdb, elem *e,ref regm_t pretregs)
  */
 
 @trusted
-private void opass_complex87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+private void opass_complex87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     regm_t retregs;
     regm_t idxregs;
@@ -2770,13 +2770,13 @@ private void opass_complex87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdnegass87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdnegass87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     regm_t retregs;
     uint op;
 
     //printf("cdnegass87(e = %p, pretregs = %s)\n", e, regm_str(pretregs));
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     tym_t tyml = tybasic(e1.Ety);            // type of lvalue
     int sz = _tysize[tyml];
 
@@ -2845,7 +2845,7 @@ void cdnegass87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void post87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void post87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     uint op;
     opcode_t op1;
@@ -2925,7 +2925,7 @@ void post87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  *      OPd_u64
  *      OPld_u64
  */
-void cdd_u64(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdd_u64(ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     assert(I32 || I64);
     assert(pretregs);
@@ -2936,7 +2936,7 @@ void cdd_u64(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
 }
 
 @trusted
-private void cdd_u64_I32(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+private void cdd_u64_I32(ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     /* Generate:
             mov         EDX,0x8000_0000
@@ -2979,12 +2979,12 @@ private void cdd_u64_I32(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
     getregs(cdb,mask(reg2) | mAX);
 
     cdb.genfltreg(0xC7,0,0);
-    code *cf1 = cdb.last();
+    code* cf1 = cdb.last();
     cf1.IFL2 = FL.const_;
     cf1.IEV2.Vint = 0;                             // MOV floatreg+0,0
     cdb.genfltreg(STO,reg2,4);                      // MOV floatreg+4,EDX
     cdb.genfltreg(0xC7,0,8);
-    code *cf3 = cdb.last();
+    code* cf3 = cdb.last();
     cf3.IFL2 = FL.const_;
     cf3.IEV2.Vint = 0xFBF403E;                     // MOV floatreg+8,(roundTo0<<16)|adjust
 
@@ -2996,8 +2996,8 @@ private void cdd_u64_I32(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
     cdb.genfltreg(0xD9,7,12);                       // FSTCW floatreg+12
     cdb.genfltreg(0xD9,5,10);                       // FLDCW floatreg+10
     cdb.genc2(0xF6,modregrm(3,0,4),1);              // TEST AH,1
-    code *cnop1 = gennop(null);
-    genjmp(cdb,JE,FL.code,cast(block *)cnop1);       // JZ L1
+    code* cnop1 = gennop(null);
+    genjmp(cdb,JE,FL.code,cast(block*)cnop1);       // JZ L1
 
     cdb.genfltreg(0xDB,5,0);                        // FLD real ptr floatreg
     cdb.genf2(0xDE,0xE8+1);                         // FSUBP ST(1),ST
@@ -3005,8 +3005,8 @@ private void cdd_u64_I32(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
     cdb.genfltreg(LOD,reg,0);                       // MOV reg,floatreg
     cdb.genfltreg(0x03,reg2,4);                     // ADD reg,floatreg+4
     cdb.genfltreg(0xD9,5,12);                       // FLDCW floatreg+12
-    code *cnop2 = gennop(null);
-    genjmp(cdb,JMP,FL.code,cast(block *)cnop2);      // JMP L2
+    code* cnop2 = gennop(null);
+    genjmp(cdb,JMP,FL.code,cast(block*)cnop2);      // JMP L2
 
     cdb.append(cnop1);
     cdb.genfltreg(0xDF,7,0);                        // FISTP dword ptr floatreg
@@ -3020,7 +3020,7 @@ private void cdd_u64_I32(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
 }
 
 @trusted
-private void cdd_u64_I64(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+private void cdd_u64_I64(ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     /* Generate:
             mov         EDX,0x8000_0000
@@ -3063,12 +3063,12 @@ private void cdd_u64_I64(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
     getregs(cdb,mask(reg2) | mAX);
 
     cdb.genfltreg(0xC7,0,0);
-    code *cf1 = cdb.last();
+    code* cf1 = cdb.last();
     cf1.IFL2 = FL.const_;
     cf1.IEV2.Vint = 0;                             // MOV floatreg+0,0
     cdb.genfltreg(STO,reg2,4);                      // MOV floatreg+4,EDX
     cdb.genfltreg(0xC7,0,8);
-    code *cf3 = cdb.last();
+    code* cf3 = cdb.last();
     cf3.IFL2 = FL.const_;
     cf3.IEV2.Vint = 0xFBF403E;                     // MOV floatreg+8,(roundTo0<<16)|adjust
 
@@ -3080,8 +3080,8 @@ private void cdd_u64_I64(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
     cdb.genfltreg(0xD9,7,12);                       // FSTCW floatreg+12
     cdb.genfltreg(0xD9,5,10);                       // FLDCW floatreg+10
     cdb.genc2(0xF6,modregrm(3,0,4),1);              // TEST AH,1
-    code *cnop1 = gennop(null);
-    genjmp(cdb,JE,FL.code,cast(block *)cnop1);       // JZ L1
+    code* cnop1 = gennop(null);
+    genjmp(cdb,JE,FL.code,cast(block*)cnop1);       // JZ L1
 
     cdb.genfltreg(0xDB,5,0);                        // FLD real ptr floatreg
     cdb.genf2(0xDE,0xE8+1);                         // FSUBP ST(1),ST
@@ -3091,8 +3091,8 @@ private void cdd_u64_I64(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
     cdb.genc2(0xC1,(REX_W << 16) | modregrmx(3,4,reg2),32); // SHL reg2,32
     cdb.gen2(0x03,(REX_W << 16) | modregxrmx(3,reg,reg2));  // ADD reg,reg2
     cdb.genfltreg(0xD9,5,12);                       // FLDCW floatreg+12
-    code *cnop2 = gennop(null);
-    genjmp(cdb,JMP,FL.code,cast(block *)cnop2);      // JMP L2
+    code* cnop2 = gennop(null);
+    genjmp(cdb,JMP,FL.code,cast(block*)cnop2);      // JMP L2
 
     cdb.append(cnop1);
     cdb.genfltreg(0xDF,7,0);                        // FISTP dword ptr floatreg
@@ -3110,7 +3110,7 @@ private void cdd_u64_I64(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  *      OPd_u32
  */
 @trusted
-void cdd_u32(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdd_u32(ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     assert(I32 || I64);
 
@@ -3131,7 +3131,7 @@ void cdd_u32(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
     const reg = allocreg(cdb,retregs,tym);
 
     cdb.genfltreg(0xC7,0,8);
-    code *cf3 = cdb.last();
+    code* cf3 = cdb.last();
     cf3.IFL2 = FL.const_;
     cf3.IEV2.Vint = 0x0FBF0000;                 // MOV floatreg+8,(roundTo0<<16)
 
@@ -3154,7 +3154,7 @@ void cdd_u32(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  *      OPd_s64
  */
 @trusted
-void cnvt87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cnvt87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     regm_t retregs;
     uint mf,rf;
@@ -3307,7 +3307,7 @@ void cnvt87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  * Do OPrndtol.
  */
 @trusted
-void cdrndtol(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdrndtol(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (pretregs == 0)
     {
@@ -3363,7 +3363,7 @@ void cdrndtol(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  * Do OPscale, OPyl2x, OPyl2xp1.
  */
 @trusted
-void cdscale(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdscale(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     assert(pretregs != 0);
 
@@ -3399,7 +3399,7 @@ void cdscale(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  * Unary -, absolute value, square root, sine, cosine
  */
 @trusted
-void neg87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void neg87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("neg87()\n");
 
@@ -3426,7 +3426,7 @@ void neg87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void neg_complex87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void neg_complex87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     assert(e.Eoper == OPneg);
     regm_t retregs = mST01;
@@ -3442,7 +3442,7 @@ void neg_complex87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdind87(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdind87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdind87(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
     code cs;
@@ -3501,7 +3501,7 @@ private void genSetRoundingMode(ref CodeBuilder cdb, CW cw)
     if (config.flags3 & CFG3pic)
     {
         cdb.genfltreg(0xC7, 0, 0);       // MOV floatreg, cw
-        code *c1 = cdb.last();
+        code* c1 = cdb.last();
         c1.IFL2 = FL.const_;
         c1.IEV2.Vuns = cw;
 
@@ -3518,7 +3518,7 @@ private void genSetRoundingMode(ref CodeBuilder cdb, CW cw)
             cwi = CW.roundtonearest;            // round to nearest
             oldd.roundtonearest = out_readonly_sym(TYshort,&cwi,2);
         }
-        Symbol *rnddir = (cw == CW.roundto0) ? oldd.roundto0 : oldd.roundtonearest;
+        Symbol* rnddir = (cw == CW.roundto0) ? oldd.roundto0 : oldd.roundtonearest;
         code cs;
         cs.Iop = 0xD9;
         cs.Iflags = CFoff;
@@ -3540,7 +3540,7 @@ private void genSetRoundingMode(ref CodeBuilder cdb, CW cw)
  */
 
 @trusted
-private void genctst(ref CodeBuilder cdb,elem *e,int pop)
+private void genctst(ref CodeBuilder cdb,elem* e,int pop)
 {
     assert(pop == 0 || pop == 1);
 
@@ -3584,15 +3584,15 @@ private void genctst(ref CodeBuilder cdb,elem *e,int pop)
     CodeBuilder cdbnop;
     cdbnop.ctor();
     cdbnop.gennop();
-    code *cnop = cdbnop.peek();
+    code* cnop = cdbnop.peek();
     push87(cdb);
     cdb.gen2(0xD9,0xEE);                       // FLDZ
     if (NOSAHF)
     {
         cdb.gen2(0xDF,0xE9);                   // FUCOMIP
         pop87();
-        genjmp(cdb,JNE,FL.code,cast(block *) cnop); // JNE     L1
-        genjmp(cdb,JP, FL.code,cast(block *) cnop); // JP      L1
+        genjmp(cdb,JNE,FL.code,cast(block*) cnop); // JNE     L1
+        genjmp(cdb,JP, FL.code,cast(block*) cnop); // JP      L1
         cdb.gen2(0xD9,0xEE);                   // FLDZ
         cdb.gen2(0xDF,0xEA);                   // FUCOMIP ST(2)
         if (pop)
@@ -3612,8 +3612,8 @@ private void genctst(ref CodeBuilder cdb,elem *e,int pop)
         cdb.gen2(0xD9,0xEE);                   // FLDZ
         cdb.gen2(0xDA,0xE9);                   // FUCOMPP
         pop87();
-        genjmp(cdb,JNE,FL.code,cast(block *) cnop); // JNE     L1
-        genjmp(cdb,JP, FL.code,cast(block *) cnop); // JP      L1
+        genjmp(cdb,JNE,FL.code,cast(block*) cnop); // JNE     L1
+        genjmp(cdb,JP, FL.code,cast(block*) cnop); // JP      L1
         cg87_87topsw(cdb);                     // put 8087 flags in CPU flags
     }
     else
@@ -3622,8 +3622,8 @@ private void genctst(ref CodeBuilder cdb,elem *e,int pop)
         cg87_87topsw(cdb);                     // put 8087 flags in CPU flags
         cdb.gen2(0xDD,0xEA);                   // FUCOMP ST(2)
         pop87();
-        genjmp(cdb,JNE,FL.code,cast(block *) cnop); // JNE     L1
-        genjmp(cdb,JP, FL.code,cast(block *) cnop); // JP      L1
+        genjmp(cdb,JNE,FL.code,cast(block*) cnop); // JNE     L1
+        genjmp(cdb,JP, FL.code,cast(block*) cnop); // JP      L1
         cg87_87topsw(cdb);                     // put 8087 flags in CPU flags
     }
     cdb.append(cdbnop);
@@ -3635,7 +3635,7 @@ private void genctst(ref CodeBuilder cdb,elem *e,int pop)
  */
 
 @trusted
-void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs, ref regm_t outretregs, bool isReturnValue = false)
+void fixresult_complex87(ref CodeBuilder cdb,elem* e,regm_t retregs, ref regm_t outretregs, bool isReturnValue = false)
 {
     static if (0)
     {
@@ -3763,7 +3763,7 @@ void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs, ref regm_t 
  * Operators OPc_r and OPc_i
  */
 @trusted
-void cdconvt87(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdconvt87(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     regm_t retregs = mST01;
     codelem(cgstate,cdb,e.E1, retregs, false);
@@ -3791,7 +3791,7 @@ void cdconvt87(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs
  */
 
 @trusted
-void cload87(ref CodeBuilder cdb, elem *e, ref regm_t outretregs)
+void cload87(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
 {
     //printf("e = %p, outretregs = %s)\n", e, regm_str(outretregs));
     //elem_print(e);
@@ -3891,7 +3891,7 @@ void cload87(ref CodeBuilder cdb, elem *e, ref regm_t outretregs)
  * Load OPpair or OPrpair into mST01
  */
 @trusted
-void loadPair87(ref CodeBuilder cdb, elem *e, ref regm_t outretregs)
+void loadPair87(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
 {
     assert(e.Eoper == OPpair || e.Eoper == OPrpair);
     regm_t retregs = mST0;

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -75,7 +75,7 @@ regm_t BYTEREGS() { return I64 ? ALLREGS
  *      sfunc = function to generate code for
  */
 @trusted
-void codgen(Symbol *sfunc)
+void codgen(Symbol* sfunc)
 {
     //printf("codgen('%s')\n",funcsym_p.Sident.ptr);
     assert(sfunc == funcsym_p);
@@ -289,7 +289,7 @@ void codgen(Symbol *sfunc)
 
     CodeBuilder cdbprolog; cdbprolog.ctor();
     prolog(cgstate, cdbprolog);           // gen function start code
-    code *cprolog = cdbprolog.finish();
+    code* cprolog = cdbprolog.finish();
     if (cprolog)
         pinholeopt(cprolog,null);       // optimize
 
@@ -614,7 +614,7 @@ void prolog(ref CGstate cg, ref CodeBuilder cdb)
         cdb.gen1(I32 ? ENDBR32 : ENDBR64);
 
     // Special Intel 64 bit ABI prolog setup for variadic functions
-    Symbol *sv64 = null;                        // set to __va_argsave
+    Symbol* sv64 = null;                        // set to __va_argsave
     if (I64 && variadic(funcsym_p.Stype))
     {
         /* The Intel 64 bit ABI scheme.
@@ -965,13 +965,13 @@ else
      */
     if (config.exe == EX_WIN64)
     {
-        code *c = cdbx.peek();
+        code* c = cdbx.peek();
         pinholeopt(c, null);
         cg.prolog_allocoffset = calcblksize(c);
     }
 
     if (cg.usednteh & NTEHjmonitor)
-    {   Symbol *sthis;
+    {   Symbol* sthis;
 
         for (SYMIDX si = 0; 1; si++)
         {   assert(si < globsym.length);
@@ -1030,10 +1030,10 @@ Lcont:
 
 @trusted
 extern (C) int
- autosort_cmp(scope const void *ps1, scope const void *ps2)
+ autosort_cmp(scope const void* ps1, scope const void* ps2)
 {
-    Symbol *s1 = *cast(Symbol **)ps1;
-    Symbol *s2 = *cast(Symbol **)ps2;
+    Symbol* s1 = *cast(Symbol**)ps1;
+    Symbol* s2 = *cast(Symbol**)ps2;
 
     /* Largest align size goes furthest away from frame pointer,
      * so they get allocated first.
@@ -1085,20 +1085,20 @@ void stackoffsets(ref CGstate cg, ref symtab_t symtab, bool estimate)
 
     // Put autos in another array so we can do optimizations on the stack layout
     Symbol*[10] autotmp = void;
-    Symbol **autos = null;
+    Symbol** autos = null;
     if (doAutoOpt)
     {
         if (symtab.length <= autotmp.length)
             autos = autotmp.ptr;
         else
-        {   autos = cast(Symbol **)malloc(symtab.length * (*autos).sizeof);
+        {   autos = cast(Symbol**)malloc(symtab.length * (*autos).sizeof);
             assert(autos);
         }
     }
     size_t autosi = 0;  // number used in autos[]
 
     for (int si = 0; si < symtab.length; si++)
-    {   Symbol *s = symtab[si];
+    {   Symbol* s = symtab[si];
 
         /* Don't allocate space for dead or zero size parameters
          */
@@ -1226,13 +1226,13 @@ void stackoffsets(ref CGstate cg, ref symtab_t symtab, bool estimate)
 
     if (autosi)
     {
-        qsort(autos, autosi, (Symbol *).sizeof, &autosort_cmp);
+        qsort(autos, autosi, (Symbol*).sizeof, &autosort_cmp);
 
         vec_t tbl = vec_calloc(autosi);
 
         for (size_t si = 0; si < autosi; si++)
         {
-            Symbol *s = autos[si];
+            Symbol* s = autos[si];
 
             targ_size_t sz = type_size(s.Stype);
             if (sz == 0)
@@ -1254,7 +1254,7 @@ void stackoffsets(ref CGstate cg, ref symtab_t symtab, bool estimate)
                 {
                     if (!vec_testbit(i,tbl))
                         continue;
-                    Symbol *sp = autos[i];
+                    Symbol* sp = autos[i];
 //printf("auto    s = '%s', sp = '%s', %d, %d, %d\n",s.Sident,sp.Sident,dfo.length,vec_numbits(s.Srange),vec_numbits(sp.Srange));
                     if (vec_disjoint(s.Srange,sp.Srange) &&
                         !(sp.Soffset & (alignsize - 1)) &&
@@ -1294,7 +1294,7 @@ void stackoffsets(ref CGstate cg, ref symtab_t symtab, bool estimate)
  */
 
 @trusted
-private void blcodgen(ref CGstate cg, block *bl)
+private void blcodgen(ref CGstate cg, block* bl)
 {
     regm_t mfuncregsave = cg.mfuncreg;
 
@@ -1308,7 +1308,7 @@ private void blcodgen(ref CGstate cg, block *bl)
 //    cg.regcon.cse.mval = 0;
     foreach (bpl; ListRange(bl.Bpred))
     {
-        block *bp = list_block(bpl);
+        block* bp = list_block(bpl);
 
         if (bpl == bl.Bpred)
         {   cg.regcon.immed = bp.Bregcon.immed;
@@ -1412,7 +1412,7 @@ private void blcodgen(ref CGstate cg, block *bl)
 
     for (int i = 0; i < anyspill; i++)
     {
-        Symbol *s = globsym[i];
+        Symbol* s = globsym[i];
         s.Sfl = sflsave[i];    // undo block register assignments
     }
 
@@ -1478,7 +1478,7 @@ reg_t findreg(regm_t regm, int line, const(char)* file)
  */
 
 @trusted
-void freenode(elem *e)
+void freenode(elem* e)
 {
     elem_debug(e);
     //dbg_printf("freenode(%p) : comsub = %d, count = %d\n",e,e.Ecomsub,e.Ecount);
@@ -1502,7 +1502,7 @@ void freenode(elem *e)
  */
 
 @trusted
-private void resetEcomsub(elem *e)
+private void resetEcomsub(elem* e)
 {
     while (1)
     {
@@ -1531,7 +1531,7 @@ private void resetEcomsub(elem *e)
  */
 
 @trusted
-bool isregvar(elem *e, ref regm_t pregm, ref reg_t preg)
+bool isregvar(elem* e, ref regm_t pregm, ref reg_t preg)
 {
     regm_t regm;
     reg_t reg;
@@ -1956,7 +1956,7 @@ void cse_flush(ref CodeBuilder cdb, int do87)
  */
 
 @trusted
-bool cssave(elem *e, regm_t regm, bool opsflag)
+bool cssave(elem* e, regm_t regm, bool opsflag)
 {
     bool result = false;
 
@@ -2006,7 +2006,7 @@ bool cssave(elem *e, regm_t regm, bool opsflag)
  */
 
 @trusted
-bool evalinregister(elem *e)
+bool evalinregister(elem* e)
 {
     if (config.exe == EX_WIN64 && e.Eoper == OPrelconst)
         return true;
@@ -2086,7 +2086,7 @@ regm_t getscratch()
  */
 
 @trusted
-private void comsub(ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
+private void comsub(ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
 {
     tym_t tym;
     regm_t regm,emask;
@@ -2189,7 +2189,7 @@ private void comsub(ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
                 else if (!(retregs & cgstate.allregs))
                     retregs = cgstate.allregs;
                 reg = allocreg(cdb,retregs,tym);
-                code *cr = &cse.csimple;
+                code* cr = &cse.csimple;
                 cr.setReg(reg);
                 if (I64 && reg >= 4 && tysize(cse.e.Ety) == 1)
                     cr.Irex |= REX;
@@ -2359,7 +2359,7 @@ reload:                                 /* reload result from memory    */
  */
 
 @trusted
-private void loadcse(ref CodeBuilder cdb,elem *e,reg_t reg,regm_t regm)
+private void loadcse(ref CodeBuilder cdb,elem* e,reg_t reg,regm_t regm)
 {
     foreach (ref cse; CSE.filter(e))
     {
@@ -2384,7 +2384,7 @@ private void loadcse(ref CodeBuilder cdb,elem *e,reg_t reg,regm_t regm)
 }
 
 
-void callcdxxx(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs, OPER op)
+void callcdxxx(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs, OPER op)
 {
     (*cdxxx[op])(cg, cdb, e, pretregs);
 }
@@ -2599,9 +2599,9 @@ private immutable nothrow void function (ref CGstate, ref CodeBuilder,elem *,ref
  *                      2 for freenode() not called.
  */
 @trusted
-void codelem(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs,uint constflag)
+void codelem(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs,uint constflag)
 {
-    Symbol *s;
+    Symbol* s;
 
     debug if (debugw)
     {
@@ -2765,7 +2765,7 @@ L1:
  *                      registers returned in pretregs.
  */
 @trusted
-void scodelem(ref CGstate cg, ref CodeBuilder cdb, elem *e,ref regm_t pretregs,regm_t keepmsk,bool constflag)
+void scodelem(ref CGstate cg, ref CodeBuilder cdb, elem* e,ref regm_t pretregs,regm_t keepmsk,bool constflag)
 {
     regm_t touse;
 
@@ -2861,7 +2861,7 @@ void scodelem(ref CGstate cg, ref CodeBuilder cdb, elem *e,ref regm_t pretregs,r
     }
 
     CodeBuilder cdbs1; cdbs1.ctor();
-    code *cs2 = null;
+    code* cs2 = null;
     int adjesp = 0;
 
     for (reg_t i = 0; tosave; i++)
@@ -2916,7 +2916,7 @@ void scodelem(ref CGstate cg, ref CodeBuilder cdb, elem *e,ref regm_t pretregs,r
     {
         // If this is done an odd number of times, it
         // will throw off the 8 byte stack alignment.
-        // We should *only* worry about this if a function
+        // We should* only* worry about this if a function
         // was called in the code generation by codelem().
         int sz = -(adjesp & (STACKALIGN - 1)) & (STACKALIGN - 1);
         if (cg.calledafunc && !I16 && sz && (STACKALIGN >= 16 || config.flags4 & CFG4stackalign))
@@ -2984,7 +2984,7 @@ const(char)* regm_str(regm_t rm)
         if (rm == XMMREGS)
             return "XMMREGS";
     }
-    char *p = str[i].ptr;
+    char* p = str[i].ptr;
     if (++i == NUM)
         i = 0;
     *p = 0;
@@ -3016,7 +3016,7 @@ const(char)* regm_str(regm_t rm)
     if (rm)
     {
         const pstrlen = strlen(p);
-        char *s = p + pstrlen;
+        char* s = p + pstrlen;
         snprintf(s, SMAX - pstrlen, "x%02llx", cast(ulong)rm);
     }
     assert(strlen(p) <= SMAX);
@@ -3032,7 +3032,7 @@ const(char)* regm_str(regm_t rm)
  */
 
 @trusted
-void docommas(ref CodeBuilder cdb, ref elem *pe)
+void docommas(ref CodeBuilder cdb, ref elem* pe)
 {
     uint stackpushsave = cgstate.stackpush;
     int stackcleansave = cgstate.stackclean;

--- a/compiler/src/dmd/backend/x86/cgreg.d
+++ b/compiler/src/dmd/backend/x86/cgreg.d
@@ -201,7 +201,7 @@ void cgreg_used(uint bi,regm_t used)
  */
 
 @trusted
-private void el_weights(int bi,elem *e,uint weight)
+private void el_weights(int bi,elem* e,uint weight)
 {
     while (1)
     {   elem_debug(e);
@@ -236,7 +236,7 @@ private void el_weights(int bi,elem *e,uint weight)
             switch (op)
             {
                 case OPvar:
-                    Symbol *s = e.Vsym;
+                    Symbol* s = e.Vsym;
                     if (s.Ssymnum != SYMIDX.max && s.Sflags & GTregcand)
                     {
                         s.Sweight += weight;
@@ -261,11 +261,11 @@ private void el_weights(int bi,elem *e,uint weight)
  */
 
 @trusted
-private int cgreg_benefit(Symbol *s, reg_t reg, Symbol *retsym)
+private int cgreg_benefit(Symbol* s, reg_t reg, Symbol* retsym)
 {
     int benefit;
     int benefit2;
-    block *b;
+    block* b;
     int bi;
     int gotoepilog;
     int retsym_cnt;
@@ -339,7 +339,7 @@ static if (1) // causes assert failure in std.range(4488) from std.parallelism's
         benefit2 = 0;
         foreach (bl; ListRange(b.Bpred))
         {
-            block *bp = list_block(bl);
+            block* bp = list_block(bl);
             int bpi = bp.Bdfoidx;
             if (!vec_testbit(bpi,s.Srange))
                 continue;
@@ -443,7 +443,7 @@ Lcant:
  * or by prolog (0).
  */
 
-int cgreg_gotoepilog(block *b,Symbol *s)
+int cgreg_gotoepilog(block* b,Symbol* s)
 {
     int bi = b.Bdfoidx;
 
@@ -458,7 +458,7 @@ int cgreg_gotoepilog(block *b,Symbol *s)
     int inoutp = 0;
     foreach (bl; ListRange(b.Bpred))
     {
-        block *bp = list_block(bl);
+        block* bp = list_block(bl);
         int bpi = bp.Bdfoidx;
         if (!vec_testbit(bpi,s.Srange))
             continue;
@@ -528,7 +528,7 @@ Lcant:
  *      cdbstore = append store code to this
  *      cdbload = append load code to this
  */
-void cgreg_spillreg_prolog(block *b,Symbol *s,ref CodeBuilder cdbstore,ref CodeBuilder cdbload)
+void cgreg_spillreg_prolog(block* b,Symbol* s,ref CodeBuilder cdbstore,ref CodeBuilder cdbload)
 {
     const int bi = b.Bdfoidx;
 
@@ -602,7 +602,7 @@ void cgreg_spillreg_prolog(block *b,Symbol *s,ref CodeBuilder cdbstore,ref CodeB
  *      cdbstore = append store code to this
  *      cdbload = append load code to this
  */
-void cgreg_spillreg_epilog(block *b,Symbol *s,ref CodeBuilder cdbstore, ref CodeBuilder cdbload)
+void cgreg_spillreg_epilog(block* b,Symbol* s,ref CodeBuilder cdbstore, ref CodeBuilder cdbload)
 {
     const bi = b.Bdfoidx;
     //printf("cgreg_spillreg_epilog(block %d, s = '%s')\n",bi,s.Sident.ptr);
@@ -646,7 +646,7 @@ void cgreg_spillreg_epilog(block *b,Symbol *s,ref CodeBuilder cdbstore, ref Code
  */
 
 @trusted
-private void cgreg_map(Symbol *s, reg_t regmsw, reg_t reglsw)
+private void cgreg_map(Symbol* s, reg_t regmsw, reg_t reglsw)
 {
     //assert(I64 || reglsw < 8);
 
@@ -762,14 +762,14 @@ void cgreg_unregister(regm_t conflict)
 
 struct Reg              // data for trial register assignment
 {
-    Symbol *sym;
+    Symbol* sym;
     int benefit;
     reg_t reglsw;
     reg_t regmsw;
 }
 
 @trusted
-int cgreg_assign(Symbol *retsym)
+int cgreg_assign(Symbol* retsym)
 {
     int flag = false;                   // assume no changes
 

--- a/compiler/src/dmd/backend/x86/cgxmm.d
+++ b/compiler/src/dmd/backend/x86/cgxmm.d
@@ -122,7 +122,7 @@ void movxmmconst(ref CodeBuilder cdb, reg_t xreg, tym_t ty, Vconst* pev, regm_t 
         U u = void;
         u.l[1] = 0;
         u.s = value;
-        targ_long *p = &u.l[0];
+        targ_long* p = &u.l[0];
         movregconst(cdb,r,p[0],0);
         cdb.genfltreg(STO,r,0);                     // MOV floatreg,r
         movregconst(cdb,r,p[1],0);
@@ -145,11 +145,11 @@ void movxmmconst(ref CodeBuilder cdb, reg_t xreg, tym_t ty, Vconst* pev, regm_t 
  * Do simple orthogonal operators for XMM registers.
  */
 @trusted
-void orthxmm(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void orthxmm(ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     //printf("orthxmm(e = %p, pretregs = %s)\n", e, regm_str(pretregs));
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
 
     // float + ifloat is not actually addition
     if ((e.Eoper == OPadd || e.Eoper == OPmin) &&
@@ -256,12 +256,12 @@ void orthxmm(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  *      opcode = store opcode to use, CMP means generate one
  */
 @trusted
-void xmmeq(ref CodeBuilder cdb, elem *e, opcode_t op, elem *e1, elem *e2,ref regm_t pretregs)
+void xmmeq(ref CodeBuilder cdb, elem* e, opcode_t op, elem* e1, elem* e2,ref regm_t pretregs)
 {
     tym_t tymll;
     int i;
     code cs;
-    elem *e11;
+    elem* e11;
     bool regvar;                  /* true means evaluate into register variable */
     targ_int postinc;
 
@@ -387,7 +387,7 @@ void xmmeq(ref CodeBuilder cdb, elem *e, opcode_t op, elem *e1, elem *e2,ref reg
  *
  */
 @trusted
-void xmmcnvt(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void xmmcnvt(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("xmmconvt: %p, %s\n", e, regm_str(pretregs));
     opcode_t op = NoOpcode;
@@ -401,7 +401,7 @@ void xmmcnvt(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
      * try to fuse chained conversions. Be careful not to loose
      * precision for real to long.
      */
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     switch (e.Eoper)
     {
     case OPd_f:
@@ -524,9 +524,9 @@ void xmmcnvt(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  * Generate code for op=
  */
 @trusted
-void xmmopass(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
-{   elem *e1 = e.E1;
-    elem *e2 = e.E2;
+void xmmopass(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
+{   elem* e1 = e.E1;
+    elem* e2 = e.E2;
     tym_t ty1 = tybasic(e1.Ety);
     const sz1 = _tysize[ty1];
     regm_t rretregs = XMMREGS & ~pretregs;
@@ -598,10 +598,10 @@ void xmmopass(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void xmmpost(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void xmmpost(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     tym_t ty1 = tybasic(e1.Ety);
 
     regm_t retregs;
@@ -682,7 +682,7 @@ void xmmpost(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void xmmneg(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void xmmneg(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("xmmneg()\n");
     //elem_print(e);
@@ -723,7 +723,7 @@ void xmmneg(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void xmmabs(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void xmmabs(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("xmmabs()\n");
     //elem_print(e);
@@ -1175,7 +1175,7 @@ private opcode_t xmmoperator(tym_t tym, OPER oper)
 }
 
 @trusted
-void cdvector(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdvector(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     /* e should look like one of:
      *    vector
@@ -1193,10 +1193,10 @@ void cdvector(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
     }
 
     const n = el_nparams(e.E1);
-    assert(n < size_t.max / (2 * (elem *).sizeof));   // conservative overflow check
-    elem **params = cast(elem **)malloc(n * (elem *).sizeof);
+    assert(n < size_t.max / (2 * (elem*).sizeof));   // conservative overflow check
+    elem** params = cast(elem**)malloc(n * (elem*).sizeof);
     assert(params);
-    elem **tmp = params;
+    elem** tmp = params;
     el_paramArray(&tmp, e.E1);
 
 static if (0)
@@ -1222,9 +1222,9 @@ static if (0)
 
     assert(n >= 2 && n <= 4);
 
-    elem *eop = params[0];
-    elem *op1 = params[1];
-    elem *op2 = null;
+    elem* eop = params[0];
+    elem* op1 = params[1];
+    elem* op2 = null;
     tym_t ty2 = 0;
     if (n >= 3)
     {   op2 = params[2];
@@ -1359,7 +1359,7 @@ static if (0)
 
         if (n == 4)
         {
-            elem *imm8 = params[3];
+            elem* imm8 = params[3];
             cs.IFL2 = FL.const_;
             if (imm8.Eoper != OPconst)
             {
@@ -1387,13 +1387,13 @@ static if (0)
  * where op is the store instruction STOxxxx.
  */
 @trusted
-void cdvecsto(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdvecsto(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     //printf("cdvecsto()\n");
     //elem_print(e);
-    elem *op1 = e.E1;
-    elem *op2 = e.E2.E2;
-    elem *eop = e.E2.E1;
+    elem* op1 = e.E1;
+    elem* op2 = e.E2.E2;
+    elem* eop = e.E2.E1;
     const op = cast(opcode_t)el_tolong(eop);
     debug assert(isXMMstore(op));
     xmmeq(cdb, e, op, op1, op2, pretregs);
@@ -1405,7 +1405,7 @@ void cdvecsto(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  * fills the vector type with it.
  */
 @trusted
-void cdvecfill(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdvecfill(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     //printf("cdvecfill(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
 
@@ -1413,10 +1413,10 @@ void cdvecfill(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs
     if (!retregs)
         retregs = XMMREGS;
 
-    code *c;
+    code* c;
     code cs;
 
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
 static if (0)
 {
     if ((e1.Eoper == OPind && !e1.Ecount) || e1.Eoper == OPvar)
@@ -1768,11 +1768,11 @@ static if (0)
  */
 
 @trusted
-bool xmmIsAligned(elem *e)
+bool xmmIsAligned(elem* e)
 {
     if (tyvector(e.Ety) && e.Eoper == OPvar)
     {
-        Symbol *s = e.Vsym;
+        Symbol* s = e.Vsym;
         const alignsz = tyalignsize(e.Ety);
         if (Symbol_Salignsize(*s) < alignsz ||
             e.Voffset & (alignsz - 1) ||
@@ -1788,7 +1788,7 @@ bool xmmIsAligned(elem *e)
  * If it must be 3 bytes, set the CFvex3 flag.
  */
 
-void checkSetVex3(code *c)
+void checkSetVex3(code* c)
 {
     // See Intel Vol. 2A 2.3.5.6
     if (c.Ivex.w || !c.Ivex.x || !c.Ivex.b || c.Ivex.mmmm > 0x1 ||
@@ -1808,7 +1808,7 @@ void checkSetVex3(code *c)
  */
 
 @trusted
-void checkSetVex(code *c, tym_t ty)
+void checkSetVex(code* c, tym_t ty)
 {
     //printf("checkSetVex() %d %x\n", tysize(ty), c.Iop);
     if (config.avx || tysize(ty) == 32)
@@ -1912,7 +1912,7 @@ void checkSetVex(code *c, tym_t ty)
  * Load complex operand into XMM registers or flags or both.
  */
 @trusted
-void cloadxmm(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cloadxmm(ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     //printf("e = %p, pretregs = %s)\n", e, regm_str(pretregs));
     //elem_print(e);
@@ -1951,7 +1951,7 @@ void cloadxmm(ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  *      true if it can be done
  */
 @trusted
-bool loadxmmconst(elem *e)
+bool loadxmmconst(elem* e)
 {
     //printf("loadxmmconst() "); elem_print_const(e); printf("\n");
     const sz = tysize(e.Ety);

--- a/compiler/src/dmd/backend/x86/cod1.d
+++ b/compiler/src/dmd/backend/x86/cod1.d
@@ -49,7 +49,7 @@ private void genorreg(ref CodeBuilder c, uint t, uint f) { genregs(c, 0x09, f, t
 private __gshared const byte[8] regtorm32 =   [  0, 1, 2, 3,-1, 5, 6, 7 ];
 __gshared const   byte[8] regtorm   =   [ -1,-1,-1, 7,-1, 6, 4, 5 ];
 
-//void funccall(ref CodeBuilder cdb,elem *e,uint numpara,uint numalign,
+//void funccall(ref CodeBuilder cdb,elem* e,uint numpara,uint numalign,
 //        ref regm_t pretregs,regm_t keepmsk, bool usefuncarg);
 
 /*********************************
@@ -78,7 +78,7 @@ bool regParamInPreg(ref Symbol s)
  */
 
 @trusted
-int isscaledindex(elem *e)
+int isscaledindex(elem* e)
 {
     targ_uns ss;
 
@@ -99,7 +99,7 @@ int isscaledindex(elem *e)
 
 @trusted
 //private
-void cdisscaledindex(ref CodeBuilder cdb,elem *e,ref regm_t pidxregs,regm_t keepmsk)
+void cdisscaledindex(ref CodeBuilder cdb,elem* e,ref regm_t pidxregs,regm_t keepmsk)
 {
     // Load index register with result of e.E1
     while (e.Eoper == OPcomma)
@@ -191,7 +191,7 @@ int ssindex(OPER op,targ_uns product)
  */
 
 @safe
-void buildEA(code *c,int base,int index,int scale,targ_size_t disp)
+void buildEA(code* c,int base,int index,int scale,targ_size_t disp)
 {
     ubyte rm;
     ubyte sib;
@@ -320,7 +320,7 @@ void genEEcode()
     cdb.genpush(SI);                      // PUSH ESI
     cdb.genadjesp(cast(int)cgstate.EEStack.offset);
     gencodelem(cdb, eecontext.EEelem, retregs, false);
-    code *c = cdb.finish();
+    code* c = cdb.finish();
     assignaddrc(c);
     pinholeopt(c,null);
     jmpaddr(c);
@@ -413,7 +413,7 @@ uint gensaverestore(regm_t regm,ref CodeBuilder cdbsave,ref CodeBuilder cdbresto
 
     while (i)
     {
-        code *c = restore[--i];
+        code* c = restore[--i];
         if (c)
         {
             cdbrestore.append(c);
@@ -481,7 +481,7 @@ void genstackclean(ref CodeBuilder cdb,uint numpara,regm_t keepmsk)
  */
 
 @trusted
-void logexp(ref CodeBuilder cdb, elem *e, int jcond, FL fltarg, code *targ)
+void logexp(ref CodeBuilder cdb, elem* e, int jcond, FL fltarg, code* targ)
 {
     if (cgstate.AArch64)
     {
@@ -520,7 +520,7 @@ void logexp(ref CodeBuilder cdb, elem *e, int jcond, FL fltarg, code *targ)
                 }
                 else
                 {
-                    code *cnop = gennop(null);
+                    code* cnop = gennop(null);
                     logexp(cdb, e.E1, jcond | 1, FL.code, cnop);
                     regconsave = cgstate.regcon;
                     logexp(cdb, e.E2, jcond, fltarg, targ);
@@ -537,7 +537,7 @@ void logexp(ref CodeBuilder cdb, elem *e, int jcond, FL fltarg, code *targ)
                 con_t regconsave;
                 if (jcond & 1)
                 {
-                    code *cnop = gennop(null);    // a dummy target address
+                    code* cnop = gennop(null);    // a dummy target address
                     logexp(cdb, e.E1, jcond & ~1, FL.code, cnop);
                     regconsave = cgstate.regcon;
                     logexp(cdb, e.E2, jcond, fltarg, targ);
@@ -575,12 +575,12 @@ void logexp(ref CodeBuilder cdb, elem *e, int jcond, FL fltarg, code *targ)
 
             case OPcond:
             {
-                code *cnop2 = gennop(null);   // addresses of start of leaves
-                code *cnop = gennop(null);
+                code* cnop2 = gennop(null);   // addresses of start of leaves
+                code* cnop = gennop(null);
                 logexp(cdb, e.E1, false, FL.code, cnop2);   // eval condition
                 con_t regconold = cgstate.regcon;
                 logexp(cdb, e.E2.E1, jcond, fltarg, targ);
-                genjmp(cdb, JMP, FL.code, cast(block *) cnop); // skip second leaf
+                genjmp(cdb, JMP, FL.code, cast(block*) cnop); // skip second leaf
 
                 con_t regconsave = cgstate.regcon;
                 cgstate.regcon = regconold;
@@ -622,7 +622,7 @@ void logexp(ref CodeBuilder cdb, elem *e, int jcond, FL fltarg, code *targ)
     codelem(cgstate,cdb, e, retregs, true);         // evaluate elem
     if (no87)
         cse_flush(cdb,no87);              // flush CSE's to memory
-    genjmp(cdb, op, fltarg, cast(block *) targ); // generate jmp instruction
+    genjmp(cdb, op, fltarg, cast(block*) targ); // generate jmp instruction
     cgstate.stackclean--;
 }
 
@@ -643,7 +643,7 @@ void logexp(ref CodeBuilder cdb, elem *e, int jcond, FL fltarg, code *targ)
  */
 
 @trusted
-void loadea(ref CodeBuilder cdb,elem *e,ref code cs,uint op,reg_t reg,targ_size_t offset,
+void loadea(ref CodeBuilder cdb,elem* e,ref code cs,uint op,reg_t reg,targ_size_t offset,
             regm_t keepmsk,regm_t desmsk, RM rmx = RM.rw)
 {
     code* c, cg, cd;
@@ -886,7 +886,7 @@ void getlvalue_lsw(ref code c)
  */
 
 @trusted
-void getlvalue(ref CodeBuilder cdb,ref code pcs,elem *e,regm_t keepmsk,RM rm = RM.rw)
+void getlvalue(ref CodeBuilder cdb,ref code pcs,elem* e,regm_t keepmsk,RM rm = RM.rw)
 {
     FL fl;
     FL f;
@@ -1363,7 +1363,7 @@ void getlvalue(ref CodeBuilder cdb,ref code pcs,elem *e,regm_t keepmsk,RM rm = R
                 return Lptr();
             }
 
-            /* give up and replace *e1 with
+            /* give up and replace* e1 with
              *      MOV     idxreg,e
              *      EA =    0[idxreg]
              * pinholeopt() will usually correct the 0, we need it in case
@@ -1784,9 +1784,9 @@ void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, bool saveflag)
         cdb.gen2(op | XORPS, modregrm(3, xreg-XMM0, xreg-XMM0));      // XORPS xreg,xreg
         cdb.gen2(op | UCOMISS, modregrm(3, xreg-XMM0, reg-XMM0));     // UCOMISS xreg,reg
         if (tym == TYcfloat || tym == TYcdouble)
-        {   code *cnop = gennop(null);
-            genjmp(cdb, JNE, FL.code, cast(block *) cnop); // JNE     L1
-            genjmp(cdb,  JP, FL.code, cast(block *) cnop); // JP      L1
+        {   code* cnop = gennop(null);
+            genjmp(cdb, JNE, FL.code, cast(block*) cnop); // JNE     L1
+            genjmp(cdb,  JP, FL.code, cast(block*) cnop); // JP      L1
             reg = findreg(regm & ~mask(reg));
             cdb.gen2(op | UCOMISS, modregrm(3, xreg-XMM0, reg-XMM0)); // UCOMISS xreg,reg
             cdb.append(cnop);
@@ -1902,7 +1902,7 @@ void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, bool saveflag)
  */
 
 @trusted
-void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, ref regm_t outretregs)
+void fixresult(ref CodeBuilder cdb, elem* e, regm_t retregs, ref regm_t outretregs)
 {
     if (cgstate.AArch64)
     {
@@ -2112,7 +2112,7 @@ int clib_inited = false;          // true if initialized
 
 Symbol* symboly(string name, regm_t desregs)
 {
-    Symbol *s = symbol_calloc(name);
+    Symbol* s = symbol_calloc(name);
     s.Stype = tsclib;
     s.Sclass = SC.extern_;
     s.Sfl = FL.func;
@@ -3025,7 +3025,7 @@ FuncParamRegs FuncParamRegs_create(tym_t tyf)
 }
 
 /*****************************************
- * Allocate parameter of type t and ty to registers *preg1 and *preg2.
+ * Allocate parameter of type t and ty to registers* preg1 and* preg2.
  * Params:
  *      fpr = context
  *      t = type, valid only if ty is TYstruct or TYarray
@@ -3351,7 +3351,7 @@ void cdfunc(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 
     // Easier to deal with parameters as an array: parameters[0..np]
     int np = OTbinary(e.Eoper) ? el_nparams(e.E2) : 0;
-    Parameter *parameters = cast(Parameter *)alloca(np * Parameter.sizeof);
+    Parameter* parameters = cast(Parameter*)alloca(np * Parameter.sizeof);
 
     if (np)
     {
@@ -3360,7 +3360,7 @@ void cdfunc(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
         assert(n == np);
     }
 
-    Symbol *sf = null;                  // symbol of the function being called
+    Symbol* sf = null;                  // symbol of the function being called
     if (e.E1.Eoper == OPvar)
         sf = e.E1.Vsym;
 
@@ -3388,7 +3388,7 @@ void cdfunc(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
     FuncParamRegs fpr = FuncParamRegs_create(tyf);
     for (int i = np; --i >= 0;)
     {
-        elem *ep = parameters[i].e;
+        elem* ep = parameters[i].e;
         uint psize = cast(uint)_align(stackalign, paramsize(ep, tyf));     // align on stack boundary
         if (config.exe == EX_WIN64)
         {
@@ -3978,7 +3978,7 @@ private void funccall(ref CodeBuilder cdb, elem* e, uint numpara, uint numalign,
         if (e1.Eoper != OPind) { printf("e1.fl: %s, e1.Eoper: %s\n", fl_str(el_fl(e1)), oper_str(e1.Eoper)); }
         save87(cdb);                   // assume 8087 regs are all trashed
         assert(e1.Eoper == OPind);
-        elem *e11 = e1.E1;
+        elem* e11 = e1.E1;
         tym_t e11ty = tybasic(e11.Ety);
         assert(!I16 || (e11ty == (farfunc ? TYfptr : TYnptr)));
         load_localgot(cdb);
@@ -4317,7 +4317,7 @@ private void movParams(ref CodeBuilder cdb, elem* e, uint stackalign, uint funca
                 cs.IFL1 = FL.funcarg;
                 cs.IEV1.Voffset = funcargtos - sz;
                 cs.IFL2 = FL.const_;
-                targ_size_t *p = cast(targ_size_t *) &(e.EV);
+                targ_size_t* p = cast(targ_size_t*) &(e.EV);
                 cs.IEV2.Vsize_t = *p;
                 if (I64 && tym == TYcldouble)
                     // The alignment of EV.Vcldouble is not the same on the compiler
@@ -4334,10 +4334,10 @@ private void movParams(ref CodeBuilder cdb, elem* e, uint stackalign, uint funca
                             // MOV EA,reg
                             goto Lbreak;
                         }
-                        p = cast(targ_size_t *)(cast(char *) p + REGSIZE);
+                        p = cast(targ_size_t*)(cast(char*) p + REGSIZE);
                         i -= REGSIZE;
                     } while (i > 0);
-                    p = cast(targ_size_t *) &(e.EV);
+                    p = cast(targ_size_t*) &(e.EV);
                 }
 
                 int i = cast(int)sz;
@@ -4358,7 +4358,7 @@ private void movParams(ref CodeBuilder cdb, elem* e, uint stackalign, uint funca
                         cs.Irex |= REX_W;
                     cdb.gen(&cs);           // MOV EA,const
 
-                    p = cast(targ_size_t *)(cast(char *) p + regsize);
+                    p = cast(targ_size_t*)(cast(char*) p + regsize);
                     cs.Iop = 0xC7;
                     cs.Irm &= cast(ubyte)~cast(int)modregrm(0, 7, 0);
                     cs.Irex &= ~REX_R;
@@ -4663,14 +4663,14 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
                 code* c3 = cdb.last();
                 cdb.genc2(0x81,grex | buildModregrm(3, 5,reg), pushsize);  // SUB reg,pushsize
                 if (I16 || config.flags4 & CFG4space)
-                    genjmp(cdb,0xE2,FL.code,cast(block *)c3);// LOOP c3
+                    genjmp(cdb,0xE2,FL.code,cast(block*)c3);// LOOP c3
                 else
                 {
                     if (I64)
                         cdb.gen2(0xFF, modregrm(3, 1, CX));// DEC CX
                     else
                         cdb.gen1(0x48 + CX);            // DEC CX
-                    genjmp(cdb, JNE, FL.code, cast(block *)c3); // JNE c3
+                    genjmp(cdb, JNE, FL.code, cast(block*)c3); // JNE c3
                 }
                 cgstate.regimmed_set(CX,0);
                 cdb.genadjesp(cast(int)sz);
@@ -4681,7 +4681,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
         }
 
         case OPind:
-            if (!e.Ecount)                         /* if *e1       */
+            if (!e.Ecount)                         /* if* e1       */
             {
                 if (sz < REGSIZE)
                 {
@@ -4928,8 +4928,8 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
             cgstate.stackpush += sz;
             cdb.genadjesp(cast(int)sz);
             targ_uns* pi = &e.Vuns;     // point to start of Vdouble
-            targ_ushort* ps = cast(targ_ushort *) pi;
-            targ_ullong* pl = cast(targ_ullong *)pi;
+            targ_ushort* ps = cast(targ_ushort*) pi;
+            targ_ullong* pl = cast(targ_ullong*)pi;
             i /= regsize;
             do
             {
@@ -5252,7 +5252,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
     cs.Irex = 0;
     if (outretregs == mPSW)
     {
-        Symbol *s;
+        Symbol* s;
         regm = cgstate.allregs;
         if (e.Eoper == OPconst)
         {       /* true:        OR SP,SP        (SP is never 0)         */
@@ -5303,7 +5303,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
 
                 // Convert to TEST instruction if EA is a register
                 // (to avoid register contention on Pentium)
-                code *c = cdb.last();
+                code* c = cdb.last();
                 if ((c.Iop & ~1) == 0x38 &&
                     (c.Irm & modregrm(3, 0, 0)) == modregrm(3, 0, 0)
                    )
@@ -5340,7 +5340,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
             while ((i -= REGSIZE) >= 0)
             {
                 loadea(cdb, e, cs, 0x0B, reg, i, regm, 0); // OR reg,data+i
-                code *c = cdb.last();
+                code* c = cdb.last();
                 if (i == 0)
                     c.Iflags |= CFpsw;                      // need the flags on last OR
             }
@@ -5431,7 +5431,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
         {
             if (I32)
             {
-                targ_long *p = cast(targ_long *)cast(void*)&e.Vdouble;
+                targ_long* p = cast(targ_long*)cast(void*)&e.Vdouble;
                 if (isXMMreg(reg))
                 {   /* This comes about because 0, 1, pi, etc., constants don't get stored
                      * in the data segment, because they are x87 opcodes.
@@ -5454,7 +5454,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
                 }
             }
             else
-            {   targ_short *p = &e.Vshort;  // point to start of Vdouble
+            {   targ_short* p = &e.Vshort;  // point to start of Vdouble
 
                 assert(reg == AX);
                 movregconst(cdb, AX, p[3], 0);   // MOV AX,p[3]
@@ -5556,7 +5556,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
             opcode_t opmv = xmmload(tym, xmmIsAligned(e));
             if (e.Eoper == OPvar)
             {
-                Symbol *s = e.Vsym;
+                Symbol* s = e.Vsym;
                 if (s.Sfl == FL.reg && !(mask(s.Sreglsw) & XMMREGS))
                 {   opmv = LODD;          // MOVD/MOVQ
                     /* getlvalue() will unwind this and unregister s; could use a better solution */

--- a/compiler/src/dmd/backend/x86/cod2.d
+++ b/compiler/src/dmd/backend/x86/cod2.d
@@ -64,7 +64,7 @@ private void swap(ref reg_t a, ref reg_t b)
  */
 
 @trusted
-bool movOnly(const elem *e)
+bool movOnly(const elem* e)
 {
     if (config.exe & EX_OSX64 && config.flags3 & CFG3pic && e.Eoper == OPvar)
     {
@@ -122,7 +122,7 @@ regm_t idxregm(const code* c)
  */
 
 @trusted
-void opdouble(ref CodeBuilder cdb, elem *e,ref regm_t pretregs,uint clib)
+void opdouble(ref CodeBuilder cdb, elem* e,ref regm_t pretregs,uint clib)
 {
     if (config.inline8087)
     {
@@ -164,14 +164,14 @@ void opdouble(ref CodeBuilder cdb, elem *e,ref regm_t pretregs,uint clib)
  */
 
 @trusted
-void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdorth(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cdorth(cg, cdb, e, pretregs);
 
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     if (pretregs == 0)                   // if don't want result
     {
         codelem(cgstate,cdb,e1,pretregs,false); // eval left leaf
@@ -390,8 +390,8 @@ void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
             !e1.Ecount
            )
         {
-            elem *ebase;
-            elem *edisp;
+            elem* ebase;
+            elem* edisp;
             if (e2oper == OPconst && el_signx32(e2))
             {   edisp = e2;
                 ebase = e1.E2;
@@ -632,7 +632,7 @@ void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                  regm != retregs &&
                  _tysize[ty1] == _tysize[ty2])
         {
-            elem *es = e1;
+            elem* es = e1;
             e1 = e2;
             e2 = es;
         }
@@ -888,14 +888,14 @@ void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdmul(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdmul(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cdmul(cg, cdb, e, pretregs);
 
     //printf("cdmul()\n");
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     if (pretregs == 0)                         // if don't want result
     {
         codelem(cgstate,cdb,e1,pretregs,false);      // eval left leaf
@@ -1277,14 +1277,14 @@ void cdmul(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cddiv(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cddiv(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cddiv(cg, cdb, e, pretregs);
 
     //printf("cddiv()\n");
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     if (pretregs == 0)                         // if don't want result
     {
         codelem(cgstate,cdb,e1,pretregs,false);      // eval left leaf
@@ -1991,13 +1991,13 @@ void cddiv(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdnot(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdnot(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdnot()\n");
     reg_t reg;
     regm_t forflags;
     regm_t retregs;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
 
     if (pretregs == 0)
         goto L1;
@@ -2134,8 +2134,8 @@ void cdnot(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         return;
     }
     }
-    code *cnop = gennop(null);
-    code *ctrue = gennop(null);
+    code* cnop = gennop(null);
+    code* ctrue = gennop(null);
     logexp(cdb,e.E1,(op == OPnot) ? false : true,FL.code,ctrue);
     forflags = pretregs & mPSW;
     if (I64 && sz == 8)
@@ -2144,11 +2144,11 @@ void cdnot(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     CodeBuilder cdbfalse;
     cdbfalse.ctor();
     reg = allocreg(cdbfalse,pretregs,e.Ety);        // allocate reg for result
-    code *cfalse = cdbfalse.finish();
+    code* cfalse = cdbfalse.finish();
     CodeBuilder cdbtrue;
     cdbtrue.ctor();
     cdbtrue.append(ctrue);
-    for (code *c1 = cfalse; c1; c1 = code_next(c1))
+    for (code* c1 = cfalse; c1; c1 = code_next(c1))
         cdbtrue.gen(c1);                                      // duplicate reg save code
     CodeBuilder cdbfalse2;
     cdbfalse2.ctor();
@@ -2156,7 +2156,7 @@ void cdnot(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     cgstate.regcon.immed.mval &= ~mask(reg);                          // mark reg as unavail
     movregconst(cdbtrue,reg,1,forflags);                      // mov 1 into reg
     cgstate.regcon.immed.mval &= ~mask(reg);                          // mark reg as unavail
-    genjmp(cdbfalse2,JMP,FL.code,cast(block *) cnop);          // skip over ctrue
+    genjmp(cdbfalse2,JMP,FL.code,cast(block*) cnop);          // skip over ctrue
     cdb.append(cfalse);
     cdb.append(cdbfalse2);
     cdb.append(cdbtrue);
@@ -2169,7 +2169,7 @@ void cdnot(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdcom(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdcom(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cdcom(cg, cdb, e, pretregs);
@@ -2218,7 +2218,7 @@ void cdcom(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdbswap(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdbswap(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cdbswap(cg, cdb, e, pretregs);
@@ -2274,7 +2274,7 @@ void cdbswap(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cdcond(cg, cdb, e, pretregs);
@@ -2284,10 +2284,10 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     NDP[global87.stack.length] _8087save;
 
     //printf("cdcond(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
-    elem *e21 = e2.E1;
-    elem *e22 = e2.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
+    elem* e21 = e2.E1;
+    elem* e22 = e2.E2;
     regm_t psw = pretregs & mPSW;               /* save PSW bit                 */
     const op1 = e1.Eoper;
     uint sz1 = tysize(e1.Ety);
@@ -2303,12 +2303,12 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         sz1 <= REGSIZE && !tyfloating(e1.Ety))
     {   // Recognize (e ? e : f)
 
-        code *cnop1 = gennop(null);
+        code* cnop1 = gennop(null);
         regm_t retregs = pretregs | mPSW;
         codelem(cgstate,cdb,e1,retregs,false);
 
         cse_flush(cdb,1);                // flush CSEs to memory
-        genjmp(cdb,jop,FL.code,cast(block *)cnop1);
+        genjmp(cdb,jop,FL.code,cast(block*)cnop1);
         freenode(e21);
 
         const regconsave = cgstate.regcon;
@@ -2440,7 +2440,7 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         tysize(e21.Ety) <= REGSIZE && !tyfloating(e21.Ety))
     {   // Recognize (e ? c : f)
 
-        code *cnop1 = gennop(null);
+        code* cnop1 = gennop(null);
         regm_t retregs = mPSW;
         jop = jmpopcode(e1);            // get jmp condition
         codelem(cgstate,cdb,e1,retregs,false);
@@ -2455,7 +2455,7 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         retregs = mask(reg);
 
         cse_flush(cdb,1);                // flush CSE's to memory
-        genjmp(cdb,jop,FL.code,cast(block *)cnop1);
+        genjmp(cdb,jop,FL.code,cast(block*)cnop1);
         freenode(e21);
 
         const regconsave = cgstate.regcon;
@@ -2473,8 +2473,8 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         return;
     }
 
-    code *cnop1 = gennop(null);
-    code *cnop2 = gennop(null);         // dummy target addresses
+    code* cnop1 = gennop(null);
+    code* cnop2 = gennop(null);         // dummy target addresses
     logexp(cdb,e1,false,FL.code,cnop1);  // evaluate condition
     const regconold = cgstate.regcon;
     const stackusedold = global87.stackused;
@@ -2544,7 +2544,7 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     assert(cgstate.stackpush == stackpushsave);
     memcpy(global87.stack.ptr,_8087save.ptr,global87.stack.sizeof);
     freenode(e2);
-    genjmp(cdb,JMP,FL.code,cast(block *) cnop2);
+    genjmp(cdb,JMP,FL.code,cast(block*) cnop2);
     cdb.append(cnop1);
     cdb.append(cdb2);
     cdb.append(cnop2);
@@ -2559,7 +2559,7 @@ void cdcond(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdcomma(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdcomma(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     regm_t retregs = 0;
     codelem(cgstate,cdb,e.E1,retregs,false);   // ignore value from left leaf
@@ -2588,7 +2588,7 @@ void cdcomma(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cdloglog(cg, cdb, e, pretregs);
@@ -2602,12 +2602,12 @@ void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
 
     //printf("cdloglog() pretregs: %s\n", regm_str(pretregs));
     cgstate.stackclean++;
-    code *cnop1 = gennop(null);
+    code* cnop1 = gennop(null);
     CodeBuilder cdb1;
     cdb1.ctor();
     cdb1.append(cnop1);
-    code *cnop3 = gennop(null);
-    elem *e2 = e.E2;
+    code* cnop3 = gennop(null);
+    elem* e2 = e.E2;
     (e.Eoper == OPoror)
         ? logexp(cdb,e.E1,1,FL.code,cnop1)
         : logexp(cdb,e.E1,0,FL.code,cnop3);
@@ -2654,7 +2654,7 @@ void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         return;
     }
 
-    code *cnop2 = gennop(null);
+    code* cnop2 = gennop(null);
     uint sz = tysize(e.Ety);
     if (tybasic(e2.Ety) == TYbool &&
       sz == tysize(e2.Ety) &&
@@ -2677,13 +2677,13 @@ void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         if (e.Eoper == OPoror)
         {
             cdb.append(cnop3);
-            genjmp(cdb,JMP,FL.code,cast(block *) cnop2);    // JMP cnop2
+            genjmp(cdb,JMP,FL.code,cast(block*) cnop2);    // JMP cnop2
             cdb.append(cdb1);
             cdb.append(cnop2);
         }
         else
         {
-            genjmp(cdb,JMP,FL.code,cast(block *) cnop2);    // JMP cnop2
+            genjmp(cdb,JMP,FL.code,cast(block*) cnop2);    // JMP cnop2
             cdb.append(cnop3);
             cdb.append(cdb1);
             cdb.append(cnop2);
@@ -2705,14 +2705,14 @@ void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     CodeBuilder cdbcg;
     cdbcg.ctor();
     const reg = allocreg(cdbcg,retregs,TYint);               // allocate reg for result
-    code *cd = cdbcg.finish();
-    for (code *c1 = cd; c1; c1 = code_next(c1))              // for each instruction
+    code* cd = cdbcg.finish();
+    for (code* c1 = cd; c1; c1 = code_next(c1))              // for each instruction
         cdb1.gen(c1);                                        // duplicate it
     CodeBuilder cdbcg2;
     cdbcg2.ctor();
     movregconst(cdbcg2,reg,0,pretregs & mPSW);              // MOV reg,0
     cgstate.regcon.immed.mval &= ~mask(reg);                 // mark reg as unavail
-    genjmp(cdbcg2, JMP,FL.code,cast(block *) cnop2);          // JMP cnop2
+    genjmp(cdbcg2, JMP,FL.code,cast(block*) cnop2);          // JMP cnop2
     movregconst(cdb1,reg,1,pretregs & mPSW);                // reg = 1
     cgstate.regcon.immed.mval &= ~mask(reg);                 // mark reg as unavail
     pretregs = retregs;
@@ -2730,7 +2730,7 @@ void cdloglog(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdshift(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdshift(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cdshift(cg, cdb, e, pretregs);
@@ -2740,7 +2740,7 @@ void cdshift(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     uint shiftcnt;
     regm_t retregs,rretregs;
 
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (pretregs == 0)                   // if don't want result
     {
         codelem(cgstate,cdb,e1,pretregs,false); // eval left leaf
@@ -2781,7 +2781,7 @@ void cdshift(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     }
 
     reg_t sreg = NOREG;                   // guard against using value without assigning to sreg
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     regm_t forccs = pretregs & mPSW;            // if return result in CCs
     regm_t forregs = pretregs & (ALLREGS | mBP); // mask of possible return regs
     bool e2isconst = false;                    // assume for the moment
@@ -3137,7 +3137,7 @@ void cdshift(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                         genmovreg(cdb1,hreg,lreg);
                         genregs(cdb1,0x31,lreg,lreg);
 
-                        genjmp(cdb,JNE,FL.code,cast(block *)cl1);
+                        genjmp(cdb,JNE,FL.code,cast(block*)cl1);
                         cdb.gen2(0x0FA5,modregrm(3,lreg,hreg));
                         cdb.gen2(0xD3,modregrm(3,4,lreg));
                     }
@@ -3182,12 +3182,12 @@ void cdshift(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                             genmovreg(cdb1,lreg,hreg);
                             genregs(cdb1,0x31,hreg,hreg);
                         }
-                        genjmp(cdb,JNE,FL.code,cast(block *)cl1);
+                        genjmp(cdb,JNE,FL.code,cast(block*)cl1);
                         cdb.gen2(0x0FAD,modregrm(3,hreg,lreg));
                         cdb.gen2(0xD3,modregrm(3,s1,hreg));
                     }
                     cl2 = gennop(null);
-                    genjmp(cdb,JMPS,FL.code,cast(block *)cl2);
+                    genjmp(cdb,JMPS,FL.code,cast(block*)cl2);
                     cdb.append(cdb1);
                     cdb.append(cl2);
                 }
@@ -3220,7 +3220,7 @@ void cdshift(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdind(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdind(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cdind(cg, cdb, e, pretregs);
@@ -3256,7 +3256,7 @@ void cdind(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         }
     }
 
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     assert(e1);
     switch (tym)
     {
@@ -3436,7 +3436,7 @@ void cdind(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                     retregs |= mLSW & ~idxregs;
 
                     // We can run out of registers, so if that's possible,
-                    // give us *one* of the idxregs
+                    // give us* one* of the idxregs
                     if ((retregs & ~cgstate.regcon.mvar & mLSW) == 0)
                     {
                         regm_t x = idxregs & mLSW;
@@ -3520,7 +3520,7 @@ void cdind(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-private code *cod2_setES(tym_t ty)
+private code* cod2_setES(tym_t ty)
 {
     if (config.exe & EX_flat)
         return null;
@@ -3562,7 +3562,7 @@ private code *cod2_setES(tym_t ty)
  */
 
 @trusted
-void cdstrlen(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdstrlen(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     /* Generate strlen in CX:
         LES     DI,e1
@@ -3611,7 +3611,7 @@ void cdstrlen(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  */
 
 @trusted
-void cdstrcmp(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdstrcmp(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     char need_DS;
     int segreg;
@@ -3699,10 +3699,10 @@ void cdstrcmp(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
     cdb.gen1(0xA6);                              // CMPSB
     if (need_DS)
         cdb.gen1(0x1F);                          // POP DS
-    code *c4 = gennop(null);
+    code* c4 = gennop(null);
     if (pretregs != mPSW)                       // if not flags only
     {
-        genjmp(cdb,JE,FL.code,cast(block *) c4);      // JE L1
+        genjmp(cdb,JE,FL.code,cast(block*) c4);      // JE L1
         getregs(cdb,mAX);
         genregs(cdb,0x1B,AX,AX);                 // SBB AX,AX
         code_orrex(cdb.last(),rex);
@@ -3719,7 +3719,7 @@ void cdstrcmp(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  */
 
 @trusted
-void cdmemcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdmemcmp(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     char need_DS;
     int segreg;
@@ -3740,7 +3740,7 @@ void cdmemcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     L1:
     */
 
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     assert(e1.Eoper == OPparam);
 
     // Get s1 into DX:SI
@@ -3819,8 +3819,8 @@ void cdmemcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         cdb.gen1(0x1F);                         // POP DS
     if (pretregs != mPSW)                      // if not flags only
     {
-        code *c4 = gennop(null);
-        genjmp(cdb,JE,FL.code,cast(block *) c4);  // JE L1
+        code* c4 = gennop(null);
+        genjmp(cdb,JE,FL.code,cast(block*) c4);  // JE L1
         getregs(cdb,mAX);
         genregs(cdb,0x1B,AX,AX);             // SBB AX,AX
         cdb.genc2(0x81,modregrm(3,3,AX),cast(targ_uns)-1);    // SBB AX,-1
@@ -3836,7 +3836,7 @@ void cdmemcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdstrcpy(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdstrcpy(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     char need_DS;
     int segreg;
@@ -3949,7 +3949,7 @@ void cdstrcpy(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdmemcpy(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdmemcpy(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     char need_DS;
     int segreg;
@@ -3966,7 +3966,7 @@ void cdmemcpy(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         POP     DS
     */
 
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     assert(e2.Eoper == OPparam);
 
     // Get s2 into DX:SI
@@ -4056,15 +4056,15 @@ void cdmemcpy(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         getregs(cdb,mSI | mDI | mCX | mDX);
         genmovreg(cdb,DX,CX);                  // MOV EDX,ECX
         cdb.genc2(0xC1,modregrm(3,5,CX),2);                 // SHR ECX,2
-        code *cx = gennop(null);
-        genjmp(cdb, JE, FL.code, cast(block *)cx);  // JZ L1
+        code* cx = gennop(null);
+        genjmp(cdb, JE, FL.code, cast(block*)cx);  // JZ L1
         cdb.gen1(0xF3);                                     // REPE
         cdb.gen1(0xA5);                                     // MOVSW
         cdb.append(cx);
         cdb.genc2(0x81, modregrm(3,4,DX),3);                // AND EDX,3
 
-        code *cnop = gennop(null);
-        genjmp(cdb, JE, FL.code, cast(block *)cnop);  // JZ L2
+        code* cnop = gennop(null);
+        genjmp(cdb, JE, FL.code, cast(block*)cnop);  // JZ L2
         genmovreg(cdb,CX,DX);                    // MOV ECX,EDX
         cdb.gen1(0xF3);                          // REPE
         cdb.gen1(0xA4);                          // MOVSB
@@ -4080,7 +4080,7 @@ void cdmemcpy(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
             gentstreg(cdb,CX);                           // TEST ECX,ECX
             if (I64)
                 code_orrex(cdb.last, REX_W);
-            genjmp(cdb, JE, FL.code, cast(block *)cnop);  // JZ cnop
+            genjmp(cdb, JE, FL.code, cast(block*)cnop);  // JZ cnop
         }
 
         if (I16 && config.flags4 & CFG4speed)          // if speed optimization
@@ -4108,7 +4108,7 @@ void cdmemcpy(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdmemset(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdmemset(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     regm_t retregs1;
     regm_t retregs3;
@@ -4120,7 +4120,7 @@ void cdmemset(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     uint m;
 
     //printf("cdmemset(pretregs = %s)\n", regm_str(pretregs));
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     assert(e2.Eoper == OPparam);
 
     elem* evalue = e2.E2;
@@ -4312,10 +4312,10 @@ void cdmemset(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  * Doesn't work for 16 bit code.
  */
 @trusted
-private void cdmemsetn(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+private void cdmemsetn(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdmemsetn(pretregs = %s)\n", regm_str(pretregs));
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     assert(e2.Eoper == OPparam);
 
     elem* evalue = e2.E2;
@@ -4395,7 +4395,7 @@ private void cdmemsetn(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pr
      *  NOP
      */
     code* c1 = gennop(null);
-    genjmp(cdb, JCXZ, FL.code, cast(block *)c1);
+    genjmp(cdb, JCXZ, FL.code, cast(block*)c1);
     code cs;
     buildEA(&cs,idxreg,-1,1,0);
     cs.Iop = 0x89;
@@ -4413,7 +4413,7 @@ private void cdmemsetn(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pr
         cdb.gen(&cs);                                   // MOV REGSIZE[idxreg],DX
     }
     cdb.genc2(0x81, grex | modregrmx(3,0,idxreg), sz);  // ADD idxreg,sz
-    genjmp(cdb, LOOP, FL.code, cast(block *)c2);         // LOOP L2
+    genjmp(cdb, LOOP, FL.code, cast(block*)c2);         // LOOP L2
     cdb.append(c1);
 
     cgstate.regimmed_set(CX, 0);                  // CX is now 0
@@ -4428,11 +4428,11 @@ private void cdmemsetn(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pr
  */
 
 @trusted
-void cdstreq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdstreq(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     char need_DS = false;
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     int segreg;
     uint numbytes = cast(uint)type_size(e.ET);          // # of bytes in structure/union
     ubyte rex = I64 ? REX_W : 0;
@@ -4443,7 +4443,7 @@ void cdstreq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     regm_t srcregs = mSI;                      // source is DS:SI
     docommas(cdb,e2);
     if (e2.Eoper == OPind)             // if (.. = *p)
-    {   elem *e21 = e2.E1;
+    {   elem* e21 = e2.E1;
 
         segreg = SEG_DS;
         switch (tybasic(e21.Ety))
@@ -4637,7 +4637,7 @@ else
  */
 
 @trusted
-void cdrelconst(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdrelconst(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdrelconst(e = %p, pretregs = %s)\n", e, regm_str(pretregs));
 
@@ -4707,7 +4707,7 @@ void cdrelconst(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         /* if (get segment of function that isn't necessarily in the
          * current segment (i.e. CS doesn't have the right value in it)
          */
-        Symbol *s = e.Vsym;
+        Symbol* s = e.Vsym;
         if (s.Sfl == FL.datseg)
         {   assert(0);
         }
@@ -4740,7 +4740,7 @@ void cdrelconst(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void getoffset(ref CGstate cg, ref CodeBuilder cdb,elem *e,reg_t reg)
+void getoffset(ref CGstate cg, ref CodeBuilder cdb,elem* e,reg_t reg)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.getoffset(cg, cdb, e, reg);
@@ -4985,7 +4985,7 @@ void getoffset(ref CGstate cg, ref CodeBuilder cdb,elem *e,reg_t reg)
  */
 
 @trusted
-void cdneg(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdneg(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cdneg(cg, cdb, e, pretregs);
@@ -5073,7 +5073,7 @@ void cdneg(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
 
 
 @trusted
-void cdabs(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
+void cdabs(ref CGstate cg, ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
 {
     //printf("cdabs(e = %p, pretregs = %s)\n", e, regm_str(pretregs));
     if (cg.AArch64)
@@ -5177,11 +5177,11 @@ void cdabs(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
             L2:
          */
 
-        code *cnop = gennop(null);
+        code* cnop = gennop(null);
         const msreg = findregmsw(retregs);
         const lsreg = findreglsw(retregs);
         genregs(cdb,0x09,msreg,msreg);            // OR msreg,msreg
-        genjmp(cdb,JNS,FL.code,cast(block *)cnop);
+        genjmp(cdb,JNS,FL.code,cast(block*)cnop);
         cdb.gen2(0xF7,modregrm(3,3,msreg));       // NEG msreg
         cdb.gen2(0xF7,modregrm(3,3,lsreg));       // NEG lsreg+1
         cdb.genc2(0x81,modregrm(3,3,msreg),0);    // SBB msreg,0
@@ -5197,7 +5197,7 @@ void cdabs(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
  */
 
 @trusted
-void cdpost(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdpost(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -5215,7 +5215,7 @@ void cdpost(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     }
     const tym_t tyml = tybasic(e.E1.Ety);
     const sz = _tysize[tyml];
-    elem *e2 = e.E2;
+    elem* e2 = e.E2;
     const rex = (I64 && sz == 8) ? REX_W : 0;
 
     if (tyfloating(tyml))
@@ -5602,7 +5602,7 @@ if (config.exe & EX_windos)
 }
 
 
-void cderr(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cderr(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     debug
         elem_print(e);
@@ -5614,7 +5614,7 @@ void cderr(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
 }
 
 @trusted
-void cdinfo(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdinfo(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     switch (e.E1.Eoper)
     {
@@ -5634,7 +5634,7 @@ void cdinfo(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cddctor(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cddctor(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     /* Generate:
         PSOP.dctor
@@ -5663,7 +5663,7 @@ void cddctor(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdddtor(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdddtor(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (config.ehmethod == EHmethod.EH_DWARF)
     {
@@ -5721,7 +5721,7 @@ void cdddtor(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         cdbx.ctor();
         codelem(cgstate,cdbx,e.E1,pretregs,false);
         cdbx.gen1(0xC3);                      // RET
-        code *c = cdbx.finish();
+        code* c = cdbx.finish();
 
         int nalign = 0;
         if (STACKALIGN >= 16)
@@ -5730,13 +5730,13 @@ void cdddtor(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
             cod3_stackadj(cdb, nalign);
         }
         cgstate.calledafunc = 1;
-        genjmp(cdb,0xE8,FL.code,cast(block *)c);   // CALL Ldtor
+        genjmp(cdb,0xE8,FL.code,cast(block*)c);   // CALL Ldtor
         if (nalign)
             cod3_stackadj(cdb, -nalign);
 
-        code *cnop = gennop(null);
+        code* cnop = gennop(null);
 
-        genjmp(cdb,JMP,FL.code,cast(block *)cnop);
+        genjmp(cdb,JMP,FL.code,cast(block*)cnop);
         cdb.append(cdbx);
         cdb.append(cnop);
         return;
@@ -5747,24 +5747,24 @@ void cdddtor(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
 /*******************************************
  * C++ constructor.
  */
-void cdctor(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdctor(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
 }
 
 /******
  * OPdtor
  */
-void cddtor(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cddtor(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
 }
 
-void cdmark(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdmark(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
 }
 
 static if (!NTEXCEPTIONS)
 {
-void cdsetjmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdsetjmp(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     assert(0);
 }
@@ -5774,7 +5774,7 @@ void cdsetjmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdvoid(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdvoid(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     assert(pretregs == 0);
     codelem(cgstate,cdb,e.E1,pretregs,false);
@@ -5784,7 +5784,7 @@ void cdvoid(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdhalt(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdhalt(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
         return dmd.backend.arm.cod2.cdhalt(cg, cdb, e, pretregs);

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -263,7 +263,7 @@ void REGSAVE_restore(const ref REGSAVE regsave, ref CodeBuilder cdb, reg_t reg, 
  */
 
 @trusted
-ubyte vex_inssize(code *c)
+ubyte vex_inssize(code* c)
 {
     assert(c.Iflags & CFvex && c.Ivex.pfx == 0xC4);
     ubyte ins;
@@ -853,7 +853,7 @@ void cgreg_set_priorities(tym_t ty, const(reg_t)** pseq, const(reg_t)** pseqmsw)
  *      code generated
  */
 @trusted
-private code *callFinallyBlock(block *bf, regm_t retregs)
+private code* callFinallyBlock(block* bf, regm_t retregs)
 {
     CodeBuilder cdbs; cdbs.ctor();
     CodeBuilder cdbr; cdbr.ctor();
@@ -881,11 +881,11 @@ private code *callFinallyBlock(block *bf, regm_t retregs)
  * Generate block exit code
  */
 @trusted
-void outblkexitcode(ref CodeBuilder cdb, block *bl, ref int anyspill, const(FL)* sflsave, Symbol** retsym, const regm_t mfuncregsave)
+void outblkexitcode(ref CodeBuilder cdb, block* bl, ref int anyspill, const(FL)* sflsave, Symbol** retsym, const regm_t mfuncregsave)
 {
     CodeBuilder cdb2; cdb2.ctor();
-    elem *e = bl.Belem;
-    block *nextb;
+    elem* e = bl.Belem;
+    block* nextb;
     regm_t retregs = 0;
 
     if (bl.bc != BC.asm_)
@@ -896,18 +896,18 @@ void outblkexitcode(ref CodeBuilder cdb, block *bl, ref int anyspill, const(FL)*
         case BC.iftrue:
         {
             bool jcond = true;
-            block *bs1 = bl.nthSucc(0);
-            block *bs2 = bl.nthSucc(1);
+            block* bs1 = bl.nthSucc(0);
+            block* bs2 = bl.nthSucc(1);
             if (bs1 == bl.Bnext)
             {   // Swap bs1 and bs2
-                block *btmp;
+                block* btmp;
 
                 jcond ^= 1;
                 btmp = bs1;
                 bs1 = bs2;
                 bs2 = btmp;
             }
-            logexp(cdb,e,jcond,FL.block,cast(code *) bs1);
+            logexp(cdb,e,jcond,FL.block,cast(code*) bs1);
             nextb = bs2;
         }
         L5:
@@ -980,12 +980,12 @@ void outblkexitcode(ref CodeBuilder cdb, block *bl, ref int anyspill, const(FL)*
                 if (toindex + 1 <= fromindex)
                 {
                     //c = cat(c, linux_unwind(0, toindex));
-                    block *bt;
+                    block* bt;
 
                     //printf("B%d: fromindex = %d, toindex = %d\n", bl.Bdfoidx, fromindex, toindex);
                     bt = bl;
                     while ((bt = bt.Btry) != null && bt.Bscope_index != toindex)
-                    {   block *bf;
+                    {   block* bf;
 
                         //printf("\tbt.Bscope_index = %d, bt.Blast_index = %d\n", bt.Bscope_index, bt.Blast_index);
                         bf = bt.nthSucc(1);
@@ -1018,7 +1018,7 @@ void outblkexitcode(ref CodeBuilder cdb, block *bl, ref int anyspill, const(FL)*
                 CodeBuilder cdbload;  cdbload.ctor();
 
                 for (int i = 0; i < anyspill; i++)
-                {   Symbol *s = globsym[i];
+                {   Symbol* s = globsym[i];
 
                     if (s.Sflags & SFLspill &&
                         vec_testbit(cgstate.dfoidx,s.Srange))
@@ -1181,7 +1181,7 @@ static if (NTEXCEPTIONS)
                     gencodelem(cdb,e,retregs,true);
                     cgstate.regcon.used = usedsave;
                     if (e.Eoper == OPvar)
-                    {   Symbol *s = e.Vsym;
+                    {   Symbol* s = e.Vsym;
 
                         if (s.Sfl == FL.reg && s.Sregm != mAX)
                             *retsym = s;
@@ -1265,10 +1265,10 @@ static if (NTEXCEPTIONS)
 
             if (MARS || cgstate.usednteh & NTEH_try)
             {
-                block *bt = bl;
+                block* bt = bl;
                 while ((bt = bt.Btry) != null)
                 {
-                    block *bf = bt.nthSucc(1);
+                    block* bf = bt.nthSucc(1);
                     // Only look at try-finally blocks
                     if (bf.bc == BC.jcatch)
                     {
@@ -1319,7 +1319,7 @@ static if (NTEXCEPTIONS)
             CodeBuilder cdbx; cdbx.ctor();
             cgstate.refparam |= bl.bIasmrefparam;
             getregs(cdbx, iasm_regs(bl));         // mark destroyed registers
-            code *c = cdbx.finish();
+            code* c = cdbx.finish();
             if (bl.Bsucc)
             {   nextb = bl.nthSucc(0);
                 if (!bl.Bnext)
@@ -1335,7 +1335,7 @@ static if (NTEXCEPTIONS)
                      nextb == bl.Bnext.nthSucc(0)))
                 {
                     // See if already have JMP at end of block
-                    code *cl = code_last(bl.Bcode);
+                    code* cl = code_last(bl.Bcode);
                     if (!cl || cl.Iop != JMP)
                     {
                         cdb.append(bl.Bcode);
@@ -1557,7 +1557,7 @@ extern(C) void qsort(void* base, size_t nmemb, size_t size, _compare_fp_t compar
 struct CaseVal
 {
     targ_ullong val;
-    block *target;
+    block* target;
 
     /* Sort function for qsort() */
     @trusted
@@ -1597,8 +1597,8 @@ private void cmpval(ref CodeBuilder cdb, targ_llong val, uint sz, reg_t reg, reg
     else
     {
         cdb.genc2(0x81,modregrm(3,7,reg2),cast(targ_size_t)MSREG(val));  // CMP reg2,MSREG(casevalue)
-        code *cnext = gennop(null);
-        genjmp(cdb,JNE,FL.code,cast(block *) cnext);  // JNE cnext
+        code* cnext = gennop(null);
+        genjmp(cdb,JNE,FL.code,cast(block*) cnext);  // JNE cnext
         cdb.genc2(0x81,modregrm(3,7,reg),cast(targ_size_t)val);          // CMP reg,casevalue
         cdb.append(cnext);
     }
@@ -1606,7 +1606,7 @@ private void cmpval(ref CodeBuilder cdb, targ_llong val, uint sz, reg_t reg, reg
 
 @trusted extern (D)
 private void ifthen(ref CodeBuilder cdb, scope CaseVal[] casevals,
-        uint sz, reg_t reg, reg_t reg2, reg_t sreg, block *bdefault, bool last)
+        uint sz, reg_t reg, reg_t reg2, reg_t sreg, block* bdefault, bool last)
 {
     const ncases = casevals.length;
     if (ncases >= 4 && config.flags4 & CFG4speed)
@@ -1620,13 +1620,13 @@ private void ifthen(ref CodeBuilder cdb, scope CaseVal[] casevals,
         // Compares for casevals[pivot+1..ncases]
         CodeBuilder cdb2; cdb2.ctor();
         ifthen(cdb2, casevals[pivot + 1 .. $], sz, reg, reg2, sreg, bdefault, last);
-        code *c2 = gennop(null);
+        code* c2 = gennop(null);
 
         // Compare for caseval[pivot]
         cmpval(cdb, casevals[pivot].val, sz, reg, reg2, sreg);
         genjmp(cdb,JE,FL.block,casevals[pivot].target); // JE target
         // Note uint jump here, as cases were sorted using uint comparisons
-        genjmp(cdb,JA,FL.code,cast(block *) c2);           // JG c2
+        genjmp(cdb,JA,FL.code,cast(block*) c2);           // JG c2
 
         cdb.append(cdb1);
         cdb.append(c2);
@@ -1638,11 +1638,11 @@ private void ifthen(ref CodeBuilder cdb, scope CaseVal[] casevals,
         {
             targ_llong val = casevals[n].val;
             cmpval(cdb, val, sz, reg, reg2, sreg);
-            code *cnext = null;
+            code* cnext = null;
             if (reg2 != NOREG)
             {
                 cnext = gennop(null);
-                genjmp(cdb,JNE,FL.code,cast(block *) cnext);  // JNE cnext
+                genjmp(cdb,JNE,FL.code,cast(block*) cnext);  // JNE cnext
                 cdb.genc2(0x81,modregrm(3,7,reg2),cast(targ_size_t)MSREG(val));   // CMP reg2,MSREG(casevalue)
             }
             genjmp(cdb,JE,FL.block,casevals[n].target);   // JE caseaddr
@@ -1663,13 +1663,13 @@ private void ifthen(ref CodeBuilder cdb, scope CaseVal[] casevals,
  */
 
 @trusted
-void doswitch(ref CodeBuilder cdb, block *b)
+void doswitch(ref CodeBuilder cdb, block* b)
 {
     // If switch tables are in code segment and we need a CS: override to get at them
     bool csseg = cast(bool)(config.flags & CFGromable);
 
     //printf("doswitch(%d)\n", b.bc);
-    elem *e = b.Belem;
+    elem* e = b.Belem;
     elem_debug(e);
     docommas(cdb,e);
     cgstate.stackclean++;
@@ -1737,7 +1737,7 @@ void doswitch(ref CodeBuilder cdb, block *b)
             reg2 = NOREG;
         }
         list_t bl = b.Bsucc;
-        block *bdefault = b.nthSucc(0);
+        block* bdefault = b.nthSucc(0);
         if (dword && mswsame)
         {
             cdb.genc2(0x81,modregrm(3,7,reg2),msw);   // CMP reg2,MSW
@@ -1859,7 +1859,7 @@ void doswitch(ref CodeBuilder cdb, block *b)
                 cdbe.gen2(0xFF,modregrmx(3,4,r1));                                          // JMP R1
 
                 b.Btablesize = cast(int) (vmax - vmin + 1) * 4;
-                code *ce = cdbe.finish();
+                code* ce = cdbe.finish();
                 pinholeopt(ce, null);
 
                 cdb.append(cdbe);
@@ -1885,10 +1885,10 @@ static if (JMPJMPTABLE)
                ...
              */
             CodeBuilder ctable; ctable.ctor();
-            block *bdef = b.nthSucc(0);
+            block* bdef = b.nthSucc(0);
             targ_llong u;
             for (u = vmin; ; u++)
-            {   block *targ = bdef;
+            {   block* targ = bdef;
                 foreach (n, val; b.Bswitch)
                 {
                     if (val == u)
@@ -2008,7 +2008,7 @@ else
             cdb.genpop(DI);             // L1: POP EDI
 
                                         //     ADD EDI,_GLOBAL_OFFSET_TABLE_+3
-            Symbol *gotsym = Obj.getGOTsym();
+            Symbol* gotsym = Obj.getGOTsym();
             cdb.gencs(0x81,modregrm(3,0,DI),FL.extern_,gotsym);
             cdb.last().Iflags = CFoff;
             cdb.last().IEV2.Voffset = 3;
@@ -2056,10 +2056,10 @@ else
              */
 
             const int mod = (disp > 127) ? 2 : 1;         // displacement size
-            code *cloop = genc2(null,0xE0,0,-7 - mod - csseg);   // LOOPNE scasw
+            code* cloop = genc2(null,0xE0,0,-7 - mod - csseg);   // LOOPNE scasw
             cdb.gen1(0xAF);                                      // SCASW
             code_orflag(cdb.last(),CFtarg2);                     // target of jump
-            genjmp(cdb,JNE,FL.code,cast(block *) cloop); // JNE loop
+            genjmp(cdb,JNE,FL.code,cast(block*) cloop); // JNE loop
                                                                  // CMP DX,[CS:]disp[DI]
             cdb.genc1(0x39,modregrm(mod,DX,5),FL.const_,disp);
             cdb.last().Iflags |= csseg ? CFcs : 0;              // possible seg override
@@ -2103,7 +2103,7 @@ else
  */
 
 @trusted
-void outjmptab(block *b)
+void outjmptab(block* b)
 {
     if (JMPJMPTABLE && I32)
         return;
@@ -2127,7 +2127,7 @@ void outjmptab(block *b)
     /* Segment and offset into which the jump table will be emitted
      */
     int jmpseg = objmod.jmpTableSegment(funcsym_p);
-    targ_size_t *poffset = &Offset(jmpseg);
+    targ_size_t* poffset = &Offset(jmpseg);
 
     /* Align start of jump table
      */
@@ -2135,7 +2135,7 @@ void outjmptab(block *b)
     objmod.lidata(jmpseg,*poffset,alignbytes);
     assert(*poffset == b.Btableoffset);        // should match precomputed value
 
-    Symbol *gotsym = null;
+    Symbol* gotsym = null;
     targ_size_t def = b.nthSucc(0).Boffset;  // default address
     for (targ_llong u = vmin; ; u++)
     {   targ_size_t targ = def;                     // default
@@ -2198,13 +2198,13 @@ void outjmptab(block *b)
  */
 
 @trusted
-void outswitab(block *b)
+void outswitab(block* b)
 {
     //printf("outswitab()\n");
     const ncases = b.Bswitch.length;     // number of cases
 
     const int seg = objmod.jmpTableSegment(funcsym_p);
-    targ_size_t *poffset = &Offset(seg);
+    targ_size_t* poffset = &Offset(seg);
     targ_size_t offset = *poffset;
     targ_size_t alignbytes = _align(0,*poffset) - *poffset;
     objmod.lidata(seg,*poffset,alignbytes);  // any alignment bytes necessary
@@ -2247,7 +2247,7 @@ void outswitab(block *b)
  */
 
 @trusted
-int jmpopcode(elem *e)
+int jmpopcode(elem* e)
 {
     //printf("jmpopcode()\n"); elem_print(e);
     tym_t tym;
@@ -2470,7 +2470,7 @@ void cod3_ptrchk(ref CodeBuilder cdb,ref code pcs,regm_t keepmsk)
     //used = (mBP | ALLREGS | mES) & ~fregsaved;
     regm_t used = 0;                           // much less code generated this way
 
-    code *cs2 = null;
+    code* cs2 = null;
     regm_t tosave = used & (keepmsk | idxregs);
     for (int i = 0; tosave; i++)
     {
@@ -2603,7 +2603,7 @@ Lcant:
  */
 
 @trusted
-bool cse_simple(code *c, elem *e)
+bool cse_simple(code* c, elem* e)
 {
     regm_t regm;
     reg_t reg;
@@ -2724,7 +2724,7 @@ void gen_loadcse(ref CodeBuilder cdb, tym_t tym, reg_t reg, size_t slot)
  */
 
 @trusted
-void cdframeptr(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdframeptr(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     regm_t retregs = pretregs & cgstate.allregs;
     if  (!retregs)
@@ -2746,7 +2746,7 @@ void cdframeptr(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretreg
  */
 
 @trusted
-void cdgot(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdgot(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     if (config.exe & (EX_OSX | EX_OSX64))
     {
@@ -2771,14 +2771,14 @@ void cdgot(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
         cdb.genpop(reg);            // L1: POP reg
 
                                     //     ADD reg,_GLOBAL_OFFSET_TABLE_+3
-        Symbol *gotsym = Obj.getGOTsym();
+        Symbol* gotsym = Obj.getGOTsym();
         cdb.gencs(0x81,modregrm(3,0,reg),FL.extern_,gotsym);
         /* Because the 2:3 offset from L1: is hardcoded,
          * this sequence of instructions must not
          * have any instructions in between,
          * so set CFvolatile to prevent the scheduler from rearranging it.
          */
-        code *cgot = cdb.last();
+        code* cgot = cdb.last();
         cgot.Iflags = CFoff | CFvolatile;
         cgot.IEV2.Voffset = (reg == AX) ? 2 : 3;
 
@@ -2803,14 +2803,14 @@ void load_localgot(ref CodeBuilder cdb)
             if (localgot && !(localgot.Sflags & SFLdead))
             {
                 localgot.Sflags &= ~GTregcand;     // because this hack doesn't work with reg allocator
-                elem *e = el_var(localgot);
+                elem* e = el_var(localgot);
                 regm_t retregs = mBX;
                 codelem(cgstate,cdb,e,retregs,false);
                 el_free(e);
             }
             else
             {
-                elem *e = el_long(TYnptr, 0);
+                elem* e = el_long(TYnptr, 0);
                 e.Eoper = OPgot;
                 regm_t retregs = mBX;
                 codelem(cgstate,cdb,e,retregs,false);
@@ -2827,12 +2827,12 @@ void load_localgot(ref CodeBuilder cdb)
 
 
 @trusted
-int obj_namestring(char *p,const(char)* name)
+int obj_namestring(char* p,const(char)* name)
 {
     size_t len = strlen(name);
     if (len > 255)
     {
-        short *ps = cast(short *)p;
+        short* ps = cast(short*)p;
         p[0] = 0xFF;
         p[1] = 0;
         ps[1] = cast(short)len;
@@ -3291,7 +3291,7 @@ L3:
  */
 
 @trusted
-void genjmp(ref CodeBuilder cdb, opcode_t op, FL fltarg, block *targ)
+void genjmp(ref CodeBuilder cdb, opcode_t op, FL fltarg, block* targ)
 {
     code cs;
     cs.Iop = op & 0xFF;
@@ -3302,7 +3302,7 @@ void genjmp(ref CodeBuilder cdb, opcode_t op, FL fltarg, block *targ)
     cs.IFL2 = fltarg;                   // FL.block (or FL.code)
     cs.IEV2.Vblock = targ;              // target block (or code)
     if (fltarg == FL.code)
-        (cast(code *)targ).Iflags |= CFtarg;
+        (cast(code*)targ).Iflags |= CFtarg;
 
     if (config.flags4 & CFG4fastfloat)  // if fast floating point
     {
@@ -3322,8 +3322,8 @@ void genjmp(ref CodeBuilder cdb, opcode_t op, FL fltarg, block *targ)
         case JNP << 8:
         {
             // Do a JP around the jump instruction
-            code *cnop = gennop(null);
-            genjmp(cdb,JP,FL.code,cast(block *) cnop);
+            code* cnop = gennop(null);
+            genjmp(cdb,JP,FL.code,cast(block*) cnop);
             cdb.gen(&cs);
             cdb.append(cnop);
             break;
@@ -3374,7 +3374,7 @@ void prolog_ifunc2(ref CodeBuilder cdb, tym_t tyf, tym_t tym, bool pushds)
             cdb.gen1(0x1E);                    // PUSH DS
         cgstate.spoff += _tysize[TYint];
         cdb.genc(0xC7, modregrm(3,0,AX), FL.unde, 0, FL.datseg, cast(targ_uns) 0); // MOV  AX,DGROUP
-        code *c = cdb.last();
+        code* c = cdb.last();
         c.IEV2.Vseg = DATA;
         c.Iflags ^= CFseg | CFoff;            // turn off CFoff, on CFseg
         cdb.gen2(0x8E,modregrm(3,3,AX));       // MOV  DS,AX
@@ -3404,7 +3404,7 @@ void prolog_16bit_windows_farfunc(ref CodeBuilder cdb, tym_t* tyf, bool* pushds)
             if (wflags & WFreduced)
                 *tyf &= ~mTYloadds;          // remove redundancy
             cdb.genc(0xC7, modregrm(3, 0, AX), FL.unde, 0, FL.datseg, cast(targ_uns) 0);
-            code *c = cdb.last();
+            code* c = cdb.last();
             c.IEV2.Vseg = DATA;
             c.Iflags ^= CFseg | CFoff;     // turn off CFoff, on CFseg
             break;
@@ -3809,7 +3809,7 @@ void prolog_saveregs(ref CGstate cg, ref CodeBuilder cdb, regm_t topush, int cfa
                 if (config.fulltypes == CVDWARF_C || config.fulltypes == CVDWARF_D ||
                     config.ehmethod == EHmethod.EH_DWARF)
                 {   // Emit debug_frame data giving location of saved register
-                    code *c = cdb.finish();
+                    code* c = cdb.finish();
                     pinholeopt(c, null);
                     dwarf_CFA_set_loc(calcblksize(c));  // address after save
                     dwarf_CFA_offset(reg, cast(int)(gpoffset - cfa_offset));
@@ -3844,7 +3844,7 @@ void prolog_saveregs(ref CGstate cg, ref CodeBuilder cdb, regm_t topush, int cfa
                     config.ehmethod == EHmethod.EH_DWARF)
                 {   // Emit debug_frame data giving location of saved register
                     // relative to 0[EBP]
-                    code *c = cdb.finish();
+                    code* c = cdb.finish();
                     pinholeopt(c, null);
                     dwarf_CFA_set_loc(calcblksize(c));  // address after PUSH reg
                     dwarf_CFA_offset(reg, -cg.EBPtoESP - cfa_offset);
@@ -4023,7 +4023,7 @@ void prolog_genvarargs(ref CGstate cg, ref CodeBuilder cdb, Symbol* sv)
     int raxoff = cast(int)(voff+6*8+0x7F);
     cdb.genc1(LEA,ea,FL.const_,raxoff);          // LEA RAX,voff+vsize-6*8-16+0x7F[RBP]
 
-    genjmp(cdb,JE,FL.code, cast(block *)cnop);  // JE L2
+    genjmp(cdb,JE,FL.code, cast(block*)cnop);  // JE L2
 
     foreach (i; 0 .. 8)
     {
@@ -4214,8 +4214,8 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
             continue;
         // Argument is passed in a register
 
-        type *t = s.Stype;
-        type *t2 = null;
+        type* t = s.Stype;
+        type* t2 = null;
 
         tym_t tyb = tybasic(t.Tty);
 
@@ -4225,7 +4225,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
         // (Don't put volatile parameters in registers on Windows)
         if (tyb == TYarray && (config.exe != EX_WIN64 || !(t.Tty & mTYvolatile)))
         {
-            type *targ1;
+            type* targ1;
             argtypes(t, targ1, t2);
             if (targ1)
                 t = targ1;
@@ -4238,7 +4238,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
             // regardless of the struct size or the number & types of its fields.
             if (config.exe != EX_WIN64)
             {
-                type *targ1 = t.Ttag.Sstruct.Sarg1type;
+                type* targ1 = t.Ttag.Sstruct.Sarg1type;
                 t2 = t.Ttag.Sstruct.Sarg2type;
                 if (targ1)
                     t = targ1;
@@ -4386,10 +4386,10 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
             continue;
         }
 
-        type *t = s.Stype;
-        type *t2 = null;
+        type* t = s.Stype;
+        type* t2 = null;
         if (tybasic(t.Tty) == TYstruct && config.exe != EX_WIN64)
-        {   type *targ1 = t.Ttag.Sstruct.Sarg1type;
+        {   type* targ1 = t.Ttag.Sstruct.Sarg1type;
             t2 = t.Ttag.Sstruct.Sarg2type;
             if (targ1)
                 t = targ1;
@@ -4455,7 +4455,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
             cdb.genc1(op,modregxrm(2,xreg,BPRM),FL.const_,cgstate.Para.size + s.Soffset);
             if (!cgstate.hasframe)
             {   // Convert to ESP relative address rather than EBP
-                code *c = cdb.last();
+                code* c = cdb.last();
                 c.Irm = cast(ubyte)modregxrm(2,xreg,4);
                 c.Isib = modregrm(0,4,SP);
                 c.IEV1.Vpointer += cgstate.EBPtoESP;
@@ -4465,7 +4465,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
 
         cdb.genc1(sz == 1 ? 0x8A : 0x8B,
             modregxrm(2,s.Sreglsw,BPRM),FL.const_,cgstate.Para.size + s.Soffset);
-        code *c = cdb.last();
+        code* c = cdb.last();
         if (!I16 && sz == SHORTSIZE)
             c.Iflags |= CFopsize; // operand size
         if (I64 && sz >= REGSIZE)
@@ -4483,7 +4483,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
         {
             cdb.genc1(0x8B,
                 modregxrm(2,s.Sregmsw,BPRM),FL.const_,cgstate.Para.size + s.Soffset + REGSIZE);
-            code *cx = cdb.last();
+            code* cx = cdb.last();
             if (I64)
                 cx.Irex |= REX_W;
             if (!cgstate.hasframe)
@@ -4504,12 +4504,12 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
  */
 
 @trusted
-void epilog(block *b)
+void epilog(block* b)
 {
     if (cgstate.AArch64)
         return dmd.backend.arm.cod3.epilog(b);
 
-    code *cpopds;
+    code* cpopds;
     reg_t reg;
     reg_t regx;                      // register that's not a return reg
     regm_t topop,regm;
@@ -4551,7 +4551,7 @@ void epilog(block *b)
         )
        )
     {
-        Symbol *s = getRtlsym(farfunc ? RTLSYM.TRACE_EPI_F : RTLSYM.TRACE_EPI_N);
+        Symbol* s = getRtlsym(farfunc ? RTLSYM.TRACE_EPI_F : RTLSYM.TRACE_EPI_N);
         makeitextern(s);
         cdbx.gencs(I16 ? 0x9A : CALL,0,FL.func,s);      // CALLF _trace
         if (!I16)
@@ -4642,12 +4642,12 @@ void epilog(block *b)
                     uint grex = I64 ? REX_W << 16 : 0;
                     cdbx.genc2(0xC7,grex | modregrmx(3,0,regcx),value);   // MOV regcx,value
                     cdbx.gen2sib(0x89,grex | modregrm(0,regcx,4),modregrm(0,4,SP)); // MOV [ESP],regcx
-                    code *c1 = cdbx.last();
+                    code* c1 = cdbx.last();
                     cdbx.genc2(0x81,grex | modregrm(3,0,SP),REGSIZE);     // ADD ESP,REGSIZE
                     genregs(cdbx,0x39,SP,BP);                             // CMP EBP,ESP
                     if (I64)
                         code_orrex(cdbx.last(),REX_W);
-                    genjmp(cdbx,JNE,FL.code,cast(block *)c1);                  // JNE L1
+                    genjmp(cdbx,JNE,FL.code,cast(block*)c1);                  // JNE L1
                     // explicitly mark as short jump, needed for correct retsize calculation (Bugzilla 15779)
                     cdbx.last().Iflags &= ~CFjmp16;
                     cdbx.genpop(BP);                                      // POP BP
@@ -4732,8 +4732,8 @@ Lopt:
     // in c sets SP, we can dump the ADD.
     CodeBuilder cdb; cdb.ctor();
     cdb.append(b.Bcode);
-    code *cr = cdb.last();
-    code *c = cdbx.peek();
+    code* cr = cdb.last();
+    code* c = cdbx.peek();
     if (cr && c && !I64)
     {
         if (cr.Iop == 0x81 && cr.Irm == modregrm(3,0,SP))     // if ADD SP,imm
@@ -4850,7 +4850,7 @@ void gen_spill_reg(ref CodeBuilder cdb, Symbol* s, bool toreg)
  */
 
 @trusted
-void cod3_thunk(Symbol *sthunk,Symbol *sfunc,uint p,tym_t thisty,
+void cod3_thunk(Symbol* sthunk,Symbol* sfunc,uint p,tym_t thisty,
         uint d,int i,uint d2)
 {
     targ_size_t thunkoffset;
@@ -5002,7 +5002,7 @@ void cod3_thunk(Symbol *sthunk,Symbol *sfunc,uint p,tym_t thisty,
             localgot = null;                // no local variables
             CodeBuilder cdbgot; cdbgot.ctor();
             load_localgot(cdbgot);          // load GOT in EBX
-            code *c1 = cdbgot.finish();
+            code* c1 = cdbgot.finish();
             if (c1)
             {
                 assignaddrc(c1);
@@ -5014,7 +5014,7 @@ void cod3_thunk(Symbol *sthunk,Symbol *sfunc,uint p,tym_t thisty,
     }
 
     thunkoffset = Offset(seg);
-    code *c = cdb.finish();
+    code* c = cdb.finish();
     pinholeopt(c,null);
     targ_size_t framehandleroffset;
     codout(seg,c,null,framehandleroffset);
@@ -5035,7 +5035,7 @@ void cod3_thunk(Symbol *sthunk,Symbol *sfunc,uint p,tym_t thisty,
  */
 
 @trusted
-void makeitextern(Symbol *s)
+void makeitextern(Symbol* s)
 {
     if (s.Sxtrnnum == 0)
     {
@@ -5059,7 +5059,7 @@ void makeitextern(Symbol *s)
  */
 
 @trusted
-int branch(block *bl,int flag)
+int branch(block* bl,int flag)
 {
     if (cgstate.AArch64)
     {
@@ -5107,7 +5107,7 @@ int branch(block *bl,int flag)
                     if (disp >= 0x7F-4 && c.IEV2.Vblock.Boffset > offset)
                     {   /* Look for intervening alignment
                          */
-                        for (block *b = bl.Bnext; b; b = b.Bnext)
+                        for (block* b = bl.Bnext; b; b = b.Bnext)
                         {
                             if (b.Balign)
                             {
@@ -5123,7 +5123,7 @@ int branch(block *bl,int flag)
 
                 case FL.code:
                 {
-                    code *cr;
+                    code* cr;
 
                     disp = 0;
 
@@ -5232,7 +5232,7 @@ int branch(block *bl,int flag)
                         // If nobody else points to ct, we can remove the CFtarg
                         if (flag && ct)
                         {
-                            code *cx;
+                            code* cx;
                             for (cx = bl.Bcode; 1; cx = code_next(cx))
                             {
                                 if (!cx)
@@ -5331,7 +5331,7 @@ void cod3_adjSymOffsets()
  */
 
 @trusted
-void assignaddr(block *bl)
+void assignaddr(block* bl)
 {
     int EBPtoESPsave = cgstate.EBPtoESP;
     const hasframesave = cgstate.hasframe;
@@ -5347,7 +5347,7 @@ void assignaddr(block *bl)
 }
 
 @trusted
-void assignaddrc(code *c)
+void assignaddrc(code* c)
 {
     if (cgstate.AArch64)
     {
@@ -5356,7 +5356,7 @@ void assignaddrc(code *c)
     }
 
     int sn;
-    Symbol *s;
+    Symbol* s;
     ubyte ins,rm;
     targ_size_t soff;
     targ_size_t base;
@@ -5404,7 +5404,7 @@ void assignaddrc(code *c)
                     if (cgstate.enforcealign)
                     {
                         // AND ESP, -STACKALIGN
-                        code *cn = code_calloc();
+                        code* cn = code_calloc();
                         cn.Iop = 0x81;
                         cn.Irm = modregrm(3, 4, SP);
                         cn.Iflags = CFoff;
@@ -5749,7 +5749,7 @@ void assignaddrc(code *c)
  */
 
 @trusted
-targ_size_t cod3_bpoffset(Symbol *s)
+targ_size_t cod3_bpoffset(Symbol* s)
 {
     targ_size_t offset;
 
@@ -5794,7 +5794,7 @@ targ_size_t cod3_bpoffset(Symbol *s)
  */
 
 @trusted
-void pinholeopt(code *c,block *b)
+void pinholeopt(code* c,block* b)
 {
     if (cgstate.AArch64)
         return;
@@ -5805,7 +5805,7 @@ void pinholeopt(code *c,block *b)
     int usespace;
     int useopsize;
     int space;
-    block *bn;
+    block* bn;
 
     debug
     {
@@ -5814,7 +5814,7 @@ void pinholeopt(code *c,block *b)
 
     debug
     {
-        code *cstart = c;
+        code* cstart = c;
         if (debugc)
         {
             printf("+pinholeopt(%p)\n",c);
@@ -6434,8 +6434,8 @@ private void pinholeopt_unittest()
 
     //config.flags4 |= CFG4space;
     for (int i = 0; i < tests.length; i++)
-    {   CS *pin  = &tests[i][0];
-        CS *pout = &tests[i][1];
+    {   CS* pin  = &tests[i][0];
+        CS* pout = &tests[i][1];
         code cs = void;
         memset(&cs, 0, cs.sizeof);
         if (pin.model)
@@ -6499,7 +6499,7 @@ void simplify_code(code* c)
  */
 
 @trusted
-void jmpaddr(code *c)
+void jmpaddr(code* c)
 {
     if (cgstate.AArch64)
     {
@@ -6577,7 +6577,7 @@ void jmpaddr(code *c)
  * Calculate bl.Bsize.
  */
 
-uint calcblksize(code *c)
+uint calcblksize(code* c)
 {
     uint size;
     for (size = 0; c; c = code_next(c))
@@ -6598,7 +6598,7 @@ uint calcblksize(code *c)
  */
 
 @trusted
-uint calccodsize(code *c)
+uint calccodsize(code* c)
 {
     if (cgstate.AArch64)
     {
@@ -6818,7 +6818,7 @@ Lret2:
 static if (0)
 {
 
-int code_match(code *c1,code *c2)
+int code_match(code* c1,code* c2)
 {
     code cs1,cs2;
     ubyte ins;
@@ -6955,7 +6955,7 @@ nothrow:
     void gen32(uint c)  { assert(index <= bytes.length - 4); *(cast(uint*)(&bytes[index])) = c; index += 4; }
 
     @trusted
-    void genp(uint n, void *p) { memcpy(&bytes[index], p, n); index += n; }
+    void genp(uint n, void* p) { memcpy(&bytes[index], p, n); index += n; }
 
     void flush() { if (index) flushx(); }
 
@@ -7016,16 +7016,16 @@ nothrow:
  */
 
 @trusted
-uint codout(int seg, code *c, Barray!ubyte* disasmBuf, ref targ_size_t framehandleroffset)
+uint codout(int seg, code* c, Barray!ubyte* disasmBuf, ref targ_size_t framehandleroffset)
 {
     if (cgstate.AArch64)
         return dmd.backend.arm.cod3.codout(seg, c, disasmBuf, framehandleroffset);
 
     ubyte rm,mod;
     ubyte ins;
-    code *cn;
+    code* cn;
     uint flags;
-    Symbol *s;
+    Symbol* s;
 
     debug
     if (debugc) printf("codout(%p), Coffset = x%llx\n",c,cast(ulong)Offset(seg));
@@ -7479,15 +7479,15 @@ uint codout(int seg, code *c, Barray!ubyte* disasmBuf, ref targ_size_t framehand
 @trusted
 private void do64bit(ref MiniCodeBuf pbuf, FL fl, ref evc uev,int flags)
 {
-    char *p;
-    Symbol *s;
+    char* p;
+    Symbol* s;
     targ_size_t ad;
 
     assert(I64);
     switch (fl)
     {
         case FL.const_:
-            ad = *cast(targ_size_t *) &uev;
+            ad = *cast(targ_size_t*) &uev;
         L1:
             pbuf.genp(8,&ad);
             return;
@@ -7593,8 +7593,8 @@ private void do64bit(ref MiniCodeBuf pbuf, FL fl, ref evc uev,int flags)
 @trusted
 private void do32bit(ref MiniCodeBuf pbuf, FL fl, ref evc uev,int flags, int val)
 {
-    char *p;
-    Symbol *s;
+    char* p;
+    Symbol* s;
     targ_size_t ad;
 
     //printf("do32bit(flags = x%x)\n", flags);
@@ -7602,7 +7602,7 @@ private void do32bit(ref MiniCodeBuf pbuf, FL fl, ref evc uev,int flags, int val
     {
         case FL.const_:
             assert(targ_size_t.sizeof == 4 || targ_size_t.sizeof == 8);
-            ad = * cast(targ_size_t *) &uev;
+            ad = * cast(targ_size_t*) &uev;
         L1:
             pbuf.genp(4,&ad);
             return;
@@ -7657,7 +7657,7 @@ private void do32bit(ref MiniCodeBuf pbuf, FL fl, ref evc uev,int flags, int val
         case FL.code:
             //assert(JMPJMPTABLE);            // the only use case
             pbuf.flush();
-            ad = *cast(targ_size_t *) &uev + pbuf.getOffset();
+            ad = *cast(targ_size_t*) &uev + pbuf.getOffset();
             objmod.reftocodeseg(pbuf.seg,pbuf.offset,ad);
             pbuf.write32(cast(uint)ad);
             break;
@@ -7773,14 +7773,14 @@ private void do32bit(ref MiniCodeBuf pbuf, FL fl, ref evc uev,int flags, int val
 @trusted
 private void do16bit(ref MiniCodeBuf pbuf, FL fl, ref evc uev,int flags)
 {
-    char *p;
-    Symbol *s;
+    char* p;
+    Symbol* s;
     targ_size_t ad;
 
     switch (fl)
     {
         case FL.const_:
-            pbuf.genp(2,cast(char *) &uev);
+            pbuf.genp(2,cast(char*) &uev);
             return;
 
         case FL.datseg:
@@ -7894,7 +7894,7 @@ private void do8bit(ref MiniCodeBuf pbuf, FL fl, ref evc uev)
  * Debug code to dump code structure.
  */
 
-void WRcodlst(code *c)
+void WRcodlst(code* c)
 {
     for (; c; c = code_next(c))
         code_print(c);

--- a/compiler/src/dmd/backend/x86/cod4.d
+++ b/compiler/src/dmd/backend/x86/cod4.d
@@ -51,7 +51,7 @@ nothrow:
  */
 
 @trusted
-private int intree(ref Symbol s,elem *e)
+private int intree(ref Symbol s,elem* e)
 {
     if (!OTleaf(e.Eoper))
         return intree(s,e.E1) + (OTbinary(e.Eoper) ? intree(s,e.E2) : 0);
@@ -68,7 +68,7 @@ private int intree(ref Symbol s,elem *e)
  */
 
 @trusted
-int doinreg(Symbol *s, elem *e)
+int doinreg(Symbol* s, elem* e)
 {
     int in_ = 0;
     OPER op;
@@ -113,7 +113,7 @@ int doinreg(Symbol *s, elem *e)
  * This is called just before modifying an EA.
  */
 
-void modEA(ref CodeBuilder cdb,code *c)
+void modEA(ref CodeBuilder cdb,code* c)
 {
     if ((c.Irm & 0xC0) == 0xC0)        // addressing mode refers to a register
     {
@@ -131,7 +131,7 @@ void modEA(ref CodeBuilder cdb,code *c)
  * Gen code for op= for doubles.
  */
 @trusted
-private void opassdbl(ref CodeBuilder cdb,elem *e,ref regm_t pretregs,OPER op)
+private void opassdbl(ref CodeBuilder cdb,elem* e,ref regm_t pretregs,OPER op)
 {
     assert(config.exe & EX_windos);  // for targets that may not have an 8087
 
@@ -149,7 +149,7 @@ private void opassdbl(ref CodeBuilder cdb,elem *e,ref regm_t pretregs,OPER op)
     regm_t retregs2,retregs,idxregs;
 
     uint clib = clibtab[op - OPpostinc];
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     tym_t tym = tybasic(e1.Ety);
     getlvalue(cdb,cs,e1,DOUBLEREGS | mBX | mCX);
 
@@ -232,7 +232,7 @@ private void opassdbl(ref CodeBuilder cdb,elem *e,ref regm_t pretregs,OPER op)
  */
 
 @trusted
-private void opnegassdbl(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+private void opnegassdbl(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     assert(config.exe & EX_windos);  // for targets that may not have an 8087
 
@@ -241,7 +241,7 @@ private void opnegassdbl(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         cdnegass87(cdb,e,pretregs);
         return;
     }
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     tym_t tym = tybasic(e1.Ety);
     int sz = _tysize[tym];
     code cs;
@@ -342,7 +342,7 @@ private void opnegassdbl(ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  * Generate code for an assignment.
  */
 @trusted
-void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -353,15 +353,15 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     tym_t tymll;
     reg_t reg;
     code cs;
-    elem *e11;
+    elem* e11;
     bool regvar;                  // true means evaluate into register variable
     regm_t varregm;
     reg_t varreg;
     targ_int postinc;
 
     //printf("cdeq(e = %p, pretregs = %s)\n", e, regm_str(pretregs));
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     int e2oper = e2.Eoper;
     tym_t tyml = tybasic(e1.Ety);              // type of lvalue
     regm_t retregs = pretregs;
@@ -441,7 +441,7 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                 (!I16 || e11.E1.Vsym.Sregm & IDXREGS)
                )
             {
-                Symbol *s = e11.E1.Vsym;
+                Symbol* s = e11.E1.Vsym;
                 if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg)
                 {
                     cgstate.regcon.params &= ~s.Spregm();
@@ -543,7 +543,7 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
             {
                 assert(e2oper == OPconst);
                 cs.IFL2 = FL.const_;
-                targ_size_t *p = cast(targ_size_t *) &(e2.EV);
+                targ_size_t* p = cast(targ_size_t*) &(e2.EV);
                 cs.IEV2.Vsize_t = *p;
                 // Look for loading a register variable
                 if ((cs.Irm & 0xC0) == 0xC0)
@@ -559,9 +559,9 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                     if (sz == 2 * REGSIZE)
                     {   getlvalue_msw(cs);
                         if (REGSIZE == 2)
-                            movregconst(cdb,cs.Irm & 7,(cast(ushort *)p)[1],0);
+                            movregconst(cdb,cs.Irm & 7,(cast(ushort*)p)[1],0);
                         else if (REGSIZE == 4)
-                            movregconst(cdb,cs.Irm & 7,(cast(uint *)p)[1],0);
+                            movregconst(cdb,cs.Irm & 7,(cast(uint*)p)[1],0);
                         else if (REGSIZE == 8)
                             movregconst(cdb,cs.Irm & 7,p[1],0);
                         else
@@ -619,7 +619,7 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                         }
                         cdb.gen(&cs);           // MOV EA,const
 
-                        p = cast(targ_size_t *)(cast(char *) p + regsize);
+                        p = cast(targ_size_t*)(cast(char*) p + regsize);
                         cs.Iop = (cs.Iop & 1) | 0xC6;
                         cs.Irm &= cast(ubyte)~cast(int)modregrm(0,7,0);
                         cs.Irex &= ~REX_R;
@@ -708,7 +708,7 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         (!I16 || e11.E1.Vsym.Sregm & IDXREGS)
        )
     {
-        Symbol *s = e11.E1.Vsym;
+        Symbol* s = e11.E1.Vsym;
         if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg)
         {
             cgstate.regcon.params &= ~s.Spregm();
@@ -844,7 +844,7 @@ Lp:
  */
 
 @trusted
-void cdaddass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdaddass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -856,7 +856,7 @@ void cdaddass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     OPER op = e.Eoper;
     regm_t retregs = 0;
     uint reverse = 0;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     tym_t tyml = tybasic(e1.Ety);            // type of lvalue
     int sz = _tysize[tyml];
     int isbyte = (sz == 1);                     // 1 for byte operation, else 0
@@ -897,7 +897,7 @@ void cdaddass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     reg_t reg;
     uint op1,op2,mode;
     code cs;
-    elem *e2;
+    elem* e2;
     regm_t varregm;
     reg_t varreg;
     uint jop;
@@ -1395,7 +1395,7 @@ void cdaddass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdmulass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdmulass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -1409,8 +1409,8 @@ void cdmulass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     uint opr,isbyte;
 
     //printf("cdmulass(e=%p, pretregs = %s)\n",e,regm_str(pretregs));
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     OPER op = e.Eoper;                     // OPxxxx
 
     tym_t tyml = tybasic(e1.Ety);              // type of lvalue
@@ -1692,7 +1692,7 @@ void cdmulass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cddivass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cddivass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -1700,8 +1700,8 @@ void cddivass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
         return cddivass(cg, cdb, e, pretregs);
     }
 
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
 
     tym_t tyml = tybasic(e1.Ety);              // type of lvalue
     OPER op = e.Eoper;                     // OPxxxx
@@ -2275,7 +2275,7 @@ void cddivass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdshass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdshass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -2286,8 +2286,8 @@ void cdshass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     code cs;
     uint op1,op2;
 
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
 
     tym_t tyml = tybasic(e1.Ety);              // type of lvalue
     uint sz = _tysize[tyml];
@@ -2381,17 +2381,17 @@ void cdshass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
             else // TYlong
             {
                 cs.Iop = 0xD1;            // plain shift
-                code *ce = gennop(null);                  // ce: NOP
+                code* ce = gennop(null);                  // ce: NOP
                 if (v == 0xD3)
                 {
                     getregs(cdb,mCX);
                     if (!conste2)
                     {
                         assert(loopcnt == 0);
-                        genjmp(cdb,JCXZ,FL.code,cast(block *) ce);   // JCXZ ce
+                        genjmp(cdb,JCXZ,FL.code,cast(block*) ce);   // JCXZ ce
                     }
                 }
-                code *cd;
+                code* cd;
                 if (oper == OPshlass)
                 {
                     cdb.gen(&cs);               // cd: SHIFT EA
@@ -2414,7 +2414,7 @@ void cdshass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                 }
                 if (v == 0xD3)                    // if building a loop
                 {
-                    genjmp(cdb,LOOP,FL.code,cast(block *) cd); // LOOP cd
+                    genjmp(cdb,LOOP,FL.code,cast(block*) cd); // LOOP cd
                     cgstate.regimmed_set(CX,0);           // note that now CX == 0
                 }
                 cdb.append(ce);
@@ -2524,7 +2524,7 @@ void cdshass(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -2541,8 +2541,8 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     int flag = cg.cmp_flag;
     cg.cmp_flag = 0;
 
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     if (pretregs == 0)                 // if don't want result
     {
         codelem(cgstate,cdb,e1,pretregs,false);
@@ -2570,7 +2570,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     uint grex = rex << 16;          // 64 bit operands
 
     code cs;
-    code *ce;
+    code* ce;
     if (tyfloating(tym))                  // if floating operation
     {
         if (config.fpxmmregs)
@@ -2663,15 +2663,15 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
              */
              getregs(cdb,mDX);
              genregs(cdb,0x39,CX,DX);             // CMP EDX,ECX
-             code *c1 = gennop(null);
-             genjmp(cdb,JNE,FL.code,cast(block *)c1);  // JNE C1
+             code* c1 = gennop(null);
+             genjmp(cdb,JNE,FL.code,cast(block*)c1);  // JNE C1
              movregconst(cdb,DX,0,0);             // XOR EDX,EDX
              genregs(cdb,0x39,BX,AX);             // CMP EAX,EBX
-             genjmp(cdb,JE,FL.code,cast(block *)c1);   // JZ C1
-             code *c3 = gen1(null,0x40 + DX);                  // INC EDX
-             genjmp(cdb,JA,FL.code,cast(block *)c3);   // JA C3
+             genjmp(cdb,JE,FL.code,cast(block*)c1);   // JZ C1
+             code* c3 = gen1(null,0x40 + DX);                  // INC EDX
+             genjmp(cdb,JA,FL.code,cast(block*)c3);   // JA C3
              cdb.gen1(0x48 + DX);                              // DEC EDX
-             genjmp(cdb,JMPS,FL.code,cast(block *)c1); // JMP C1
+             genjmp(cdb,JMPS,FL.code,cast(block*)c1); // JMP C1
              cdb.append(c3);
              cdb.append(c1);
              getregs(cdb,mDX);
@@ -2742,7 +2742,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                     cdb.last().Iflags |= CFopsize;         // seg is only 16 bits
                 else if (I64)
                     code_orrex(cdb.last(), REX_W);
-                genjmp(cdb,JNE,FL.code,cast(block *) ce);   // JNE nop
+                genjmp(cdb,JNE,FL.code,cast(block*) ce);   // JNE nop
 
                 reg = findreglsw(retregs);
                 rreg = findreglsw(rretregs);
@@ -2921,7 +2921,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                             cdb.last().Iflags |= CFopsize;      // seg is only 16 bits
                         if (I64 && isbyte && rreg >= 4)
                             cdb.last().Irex |= REX;
-                        genjmp(cdb,JNE,FL.code,cast(block *) ce); // JNE nop
+                        genjmp(cdb,JNE,FL.code,cast(block*) ce); // JNE nop
                         rreg = findreglsw(rretregs);
                         NEWREG(cs.Irm,rreg);
                         getlvalue_lsw(cs);
@@ -2949,7 +2949,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                         cdb.gen(&cs);              // CMP EA+2,const
                         if (!I16 && sz == 6)
                             cdb.last().Iflags |= CFopsize;      // seg is only 16 bits
-                        genjmp(cdb,JNE,FL.code, cast(block *) ce); // JNE nop
+                        genjmp(cdb,JNE,FL.code, cast(block*) ce); // JNE nop
                         if (e2.Eoper == OPconst)
                             cs.IEV2.Vint = cast(int)e2.Vllong;
                         else if (e2.Eoper == OPrelconst)
@@ -3033,7 +3033,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                 cdb.gen(&cs);                       // CMP reg,MSW
                 if (I32 && sz == 6)
                     cdb.last().Iflags |= CFopsize;  // seg is only 16 bits
-                genjmp(cdb,JNE,FL.code, cast(block *) ce);  // JNE ce
+                genjmp(cdb,JNE,FL.code, cast(block*) ce);  // JNE ce
 
                 reg = findreglsw(retregs);
                 cs.Irm = modregrm(3,7,reg);
@@ -3102,7 +3102,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
                 loadea(cdb,e2,cs,0x3B ^ reverse,reg,REGSIZE,retregs,0,RM.load);
                 if (I32 && sz == 6)
                     cdb.last().Iflags |= CFopsize;        // seg is only 16 bits
-                genjmp(cdb,JNE,FL.code, cast(block *) ce);  // JNE ce
+                genjmp(cdb,JNE,FL.code, cast(block*) ce);  // JNE ce
                 reg = findreglsw(retregs);
                 if (e2.Eoper == OPind)
                 {
@@ -3149,7 +3149,7 @@ L3:
         }
         else
         {
-            code *nop = null;
+            code* nop = null;
             regm_t save = cgstate.regcon.immed.mval;
             reg = allocreg(cdb,retregs,TYint);
             cgstate.regcon.immed.mval = save;
@@ -3183,7 +3183,7 @@ L3:
                 assert(!flag);
                 movregconst(cdb,reg,1,64|8);   // MOV reg,1
                 nop = gennop(nop);
-                genjmp(cdb,jop,FL.code,cast(block *) nop);  // Jtrue nop
+                genjmp(cdb,jop,FL.code,cast(block*) nop);  // Jtrue nop
                                                             // MOV reg,0
                 movregconst(cdb,reg,0,(pretregs & mPSW) ? 64|8 : 64);
                 cgstate.regcon.immed.mval &= ~mask(reg);
@@ -3193,7 +3193,7 @@ L3:
                 assert(!flag);
                 movregconst(cdb,reg,1,8);      // MOV reg,1
                 nop = gennop(nop);
-                genjmp(cdb,jop,FL.code,cast(block *) nop);  // Jtrue nop
+                genjmp(cdb,jop,FL.code,cast(block*) nop);  // Jtrue nop
                                                             // MOV reg,0
                 movregconst(cdb,reg,0,(pretregs & mPSW) ? 8 : 0);
                 cgstate.regcon.immed.mval &= ~mask(reg);
@@ -3221,8 +3221,8 @@ void longcmp(ref CodeBuilder cdb, elem* e, bool jcond, FL fltarg, code* targ)
     static immutable ubyte[4] joplsw = [JBE, JA, JB, JAE ];
 
     //printf("longcmp(e = %p)\n", e);
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     OPER op = e.Eoper;
 
     // See if we should swap operands
@@ -3237,7 +3237,7 @@ void longcmp(ref CodeBuilder cdb, elem* e, bool jcond, FL fltarg, code* targ)
     cs.Iflags = 0;
     cs.Irex = 0;
 
-    code *ce = gennop(null);
+    code* ce = gennop(null);
     regm_t retregs = ALLREGS;
     regm_t rretregs;
     reg_t reg,rreg;
@@ -3246,8 +3246,8 @@ void longcmp(ref CodeBuilder cdb, elem* e, bool jcond, FL fltarg, code* targ)
     if (!(jcond & 1)) jop ^= (JL ^ JG);                   // toggle jump condition
     CodeBuilder cdbjmp;
     cdbjmp.ctor();
-    genjmp(cdbjmp, jop, fltarg, cast(block *) targ);             // Jx targ
-    genjmp(cdbjmp,jop ^ (JL ^ JG),FL.code, cast(block *) ce);   // Jy nop
+    genjmp(cdbjmp, jop, fltarg, cast(block*) targ);             // Jx targ
+    genjmp(cdbjmp,jop ^ (JL ^ JG),FL.code, cast(block*) ce);   // Jy nop
 
     switch (e2.Eoper)
     {
@@ -3364,7 +3364,7 @@ void longcmp(ref CodeBuilder cdb, elem* e, bool jcond, FL fltarg, code* targ)
 
     jop = joplsw[op - OPle];
     if (!(jcond & 1)) jop ^= 1;                           // toggle jump condition
-    genjmp(cdb,jop,fltarg,cast(block *) targ);   // Jcond targ
+    genjmp(cdb,jop,fltarg,cast(block*) targ);   // Jcond targ
 
     cdb.append(ce);
     freenode(e);
@@ -3390,7 +3390,7 @@ void longcmp(ref CodeBuilder cdb, elem* e, bool jcond, FL fltarg, code* targ)
     OPld_d
  */
 @trusted
-void cdcnvt(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
+void cdcnvt(ref CGstate cg, ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -3622,7 +3622,7 @@ L1:
  */
 
 @trusted
-void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -3686,7 +3686,7 @@ void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     }
     else if (I64 && op == OPu32_64)
     {
-        elem *e1 = e.E1;
+        elem* e1 = e.E1;
         retregs = pretregs;
         if (e1.Eoper == OPvar || (e1.Eoper == OPind && !e1.Ecount))
         {
@@ -3730,8 +3730,8 @@ void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     else if (!I16 && (op == OPs16_32 || op == OPu16_32) ||
               I64 && op == OPs32_64)
     {
-        elem *e11;
-        elem *e1 = e.E1;
+        elem* e11;
+        elem* e1 = e.E1;
 
         if (e1.Eoper == OPu8_16 && !e1.Ecount &&
             ((e11 = e1.E1).Eoper == OPvar || (e11.Eoper == OPind && !e11.Ecount))
@@ -3779,7 +3779,7 @@ void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
             CodeBuilder cdbx;
             cdbx.ctor();
             codelem(cgstate,cdbx,e1,retregs,false);
-            code *cx = cdbx.finish() ? cdbx.last() : null;
+            code* cx = cdbx.finish() ? cdbx.last() : null;
             cdb.append(cdbx);
             getregs(cdb,retregs);
             if (op == OPu16_32 && cx)
@@ -3864,7 +3864,7 @@ void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdbyteint(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdbyteint(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -3883,7 +3883,7 @@ void cdbyteint(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
 
     //printf("cdbyteint(e = %p, pretregs = %s\n", e, regm_str(pretregs));
     char op = e.Eoper;
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
     if (e1.Eoper == OPcomma)
         docommas(cdb,e1);
     if (!I16)
@@ -3936,10 +3936,10 @@ void cdbyteint(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
     CodeBuilder cdb1;
     cdb1.ctor();
     codelem(cgstate,cdb1,e1,retregs,false);
-    code *c1 = cdb1.finish();
+    code* c1 = cdb1.finish();
     cdb.append(cdb1);
     reg_t reg = findreg(retregs);
-    code *c;
+    code* c;
     if (!c1)
         goto L1;
 
@@ -4008,7 +4008,7 @@ void cdbyteint(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdlngsht(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdlngsht(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -4081,7 +4081,7 @@ void cdlngsht(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdmsw(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdmsw(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -4122,12 +4122,12 @@ void cdmsw(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdport(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdport(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     //printf("cdport\n");
     assert(!cg.AArch64);
     ubyte op = 0xE4;            // root of all IN/OUT opcodes
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
 
     // See if we can use immediate mode of IN/OUT opcodes
     ubyte port;
@@ -4174,7 +4174,7 @@ void cdport(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdasm(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdasm(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -4196,10 +4196,10 @@ void cdasm(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdfar16(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdfar16(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     assert(!cg.AArch64);
-    code *cnop;
+    code* cnop;
     code cs;
 
     assert(I32);
@@ -4243,7 +4243,7 @@ void cdfar16(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
             gentstreg(cdb,reg);
             jop = JE;
         }
-        genjmp(cdb,jop,FL.code, cast(block *)cnop);  // Jop L1
+        genjmp(cdb,jop,FL.code, cast(block*)cnop);  // Jop L1
         NEWREG(cs.Irm,4);
         cdb.gen(&cs);                                   // SHL reg,3
         genregs(cdb,0x8C,2,rx);            // MOV rx,SS
@@ -4270,7 +4270,7 @@ void cdfar16(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  */
 
 @trusted
-void cdbtst(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdbtst(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     assert(!cg.AArch64);
     regm_t retregs;
@@ -4281,8 +4281,8 @@ void cdbtst(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
     opcode_t op = 0xA3;                        // BT EA,value
     int mode = 4;
 
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     code cs;
     cs.Iflags = 0;
 
@@ -4380,7 +4380,7 @@ void cdbtst(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
         }
         else
         {
-            code *cnop = null;
+            code* cnop = null;
             regm_t save = cgstate.regcon.immed.mval;
             reg = allocreg(cdb,retregs,TYint);
             cgstate.regcon.immed.mval = save;
@@ -4394,7 +4394,7 @@ void cdbtst(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
             {
                 movregconst(cdb,reg,1,8);      // MOV reg,1
                 cnop = gennop(null);
-                genjmp(cdb,JC,FL.code, cast(block *) cnop);  // Jtrue nop
+                genjmp(cdb,JC,FL.code, cast(block*) cnop);  // Jtrue nop
                                                             // MOV reg,0
                 movregconst(cdb,reg,0,8);
                 cgstate.regcon.immed.mval &= ~mask(reg);
@@ -4410,7 +4410,7 @@ void cdbtst(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  */
 
 @trusted
-void cdbt(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
+void cdbt(ref CGstate cg, ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
 {
     //printf("cdbt(%p, %s)\n", e, regm_str(pretregs));
     assert(!cg.AArch64);
@@ -4430,8 +4430,8 @@ void cdbt(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
             assert(0);
     }
 
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     code cs;
     cs.Iflags = 0;
 
@@ -4500,7 +4500,7 @@ void cdbt(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
         }
         else
         {
-            code *cnop = null;
+            code* cnop = null;
             const save = cgstate.regcon.immed.mval;
             reg = allocreg(cdb,retregs,TYint);
             cgstate.regcon.immed.mval = save;
@@ -4514,7 +4514,7 @@ void cdbt(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
             {
                 movregconst(cdb,reg,1,8);      // MOV reg,1
                 cnop = gennop(null);
-                genjmp(cdb,JC,FL.code, cast(block *) cnop);    // Jtrue nop
+                genjmp(cdb,JC,FL.code, cast(block*) cnop);    // Jtrue nop
                                                             // MOV reg,0
                 movregconst(cdb,reg,0,8);
                 cgstate.regcon.immed.mval &= ~mask(reg);
@@ -4530,7 +4530,7 @@ void cdbt(ref CGstate cg, ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
  */
 
 @trusted
-void cdbscan(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdbscan(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     //printf("cdbscan()\n");
     //elem_print(e);
@@ -4583,7 +4583,7 @@ void cdbscan(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  */
 
 @trusted
-void cdpopcnt(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
+void cdpopcnt(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -4647,7 +4647,7 @@ void cdpopcnt(ref CGstate cg, ref CodeBuilder cdb,elem *e,ref regm_t pretregs)
  */
 
 @trusted
-void cdpair(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdpair(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     if (pretregs == 0)                         // if don't want result
     {
@@ -4719,7 +4719,7 @@ void cdpair(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
  */
 
 @trusted
-void cdcmpxchg(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdcmpxchg(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     /* The form is:
      *     OPcmpxchg
@@ -4731,8 +4731,8 @@ void cdcmpxchg(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs
 
     assert(!cg.AArch64);
     //printf("cdcmpxchg(e=%p, pretregs = %s)\n",e,regm_str(pretregs));
-    elem *e1 = e.E1;
-    elem *e2 = e.E2;
+    elem* e1 = e.E1;
+    elem* e2 = e.E2;
     assert(e2.Eoper == OPparam);
     assert(!e2.Ecount);
 
@@ -4810,7 +4810,7 @@ void cdcmpxchg(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs
  */
 
 @trusted
-void cdprefetch(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretregs)
+void cdprefetch(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     /* Generate the following based on e2:
      *    0: prefetch0
@@ -4822,7 +4822,7 @@ void cdprefetch(ref CGstate cg, ref CodeBuilder cdb, elem *e, ref regm_t pretreg
      */
     assert(!cg.AArch64);
     //printf("cdprefetch\n");
-    elem *e1 = e.E1;
+    elem* e1 = e.E1;
 
     assert(pretregs == 0);
     assert(e.E2.Eoper == OPconst);

--- a/compiler/src/dmd/backend/x86/cod5.d
+++ b/compiler/src/dmd/backend/x86/cod5.d
@@ -48,8 +48,8 @@ else
 {
     tym_t tym;
     tym_t tyf;
-    block *b;
-    block *bp;
+    block* b;
+    block* bp;
     int nepis;
 
     tyf = funcsym_p.ty();
@@ -153,7 +153,7 @@ else
  */
 void cod5_noprol(block* startblock)
 {
-    block *b;
+    block* b;
 
     //printf("no prolog optimization\n");
     startblock.Bflags |= BFL.prolog;
@@ -176,7 +176,7 @@ void cod5_noprol(block* startblock)
  * the function prolog.
  */
 
-private void pe_add(block *b)
+private void pe_add(block* b)
 {
     if (b.Bflags & BFL.outsideprolog ||
         need_prolog(b))
@@ -192,7 +192,7 @@ private void pe_add(block *b)
  */
 
 @trusted
-private int need_prolog(block *b)
+private int need_prolog(block* b)
 {
     if (b.Bregcon.used & fregsaved)
         goto Lneed;

--- a/compiler/src/dmd/backend/x86/code_x86.d
+++ b/compiler/src/dmd/backend/x86/code_x86.d
@@ -302,7 +302,7 @@ enum
 
 struct code
 {
-    code *next;
+    code* next;
     code_flags_t Iflags;
 
     union
@@ -565,7 +565,7 @@ bool ADDFWAIT() { return config.target_cpu <= TARGET_80286; }
 
 struct NDP
 {
-    elem *e;                    // which elem is stored here (NULL if none)
+    elem* e;                    // which elem is stored here (NULL if none)
     uint offset;            // offset from e (used for complex numbers)
 }
 

--- a/compiler/src/dmd/backend/x86/disasm86.d
+++ b/compiler/src/dmd/backend/x86/disasm86.d
@@ -485,12 +485,12 @@ addr EAbytes(uint c)
  */
 
 
-char *getEAxmm(ubyte rex, uint c)
+char* getEAxmm(ubyte rex, uint c)
 {
     return getEAimpl(rex, c, 1, 128);
 }
 
-char *getEAxmmymm(ubyte rex, uint c, uint vlen)
+char* getEAxmmymm(ubyte rex, uint c, uint vlen)
 {
     return getEAimpl(rex, c, 2, vlen);
 }
@@ -510,7 +510,7 @@ const(char)* getEAvec(ubyte rex, uint c)
     return p;
 }
 
-char *getEA(ubyte rex, uint c)
+char* getEA(ubyte rex, uint c)
 {
     return getEAimpl(rex, c, 0, 128);
 }
@@ -519,7 +519,7 @@ char *getEA(ubyte rex, uint c)
  * Params:
  *      vlen = 128: XMM, 256: YMM
  */
-char *getEAimpl(ubyte rex, uint c, int do_xmm, uint vlen)
+char* getEAimpl(ubyte rex, uint c, int do_xmm, uint vlen)
 {
     ubyte modrgrm,mod,reg,rm;
     uint opcode;
@@ -534,7 +534,7 @@ char *getEAimpl(ubyte rex, uint c, int do_xmm, uint vlen)
     uint xmm;           // != 0 if xmm opcode
     uint r32;           // != 0 if r32
 
-    char *displacement(addr w, const(char)* postfix)
+    char* displacement(addr w, const(char)* postfix)
     {
         const(char)* s = "".ptr;
         if (cast(short) w < 0)
@@ -551,7 +551,7 @@ char *getEAimpl(ubyte rex, uint c, int do_xmm, uint vlen)
         return EAb.ptr;
     }
 
-    char *displacementFixup(addr c, uint sz, const(char)* postfix)
+    char* displacementFixup(addr c, uint sz, const(char)* postfix)
     {
         uint value = sz == 2 ? word(code, c) : dword(code, c);
         auto p = mem(c, sz, value);
@@ -915,7 +915,7 @@ int prefixbyte(uint c)
  *      p0 = hex bytes dump
  */
 
-void getVEXstring(addr c, addr siz, char *p0)
+void getVEXstring(addr c, addr siz, char* p0)
 {
     /* Parse VEX prefix,
      * fill in the following variables,
@@ -1078,7 +1078,7 @@ void getVEXstring(addr c, addr siz, char *p0)
             case 0x71:
             {   __gshared const char*[8] reg71 =
                 [ null, null, "vpsrlw", null, "vpsraw", null, "vpslw", null ];
-                const char *p = reg71[reg];
+                const char* p = reg71[reg];
                 if (!p)
                     goto Ldefault;
                 p1 = p;
@@ -1087,7 +1087,7 @@ void getVEXstring(addr c, addr siz, char *p0)
             case 0x72:
             {   __gshared const char*[8] reg72 =
                 [ null, null, "vpsrld", null, "vpsrad", null, "vpslld", null ];
-                const char *p = reg72[reg];
+                const char* p = reg72[reg];
                 if (!p)
                     goto Ldefault;
                 p1 = p;
@@ -1096,7 +1096,7 @@ void getVEXstring(addr c, addr siz, char *p0)
             case 0x73:
             {   __gshared const char*[8] reg73 =
                 [ null, null, "vpsrlq", "vpsrldq", null, null, "vpsllq", "vpslldq" ];
-                const char *p = reg73[reg];
+                const char* p = reg73[reg];
                 if (!p)
                     goto Ldefault;
                 p1 = p;
@@ -1503,7 +1503,7 @@ Ldone:
  *      waitflag        if 1 then generate FWAIT form of instruction
  */
 
-void get87string(addr c,char *p0,int waitflag)
+void get87string(addr c,char* p0,int waitflag)
 {
     uint opcode,reg,modrgrm,mod;
     const(char)* p1, p2, p3;

--- a/compiler/src/dmd/backend/x86/nteh.d
+++ b/compiler/src/dmd/backend/x86/nteh.d
@@ -43,8 +43,8 @@ import dmd.backend.eh : except_fillInEHTable;
 
 private __gshared
 {
-    Symbol *s_table;
-    //Symbol *s_context;
+    Symbol* s_table;
+    //Symbol* s_context;
 }
 
 private
@@ -68,7 +68,7 @@ int nteh_offset_info()          { return 4; }
  */
 
 @trusted
-ubyte *nteh_context_string()
+ubyte* nteh_context_string()
 {
     if (config.exe == EX_WIN32)
     {
@@ -77,7 +77,7 @@ ubyte *nteh_context_string()
                 "int esp; int info; int prev; int handler; int stable; int sindex; int ebp;" ~
              "};\n";
 
-        return cast(ubyte *)text_nt.ptr;
+        return cast(ubyte*)text_nt.ptr;
     }
     else
         return null;
@@ -90,10 +90,10 @@ ubyte *nteh_context_string()
  */
 
 @trusted
-private Symbol *nteh_scopetable()
+private Symbol* nteh_scopetable()
 {
-    Symbol *s;
-    type *t;
+    Symbol* s;
+    type* t;
 
     if (!s_table)
     {
@@ -112,7 +112,7 @@ private Symbol *nteh_scopetable()
 @trusted
 void nteh_filltables()
 {
-    Symbol *s = s_table;
+    Symbol* s = s_table;
     symbol_debug(s);
     except_fillInEHTable(s);
 }
@@ -123,9 +123,9 @@ void nteh_filltables()
  */
 
 @trusted
-void nteh_gentables(Symbol *sfunc)
+void nteh_gentables(Symbol* sfunc)
 {
-    Symbol *s = s_table;
+    Symbol* s = s_table;
     symbol_debug(s);
     //except_fillInEHTable(s);
 
@@ -139,7 +139,7 @@ void nteh_gentables(Symbol *sfunc)
  */
 
 @trusted
-void nteh_declarvars(BlockState *bx)
+void nteh_declarvars(BlockState* bx)
 {
     //printf("nteh_declarvars()\n");
     if (!(bx.funcsym.Sfunc.Fflags3 & Fnteh)) // if haven't already done it
@@ -156,7 +156,7 @@ void nteh_declarvars(BlockState *bx)
 /**************************************
  * Generate elem that sets the context index into the scope table.
  */
-elem *nteh_setScopeTableIndex(BlockState *blx, int scope_index)
+elem* nteh_setScopeTableIndex(BlockState* blx, int scope_index)
 {
     Symbol* s = blx.context;
     symbol_debug(s);
@@ -171,7 +171,7 @@ elem *nteh_setScopeTableIndex(BlockState *blx, int scope_index)
  */
 
 @trusted
-Symbol *nteh_contextsym()
+Symbol* nteh_contextsym()
 {
     foreach (Symbol* sp; globsym)
     {
@@ -212,7 +212,7 @@ uint nteh_contextsym_size()
  */
 
 @trusted
-Symbol *nteh_ecodesym()
+Symbol* nteh_ecodesym()
 {
     foreach (Symbol* sp; globsym)
     {
@@ -382,7 +382,7 @@ void nteh_setsp(ref CodeBuilder cdb, opcode_t op)
  */
 
 @trusted
-void nteh_filter(ref CodeBuilder cdb, block *b)
+void nteh_filter(ref CodeBuilder cdb, block* b)
 {
     assert(b.bc == BC._filter);
     if (b.Bflags & BFL.ehcode)          // if referenced __ecode
@@ -423,7 +423,7 @@ void nteh_filter(ref CodeBuilder cdb, block *b)
  * Generate C++ or D frame handler.
  */
 
-void nteh_framehandler(Symbol *sfunc, Symbol *scopetable)
+void nteh_framehandler(Symbol* sfunc, Symbol* scopetable)
 {
     // Generate:
     //  MOV     EAX,&scope_table
@@ -438,7 +438,7 @@ void nteh_framehandler(Symbol *sfunc, Symbol *scopetable)
 
         cdb.gencs(0xE9,0,FL.func,getRtlsym(RTLSYM.D_HANDLER));      // JMP _d_framehandler
 
-        code *c = cdb.finish();
+        code* c = cdb.finish();
         pinholeopt(c,null);
         targ_size_t framehandleroffset;
         codout(sfunc.Sseg,c,null,framehandleroffset);
@@ -450,7 +450,7 @@ void nteh_framehandler(Symbol *sfunc, Symbol *scopetable)
  * Generate code to set scope index.
  */
 
-code *nteh_patchindex(code* c, int sindex)
+code* nteh_patchindex(code* c, int sindex)
 {
     c.IEV2.Vsize_t = sindex;
     return c;
@@ -475,7 +475,7 @@ void nteh_gensindex(ref CodeBuilder cdb, int sindex)
  */
 
 @trusted
-void cdsetjmp(ref CGstate cg, ref CodeBuilder cdb, elem *e,ref regm_t pretregs)
+void cdsetjmp(ref CGstate cg, ref CodeBuilder cdb, elem* e,ref regm_t pretregs)
 {
     code cs;
     regm_t retregs;
@@ -610,7 +610,7 @@ void nteh_unwind(ref CodeBuilder cdb,regm_t saveregs,uint stop_index)
  */
 
 @trusted
-void nteh_monitor_prolog(ref CodeBuilder cdb, Symbol *shandle)
+void nteh_monitor_prolog(ref CodeBuilder cdb, Symbol* shandle)
 {
     /*
      *  PUSH    handle
@@ -638,7 +638,7 @@ void nteh_monitor_prolog(ref CodeBuilder cdb, Symbol *shandle)
         cdbx.gen1(0x50 + CX);                      // PUSH ECX
     }
 
-    Symbol *smh = getRtlsym(RTLSYM.MONITOR_HANDLER);
+    Symbol* smh = getRtlsym(RTLSYM.MONITOR_HANDLER);
     cdbx.gencs(0x68,0,FL.extern_,smh);             // PUSH offset _d_monitor_handler
     makeitextern(smh);
 
@@ -655,7 +655,7 @@ void nteh_monitor_prolog(ref CodeBuilder cdb, Symbol *shandle)
 
     cdbx.gen1(0x50 + DX);                  // PUSH EDX
 
-    Symbol *s = getRtlsym(RTLSYM.MONITOR_PROLOG);
+    Symbol* s = getRtlsym(RTLSYM.MONITOR_PROLOG);
     regm_t desregs = ~s.Sregsaved & ALLREGS;
     getregs(cdbx,desregs);
     cdbx.gencs(0xE8,0,FL.func,s);       // CALL _d_monitor_prolog
@@ -683,7 +683,7 @@ void nteh_monitor_epilog(ref CodeBuilder cdb,regm_t retregs)
 
     assert(config.exe == EX_WIN32);    // BUG: figure out how to implement for other EX's
 
-    Symbol *s = getRtlsym(RTLSYM.MONITOR_EPILOG);
+    Symbol* s = getRtlsym(RTLSYM.MONITOR_EPILOG);
     //desregs = ~s.Sregsaved & ALLREGS;
     regm_t desregs = 0;
     CodeBuilder cdbs;

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -679,7 +679,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     Symbol **params = paramsbuf.ptr;    // allocate on stack if possible
     if (pi + 2 > paramsbuf.length)      // allow extra 2 for sthis and shidden
     {
-        params = cast(Symbol **)Mem.check(malloc((pi + 2) * (Symbol *).sizeof));
+        params = cast(Symbol**)Mem.check(malloc((pi + 2) * (Symbol*).sizeof));
     }
 
     // Get the actual number of parameters, pi, and fill in the params[]


### PR DESCRIPTION
Seeing C syntax everywhere is one of things making backend code annoying to read. It's a lot of churn, but there's few open backend PRs currently, and master is going to be merged into stable soon, so this would be a convenient time to get this over with.

The only changes in this PR are removing and inserting spaces, nothing else.