### PR TITLE
Port ntdef macros `NT_INFORMATION`, `NT_WARNING` and `NT_ERROR`

### DIFF
--- a/druntime/src/core/sys/windows/ntdef.d
+++ b/druntime/src/core/sys/windows/ntdef.d
@@ -33,7 +33,12 @@ void InitializeObjectAttributes(OBJECT_ATTRIBUTES* p, UNICODE_STRING* n,
     }
 }
 
-pragma(inline, true) bool NT_SUCCESS(NTSTATUS x) @safe pure nothrow @nogc { return x >= 0; }
+pragma(inline, true) @safe pure nothrow @nogc {
+    bool NT_SUCCESS(NTSTATUS Status)     { return Status >= 0; }
+    bool NT_INFORMATION(NTSTATUS Status) { return ((cast(ULONG) Status) >> 30) == 1; }
+    bool NT_WARNING(NTSTATUS Status)     { return ((cast(ULONG) Status) >> 30) == 2; }
+    bool NT_ERROR(NTSTATUS Status)       { return ((cast(ULONG) Status) >> 30) == 3; }
+}
 
 /*  In MinGW, NTSTATUS, UNICODE_STRING, STRING and their associated pointer
  *  type aliases are defined in ntdef.h, ntsecapi.h and subauth.h, each of


### PR DESCRIPTION
Reference: <https://sourceforge.net/p/mingw-w64/mingw-w64/ci/v12.0.0/tree/mingw-w64-headers/include/ntdef.h#l476>