### PR TITLE
Fix #20730 - print SymOff with unsigned offset

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2435,7 +2435,7 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
     void visitSymOff(SymOffExp e)
     {
         if (e.offset)
-            buf.printf("(& %s%+lld)", e.var.toChars(), e.offset);
+            buf.printf("(& %s + %llu)", e.var.toChars(), e.offset);
         else if (e.var.isTypeInfoDeclaration())
             buf.writestring(e.var.toChars());
         else

--- a/compiler/test/fail_compilation/fail13902.d
+++ b/compiler/test/fail_compilation/fail13902.d
@@ -14,7 +14,7 @@ fail_compilation/fail13902.d(33): Error: returning `&s1.v` escapes a reference t
 fail_compilation/fail13902.d(38): Error: returning `& sa1` escapes a reference to local variable `sa1`
 fail_compilation/fail13902.d(39): Error: returning `& sa2` escapes a reference to local variable `sa2`
 fail_compilation/fail13902.d(40): Error: returning `& x` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(41): Error: returning `(& x+4)` escapes a reference to local variable `x`
+fail_compilation/fail13902.d(41): Error: returning `(& x + 4)` escapes a reference to local variable `x`
 fail_compilation/fail13902.d(42): Error: returning `& x + cast(long)x * 4L` escapes a reference to local variable `x`
 fail_compilation/fail13902.d(45): Error: returning `& y` escapes a reference to local variable `y`
 ---
@@ -59,7 +59,7 @@ fail_compilation/fail13902.d(76): Error: returning `&s1.v` escapes a reference t
 fail_compilation/fail13902.d(81): Error: returning `& sa1` escapes a reference to parameter `sa1`
 fail_compilation/fail13902.d(82): Error: returning `& sa2` escapes a reference to parameter `sa2`
 fail_compilation/fail13902.d(83): Error: returning `& x` escapes a reference to parameter `x`
-fail_compilation/fail13902.d(84): Error: returning `(& x+4)` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(84): Error: returning `(& x + 4)` escapes a reference to parameter `x`
 fail_compilation/fail13902.d(85): Error: returning `& x + cast(long)x * 4L` escapes a reference to parameter `x`
 fail_compilation/fail13902.d(88): Error: returning `& y` escapes a reference to parameter `y`
 ---


### PR DESCRIPTION
Adding a test for a SymOff with offset larger than 0x8000000000000000 would be annoying, and since the issue is about -vcg-ast (with no well defined output) I don't think it's worth it.