### PR TITLE
Move toChars overrides to hdrgen.d

### DIFF
--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -271,17 +271,6 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
         return new LinkDeclaration(loc, linkage, Dsymbol.arraySyntaxCopy(decl));
     }
 
-
-    override const(char)* toChars() const
-    {
-        return toString().ptr;
-    }
-
-    extern(D) override const(char)[] toString() const
-    {
-        return "extern ()";
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -311,16 +300,6 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
     {
         assert(!s);
         return new CPPMangleDeclaration(loc, cppmangle, Dsymbol.arraySyntaxCopy(decl));
-    }
-
-    override const(char)* toChars() const
-    {
-        return toString().ptr;
-    }
-
-    extern(D) override const(char)[] toString() const
-    {
-        return "extern ()";
     }
 
     override void accept(Visitor v)
@@ -381,16 +360,6 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
         assert(!s);
         return new CPPNamespaceDeclaration(
             this.loc, this.ident, this.exp, Dsymbol.arraySyntaxCopy(this.decl), this.cppnamespace);
-    }
-
-    override const(char)* toChars() const
-    {
-        return toString().ptr;
-    }
-
-    extern(D) override const(char)[] toString() const
-    {
-        return "extern (C++, `namespace`)";
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/attrib.h
+++ b/compiler/src/dmd/attrib.h
@@ -67,7 +67,6 @@ public:
 
     static LinkDeclaration *create(const Loc &loc, LINK p, Dsymbols *decl);
     LinkDeclaration *syntaxCopy(Dsymbol *s) override;
-    const char *toChars() const override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -77,7 +76,6 @@ public:
     CPPMANGLE cppmangle;
 
     CPPMangleDeclaration *syntaxCopy(Dsymbol *s) override;
-    const char *toChars() const override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -87,7 +85,6 @@ public:
     Expression *exp;
 
     CPPNamespaceDeclaration *syntaxCopy(Dsymbol *s) override;
-    const char *toChars() const override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -605,11 +605,6 @@ extern (C++) final class DebugCondition : DVCondition
     {
         v.visit(this);
     }
-
-    override const(char)* toChars() const
-    {
-        return ident ? ident.toChars() : "debug".ptr;
-    }
 }
 
 /**
@@ -887,11 +882,6 @@ extern (C++) final class VersionCondition : DVCondition
     {
         v.visit(this);
     }
-
-    override const(char)* toChars() const
-    {
-        return ident ? ident.toChars() : "version".ptr;
-    }
 }
 
 /***********************************************************
@@ -960,11 +950,6 @@ extern (C++) final class StaticIfCondition : Condition
     override inout(StaticIfCondition) isStaticIfCondition() inout
     {
         return this;
-    }
-
-    override const(char)* toChars() const
-    {
-        return exp ? exp.toChars() : "static if".ptr;
     }
 }
 

--- a/compiler/src/dmd/ctfe.h
+++ b/compiler/src/dmd/ctfe.h
@@ -48,7 +48,6 @@ class ThrownExceptionExp final : public Expression
 {
 public:
     ClassReferenceExp *thrown; // the thing being tossed
-    const char *toChars() const override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -58,6 +57,4 @@ public:
 
 class CTFEExp final : public Expression
 {
-public:
-    const char *toChars() const override;
 };

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1379,16 +1379,6 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
         assert(0); // should never be produced by syntax
     }
 
-    override final const(char)* toChars() const
-    {
-        //printf("TypeInfoDeclaration::toChars() tinfo = %s\n", tinfo.toChars());
-        OutBuffer buf;
-        buf.writestring("typeid(");
-        buf.writestring(tinfo.toChars());
-        buf.writeByte(')');
-        return buf.extractChars();
-    }
-
     override final inout(TypeInfoDeclaration) isTypeInfoDeclaration() inout @nogc nothrow pure @safe
     {
         return this;

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -342,7 +342,6 @@ public:
 
     static TypeInfoDeclaration *create(Type *tinfo);
     TypeInfoDeclaration *syntaxCopy(Dsymbol *) override final;
-    const char *toChars() const override final;
 
     TypeInfoDeclaration *isTypeInfoDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
@@ -787,7 +786,6 @@ public:
     d_bool isMoveCtor;
     CtorDeclaration *syntaxCopy(Dsymbol *) override;
     const char *kind() const override;
-    const char *toChars() const override;
     bool isVirtual() const override;
     bool addPreInvariant() override;
     bool addPostInvariant() override;
@@ -814,7 +812,6 @@ class DtorDeclaration final : public FuncDeclaration
 public:
     DtorDeclaration *syntaxCopy(Dsymbol *) override;
     const char *kind() const override;
-    const char *toChars() const override;
     bool isVirtual() const override;
     bool addPreInvariant() override;
     bool addPostInvariant() override;

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -691,9 +691,7 @@ bool emitAnchorName(ref OutBuffer buf, Dsymbol s, Scope* sc, bool includeParent)
     }
     else
     {
-        /* We just want the identifier, not overloads like TemplateDeclaration::toChars.
-         * We don't want the template parameter list and constraints. */
-        buf.writestring(s.Dsymbol.toChars());
+        buf.writestring(s.ident ? s.ident.toString : "__anonymous");
     }
     return true;
 }
@@ -796,7 +794,11 @@ void emitAnchor(ref OutBuffer buf, Dsymbol s, Scope* sc, bool forHeader = false)
     }
     else
     {
-        auto symbolName = ident.toString();
+        // buf.writestring("<<<");
+        // buf.writestring(typeof(ident).stringof);
+        // buf.writestring(">>>");
+        // auto symbolName = ident.toString();
+        auto symbolName = ident.toChars().toDString();
         buf.printf("$(%.*s %.*s", cast(int) macroName.length, macroName.ptr,
             cast(int) symbolName.length, symbolName.ptr);
 

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -297,9 +297,10 @@ extern (C++) class Dsymbol : ASTNode
         return new Dsymbol(ident);
     }
 
-    override const(char)* toChars() const
+    final override const(char)* toChars() const
     {
-        return ident ? ident.toHChars2() : "__anonymous";
+        import dmd.hdrgen : toChars;
+        return toChars(this);
     }
 
     // Getters / setters for fields stored in `DsymbolAttributes`

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -187,7 +187,7 @@ public:
     PASS semanticRun;
     unsigned short localNum;        // perturb mangled name to avoid collisions with those in FuncDeclaration.localsymtab
     static Dsymbol *create(Identifier *);
-    const char *toChars() const override;
+    const char *toChars() const final override;
     DeprecatedDeclaration* depdecl();
     CPPNamespaceDeclaration* cppnamespace();
     UserAttributeDeclaration* userAttribDecl();

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -746,14 +746,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         return (onemember && onemember.isAggregateDeclaration()) ? onemember.kind() : "template";
     }
 
-    override const(char)* toChars() const
-    {
-        HdrGenState hgs;
-        OutBuffer buf;
-        toCharsMaybeConstraints(this, buf, hgs);
-        return buf.extractChars();
-    }
-
     /****************************
      * Similar to `toChars`, but does not print the template constraints
      */
@@ -3830,13 +3822,6 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         return true;
     }
 
-    override const(char)* toChars() const
-    {
-        OutBuffer buf;
-        toCBufferInstance(this, buf);
-        return buf.extractChars();
-    }
-
     override final const(char)* toPrettyCharsHelper()
     {
         OutBuffer buf;
@@ -5522,13 +5507,6 @@ extern (C++) final class TemplateMixin : TemplateInstance
     {
         //printf("TemplateMixin.hasPointers() %s\n", toChars());
         return members.foreachDsymbol( (s) { return s.hasPointers(); } ) != 0;
-    }
-
-    override const(char)* toChars() const
-    {
-        OutBuffer buf;
-        toCBufferInstance(this, buf);
-        return buf.extractChars();
     }
 
     extern (D) bool findTempDecl(Scope* sc)

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -91,7 +91,7 @@ public:
     // kludge for template.isExpression()
     DYNCAST dyncast() const override final { return DYNCAST_EXPRESSION; }
 
-    const char *toChars() const override;
+    const char* toChars() const final override;
 
     virtual dinteger_t toInteger();
     virtual uinteger_t toUInteger();
@@ -602,7 +602,6 @@ public:
 
     bool equals(const RootObject * const o) const override;
     FuncExp *syntaxCopy() override;
-    const char *toChars() const override;
     bool checkType() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -1049,7 +1048,6 @@ class LoweredAssignExp final : public AssignExp
 public:
     Expression *lowering;
 
-    const char *toChars() const override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -467,7 +467,7 @@ public:
     PASS semanticRun;
     uint16_t localNum;
     static Dsymbol* create(Identifier* ident);
-    const char* toChars() const override;
+    const char* toChars() const final override;
     DeprecatedDeclaration* depdecl();
     CPPNamespaceDeclaration* cppnamespace();
     UserAttributeDeclaration* userAttribDecl();
@@ -1591,7 +1591,6 @@ public:
     bool overloadInsert(Dsymbol* s) override;
     bool hasStaticCtorOrDtor() override;
     const char* kind() const override;
-    const char* toChars() const override;
     const char* toCharsNoConstraints() const;
     Visibility visible() override;
     const char* getConstraintEvalError(const char*& tip);
@@ -1639,7 +1638,6 @@ public:
     Dsymbol* toAlias() final override;
     const char* kind() const override;
     bool oneMember(Dsymbol*& ps, Identifier* ident) override;
-    const char* toChars() const override;
     const char* toPrettyCharsHelper() final override;
     Identifier* getIdent() final override;
     bool equalsx(TemplateInstance* ti);
@@ -1666,7 +1664,6 @@ public:
     const char* kind() const override;
     bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     bool hasPointers() override;
-    const char* toChars() const override;
     TemplateMixin* isTemplateMixin() override;
     void accept(Visitor* v) override;
 };
@@ -2229,7 +2226,7 @@ public:
     static void deinitialize();
     virtual Expression* syntaxCopy();
     DYNCAST dyncast() const final override;
-    const char* toChars() const override;
+    const char* toChars() const final override;
     virtual dinteger_t toInteger();
     virtual uinteger_t toUInteger();
     virtual _d_real toReal();
@@ -2518,8 +2515,6 @@ public:
 
 class CTFEExp final : public Expression
 {
-public:
-    const char* toChars() const override;
 };
 
 class CallExp final : public UnaExp
@@ -3039,7 +3034,6 @@ public:
     TOK tok;
     bool equals(const RootObject* const o) const override;
     FuncExp* syntaxCopy() override;
-    const char* toChars() const override;
     bool checkType() override;
     void accept(Visitor* v) override;
 };
@@ -3163,7 +3157,6 @@ class LoweredAssignExp final : public AssignExp
 {
 public:
     Expression* lowering;
-    const char* toChars() const override;
     void accept(Visitor* v) override;
 };
 
@@ -3570,7 +3563,6 @@ class ThrownExceptionExp final : public Expression
 {
 public:
     ClassReferenceExp* thrown;
-    const char* toChars() const override;
     void accept(Visitor* v) override;
 };
 
@@ -3925,7 +3917,6 @@ public:
     bool isMoveCtor;
     CtorDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    const char* toChars() const override;
     bool isVirtual() const override;
     bool addPreInvariant() override;
     bool addPostInvariant() override;
@@ -3938,7 +3929,6 @@ class DtorDeclaration final : public FuncDeclaration
 public:
     DtorDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    const char* toChars() const override;
     bool isVirtual() const override;
     bool addPreInvariant() override;
     bool addPostInvariant() override;
@@ -6365,7 +6355,6 @@ public:
     LINK linkage;
     static LinkDeclaration* create(const Loc& loc, LINK p, Array<Dsymbol* >* decl);
     LinkDeclaration* syntaxCopy(Dsymbol* s) override;
-    const char* toChars() const override;
     void accept(Visitor* v) override;
 };
 
@@ -6374,7 +6363,6 @@ class CPPMangleDeclaration final : public AttribDeclaration
 public:
     CPPMANGLE cppmangle;
     CPPMangleDeclaration* syntaxCopy(Dsymbol* s) override;
-    const char* toChars() const override;
     void accept(Visitor* v) override;
 };
 
@@ -6383,7 +6371,6 @@ class CPPNamespaceDeclaration final : public AttribDeclaration
 public:
     Expression* exp;
     CPPNamespaceDeclaration* syntaxCopy(Dsymbol* s) override;
-    const char* toChars() const override;
     void accept(Visitor* v) override;
     CPPNamespaceDeclaration* isCPPNamespaceDeclaration() override;
 };
@@ -6557,7 +6544,6 @@ public:
     int32_t include(Scope* sc) override;
     DebugCondition* isDebugCondition() override;
     void accept(Visitor* v) override;
-    const char* toChars() const override;
 };
 
 class VersionCondition final : public DVCondition
@@ -6568,7 +6554,6 @@ public:
     int32_t include(Scope* sc) override;
     VersionCondition* isVersionCondition() override;
     void accept(Visitor* v) override;
-    const char* toChars() const override;
 };
 
 class StaticIfCondition final : public Condition
@@ -6579,7 +6564,6 @@ public:
     int32_t include(Scope* sc) override;
     void accept(Visitor* v) override;
     StaticIfCondition* isStaticIfCondition() override;
-    const char* toChars() const override;
 };
 
 extern DArray<uint8_t > preprocess(FileName csrcfile, const Loc& loc, OutBuffer& defines);
@@ -6872,7 +6856,6 @@ public:
     Type* tinfo;
     static TypeInfoDeclaration* create(Type* tinfo);
     TypeInfoDeclaration* syntaxCopy(Dsymbol* s) final override;
-    const char* toChars() const final override;
     TypeInfoDeclaration* isTypeInfoDeclaration() final override;
     void accept(Visitor* v) override;
 };

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1390,11 +1390,6 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
         return isCpCtor ? "copy constructor" : "constructor";
     }
 
-    override const(char)* toChars() const
-    {
-        return "this";
-    }
-
     override bool isVirtual() const
     {
         return false;
@@ -1494,11 +1489,6 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
     override const(char)* kind() const
     {
         return "destructor";
-    }
-
-    override const(char)* toChars() const
-    {
-        return "~this";
     }
 
     override bool isVirtual() const

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -140,6 +140,42 @@ public const(char)* toChars(const Type t)
     return buf.extractChars();
 }
 
+public const(char)* toChars(const Dsymbol d)
+{
+    if (auto td = d.isTemplateDeclaration())
+    {
+        HdrGenState hgs;
+        OutBuffer buf;
+        toCharsMaybeConstraints(td, buf, hgs);
+        return buf.extractChars();
+    }
+
+    if (auto ti = d.isTemplateInstance())
+    {
+        OutBuffer buf;
+        toCBufferInstance(ti, buf);
+        return buf.extractChars();
+    }
+
+    if (auto tm = d.isTemplateMixin())
+    {
+        OutBuffer buf;
+        toCBufferInstance(tm, buf);
+        return buf.extractChars();
+    }
+
+    if (auto tid = d.isTypeInfoDeclaration())
+    {
+        OutBuffer buf;
+        buf.writestring("typeid(");
+        buf.writestring(tid.tinfo.toChars());
+        buf.writeByte(')');
+        return buf.extractChars();
+    }
+
+    return d.ident ? d.ident.toHChars2() : "__anonymous";
+}
+
 public const(char)[] toString(const Initializer i)
 {
     OutBuffer buf;
@@ -4504,7 +4540,15 @@ string EXPtoString(EXP op)
         EXP.declaration : "declaration",
 
         EXP.interval : "interval",
-        EXP.loweredAssignExp : "="
+        EXP.loweredAssignExp : "=",
+
+        EXP.thrownException : "CTFE ThrownException",
+        EXP.cantExpression :  "<cant>",
+        EXP.voidExpression : "cast(void)0",
+        EXP.showCtfeContext : "<error>",
+        EXP.break_ : "<break>",
+        EXP.continue_ : "<continue>",
+        EXP.goto_ : "<goto>",
     ];
     const p = strings[op];
     if (!p)

--- a/compiler/src/dmd/identifier.d
+++ b/compiler/src/dmd/identifier.d
@@ -108,7 +108,8 @@ nothrow:
         const(char)* p = null;
         if (this == Id.ctor)
             p = "this";
-        else if (this == Id.dtor)
+        else if (this == Id.dtor || this == Id.__xdtor || this == Id.__fieldDtor ||
+            this == Id.__aggrDtor || this == Id.cppdtor || this == Id.ticppdtor)
             p = "~this";
         else if (this == Id.unitTest)
             p = "unittest";

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -79,7 +79,6 @@ public:
     bool overloadInsert(Dsymbol *s) override;
     bool hasStaticCtorOrDtor() override;
     const char *kind() const override;
-    const char *toChars() const override;
 
     Visibility visible() override;
 
@@ -272,7 +271,6 @@ public:
     Dsymbol *toAlias() override final;   // resolve real symbol
     const char *kind() const override;
     bool oneMember(Dsymbol *&ps, Identifier *ident) override;
-    const char *toChars() const override;
     const char* toPrettyCharsHelper() override final;
     Identifier *getIdent() override final;
 
@@ -292,7 +290,6 @@ public:
     const char *kind() const override;
     bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     bool hasPointers() override;
-    const char *toChars() const override;
 
     TemplateMixin *isTemplateMixin() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/test/compilable/extra-files/json.json
+++ b/compiler/test/compilable/extra-files/json.json
@@ -385,7 +385,7 @@
                     },
                     {
                         "kind": "alias",
-                        "name": "__xdtor",
+                        "name": "~this",
                         "protection": "public"
                     }
                 ],


### PR DESCRIPTION
It's really confusing how both `dmd.hdrgen` calls into `ASTNode.toChars`, and `toChars` calls into `dmd.hdrgen`. It's also confusing how `toChars` is sometimes unused / incomplete / used for internal debugging, and other times expected to generate working D code / stringof / error messages. This moves towards letting `ASTNode.toChars` (or `toString`) call `dmd.hdrgen`, and differentiate uses with `HdrGenState`.