### PR TITLE
Use selective imports when importing from `core.stdc` in druntime tests

### DIFF
--- a/druntime/src/test_runner.d
+++ b/druntime/src/test_runner.d
@@ -1,5 +1,5 @@
 import core.runtime, core.time : MonoTime;
-import core.stdc.stdio;
+import core.stdc.stdio : printf;
 
 version (ARM)     version = ARM_Any;
 version (AArch64) version = ARM_Any;

--- a/druntime/test/aa/src/test_aa.d
+++ b/druntime/test/aa/src/test_aa.d
@@ -585,8 +585,6 @@ void issue13078() nothrow pure
 
 void issue14104()
 {
-    import core.stdc.stdio;
-
     alias K = const(ubyte)*;
     size_t[K] aa;
     immutable key = cast(K)(cast(size_t) uint.max + 1);

--- a/druntime/test/betterc/src/test19933.d
+++ b/druntime/test/betterc/src/test19933.d
@@ -2,7 +2,7 @@
 // https://issues.dlang.org/show_bug.cgi?id=19933
 // https://issues.dlang.org/show_bug.cgi?id=18816
 
-import core.stdc.stdio;
+import core.stdc.stdio : fprintf, stderr;
 
 extern(C) int main()
 {

--- a/druntime/test/config/src/test22523.d
+++ b/druntime/test/config/src/test22523.d
@@ -1,6 +1,6 @@
 // https://issues.dlang.org/show_bug.cgi?id=22523
 
-import core.stdc.stdio;
+import core.stdc.stdio : puts;
 
 int main()
 {

--- a/druntime/test/cpuid/src/cpuid.d
+++ b/druntime/test/cpuid/src/cpuid.d
@@ -1,6 +1,6 @@
 module puid;
 import core.cpuid;
-import core.stdc.stdio;
+import core.stdc.stdio : printf;
 
 mixin template printFlag(string name)
 {

--- a/druntime/test/exceptions/src/chain.d
+++ b/druntime/test/exceptions/src/chain.d
@@ -1,7 +1,7 @@
 // Author: Ali Çehreli
 // See https://forum.dlang.org/post/o2n7f8$2p1t$1@digitalmars.com
 
-import core.stdc.stdio;
+import core.stdc.stdio : printf;
 
 class TestException : Exception
 {

--- a/druntime/test/exceptions/src/future_message.d
+++ b/druntime/test/exceptions/src/future_message.d
@@ -1,4 +1,4 @@
-import core.stdc.stdio;
+import core.stdc.stdio : fprintf, stderr;
 
 // Make sure basic stuff works with future Throwable.message
 class NoMessage : Throwable

--- a/druntime/test/exceptions/src/line_trace.d
+++ b/druntime/test/exceptions/src/line_trace.d
@@ -6,7 +6,7 @@ void main()
     }
     catch (Exception e)
     {
-        import core.stdc.stdio;
+        import core.stdc.stdio : printf;
         auto str = e.toString();
         printf("%.*s\n", cast(int)str.length, str.ptr);
     }

--- a/druntime/test/exceptions/src/long_backtrace_trunc.d
+++ b/druntime/test/exceptions/src/long_backtrace_trunc.d
@@ -30,7 +30,7 @@ void main() {
     HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH x;
     x.tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt(1);
     } catch (Exception e) {
-        import core.stdc.stdio;
+        import core.stdc.stdio : printf;
         auto str = e.toString();
         printf("%.*s\n", cast(int)str.length, str.ptr);
     }

--- a/druntime/test/exceptions/src/static_dtor.d
+++ b/druntime/test/exceptions/src/static_dtor.d
@@ -1,5 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=16594
-import core.stdc.stdio;
+import core.stdc.stdio : fprintf, stderr;
 
 shared static ~this()
 {

--- a/druntime/test/gc/forkgc.d
+++ b/druntime/test/gc/forkgc.d
@@ -1,5 +1,5 @@
 import core.memory;
-import core.stdc.stdio;
+import core.stdc.stdio : printf;
 import core.sys.posix.sys.wait;
 import core.sys.posix.unistd;
 

--- a/druntime/test/gc/hospital.d
+++ b/druntime/test/gc/hospital.d
@@ -24,7 +24,7 @@ int main(string[] args)
 
     version (VERBOSE)
     {
-        import core.stdc.stdio;
+        import core.stdc.stdio : printf;
         printf("Patients: %lld\n", t.patients);
         printf("Time:     %lld\n", t.hospitalTime);
         printf("Visits:   %lld\n", t.hospitalVisits);

--- a/druntime/test/gc/precisegc.d
+++ b/druntime/test/gc/precisegc.d
@@ -7,7 +7,7 @@
 module testgc;
 
 import core.memory;
-import core.stdc.stdio;
+import core.stdc.stdio : printf;
 
 class C
 {

--- a/druntime/test/gc/recoverfree.d
+++ b/druntime/test/gc/recoverfree.d
@@ -1,5 +1,4 @@
 // https://issues.dlang.org/show_bug.cgi?id=20438
-import core.stdc.stdio;
 import core.memory;
 
 void main()

--- a/druntime/test/hash/src/test_hash.d
+++ b/druntime/test/hash/src/test_hash.d
@@ -169,7 +169,7 @@ void issue19568()
 
         ~this() @nogc nothrow
         {
-            import core.stdc.stdio;
+            import core.stdc.stdio : puts;
             if (mptr) puts("impure");
         }
 
@@ -183,7 +183,7 @@ void issue19568()
 
         ~this() @nogc nothrow
         {
-            import core.stdc.stdio;
+            import core.stdc.stdio : puts;
             if (fd != -1) puts("impure");
         }
 

--- a/druntime/test/importc_compare/src/importc_compare.d
+++ b/druntime/test/importc_compare/src/importc_compare.d
@@ -1,4 +1,4 @@
-import core.stdc.stdio;
+import core.stdc.stdio : printf;
 
 version (OSX)
     version = Apple;

--- a/druntime/test/init_fini/src/custom_gc.d
+++ b/druntime/test/init_fini/src/custom_gc.d
@@ -1,6 +1,6 @@
-import core.gc.registry;
 import core.gc.gcinterface;
-import core.stdc.stdlib;
+import core.gc.registry;
+import core.stdc.stdlib : calloc, malloc, realloc;
 
 static import core.memory;
 

--- a/druntime/test/init_fini/src/thread_join.d
+++ b/druntime/test/init_fini/src/thread_join.d
@@ -1,7 +1,6 @@
 // Bugzilla 11309 - std.concurrency: OwnerTerminated message doesn't work
 // We need to assure that the thread dtors of parent threads run before the thread dtors of the child threads.
 import core.thread, core.sync.semaphore;
-import core.stdc.stdio;
 
 __gshared Semaphore sem;
 

--- a/druntime/test/shared/src/finalize.d
+++ b/druntime/test/shared/src/finalize.d
@@ -1,6 +1,5 @@
 import core.runtime;
-import core.stdc.stdio;
-import core.stdc.string;
+import core.stdc.string : strrchr;
 import core.thread;
 
 void runTest()

--- a/druntime/test/shared/src/load.d
+++ b/druntime/test/shared/src/load.d
@@ -1,6 +1,5 @@
 import core.runtime;
-import core.stdc.stdio;
-import core.stdc.string;
+import core.stdc.string : strrchr;
 import core.thread;
 
 version (DragonFlyBSD) import core.sys.dragonflybsd.dlfcn : RTLD_NOLOAD;

--- a/druntime/test/shared/src/load_13414.d
+++ b/druntime/test/shared/src/load_13414.d
@@ -1,6 +1,6 @@
-import core.runtime;
 import core.atomic;
-import core.stdc.string;
+import core.runtime;
+import core.stdc.string : strrchr;
 
 shared uint tlsDtor, dtor;
 void staticDtorHook() { atomicOp!"+="(tlsDtor, 1); }

--- a/druntime/test/shared/src/load_linkdep.d
+++ b/druntime/test/shared/src/load_linkdep.d
@@ -1,5 +1,5 @@
 import core.runtime;
-import core.stdc.string;
+import core.stdc.string : strrchr;
 
 extern(C) alias RunDepTests = int function();
 

--- a/druntime/test/shared/src/load_loaddep.d
+++ b/druntime/test/shared/src/load_loaddep.d
@@ -1,5 +1,5 @@
 import core.runtime;
-import core.stdc.string;
+import core.stdc.string : strrchr;
 
 extern(C) alias RunDepTests = int function(const char*);
 

--- a/druntime/test/thread/src/tlsgc_sections.d
+++ b/druntime/test/thread/src/tlsgc_sections.d
@@ -11,7 +11,7 @@ class C
 {
     ~this()
     {
-        import core.stdc.stdlib;
+        import core.stdc.stdlib : abort;
         abort();    // this gets triggered although the instance always stays referenced
     }
 }

--- a/druntime/test/thread/src/tlsstack.d
+++ b/druntime/test/thread/src/tlsstack.d
@@ -1,6 +1,6 @@
 module core.thread.test; // needs access to getStackTop()/getStackBottom()
 
-import core.stdc.stdio;
+import core.stdc.stdio : printf;
 import core.thread;
 
 ubyte[16384] data;

--- a/druntime/test/unittest/customhandler.d
+++ b/druntime/test/unittest/customhandler.d
@@ -16,6 +16,6 @@ shared static this()
 
 void main()
 {
-    import core.stdc.stdio;
+    import core.stdc.stdio : fprintf, stderr;
     fprintf(stderr, "main\n");
 }


### PR DESCRIPTION
Follows on #20742.
See #20632 for reasoning.