### PR TITLE
dcast: Don't pass format string over varargs

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -2922,7 +2922,10 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         {
             printf("DelegateExp::castTo(this=%s, type=%s, t=%s)\n", e.toChars(), e.type.toChars(), t.toChars());
         }
-        static immutable msg = "cannot form delegate due to covariant return type";
+        void errorCovariantReturnType()
+        {
+            error(e.loc, "cannot form delegate due to covariant return type");
+        }
 
         Type tb = t.toBasetype();
         Type typeb = e.type.toBasetype();
@@ -2932,7 +2935,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             int offset;
             e.func.tookAddressOf++;
             if (e.func.tintro && e.func.tintro.nextOf().isBaseOf(e.func.type.nextOf(), &offset) && offset)
-                error(e.loc, "%s", msg.ptr);
+                errorCovariantReturnType();
             auto result = e.copy();
             result.type = t;
             return result;
@@ -2947,7 +2950,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                 {
                     int offset;
                     if (f.tintro && f.tintro.nextOf().isBaseOf(f.type.nextOf(), &offset) && offset)
-                        error(e.loc, "%s", msg.ptr);
+                        errorCovariantReturnType();
                     if (f != e.func)    // if address not already marked as taken
                         f.tookAddressOf++;
                     auto result = new DelegateExp(e.loc, e.e1, f, false, e.vthis2);
@@ -2955,7 +2958,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                     return result;
                 }
                 if (e.func.tintro)
-                    error(e.loc, "%s", msg.ptr);
+                    errorCovariantReturnType();
             }
         }
 


### PR DESCRIPTION
Even if the message was dynamically generated, it is always preferred that the format string be a literal, rather than something passed over varargs.