### PR TITLE
flag non-portable bitfields

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6021,7 +6021,6 @@ struct TargetC final
     uint8_t wchar_tsize;
     Runtime runtime;
     BitFieldStyle bitFieldStyle;
-    bool contributesToAggregateAlignment(BitFieldDeclaration* bfd);
     TargetC() :
         crtDestructorsSupported(true),
         boolsize(),

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -1463,24 +1463,6 @@ struct TargetC
             crtDestructorsSupported = false;
         }
     }
-
-    /**
-     * Indicates whether the specified bit-field contributes to the alignment
-     * of the containing aggregate.
-     * E.g., (not all) ARM ABIs do NOT ignore anonymous (incl. 0-length)
-     * bit-fields.
-     */
-    extern (C++) bool contributesToAggregateAlignment(BitFieldDeclaration bfd)
-    {
-        if (bitFieldStyle == BitFieldStyle.MS)
-            return true;
-        if (bitFieldStyle == BitFieldStyle.Gcc_Clang)
-        {
-            // sufficient for DMD's currently supported architectures
-            return !bfd.isAnonymous();
-        }
-        assert(0);
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Discussed at the last DLF mtg.

The bitfield code is not amenable to flagging nonportable layouts, so I'm trying to refactor it to make it more tractable.