### PR TITLE
druntime: Add GNU_InlineAsm implementations

### DIFF
--- a/druntime/src/core/sys/windows/dll.d
+++ b/druntime/src/core/sys/windows/dll.d
@@ -402,7 +402,7 @@ private bool isWindows8OrLater() nothrow @nogc
 int dll_getRefCount( HINSTANCE hInstance ) nothrow @nogc
 {
     void** peb;
-    version (Win64)
+    version (D_InlineAsm_X86_64)
     {
         asm pure nothrow @nogc
         {
@@ -411,13 +411,20 @@ int dll_getRefCount( HINSTANCE hInstance ) nothrow @nogc
             mov peb, RAX;
         }
     }
-    else version (Win32)
+    else version (D_InlineAsm_X86)
     {
         asm pure nothrow @nogc
         {
             mov EAX,FS:[0x30];
             mov peb, EAX;
         }
+    }
+    else version (GNU_InlineAsm)
+    {
+        version (X86_64)
+            asm pure nothrow @nogc { "movq %%gs:0x60, %0;" : "=r" (peb); }
+        else version (X86)
+            asm pure nothrow @nogc { "movl %%fs:0x30, %0;" : "=r" (peb); }
     }
     dll_aux.LDR_MODULE *ldrMod = dll_aux.findLdrModule( hInstance, peb );
     if ( !ldrMod )

--- a/druntime/src/core/sys/windows/threadaux.d
+++ b/druntime/src/core/sys/windows/threadaux.d
@@ -163,7 +163,7 @@ struct thread_aux
     // get linear address of TEB of current thread
     static void** getTEB() nothrow @nogc
     {
-        version (Win32)
+        version (D_InlineAsm_X86)
         {
             asm pure nothrow @nogc
             {
@@ -172,7 +172,7 @@ struct thread_aux
                 ret;
             }
         }
-        else version (Win64)
+        else version (D_InlineAsm_X86_64)
         {
             asm pure nothrow @nogc
             {
@@ -181,6 +181,17 @@ struct thread_aux
                 mov RAX,GS:[RAX]; // immediate value causes fixup
                 ret;
             }
+        }
+        else version (GNU_InlineAsm)
+        {
+            void** teb;
+            version (X86)
+                asm pure nothrow @nogc { "movl %%fs:0x18, %0;" : "=r" (teb); }
+            else version (X86_64)
+                asm pure nothrow @nogc { "movq %%gs:0x30, %0;" : "=r" (teb); }
+            else
+                static assert(false);
+            return teb;
         }
         else
         {

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -1431,6 +1431,19 @@ private extern(D) void* getStackBottom() nothrow @nogc
                  mov RAX, GS:[RAX];
                  ret;
             }
+        else version (GNU_InlineAsm)
+        {
+            void *bottom;
+
+            version (X86)
+                asm pure nothrow @nogc { "movl %%fs:4, %0;" : "=r" (bottom); }
+            else version (X86_64)
+                asm pure nothrow @nogc { "movq %%gs:8, %0;" : "=r" (bottom); }
+            else
+                static assert(false, "Architecture not supported.");
+
+            return bottom;
+        }
         else
             static assert(false, "Architecture not supported.");
     }

--- a/druntime/src/rt/dmain2.d
+++ b/druntime/src/rt/dmain2.d
@@ -423,6 +423,14 @@ private extern (C) int _d_run_main2(char[][] args, size_t totalArgsLength, MainF
                 pop     EAX;
             }
         }
+        else version (GNU_InlineAsm)
+        {
+            size_t fpu_cw;
+            asm { "fstcw %0" : "=m" (fpu_cw); }
+            fpu_cw |= 0b11_00_111111;  // 11: use 64 bit extended-precision
+                                       // 111111: mask all FP exceptions
+            asm { "fldcw %0" : "=m" (fpu_cw); }
+        }
     }
 
     /* Create a copy of args[] on the stack to be used for main, so that rt_args()


### PR DESCRIPTION
Added where DMD IASM is not supported.  All cases are Windows where there's still some wrong assumptions that the generic `Win64` version implied `D_InlineAsm_X86_64`