### PR TITLE
Remove BinExp.att fields

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -2947,8 +2947,6 @@ extern (C++) abstract class BinExp : Expression
 {
     Expression e1;
     Expression e2;
-    Type att1;      // Save alias this type to detect recursion
-    Type att2;      // Save alias this type to detect recursion
 
     extern (D) this(const ref Loc loc, EXP op, Expression e1, Expression e2) scope @safe
     {

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -679,9 +679,6 @@ public:
     Expression *e1;
     Expression *e2;
 
-    Type *att1; // Save alias this type to detect recursion
-    Type *att2; // Save alias this type to detect recursion
-
     BinExp *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2352,8 +2352,6 @@ class BinExp : public Expression
 public:
     Expression* e1;
     Expression* e2;
-    Type* att1;
-    Type* att2;
     BinExp* syntaxCopy() override;
     void setNoderefOperands();
     void accept(Visitor* v) override;
@@ -5374,7 +5372,7 @@ private:
         char nullexp[31LLU];
         char dotvarexp[49LLU];
         char addrexp[40LLU];
-        char indexexp[74LLU];
+        char indexexp[58LLU];
         char sliceexp[65LLU];
         char vectorexp[53LLU];
     };


### PR DESCRIPTION
Can we finally get rid of those ugly fields?

Quick benchmark when compiling Phobos unittests:

Before: 25.46s, 16.158 GB
After:  25.36s, 16.068 GB
