### PR TITLE
Move AddExp type check from typeCombine to expressionSemantic

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -4147,17 +4147,6 @@ Expression typeCombine(BinExp be, Scope* sc)
     Type t1 = be.e1.type.toBasetype();
     Type t2 = be.e2.type.toBasetype();
 
-    if (be.op == EXP.min || be.op == EXP.add)
-    {
-        // struct+struct, and class+class are errors
-        if (t1.ty == Tstruct && t2.ty == Tstruct)
-            return errorReturn();
-        if (t1.ty == Tclass && t2.ty == Tclass)
-            return errorReturn();
-        if (t1.ty == Taarray && t2.ty == Taarray)
-            return errorReturn();
-    }
-
     if (auto result = typeMerge(sc, be.op, be.e1, be.e2))
     {
         if (be.type is null)

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -4144,9 +4144,6 @@ Expression typeCombine(BinExp be, Scope* sc)
         return ErrorExp.get();
     }
 
-    Type t1 = be.e1.type.toBasetype();
-    Type t2 = be.e2.type.toBasetype();
-
     if (auto result = typeMerge(sc, be.op, be.e1, be.e2))
     {
         if (be.type is null)

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -592,6 +592,13 @@ extern (C++) abstract class Expression : ASTNode
             error(loc, msg, EXPtoString(op).ptr, toChars(), type.toChars());
             return true;
         }
+
+        // FIXME: Existing code relies on adding / subtracting types in typeof() expressions:
+        // alias I = ulong; alias U = typeof(I + 1u);
+        // https://github.com/dlang/dmd/issues/20763
+        if (op == EXP.add || op == EXP.min)
+            return false;
+
         return checkValue();
     }
 
@@ -3067,9 +3074,7 @@ extern (C++) abstract class BinExp : Expression
 
     extern (D) final bool checkArithmeticBin()
     {
-        bool r1 = e1.checkArithmetic(this.op);
-        bool r2 = e2.checkArithmetic(this.op);
-        return (r1 || r2);
+        return e1.checkArithmetic(this.op) || e2.checkArithmetic(this.op);
     }
 
     /*********************

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12130,6 +12130,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
+        if (exp.checkArithmeticBin())
+            return setError();
+
         tb1 = exp.e1.type.toBasetype();
         if (!target.isVectorOpSupported(tb1, exp.op, tb2))
         {
@@ -12279,6 +12282,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp;
             return;
         }
+
+        if (exp.checkArithmeticBin())
+            return setError();
 
         t1 = exp.e1.type.toBasetype();
         t2 = exp.e2.type.toBasetype();

--- a/compiler/test/fail_compilation/fail10534.d
+++ b/compiler/test/fail_compilation/fail10534.d
@@ -1,22 +1,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10534.d(28): Error: illegal operator `+` for `a` of type `int delegate()`
-fail_compilation/fail10534.d(28): Error: illegal operator `+` for `b` of type `int delegate()`
-fail_compilation/fail10534.d(29): Error: illegal operator `-` for `a` of type `int delegate()`
-fail_compilation/fail10534.d(29): Error: illegal operator `-` for `b` of type `int delegate()`
-fail_compilation/fail10534.d(30): Error: illegal operator `/` for `a` of type `int delegate()`
-fail_compilation/fail10534.d(30): Error: illegal operator `/` for `b` of type `int delegate()`
-fail_compilation/fail10534.d(31): Error: illegal operator `*` for `a` of type `int delegate()`
-fail_compilation/fail10534.d(31): Error: illegal operator `*` for `b` of type `int delegate()`
-fail_compilation/fail10534.d(36): Error: illegal operator `+` for `a` of type `int function()`
-fail_compilation/fail10534.d(36): Error: illegal operator `+` for `b` of type `int function()`
-fail_compilation/fail10534.d(37): Error: illegal operator `-` for `a` of type `int function()`
-fail_compilation/fail10534.d(37): Error: illegal operator `-` for `b` of type `int function()`
-fail_compilation/fail10534.d(38): Error: illegal operator `/` for `a` of type `int function()`
-fail_compilation/fail10534.d(38): Error: illegal operator `/` for `b` of type `int function()`
-fail_compilation/fail10534.d(39): Error: illegal operator `*` for `a` of type `int function()`
-fail_compilation/fail10534.d(39): Error: illegal operator `*` for `b` of type `int function()`
+fail_compilation/fail10534.d(24): Error: illegal operator `+` for `a` of type `int delegate()`
+fail_compilation/fail10534.d(24): Error: illegal operator `+` for `b` of type `int delegate()`
+fail_compilation/fail10534.d(25): Error: illegal operator `-` for `a` of type `int delegate()`
+fail_compilation/fail10534.d(25): Error: illegal operator `-` for `b` of type `int delegate()`
+fail_compilation/fail10534.d(26): Error: illegal operator `/` for `a` of type `int delegate()`
+fail_compilation/fail10534.d(27): Error: illegal operator `*` for `a` of type `int delegate()`
+fail_compilation/fail10534.d(32): Error: illegal operator `+` for `a` of type `int function()`
+fail_compilation/fail10534.d(32): Error: illegal operator `+` for `b` of type `int function()`
+fail_compilation/fail10534.d(33): Error: illegal operator `-` for `a` of type `int function()`
+fail_compilation/fail10534.d(33): Error: illegal operator `-` for `b` of type `int function()`
+fail_compilation/fail10534.d(34): Error: illegal operator `/` for `a` of type `int function()`
+fail_compilation/fail10534.d(35): Error: illegal operator `*` for `a` of type `int function()`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail11445.d
+++ b/compiler/test/fail_compilation/fail11445.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11445.d(12): Error: illegal operator `+` for `a` of type `double[string]`
-fail_compilation/fail11445.d(12): Error: illegal operator `+` for `b` of type `double[string]`
+fail_compilation/fail11445.d(11): Error: illegal operator `+` for `a` of type `double[string]`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail11445.d
+++ b/compiler/test/fail_compilation/fail11445.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11445.d(11): Error: incompatible types for `(a) + (b)`: both operands are of type `double[string]`
+fail_compilation/fail11445.d(12): Error: illegal operator `+` for `a` of type `double[string]`
+fail_compilation/fail11445.d(12): Error: illegal operator `+` for `b` of type `double[string]`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail297.d
+++ b/compiler/test/fail_compilation/fail297.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail297.d(30): Error: incompatible types for `(Bar()) + (baz())`: `Bar` and `const(Bar)`
+fail_compilation/fail297.d(31): Error: operator `+` is not defined for `Bar()` of type `Bar`
+fail_compilation/fail297.d(31): Error: operator `+` is not defined for `baz()` of type `const(Bar)`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail297.d
+++ b/compiler/test/fail_compilation/fail297.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail297.d(31): Error: operator `+` is not defined for `Bar()` of type `Bar`
-fail_compilation/fail297.d(31): Error: operator `+` is not defined for `baz()` of type `const(Bar)`
+fail_compilation/fail297.d(30): Error: operator `+` is not defined for `Bar()` of type `Bar`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail3.d
+++ b/compiler/test/fail_compilation/fail3.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3.d(41): Error: incompatible types for `(a) + (b)`: both operands are of type `vec2`
+fail_compilation/fail3.d(42): Error: operator `+` is not defined for `a` of type `vec2`
+fail_compilation/fail3.d(42): Error: operator `+` is not defined for `b` of type `vec2`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail3.d
+++ b/compiler/test/fail_compilation/fail3.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3.d(42): Error: operator `+` is not defined for `a` of type `vec2`
-fail_compilation/fail3.d(42): Error: operator `+` is not defined for `b` of type `vec2`
+fail_compilation/fail3.d(41): Error: operator `+` is not defined for `a` of type `vec2`
 ---
 */
 


### PR DESCRIPTION
The arithmetic type check for + and - are weirdly performed by typeCombine, resulting in an error message inconsistent with other arithmetic operators.