### PR TITLE
Add test cases for static arrays initialization with hex string

### DIFF
--- a/compiler/test/fail_compilation/hexstring.d
+++ b/compiler/test/fail_compilation/hexstring.d
@@ -1,21 +1,24 @@
 /**
 TEST_OUTPUT:
 ---
-fail_compilation/hexstring.d(29): Error: cannot implicitly convert expression `"123F"` of type `string` to `immutable(ubyte[])`
-fail_compilation/hexstring.d(33): Error: hex string length 1 must be a multiple of 2 to cast to `immutable(ushort[])`
-fail_compilation/hexstring.d(34): Error: hex string length 3 must be a multiple of 4 to cast to `immutable(uint[])`
-fail_compilation/hexstring.d(35): Error: hex string length 5 must be a multiple of 8 to cast to `immutable(ulong[])`
-fail_compilation/hexstring.d(36): Error: array cast from `wstring` to `immutable(ulong[])` is not supported at compile time
-fail_compilation/hexstring.d(36):        perhaps remove postfix `w` from hex string
-fail_compilation/hexstring.d(37): Error: array cast from `string` to `immutable(uint[])` is not supported at compile time
-fail_compilation/hexstring.d(38): Error: array cast from `string` to `immutable(ushort[])` is not supported at compile time
-fail_compilation/hexstring.d(39): Error: array cast from `string` to `immutable(uint[])` is not supported at compile time
-fail_compilation/hexstring.d(39):        perhaps remove postfix `c` from hex string
-fail_compilation/hexstring.d(40): Error: hex string with `dstring` type needs to be multiple of 4 bytes, not 5
-fail_compilation/hexstring.d(41): Error: cannot implicitly convert expression `x"11223344"d` of type `dstring` to `immutable(float[])`
-fail_compilation/hexstring.d(42): Error: cannot implicitly convert expression `x"1122"w` of type `wstring` to `immutable(ubyte[])`
-fail_compilation/hexstring.d(50): Error: array cast from `string` to `S[]` is not supported at compile time
-fail_compilation/hexstring.d(28): Error: cannot implicitly convert expression `x"123F"` of type `string` to `ubyte[]`
+fail_compilation/hexstring.d(30): Error: array cast from `string` to `ubyte[3][1]` is not supported at compile time
+fail_compilation/hexstring.d(33): Error: cannot implicitly convert expression `"123F"` of type `string` to `immutable(ubyte[])`
+fail_compilation/hexstring.d(37): Error: hex string length 1 must be a multiple of 2 to cast to `immutable(ushort[])`
+fail_compilation/hexstring.d(38): Error: hex string length 3 must be a multiple of 4 to cast to `immutable(uint[])`
+fail_compilation/hexstring.d(39): Error: hex string length 5 must be a multiple of 8 to cast to `immutable(ulong[])`
+fail_compilation/hexstring.d(40): Error: array cast from `wstring` to `immutable(ulong[])` is not supported at compile time
+fail_compilation/hexstring.d(40):        perhaps remove postfix `w` from hex string
+fail_compilation/hexstring.d(41): Error: array cast from `string` to `immutable(uint[])` is not supported at compile time
+fail_compilation/hexstring.d(42): Error: array cast from `string` to `immutable(ushort[])` is not supported at compile time
+fail_compilation/hexstring.d(43): Error: array cast from `string` to `immutable(uint[])` is not supported at compile time
+fail_compilation/hexstring.d(43):        perhaps remove postfix `c` from hex string
+fail_compilation/hexstring.d(44): Error: hex string with `dstring` type needs to be multiple of 4 bytes, not 5
+fail_compilation/hexstring.d(45): Error: cannot implicitly convert expression `x"11223344"d` of type `dstring` to `immutable(float[])`
+fail_compilation/hexstring.d(46): Error: cannot implicitly convert expression `x"1122"w` of type `wstring` to `immutable(ubyte[])`
+fail_compilation/hexstring.d(47): Error: array cast from `string` to `ubyte[3][1]` is not supported at compile time
+fail_compilation/hexstring.d(48): Error: array cast from `string` to `ubyte[3][1][1]` is not supported at compile time
+fail_compilation/hexstring.d(56): Error: array cast from `string` to `S[]` is not supported at compile time
+fail_compilation/hexstring.d(32): Error: cannot implicitly convert expression `x"123F"` of type `string` to `ubyte[]`
 ---
 */
 immutable ubyte[] s0 = x"123F";
@@ -24,6 +27,7 @@ static assert(s0[1] == 0x3F);
 immutable byte[] s1 = x"123F";
 enum E(X) = cast(X[]) x"AABBCCDD";
 static assert(E!int[0] == 0xAABBCCDD);
+immutable ubyte[3] s2 = cast(ubyte[3][1])x"FFAAFF";
 
 ubyte[] f1 = x"123F";
 immutable ubyte[] f2 = "123F";
@@ -40,6 +44,8 @@ immutable uint[] f11 = cast(immutable uint[]) x"AABBCCDD"c;
 immutable uint[] f12 = x"1122334455"d;
 immutable float[] f13 = x"11223344"d;
 immutable ubyte[] f14 = x"1122"w;
+immutable ubyte[3][1] f16 = cast(ubyte[3][1])x"FFBBFF";
+immutable ubyte[3][1][1] f17 = cast(ubyte[3][1][1])x"FFCCFF";
 
 // https://issues.dlang.org/show_bug.cgi?id=24832
 struct S


### PR DESCRIPTION
These crashed in `dmd v2.109.1`, but give error message in `2.110.0-rc.1`