### PR TITLE
Remove redundant BinExp semantic type check

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12597,12 +12597,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     bool commonBinOpSemantic(BinExp exp)
     {
-        if (exp.type)
-        {
-            result = exp;
-            return true;
-        }
-
         if (Expression ex = binSemanticProp(exp, sc))
         {
             result = ex;


### PR DESCRIPTION
This check is already performed before entering the visitor