### PR TITLE
Don't expose internal names in errors

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -447,7 +447,8 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                   s.isTemplateDeclaration() ||
                   s.isOverloadSet()))
             {
-                .error(s.loc, "%s `%s` is not a constructor; identifiers starting with `__` are reserved for the implementation", s.kind(), s.toPrettyChars());
+                error(s.loc, "%s name `__ctor` is not allowed", s.kind);
+                errorSupplemental(s.loc, "identifiers starting with `__` are reserved for internal use");
                 errors = true;
                 s = null;
             }

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -299,7 +299,7 @@ extern (C++) class Dsymbol : ASTNode
 
     override const(char)* toChars() const
     {
-        return ident ? ident.toChars() : "__anonymous";
+        return ident ? ident.toHChars2() : "__anonymous";
     }
 
     // Getters / setters for fields stored in `DsymbolAttributes`

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -16738,7 +16738,7 @@ private Modifiable checkModify(Declaration d, Loc loc, Scope* sc, Expression e1,
             if (scx.func == vthis.parent && scx.contract != Contract.none)
             {
                 if (!(flag & ModifyFlags.noError))
-                    error(loc, "%s `%s` cannot modify parameter `this` in contract", d.kind, d.toPrettyChars);
+                    error(loc, "cannot modify member variable `%s` in contract", d.toPrettyChars());
                 return Modifiable.initialization; // do not report type related errors
             }
         }

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2237,9 +2237,20 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
             buf.writestring(e.ident.toString());
     }
 
-    void visitDsymbol(DsymbolExp e)
+    void visitDsymbol(Dsymbol s)
     {
-        buf.writestring(e.s.toChars());
+        // For -vcg-ast, print internal names such as __invariant, __ctor etc.
+        // This condition is a bit kludge, and can be cleaned up if the
+        // mutual dependency `AST.toChars <> hdrgen.d` gets refactored
+        if (hgs.vcg_ast && s.ident && !s.isTemplateInstance() && !s.isTemplateDeclaration())
+            buf.writestring(s.ident.toChars());
+        else
+            buf.writestring(s.toChars());
+    }
+
+    void visitDsymbolExp(DsymbolExp e)
+    {
+        visitDsymbol(e.s);
     }
 
     void visitThis(ThisExp e)
@@ -2444,7 +2455,7 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
 
     void visitVar(VarExp e)
     {
-        buf.writestring(e.var.toChars());
+        visitDsymbol(e.var);
     }
 
     void visitOver(OverExp e)
@@ -2678,7 +2689,7 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
     {
         expToBuffer(e.e1, PREC.primary, buf, hgs);
         buf.writeByte('.');
-        buf.writestring(e.var.toChars());
+        visitDsymbol(e.var);
     }
 
     void visitDotTemplateInstance(DotTemplateInstanceExp e)
@@ -2893,7 +2904,7 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
         case EXP.float64:       return visitReal(e.isRealExp());
         case EXP.complex80:     return visitComplex(e.isComplexExp());
         case EXP.identifier:    return visitIdentifier(e.isIdentifierExp());
-        case EXP.dSymbol:       return visitDsymbol(e.isDsymbolExp());
+        case EXP.dSymbol:       return visitDsymbolExp(e.isDsymbolExp());
         case EXP.this_:         return visitThis(e.isThisExp());
         case EXP.super_:        return visitSuper(e.isSuperExp());
         case EXP.null_:         return visitNull(e.isNullExp());

--- a/compiler/src/dmd/identifier.d
+++ b/compiler/src/dmd/identifier.d
@@ -120,6 +120,8 @@ nothrow:
             p = "result";
         else if (this == Id.returnLabel)
             p = "return";
+        else if (this == Id.postblit)
+            p = "this(this)";
         else
         {
             p = toChars();

--- a/compiler/test/compilable/extra-files/json.json
+++ b/compiler/test/compilable/extra-files/json.json
@@ -23,7 +23,7 @@
                 "endline": 9,
                 "kind": "static constructor",
                 "line": 9,
-                "name": "_staticCtor_L9_C1",
+                "name": "static this",
                 "protection": "public",
                 "storageClass": [
                     "static"
@@ -49,7 +49,7 @@
                 "endline": 11,
                 "kind": "static destructor",
                 "line": 11,
-                "name": "_staticDtor_L11_C1",
+                "name": "static ~this",
                 "protection": "public",
                 "storageClass": [
                     "static"
@@ -77,7 +77,7 @@
                         "endline": 16,
                         "kind": "static constructor",
                         "line": 16,
-                        "name": "_staticCtor_L16_C5",
+                        "name": "static this",
                         "storageClass": [
                             "static"
                         ]
@@ -99,7 +99,7 @@
                         "endline": 18,
                         "kind": "static destructor",
                         "line": 18,
-                        "name": "_staticDtor_L18_C5",
+                        "name": "static ~this",
                         "storageClass": [
                             "static"
                         ]
@@ -147,7 +147,7 @@
                         "endline": 26,
                         "kind": "static constructor",
                         "line": 26,
-                        "name": "_staticCtor_L26_C5",
+                        "name": "static this",
                         "protection": "public",
                         "storageClass": [
                             "static"
@@ -173,7 +173,7 @@
                         "endline": 28,
                         "kind": "static destructor",
                         "line": 28,
-                        "name": "_staticDtor_L28_C5",
+                        "name": "static ~this",
                         "protection": "public",
                         "storageClass": [
                             "static"

--- a/compiler/test/fail_compilation/fail10964.d
+++ b/compiler/test/fail_compilation/fail10964.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10964.d(28): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(29): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(30): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(33): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(34): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(35): Error: function `fail10964.S.__postblit` is not `nothrow`
+fail_compilation/fail10964.d(28): Error: function `fail10964.S.this(this)` is not `nothrow`
+fail_compilation/fail10964.d(29): Error: function `fail10964.S.this(this)` is not `nothrow`
+fail_compilation/fail10964.d(30): Error: function `fail10964.S.this(this)` is not `nothrow`
+fail_compilation/fail10964.d(33): Error: function `fail10964.S.this(this)` is not `nothrow`
+fail_compilation/fail10964.d(34): Error: function `fail10964.S.this(this)` is not `nothrow`
+fail_compilation/fail10964.d(35): Error: function `fail10964.S.this(this)` is not `nothrow`
 fail_compilation/fail10964.d(22): Error: function `fail10964.foo` may throw but is marked as `nothrow`
 ---
 */

--- a/compiler/test/fail_compilation/fail10968.d
+++ b/compiler/test/fail_compilation/fail10968.d
@@ -1,36 +1,36 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10968.d(43): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(43): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
-fail_compilation/fail10968.d(44): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(44): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(43): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(43): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(31):        `fail10968.SA.this(this)` is declared here
+fail_compilation/fail10968.d(44): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(44): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(31):        `fail10968.SA.this(this)` is declared here
 fail_compilation/fail10968.d(44): Error: `pure` function `fail10968.bar` cannot call impure function `core.internal.array.arrayassign._d_arraysetassign!(SA[], SA)._d_arraysetassign`
 $p:druntime/import/core/internal/array/arrayassign.d$($n$):        which calls `core.lifetime.copyEmplace!(SA, SA).copyEmplace`
-$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(45): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(45): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
+$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(45): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(45): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(31):        `fail10968.SA.this(this)` is declared here
 fail_compilation/fail10968.d(45): Error: `pure` function `fail10968.bar` cannot call impure function `core.internal.array.arrayassign._d_arrayassign_l!(SA[], SA)._d_arrayassign_l`
 $p:druntime/import/core/internal/array/arrayassign.d$-mixin-$n$($n$):        which calls `core.lifetime.copyEmplace!(SA, SA).copyEmplace`
-$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(48): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(48): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
-fail_compilation/fail10968.d(49): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(49): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
+$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(48): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(48): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(31):        `fail10968.SA.this(this)` is declared here
+fail_compilation/fail10968.d(49): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(49): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(31):        `fail10968.SA.this(this)` is declared here
 fail_compilation/fail10968.d(49): Error: `pure` function `fail10968.bar` cannot call impure function `core.internal.array.construction._d_arraysetctor!(SA[], SA)._d_arraysetctor`
 $p:druntime/import/core/internal/array/construction.d$($n$):        which calls `core.lifetime.copyEmplace!(SA, SA).copyEmplace`
-$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(50): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(50): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
+$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(50): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(50): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.this(this)`
+fail_compilation/fail10968.d(31):        `fail10968.SA.this(this)` is declared here
 fail_compilation/fail10968.d(50): Error: `pure` function `fail10968.bar` cannot call impure function `core.internal.array.construction._d_arrayctor!(SA[], SA)._d_arrayctor`
 $p:druntime/import/core/internal/array/construction.d$($n$):        which calls `core.lifetime.copyEmplace!(SA, SA).copyEmplace`
-$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.__postblit`
+$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.this(this)`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail18143.d
+++ b/compiler/test/fail_compilation/fail18143.d
@@ -1,14 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18143.d(20): Error: variable `fail18143.S.a` cannot modify parameter `this` in contract
-fail_compilation/fail18143.d(21): Error: variable `fail18143.S.a` cannot modify parameter `this` in contract
-fail_compilation/fail18143.d(25): Error: variable `fail18143.S.a` cannot modify parameter `this` in contract
-fail_compilation/fail18143.d(26): Error: variable `fail18143.S.a` cannot modify parameter `this` in contract
-fail_compilation/fail18143.d(35): Error: variable `fail18143.C.a` cannot modify parameter `this` in contract
-fail_compilation/fail18143.d(36): Error: variable `fail18143.C.a` cannot modify parameter `this` in contract
-fail_compilation/fail18143.d(40): Error: variable `fail18143.C.a` cannot modify parameter `this` in contract
-fail_compilation/fail18143.d(41): Error: variable `fail18143.C.a` cannot modify parameter `this` in contract
+fail_compilation/fail18143.d(20): Error: cannot modify member variable `fail18143.S.a` in contract
+fail_compilation/fail18143.d(21): Error: cannot modify member variable `fail18143.S.a` in contract
+fail_compilation/fail18143.d(25): Error: cannot modify member variable `fail18143.S.a` in contract
+fail_compilation/fail18143.d(26): Error: cannot modify member variable `fail18143.S.a` in contract
+fail_compilation/fail18143.d(35): Error: cannot modify member variable `fail18143.C.a` in contract
+fail_compilation/fail18143.d(36): Error: cannot modify member variable `fail18143.C.a` in contract
+fail_compilation/fail18143.d(40): Error: cannot modify member variable `fail18143.C.a` in contract
+fail_compilation/fail18143.d(41): Error: cannot modify member variable `fail18143.C.a` in contract
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4421.d
+++ b/compiler/test/fail_compilation/fail4421.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4421.d(16): Error: function `fail4421.U1.__postblit` destructors, postblits and invariants are not allowed in union `U1`
+fail_compilation/fail4421.d(16): Error: function `fail4421.U1.this(this)` destructors, postblits and invariants are not allowed in union `U1`
 fail_compilation/fail4421.d(17): Error: destructor `fail4421.U1.~this` destructors, postblits and invariants are not allowed in union `U1`
-fail_compilation/fail4421.d(18): Error: function `fail4421.U1.__invariant1` destructors, postblits and invariants are not allowed in union `U1`
+fail_compilation/fail4421.d(18): Error: function `fail4421.U1.invariant` destructors, postblits and invariants are not allowed in union `U1`
 ---
 
 

--- a/compiler/test/fail_compilation/fail6107.d
+++ b/compiler/test/fail_compilation/fail6107.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6107.d(10): Error: variable `fail6107.Foo.__ctor` is not a constructor; identifiers starting with `__` are reserved for the implementation
-fail_compilation/fail6107.d(14): Error: variable `fail6107.Bar.__ctor` is not a constructor; identifiers starting with `__` are reserved for the implementation
+fail_compilation/fail6107.d(12): Error: variable name `__ctor` is not allowed
+fail_compilation/fail6107.d(12):        identifiers starting with `__` are reserved for internal use
+fail_compilation/fail6107.d(16): Error: variable name `__ctor` is not allowed
+fail_compilation/fail6107.d(16):        identifiers starting with `__` are reserved for internal use
 ---
 */
 struct Foo

--- a/compiler/test/fail_compilation/fail7848.d
+++ b/compiler/test/fail_compilation/fail7848.d
@@ -9,12 +9,12 @@ fail_compilation/fail7848.d(21):        `fail7848.func` is declared here
 fail_compilation/fail7848.d(27): Error: `@nogc` function `fail7848.C.__unittest_L25_C30` cannot call non-@nogc function `fail7848.func`
 fail_compilation/fail7848.d(27): Error: function `fail7848.func` is not `nothrow`
 fail_compilation/fail7848.d(25): Error: function `fail7848.C.__unittest_L25_C30` may throw but is marked as `nothrow`
-fail_compilation/fail7848.d(32): Error: `pure` function `fail7848.C.__invariant0` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(32): Error: `@safe` function `fail7848.C.__invariant0` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(32): Error: `pure` function `fail7848.C.invariant` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(32): Error: `@safe` function `fail7848.C.invariant` cannot call `@system` function `fail7848.func`
 fail_compilation/fail7848.d(21):        `fail7848.func` is declared here
-fail_compilation/fail7848.d(32): Error: `@nogc` function `fail7848.C.__invariant0` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(32): Error: `@nogc` function `fail7848.C.invariant` cannot call non-@nogc function `fail7848.func`
 fail_compilation/fail7848.d(32): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(30): Error: function `fail7848.C.__invariant0` may throw but is marked as `nothrow`
+fail_compilation/fail7848.d(30): Error: function `fail7848.C.invariant` may throw but is marked as `nothrow`
 ---
 */
 

--- a/compiler/test/fail_compilation/ice12902.d
+++ b/compiler/test/fail_compilation/ice12902.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12902.d(20): Error: variable `ice12902.main.__dollar` - type `void` is inferred from initializer `s.opDollar()`, and variables cannot be of type `void`
+fail_compilation/ice12902.d(20): Error: variable `ice12902.main.$` - type `void` is inferred from initializer `s.opDollar()`, and variables cannot be of type `void`
 fail_compilation/ice12902.d(20): Error: expression `s.opDollar()` is `void` and has no value
 ---
 */


### PR DESCRIPTION
Error messages should be phrased for users to understand, not compiler developers. So call a postblit `this(this)` instead of `__postblit`.