### PR TITLE
Remove unnecessary NoPointersBitmapPayload template.

### DIFF
--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -152,11 +152,6 @@ RTInfo!(C)
 	enum immutable(void)* RTInfo = null;
 
 }
-NoPointersBitmapPayload!1$?:32=u|64=LU$
-{
-	enum $?:32=uint|64=ulong$[1] NoPointersBitmapPayload = [0$?:32=u|64=LU$];
-
-}
 values!(__c_wchar_t)
 {
 	pure nothrow @safe __c_wchar_t[] values()

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -3769,15 +3769,10 @@ template RTInfoImpl(size_t[] pointerBitmap)
     immutable size_t[pointerBitmap.length] RTInfoImpl = pointerBitmap[];
 }
 
-template NoPointersBitmapPayload(size_t N)
-{
-    enum size_t[N] NoPointersBitmapPayload = 0;
-}
-
 template RTInfo(T)
 {
     enum pointerBitmap = __traits(getPointerBitmap, T);
-    static if (pointerBitmap[1 .. $] == NoPointersBitmapPayload!(pointerBitmap.length - 1))
+    static if (pointerBitmap[1 .. $] == size_t[pointerBitmap.length - 1].init)
         enum RTInfo = rtinfoNoPointers;
     else
         enum RTInfo = RTInfoImpl!(pointerBitmap).ptr;


### PR DESCRIPTION
Just noticed this, as I was trying to work on Associative Array fixes, and felt like this was worth a quick PR. Should save a few template instantiations.