### PR TITLE
Fix race condition for new GC

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -2123,8 +2123,8 @@ version (Windows)
 
             obj.initDataStorage();
 
-            Thread.setThis(obj);
-            Thread.add(obj);
+            Thread.registerThis(obj);
+
             scope (exit)
             {
                 Thread.remove(obj);
@@ -2218,8 +2218,9 @@ else version (Posix)
             obj.initDataStorage();
 
             atomicStore!(MemoryOrder.raw)(obj.m_isRunning, true);
-            Thread.setThis(obj); // allocates lazy TLS (see Issue 11981)
-            Thread.add(obj);     // can only receive signals from here on
+
+            Thread.registerThis(obj); // can only receive signals from here on
+
             scope (exit)
             {
                 Thread.remove(obj);

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -746,6 +746,25 @@ package(core.thread):
         //       to ensure that.
         slock.unlock_nothrow();
     }
+
+    //
+    // Add a thread to the global thread list, and also register This thread
+    // for use in `getThis`. This does both operations while protected by the
+    // static lock. This helps alternative GCs that use `thread_preSuspend` to
+    // determine whether druntime will provide scanning details during
+    // `thread_scanAll`. Without holding the lock for both operations, it's
+    // possible a `thread_preSuspend` would return true, but the scanning
+    // details would not be handled.
+    //
+    static void registerThis(ThreadBase t, bool rmAboutToStart = true) nothrow @nogc
+    {
+        slock.lock_nothrow();
+        scope(exit) slock.unlock_nothrow();
+
+        setThis(t);
+        add(t, rmAboutToStart);
+    }
+
 }
 
 


### PR DESCRIPTION
The new GC depends on `thread_preSuspend` to tell it if druntime will provide scanning details (stack and TLS) for the current thread. If it returns true, then the new GC assumes it can rely on druntime to scan the details. If it returns false, then the new GC does its own scanning mechanism.

The cost of this is taking the `slock` a bit earlier than before, so it shouldn't affect anything.

There is a note about lazy TLS allocation, but whatever that is must be long gone, because the `setThis` call is a simple assignment for all platforms. This may have been related to how OSX TLS was managed years ago.

Note that this race caused a failure in a real world application. It's pretty specific to the new GC, and an internal detail to druntime, so there isn't really a test I can add, nor do I think we need to log about this.