### PR TITLE
druntime: Add version(GNU) imports to rt.deh and sections modules

### DIFF
--- a/druntime/src/rt/deh.d
+++ b/druntime/src/rt/deh.d
@@ -50,7 +50,9 @@ extern (C)
     }
 }
 
-version (Win32)
+version (GNU)
+    public import gcc.deh;
+else version (Win32)
     public import rt.deh_win32;
 else version (Win64)
     public import rt.deh_win64_posix;

--- a/druntime/src/rt/sections.d
+++ b/druntime/src/rt/sections.d
@@ -19,7 +19,9 @@ else version (TVOS)
 else version (WatchOS)
     version = Darwin;
 
-version (CRuntime_Glibc)
+version (GNU)
+    public import gcc.sections;
+else version (CRuntime_Glibc)
     public import rt.sections_elf_shared;
 else version (CRuntime_Musl)
     public import rt.sections_elf_shared;


### PR DESCRIPTION
GDC implements its own versions of EH and Section support.