### PR TITLE
Use selective imports when importing from `core.stdc` in `rt`

### DIFF
--- a/druntime/src/rt/adi.d
+++ b/druntime/src/rt/adi.d
@@ -11,12 +11,9 @@
 
 module rt.adi;
 
-//debug=adi;            // uncomment to turn on debugging printf's
+// debug = adi; // uncomment to turn on debugging printf's
 
-private
-{
-    debug(adi) import core.stdc.stdio;
-}
+debug (adi) import core.stdc.stdio : printf;
 
 /***************************************
  * Support for array equality test.

--- a/druntime/src/rt/arraycat.d
+++ b/druntime/src/rt/arraycat.d
@@ -10,12 +10,12 @@
 
 module rt.arraycat;
 
-private
-{
-    import core.stdc.string;
-    import core.internal.util.array;
-    debug(PRINTF) import core.stdc.stdio;
-}
+// debug = PRINTF;
+
+import core.internal.util.array;
+import core.stdc.string : memcpy;
+
+debug(PRINTF) import core.stdc.stdio : printf;
 
 extern (C) @trusted nothrow:
 

--- a/druntime/src/rt/cmath2.d
+++ b/druntime/src/rt/cmath2.d
@@ -14,7 +14,9 @@
  */
 module rt.cmath2;
 
-import core.stdc.math;
+import core.stdc.math : fabs;
+
+debug import core.stdc.stdio : printf;
 
 extern (C):
 

--- a/druntime/src/rt/deh_win32.d
+++ b/druntime/src/rt/deh_win32.d
@@ -17,7 +17,8 @@ import core.sys.windows.basetsd /+: ULONG_PTR+/;
 import core.sys.windows.windef /+: BOOL, BYTE, DWORD+/;
 import core.sys.windows.winnt /+: PVOID+/;
 import rt.monitor_;
-//import core.stdc.stdio;
+
+debug import core.stdc.stdio : printf;
 
 version (D_InlineAsm_X86)
 {

--- a/druntime/src/rt/dmain2.d
+++ b/druntime/src/rt/dmain2.d
@@ -11,22 +11,24 @@
 
 module rt.dmain2;
 
+import core.atomic;
+import core.internal.parseoptions : rt_parseOption;
+import core.stdc.errno : errno;
+import core.stdc.stdio : fflush, fprintf, fwrite, stderr, stdout;
+import core.stdc.stdlib : alloca, EXIT_FAILURE, EXIT_SUCCESS, free, malloc, realloc;
+import core.stdc.string : strerror;
+import rt.config : rt_cmdline_enabled, rt_configOption;
 import rt.memory;
 import rt.sections;
-import core.atomic;
-import core.stdc.stddef;
-import core.stdc.stdlib;
-import core.stdc.string;
-import core.stdc.stdio;   // for printf()
-import core.stdc.errno : errno;
 
 version (Windows)
 {
-    import core.stdc.wchar_;
+    import core.stdc.stdio : fileno;
+    import core.stdc.wchar_ : wcslen;
     import core.sys.windows.basetsd : HANDLE;
     import core.sys.windows.shellapi : CommandLineToArgvW;
-    import core.sys.windows.winbase : FreeLibrary, GetCommandLineW, GetProcAddress,
-        IsDebuggerPresent, LoadLibraryW, LocalFree, WriteFile;
+    import core.sys.windows.winbase : FreeLibrary, GetCommandLineW, GetProcAddress, IsDebuggerPresent, LoadLibraryW,
+        LocalFree, WriteFile;
     import core.sys.windows.wincon : CONSOLE_SCREEN_BUFFER_INFO, GetConsoleOutputCP,
         GetConsoleScreenBufferInfo;
     import core.sys.windows.winnls : CP_UTF8, MultiByteToWideChar, WideCharToMultiByte;
@@ -34,19 +36,12 @@ version (Windows)
     import core.sys.windows.winuser : MB_ICONERROR, MessageBoxW;
 
     pragma(lib, "shell32.lib"); // needed for CommandLineToArgvW
-}
 
-version (FreeBSD)
-{
-    import core.stdc.fenv;
+    import core.stdc.stdio : _get_osfhandle;
 }
-version (NetBSD)
+else version (Posix)
 {
-    import core.stdc.fenv;
-}
-version (DragonFlyBSD)
-{
-    import core.stdc.fenv;
+    import core.stdc.string : strlen;
 }
 
 // not sure why we can't define this in one place, but this is to keep this
@@ -444,7 +439,6 @@ private extern (C) int _d_run_main2(char[][] args, size_t totalArgsLength, MainF
         char[][] argsCopy = buff[0 .. args.length];
         auto argBuff = cast(char*) (buff + args.length);
         size_t j = 0;
-        import rt.config : rt_cmdline_enabled;
         bool parseOpts = rt_cmdline_enabled!();
         foreach (arg; args)
         {
@@ -587,8 +581,6 @@ private void formatThrowable(Throwable t, scope void delegate(in char[] s) nothr
 
 private auto parseExceptionOptions()
 {
-    import rt.config : rt_configOption;
-    import core.internal.parseoptions : rt_parseOption;
     const optName = "trapExceptions";
     auto option = rt_configOption(optName);
     auto trap = rt_trapExceptions;

--- a/druntime/src/rt/dwarfeh.d
+++ b/druntime/src/rt/dwarfeh.d
@@ -11,14 +11,14 @@
 
 module rt.dwarfeh;
 
-// debug = EH_personality;
-
 version (Posix):
 
-import rt.dmain2: _d_print_throwable;
+// debug = EH_personality;
+
 import core.internal.backtrace.unwind;
-import core.stdc.stdio;
-import core.stdc.stdlib;
+import core.stdc.stdio : fprintf, printf, stderr;
+import core.stdc.stdlib : abort, calloc, free;
+import rt.dmain2 : _d_print_throwable;
 
 /* These are the register numbers for _Unwind_SetGR().
  * Hints for these can be found by looking at the EH_RETURN_DATA_REGNO macro in
@@ -125,7 +125,8 @@ debug (EH_personality)
 {
     private void writeln(in char* format, ...) @nogc nothrow
     {
-        import core.stdc.stdarg;
+        import core.stdc.stdarg : va_list, va_start;
+        import core.stdc.stdio : fflush, stdout, vfprintf;
 
         va_list args;
         va_start(args, format);
@@ -181,7 +182,7 @@ struct ExceptionHeader
         auto eh = &ehstorage;
         if (eh.object)                  // if in use
         {
-            eh = cast(ExceptionHeader*)core.stdc.stdlib.calloc(1, ExceptionHeader.sizeof);
+            eh = cast(ExceptionHeader*).calloc(1, ExceptionHeader.sizeof);
             if (!eh)
                 terminate(__LINE__);              // out of memory while throwing - not much else can be done
         }
@@ -204,7 +205,7 @@ struct ExceptionHeader
          */
         *eh = ExceptionHeader.init;
         if (eh != &ehstorage)
-            core.stdc.stdlib.free(eh);
+            .free(eh);
     }
 
     /*************************

--- a/druntime/src/rt/ehalloc.d
+++ b/druntime/src/rt/ehalloc.d
@@ -13,10 +13,7 @@ module rt.ehalloc;
 
 //debug = PRINTF;
 
-debug(PRINTF)
-{
-    import core.stdc.stdio;
-}
+debug (PRINTF) import core.stdc.stdio : printf;
 
 
 /********************************************

--- a/druntime/src/rt/minfo.d
+++ b/druntime/src/rt/minfo.d
@@ -12,9 +12,12 @@
 
 module rt.minfo;
 
-import core.stdc.stdlib;  // alloca
-import core.stdc.string;  // memcpy
+import core.stdc.stdio : fprintf, stderr;
+import core.stdc.stdlib : free, malloc, realloc;
+import core.stdc.string : memcpy, memset;
 import rt.sections;
+
+debug (printModuleDependencies) import core.stdc.stdio : printf;
 
 enum
 {
@@ -179,7 +182,6 @@ struct ModuleGroup
         switch (cycleHandling) with(OnCycle)
         {
         case "deprecate":
-            import core.stdc.stdio : fprintf, stderr;
             // Option deprecated in 2.101, remove in 2.111
             fprintf(stderr, "`--DRT-oncycle=deprecate` is no longer supported, using `abort` instead\n");
             break;
@@ -202,8 +204,6 @@ struct ModuleGroup
 
         debug (printModuleDependencies)
         {
-            import core.stdc.stdio : printf;
-
             foreach (_m; _modules)
             {
                 printf("%s%s%s:", _m.name.ptr, (_m.flags & MIstandalone)
@@ -375,7 +375,6 @@ struct ModuleGroup
                                 case print:
                                     // print the message
                                     buildCycleMessage(idx, midx, (string x) {
-                                                      import core.stdc.stdio : fprintf, stderr;
                                                       fprintf(stderr, "%.*s", cast(int) x.length, x.ptr);
                                                       });
                                     // continue on as if this is correct.
@@ -518,7 +517,6 @@ struct ModuleGroup
             !doSort(MItlsctor | MItlsdtor, _tlsctors))
         {
             // print a warning
-            import core.stdc.stdio : fprintf, stderr;
             fprintf(stderr, "Deprecation 16211 warning:\n"
                 ~ "A cycle has been detected in your program that was undetected prior to DMD\n"
                 ~ "2.072. This program will continue, but will not operate when using DMD 2.074\n"

--- a/druntime/src/rt/msvc_math.d
+++ b/druntime/src/rt/msvc_math.d
@@ -15,7 +15,7 @@ module rt.msvc_math;
 version (CRuntime_Microsoft):
 version (X86):
 
-import core.stdc.math;
+import cmath = core.stdc.math;
 
 extern(C):
 @trusted:
@@ -24,11 +24,11 @@ nothrow:
 
 mixin template AltImpl(string baseName)
 {
-    mixin("float _msvc_"~baseName~"f(float x) { return cast(float) "~baseName~"(x); }");
+    mixin("float _msvc_"~baseName~"f(float x) { return cast(float) cmath."~baseName~"(x); }");
 }
 mixin template AltImpl2(string baseName)
 {
-    mixin("float _msvc_"~baseName~"f(float x, float y) { return cast(float) "~baseName~"(x, y); }");
+    mixin("float _msvc_"~baseName~"f(float x, float y) { return cast(float) cmath."~baseName~"(x, y); }");
 }
 
 mixin AltImpl!"acos";
@@ -53,7 +53,7 @@ mixin AltImpl2!"fmod";
 float _msvc_modff(float value, float* iptr)
 {
     double di;
-    const result = cast(float) modf(value, &di);
+    const result = cast(float) cmath.modf(value, &di);
     *iptr = cast(float) di;
     return result;
 }

--- a/druntime/src/rt/profilegc.d
+++ b/druntime/src/rt/profilegc.d
@@ -15,10 +15,9 @@ module rt.profilegc;
 
 private:
 
-import core.stdc.errno;
-import core.stdc.stdio;
-import core.stdc.stdlib;
-import core.stdc.string;
+import core.stdc.errno : errno;
+import core.stdc.stdio : fclose, FILE, fopen, fprintf, snprintf, stderr, stdout;
+import core.stdc.stdlib : free, malloc, qsort, realloc;
 
 import core.exception : onOutOfMemoryError;
 import core.internal.container.hashtab;

--- a/druntime/src/rt/sections_osx_x86.d
+++ b/druntime/src/rt/sections_osx_x86.d
@@ -24,11 +24,12 @@ version (Darwin):
 version (X86):
 
 // debug = PRINTF;
+
 import core.internal.container.array;
 import core.stdc.stdint : intptr_t;
-import core.stdc.stdio;
-import core.stdc.stdlib;
-import core.stdc.string;
+import core.stdc.stdio : fprintf, perror, stderr;
+import core.stdc.stdlib : calloc, free, malloc;
+import core.stdc.string : memcpy;
 import core.sys.darwin.mach.dyld : _dyld_register_func_for_add_image;
 import core.sys.darwin.mach.getsect : getsectbynamefromheader;
 import core.sys.darwin.mach.loader : mach_header, MH_MAGIC, SECT_BSS, SECT_COMMON, SECT_DATA, SEG_DATA;
@@ -36,6 +37,8 @@ import core.sys.posix.pthread : pthread_getspecific, pthread_key_create, pthread
     pthread_setspecific;
 import rt.deh;
 import rt.minfo;
+
+debug (PRINTF) import core.stdc.stdio : printf;
 
 struct SectionGroup
 {
@@ -169,7 +172,6 @@ ref void[] getTLSBlock() nothrow @nogc
         pary = cast(void[]*).calloc(1, (void[]).sizeof);
         if (pthread_setspecific(_tlsKey, pary) != 0)
         {
-            import core.stdc.stdio;
             perror("pthread_setspecific failed with");
             assert(0);
         }

--- a/druntime/src/rt/sections_osx_x86_64.d
+++ b/druntime/src/rt/sections_osx_x86_64.d
@@ -24,18 +24,18 @@ version (Darwin):
 version (X86_64):
 
 // debug = PRINTF;
-import core.stdc.stdio;
-import core.stdc.stdlib;
-import core.stdc.string;
-import core.stdc.stdint : intptr_t;
-import core.sys.darwin.mach.dyld : _dyld_register_func_for_add_image;
-import core.sys.darwin.mach.getsect : mach_header;
 
 import core.internal.container.array;
+import core.stdc.stdint : intptr_t;
+import core.stdc.stdio : fprintf, stderr;
+import core.sys.darwin.mach.dyld : _dyld_register_func_for_add_image;
+import core.sys.darwin.mach.getsect : mach_header;
 import rt.deh;
 import rt.minfo;
 import rt.sections_darwin_64;
 import rt.util.utility : safeAssert;
+
+debug (PRINTF) import core.stdc.stdio : printf;
 
 struct SectionGroup
 {

--- a/druntime/src/rt/sections_solaris.d
+++ b/druntime/src/rt/sections_solaris.d
@@ -15,20 +15,18 @@
 module rt.sections_solaris;
 
 version (Solaris)
-{
     version = SolarisOrOpenBSD;
-}
 else version (OpenBSD)
-{
     version = SolarisOrOpenBSD;
-}
 
 version (SolarisOrOpenBSD):
 
 // debug = PRINTF;
-debug(PRINTF) import core.stdc.stdio;
-import core.stdc.stdlib : malloc, free;
-import rt.deh, rt.minfo;
+
+import rt.deh;
+import rt.minfo;
+
+debug (PRINTF) import core.stdc.stdio : printf;
 
 struct SectionGroup
 {

--- a/druntime/src/rt/sections_win64.d
+++ b/druntime/src/rt/sections_win64.d
@@ -14,21 +14,21 @@ module rt.sections_win64;
 
 version (CRuntime_Microsoft):
 
-// debug = PRINTF;
-debug(PRINTF) import core.stdc.stdio;
-import core.memory;
-import core.stdc.stdlib : calloc, malloc, free;
-import core.sys.windows.winbase : FreeLibrary, GetCurrentThreadId, GetModuleHandleExW,
-    GetProcAddress, LoadLibraryA, LoadLibraryW,
-    GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
-import core.sys.windows.winnt : WCHAR, IMAGE_DOS_HEADER, IMAGE_DOS_SIGNATURE, IMAGE_FILE_HEADER,
-    IMAGE_NT_HEADERS, IMAGE_SECTION_HEADER, IMAGE_TLS_DIRECTORY, IMAGE_DIRECTORY_ENTRY_TLS;
-import core.sys.windows.threadaux;
-import core.thread;
-import rt.deh, rt.minfo;
-import core.internal.container.array;
-
 version (DigitalMars) version (Win64) version = hasEHTables;
+
+// debug = PRINTF;
+
+import core.internal.container.array;
+import core.memory;
+import core.stdc.stdlib : calloc, free, malloc;
+import core.sys.windows.threadaux;
+import core.sys.windows.winbase : FreeLibrary, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, GetModuleHandleExW, GetProcAddress, LoadLibraryA, LoadLibraryW;
+import core.sys.windows.winnt : IMAGE_DIRECTORY_ENTRY_TLS, IMAGE_DOS_HEADER, IMAGE_DOS_SIGNATURE, IMAGE_NT_HEADERS, IMAGE_SECTION_HEADER, IMAGE_TLS_DIRECTORY, WCHAR;
+import core.thread;
+import rt.deh;
+import rt.minfo;
+
+debug (PRINTF) import core.stdc.stdio : printf;
 
 struct SectionGroup
 {
@@ -93,7 +93,7 @@ void initSections() nothrow @nogc
 
 void initSections(void* handle) nothrow @nogc
 {
-    auto sectionGroup = cast(SectionGroup*)calloc(1, SectionGroup.sizeof);
+    auto sectionGroup = cast(SectionGroup*).calloc(1, SectionGroup.sizeof);
     sectionGroup._moduleGroup = ModuleGroup(getModuleInfos(handle));
     sectionGroup._handle = handle;
     version (hasEHTables)
@@ -124,7 +124,7 @@ void initSections(void* handle) nothrow @nogc
 
     if (conservative)
     {
-        sectionGroup._gcRanges = (cast(void[]*) malloc((void[]).sizeof))[0..1];
+        sectionGroup._gcRanges = (cast(void[]*).malloc((void[]).sizeof))[0..1];
         sectionGroup._gcRanges[0] = dataSection;
     }
     else
@@ -134,7 +134,7 @@ void initSections(void* handle) nothrow @nogc
         debug(PRINTF) printf("found .dp section: [%p,+%llx]\n", dpSection.ptr,
                              cast(ulong)dpSection.length);
         auto dp = cast(uint[]) dpSection;
-        auto ranges = cast(void[]*) malloc(dp.length * (void[]).sizeof);
+        auto ranges = cast(void[]*).malloc(dp.length * (void[]).sizeof);
         size_t r = 0;
         void* prev = null;
         foreach (off; dp)

--- a/druntime/src/rt/tlsgc.d
+++ b/druntime/src/rt/tlsgc.d
@@ -13,9 +13,9 @@
  */
 module rt.tlsgc;
 
-import core.stdc.stdlib;
-
-static import rt.lifetime, rt.sections;
+import core.exception : onOutOfMemoryError;
+import core.stdc.stdlib : free, malloc;
+static import rt.sections;
 
 /**
  * Per thread record to store thread associated data for garbage collection.
@@ -32,8 +32,7 @@ struct Data
 void* init() nothrow @nogc
 {
     auto data = cast(Data*).malloc(Data.sizeof);
-    import core.exception;
-    if ( data is null ) core.exception.onOutOfMemoryError();
+    if ( data is null ) onOutOfMemoryError();
     *data = Data.init;
 
     // do module specific initialization

--- a/druntime/src/rt/trace.d
+++ b/druntime/src/rt/trace.d
@@ -12,13 +12,21 @@
 module rt.trace;
 
 import core.demangle;
-import core.stdc.ctype;
-import core.stdc.stdio;
-import core.stdc.stdlib;
-import core.stdc.string;
+import core.stdc.ctype : isalpha, isgraph, isspace;
+import core.stdc.stdio : EOF, fclose, fgetc, FILE, fopen, fprintf, stderr, stdout;
+import core.stdc.stdlib : exit, EXIT_FAILURE, free, malloc, qsort, realloc, strtoul;
+import core.stdc.string : memcmp, memset, strdup, strlen;
+
+debug import core.stdc.stdio : printf;
 
 version (CRuntime_Microsoft)
-    private alias core.stdc.stdlib._strtoui64 strtoull;
+{
+    import core.stdc.stdlib : strtoull = _strtoui64;
+}
+else
+{
+    import core.stdc.stdlib : strtoull;
+}
 
 shared static this ()
 {

--- a/druntime/src/rt/tracegc.d
+++ b/druntime/src/rt/tracegc.d
@@ -71,7 +71,7 @@ enum accumulator = q{
 
     version (tracegc)
     {
-        import core.stdc.stdio;
+        import core.stdc.stdio : printf;
 
         printf("%s file = '%.*s' line = %d function = '%.*s' type = %.*s\n",
             __FUNCTION__.ptr,


### PR DESCRIPTION
Follows on #20725.
See #20632 for reasoning.

In `cover.d` I also fixed some versions that assume that "not Windows" means Posix.
In `lifetime.d` there were many duplicate local imports, so I moved those to the module level as selective imports. The same applies (to a much lesser extent) to `sections_osx_x86.d` and `tlsgc.d`.
In `monitor_.d` I moved the `package` imports to the beginning of the file, without the `package` attribute as that's bugged as per #20631.