### PR TITLE
Shrink Loc from 12 to 4 bytes

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -6324,7 +6324,6 @@ final class CParser(AST) : Parser!AST
             while (*p)
                 ++p;
             ++p; // advance to start of next line
-            scanloc.linnum = scanloc.linnum + 1;
         }
 
         if (newSymbols.length)

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -805,7 +805,7 @@ extern (C++) final class Module : Package
             checkCompiledImport();
             members = p.parseModule();
             assert(!p.md); // C doesn't have module declarations
-            numlines = p.scanloc.linnum;
+            numlines = p.linnum;
         }
         else
         {
@@ -829,7 +829,7 @@ extern (C++) final class Module : Package
             checkCompiledImport();
 
             members = p.parseModuleContent();
-            numlines = p.scanloc.linnum;
+            numlines = p.linnum;
         }
 
         /* The symbol table into which the module is to be inserted.

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -119,7 +119,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     extern (D) this(const ref Loc loc, Identifier id, bool inObject)
     {
         super(loc, id);
-        // zeroInit = false; // assume false until we do semantic processing
+        zeroInit = false; // assume false until we do semantic processing
         ispod = ThreeState.none;
         // For forward references
         type = new TypeStruct(this);

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -119,7 +119,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     extern (D) this(const ref Loc loc, Identifier id, bool inObject)
     {
         super(loc, id);
-        zeroInit = false; // assume false until we do semantic processing
+        // zeroInit = false; // assume false until we do semantic processing
         ispod = ThreeState.none;
         // For forward references
         type = new TypeStruct(this);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7659,8 +7659,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         const len = buf.length;
         const str = buf.extractChars()[0 .. len];
         const bool doUnittests = global.params.parsingUnittestsRequired();
-        auto loc = adjustLocForMixin(str, exp.loc, global.params.mixinOut);
-        scope p = new Parser!ASTCodegen(loc, sc._module, str, false, global.errorSink, &global.compileEnv, doUnittests);
+        scope p = new Parser!ASTCodegen(sc._module, str, false, global.errorSink, &global.compileEnv, doUnittests);
+        adjustLocForMixin(str, exp.loc, *p.baseLoc, global.params.mixinOut);
+        p.linnum = p.baseLoc.startLine;
         p.nextToken();
         //printf("p.loc.linnum = %d\n", p.loc.linnum);
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -385,6 +385,7 @@ public:
     static bool showColumns;
     static MessageStyle messageStyle;
     static void set(bool showColumns, MessageStyle messageStyle);
+    static Loc singleFilename(const char* const filename);
     uint32_t charnum() const;
     uint32_t linnum() const;
     const char* filename() const;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -380,28 +380,23 @@ enum class MessageStyle : uint8_t
 struct Loc final
 {
 private:
-    uint32_t _linnum;
-    uint32_t _charnum;
-    uint32_t fileIndex;
+    uint32_t index;
 public:
     static bool showColumns;
     static MessageStyle messageStyle;
     static void set(bool showColumns, MessageStyle messageStyle);
-    Loc(const char* filename, uint32_t linnum, uint32_t charnum);
     uint32_t charnum() const;
-    uint32_t charnum(uint32_t num);
     uint32_t linnum() const;
-    uint32_t linnum(uint32_t num);
     const char* filename() const;
-    void filename(const char* name);
     const char* toChars(bool showColumns = Loc::showColumns, MessageStyle messageStyle = Loc::messageStyle) const;
     bool equals(const Loc& loc) const;
     Loc() :
-        _linnum(),
-        _charnum(),
-        fileIndex()
+        index(0u)
     {
     }
+    Loc(uint32_t index) :
+        index(index)
+        {}
 };
 
 enum class PASS : uint8_t
@@ -5381,23 +5376,23 @@ struct UnionExp final
 private:
     union _AnonStruct_u
     {
-        char exp[30LLU];
-        char integerexp[40LLU];
-        char errorexp[30LLU];
+        char exp[22LLU];
+        char integerexp[32LLU];
+        char errorexp[22LLU];
         char realexp[48LLU];
         char complexexp[64LLU];
-        char symoffexp[64LLU];
-        char stringexp[51LLU];
-        char arrayliteralexp[48LLU];
-        char assocarrayliteralexp[56LLU];
-        char structliteralexp[72LLU];
-        char compoundliteralexp[40LLU];
-        char nullexp[30LLU];
-        char dotvarexp[49LLU];
-        char addrexp[40LLU];
-        char indexexp[58LLU];
-        char sliceexp[65LLU];
-        char vectorexp[53LLU];
+        char symoffexp[56LLU];
+        char stringexp[43LLU];
+        char arrayliteralexp[40LLU];
+        char assocarrayliteralexp[48LLU];
+        char structliteralexp[64LLU];
+        char compoundliteralexp[32LLU];
+        char nullexp[22LLU];
+        char dotvarexp[41LLU];
+        char addrexp[32LLU];
+        char indexexp[50LLU];
+        char sliceexp[57LLU];
+        char vectorexp[45LLU];
     };
     #pragma pack(pop)
 

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -425,6 +425,7 @@ private:
 
 public:
     static void set(bool showColumns, MessageStyle messageStyle);
+    static Loc singleFilename(const char* const filename);
 
     static bool showColumns;
     static MessageStyle messageStyle;

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -416,9 +416,13 @@ typedef unsigned long long uinteger_t;
 struct Loc
 {
 private:
-    unsigned _linnum;
-    unsigned _charnum;
-    unsigned fileIndex;
+
+    unsigned int index;
+
+#if MARS && defined(__linux__) && defined(__i386__)
+    unsigned int dummy;
+#endif
+
 public:
     static void set(bool showColumns, MessageStyle messageStyle);
 
@@ -427,24 +431,12 @@ public:
 
     Loc()
     {
-        _linnum = 0;
-        _charnum = 0;
-        fileIndex = 0;
-    }
-
-    Loc(const char *filename, unsigned linnum, unsigned charnum)
-    {
-        this->linnum(linnum);
-        this->charnum(charnum);
-        this->filename(filename);
+        index = 0;
     }
 
     uint32_t charnum() const;
-    uint32_t charnum(uint32_t num);
     uint32_t linnum() const;
-    uint32_t linnum(uint32_t num);
     const char *filename() const;
-    void filename(const char *name);
 
     const char *toChars(
         bool showColumns = Loc::showColumns,

--- a/compiler/src/dmd/identifier.d
+++ b/compiler/src/dmd/identifier.d
@@ -224,12 +224,13 @@ nothrow:
     extern (D) static Identifier generateIdWithLoc(string prefix, const ref Loc loc, string parent = "")
     {
         // generate `<prefix>_L<line>_C<col>`
+        auto sl = SourceLoc(loc);
         OutBuffer idBuf;
         idBuf.writestring(prefix);
         idBuf.writestring("_L");
-        idBuf.print(loc.linnum);
+        idBuf.print(sl.line);
         idBuf.writestring("_C");
-        idBuf.print(loc.charnum);
+        idBuf.print(sl.column);
 
         /**
          * Make sure the identifiers are unique per filename, i.e., per module/mixin
@@ -247,13 +248,13 @@ nothrow:
          * directly, but that would unnecessary lengthen symbols names. See issue:
          * https://issues.dlang.org/show_bug.cgi?id=23722
          */
-        static struct Key { Loc loc; string prefix; string parent; }
+        static struct Key { uint fileOffset; string prefix; string parent; }
         __gshared uint[Key] counters;
 
         static if (__traits(compiles, counters.update(Key.init, () => 0u, (ref uint a) => 0u)))
         {
             // 2.082+
-            counters.update(Key(loc, prefix, parent),
+            counters.update(Key(loc.fileOffset, prefix, parent),
                 () => 1u,          // insertion
                 (ref uint counter) // update
                 {
@@ -265,7 +266,7 @@ nothrow:
         }
         else
         {
-            const key = Key(loc, prefix, parent);
+            const key = Key(loc.fileOffset, prefix, parent);
             if (auto pCounter = key in counters)
             {
                 idBuf.writestring("_");

--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -18,11 +18,6 @@ import dmd.root.array;
 import dmd.root.filename;
 import dmd.root.string: toDString;
 
-version (DMDLIB)
-{
-    version = LocOffset;
-}
-
 /// How code locations are formatted for diagnostic reporting
 enum MessageStyle : ubyte
 {
@@ -38,18 +33,18 @@ debug info etc.
 */
 struct Loc
 {
-    private uint _linnum;
-    private uint _charnum;
-    private uint fileIndex; // index into filenames[], starting from 1 (0 means no filename)
-    version (LocOffset)
-        uint fileOffset; /// utf8 code unit index relative to start of file, starting from 0
+    private uint index = 0; // offset into lineTable[]
+
+    // FIXME: This arbitrary size increase is needed to prevent segfault in
+    // runnable/test42.d on Ubuntu x86 when DMD was built with DMD 2.105 .. 2.110
+    // https://github.com/dlang/dmd/pull/20777#issuecomment-2614128849
+    version (linux) version (DigitalMars) static if (size_t.sizeof == 4)
+        private uint dummy;
 
     static immutable Loc initial; /// use for default initialization of const ref Loc's
 
     extern (C++) __gshared bool showColumns;
     extern (C++) __gshared MessageStyle messageStyle;
-
-    __gshared Array!(const(char)*) filenames;
 
 nothrow:
 
@@ -65,45 +60,33 @@ nothrow:
         this.messageStyle = messageStyle;
     }
 
-    extern (C++) this(const(char)* filename, uint linnum, uint charnum) @safe
+    static Loc singleFilename(const char* filename)
     {
-        this._linnum = linnum;
-        this._charnum = charnum;
-        this.filename = filename;
+        Loc result;
+        locFileTable ~= BaseLoc(filename.toDString, locIndex, 0, [0]);
+        result.index = locIndex++;
+        return result;
     }
 
     /// utf8 code unit index relative to start of line, starting from 1
     extern (C++) uint charnum() const @nogc @safe
     {
-        return _charnum;
-    }
-
-    /// ditto
-    extern (C++) uint charnum(uint num) @nogc @safe
-    {
-        return _charnum = num;
+        return SourceLoc(this).column;
     }
 
     /// line number, starting from 1
-    extern (C++) uint linnum() const @nogc @safe
+    extern (C++) uint linnum() const @nogc @trusted
     {
-        return _linnum;
-    }
-
-    /// ditto
-    extern (C++) uint linnum(uint num) @nogc @safe
-    {
-        return _linnum = num;
+        return SourceLoc(this).line;
     }
 
     /// Advance this location to the first column of the next line
     void nextLine()
     {
-        if (this._linnum)
-        {
-            this._linnum++;
-            this.charnum = 0;
-        }
+        const i = fileTableIndex(this.index);
+        const j = locFileTable[i].getLineIndex(this.index - locFileTable[i].startIndex);
+        if (j + 1 < locFileTable[i].lines.length)
+            index = locFileTable[i].startIndex + locFileTable[i].lines[j + 1];
     }
 
     /***
@@ -111,25 +94,7 @@ nothrow:
      */
     extern (C++) const(char)* filename() const @nogc
     {
-        return fileIndex ? filenames[fileIndex - 1] : null;
-    }
-
-    /***
-     * Set file name for this location
-     * Params:
-     *   name = file name for location, null for no file name
-     */
-    extern (C++) void filename(const(char)* name) @trusted
-    {
-        if (name)
-        {
-            //printf("setting %s\n", name);
-            filenames.push(name);
-            fileIndex = cast(uint)filenames.length;
-            assert(fileIndex, "internal compiler error: file name index overflow");
-        }
-        else
-            fileIndex = 0;
+        return SourceLoc(this).filename.ptr; // _filename;
     }
 
     extern (C++) const(char)* toChars(
@@ -137,6 +102,12 @@ nothrow:
         MessageStyle messageStyle = Loc.messageStyle) const nothrow
     {
         return SourceLoc(this).toChars(showColumns, messageStyle);
+    }
+
+    /// Returns: byte offset into source file
+    uint fileOffset() const
+    {
+        return SourceLoc(this).fileOffset;
     }
 
     /**
@@ -165,23 +136,13 @@ nothrow:
      */
     extern (D) bool opEquals(ref const(Loc) loc) const @trusted nothrow @nogc
     {
-        import core.stdc.string : strcmp;
-
-        return charnum == loc.charnum &&
-               linnum == loc.linnum &&
-               (filename == loc.filename ||
-                (filename && loc.filename && strcmp(filename, loc.filename) == 0));
+        return this.index == loc.index;
     }
 
     /// ditto
     extern (D) size_t toHash() const @trusted nothrow
     {
-        import dmd.root.string : toDString;
-
-        auto hash = hashOf(linnum);
-        hash = hashOf(charnum, hash);
-        hash = hashOf(filename.toDString, hash);
-        return hash;
+        return hashOf(this.index);
     }
 
     /******************
@@ -190,7 +151,7 @@ nothrow:
      */
     bool isValid() const pure @safe
     {
-        return fileIndex != 0;
+        return this.index != 0;
     }
 }
 
@@ -252,23 +213,27 @@ struct SourceLoc
     const(char)[] filename; /// name of source file
     uint line; /// line number (starts at 1)
     uint column; /// column number (starts at 1)
+    uint fileOffset; /// byte index into file
 
     // aliases for backwards compatibility
     alias linnum = line;
     alias charnum = column;
 
-    this(const(char)[] filename, uint line, uint column) nothrow
+    this(const(char)[] filename, uint line, uint column, uint fileOffset = 0) nothrow @nogc pure @safe
     {
         this.filename = filename;
         this.line = line;
         this.column = column;
+        this.fileOffset = fileOffset;
     }
 
-    this(Loc loc) nothrow
+    this(Loc loc) nothrow @nogc @trusted
     {
-        this.filename = loc.filename.toDString();
-        this.line = loc.linnum;
-        this.column = loc.charnum;
+        if (loc.index == 0 || locFileTable.length == 0)
+            return;
+
+        const i = fileTableIndex(loc.index);
+        this = locFileTable[i].getSourceLoc(loc.index - locFileTable[i].startIndex);
     }
 
     extern (C++) const(char)* toChars(
@@ -284,4 +249,135 @@ struct SourceLoc
     {
         return this.filename == other.filename && this.line == other.line && this.column == other.column;
     }
+
 }
+
+private size_t fileTableIndex(uint index) nothrow @nogc
+{
+    // To speed up linear find, we cache the last hit and compare that first,
+    // since usually we stay in the same file for some time when resolving source locations.
+    // If it's a differnet file now, either scan forwards / backwards
+    __gshared size_t lastI = 0; // index of last found hit
+
+    size_t i = lastI;
+    if (index >= locFileTable[i].startIndex)
+    {
+        while (i + 1 < locFileTable.length && index >= locFileTable[i+1].startIndex)
+            i++;
+    }
+    else
+    {
+        while (index < locFileTable[i].startIndex)
+            i--;
+    }
+
+    lastI = i;
+    return i;
+}
+
+/**
+ * Create a new source location map for a file
+ * Params:
+ *   filename = source file name
+ *   size = space to reserve for locations, equal to the file size in bytes
+ * Returns: new BaseLoc
+ */
+BaseLoc* newBaseLoc(const(char)* filename, size_t size) nothrow
+{
+    locFileTable ~= BaseLoc(filename.toDString, locIndex, 1, [0]);
+    // Careful: the endloc of a funcdeclaration can
+    // be one past the very last byte in the file, so account for that
+    locIndex += size + 1;
+    return &locFileTable[$ - 1];
+}
+
+/// Mapping from byte offset into source file to line/column numbers
+struct BaseLoc
+{
+@safe nothrow:
+
+    const(char)[] filename; // Source file name
+    uint startIndex; // Subtract this from Loc.index to get file offset
+    int startLine = 1; // Line number at index 0
+    uint[] lines; // For each line, the file offset at which it starts
+    BaseLoc[] substitutions; // Substitutions from #line / #file directives
+
+    /// Register that a new line starts at `offset`
+    void newLine(uint offset)
+    {
+        lines ~= offset;
+    }
+
+    Loc getLoc(uint offset) @nogc
+    {
+        Loc result;
+        // import std.stdio; debug writeln(startIndex, " + ", offset, " = ", startIndex + offset);
+        result.index = startIndex + offset;
+        return result;
+    }
+
+    /// Handles #file and #line directives
+    void addSubstitution(uint offset, const(char)* filename, uint linnum) @system
+    {
+        auto fname = filename.toDString;
+        if (fname.length == 0 && substitutions.length > 0)
+            fname = substitutions[$ - 1].filename;
+        substitutions ~= BaseLoc(fname, offset, cast(int) (linnum - lines.length + startLine - 2));
+    }
+
+    /// Returns: `loc` modified by substitutions from #file / #line directives
+    SourceLoc substitute(SourceLoc loc, uint offset) @nogc
+    {
+        // printf("substitutions: %d\n", cast(int) substitutions.length);
+        size_t latest = -1;
+        foreach (i, ref sub; substitutions)
+        {
+            if (offset >= sub.startIndex)
+                latest = i;
+            else
+                break;
+        }
+        if (latest != -1)
+        {
+            if (substitutions[latest].filename.length > 0)
+                loc.filename = substitutions[latest].filename;
+            loc.linnum += substitutions[latest].startLine;
+        }
+        return loc;
+    }
+
+    // Resolve an offset into this file to a filename + line + column
+    private SourceLoc getSourceLoc(uint offset) @nogc
+    {
+        const i = getLineIndex(offset);
+        const sl = SourceLoc(filename, cast(int) (i + startLine), cast(int) (1 + offset - lines[i]), offset);
+        return substitute(sl, offset);
+    }
+
+    // Binary search the index in this.lines corresponding to `offset`
+    private size_t getLineIndex(uint offset) @nogc
+    {
+        size_t lo = 0;
+        size_t hi = lines.length + -1;
+        size_t mid = 0;
+        while (lo <= hi)
+        {
+            mid = lo + (hi - lo) / 2;
+            if (lines[mid] <= offset)
+            {
+                if (mid == lines.length - 1 || lines[mid + 1] > offset)
+                    return mid;
+
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+        assert(0);
+    }
+}
+
+private __gshared uint locIndex = 1; // Index of start of the file
+private __gshared BaseLoc[] locFileTable;

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1801,7 +1801,7 @@ bool createModule(const(char)* file, ref Strings libmodules, const ref Target ta
     }
     const(char)[] p = FileName.name(file.toDString()); // strip path
     const(char)[] ext = FileName.ext(p);
-    Loc loc = Loc(file, 0, 0);
+    Loc loc = Loc.singleFilename(file);
     if (!ext)
     {
         if (!p.length)

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4835,8 +4835,9 @@ private Statements* flatten(Statement statement, Scope* sc)
             buf.writeByte(0);
             const str = buf.extractSlice()[0 .. len];
             const bool doUnittests = global.params.parsingUnittestsRequired();
-            auto loc = adjustLocForMixin(str, cs.loc, global.params.mixinOut);
-            scope p = new Parser!ASTCodegen(loc, sc._module, str, false, global.errorSink, &global.compileEnv, doUnittests);
+            scope p = new Parser!ASTCodegen(sc._module, str, false, global.errorSink, &global.compileEnv, doUnittests);
+            adjustLocForMixin(str, cs.loc, *p.baseLoc, global.params.mixinOut);
+            p.linnum = p.baseLoc.startLine;
             p.nextToken();
 
             auto a = new Statements();

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -7942,8 +7942,9 @@ RootObject compileTypeMixin(TypeMixin tm, ref const Loc loc, Scope* sc)
     buf.writeByte(0);
     const str = buf.extractSlice()[0 .. len];
     const bool doUnittests = global.params.parsingUnittestsRequired();
-    auto locm = adjustLocForMixin(str, loc, global.params.mixinOut);
-    scope p = new Parser!ASTCodegen(locm, sc._module, str, false, global.errorSink, &global.compileEnv, doUnittests);
+    scope p = new Parser!ASTCodegen(sc._module, str, false, global.errorSink, &global.compileEnv, doUnittests);
+    adjustLocForMixin(str, loc, *p.baseLoc, global.params.mixinOut);
+    p.linnum = p.baseLoc.startLine;
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
 

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -391,16 +391,9 @@ void test_types()
 
 void test_location()
 {
-    Loc loc1 = Loc("test.d", 24, 42);
-    assert(loc1.equals(Loc("test.d", 24, 42)));
-    assert(strcmp(loc1.toChars(true, MessageStyle::digitalmars), "test.d(24,42)") == 0);
-    assert(strcmp(loc1.toChars(true, MessageStyle::gnu), "test.d:24:42") == 0);
-
-    assert(strcmp(loc1.toChars(), "test.d(24)") == 0);
-    Loc::set(true, MessageStyle::digitalmars);
-    assert(strcmp(loc1.toChars(), "test.d(24,42)") == 0);
-    Loc::set(false, MessageStyle::gnu);
-    assert(strcmp(loc1.toChars(), "test.d:24") == 0);
+    Loc loc = Loc();
+    assert(strcmp(loc.toChars(true, MessageStyle::digitalmars), "") == 0);
+    assert(strcmp(loc.toChars(true, MessageStyle::gnu), "") == 0);
 }
 
 /**********************************/

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -391,9 +391,9 @@ void test_types()
 
 void test_location()
 {
-    Loc loc = Loc();
-    assert(strcmp(loc.toChars(true, MessageStyle::digitalmars), "") == 0);
-    assert(strcmp(loc.toChars(true, MessageStyle::gnu), "") == 0);
+    Loc loc = Loc::singleFilename("app.d");
+    assert(strcmp(loc.toChars(true, MessageStyle::digitalmars), "app.d") == 0);
+    assert(strcmp(loc.toChars(true, MessageStyle::gnu), "app.d") == 0);
 }
 
 /**********************************/


### PR DESCRIPTION
Instead of storing separate filename, line, column fields in `Loc`, make it a 4-byte index into a data structure.

Firstly, this adds easy `fileOffset` access to `Loc` without needing `version (DMDLIB)` anymore (which increases Loc.sizeof from 12 to 16). Secondly, this reduces memory consumption and page faults:

When compiling Phobos unittests:

```
Command being timed: "dmdmaster -i=std -c -unittest -version=StdUnittest -preview=dip1000 std/package.d"
User time (seconds): 27.00
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:33.57
Maximum resident set size (kbytes): 16069584
Minor (reclaiming a frame) page faults: 3521363

Command being timed: "dmdbranch -i=std -c -unittest -version=StdUnittest -preview=dip1000 std/package.d"
User time (seconds): 27.23
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:33.84
Maximum resident set size (kbytes): 15001208
Minor (reclaiming a frame) page faults: 3254426
```

So RAM usage basically goes from 16GB to 15Gb.

As you can see the total time is still slightly larger, because retrieving a loc's line / column data now requires a binary search instead of just reading a variable. However, this can still be optimized further.

I'll document this more later, for now I'm focusing on testing if it works.

Edit: documentation on how it works can be found in comment above `struct BaseLoc`
