### PR TITLE
Extract Dsymbol.checkCtorConstInit and make it a visitor in dsymbolsem

### DIFF
--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -32,7 +32,7 @@ import dmd.declaration;
 import dmd.dmodule;
 import dmd.dscope;
 import dmd.dsymbol;
-import dmd.dsymbolsem : setScope, addMember, include;
+import dmd.dsymbolsem : include;
 import dmd.expression;
 import dmd.func;
 import dmd.globals;
@@ -123,11 +123,6 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
     override final bool hasStaticCtorOrDtor()
     {
         return this.include(null).foreachDsymbol( (s) { return s.hasStaticCtorOrDtor(); } ) != 0;
-    }
-
-    override final void checkCtorConstInit()
-    {
-        this.include(null).foreachDsymbol( s => s.checkCtorConstInit() );
     }
 
     /****************************************

--- a/compiler/src/dmd/attrib.h
+++ b/compiler/src/dmd/attrib.h
@@ -32,7 +32,6 @@ public:
     bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     bool hasPointers() override final;
     bool hasStaticCtorOrDtor() override final;
-    void checkCtorConstInit() override final;
     AttribDeclaration *isAttribDeclaration() override { return this; }
 
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1124,16 +1124,6 @@ extern (C++) class VarDeclaration : Declaration
         return e;
     }
 
-    override final void checkCtorConstInit()
-    {
-        version (none)
-        {
-            /* doesn't work if more than one static ctor */
-            if (ctorinit == 0 && isCtorinit() && !isField())
-                error("missing initializer in static constructor for const variable");
-        }
-    }
-
     /************************************
      * Check to see if this variable is actually in an enclosing function
      * rather than the current one.

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -299,7 +299,6 @@ public:
     bool hasPointers() override final;
     bool canTakeAddressOf();
     bool needsScopeDtor();
-    void checkCtorConstInit() override final;
     Dsymbol *toAlias() override final;
     // Eliminate need for dynamic_cast
     VarDeclaration *isVarDeclaration() override final { return (VarDeclaration *)this; }

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -916,10 +916,6 @@ extern (C++) class Dsymbol : ASTNode
     {
     }
 
-    void checkCtorConstInit()
-    {
-    }
-
     /****************************************
      * Add documentation comment to Dsymbol.
      * Ignore NULL comments.

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -241,7 +241,6 @@ public:
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
     virtual void addObjcSymbols(ClassDeclarations *, ClassDeclarations *) { }
-    virtual void checkCtorConstInit() { }
 
     virtual void addComment(const utf8_t *comment);
     const utf8_t *comment();                      // current value of comment

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -7940,3 +7940,30 @@ extern (C++) class AddCommentVisitor: Visitor
     }
     override void visit(StaticForeachDeclaration sfd) {}
 }
+
+void checkCtorConstInit(Dsymbol d)
+{
+    scope v = new CheckCtorConstInitVisitor();
+    d.accept(v);
+}
+
+private extern(C++) class CheckCtorConstInitVisitor : Visitor
+{
+    alias visit = Visitor.visit;
+
+    override void visit(AttribDeclaration ad){
+        ad.include(null).foreachDsymbol( s => s.checkCtorConstInit() );
+    }
+
+    override void visit(VarDeclaration vd){
+        version (none)
+        {
+            /* doesn't work if more than one static ctor */
+            if (vd.ctorinit == 0 && vd.isCtorinit() && !vd.isField())
+                error("missing initializer in static constructor for const variable");
+        }
+    }
+
+    override void visit(Dsymbol d){
+    }
+}

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -7951,11 +7951,13 @@ private extern(C++) class CheckCtorConstInitVisitor : Visitor
 {
     alias visit = Visitor.visit;
 
-    override void visit(AttribDeclaration ad){
+    override void visit(AttribDeclaration ad)
+    {
         ad.include(null).foreachDsymbol( s => s.checkCtorConstInit() );
     }
 
-    override void visit(VarDeclaration vd){
+    override void visit(VarDeclaration vd)
+    {
         version (none)
         {
             /* doesn't work if more than one static ctor */
@@ -7964,6 +7966,5 @@ private extern(C++) class CheckCtorConstInitVisitor : Visitor
         }
     }
 
-    override void visit(Dsymbol d){
-    }
+    override void visit(Dsymbol d){}
 }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -514,7 +514,6 @@ public:
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
     virtual void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories);
-    virtual void checkCtorConstInit();
     virtual void addComment(const char* comment);
     const char* comment();
     void comment(const char* comment);
@@ -6320,7 +6319,6 @@ public:
     bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     bool hasPointers() final override;
     bool hasStaticCtorOrDtor() final override;
-    void checkCtorConstInit() final override;
     void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories) final override;
     AttribDeclaration* isAttribDeclaration() override;
     void accept(Visitor* v) override;
@@ -6820,7 +6818,6 @@ public:
     bool hasPointers() final override;
     bool canTakeAddressOf();
     bool needsScopeDtor();
-    void checkCtorConstInit() final override;
     Dsymbol* toAlias() final override;
     VarDeclaration* isVarDeclaration() final override;
     void accept(Visitor* v) override;


### PR DESCRIPTION
This is a component of the project to separate semantic routines from AST nodes specified in the [dlang project-ideas repository](https://github.com/dlang/project-ideas/blob/master/separate-semantic-routines-from-ast-nodes/description.md). I am working on this project under the guidance of @RazvanN7.