### PR TITLE
Remove dead debug/version level logic

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -451,16 +451,13 @@ struct ASTBase
 
     extern (C++) final class DebugSymbol : Dsymbol
     {
-        uint level;
-
         extern (D) this(const ref Loc loc, Identifier ident)
         {
             super(ident);
             this.loc = loc;
         }
-        extern (D) this(const ref Loc loc, uint level)
+        extern (D) this(const ref Loc loc)
         {
-            this.level = level;
             this.loc = loc;
         }
 
@@ -472,16 +469,13 @@ struct ASTBase
 
     extern (C++) final class VersionSymbol : Dsymbol
     {
-        uint level;
-
         extern (D) this(const ref Loc loc, Identifier ident)
         {
             super(ident);
             this.loc = loc;
         }
-        extern (D) this(const ref Loc loc, uint level)
+        extern (D) this(const ref Loc loc)
         {
-            this.level = level;
             this.loc = loc;
         }
 
@@ -6542,11 +6536,10 @@ struct ASTBase
 
     extern (C++) class DVCondition : Condition
     {
-        uint level;
         Identifier ident;
         Module mod;
 
-        final extern (D) this(const ref Loc loc, Module mod, uint level, Identifier ident)
+        final extern (D) this(const ref Loc loc, Module mod, Identifier ident)
         {
             super(loc);
             this.mod = mod;
@@ -6561,9 +6554,9 @@ struct ASTBase
 
     extern (C++) final class DebugCondition : DVCondition
     {
-        extern (D) this(const ref Loc loc, Module mod, uint level, Identifier ident)
+        extern (D) this(const ref Loc loc, Module mod, Identifier ident)
         {
-            super(loc, mod, level, ident);
+            super(loc, mod, ident);
         }
 
         override void accept(Visitor v)
@@ -6574,9 +6567,9 @@ struct ASTBase
 
     extern (C++) final class VersionCondition : DVCondition
     {
-        extern (D) this(const ref Loc loc, Module mod, uint level, Identifier ident)
+        extern (D) this(const ref Loc loc, Module mod, Identifier ident)
         {
-            super(loc, mod, level, ident);
+            super(loc, mod, ident);
         }
 
         override void accept(Visitor v)

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -493,15 +493,13 @@ extern (C++) final class StaticForeach : RootObject
  */
 extern (C++) class DVCondition : Condition
 {
-    uint level;
     Identifier ident;
     Module mod;
 
-    extern (D) this(const ref Loc loc, Module mod, uint level, Identifier ident) @safe
+    extern (D) this(const ref Loc loc, Module mod, Identifier ident) @safe
     {
         super(loc);
         this.mod = mod;
-        this.level = level;
         this.ident = ident;
     }
 
@@ -556,15 +554,13 @@ extern (C++) final class DebugCondition : DVCondition
      *
      * Params:
      *   mod = Module this node belongs to
-     *   level = Minimum global level this condition needs to pass.
-     *           Only used if `ident` is `null`.
      *   ident = Identifier required for this condition to pass.
      *           If `null`, this conditiion will use an integer level.
      *  loc = Location in the source file
      */
-    extern (D) this(const ref Loc loc, Module mod, uint level, Identifier ident) @safe
+    extern (D) this(const ref Loc loc, Module mod, Identifier ident) @safe
     {
-        super(loc, mod, level, ident);
+        super(loc, mod, ident);
     }
 
     override int include(Scope* sc)
@@ -592,8 +588,9 @@ extern (C++) final class DebugCondition : DVCondition
                 mod.debugidsNot.push(ident);
             }
         }
-        else if (level <= global.params.debuglevel || level <= mod.debuglevel)
+        else if (global.params.debugEnabled)
             inc = Include.yes;
+
         if (!definedInModule)
             printDepsConditional(sc, this, "depsDebug ");
         return (inc == Include.yes);
@@ -837,15 +834,13 @@ extern (C++) final class VersionCondition : DVCondition
      *
      * Params:
      *   mod = Module this node belongs to
-     *   level = Minimum global level this condition needs to pass.
-     *           Only used if `ident` is `null`.
      *   ident = Identifier required for this condition to pass.
      *           If `null`, this conditiion will use an integer level.
      *  loc = Location in the source file
      */
-    extern (D) this(const ref Loc loc, Module mod, uint level, Identifier ident) @safe
+    extern (D) this(const ref Loc loc, Module mod, Identifier ident) @safe
     {
-        super(loc, mod, level, ident);
+        super(loc, mod, ident);
     }
 
     override int include(Scope* sc)
@@ -875,8 +870,6 @@ extern (C++) final class VersionCondition : DVCondition
                 mod.versionidsNot.push(ident);
             }
         }
-        else if (level <= global.params.versionlevel || level <= mod.versionlevel)
-            inc = Include.yes;
         if (!definedInModule &&
             (!ident || (!isReserved(ident.toString()) && ident != Id._unittest && ident != Id._assert)))
         {
@@ -1010,7 +1003,5 @@ private void printDepsConditional(Scope* sc, DVCondition condition, const(char)[
     ob.writestring(") : ");
     if (condition.ident)
         ob.writestring(condition.ident.toString());
-    else
-        ob.print(condition.level);
     ob.writeByte('\n');
 }

--- a/compiler/src/dmd/cond.h
+++ b/compiler/src/dmd/cond.h
@@ -58,7 +58,6 @@ public:
 class DVCondition : public Condition
 {
 public:
-    unsigned level;
     Identifier *ident;
     Module *mod;
 

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -430,11 +430,9 @@ extern (C++) final class Module : Package
 
     Modules aimports;           // all imported modules
 
-    uint debuglevel;            // debug level
     Identifiers* debugids;      // debug identifiers
     Identifiers* debugidsNot;   // forward referenced debug identifiers
 
-    uint versionlevel;          // version level
     Identifiers* versionids;    // version identifiers
     Identifiers* versionidsNot; // forward referenced version identifiers
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4352,34 +4352,21 @@ private extern(C++) class AddMemberVisitor : Visitor
         Module m = sds.isModule();
         // Do not add the member to the symbol table,
         // just make sure subsequent debug declarations work.
-        if (ds.ident)
+        if (!m)
         {
-            if (!m)
-            {
-                .error(ds.loc, "%s `%s` declaration must be at module level", ds.kind, ds.toPrettyChars);
-                ds.errors = true;
-            }
-            else
-            {
-                if (m.debugidsNot && findCondition(*m.debugidsNot, ds.ident))
-                {
-                    .error(ds.loc, "%s `%s` defined after use", ds.kind, ds.toPrettyChars);
-                    ds.errors = true;
-                }
-                if (!m.debugids)
-                    m.debugids = new Identifiers();
-                m.debugids.push(ds.ident);
-            }
+            .error(ds.loc, "%s `%s` declaration must be at module level", ds.kind, ds.toPrettyChars);
+            ds.errors = true;
         }
         else
         {
-            if (!m)
+            if (m.debugidsNot && findCondition(*m.debugidsNot, ds.ident))
             {
-                .error(ds.loc, "%s `%s` level declaration must be at module level", ds.kind, ds.toPrettyChars);
+                .error(ds.loc, "%s `%s` defined after use", ds.kind, ds.toPrettyChars);
                 ds.errors = true;
             }
-            else
-                m.debuglevel = ds.level;
+            if (!m.debugids)
+                m.debugids = new Identifiers();
+            m.debugids.push(ds.ident);
         }
     }
 
@@ -4389,36 +4376,24 @@ private extern(C++) class AddMemberVisitor : Visitor
         Module m = sds.isModule();
         // Do not add the member to the symbol table,
         // just make sure subsequent debug declarations work.
-        if (vs.ident)
+        VersionCondition.checkReserved(vs.loc, vs.ident.toString());
+        if (!m)
         {
-            VersionCondition.checkReserved(vs.loc, vs.ident.toString());
-            if (!m)
-            {
-                .error(vs.loc, "%s `%s` declaration must be at module level", vs.kind, vs.toPrettyChars);
-                vs.errors = true;
-            }
-            else
-            {
-                if (m.versionidsNot && findCondition(*m.versionidsNot, vs.ident))
-                {
-                    .error(vs.loc, "%s `%s` defined after use", vs.kind, vs.toPrettyChars);
-                    vs.errors = true;
-                }
-                if (!m.versionids)
-                    m.versionids = new Identifiers();
-                m.versionids.push(vs.ident);
-            }
+            .error(vs.loc, "%s `%s` declaration must be at module level", vs.kind, vs.toPrettyChars);
+            vs.errors = true;
         }
         else
         {
-            if (!m)
+            if (m.versionidsNot && findCondition(*m.versionidsNot, vs.ident))
             {
-                .error(vs.loc, "%s `%s` level declaration must be at module level", vs.kind, vs.toPrettyChars);
+                .error(vs.loc, "%s `%s` defined after use", vs.kind, vs.toPrettyChars);
                 vs.errors = true;
             }
-            else
-                m.versionlevel = vs.level;
+            if (!m.versionids)
+                m.versionids = new Identifiers();
+            m.versionids.push(vs.ident);
         }
+
     }
 
     override void visit(Nspace ns)

--- a/compiler/src/dmd/dversion.d
+++ b/compiler/src/dmd/dversion.d
@@ -29,21 +29,17 @@ import dmd.visitor;
 /***********************************************************
  * DebugSymbol's happen for statements like:
  *      debug = identifier;
- *      debug = integer;
  */
 extern (C++) final class DebugSymbol : Dsymbol
 {
-    uint level;
-
     extern (D) this(const ref Loc loc, Identifier ident) @safe
     {
         super(loc, ident);
     }
 
-    extern (D) this(const ref Loc loc, uint level) @safe
+    extern (D) this(const ref Loc loc) @safe
     {
         super(loc, null);
-        this.level = level;
     }
 
     override DebugSymbol syntaxCopy(Dsymbol s)
@@ -51,17 +47,7 @@ extern (C++) final class DebugSymbol : Dsymbol
         assert(!s);
         auto ds = new DebugSymbol(loc, ident);
         ds.comment = comment;
-        ds.level = level;
         return ds;
-    }
-
-    override const(char)* toChars() const nothrow
-    {
-        if (ident)
-            return ident.toChars();
-        OutBuffer buf;
-        buf.print(level);
-        return buf.extractChars();
     }
 
     override const(char)* kind() const nothrow
@@ -83,39 +69,26 @@ extern (C++) final class DebugSymbol : Dsymbol
 /***********************************************************
  * VersionSymbol's happen for statements like:
  *      version = identifier;
- *      version = integer;
  */
 extern (C++) final class VersionSymbol : Dsymbol
 {
-    uint level;
 
     extern (D) this(const ref Loc loc, Identifier ident) @safe
     {
         super(loc, ident);
     }
 
-    extern (D) this(const ref Loc loc, uint level) @safe
+    extern (D) this(const ref Loc loc) @safe
     {
         super(loc, null);
-        this.level = level;
     }
 
     override VersionSymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        auto ds = ident ? new VersionSymbol(loc, ident)
-                        : new VersionSymbol(loc, level);
+        auto ds = new VersionSymbol(loc, ident);
         ds.comment = comment;
         return ds;
-    }
-
-    override const(char)* toChars() const nothrow
-    {
-        if (ident)
-            return ident.toChars();
-        OutBuffer buf;
-        buf.print(level);
-        return buf.extractChars();
     }
 
     override const(char)* kind() const nothrow

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2020,9 +2020,7 @@ public:
 class DebugSymbol final : public Dsymbol
 {
 public:
-    uint32_t level;
     DebugSymbol* syntaxCopy(Dsymbol* s) override;
-    const char* toChars() const override;
     const char* kind() const override;
     DebugSymbol* isDebugSymbol() override;
     void accept(Visitor* v) override;
@@ -2031,9 +2029,7 @@ public:
 class VersionSymbol final : public Dsymbol
 {
 public:
-    uint32_t level;
     VersionSymbol* syntaxCopy(Dsymbol* s) override;
-    const char* toChars() const override;
     const char* kind() const override;
     VersionSymbol* isVersionSymbol() override;
     void accept(Visitor* v) override;
@@ -6548,7 +6544,6 @@ public:
 class DVCondition : public Condition
 {
 public:
-    uint32_t level;
     Identifier* ident;
     Module* mod;
     DVCondition* syntaxCopy() final override;
@@ -7129,10 +7124,8 @@ public:
     Module* importedFrom;
     Array<Dsymbol* >* decldefs;
     Array<Module* > aimports;
-    uint32_t debuglevel;
     Array<Identifier* >* debugids;
     Array<Identifier* >* debugidsNot;
-    uint32_t versionlevel;
     Array<Identifier* >* versionids;
     Array<Identifier* >* versionidsNot;
     MacroTable macrotable;
@@ -8444,8 +8437,7 @@ struct Param final
     Output makeDeps;
     Output mixinOut;
     Output moduleDeps;
-    uint32_t debuglevel;
-    uint32_t versionlevel;
+    bool debugEnabled;
     bool run;
     Array<const char* > runargs;
     Array<const char* > cppswitches;
@@ -8524,8 +8516,7 @@ struct Param final
         makeDeps(),
         mixinOut(),
         moduleDeps(),
-        debuglevel(),
-        versionlevel(),
+        debugEnabled(),
         run(),
         runargs(),
         cppswitches(),
@@ -8545,7 +8536,7 @@ struct Param final
         timeTraceFile()
     {
     }
-    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting useWarnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState safer = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<ImportPathInfo > imppath = Array<ImportPathInfo >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, uint32_t versionlevel = 0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool fullyQualifiedObjectFiles = false, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
+    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting useWarnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState safer = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<ImportPathInfo > imppath = Array<ImportPathInfo >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), bool debugEnabled = false, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool fullyQualifiedObjectFiles = false, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
         obj(obj),
         multiobj(multiobj),
         trace(trace),
@@ -8613,8 +8604,7 @@ struct Param final
         makeDeps(makeDeps),
         mixinOut(mixinOut),
         moduleDeps(moduleDeps),
-        debuglevel(debuglevel),
-        versionlevel(versionlevel),
+        debugEnabled(debugEnabled),
         run(run),
         runargs(runargs),
         cppswitches(cppswitches),

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -242,8 +242,7 @@ extern (C++) struct Param
     Output mixinOut;                    // write expanded mixins for debugging
     Output moduleDeps;                  // Generate `.deps` module dependencies
 
-    uint debuglevel;                    // debug level
-    uint versionlevel;                  // version level
+    bool debugEnabled;                  // Global -debug flag (no -debug=XXX) is active
 
     bool run; // run resulting executable
     Strings runargs; // arguments for executable

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -250,8 +250,7 @@ struct Param
     Output mixinOut;          // write expanded mixins for debugging
     Output moduleDeps;        // Generate `.deps` module dependencies
 
-    unsigned debuglevel;   // debug level
-    unsigned versionlevel; // version level
+    d_bool debugEnabled;   // -debug flag is passed
 
     d_bool run;           // run resulting executable
     Strings runargs;    // arguments for executable

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -880,10 +880,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     void visitDebugSymbol(DebugSymbol s)
     {
         buf.writestring("debug = ");
-        if (s.ident)
-            buf.writestring(s.ident.toString());
-        else
-            buf.print(s.level);
+        buf.writestring(s.ident.toString());
         buf.writeByte(';');
         buf.writenl();
     }
@@ -891,10 +888,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     void visitVersionSymbol(VersionSymbol s)
     {
         buf.writestring("version = ");
-        if (s.ident)
-            buf.writestring(s.ident.toString());
-        else
-            buf.print(s.level);
+        buf.writestring(s.ident.toString());
         buf.writeByte(';');
         buf.writenl();
     }
@@ -3112,20 +3106,14 @@ public:
     override void visit(DebugCondition c)
     {
         buf.writestring("debug (");
-        if (c.ident)
-            buf.writestring(c.ident.toString());
-        else
-            buf.print(c.level);
+        buf.writestring(c.ident.toString());
         buf.writeByte(')');
     }
 
     override void visit(VersionCondition c)
     {
         buf.writestring("version (");
-        if (c.ident)
-            buf.writestring(c.ident.toString());
-        else
-            buf.print(c.level);
+        buf.writestring(c.ident.toString());
         buf.writeByte(')');
     }
 

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1604,7 +1604,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             else if (p[6])
                 goto Lerror;
             else
-                params.debuglevel = 1;
+                params.debugEnabled = true;
         }
         else if (startsWith(p + 1, "version")) // https://dlang.org/dmd.html#switch-version
         {

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -109,11 +109,9 @@ public:
 
     Modules aimports;             // all imported modules
 
-    unsigned debuglevel;        // debug level
     Identifiers *debugids;      // debug identifiers
     Identifiers *debugidsNot;   // forward referenced debug identifiers
 
-    unsigned versionlevel;      // version level
     Identifiers *versionids;    // version identifiers
     Identifiers *versionidsNot; // forward referenced version identifiers
 

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -2274,7 +2274,6 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      */
     private AST.Condition parseDebugCondition()
     {
-        uint level = 1;
         Identifier id = null;
         Loc loc = token.loc;
 
@@ -2290,7 +2289,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             nextToken();
             check(TOK.rightParenthesis);
         }
-        return new AST.DebugCondition(loc, mod, level, id);
+        return new AST.DebugCondition(loc, mod, id);
     }
 
     /**************************************
@@ -2319,7 +2318,6 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      */
     private AST.Condition parseVersionCondition()
     {
-        uint level = 1;
         Identifier id = null;
         Loc loc;
 
@@ -2345,7 +2343,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         }
         else
             error("(condition) expected following `version`");
-        return new AST.VersionCondition(loc, mod, level, id);
+        return new AST.VersionCondition(loc, mod, id);
     }
 
     /***********************************************
@@ -6255,12 +6253,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (token.value == TOK.assign)
             {
                 if (auto ds = parseDebugSpecification())
-                {
-                    if (ds.ident)
-                        eSink.error(ds.loc, "%s `%s` declaration must be at module level", ds.kind, ds.toPrettyChars);
-                    else
-                        eSink.error(ds.loc, "%s `%s` level declaration must be at module level", ds.kind, ds.toPrettyChars);
-                }
+                    eSink.error(ds.loc, "%s `%s` declaration must be at module level", ds.kind, ds.toPrettyChars);
+
                 break;
             }
             cond = parseDebugCondition();
@@ -6271,12 +6265,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (token.value == TOK.assign)
             {
                 if (auto vs = parseVersionSpecification())
-                {
-                    if (vs.ident)
-                        eSink.error(vs.loc, "%s `%s` declaration must be at module level", vs.kind, vs.toPrettyChars);
-                    else
-                        eSink.error(vs.loc, "%s `%s` level declaration must be at module level", vs.kind, vs.toPrettyChars);
-                }
+                    eSink.error(vs.loc, "%s `%s` declaration must be at module level", vs.kind, vs.toPrettyChars);
+
                 break;
             }
             cond = parseVersionCondition();

--- a/compiler/src/dmd/version.h
+++ b/compiler/src/dmd/version.h
@@ -15,11 +15,8 @@
 class DebugSymbol final : public Dsymbol
 {
 public:
-    unsigned level;
-
     DebugSymbol *syntaxCopy(Dsymbol *) override;
 
-    const char *toChars() const override;
     const char *kind() const override;
     DebugSymbol *isDebugSymbol() override;
     void accept(Visitor *v) override { v->visit(this); }
@@ -28,11 +25,8 @@ public:
 class VersionSymbol final : public Dsymbol
 {
 public:
-    unsigned level;
-
     VersionSymbol *syntaxCopy(Dsymbol *) override;
 
-    const char *toChars() const override;
     const char *kind() const override;
     VersionSymbol *isVersionSymbol() override;
     void accept(Visitor *v) override { v->visit(this); }


### PR DESCRIPTION
Since `debug(2)` and `version(4)` have been removed from the language, all this code is never executed.