### PR TITLE
Rename short Scope fields

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -131,10 +131,10 @@ extern (C++) struct Scope
     VarDeclaration varDecl;         /// variable we are in during semantic2
     Dsymbol parent;                 /// parent to use
     LabelStatement slabel;          /// enclosing labelled statement
-    SwitchStatement sw;             /// enclosing switch statement
+    SwitchStatement switchStatement;/// enclosing switch statement
     Statement tryBody;              /// enclosing _body of TryCatchStatement or TryFinallyStatement
-    TryFinallyStatement tf;         /// enclosing try finally statement
-    ScopeGuardStatement os;            /// enclosing scope(xxx) statement
+    TryFinallyStatement tryFinally; /// enclosing try finally statement
+    ScopeGuardStatement scopeGuard; /// enclosing scope(xxx) statement
     Statement sbreak;               /// enclosing statement that supports "break"
     Statement scontinue;            /// enclosing statement that supports "continue"
     ForeachStatement fes;           /// if nested function for ForeachStatement, this is it

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5271,7 +5271,7 @@ public:
     bool hasVars;
     DefaultStatement* sdefault;
     Statement* tryBody;
-    TryFinallyStatement* tf;
+    TryFinallyStatement* tryFinally;
     Array<GotoCaseStatement* > gotoCases;
     Array<CaseStatement* >* cases;
     VarDeclaration* lastVar;
@@ -7170,10 +7170,10 @@ struct Scope final
     VarDeclaration* varDecl;
     Dsymbol* parent;
     LabelStatement* slabel;
-    SwitchStatement* sw;
+    SwitchStatement* switchStatement;
     Statement* tryBody;
-    TryFinallyStatement* tf;
-    ScopeGuardStatement* os;
+    TryFinallyStatement* tryFinally;
+    ScopeGuardStatement* scopeGuard;
     Statement* sbreak;
     Statement* scontinue;
     ForeachStatement* fes;
@@ -7242,10 +7242,10 @@ public:
         varDecl(),
         parent(),
         slabel(),
-        sw(),
+        switchStatement(),
         tryBody(),
-        tf(),
-        os(),
+        tryFinally(),
+        scopeGuard(),
         sbreak(),
         scontinue(),
         fes(),
@@ -7278,7 +7278,7 @@ public:
         argStruct()
     {
     }
-    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* sw = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tf = nullptr, ScopeGuardStatement* os = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, bool inDefaultArg = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, uint64_t stc = 0LLU, DeprecatedDeclaration* depdecl = nullptr, uint16_t bitFields = 0u, Previews previews = Previews(), UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr, StructDeclaration* argStruct = nullptr) :
+    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* switchStatement = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tryFinally = nullptr, ScopeGuardStatement* scopeGuard = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, bool inDefaultArg = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, uint64_t stc = 0LLU, DeprecatedDeclaration* depdecl = nullptr, uint16_t bitFields = 0u, Previews previews = Previews(), UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr, StructDeclaration* argStruct = nullptr) :
         enclosing(enclosing),
         _module(_module),
         scopesym(scopesym),
@@ -7286,10 +7286,10 @@ public:
         varDecl(varDecl),
         parent(parent),
         slabel(slabel),
-        sw(sw),
+        switchStatement(switchStatement),
         tryBody(tryBody),
-        tf(tf),
-        os(os),
+        tryFinally(tryFinally),
+        scopeGuard(scopeGuard),
         sbreak(sbreak),
         scontinue(scontinue),
         fes(fes),

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -58,10 +58,10 @@ struct Scope final
     VarDeclaration  *varDecl;   // variable we are in during semantic2
     Dsymbol *parent;            // parent to use
     LabelStatement *slabel;     // enclosing labelled statement
-    SwitchStatement *sw;        // enclosing switch statement
+    SwitchStatement *switchStatement; // enclosing switch statement
     Statement *tryBody;         // enclosing _body of TryCatchStatement or TryFinallyStatement
-    TryFinallyStatement *tf;    // enclosing try finally statement
-    ScopeGuardStatement *os;       // enclosing scope(xxx) statement
+    TryFinallyStatement *tryFinally; // enclosing try finally statement
+    ScopeGuardStatement *scopeGuard; // enclosing scope(xxx) statement
     Statement *sbreak;          // enclosing statement that supports "break"
     Statement *scontinue;       // enclosing statement that supports "continue"
     ForeachStatement *fes;      // if nested function for ForeachStatement, this is it

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -338,7 +338,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             sc2.ctorflow.callSuper = CSX.none;
             sc2.sbreak = null;
             sc2.scontinue = null;
-            sc2.sw = null;
+            sc2.switchStatement = null;
             sc2.fes = funcdecl.fes;
             sc2.linkage = funcdecl.isCsymbol() ? LINK.c : LINK.d;
             sc2.stc &= STC.flowThruFunction;
@@ -350,8 +350,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 sc2.copyFlagsFrom(sc);
                 sc2.contract = Contract.none;
             }
-            sc2.tf = null;
-            sc2.os = null;
+            sc2.tryFinally = null;
+            sc2.scopeGuard = null;
             sc2.inLoop = false;
             sc2.inDefaultArg = false;
             sc2.userAttribDecl = null;

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1106,7 +1106,7 @@ extern (C++) final class SwitchStatement : Statement
     bool hasVars;                   /// true if has variable case values
     DefaultStatement sdefault;      /// default:
     Statement tryBody;              /// set to TryCatchStatement or TryFinallyStatement if in _body portion
-    TryFinallyStatement tf;         /// set if in the 'finally' block of a TryFinallyStatement
+    TryFinallyStatement tryFinally; /// set if in the 'finally' block of a TryFinallyStatement
     GotoCaseStatements gotoCases;   /// array of unresolved GotoCaseStatement's
     CaseStatements* cases;          /// array of CaseStatement's
     VarDeclaration lastVar;         /// last observed variable declaration in this statement

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1804,7 +1804,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         //printf("SwitchStatement::semantic(%p)\n", ss);
         ss.tryBody = sc.tryBody;
-        ss.tf = sc.tf;
+        ss.tryFinally = sc.tryFinally;
         if (ss.cases)
         {
             result = ss; // already run
@@ -1898,7 +1898,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         sc = sc.push();
         sc.sbreak = ss;
-        sc.sw = ss;
+        sc.switchStatement = ss;
 
         ss.cases = new CaseStatements();
         const inLoopSave = sc.inLoop;
@@ -1925,9 +1925,9 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
             for (Scope* scx = sc; scx; scx = scx.enclosing)
             {
-                if (!scx.sw)
+                if (!scx.switchStatement)
                     continue;
-                foreach (cs; *scx.sw.cases)
+                foreach (cs; *scx.switchStatement.cases)
                 {
                     if (cs.exp.equals(gcs.exp))
                     {
@@ -1986,7 +1986,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 needswitcherror = true;
         }
 
-        ss.hasDefault = sc.sw.sdefault ||
+        ss.hasDefault = sc.switchStatement.sdefault ||
             !(!ss.isFinal || needswitcherror || global.params.useAssert == CHECKENABLE.on || sc.func.isSafe || sc.func.isSaferD);
         if (!ss.hasDefault)
         {
@@ -2040,11 +2040,11 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 s = new ExpStatement(ss.loc, new HaltExp(ss.loc));
 
             a.reserve(2);
-            sc.sw.sdefault = new DefaultStatement(ss.loc, s);
+            sc.switchStatement.sdefault = new DefaultStatement(ss.loc, s);
             a.push(ss._body);
             if (ss._body.blockExit(sc.func, null) & BE.fallthru)
                 a.push(new BreakStatement(Loc.initial, null));
-            a.push(sc.sw.sdefault);
+            a.push(sc.switchStatement.sdefault);
             cs = new CompoundStatement(ss.loc, a);
             ss._body = cs;
         }
@@ -2141,7 +2141,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
     void visitCase(CaseStatement cs)
     {
-        SwitchStatement sw = sc.sw;
+        SwitchStatement sw = sc.switchStatement;
         bool errors = false;
 
         //printf("CaseStatement::semantic() %s\n", toChars());
@@ -2197,9 +2197,9 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     */
                     for (Scope* scx = sc; scx; scx = scx.enclosing)
                     {
-                        if (scx.enclosing && scx.enclosing.sw == sw)
+                        if (scx.enclosing && scx.enclosing.switchStatement == sw)
                             continue;
-                        assert(scx.sw == sw);
+                        assert(scx.switchStatement == sw);
 
                         Dsymbol pscopesym;
                         if (!scx.search(cs.exp.loc, v.ident, pscopesym))
@@ -2254,12 +2254,12 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 i++;
             }
 
-            if (sc.sw.tf != sc.tf)
+            if (sc.switchStatement.tryFinally != sc.tryFinally)
             {
                 error(cs.loc, "`switch` and `case` are in different `finally` blocks");
                 errors = true;
             }
-            if (sc.sw.tryBody != sc.tryBody)
+            if (sc.switchStatement.tryBody != sc.tryBody)
             {
                 error(cs.loc, "case cannot be in different `try` block level from `switch`");
                 errors = true;
@@ -2287,7 +2287,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
     void visitCaseRange(CaseRangeStatement crs)
     {
-        SwitchStatement sw = sc.sw;
+        SwitchStatement sw = sc.switchStatement;
         if (sw is null)
         {
             error(crs.loc, "case range not in `switch` statement");
@@ -2372,26 +2372,26 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
     {
         //printf("DefaultStatement::semantic()\n");
         bool errors = false;
-        if (sc.sw)
+        if (sc.switchStatement)
         {
-            if (sc.sw.sdefault)
+            if (sc.switchStatement.sdefault)
             {
                 error(ds.loc, "`switch` statement already has a default");
                 errors = true;
             }
-            sc.sw.sdefault = ds;
+            sc.switchStatement.sdefault = ds;
 
-            if (sc.sw.tf != sc.tf)
+            if (sc.switchStatement.tryFinally != sc.tryFinally)
             {
                 error(ds.loc, "`switch` and `default` are in different `finally` blocks");
                 errors = true;
             }
-            if (sc.sw.tryBody != sc.tryBody)
+            if (sc.switchStatement.tryBody != sc.tryBody)
             {
                 error(ds.loc, "default cannot be in different `try` block level from `switch`");
                 errors = true;
             }
-            if (sc.sw.isFinal)
+            if (sc.switchStatement.isFinal)
             {
                 error(ds.loc, "`default` statement not allowed in `final switch` statement");
                 errors = true;
@@ -2417,7 +2417,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         /* https://dlang.org/spec/statement.html#goto-statement
          */
 
-        gds.sw = sc.sw;
+        gds.sw = sc.switchStatement;
         if (!gds.sw)
         {
             error(gds.loc, "`goto default` not in `switch` statement");
@@ -2436,7 +2436,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         /* https://dlang.org/spec/statement.html#goto-statement
          */
 
-        if (!sc.sw)
+        if (!sc.switchStatement)
         {
             error(gcs.loc, "`goto case` not in `switch` statement");
             return setError();
@@ -2445,13 +2445,13 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         if (gcs.exp)
         {
             gcs.exp = gcs.exp.expressionSemantic(sc);
-            gcs.exp = gcs.exp.implicitCastTo(sc, sc.sw.condition.type);
+            gcs.exp = gcs.exp.implicitCastTo(sc, sc.switchStatement.condition.type);
             gcs.exp = gcs.exp.optimize(WANTvalue);
             if (gcs.exp.op == EXP.error)
                 return setError();
         }
 
-        sc.sw.gotoCases.push(gcs);
+        sc.switchStatement.gotoCases.push(gcs);
         result = gcs;
     }
 
@@ -2505,22 +2505,22 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             error(rs.loc, "`return` statements cannot be in contracts");
             errors = true;
         }
-        if (sc.os)
+        if (sc.scopeGuard)
         {
             // @@@DEPRECATED_2.112@@@
             // Deprecated in 2.100, transform into an error in 2.112
-            if (sc.os.tok == TOK.onScopeFailure)
+            if (sc.scopeGuard.tok == TOK.onScopeFailure)
             {
                 deprecation(rs.loc, "`return` statements cannot be in `scope(failure)` bodies.");
                 deprecationSupplemental(rs.loc, "Use try-catch blocks for this purpose");
             }
             else
             {
-                error(rs.loc, "`return` statements cannot be in `%s` bodies", Token.toChars(sc.os.tok));
+                error(rs.loc, "`return` statements cannot be in `%s` bodies", Token.toChars(sc.scopeGuard.tok));
                 errors = true;
             }
         }
-        if (sc.tf)
+        if (sc.tryFinally)
         {
             error(rs.loc, "`return` statements cannot be in `finally` bodies");
             errors = true;
@@ -2901,7 +2901,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     Statement s = ls.statement;
                     if (!s || !s.hasBreak())
                         error(bs.loc, "label `%s` has no `break`", bs.ident.toChars());
-                    else if (ls.tf != sc.tf)
+                    else if (ls.tf != sc.tryFinally)
                         error(bs.loc, "cannot break out of `finally` block");
                     else
                     {
@@ -2917,9 +2917,9 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         }
         else if (!sc.sbreak)
         {
-            if (sc.os && sc.os.tok != TOK.onScopeFailure)
+            if (sc.scopeGuard && sc.scopeGuard.tok != TOK.onScopeFailure)
             {
-                error(bs.loc, "`break` is not allowed inside `%s` bodies", Token.toChars(sc.os.tok));
+                error(bs.loc, "`break` is not allowed inside `%s` bodies", Token.toChars(sc.scopeGuard.tok));
             }
             else if (sc.fes)
             {
@@ -2989,7 +2989,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     Statement s = ls.statement;
                     if (!s || !s.hasContinue())
                         error(cs.loc, "label `%s` has no `continue`", cs.ident.toChars());
-                    else if (ls.tf != sc.tf)
+                    else if (ls.tf != sc.tryFinally)
                         error(cs.loc, "cannot continue out of `finally` block");
                     else
                     {
@@ -3004,9 +3004,9 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         }
         else if (!sc.scontinue)
         {
-            if (sc.os && sc.os.tok != TOK.onScopeFailure)
+            if (sc.scopeGuard && sc.scopeGuard.tok != TOK.onScopeFailure)
             {
-                error(cs.loc, "`continue` is not allowed inside `%s` bodies", Token.toChars(sc.os.tok));
+                error(cs.loc, "`continue` is not allowed inside `%s` bodies", Token.toChars(sc.scopeGuard.tok));
             }
             else if (sc.fes)
             {
@@ -3382,7 +3382,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         tfs._body = tfs._body.semanticScope(sc, null, null, tfs);
 
         sc = sc.push();
-        sc.tf = tfs;
+        sc.tryFinally = tfs;
         sc.sbreak = null;
         sc.scontinue = null; // no break or continue out of finally block
         tfs.finalbody = tfs.finalbody.semanticNoScope(sc);
@@ -3435,13 +3435,13 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             // scope(success) and scope(failure) are rewritten to try-catch(-finally) statement,
             // so the generated catch block cannot be placed in finally block.
             // See also Catch::semantic.
-            if (sc.os && sc.os.tok != TOK.onScopeFailure)
+            if (sc.scopeGuard && sc.scopeGuard.tok != TOK.onScopeFailure)
             {
                 // If enclosing is scope(success) or scope(exit), this will be placed in finally block.
-                error(oss.loc, "cannot put `%s` statement inside `%s`", Token.toChars(oss.tok), Token.toChars(sc.os.tok));
+                error(oss.loc, "cannot put `%s` statement inside `%s`", Token.toChars(oss.tok), Token.toChars(sc.scopeGuard.tok));
                 return setError();
             }
-            if (sc.tf)
+            if (sc.tryFinally)
             {
                 error(oss.loc, "cannot put `%s` statement inside `finally` block", Token.toChars(oss.tok));
                 return setError();
@@ -3449,8 +3449,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         }
 
         sc = sc.push();
-        sc.tf = null;
-        sc.os = oss;
+        sc.tryFinally = null;
+        sc.scopeGuard = oss;
         if (oss.tok != TOK.onScopeFailure)
         {
             // Jump out from scope(failure) block is allowed.
@@ -3504,8 +3504,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         gs.ident = fixupLabelName(sc, gs.ident);
         gs.label = fd.searchLabel(gs.ident, gs.loc);
         gs.tryBody = sc.tryBody;
-        gs.tf = sc.tf;
-        gs.os = sc.os;
+        gs.tf = sc.tryFinally;
+        gs.os = sc.scopeGuard;
         gs.lastVar = sc.lastVar;
         gs.inCtfeBlock = sc.ctfeBlock;
 
@@ -3544,8 +3544,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         ls.ident = fixupLabelName(sc, ls.ident);
         ls.tryBody = sc.tryBody;
-        ls.tf = sc.tf;
-        ls.os = sc.os;
+        ls.tf = sc.tryFinally;
+        ls.os = sc.scopeGuard;
         ls.lastVar = sc.lastVar;
         ls.inCtfeBlock = sc.ctfeBlock;
 
@@ -4053,13 +4053,13 @@ void catchSemantic(Catch c, Scope* sc)
 {
     //printf("Catch::semantic(%s)\n", ident.toChars());
 
-    if (sc.os && sc.os.tok != TOK.onScopeFailure)
+    if (sc.scopeGuard && sc.scopeGuard.tok != TOK.onScopeFailure)
     {
         // If enclosing is scope(success) or scope(exit), this will be placed in finally block.
-        error(c.loc, "cannot put `catch` statement inside `%s`", Token.toChars(sc.os.tok));
+        error(c.loc, "cannot put `catch` statement inside `%s`", Token.toChars(sc.scopeGuard.tok));
         c.errors = true;
     }
-    if (sc.tf)
+    if (sc.tryFinally)
     {
         /* This is because the _d_local_unwind() gets the stack munged
          * up on this. The workaround is to place any try-catches into


### PR DESCRIPTION
They're not used so much that they warrant a cryptic 2-letter name.