### PR TITLE
Remove `const ref` from `Loc` parameters

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -154,7 +154,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     bool disableNew;                /// disallow allocations using `new`
     Sizeok sizeok = Sizeok.none;    /// set when structsize contains valid data
 
-    final extern (D) this(const ref Loc loc, Identifier id)
+    final extern (D) this(Loc loc, Identifier id)
     {
         super(loc, id);
         visibility = Visibility(Visibility.Kind.public_);
@@ -189,7 +189,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     abstract void finalizeSize();
 
-    override final uinteger_t size(const ref Loc loc)
+    override final uinteger_t size(Loc loc)
     {
         //printf("+AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
         bool ok = determineSize(this, loc);

--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -45,7 +45,7 @@ namespace dmd
 {
     FuncDeclaration *search_toString(StructDeclaration *sd);
     void semanticTypeInfoMembers(StructDeclaration *sd);
-    bool fill(StructDeclaration* sd, const Loc &loc, Expressions &elements, bool ctorinit);
+    bool fill(StructDeclaration* sd, Loc loc, Expressions &elements, bool ctorinit);
 }
 
 enum class ClassKind : uint8_t
@@ -119,7 +119,7 @@ public:
 
     virtual Scope *newScope(Scope *sc);
     virtual void finalizeSize() = 0;
-    uinteger_t size(const Loc &loc) override final;
+    uinteger_t size(Loc loc) override final;
     Type *getType() override final;
     bool isDeprecated() const override final; // is aggregate deprecated?
     bool isNested() const;
@@ -168,7 +168,7 @@ public:
 private:
     uint16_t bitFields;
 public:
-    static StructDeclaration *create(const Loc &loc, Identifier *id, bool inObject);
+    static StructDeclaration *create(Loc loc, Identifier *id, bool inObject);
     StructDeclaration *syntaxCopy(Dsymbol *s) override;
     const char *kind() const override;
     void finalizeSize() override final;
@@ -278,7 +278,7 @@ public:
     ObjcClassDeclaration objc;          // Data for a class declaration that is needed for the Objective-C integration
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
-    static ClassDeclaration *create(const Loc &loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);
+    static ClassDeclaration *create(Loc loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);
     const char *toPrettyChars(bool QualifyTypes = false) override;
     ClassDeclaration *syntaxCopy(Dsymbol *s) override;
     Scope *newScope(Scope *sc) override;

--- a/compiler/src/dmd/aliasthis.d
+++ b/compiler/src/dmd/aliasthis.d
@@ -31,7 +31,7 @@ extern (C++) final class AliasThis : Dsymbol
     /// Whether this `alias this` is deprecated or not
     bool isDeprecated_;
 
-    extern (D) this(const ref Loc loc, Identifier ident) @safe
+    extern (D) this(Loc loc, Identifier ident) @safe
     {
         super(loc, null);    // it's anonymous (no identifier)
         this.ident = ident;

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -81,7 +81,7 @@ struct ASTBase
             this.ident = ident;
         }
 
-        final extern (D) this(const ref Loc loc, Identifier ident)
+        final extern (D) this(Loc loc, Identifier ident)
         {
             this.loc = loc;
             this.ident = ident;
@@ -266,7 +266,7 @@ struct ASTBase
     {
         Identifier ident;
 
-        extern (D) this(const ref Loc loc, Identifier ident)
+        extern (D) this(Loc loc, Identifier ident)
         {
             super(null);
             this.loc = loc;
@@ -285,7 +285,7 @@ struct ASTBase
         Type type;
         Dsymbol aliassym;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Type type, Dsymbol aliassym)
+        extern (D) this(Loc loc, Identifier ident, Type type, Dsymbol aliassym)
         {
             super(null);
             this.loc = loc;
@@ -342,7 +342,7 @@ struct ASTBase
         {
             super(id);
         }
-        final extern (D) this(const ref Loc loc, Identifier ident)
+        final extern (D) this(Loc loc, Identifier ident)
         {
             super(loc, ident);
         }
@@ -364,7 +364,7 @@ struct ASTBase
         Identifiers names;
         Identifiers aliases;
 
-        extern (D) this(const ref Loc loc, Identifier[] packages, Identifier id, Identifier aliasId, int isstatic)
+        extern (D) this(Loc loc, Identifier[] packages, Identifier id, Identifier aliasId, int isstatic)
         {
             super(null);
             this.loc = loc;
@@ -406,7 +406,7 @@ struct ASTBase
             this.decl = decl;
         }
 
-        final extern (D) this(const ref Loc loc, Identifier ident, Dsymbols* decl)
+        final extern (D) this(Loc loc, Identifier ident, Dsymbols* decl)
         {
             super(loc, ident);
             this.decl = decl;
@@ -428,7 +428,7 @@ struct ASTBase
         Expression exp;
         Expressions* msgs;
 
-        extern (D) this(const ref Loc loc, Expression exp, Expression msg)
+        extern (D) this(Loc loc, Expression exp, Expression msg)
         {
             super(loc, Id.empty);
             this.exp = exp;
@@ -436,7 +436,7 @@ struct ASTBase
             (*this.msgs)[0] = msg;
         }
 
-        extern (D) this(const ref Loc loc, Expression exp, Expressions* msgs)
+        extern (D) this(Loc loc, Expression exp, Expressions* msgs)
         {
             super(loc, Id.empty);
             this.exp = exp;
@@ -451,12 +451,12 @@ struct ASTBase
 
     extern (C++) final class DebugSymbol : Dsymbol
     {
-        extern (D) this(const ref Loc loc, Identifier ident)
+        extern (D) this(Loc loc, Identifier ident)
         {
             super(ident);
             this.loc = loc;
         }
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             this.loc = loc;
         }
@@ -469,12 +469,12 @@ struct ASTBase
 
     extern (C++) final class VersionSymbol : Dsymbol
     {
-        extern (D) this(const ref Loc loc, Identifier ident)
+        extern (D) this(Loc loc, Identifier ident)
         {
             super(ident);
             this.loc = loc;
         }
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             this.loc = loc;
         }
@@ -509,7 +509,7 @@ struct ASTBase
         uint ctfeAdrOnStack;
         uint sequenceNumber;
 
-        final extern (D) this(const ref Loc loc, Type type, Identifier id, Initializer _init, StorageClass st = STC.undefined_)
+        final extern (D) this(Loc loc, Type type, Identifier id, Initializer _init, StorageClass st = STC.undefined_)
         {
             super(id);
             this.type = type;
@@ -537,7 +537,7 @@ struct ASTBase
         uint fieldWidth;
         uint bitOffset;
 
-        final extern (D) this(const ref Loc loc, Type type, Identifier id, Expression width)
+        final extern (D) this(Loc loc, Type type, Identifier id, Expression width)
         {
             super(loc, type, id, cast(Initializer)null, cast(StorageClass)STC.undefined_);
 
@@ -574,7 +574,7 @@ struct ASTBase
         ForeachStatement fes;
         FuncDeclaration overnext0;
 
-        final extern (D) this(const ref Loc loc, Loc endloc, Identifier id, StorageClass storage_class, Type type, bool noreturn = false)
+        final extern (D) this(Loc loc, Loc endloc, Identifier id, StorageClass storage_class, Type type, bool noreturn = false)
         {
             super(id);
             this.storage_class = storage_class;
@@ -615,14 +615,14 @@ struct ASTBase
     {
         Dsymbol aliassym;
 
-        extern (D) this(const ref Loc loc, Identifier id, Dsymbol s)
+        extern (D) this(Loc loc, Identifier id, Dsymbol s)
         {
             super(id);
             this.loc = loc;
             this.aliassym = s;
         }
 
-        extern (D) this(const ref Loc loc, Identifier id, Type type)
+        extern (D) this(Loc loc, Identifier id, Type type)
         {
             super(id);
             this.loc = loc;
@@ -646,7 +646,7 @@ struct ASTBase
     {
         Objects* objects;
 
-        extern (D) this(const ref Loc loc, Identifier id, Objects* objects)
+        extern (D) this(Loc loc, Identifier id, Objects* objects)
         {
             super(id);
             this.loc = loc;
@@ -663,7 +663,7 @@ struct ASTBase
     {
         TOK tok;
 
-        extern (D) this(const ref Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, StorageClass storage_class = STC.undefined_)
+        extern (D) this(Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, StorageClass storage_class = STC.undefined_)
         {
             super(loc, endloc, null, storage_class, type);
             this.ident = id ? id : Id.empty;
@@ -684,7 +684,7 @@ struct ASTBase
 
     extern (C++) final class PostBlitDeclaration : FuncDeclaration
     {
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, Identifier id)
+        extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id)
         {
             super(loc, endloc, id, stc, null);
         }
@@ -697,7 +697,7 @@ struct ASTBase
 
     extern (C++) final class CtorDeclaration : FuncDeclaration
     {
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, Type type, bool isCopyCtor = false)
+        extern (D) this(Loc loc, Loc endloc, StorageClass stc, Type type, bool isCopyCtor = false)
         {
             super(loc, endloc, Id.ctor, stc, type);
         }
@@ -715,11 +715,11 @@ struct ASTBase
 
     extern (C++) final class DtorDeclaration : FuncDeclaration
     {
-        extern (D) this(const ref Loc loc, Loc endloc)
+        extern (D) this(Loc loc, Loc endloc)
         {
             super(loc, endloc, Id.dtor, STC.undefined_, null);
         }
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, Identifier id)
+        extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id)
         {
             super(loc, endloc, id, stc, null);
         }
@@ -737,7 +737,7 @@ struct ASTBase
 
     extern (C++) final class InvariantDeclaration : FuncDeclaration
     {
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, Identifier id, Statement fbody)
+        extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id, Statement fbody)
         {
             super(loc, endloc, id ? id : Identifier.generateIdWithLoc("__invariant", loc), stc, null);
             this.fbody = fbody;
@@ -753,7 +753,7 @@ struct ASTBase
     {
         char* codedoc;
 
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, char* codedoc)
+        extern (D) this(Loc loc, Loc endloc, StorageClass stc, char* codedoc)
         {
             super(loc, endloc, Identifier.generateIdWithLoc("__unittest", loc), stc, null);
             this.codedoc = codedoc;
@@ -767,7 +767,7 @@ struct ASTBase
 
     extern (C++) final class NewDeclaration : FuncDeclaration
     {
-        extern (D) this(const ref Loc loc, StorageClass stc)
+        extern (D) this(Loc loc, StorageClass stc)
         {
             super(loc, Loc.initial, Id.classNew, STC.static_ | stc, null);
         }
@@ -780,11 +780,11 @@ struct ASTBase
 
     extern (C++) class StaticCtorDeclaration : FuncDeclaration
     {
-        final extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc)
+        final extern (D) this(Loc loc, Loc endloc, StorageClass stc)
         {
             super(loc, endloc, Identifier.generateIdWithLoc("_staticCtor", loc), STC.static_ | stc, null);
         }
-        final extern (D) this(const ref Loc loc, Loc endloc, string name, StorageClass stc)
+        final extern (D) this(Loc loc, Loc endloc, string name, StorageClass stc)
         {
             super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
         }
@@ -801,7 +801,7 @@ struct ASTBase
         {
             super(loc, endloc, Identifier.generateIdWithLoc("__staticDtor", loc), STC.static_ | stc, null);
         }
-        final extern (D) this(const ref Loc loc, Loc endloc, string name, StorageClass stc)
+        final extern (D) this(Loc loc, Loc endloc, string name, StorageClass stc)
         {
             super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
         }
@@ -814,7 +814,7 @@ struct ASTBase
 
     extern (C++) final class SharedStaticCtorDeclaration : StaticCtorDeclaration
     {
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc)
+        extern (D) this(Loc loc, Loc endloc, StorageClass stc)
         {
             super(loc, endloc, "_sharedStaticCtor", stc);
         }
@@ -827,7 +827,7 @@ struct ASTBase
 
     extern (C++) final class SharedStaticDtorDeclaration : StaticDtorDeclaration
     {
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc)
+        extern (D) this(Loc loc, Loc endloc, StorageClass stc)
         {
             super(loc, endloc, "_sharedStaticDtor", stc);
         }
@@ -843,7 +843,7 @@ struct ASTBase
         PKG isPkgMod;
         uint tag;
 
-        final extern (D) this(const ref Loc loc, Identifier ident)
+        final extern (D) this(Loc loc, Identifier ident)
         {
             super(loc, ident);
             this.isPkgMod = PKG.unknown;
@@ -863,7 +863,7 @@ struct ASTBase
         Type memtype;
         Visibility visibility;
 
-        extern (D) this(const ref Loc loc, Identifier id, Type memtype)
+        extern (D) this(Loc loc, Identifier id, Type memtype)
         {
             super(id);
             this.loc = loc;
@@ -884,7 +884,7 @@ struct ASTBase
         Sizeok sizeok;
         Type type;
 
-        final extern (D) this(const ref Loc loc, Identifier id)
+        final extern (D) this(Loc loc, Identifier id)
         {
             super(id);
             this.loc = loc;
@@ -914,7 +914,7 @@ struct ASTBase
         Visibility visibility;
         Dsymbol onemember;
 
-        extern (D) this(const ref Loc loc, Identifier id, TemplateParameters* parameters, Expression constraint, Dsymbols* decldefs, bool ismixin = false, bool literal = false)
+        extern (D) this(Loc loc, Identifier id, TemplateParameters* parameters, Expression constraint, Dsymbols* decldefs, bool ismixin = false, bool literal = false)
         {
             super(id);
             this.loc = loc;
@@ -963,7 +963,7 @@ struct ASTBase
         bool havetempdecl;
         TemplateInstance inst;
 
-        final extern (D) this(const ref Loc loc, Identifier ident, Objects* tiargs)
+        final extern (D) this(Loc loc, Identifier ident, Objects* tiargs)
         {
             super(null);
             this.loc = loc;
@@ -971,7 +971,7 @@ struct ASTBase
             this.tiargs = tiargs;
         }
 
-        final extern (D) this(const ref Loc loc, TemplateDeclaration td, Objects* tiargs)
+        final extern (D) this(Loc loc, TemplateDeclaration td, Objects* tiargs)
         {
             super(null);
             this.loc = loc;
@@ -1034,7 +1034,7 @@ struct ASTBase
          */
         Expression identExp;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members)
+        extern (D) this(Loc loc, Identifier ident, Expression identExp, Dsymbols* members)
         {
             super(ident);
             this.loc = loc;
@@ -1052,7 +1052,7 @@ struct ASTBase
     {
         Expressions* exps;
 
-        extern (D) this(const ref Loc loc, Expressions* exps)
+        extern (D) this(Loc loc, Expressions* exps)
         {
             super(null);
             this.loc = loc;
@@ -1116,7 +1116,7 @@ struct ASTBase
     {
         LINK linkage;
 
-        extern (D) this(const ref Loc loc, LINK p, Dsymbols* decl)
+        extern (D) this(Loc loc, LINK p, Dsymbols* decl)
         {
             super(loc, null, decl);
             this.linkage = p;
@@ -1132,7 +1132,7 @@ struct ASTBase
     {
         bool isunion;
 
-        extern (D) this(const ref Loc loc, bool isunion, Dsymbols* decl)
+        extern (D) this(Loc loc, bool isunion, Dsymbols* decl)
         {
             super(decl);
             this.loc = loc;
@@ -1150,7 +1150,7 @@ struct ASTBase
         Expressions* exps;
         structalign_t salign;
 
-        extern (D) this(const ref Loc loc, Expression exp, Dsymbols* decl)
+        extern (D) this(Loc loc, Expression exp, Dsymbols* decl)
         {
             super(decl);
             this.loc = loc;
@@ -1161,7 +1161,7 @@ struct ASTBase
             }
         }
 
-        extern (D) this(const ref Loc loc, Expressions* exps, Dsymbols* decl)
+        extern (D) this(Loc loc, Expressions* exps, Dsymbols* decl)
         {
             super(decl);
             this.loc = loc;
@@ -1178,7 +1178,7 @@ struct ASTBase
     {
         CPPMANGLE cppmangle;
 
-        extern (D) this(const ref Loc loc, CPPMANGLE p, Dsymbols* decl)
+        extern (D) this(Loc loc, CPPMANGLE p, Dsymbols* decl)
         {
             super(loc, null, decl);
             cppmangle = p;
@@ -1194,12 +1194,12 @@ struct ASTBase
     {
         Expression exp;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Dsymbols* decl)
+        extern (D) this(Loc loc, Identifier ident, Dsymbols* decl)
         {
             super(loc, ident, decl);
         }
 
-        extern (D) this(const ref Loc loc, Expression exp, Dsymbols* decl)
+        extern (D) this(Loc loc, Expression exp, Dsymbols* decl)
         {
             super(loc, null, decl);
             this.exp = exp;
@@ -1216,13 +1216,13 @@ struct ASTBase
         Visibility visibility;
         Identifier[] pkg_identifiers;
 
-        extern (D) this(const ref Loc loc, Visibility v, Dsymbols* decl)
+        extern (D) this(Loc loc, Visibility v, Dsymbols* decl)
         {
             super(decl);
             this.loc = loc;
             this.visibility = v;
         }
-        extern (D) this(const ref Loc loc, Identifier[] pkg_identifiers, Dsymbols* decl)
+        extern (D) this(Loc loc, Identifier[] pkg_identifiers, Dsymbols* decl)
         {
             super(decl);
             this.loc = loc;
@@ -1241,7 +1241,7 @@ struct ASTBase
     {
         Expressions* args;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Expressions* args, Dsymbols* decl)
+        extern (D) this(Loc loc, Identifier ident, Expressions* args, Dsymbols* decl)
         {
             super(decl);
             this.loc = loc;
@@ -1265,7 +1265,7 @@ struct ASTBase
             this.stc = stc;
         }
 
-        final extern (D) this(const ref Loc loc, StorageClass stc, Dsymbols* decl)
+        final extern (D) this(Loc loc, StorageClass stc, Dsymbols* decl)
         {
             super(decl);
             this.loc = loc;
@@ -1288,7 +1288,7 @@ struct ASTBase
         Condition condition;
         Dsymbols* elsedecl;
 
-        final extern (D) this(const ref Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl)
+        final extern (D) this(Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl)
         {
             super(loc, null, decl);
             this.condition = condition;
@@ -1319,7 +1319,7 @@ struct ASTBase
 
     extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
     {
-        extern (D) this(const ref Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl)
+        extern (D) this(Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl)
         {
             super(loc, condition, decl, elsedecl);
         }
@@ -1353,14 +1353,14 @@ struct ASTBase
 
         @property ref value() { return (cast(ExpInitializer)_init).exp; }
 
-        extern (D) this(const ref Loc loc, Identifier id, Expression value, Type origType)
+        extern (D) this(Loc loc, Identifier id, Expression value, Type origType)
         {
             super(loc, null, id ? id : Id.empty, new ExpInitializer(loc, value));
             this.origValue = value;
             this.origType = origType;
         }
 
-        extern(D) this(const ref Loc loc, Identifier id, Expression value, Type memtype,
+        extern(D) this(Loc loc, Identifier id, Expression value, Type memtype,
             StorageClass stc, UserAttributeDeclaration uad, DeprecatedDeclaration dd)
         {
             this(loc, id, value, memtype);
@@ -1383,7 +1383,7 @@ struct ASTBase
         const(char)[] arg;
         Edition edition = Edition.legacy;
 
-        extern (D) this(const ref Loc loc, const(char)[] filename, Identifier ident, int doDocComment, int doHdrGen)
+        extern (D) this(Loc loc, const(char)[] filename, Identifier ident, int doDocComment, int doHdrGen)
         {
             super(loc, ident);
             this.arg = filename;
@@ -1408,7 +1408,7 @@ struct ASTBase
         int zeroInit;
         ThreeState ispod;
 
-        final extern (D) this(const ref Loc loc, Identifier id, bool inObject)
+        final extern (D) this(Loc loc, Identifier id, bool inObject)
         {
             super(loc, id);
             zeroInit = 0;
@@ -1434,7 +1434,7 @@ struct ASTBase
 
     extern (C++) final class UnionDeclaration : StructDeclaration
     {
-        extern (D) this(const ref Loc loc, Identifier id)
+        extern (D) this(Loc loc, Identifier id)
         {
             super(loc, id, false);
         }
@@ -1465,7 +1465,7 @@ struct ASTBase
         BaseClasses* baseclasses;
         Baseok baseok;
 
-        final extern (D) this(const ref Loc loc, Identifier id, BaseClasses* baseclasses, Dsymbols* members, bool inObject)
+        final extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses, Dsymbols* members, bool inObject)
         {
             if(!id)
                 id = Identifier.generateId("__anonclass");
@@ -1651,7 +1651,7 @@ struct ASTBase
 
     extern (C++) class InterfaceDeclaration : ClassDeclaration
     {
-        final extern (D) this(const ref Loc loc, Identifier id, BaseClasses* baseclasses)
+        final extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses)
         {
             super(loc, id, baseclasses, null, false);
         }
@@ -1666,7 +1666,7 @@ struct ASTBase
     {
         TypeQualified tqual;
 
-        extern (D) this(const ref Loc loc, Identifier ident, TypeQualified tqual, Objects* tiargs)
+        extern (D) this(Loc loc, Identifier ident, TypeQualified tqual, Objects* tiargs)
         {
             super(loc,
                   tqual.idents.length ? cast(Identifier)tqual.idents[tqual.idents.length - 1] : (cast(TypeIdentifier)tqual).ident,
@@ -1706,7 +1706,7 @@ struct ASTBase
 
         extern (D) alias ForeachDg = int delegate(size_t idx, Parameter param);
 
-        final extern (D) this(const ref Loc loc, StorageClass storageClass, Type type, Identifier ident, Expression defaultArg, UserAttributeDeclaration userAttribDecl)
+        final extern (D) this(Loc loc, StorageClass storageClass, Type type, Identifier ident, Expression defaultArg, UserAttributeDeclaration userAttribDecl)
         {
             this.storageClass = storageClass;
             this.type = type;
@@ -1806,7 +1806,7 @@ struct ASTBase
         Loc loc;
         STMT stmt;
 
-        final extern (D) this(const ref Loc loc, STMT stmt)
+        final extern (D) this(Loc loc, STMT stmt)
         {
             this.loc = loc;
             this.stmt = stmt;
@@ -1834,7 +1834,7 @@ struct ASTBase
     {
         Dsymbols* imports;
 
-        extern (D) this(const ref Loc loc, Dsymbols* imports)
+        extern (D) this(Loc loc, Dsymbols* imports)
         {
             super(loc, STMT.Import);
             this.imports = imports;
@@ -1851,7 +1851,7 @@ struct ASTBase
         Statement statement;
         Loc endloc;
 
-        extern (D) this(const ref Loc loc, Statement s, Loc endloc)
+        extern (D) this(Loc loc, Statement s, Loc endloc)
         {
             super(loc, STMT.Scope);
             this.statement = s;
@@ -1868,7 +1868,7 @@ struct ASTBase
     {
         Expression exp;
 
-        extern (D) this(const ref Loc loc, Expression exp)
+        extern (D) this(Loc loc, Expression exp)
         {
             super(loc, STMT.Return);
             this.exp = exp;
@@ -1885,7 +1885,7 @@ struct ASTBase
         Identifier ident;
         Statement statement;
 
-        final extern (D) this(const ref Loc loc, Identifier ident, Statement statement)
+        final extern (D) this(Loc loc, Identifier ident, Statement statement)
         {
             super(loc, STMT.Label);
             this.ident = ident;
@@ -1918,7 +1918,7 @@ struct ASTBase
     {
         Expressions* exps;
 
-        final extern (D) this(const ref Loc loc, Expressions* exps)
+        final extern (D) this(Loc loc, Expressions* exps)
         {
             super(loc, STMT.Mixin);
             this.exps = exps;
@@ -1937,7 +1937,7 @@ struct ASTBase
         Statement _body;
         Loc endloc;
 
-        extern (D) this(const ref Loc loc, Expression c, Statement b, Loc endloc, Parameter param = null)
+        extern (D) this(Loc loc, Expression c, Statement b, Loc endloc, Parameter param = null)
         {
             super(loc, STMT.While);
             condition = c;
@@ -1959,7 +1959,7 @@ struct ASTBase
         Statement _body;
         Loc endloc;
 
-        extern (D) this(const ref Loc loc, Statement _init, Expression condition, Expression increment, Statement _body, Loc endloc)
+        extern (D) this(Loc loc, Statement _init, Expression condition, Expression increment, Statement _body, Loc endloc)
         {
             super(loc, STMT.For);
             this._init = _init;
@@ -1981,7 +1981,7 @@ struct ASTBase
         Expression condition;
         Loc endloc;
 
-        extern (D) this(const ref Loc loc, Statement b, Expression c, Loc endloc)
+        extern (D) this(Loc loc, Statement b, Expression c, Loc endloc)
         {
             super(loc, STMT.Do);
             _body = b;
@@ -2005,7 +2005,7 @@ struct ASTBase
         Loc endloc;             // location of closing curly bracket
 
 
-        extern (D) this(const ref Loc loc, TOK op, Parameter param, Expression lwr, Expression upr, Statement _body, Loc endloc)
+        extern (D) this(Loc loc, TOK op, Parameter param, Expression lwr, Expression upr, Statement _body, Loc endloc)
         {
             super(loc, STMT.ForeachRange);
             this.op = op;
@@ -2030,7 +2030,7 @@ struct ASTBase
         Statement _body;
         Loc endloc;                 // location of closing curly bracket
 
-        extern (D) this(const ref Loc loc, TOK op, Parameters* parameters, Expression aggr, Statement _body, Loc endloc)
+        extern (D) this(Loc loc, TOK op, Parameters* parameters, Expression aggr, Statement _body, Loc endloc)
         {
             super(loc, STMT.Foreach);
             this.op = op;
@@ -2055,7 +2055,7 @@ struct ASTBase
         VarDeclaration match;   // for MatchExpression results
         Loc endloc;                 // location of closing curly bracket
 
-        extern (D) this(const ref Loc loc, Parameter param, Expression condition, Statement ifbody, Statement elsebody, Loc endloc)
+        extern (D) this(Loc loc, Parameter param, Expression condition, Statement ifbody, Statement elsebody, Loc endloc)
         {
             super(loc, STMT.If);
             this.param = param;
@@ -2076,7 +2076,7 @@ struct ASTBase
         TOK tok;
         Statement statement;
 
-        extern (D) this(const ref Loc loc, TOK tok, Statement statement)
+        extern (D) this(Loc loc, TOK tok, Statement statement)
         {
             super(loc, STMT.ScopeGuard);
             this.tok = tok;
@@ -2095,7 +2095,7 @@ struct ASTBase
         Statement ifbody;
         Statement elsebody;
 
-        extern (D) this(const ref Loc loc, Condition condition, Statement ifbody, Statement elsebody)
+        extern (D) this(Loc loc, Condition condition, Statement ifbody, Statement elsebody)
         {
             super(loc, STMT.Conditional);
             this.condition = condition;
@@ -2113,7 +2113,7 @@ struct ASTBase
     {
         StaticForeach sfe;
 
-        extern (D) this(const ref Loc loc, StaticForeach sfe)
+        extern (D) this(Loc loc, StaticForeach sfe)
         {
             super(loc, STMT.StaticForeach);
             this.sfe = sfe;
@@ -2131,7 +2131,7 @@ struct ASTBase
         Expressions* args;      // array of Expression's
         Statement _body;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Expressions* args, Statement _body)
+        extern (D) this(Loc loc, Identifier ident, Expressions* args, Statement _body)
         {
             super(loc, STMT.Pragma);
             this.ident = ident;
@@ -2153,7 +2153,7 @@ struct ASTBase
         bool isFinal;
         Loc endloc;             // location of closing curly bracket
 
-        extern (D) this(const ref Loc loc, Parameter param, Expression c, Statement b, bool isFinal, Loc endloc)
+        extern (D) this(Loc loc, Parameter param, Expression c, Statement b, bool isFinal, Loc endloc)
         {
             super(loc, STMT.Switch);
             this.param = param;
@@ -2175,7 +2175,7 @@ struct ASTBase
         Expression last;
         Statement statement;
 
-        extern (D) this(const ref Loc loc, Expression first, Expression last, Statement s)
+        extern (D) this(Loc loc, Expression first, Expression last, Statement s)
         {
             super(loc, STMT.CaseRange);
             this.first = first;
@@ -2194,7 +2194,7 @@ struct ASTBase
         Expression exp;
         Statement statement;
 
-        extern (D) this(const ref Loc loc, Expression exp, Statement s)
+        extern (D) this(Loc loc, Expression exp, Statement s)
         {
             super(loc, STMT.Case);
             this.exp = exp;
@@ -2211,7 +2211,7 @@ struct ASTBase
     {
         Statement statement;
 
-        extern (D) this(const ref Loc loc, Statement s)
+        extern (D) this(Loc loc, Statement s)
         {
             super(loc, STMT.Default);
             this.statement = s;
@@ -2227,7 +2227,7 @@ struct ASTBase
     {
         Identifier ident;
 
-        extern (D) this(const ref Loc loc, Identifier ident)
+        extern (D) this(Loc loc, Identifier ident)
         {
             super(loc, STMT.Break);
             this.ident = ident;
@@ -2243,7 +2243,7 @@ struct ASTBase
     {
         Identifier ident;
 
-        extern (D) this(const ref Loc loc, Identifier ident)
+        extern (D) this(Loc loc, Identifier ident)
         {
             super(loc, STMT.Continue);
             this.ident = ident;
@@ -2257,7 +2257,7 @@ struct ASTBase
 
     extern (C++) final class GotoDefaultStatement : Statement
     {
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, STMT.GotoDefault);
         }
@@ -2272,7 +2272,7 @@ struct ASTBase
     {
         Expression exp;
 
-        extern (D) this(const ref Loc loc, Expression exp)
+        extern (D) this(Loc loc, Expression exp)
         {
             super(loc, STMT.GotoCase);
             this.exp = exp;
@@ -2288,7 +2288,7 @@ struct ASTBase
     {
         Identifier ident;
 
-        extern (D) this(const ref Loc loc, Identifier ident)
+        extern (D) this(Loc loc, Identifier ident)
         {
             super(loc, STMT.Goto);
             this.ident = ident;
@@ -2305,7 +2305,7 @@ struct ASTBase
         Expression exp;
         Statement _body;
 
-        extern (D) this(const ref Loc loc, Expression exp, Statement _body)
+        extern (D) this(Loc loc, Expression exp, Statement _body)
         {
             super(loc, STMT.Synchronized);
             this.exp = exp;
@@ -2324,7 +2324,7 @@ struct ASTBase
         Statement _body;
         Loc endloc;
 
-        extern (D) this(const ref Loc loc, Expression exp, Statement _body, Loc endloc)
+        extern (D) this(Loc loc, Expression exp, Statement _body, Loc endloc)
         {
             super(loc, STMT.With);
             this.exp = exp;
@@ -2343,7 +2343,7 @@ struct ASTBase
         Statement _body;
         Catches* catches;
 
-        extern (D) this(const ref Loc loc, Statement _body, Catches* catches)
+        extern (D) this(Loc loc, Statement _body, Catches* catches)
         {
             super(loc, STMT.TryCatch);
             this._body = _body;
@@ -2361,7 +2361,7 @@ struct ASTBase
         Statement _body;
         Statement finalbody;
 
-        extern (D) this(const ref Loc loc, Statement _body, Statement finalbody)
+        extern (D) this(Loc loc, Statement _body, Statement finalbody)
         {
             super(loc, STMT.TryFinally);
             this._body = _body;
@@ -2378,7 +2378,7 @@ struct ASTBase
     {
         Expression exp;
 
-        extern (D) this(const ref Loc loc, Expression exp)
+        extern (D) this(Loc loc, Expression exp)
         {
             super(loc, STMT.Throw);
             this.exp = exp;
@@ -2395,13 +2395,13 @@ struct ASTBase
         Token* tokens;
         bool caseSensitive;
 
-        extern (D) this(const ref Loc loc, Token* tokens)
+        extern (D) this(Loc loc, Token* tokens)
         {
             super(loc, STMT.Asm);
             this.tokens = tokens;
         }
 
-        extern (D) this(const ref Loc loc, Token* tokens, STMT stmt)
+        extern (D) this(Loc loc, Token* tokens, STMT stmt)
         {
             super(loc, stmt);
             this.tokens = tokens;
@@ -2415,7 +2415,7 @@ struct ASTBase
 
     extern (C++) final class InlineAsmStatement : AsmStatement
     {
-        extern (D) this(const ref Loc loc, Token* tokens)
+        extern (D) this(Loc loc, Token* tokens)
         {
             super(loc, tokens, STMT.InlineAsm);
         }
@@ -2428,7 +2428,7 @@ struct ASTBase
 
     extern (C++) final class GccAsmStatement : AsmStatement
     {
-        extern (D) this(const ref Loc loc, Token* tokens)
+        extern (D) this(Loc loc, Token* tokens)
         {
             super(loc, tokens, STMT.GccAsm);
         }
@@ -2443,12 +2443,12 @@ struct ASTBase
     {
         Expression exp;
 
-        final extern (D) this(const ref Loc loc, Expression exp)
+        final extern (D) this(Loc loc, Expression exp)
         {
             super(loc, STMT.Exp);
             this.exp = exp;
         }
-        final extern (D) this(const ref Loc loc, Dsymbol declaration)
+        final extern (D) this(Loc loc, Dsymbol declaration)
         {
             super(loc, STMT.Exp);
             this.exp = new DeclarationExp(loc, declaration);
@@ -2464,19 +2464,19 @@ struct ASTBase
     {
         Statements* statements;
 
-        final extern (D) this(const ref Loc loc, Statements* statements)
+        final extern (D) this(Loc loc, Statements* statements)
         {
             super(loc, STMT.Compound);
             this.statements = statements;
         }
 
-        final extern (D) this(const ref Loc loc, Statements* statements, STMT stmt)
+        final extern (D) this(Loc loc, Statements* statements, STMT stmt)
         {
             super(loc, stmt);
             this.statements = statements;
         }
 
-        final extern (D) this(const ref Loc loc, Statement[] sts...)
+        final extern (D) this(Loc loc, Statement[] sts...)
         {
             super(loc, STMT.Compound);
             statements = new Statements();
@@ -2507,7 +2507,7 @@ struct ASTBase
 
     extern (C++) final class CompoundDeclarationStatement : CompoundStatement
     {
-        final extern (D) this(const ref Loc loc, Statements* statements)
+        final extern (D) this(Loc loc, Statements* statements)
         {
             super(loc, statements, STMT.CompoundDeclaration);
         }
@@ -2522,7 +2522,7 @@ struct ASTBase
     {
         StorageClass stc;
 
-        final extern (D) this(const ref Loc loc, Statements* s, StorageClass stc)
+        final extern (D) this(Loc loc, Statements* s, StorageClass stc)
         {
             super(loc, s, STMT.CompoundAsm);
             this.stc = stc;
@@ -2541,7 +2541,7 @@ struct ASTBase
         Identifier ident;
         Statement handler;
 
-        extern (D) this(const ref Loc loc, Type t, Identifier id, Statement handler)
+        extern (D) this(Loc loc, Type t, Identifier id, Statement handler)
         {
             this.loc = loc;
             this.type = t;
@@ -3781,7 +3781,7 @@ struct ASTBase
         Type resolved;
         MOD mod;
 
-        extern (D) this(const ref Loc loc, TOK tok, Identifier id, structalign_t packalign, Type base, Dsymbols* members)
+        extern (D) this(Loc loc, TOK tok, Identifier id, structalign_t packalign, Type base, Dsymbols* members)
         {
             //printf("TypeTag %p\n", this);
             super(Ttag);
@@ -4375,7 +4375,7 @@ struct ASTBase
         TraitsExp exp;
         Loc loc;
 
-        extern (D) this(const ref Loc loc, TraitsExp exp)
+        extern (D) this(Loc loc, TraitsExp exp)
         {
             super(Tident);
             this.loc = loc;
@@ -4402,7 +4402,7 @@ struct ASTBase
         Expressions* exps;
         RootObject obj;
 
-        extern (D) this(const ref Loc loc, Expressions* exps)
+        extern (D) this(Loc loc, Expressions* exps)
         {
             super(Tmixin);
             this.loc = loc;
@@ -4438,7 +4438,7 @@ struct ASTBase
     {
         Identifier ident;
 
-        extern (D) this(const ref Loc loc, Identifier ident)
+        extern (D) this(Loc loc, Identifier ident)
         {
             super(Tident, loc);
             this.ident = ident;
@@ -4465,7 +4465,7 @@ struct ASTBase
 
     extern (C++) final class TypeReturn : TypeQualified
     {
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(Treturn, loc);
         }
@@ -4488,7 +4488,7 @@ struct ASTBase
     {
         Expression exp;
 
-        extern (D) this(const ref Loc loc, Expression exp)
+        extern (D) this(Loc loc, Expression exp)
         {
             super(Ttypeof, loc);
             this.exp = exp;
@@ -4512,7 +4512,7 @@ struct ASTBase
     {
         TemplateInstance tempinst;
 
-        final extern (D) this(const ref Loc loc, TemplateInstance tempinst)
+        final extern (D) this(Loc loc, TemplateInstance tempinst)
         {
             super(Tinstance, loc);
             this.tempinst = tempinst;
@@ -4546,7 +4546,7 @@ struct ASTBase
         Type type;
         Loc loc;
 
-        final extern (D) this(const ref Loc loc, EXP op, int size)
+        final extern (D) this(Loc loc, EXP op, int size)
         {
             this.loc = loc;
             this.op = op;
@@ -4702,7 +4702,7 @@ struct ASTBase
     {
         Dsymbol declaration;
 
-        extern (D) this(const ref Loc loc, Dsymbol declaration)
+        extern (D) this(Loc loc, Dsymbol declaration)
         {
             super(loc, EXP.declaration, __traits(classInstanceSize, DeclarationExp));
             this.declaration = declaration;
@@ -4718,7 +4718,7 @@ struct ASTBase
     {
         dinteger_t value;
 
-        extern (D) this(const ref Loc loc, dinteger_t value, Type type)
+        extern (D) this(Loc loc, dinteger_t value, Type type)
         {
             super(loc, EXP.int64, __traits(classInstanceSize, IntegerExp));
             assert(type);
@@ -4809,7 +4809,7 @@ struct ASTBase
         ClassDeclaration cd;    // class being instantiated
         Expressions* arguments; // Array of Expression's to call class constructor
 
-        extern (D) this(const ref Loc loc, Expression thisexp, ClassDeclaration cd, Expressions* arguments)
+        extern (D) this(Loc loc, Expression thisexp, ClassDeclaration cd, Expressions* arguments)
         {
             super(loc, EXP.newAnonymousClass, __traits(classInstanceSize, NewAnonClassExp));
             this.thisexp = thisexp;
@@ -4832,7 +4832,7 @@ struct ASTBase
         TOK tok;            // ':' or '=='
         TOK tok2;           // 'struct', 'union', etc.
 
-        extern (D) this(const ref Loc loc, Type targ, Identifier id, TOK tok, Type tspec, TOK tok2, TemplateParameters* parameters)
+        extern (D) this(Loc loc, Type targ, Identifier id, TOK tok, Type tspec, TOK tok2, TemplateParameters* parameters)
         {
             super(loc, EXP.is_, __traits(classInstanceSize, IsExp));
             this.targ = targ;
@@ -4853,7 +4853,7 @@ struct ASTBase
     {
         real_t value;
 
-        extern (D) this(const ref Loc loc, real_t value, Type type)
+        extern (D) this(Loc loc, real_t value, Type type)
         {
             super(loc, EXP.float64, __traits(classInstanceSize, RealExp));
             this.value = value;
@@ -4868,7 +4868,7 @@ struct ASTBase
 
     extern (C++) final class NullExp : Expression
     {
-        extern (D) this(const ref Loc loc, Type type = null)
+        extern (D) this(Loc loc, Type type = null)
         {
             super(loc, EXP.null_, __traits(classInstanceSize, NullExp));
             this.type = type;
@@ -4884,7 +4884,7 @@ struct ASTBase
     {
         RootObject obj;
 
-        extern (D) this(const ref Loc loc, RootObject o)
+        extern (D) this(Loc loc, RootObject o)
         {
             super(loc, EXP.typeid_, __traits(classInstanceSize, TypeidExp));
             this.obj = o;
@@ -4901,7 +4901,7 @@ struct ASTBase
         Identifier ident;
         Objects* args;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Objects* args)
+        extern (D) this(Loc loc, Identifier ident, Objects* args)
         {
             super(loc, EXP.traits, __traits(classInstanceSize, TraitsExp));
             this.ident = ident;
@@ -4924,7 +4924,7 @@ struct ASTBase
         InterpolatedSet* interpolatedSet;
         char postfix = 0;   // 'c', 'w', 'd'
 
-        extern (D) this(const ref Loc loc, InterpolatedSet* interpolatedSet, char postfix = 0)
+        extern (D) this(Loc loc, InterpolatedSet* interpolatedSet, char postfix = 0)
         {
             super(loc, EXP.interpolated, __traits(classInstanceSize, InterpExp));
             this.interpolatedSet = interpolatedSet;
@@ -4953,7 +4953,7 @@ struct ASTBase
         /// If the string is parsed from a hex string literal
         bool hexString = false;
 
-        extern (D) this(const ref Loc loc, const(void)[] string)
+        extern (D) this(Loc loc, const(void)[] string)
         {
             super(loc, EXP.string_, __traits(classInstanceSize, StringExp));
             this.string = cast(char*)string.ptr;
@@ -4961,7 +4961,7 @@ struct ASTBase
             this.sz = 1;                    // work around LDC bug #1286
         }
 
-        extern (D) this(const ref Loc loc, const(void)[] string, size_t len, ubyte sz, char postfix = 0)
+        extern (D) this(Loc loc, const(void)[] string, size_t len, ubyte sz, char postfix = 0)
         {
             super(loc, EXP.string_, __traits(classInstanceSize, StringExp));
             this.string = cast(char*)string;
@@ -5021,7 +5021,7 @@ struct ASTBase
         Expressions* arguments;     // Array of Expression's
         Identifiers* names;         // Array of names corresponding to expressions
 
-        extern (D) this(const ref Loc loc, Expression thisexp, Type newtype, Expressions* arguments, Identifiers* names = null)
+        extern (D) this(Loc loc, Expression thisexp, Type newtype, Expressions* arguments, Identifiers* names = null)
         {
             super(loc, EXP.new_, __traits(classInstanceSize, NewExp));
             this.thisexp = thisexp;
@@ -5041,7 +5041,7 @@ struct ASTBase
         Expressions* keys;
         Expressions* values;
 
-        extern (D) this(const ref Loc loc, Expressions* keys, Expressions* values)
+        extern (D) this(Loc loc, Expressions* keys, Expressions* values)
         {
             super(loc, EXP.assocArrayLiteral, __traits(classInstanceSize, AssocArrayLiteralExp));
             assert(keys.length == values.length);
@@ -5060,20 +5060,20 @@ struct ASTBase
         Expression basis;
         Expressions* elements;
 
-        extern (D) this(const ref Loc loc, Expressions* elements)
+        extern (D) this(Loc loc, Expressions* elements)
         {
             super(loc, EXP.arrayLiteral, __traits(classInstanceSize, ArrayLiteralExp));
             this.elements = elements;
         }
 
-        extern (D) this(const ref Loc loc, Expression e)
+        extern (D) this(Loc loc, Expression e)
         {
             super(loc, EXP.arrayLiteral, __traits(classInstanceSize, ArrayLiteralExp));
             elements = new Expressions();
             elements.push(e);
         }
 
-        extern (D) this(const ref Loc loc, Expression basis, Expressions* elements)
+        extern (D) this(Loc loc, Expression basis, Expressions* elements)
         {
             super(loc, EXP.arrayLiteral, __traits(classInstanceSize, ArrayLiteralExp));
             this.basis = basis;
@@ -5092,7 +5092,7 @@ struct ASTBase
         TemplateDeclaration td;
         TOK tok;
 
-        extern (D) this(const ref Loc loc, Dsymbol s)
+        extern (D) this(Loc loc, Dsymbol s)
         {
             super(loc, EXP.function_, __traits(classInstanceSize, FuncExp));
             this.td = s.isTemplateDeclaration();
@@ -5118,7 +5118,7 @@ struct ASTBase
         Expression lwr;
         Expression upr;
 
-        extern (D) this(const ref Loc loc, Expression lwr, Expression upr)
+        extern (D) this(Loc loc, Expression lwr, Expression upr)
         {
             super(loc, EXP.interval, __traits(classInstanceSize, IntervalExp));
             this.lwr = lwr;
@@ -5133,7 +5133,7 @@ struct ASTBase
 
     extern (C++) final class TypeExp : Expression
     {
-        extern (D) this(const ref Loc loc, Type type)
+        extern (D) this(Loc loc, Type type)
         {
             super(loc, EXP.type, __traits(classInstanceSize, TypeExp));
             this.type = type;
@@ -5149,7 +5149,7 @@ struct ASTBase
     {
         ScopeDsymbol sds;
 
-        extern (D) this(const ref Loc loc, ScopeDsymbol sds)
+        extern (D) this(Loc loc, ScopeDsymbol sds)
         {
             super(loc, EXP.scope_, __traits(classInstanceSize, ScopeExp));
             this.sds = sds;
@@ -5166,7 +5166,7 @@ struct ASTBase
     {
         Identifier ident;
 
-        final extern (D) this(const ref Loc loc, Identifier ident)
+        final extern (D) this(Loc loc, Identifier ident)
         {
             super(loc, EXP.identifier, __traits(classInstanceSize, IdentifierExp));
             this.ident = ident;
@@ -5182,7 +5182,7 @@ struct ASTBase
     {
         Expression e1;
 
-        final extern (D) this(const ref Loc loc, EXP op, int size, Expression e1)
+        final extern (D) this(Loc loc, EXP op, int size, Expression e1)
         {
             super(loc, op, size);
             this.e1 = e1;
@@ -5196,7 +5196,7 @@ struct ASTBase
 
     extern (C++) class DefaultInitExp : Expression
     {
-        final extern (D) this(const ref Loc loc, EXP op, int size)
+        final extern (D) this(Loc loc, EXP op, int size)
         {
             super(loc, op, size);
         }
@@ -5212,7 +5212,7 @@ struct ASTBase
         Expression e1;
         Expression e2;
 
-        final extern (D) this(const ref Loc loc, EXP op, int size, Expression e1, Expression e2)
+        final extern (D) this(Loc loc, EXP op, int size, Expression e1, Expression e2)
         {
             super(loc, op, size);
             this.e1 = e1;
@@ -5230,7 +5230,7 @@ struct ASTBase
         Dsymbol s;
         bool hasOverloads;
 
-        extern (D) this(const ref Loc loc, Dsymbol s, bool hasOverloads = true)
+        extern (D) this(Loc loc, Dsymbol s, bool hasOverloads = true)
         {
             super(loc, EXP.dSymbol, __traits(classInstanceSize, DsymbolExp));
             this.s = s;
@@ -5248,7 +5248,7 @@ struct ASTBase
         TemplateDeclaration td;
         FuncDeclaration fd;
 
-        extern (D) this(const ref Loc loc, TemplateDeclaration td, FuncDeclaration fd = null)
+        extern (D) this(Loc loc, TemplateDeclaration td, FuncDeclaration fd = null)
         {
             super(loc, EXP.template_, __traits(classInstanceSize, TemplateExp));
             //printf("TemplateExp(): %s\n", td.toChars());
@@ -5267,7 +5267,7 @@ struct ASTBase
         Declaration var;
         bool hasOverloads;
 
-        final extern (D) this(const ref Loc loc, EXP op, int size, Declaration var, bool hasOverloads)
+        final extern (D) this(Loc loc, EXP op, int size, Declaration var, bool hasOverloads)
         {
             super(loc, op, size);
             assert(var);
@@ -5283,7 +5283,7 @@ struct ASTBase
 
     extern (C++) final class VarExp : SymbolExp
     {
-        extern (D) this(const ref Loc loc, Declaration var, bool hasOverloads = true)
+        extern (D) this(Loc loc, Declaration var, bool hasOverloads = true)
         {
             if (var.isVarDeclaration())
                 hasOverloads = false;
@@ -5303,7 +5303,7 @@ struct ASTBase
         Expression e0;
         Expressions* exps;
 
-        extern (D) this(const ref Loc loc, Expression e0, Expressions* exps)
+        extern (D) this(Loc loc, Expression e0, Expressions* exps)
         {
             super(loc, EXP.tuple, __traits(classInstanceSize, TupleExp));
             //printf("TupleExp(this = %p)\n", this);
@@ -5311,14 +5311,14 @@ struct ASTBase
             this.exps = exps;
         }
 
-        extern (D) this(const ref Loc loc, Expressions* exps)
+        extern (D) this(Loc loc, Expressions* exps)
         {
             super(loc, EXP.tuple, __traits(classInstanceSize, TupleExp));
             //printf("TupleExp(this = %p)\n", this);
             this.exps = exps;
         }
 
-        extern (D) this(const ref Loc loc, TupleDeclaration tup)
+        extern (D) this(Loc loc, TupleDeclaration tup)
         {
             super(loc, EXP.tuple, __traits(classInstanceSize, TupleExp));
             this.exps = new Expressions();
@@ -5400,7 +5400,7 @@ struct ASTBase
 
     extern (C++) final class DollarExp : IdentifierExp
     {
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, Id.dollar);
         }
@@ -5413,7 +5413,7 @@ struct ASTBase
 
     extern (C++) class ThisExp : Expression
     {
-        final extern (D) this(const ref Loc loc)
+        final extern (D) this(Loc loc)
         {
             super(loc, EXP.this_, __traits(classInstanceSize, ThisExp));
         }
@@ -5426,7 +5426,7 @@ struct ASTBase
 
     extern (C++) final class SuperExp : ThisExp
     {
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc);
             op = EXP.super_;
@@ -5440,7 +5440,7 @@ struct ASTBase
 
     extern (C++) final class AddrExp : UnaExp
     {
-        extern (D) this(const ref Loc loc, Expression e)
+        extern (D) this(Loc loc, Expression e)
         {
             super(loc, EXP.address, __traits(classInstanceSize, AddrExp), e);
         }
@@ -5466,11 +5466,11 @@ struct ASTBase
 
     extern (C++) final class PtrExp : UnaExp
     {
-        extern (D) this(const ref Loc loc, Expression e)
+        extern (D) this(Loc loc, Expression e)
         {
             super(loc, EXP.star, __traits(classInstanceSize, PtrExp), e);
         }
-        extern (D) this(const ref Loc loc, Expression e, Type t)
+        extern (D) this(Loc loc, Expression e, Type t)
         {
             super(loc, EXP.star, __traits(classInstanceSize, PtrExp), e);
             type = t;
@@ -5484,7 +5484,7 @@ struct ASTBase
 
     extern (C++) final class NegExp : UnaExp
     {
-        extern (D) this(const ref Loc loc, Expression e)
+        extern (D) this(Loc loc, Expression e)
         {
             super(loc, EXP.negate, __traits(classInstanceSize, NegExp), e);
         }
@@ -5497,7 +5497,7 @@ struct ASTBase
 
     extern (C++) final class UAddExp : UnaExp
     {
-        extern (D) this(const ref Loc loc, Expression e)
+        extern (D) this(Loc loc, Expression e)
         {
             super(loc, EXP.uadd, __traits(classInstanceSize, UAddExp), e);
         }
@@ -5510,7 +5510,7 @@ struct ASTBase
 
     extern (C++) final class NotExp : UnaExp
     {
-        extern (D) this(const ref Loc loc, Expression e)
+        extern (D) this(Loc loc, Expression e)
         {
             super(loc, EXP.not, __traits(classInstanceSize, NotExp), e);
         }
@@ -5523,7 +5523,7 @@ struct ASTBase
 
     extern (C++) final class ComExp : UnaExp
     {
-        extern (D) this(const ref Loc loc, Expression e)
+        extern (D) this(Loc loc, Expression e)
         {
             super(loc, EXP.tilde, __traits(classInstanceSize, ComExp), e);
         }
@@ -5538,7 +5538,7 @@ struct ASTBase
     {
         bool isRAII;
 
-        extern (D) this(const ref Loc loc, Expression e, bool isRAII)
+        extern (D) this(Loc loc, Expression e, bool isRAII)
         {
             super(loc, EXP.delete_, __traits(classInstanceSize, DeleteExp), e);
             this.isRAII = isRAII;
@@ -5555,12 +5555,12 @@ struct ASTBase
         Type to;
         ubyte mod = cast(ubyte)~0;
 
-        extern (D) this(const ref Loc loc, Expression e, Type t)
+        extern (D) this(Loc loc, Expression e, Type t)
         {
             super(loc, EXP.cast_, __traits(classInstanceSize, CastExp), e);
             this.to = t;
         }
-        extern (D) this(const ref Loc loc, Expression e, ubyte mod)
+        extern (D) this(Loc loc, Expression e, ubyte mod)
         {
             super(loc, EXP.cast_, __traits(classInstanceSize, CastExp), e);
             this.mod = mod;
@@ -5577,19 +5577,19 @@ struct ASTBase
         Expressions* arguments;
         Identifiers* names;
 
-        extern (D) this(const ref Loc loc, Expression e, Expressions* exps, Identifiers* names = null)
+        extern (D) this(Loc loc, Expression e, Expressions* exps, Identifiers* names = null)
         {
             super(loc, EXP.call, __traits(classInstanceSize, CallExp), e);
             this.arguments = exps;
             this.names = names;
         }
 
-        extern (D) this(const ref Loc loc, Expression e)
+        extern (D) this(Loc loc, Expression e)
         {
             super(loc, EXP.call, __traits(classInstanceSize, CallExp), e);
         }
 
-        extern (D) this(const ref Loc loc, Expression e, Expression earg1)
+        extern (D) this(Loc loc, Expression e, Expression earg1)
         {
             super(loc, EXP.call, __traits(classInstanceSize, CallExp), e);
             auto arguments = new Expressions(earg1 ? 1 : 0);
@@ -5598,7 +5598,7 @@ struct ASTBase
             this.arguments = arguments;
         }
 
-        extern (D) this(const ref Loc loc, Expression e, Expression earg1, Expression earg2)
+        extern (D) this(Loc loc, Expression e, Expression earg1, Expression earg2)
         {
             super(loc, EXP.call, __traits(classInstanceSize, CallExp), e);
             auto arguments = new Expressions(2);
@@ -5617,7 +5617,7 @@ struct ASTBase
     {
         Identifier ident;
 
-        extern (D) this(const ref Loc loc, Expression e, Identifier ident)
+        extern (D) this(Loc loc, Expression e, Identifier ident)
         {
             super(loc, EXP.dotIdentifier, __traits(classInstanceSize, DotIdExp), e);
             this.ident = ident;
@@ -5633,7 +5633,7 @@ struct ASTBase
     {
         Expression msg;
 
-        extern (D) this(const ref Loc loc, Expression e, Expression msg = null)
+        extern (D) this(Loc loc, Expression e, Expression msg = null)
         {
             super(loc, EXP.assert_, __traits(classInstanceSize, AssertExp), e);
             this.msg = msg;
@@ -5647,7 +5647,7 @@ struct ASTBase
 
     extern (C++) final class ThrowExp : UnaExp
     {
-        extern (D) this(const ref Loc loc, Expression e)
+        extern (D) this(Loc loc, Expression e)
         {
             super(loc, EXP.throw_, __traits(classInstanceSize, ThrowExp), e);
             this.type = Type.tnoreturn;
@@ -5668,7 +5668,7 @@ struct ASTBase
     {
         Expressions* exps;
 
-        extern (D) this(const ref Loc loc, Expressions* exps)
+        extern (D) this(Loc loc, Expressions* exps)
         {
             super(loc, EXP.mixin_, __traits(classInstanceSize, MixinExp));
             this.exps = exps;
@@ -5682,7 +5682,7 @@ struct ASTBase
 
     extern (C++) final class ImportExp : UnaExp
     {
-        extern (D) this(const ref Loc loc, Expression e)
+        extern (D) this(Loc loc, Expression e)
         {
             super(loc, EXP.import_, __traits(classInstanceSize, ImportExp), e);
         }
@@ -5697,12 +5697,12 @@ struct ASTBase
     {
         TemplateInstance ti;
 
-        extern (D) this(const ref Loc loc, Expression e, Identifier name, Objects* tiargs)
+        extern (D) this(Loc loc, Expression e, Identifier name, Objects* tiargs)
         {
             super(loc, EXP.dotTemplateInstance, __traits(classInstanceSize, DotTemplateInstanceExp), e);
             this.ti = new TemplateInstance(loc, name, tiargs);
         }
-        extern (D) this(const ref Loc loc, Expression e, TemplateInstance ti)
+        extern (D) this(Loc loc, Expression e, TemplateInstance ti)
         {
             super(loc, EXP.dotTemplateInstance, __traits(classInstanceSize, DotTemplateInstanceExp), e);
             this.ti = ti;
@@ -5718,7 +5718,7 @@ struct ASTBase
     {
         Expressions* arguments;
 
-        extern (D) this(const ref Loc loc, Expression e1, Expression index = null)
+        extern (D) this(Loc loc, Expression e1, Expression index = null)
         {
             super(loc, EXP.array, __traits(classInstanceSize, ArrayExp), e1);
             arguments = new Expressions();
@@ -5726,7 +5726,7 @@ struct ASTBase
                 arguments.push(index);
         }
 
-        extern (D) this(const ref Loc loc, Expression e1, Expressions* args)
+        extern (D) this(Loc loc, Expression e1, Expressions* args)
         {
             super(loc, EXP.array, __traits(classInstanceSize, ArrayExp), e1);
             arguments = args;
@@ -5740,7 +5740,7 @@ struct ASTBase
 
     extern (C++) final class FuncInitExp : DefaultInitExp
     {
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, EXP.functionString, __traits(classInstanceSize, FuncInitExp));
         }
@@ -5753,7 +5753,7 @@ struct ASTBase
 
     extern (C++) final class PrettyFuncInitExp : DefaultInitExp
     {
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, EXP.prettyFunction, __traits(classInstanceSize, PrettyFuncInitExp));
         }
@@ -5766,7 +5766,7 @@ struct ASTBase
 
     extern (C++) final class FileInitExp : DefaultInitExp
     {
-        extern (D) this(const ref Loc loc, EXP tok)
+        extern (D) this(Loc loc, EXP tok)
         {
             super(loc, tok, __traits(classInstanceSize, FileInitExp));
         }
@@ -5779,7 +5779,7 @@ struct ASTBase
 
     extern (C++) final class LineInitExp : DefaultInitExp
     {
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, EXP.line, __traits(classInstanceSize, LineInitExp));
         }
@@ -5792,7 +5792,7 @@ struct ASTBase
 
     extern (C++) final class ModuleInitExp : DefaultInitExp
     {
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, EXP.moduleString, __traits(classInstanceSize, ModuleInitExp));
         }
@@ -5808,7 +5808,7 @@ struct ASTBase
         const bool isGenerated;
         bool allowCommaExp;
 
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2, bool generated = true)
+        extern (D) this(Loc loc, Expression e1, Expression e2, bool generated = true)
         {
             super(loc, EXP.comma, __traits(classInstanceSize, CommaExp), e1, e2);
             allowCommaExp = isGenerated = generated;
@@ -5835,7 +5835,7 @@ struct ASTBase
 
     extern (C++) final class PowExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.pow, __traits(classInstanceSize, PowExp), e1, e2);
         }
@@ -5848,7 +5848,7 @@ struct ASTBase
 
     extern (C++) final class MulExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.mul, __traits(classInstanceSize, MulExp), e1, e2);
         }
@@ -5861,7 +5861,7 @@ struct ASTBase
 
     extern (C++) final class DivExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.div, __traits(classInstanceSize, DivExp), e1, e2);
         }
@@ -5874,7 +5874,7 @@ struct ASTBase
 
     extern (C++) final class ModExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.mod, __traits(classInstanceSize, ModExp), e1, e2);
         }
@@ -5887,7 +5887,7 @@ struct ASTBase
 
     extern (C++) final class AddExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.add, __traits(classInstanceSize, AddExp), e1, e2);
         }
@@ -5900,7 +5900,7 @@ struct ASTBase
 
     extern (C++) final class MinExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.min, __traits(classInstanceSize, MinExp), e1, e2);
         }
@@ -5913,7 +5913,7 @@ struct ASTBase
 
     extern (C++) final class CatExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.concatenate, __traits(classInstanceSize, CatExp), e1, e2);
         }
@@ -5926,7 +5926,7 @@ struct ASTBase
 
     extern (C++) final class ShlExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.leftShift, __traits(classInstanceSize, ShlExp), e1, e2);
         }
@@ -5939,7 +5939,7 @@ struct ASTBase
 
     extern (C++) final class ShrExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.rightShift, __traits(classInstanceSize, ShrExp), e1, e2);
         }
@@ -5952,7 +5952,7 @@ struct ASTBase
 
     extern (C++) final class UshrExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.unsignedRightShift, __traits(classInstanceSize, UshrExp), e1, e2);
         }
@@ -5979,7 +5979,7 @@ struct ASTBase
 
     extern (C++) final class InExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.in_, __traits(classInstanceSize, InExp), e1, e2);
         }
@@ -6018,7 +6018,7 @@ struct ASTBase
 
     extern (C++) final class AndExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.and, __traits(classInstanceSize, AndExp), e1, e2);
         }
@@ -6031,7 +6031,7 @@ struct ASTBase
 
     extern (C++) final class XorExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.xor, __traits(classInstanceSize, XorExp), e1, e2);
         }
@@ -6044,7 +6044,7 @@ struct ASTBase
 
     extern (C++) final class OrExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.or, __traits(classInstanceSize, OrExp), e1, e2);
         }
@@ -6057,7 +6057,7 @@ struct ASTBase
 
     extern (C++) final class LogicalExp : BinExp
     {
-        extern (D) this(const ref Loc loc, EXP op, Expression e1, Expression e2)
+        extern (D) this(Loc loc, EXP op, Expression e1, Expression e2)
         {
             super(loc, op, __traits(classInstanceSize, LogicalExp), e1, e2);
         }
@@ -6072,7 +6072,7 @@ struct ASTBase
     {
         Expression econd;
 
-        extern (D) this(const ref Loc loc, Expression econd, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression econd, Expression e1, Expression e2)
         {
             super(loc, EXP.question, __traits(classInstanceSize, CondExp), e1, e2);
             this.econd = econd;
@@ -6086,7 +6086,7 @@ struct ASTBase
 
     extern (C++) final class AssignExp : BinExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.assign, __traits(classInstanceSize, AssignExp), e1, e2);
         }
@@ -6099,7 +6099,7 @@ struct ASTBase
 
     extern (C++) class BinAssignExp : BinExp
     {
-        final extern (D) this(const ref Loc loc, EXP op, int size, Expression e1, Expression e2)
+        final extern (D) this(Loc loc, EXP op, int size, Expression e1, Expression e2)
         {
             super(loc, op, size, e1, e2);
         }
@@ -6112,7 +6112,7 @@ struct ASTBase
 
     extern (C++) final class AddAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.addAssign, __traits(classInstanceSize, AddAssignExp), e1, e2);
         }
@@ -6125,7 +6125,7 @@ struct ASTBase
 
     extern (C++) final class MinAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.minAssign, __traits(classInstanceSize, MinAssignExp), e1, e2);
         }
@@ -6138,7 +6138,7 @@ struct ASTBase
 
     extern (C++) final class MulAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.mulAssign, __traits(classInstanceSize, MulAssignExp), e1, e2);
         }
@@ -6151,7 +6151,7 @@ struct ASTBase
 
     extern (C++) final class DivAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.divAssign, __traits(classInstanceSize, DivAssignExp), e1, e2);
         }
@@ -6164,7 +6164,7 @@ struct ASTBase
 
     extern (C++) final class ModAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.modAssign, __traits(classInstanceSize, ModAssignExp), e1, e2);
         }
@@ -6177,7 +6177,7 @@ struct ASTBase
 
     extern (C++) final class PowAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.powAssign, __traits(classInstanceSize, PowAssignExp), e1, e2);
         }
@@ -6190,7 +6190,7 @@ struct ASTBase
 
     extern (C++) final class AndAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.andAssign, __traits(classInstanceSize, AndAssignExp), e1, e2);
         }
@@ -6203,7 +6203,7 @@ struct ASTBase
 
     extern (C++) final class OrAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.orAssign, __traits(classInstanceSize, OrAssignExp), e1, e2);
         }
@@ -6216,7 +6216,7 @@ struct ASTBase
 
     extern (C++) final class XorAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.xorAssign, __traits(classInstanceSize, XorAssignExp), e1, e2);
         }
@@ -6229,7 +6229,7 @@ struct ASTBase
 
     extern (C++) final class ShlAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.leftShiftAssign, __traits(classInstanceSize, ShlAssignExp), e1, e2);
         }
@@ -6242,7 +6242,7 @@ struct ASTBase
 
     extern (C++) final class ShrAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.rightShiftAssign, __traits(classInstanceSize, ShrAssignExp), e1, e2);
         }
@@ -6255,7 +6255,7 @@ struct ASTBase
 
     extern (C++) final class UshrAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.unsignedRightShiftAssign, __traits(classInstanceSize, UshrAssignExp), e1, e2);
         }
@@ -6268,12 +6268,12 @@ struct ASTBase
 
     extern (C++) class CatAssignExp : BinAssignExp
     {
-        extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.concatenateAssign, __traits(classInstanceSize, CatAssignExp), e1, e2);
         }
 
-        extern (D) this(const ref Loc loc, EXP tok, Expression e1, Expression e2)
+        extern (D) this(Loc loc, EXP tok, Expression e1, Expression e2)
         {
             super(loc, tok, __traits(classInstanceSize, CatAssignExp), e1, e2);
         }
@@ -6286,7 +6286,7 @@ struct ASTBase
 
     extern (C++) final class CatElemAssignExp : CatAssignExp
     {
-        extern (D) this(const ref Loc loc, Type type, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Type type, Expression e1, Expression e2)
         {
             super(loc, EXP.concatenateElemAssign, e1, e2);
             this.type = type;
@@ -6300,7 +6300,7 @@ struct ASTBase
 
     extern (C++) final class CatDcharAssignExp : CatAssignExp
     {
-        extern (D) this(const ref Loc loc, Type type, Expression e1, Expression e2)
+        extern (D) this(Loc loc, Type type, Expression e1, Expression e2)
         {
             super(loc, EXP.concatenateDcharAssign, e1, e2);
             this.type = type;
@@ -6318,7 +6318,7 @@ struct ASTBase
         Types* types;
         Expressions* exps;
 
-        extern (D) this(const ref Loc loc, Expression cntlExp, Types* types, Expressions* exps)
+        extern (D) this(Loc loc, Expression cntlExp, Types* types, Expressions* exps)
         {
             super(loc, EXP._Generic, __traits(classInstanceSize, GenericExp));
             this.cntlExp = cntlExp;
@@ -6370,7 +6370,7 @@ struct ASTBase
         Loc loc;
         Identifier ident;
 
-        final extern (D) this(const ref Loc loc, Identifier ident)
+        final extern (D) this(Loc loc, Identifier ident)
         {
             this.loc = loc;
             this.ident = ident;
@@ -6390,7 +6390,7 @@ struct ASTBase
         RootObject specAlias;
         RootObject defaultAlias;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Type specType, RootObject specAlias, RootObject defaultAlias)
+        extern (D) this(Loc loc, Identifier ident, Type specType, RootObject specAlias, RootObject defaultAlias)
         {
             super(loc, ident);
             this.ident = ident;
@@ -6410,7 +6410,7 @@ struct ASTBase
         Type specType;
         Type defaultType;
 
-        final extern (D) this(const ref Loc loc, Identifier ident, Type specType, Type defaultType)
+        final extern (D) this(Loc loc, Identifier ident, Type specType, Type defaultType)
         {
             super(loc, ident);
             this.ident = ident;
@@ -6426,7 +6426,7 @@ struct ASTBase
 
     extern (C++) final class TemplateTupleParameter : TemplateParameter
     {
-        extern (D) this(const ref Loc loc, Identifier ident)
+        extern (D) this(Loc loc, Identifier ident)
         {
             super(loc, ident);
             this.ident = ident;
@@ -6444,7 +6444,7 @@ struct ASTBase
         Expression specValue;
         Expression defaultValue;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Type valType,
+        extern (D) this(Loc loc, Identifier ident, Type valType,
             Expression specValue, Expression defaultValue)
         {
             super(loc, ident);
@@ -6462,7 +6462,7 @@ struct ASTBase
 
     extern (C++) final class TemplateThisParameter : TemplateTypeParameter
     {
-        extern (D) this(const ref Loc loc, Identifier ident, Type specType, Type defaultType)
+        extern (D) this(Loc loc, Identifier ident, Type specType, Type defaultType)
         {
             super(loc, ident, specType, defaultType);
         }
@@ -6477,7 +6477,7 @@ struct ASTBase
     {
         Loc loc;
 
-        final extern (D) this(const ref Loc loc)
+        final extern (D) this(Loc loc)
         {
             this.loc = loc;
         }
@@ -6500,7 +6500,7 @@ struct ASTBase
         ForeachStatement aggrfe;
         ForeachRangeStatement rangefe;
 
-        final extern (D) this(const ref Loc loc, ForeachStatement aggrfe, ForeachRangeStatement rangefe)
+        final extern (D) this(Loc loc, ForeachStatement aggrfe, ForeachRangeStatement rangefe)
         in
         {
             assert(!!aggrfe ^ !!rangefe);
@@ -6517,7 +6517,7 @@ struct ASTBase
     {
         Expression exp;
 
-        final extern (D) this(const ref Loc loc, Expression exp)
+        final extern (D) this(Loc loc, Expression exp)
         {
             super(loc);
             this.exp = exp;
@@ -6539,7 +6539,7 @@ struct ASTBase
         Identifier ident;
         Module mod;
 
-        final extern (D) this(const ref Loc loc, Module mod, Identifier ident)
+        final extern (D) this(Loc loc, Module mod, Identifier ident)
         {
             super(loc);
             this.mod = mod;
@@ -6554,7 +6554,7 @@ struct ASTBase
 
     extern (C++) final class DebugCondition : DVCondition
     {
-        extern (D) this(const ref Loc loc, Module mod, Identifier ident)
+        extern (D) this(Loc loc, Module mod, Identifier ident)
         {
             super(loc, mod, ident);
         }
@@ -6567,7 +6567,7 @@ struct ASTBase
 
     extern (C++) final class VersionCondition : DVCondition
     {
-        extern (D) this(const ref Loc loc, Module mod, Identifier ident)
+        extern (D) this(Loc loc, Module mod, Identifier ident)
         {
             super(loc, mod, ident);
         }
@@ -6583,7 +6583,7 @@ struct ASTBase
         Loc loc;
         InitKind kind;
 
-        final extern (D) this(const ref Loc loc, InitKind kind)
+        final extern (D) this(Loc loc, InitKind kind)
         {
             this.loc = loc;
             this.kind = kind;
@@ -6610,7 +6610,7 @@ struct ASTBase
     {
         Expression exp;
 
-        extern (D) this(const ref Loc loc, Expression exp)
+        extern (D) this(Loc loc, Expression exp)
         {
             super(loc, InitKind.exp);
             this.exp = exp;
@@ -6627,7 +6627,7 @@ struct ASTBase
         Identifiers field;
         Initializers value;
 
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, InitKind.struct_);
         }
@@ -6651,7 +6651,7 @@ struct ASTBase
         uint dim;
         Type type;
 
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, InitKind.array);
         }
@@ -6672,7 +6672,7 @@ struct ASTBase
 
     extern (C++) final class VoidInitializer : Initializer
     {
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, InitKind.void_);
         }
@@ -6685,7 +6685,7 @@ struct ASTBase
 
     extern (C++) final class DefaultInitializer : Initializer
     {
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, InitKind.default_);
         }
@@ -6715,7 +6715,7 @@ struct ASTBase
     {
         DesigInits initializerList; /// initializer-list
 
-        extern (D) this(const ref Loc loc)
+        extern (D) this(Loc loc)
         {
             super(loc, InitKind.C_);
         }
@@ -6755,7 +6755,7 @@ struct ASTBase
         bool isdeprecated;
         Expression msg;
 
-        extern (D) this(const ref Loc loc, Identifier[] packages, Identifier id, Expression msg, bool isdeprecated)
+        extern (D) this(Loc loc, Identifier[] packages, Identifier id, Expression msg, bool isdeprecated)
         {
             this.loc = loc;
             this.packages = packages;

--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -60,13 +60,13 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         this.decl = decl;
     }
 
-    extern (D) this(const ref Loc loc, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, Dsymbols* decl) @safe
     {
         super(loc, null);
         this.decl = decl;
     }
 
-    extern (D) this(const ref Loc loc, Identifier ident, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, Identifier ident, Dsymbols* decl) @safe
     {
         super(loc, ident);
         this.decl = decl;
@@ -163,7 +163,7 @@ extern (C++) class StorageClassDeclaration : AttribDeclaration
         this.stc = stc;
     }
 
-    extern (D) this(const ref Loc loc, StorageClass stc, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, StorageClass stc, Dsymbols* decl) @safe
     {
         super(loc, decl);
         this.stc = stc;
@@ -253,14 +253,14 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
 {
     LINK linkage; /// either explicitly set or `default_`
 
-    extern (D) this(const ref Loc loc, LINK linkage, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, LINK linkage, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
         //printf("LinkDeclaration(linkage = %d, decl = %p)\n", linkage, decl);
         this.linkage = linkage;
     }
 
-    static LinkDeclaration create(const ref Loc loc, LINK p, Dsymbols* decl) @safe
+    static LinkDeclaration create(Loc loc, LINK p, Dsymbols* decl) @safe
     {
         return new LinkDeclaration(loc, p, decl);
     }
@@ -289,7 +289,7 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
 {
     CPPMANGLE cppmangle;
 
-    extern (D) this(const ref Loc loc, CPPMANGLE cppmangle, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, CPPMANGLE cppmangle, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
         //printf("CPPMangleDeclaration(cppmangle = %d, decl = %p)\n", cppmangle, decl);
@@ -336,18 +336,18 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
     /// CTFE-able expression, resolving to `TupleExp` or `StringExp`
     Expression exp;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, Identifier ident, Dsymbols* decl) @safe
     {
         super(loc, ident, decl);
     }
 
-    extern (D) this(const ref Loc loc, Expression exp, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, Expression exp, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
         this.exp = exp;
     }
 
-    extern (D) this(const ref Loc loc, Identifier ident, Expression exp, Dsymbols* decl,
+    extern (D) this(Loc loc, Identifier ident, Expression exp, Dsymbols* decl,
                     CPPNamespaceDeclaration parent) @safe
     {
         super(loc, ident, decl);
@@ -387,7 +387,7 @@ extern (C++) final class VisibilityDeclaration : AttribDeclaration
      *  visibility = visibility attribute data
      *  decl = declarations which are affected by this visibility attribute
      */
-    extern (D) this(const ref Loc loc, Visibility visibility, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, Visibility visibility, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
         this.visibility = visibility;
@@ -400,7 +400,7 @@ extern (C++) final class VisibilityDeclaration : AttribDeclaration
      *  pkg_identifiers = list of identifiers for a qualified package name
      *  decl = declarations which are affected by this visibility attribute
      */
-    extern (D) this(const ref Loc loc, Identifier[] pkg_identifiers, Dsymbols* decl)
+    extern (D) this(Loc loc, Identifier[] pkg_identifiers, Dsymbols* decl)
     {
         super(loc, null, decl);
         this.visibility.kind = Visibility.Kind.package_;
@@ -462,7 +462,7 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
     structalign_t salign;
 
 
-    extern (D) this(const ref Loc loc, Expression exp, Dsymbols* decl)
+    extern (D) this(Loc loc, Expression exp, Dsymbols* decl)
     {
         super(loc, null, decl);
         if (exp)
@@ -472,13 +472,13 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
         }
     }
 
-    extern (D) this(const ref Loc loc, Expressions* exps, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, Expressions* exps, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
         this.exps = exps;
     }
 
-    extern (D) this(const ref Loc loc, structalign_t salign, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, structalign_t salign, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
         this.salign = salign;
@@ -509,7 +509,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
     uint anonstructsize;    /// size of anonymous struct
     uint anonalignsize;     /// size of anonymous struct for alignment purposes
 
-    extern (D) this(const ref Loc loc, bool isunion, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, bool isunion, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
         this.isunion = isunion;
@@ -547,7 +547,7 @@ extern (C++) final class PragmaDeclaration : AttribDeclaration
 {
     Expressions* args;      /// parameters of this pragma
 
-    extern (D) this(const ref Loc loc, Identifier ident, Expressions* args, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, Identifier ident, Expressions* args, Dsymbols* decl) @safe
     {
         super(loc, ident, decl);
         this.args = args;
@@ -582,7 +582,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
     Condition condition;    /// condition deciding whether decl or elsedecl applies
     Dsymbols* elsedecl;     /// array of Dsymbol's for else block
 
-    extern (D) this(const ref Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl) @safe
+    extern (D) this(Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl) @safe
     {
         super(loc, null, decl);
         //printf("ConditionalDeclaration::ConditionalDeclaration()\n");
@@ -629,7 +629,7 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
     bool addisdone = false; /// true if members have been added to scope
     bool onStack = false;   /// true if a call to `include` is currently active
 
-    extern (D) this(const ref Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl) @safe
+    extern (D) this(Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl) @safe
     {
         super(loc, condition, decl, elsedecl);
         //printf("StaticIfDeclaration::StaticIfDeclaration()\n");
@@ -779,7 +779,7 @@ extern (C++) final class MixinDeclaration : AttribDeclaration
     ScopeDsymbol scopesym;
     bool compiled;
 
-    extern (D) this(const ref Loc loc, Expressions* exps) @safe
+    extern (D) this(Loc loc, Expressions* exps) @safe
     {
         super(loc, null, null);
         //printf("MixinDeclaration(loc = %d)\n", loc.linnum);

--- a/compiler/src/dmd/attrib.h
+++ b/compiler/src/dmd/attrib.h
@@ -65,7 +65,7 @@ class LinkDeclaration final : public AttribDeclaration
 public:
     LINK linkage;
 
-    static LinkDeclaration *create(const Loc &loc, LINK p, Dsymbols *decl);
+    static LinkDeclaration *create(Loc loc, LINK p, Dsymbols *decl);
     LinkDeclaration *syntaxCopy(Dsymbol *s) override;
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -510,7 +510,7 @@ int blockExit(Statement s, FuncDeclaration func, ErrorSink eSink)
  +
  + Returns: `BE.[err]throw` depending on the type of `exp`
  +/
-BE checkThrow(ref const Loc loc, Expression exp, FuncDeclaration func, ErrorSink eSink)
+BE checkThrow(Loc loc, Expression exp, FuncDeclaration func, ErrorSink eSink)
 {
     Type t = exp.type.toBasetype();
     ClassDeclaration cd = t.isClassHandle();

--- a/compiler/src/dmd/builtin.d
+++ b/compiler/src/dmd/builtin.d
@@ -44,7 +44,7 @@ public extern (C++) BUILTIN isBuiltin(FuncDeclaration fd)
  * Evaluate builtin function.
  * Return result; NULL if cannot evaluate it.
  */
-public extern (C++) Expression eval_builtin(const ref Loc loc, FuncDeclaration fd, Expressions* arguments)
+public extern (C++) Expression eval_builtin(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     if (fd.builtin == BUILTIN.unimp)
         return null;

--- a/compiler/src/dmd/chkformat.d
+++ b/compiler/src/dmd/chkformat.d
@@ -63,7 +63,7 @@ import dmd.target;
  * https://www.cplusplus.com/reference/cstdio/printf/
  */
 public
-bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expression[] args, bool isVa_list, ErrorSink eSink)
+bool checkPrintfFormat(Loc loc, scope const char[] format, scope Expression[] args, bool isVa_list, ErrorSink eSink)
 {
     //printf("checkPrintFormat('%.*s')\n", cast(int)format.length, format.ptr);
     size_t n;    // index in args
@@ -339,7 +339,7 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
  * https://www.cplusplus.com/reference/cstdio/scanf/
  */
 public
-bool checkScanfFormat(ref const Loc loc, scope const char[] format, scope Expression[] args, bool isVa_list, ErrorSink eSink)
+bool checkScanfFormat(Loc loc, scope const char[] format, scope Expression[] args, bool isVa_list, ErrorSink eSink)
 {
     size_t n = 0;
     for (size_t i = 0; i < format.length;)

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -64,7 +64,7 @@ extern (C++) abstract class Condition : ASTNode
         return DYNCAST.condition;
     }
 
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         this.loc = loc;
     }
@@ -126,7 +126,7 @@ extern (C++) final class StaticForeach : RootObject
      */
     bool needExpansion = false;
 
-    extern (D) this(const ref Loc loc, ForeachStatement aggrfe, ForeachRangeStatement rangefe) @safe
+    extern (D) this(Loc loc, ForeachStatement aggrfe, ForeachRangeStatement rangefe) @safe
     {
         assert(!!aggrfe ^ !!rangefe);
 
@@ -198,7 +198,7 @@ extern (C++) final class StaticForeach : RootObject
      * Returns:
      *     AST of the expression `(){ s; }()` with location loc.
      */
-    private extern(D) Expression wrapAndCall(const ref Loc loc, Statement s)
+    private extern(D) Expression wrapAndCall(Loc loc, Statement s)
     {
         auto tf = new TypeFunction(ParameterList(), null, LINK.default_, 0);
         auto fd = new FuncLiteralDeclaration(loc, loc, tf, TOK.reserved, null);
@@ -221,7 +221,7 @@ extern (C++) final class StaticForeach : RootObject
      *     `foreach (parameters; lower .. upper) s;`
      *     Where aggregate/lower, upper are as for the current StaticForeach.
      */
-    private extern(D) Statement createForeach(const ref Loc loc, Parameters* parameters, Statement s)
+    private extern(D) Statement createForeach(Loc loc, Parameters* parameters, Statement s)
     {
         if (aggrfe)
         {
@@ -254,7 +254,7 @@ extern (C++) final class StaticForeach : RootObject
      *         }
      */
 
-    private extern(D) TypeStruct createTupleType(const ref Loc loc, Expressions* e, Scope* sc)
+    private extern(D) TypeStruct createTupleType(Loc loc, Expressions* e, Scope* sc)
     {   // TODO: move to druntime?
         auto sid = Identifier.generateId("Tuple");
         auto sdecl = new StructDeclaration(loc, sid, false);
@@ -280,7 +280,7 @@ extern (C++) final class StaticForeach : RootObject
      *     An AST for the expression `Tuple(e)`.
      */
 
-    private extern(D) Expression createTuple(const ref Loc loc, TypeStruct type, Expressions* e) @safe
+    private extern(D) Expression createTuple(Loc loc, TypeStruct type, Expressions* e) @safe
     {   // TODO: move to druntime?
         return new CallExp(loc, new TypeExp(loc, type), e);
     }
@@ -496,7 +496,7 @@ extern (C++) class DVCondition : Condition
     Identifier ident;
     Module mod;
 
-    extern (D) this(const ref Loc loc, Module mod, Identifier ident) @safe
+    extern (D) this(Loc loc, Module mod, Identifier ident) @safe
     {
         super(loc);
         this.mod = mod;
@@ -558,7 +558,7 @@ extern (C++) final class DebugCondition : DVCondition
      *           If `null`, this conditiion will use an integer level.
      *  loc = Location in the source file
      */
-    extern (D) this(const ref Loc loc, Module mod, Identifier ident) @safe
+    extern (D) this(Loc loc, Module mod, Identifier ident) @safe
     {
         super(loc, mod, ident);
     }
@@ -757,7 +757,7 @@ extern (C++) final class VersionCondition : DVCondition
      *   loc = Where the identifier is set
      *   ident = identifier being checked (ident[$] must be '\0')
      */
-    extern(D) static void checkReserved(const ref Loc loc, const(char)[] ident)
+    extern(D) static void checkReserved(Loc loc, const(char)[] ident)
     {
         if (isReserved(ident))
             error(loc, "version identifier `%s` is reserved and cannot be set",
@@ -833,7 +833,7 @@ extern (C++) final class VersionCondition : DVCondition
      *           If `null`, this conditiion will use an integer level.
      *  loc = Location in the source file
      */
-    extern (D) this(const ref Loc loc, Module mod, Identifier ident) @safe
+    extern (D) this(Loc loc, Module mod, Identifier ident) @safe
     {
         super(loc, mod, ident);
     }
@@ -890,7 +890,7 @@ extern (C++) final class StaticIfCondition : Condition
 {
     Expression exp;
 
-    extern (D) this(const ref Loc loc, Expression exp) @safe
+    extern (D) this(Loc loc, Expression exp) @safe
     {
         super(loc);
         this.exp = exp;

--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -107,7 +107,7 @@ UnionExp Not(Type type, Expression e1)
     return ue;
 }
 
-UnionExp Add(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Add(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     static if (LOG)
@@ -212,7 +212,7 @@ UnionExp Add(const ref Loc loc, Type type, Expression e1, Expression e2)
     return ue;
 }
 
-UnionExp Min(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Min(Loc loc, Type type, Expression e1, Expression e2)
 {
     // Compute e1-e2 as e1+(-e2)
     UnionExp neg = Neg(e2.type, e2);
@@ -220,7 +220,7 @@ UnionExp Min(const ref Loc loc, Type type, Expression e1, Expression e2)
     return ue;
 }
 
-UnionExp Mul(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Mul(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     if (type.isFloating())
@@ -269,7 +269,7 @@ UnionExp Mul(const ref Loc loc, Type type, Expression e1, Expression e2)
     return ue;
 }
 
-UnionExp Div(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Div(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     if (type.isFloating())
@@ -344,7 +344,7 @@ UnionExp Div(const ref Loc loc, Type type, Expression e1, Expression e2)
     return ue;
 }
 
-UnionExp Mod(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Mod(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     if (type.isFloating())
@@ -409,7 +409,7 @@ UnionExp Mod(const ref Loc loc, Type type, Expression e1, Expression e2)
     return ue;
 }
 
-UnionExp Pow(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Pow(Loc loc, Type type, Expression e1, Expression e2)
 {
     //printf("Pow()\n");
     UnionExp ue;
@@ -489,14 +489,14 @@ UnionExp Pow(const ref Loc loc, Type type, Expression e1, Expression e2)
     return ue;
 }
 
-UnionExp Shl(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Shl(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() << e2.toInteger(), type);
     return ue;
 }
 
-UnionExp Shr(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Shr(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     dinteger_t value = e1.toInteger();
@@ -542,7 +542,7 @@ UnionExp Shr(const ref Loc loc, Type type, Expression e1, Expression e2)
     return ue;
 }
 
-UnionExp Ushr(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Ushr(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     dinteger_t value = e1.toInteger();
@@ -582,21 +582,21 @@ UnionExp Ushr(const ref Loc loc, Type type, Expression e1, Expression e2)
     return ue;
 }
 
-UnionExp And(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp And(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() & e2.toInteger(), type);
     return ue;
 }
 
-UnionExp Or(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Or(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() | e2.toInteger(), type);
     return ue;
 }
 
-UnionExp Xor(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Xor(Loc loc, Type type, Expression e1, Expression e2)
 {
     //printf("Xor(linnum = %d, e1 = %s, e2 = %s)\n", loc.linnum, e1.toChars(), e2.toChars());
     UnionExp ue = void;
@@ -606,7 +606,7 @@ UnionExp Xor(const ref Loc loc, Type type, Expression e1, Expression e2)
 
 /* Also returns EXP.cantExpression if cannot be computed.
  */
-UnionExp Equal(EXP op, const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Equal(EXP op, Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     int cmp = 0;
@@ -804,7 +804,7 @@ UnionExp Equal(EXP op, const ref Loc loc, Type type, Expression e1, Expression e
     return ue;
 }
 
-UnionExp Identity(EXP op, const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Identity(EXP op, Loc loc, Type type, Expression e1, Expression e2)
 {
     //printf("Identity %s %s\n", e1.toChars(), e2.toChars());
     UnionExp ue = void;
@@ -849,7 +849,7 @@ UnionExp Identity(EXP op, const ref Loc loc, Type type, Expression e1, Expressio
     return ue;
 }
 
-UnionExp Cmp(EXP op, const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Cmp(EXP op, Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     dinteger_t n;
@@ -913,7 +913,7 @@ UnionExp Cmp(EXP op, const ref Loc loc, Type type, Expression e1, Expression e2)
  *  to: type to cast to
  *  type: type to paint the result
  */
-UnionExp Cast(const ref Loc loc, Type type, Type to, Expression e1)
+UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
 {
     UnionExp ue = void;
     Type tb = to.toBasetype();
@@ -1396,7 +1396,7 @@ private Expressions* copyElements(Expression e1, Expression e2 = null)
 
 /* Also return EXP.cantExpression if this fails
  */
-UnionExp Cat(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp Cat(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     Expression e = CTFEExp.cantexp;

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5620,7 +5620,7 @@ final class CParser(AST) : Parser!AST
      * Params:
      *  startloc = location to use for error messages
      */
-    private void uupragmaDirective(const ref Loc startloc)
+    private void uupragmaDirective(Loc startloc)
     {
         const loc = startloc;
         nextToken();    // move past __pragma
@@ -5668,7 +5668,7 @@ final class CParser(AST) : Parser!AST
      * the preprocessed output. Ignore them.
      * Upon return, p is at start of next line.
      */
-    private void pragmaDirective(const ref Loc loc)
+    private void pragmaDirective(Loc loc)
     {
         Token n;
         scan(&n);
@@ -5689,7 +5689,7 @@ final class CParser(AST) : Parser!AST
      *  startloc = location to use for error messages
      *  useScan = use scan() to retrieve next token, instead of nextToken()
      */
-    private void pragmaPack(const ref Loc startloc, bool useScan)
+    private void pragmaPack(Loc startloc, bool useScan)
     {
         const loc = startloc;
 
@@ -5889,7 +5889,7 @@ final class CParser(AST) : Parser!AST
      * Params:
      *  startloc = location to use for error messages
      */
-    private void pragmaAttribute(const ref Loc startloc)
+    private void pragmaAttribute(Loc startloc)
     {
         const loc = startloc;
 

--- a/compiler/src/dmd/cpreprocess.d
+++ b/compiler/src/dmd/cpreprocess.d
@@ -47,7 +47,7 @@ version (Windows) version = runPreprocessor;
  *      the text of the preprocessed file
  */
 extern (C++)
-DArray!ubyte preprocess(FileName csrcfile, ref const Loc loc, ref OutBuffer defines)
+DArray!ubyte preprocess(FileName csrcfile, Loc loc, ref OutBuffer defines)
 {
     /* Look for "importc.h" by searching along import path.
      */

--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -522,7 +522,7 @@ uinteger_t resolveArrayLength(Expression e)
  * Returns:
  *      Constructed ArrayLiteralExp
  */
-ArrayLiteralExp createBlockDuplicatedArrayLiteral(UnionExp* pue, const ref Loc loc, Type type, Expression elem, size_t dim)
+ArrayLiteralExp createBlockDuplicatedArrayLiteral(UnionExp* pue, Loc loc, Type type, Expression elem, size_t dim)
 {
     if (type.ty == Tsarray && type.nextOf().ty == Tsarray && elem.type.ty != Tsarray)
     {
@@ -553,7 +553,7 @@ ArrayLiteralExp createBlockDuplicatedArrayLiteral(UnionExp* pue, const ref Loc l
  * Helper for NewExp
  * Create a string literal consisting of 'value' duplicated 'dim' times.
  */
-StringExp createBlockDuplicatedStringLiteral(UnionExp* pue, const ref Loc loc, Type type, dchar value, size_t dim, ubyte sz)
+StringExp createBlockDuplicatedStringLiteral(UnionExp* pue, Loc loc, Type type, dchar value, size_t dim, ubyte sz)
 {
     auto s = cast(char*)mem.xcalloc(dim, sz);
     foreach (elemi; 0 .. dim)
@@ -741,7 +741,7 @@ bool pointToSameMemoryBlock(Expression agg1, Expression agg2)
 }
 
 // return e1 - e2 as an integer, or error if not possible
-Expression pointerDifference(UnionExp* pue, const ref Loc loc, Type type, Expression e1, Expression e2)
+Expression pointerDifference(UnionExp* pue, Loc loc, Type type, Expression e1, Expression e2)
 {
     dinteger_t ofs1, ofs2;
     Expression agg1 = getAggregateFromPointer(e1, &ofs1);
@@ -774,7 +774,7 @@ Expression pointerDifference(UnionExp* pue, const ref Loc loc, Type type, Expres
 
 // Return eptr op e2, where eptr is a pointer, e2 is an integer,
 // and op is EXP.add or EXP.min
-Expression pointerArithmetic(UnionExp* pue, const ref Loc loc, EXP op, Type type, Expression eptr, Expression e2)
+Expression pointerArithmetic(UnionExp* pue, Loc loc, EXP op, Type type, Expression eptr, Expression e2)
 {
     if (eptr.type.nextOf().ty == Tvoid)
     {
@@ -1052,7 +1052,7 @@ bool realCmp(EXP op, real_t r1, real_t r2) @safe nothrow
  * Returns:
  *      -1,0,1
  */
-private int ctfeCmpArrays(const ref Loc loc, Expression e1, Expression e2, uinteger_t len)
+private int ctfeCmpArrays(Loc loc, Expression e1, Expression e2, uinteger_t len)
 {
     // Resolve slices, if necessary
     uinteger_t lo1 = 0;
@@ -1138,7 +1138,7 @@ private bool isArray(const Expression e) @safe nothrow
  * For strings, return <0 if e1 < e2, 0 if e1==e2, >0 if e1 > e2.
  * For all other types, return 0 if e1 == e2, !=0 if e1 != e2.
  */
-private int ctfeRawCmp(const ref Loc loc, Expression e1, Expression e2, bool identity = false)
+private int ctfeRawCmp(Loc loc, Expression e1, Expression e2, bool identity = false)
 {
     if (e1.op == EXP.classReference || e2.op == EXP.classReference)
     {
@@ -1310,13 +1310,13 @@ private int ctfeRawCmp(const ref Loc loc, Expression e1, Expression e2, bool ide
 }
 
 /// Evaluate ==, !=.  Resolves slices before comparing. Returns 0 or 1
-bool ctfeEqual(const ref Loc loc, EXP op, Expression e1, Expression e2)
+bool ctfeEqual(Loc loc, EXP op, Expression e1, Expression e2)
 {
     return !ctfeRawCmp(loc, e1, e2) ^ (op == EXP.notEqual);
 }
 
 /// Evaluate is, !is.  Resolves slices before comparing. Returns 0 or 1
-bool ctfeIdentity(const ref Loc loc, EXP op, Expression e1, Expression e2)
+bool ctfeIdentity(Loc loc, EXP op, Expression e1, Expression e2)
 {
     //printf("ctfeIdentity %s %s\n", e1.toChars(), e2.toChars());
     //printf("ctfeIdentity op = '%s', e1 = %s %s, e2 = %s %s\n", EXPtoString(op).ptr,
@@ -1348,7 +1348,7 @@ bool ctfeIdentity(const ref Loc loc, EXP op, Expression e1, Expression e2)
 }
 
 /// Evaluate >,<=, etc. Resolves slices before comparing. Returns 0 or 1
-bool ctfeCmp(const ref Loc loc, EXP op, Expression e1, Expression e2)
+bool ctfeCmp(Loc loc, EXP op, Expression e1, Expression e2)
 {
     Type t1 = e1.type.toBasetype();
     Type t2 = e2.type.toBasetype();
@@ -1365,7 +1365,7 @@ bool ctfeCmp(const ref Loc loc, EXP op, Expression e1, Expression e2)
         return intSignedCmp(op, e1.toInteger(), e2.toInteger());
 }
 
-UnionExp ctfeCat(const ref Loc loc, Type type, Expression e1, Expression e2)
+UnionExp ctfeCat(Loc loc, Type type, Expression e1, Expression e2)
 {
     Type t1 = e1.type.toBasetype();
     Type t2 = e2.type.toBasetype();
@@ -1459,7 +1459,7 @@ UnionExp ctfeCat(const ref Loc loc, Type type, Expression e1, Expression e2)
 /*  Given an AA literal 'ae', and a key 'e2':
  *  Return ae[e2] if present, or NULL if not found.
  */
-Expression findKeyInAA(const ref Loc loc, AssocArrayLiteralExp ae, Expression e2)
+Expression findKeyInAA(Loc loc, AssocArrayLiteralExp ae, Expression e2)
 {
     /* Search the keys backwards, in case there are duplicate keys
      */
@@ -1480,7 +1480,7 @@ Expression findKeyInAA(const ref Loc loc, AssocArrayLiteralExp ae, Expression e2
  * dynamic arrays, and strings. We know that e1 is an
  * interpreted CTFE expression, so it cannot have side-effects.
  */
-Expression ctfeIndex(UnionExp* pue, const ref Loc loc, Type type, Expression e1, uinteger_t indx)
+Expression ctfeIndex(UnionExp* pue, Loc loc, Type type, Expression e1, uinteger_t indx)
 {
     //printf("ctfeIndex(e1 = %s)\n", e1.toChars());
     assert(e1.type);
@@ -1509,7 +1509,7 @@ Expression ctfeIndex(UnionExp* pue, const ref Loc loc, Type type, Expression e1,
     assert(0);
 }
 
-Expression ctfeCast(UnionExp* pue, const ref Loc loc, Type type, Type to, Expression e, bool explicitCast = false)
+Expression ctfeCast(UnionExp* pue, Loc loc, Type type, Type to, Expression e, bool explicitCast = false)
 {
     Expression paint()
     {
@@ -1649,7 +1649,7 @@ void assignInPlace(Expression dest, Expression src)
 }
 
 // Given an AA literal aae,  set aae[index] = newval and return newval.
-Expression assignAssocArrayElement(const ref Loc loc, AssocArrayLiteralExp aae, Expression index, Expression newval)
+Expression assignAssocArrayElement(Loc loc, AssocArrayLiteralExp aae, Expression index, Expression newval)
 {
     /* Create new associative array literal reflecting updated key/value
      */
@@ -1679,7 +1679,7 @@ Expression assignAssocArrayElement(const ref Loc loc, AssocArrayLiteralExp aae, 
 /// Given array literal oldval of type ArrayLiteralExp or StringExp, of length
 /// oldlen, change its length to newlen. If the newlen is longer than oldlen,
 /// all new elements will be set to the default initializer for the element type.
-Expression changeArrayLiteralLength(UnionExp* pue, const ref Loc loc, TypeArray arrayType, Expression oldval, size_t oldlen, size_t newlen)
+Expression changeArrayLiteralLength(UnionExp* pue, Loc loc, TypeArray arrayType, Expression oldval, size_t oldlen, size_t newlen)
 {
     Type elemType = arrayType.next;
     assert(elemType);

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -153,7 +153,7 @@ void addMember(Dsymbol dsym, Scope* sc, ScopeDsymbol sds)
     return dmd.dsymbolsem.addMember(dsym, sc, sds);
 }
 
-Dsymbol search(Dsymbol d, const ref Loc loc, Identifier ident, SearchOptFlags
+Dsymbol search(Dsymbol d, Loc loc, Identifier ident, SearchOptFlags
                flags = SearchOpt.all)
 {
     import dmd.dsymbolsem;
@@ -233,7 +233,7 @@ void genCppHdrFiles(ref Modules ms)
 /***********************************************************
  * enumsem.d
  */
-Expression getDefaultValue(EnumDeclaration ed, const ref Loc loc)
+Expression getDefaultValue(EnumDeclaration ed, Loc loc)
 {
     import dmd.enumsem;
     return dmd.enumsem.getDefaultValue(ed, loc);
@@ -256,7 +256,7 @@ Expression expressionSemantic(Expression e, Scope* sc)
     return dmd.expressionsem.expressionSemantic(e, sc);
 }
 
-bool fill(StructDeclaration sd, const ref Loc loc,
+bool fill(StructDeclaration sd, Loc loc,
           ref Expressions elements, bool ctorinit)
 {
     import dmd.expressionsem;
@@ -470,13 +470,13 @@ bool hasPointers(Type t)
     return dmd.typesem.hasPointers(t);
 }
 
-Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
+Type typeSemantic(Type type, Loc loc, Scope* sc)
 {
     import dmd.typesem;
     return dmd.typesem.typeSemantic(type, loc, sc);
 }
 
-Type trySemantic(Type type, const ref Loc loc, Scope* sc)
+Type trySemantic(Type type, Loc loc, Scope* sc)
 {
     import dmd.typesem;
     return dmd.typesem.trySemantic(type, loc, sc);
@@ -494,7 +494,7 @@ Type merge2(Type type)
     return dmd.typesem.merge2(type);
 }
 
-Expression defaultInit(Type mt, const ref Loc loc, const bool isCfile = false)
+Expression defaultInit(Type mt, Loc loc, const bool isCfile = false)
 {
     import dmd.typesem;
     return dmd.typesem.defaultInit(mt, loc, isCfile);
@@ -513,7 +513,7 @@ Covariant covariant(Type src, Type t, StorageClass* pstc = null, bool
     return dmd.typesem.covariant(src, t, pstc, cppCovariant);
 }
 
-bool isZeroInit(Type t, const ref Loc loc)
+bool isZeroInit(Type t, Loc loc)
 {
     import dmd.typesem;
     return dmd.typesem.isZeroInit(t, loc);
@@ -663,7 +663,7 @@ uinteger_t size(Type type)
     return dmd.typesem.size(type);
 }
 
-uinteger_t size(Type type, const ref Loc loc)
+uinteger_t size(Type type, Loc loc)
 {
     import dmd.typesem;
     return dmd.typesem.size(type, loc);
@@ -684,7 +684,7 @@ MATCH constConv(Type from, Type to)
 /***********************************************************
  * typinf.d
  */
-bool genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc)
+bool genTypeInfo(Expression e, Loc loc, Type torig, Scope* sc)
 {
     import dmd.typinf;
     return dmd.typinf.genTypeInfo(e, loc, torig, sc);

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -198,7 +198,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
     Symbol* cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
-    final extern (D) this(const ref Loc loc, Identifier id, BaseClasses* baseclasses, Dsymbols* members, bool inObject)
+    final extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses, Dsymbols* members, bool inObject)
     {
         objc = ObjcClassDeclaration(this);
 
@@ -375,7 +375,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         .error(loc, fmt, kind, toPrettyChars, arg);
     }
 
-    static ClassDeclaration create(const ref Loc loc, Identifier id, BaseClasses* baseclasses, Dsymbols* members, bool inObject)
+    static ClassDeclaration create(Loc loc, Identifier id, BaseClasses* baseclasses, Dsymbols* members, bool inObject)
     {
         return new ClassDeclaration(loc, id, baseclasses, members, inObject);
     }
@@ -956,7 +956,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
  */
 extern (C++) final class InterfaceDeclaration : ClassDeclaration
 {
-    extern (D) this(const ref Loc loc, Identifier id, BaseClasses* baseclasses)
+    extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses)
     {
         super(loc, id, baseclasses, null, false);
         if (id == Id.IUnknown) // IUnknown is the root of all COM interfaces

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -107,7 +107,7 @@ extern (C++) abstract class Declaration : Dsymbol
         visibility = Visibility(Visibility.Kind.undefined);
     }
 
-    final extern (D) this(const ref Loc loc, Identifier ident) @safe
+    final extern (D) this(Loc loc, Identifier ident) @safe
     {
         super(loc, ident);
         visibility = Visibility(Visibility.Kind.undefined);
@@ -118,7 +118,7 @@ extern (C++) abstract class Declaration : Dsymbol
         return "declaration";
     }
 
-    override final uinteger_t size(const ref Loc loc)
+    override final uinteger_t size(Loc loc)
     {
         assert(type);
         const sz = type.size();
@@ -289,7 +289,7 @@ extern (C++) final class TupleDeclaration : Declaration
     bool isexp;             // true: expression tuple
     bool building;          // it's growing in AliasAssign semantic
 
-    extern (D) this(const ref Loc loc, Identifier ident, Objects* objects) @safe
+    extern (D) this(Loc loc, Identifier ident, Objects* objects) @safe
     {
         super(loc, ident);
         this.objects = objects;
@@ -440,7 +440,7 @@ extern (C++) final class AliasDeclaration : Declaration
     Dsymbol overnext;   // next in overload list
     Dsymbol _import;    // !=null if unresolved internal alias for selective import
 
-    extern (D) this(const ref Loc loc, Identifier ident, Type type) @safe
+    extern (D) this(Loc loc, Identifier ident, Type type) @safe
     {
         super(loc, ident);
         //debug printf("AliasDeclaration(id = '%s', type = `%s`, %p)\n", ident.toChars(), dmd.hdrgen.toChars(type), type.isTypeIdentifier());
@@ -448,7 +448,7 @@ extern (C++) final class AliasDeclaration : Declaration
         assert(type);
     }
 
-    extern (D) this(const ref Loc loc, Identifier ident, Dsymbol s) @safe
+    extern (D) this(Loc loc, Identifier ident, Dsymbol s) @safe
     {
         super(loc, ident);
         //debug printf("AliasDeclaration(id = '%s', s = `%s`)\n", ident.toChars(), s.toChars());
@@ -457,7 +457,7 @@ extern (C++) final class AliasDeclaration : Declaration
         assert(s);
     }
 
-    static AliasDeclaration create(const ref Loc loc, Identifier id, Type type) @safe
+    static AliasDeclaration create(Loc loc, Identifier id, Type type) @safe
     {
         return new AliasDeclaration(loc, id, type);
     }
@@ -882,7 +882,7 @@ extern (C++) class VarDeclaration : Declaration
     byte canassign;                 // it can be assigned to
     ubyte isdataseg;                // private data for isDataseg 0 unset, 1 true, 2 false
 
-    final extern (D) this(const ref Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
+    final extern (D) this(Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
     in
     {
         assert(ident);
@@ -907,7 +907,7 @@ extern (C++) class VarDeclaration : Declaration
         this.storage_class = storage_class;
     }
 
-    static VarDeclaration create(const ref Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
+    static VarDeclaration create(Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
     {
         return new VarDeclaration(loc, type, ident, _init, storage_class);
     }
@@ -1244,7 +1244,7 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
     uint fieldWidth;
     uint bitOffset;
 
-    final extern (D) this(const ref Loc loc, Type type, Identifier ident, Expression width)
+    final extern (D) this(Loc loc, Type type, Identifier ident, Expression width)
     {
         super(loc, type, ident, null);
 
@@ -1305,7 +1305,7 @@ extern (C++) final class SymbolDeclaration : Declaration
 {
     AggregateDeclaration dsym;
 
-    extern (D) this(const ref Loc loc, AggregateDeclaration dsym) @safe
+    extern (D) this(Loc loc, AggregateDeclaration dsym) @safe
     {
         super(loc, dsym.ident);
         this.dsym = dsym;
@@ -1795,7 +1795,7 @@ extern (C++) final class TypeInfoVectorDeclaration : TypeInfoDeclaration
  */
 extern (C++) final class ThisDeclaration : VarDeclaration
 {
-    extern (D) this(const ref Loc loc, Type t)
+    extern (D) this(Loc loc, Type t)
     {
         super(loc, t, Id.This, null);
         storage_class |= STC.nodtor;

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -128,7 +128,7 @@ public:
     DString mangleOverride;     // overridden symbol with pragma(mangle, "...")
 
     const char *kind() const override;
-    uinteger_t size(const Loc &loc) override final;
+    uinteger_t size(Loc loc) override final;
 
 
     bool isStatic() const { return (storage_class & STCstatic) != 0; }
@@ -194,7 +194,7 @@ public:
     Dsymbol *overnext;          // next in overload list
     Dsymbol *_import;           // !=NULL if unresolved internal alias for selective import
 
-    static AliasDeclaration *create(const Loc &loc, Identifier *id, Type *type);
+    static AliasDeclaration *create(Loc loc, Identifier *id, Type *type);
     AliasDeclaration *syntaxCopy(Dsymbol *) override;
     bool overloadInsert(Dsymbol *s) override;
     const char *kind() const override;
@@ -284,7 +284,7 @@ public:
 #endif
     bool systemInferred() const;
     bool systemInferred(bool v);
-    static VarDeclaration *create(const Loc &loc, Type *t, Identifier *id, Initializer *init, StorageClass storage_class = STCundefined);
+    static VarDeclaration *create(Loc loc, Type *t, Identifier *id, Initializer *init, StorageClass storage_class = STCundefined);
     VarDeclaration *syntaxCopy(Dsymbol *) override;
     const char *kind() const override;
     AggregateDeclaration *isThis() override final;
@@ -535,7 +535,7 @@ enum class BUILTIN : unsigned char
     toPrecReal
 };
 
-Expression *eval_builtin(const Loc &loc, FuncDeclaration *fd, Expressions *arguments);
+Expression *eval_builtin(Loc loc, FuncDeclaration *fd, Expressions *arguments);
 BUILTIN isBuiltin(FuncDeclaration *fd);
 
 struct ContractInfo;
@@ -684,7 +684,7 @@ public:
     // integration.
     ObjcFuncDeclaration objc;
 
-    static FuncDeclaration *create(const Loc &loc, const Loc &endloc, Identifier *id, StorageClass storage_class, Type *type, bool noreturn = false);
+    static FuncDeclaration *create(Loc loc, Loc endloc, Identifier *id, StorageClass storage_class, Type *type, bool noreturn = false);
     FuncDeclaration *syntaxCopy(Dsymbol *) override;
     Statements *frequires();
     Ensures *fensures();
@@ -706,7 +706,7 @@ public:
 
     bool overloadInsert(Dsymbol *s) override;
     bool inUnittest();
-    LabelDsymbol *searchLabel(Identifier *ident, const Loc &loc);
+    LabelDsymbol *searchLabel(Identifier *ident, Loc loc);
     const char *toPrettyChars(bool QualifyTypes = false) override;
     const char *toFullSignature();  // for diagnostics, e.g. 'int foo(int x, int y) pure'
     bool isMain() const;

--- a/compiler/src/dmd/denum.d
+++ b/compiler/src/dmd/denum.d
@@ -64,7 +64,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
 
     Symbol* sinit;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Type memtype)
+    extern (D) this(Loc loc, Identifier ident, Type memtype)
     {
         super(loc, ident);
         //printf("EnumDeclaration() %p %s : %s\n", this, toChars(), memtype.toChars());
@@ -154,7 +154,7 @@ extern (C++) final class EnumMember : VarDeclaration
 
     EnumDeclaration ed;
 
-    extern (D) this(const ref Loc loc, Identifier id, Expression value, Type origType)
+    extern (D) this(Loc loc, Identifier id, Expression value, Type origType)
     {
         super(loc, null, id ? id : Id.empty, new ExpInitializer(loc, value));
         this.origValue = value;

--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -40,7 +40,7 @@ extern (C++) final class Import : Dsymbol
     // corresponding AliasDeclarations for alias=name pairs
     AliasDeclarations aliasdecls;
 
-    extern (D) this(const ref Loc loc, Identifier[] packages, Identifier id, Identifier aliasId, int isstatic)
+    extern (D) this(Loc loc, Identifier[] packages, Identifier id, Identifier aliasId, int isstatic)
     {
         Identifier selectIdent()
         {

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -758,7 +758,7 @@ private Expression interpretFunction(UnionExp* pue, FuncDeclaration fd, InterSta
 }
 
 /// used to collect coverage information in ctfe
-void incUsageCtfe(InterState* istate, const ref Loc loc)
+void incUsageCtfe(InterState* istate, Loc loc)
 {
     if (global.params.ctfe_cov && istate)
     {
@@ -2052,7 +2052,7 @@ public:
         }
     }
 
-    static Expression getVarExp(const ref Loc loc, InterState* istate, Declaration d, CTFEGoal goal)
+    static Expression getVarExp(Loc loc, InterState* istate, Declaration d, CTFEGoal goal)
     {
         Expression e = CTFEExp.cantexp;
         if (VarDeclaration v = d.isVarDeclaration())
@@ -2752,7 +2752,7 @@ public:
 
     // Create an array literal of type 'newtype' with dimensions given by
     // 'arguments'[argnum..$]
-    static Expression recursivelyCreateArrayLiteral(UnionExp* pue, const ref Loc loc, Type newtype, InterState* istate, Expressions* arguments, int argnum)
+    static Expression recursivelyCreateArrayLiteral(UnionExp* pue, Loc loc, Type newtype, InterState* istate, Expressions* arguments, int argnum)
     {
         Expression lenExpr = interpret(pue, (*arguments)[argnum], istate);
         if (exceptionOrCantInterpret(lenExpr))
@@ -3005,8 +3005,8 @@ public:
         }
     }
 
-    private alias fp_t = extern (D) UnionExp function(const ref Loc loc, Type, Expression, Expression);
-    private alias fp2_t = extern (D) bool function(const ref Loc loc, EXP, Expression, Expression);
+    private alias fp_t = extern (D) UnionExp function(Loc loc, Type, Expression, Expression);
+    private alias fp2_t = extern (D) bool function(Loc loc, EXP, Expression, Expression);
 
     extern (D) private void interpretCommon(BinExp e, fp_t fp)
     {
@@ -6530,7 +6530,7 @@ public:
 
 /// Interpret `throw <exp>` found at the specified location `loc`
 private
-void interpretThrow(ref Expression result, Expression exp, const ref Loc loc, InterState* istate)
+void interpretThrow(ref Expression result, Expression exp, Loc loc, InterState* istate)
 {
     incUsageCtfe(istate, loc);
 
@@ -6671,7 +6671,7 @@ Expressions* copyArrayOnWrite(Expressions* exps, Expressions* original)
     true if it is safe to return, false if an error was generated.
  */
 private
-bool stopPointersEscaping(const ref Loc loc, Expression e)
+bool stopPointersEscaping(Loc loc, Expression e)
 {
     import dmd.typesem : hasPointers;
     if (!e.type.hasPointers())
@@ -6721,7 +6721,7 @@ bool stopPointersEscaping(const ref Loc loc, Expression e)
 
 // Check all elements of an array for escaping local variables. Return false if error
 private
-bool stopPointersEscapingFromArray(const ref Loc loc, Expressions* elems)
+bool stopPointersEscapingFromArray(Loc loc, Expressions* elems)
 {
     foreach (e; *elems)
     {
@@ -6785,7 +6785,7 @@ ThrownExceptionExp chainExceptions(ThrownExceptionExp oldest, ThrownExceptionExp
  * 1. all slices must be resolved.
  * 2. all .ownedByCtfe set to OwnedBy.code
  */
-private Expression scrubReturnValue(const ref Loc loc, Expression e)
+private Expression scrubReturnValue(Loc loc, Expression e)
 {
     /* Returns: true if e is void,
      * or is an array literal or struct literal of void elements.
@@ -7505,7 +7505,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
 /* If this is a built-in function, return the interpreted result,
  * Otherwise, return NULL.
  */
-private Expression evaluateIfBuiltin(UnionExp* pue, InterState* istate, const ref Loc loc, FuncDeclaration fd, Expressions* arguments, Expression pthis)
+private Expression evaluateIfBuiltin(UnionExp* pue, InterState* istate, Loc loc, FuncDeclaration fd, Expressions* arguments, Expression pthis)
 {
     Expression e = null;
     size_t nargs = arguments ? arguments.length : 0;

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -175,7 +175,7 @@ extern (C++) class Package : ScopeDsymbol
     uint tag;        // auto incremented tag, used to mask package tree in scopes
     Module mod;     // !=null if isPkgMod == PKG.module_
 
-    final extern (D) this(const ref Loc loc, Identifier ident) nothrow
+    final extern (D) this(Loc loc, Identifier ident) nothrow
     {
         super(loc, ident);
         __gshared uint packageTag;
@@ -442,7 +442,7 @@ extern (C++) final class Module : Package
     size_t nameoffset;          // offset of module name from start of ModuleInfo
     size_t namelen;             // length of module name in characters
 
-    extern (D) this(const ref Loc loc, const(char)[] filename, Identifier ident, int doDocComment, int doHdrGen)
+    extern (D) this(Loc loc, const(char)[] filename, Identifier ident, int doDocComment, int doHdrGen)
     {
         super(loc, ident);
         const(char)[] srcfilename;
@@ -512,12 +512,12 @@ extern (C++) final class Module : Package
         return ret;
     }
 
-    extern (C++) static Module load(const ref Loc loc, Identifiers* packages, Identifier ident)
+    extern (C++) static Module load(Loc loc, Identifiers* packages, Identifier ident)
     {
         return load(loc, packages ? (*packages)[] : null, ident);
     }
 
-    extern (D) static Module load(const ref Loc loc, Identifier[] packages, Identifier ident, ImportPathInfo pathInfo = ImportPathInfo.init)
+    extern (D) static Module load(Loc loc, Identifier[] packages, Identifier ident, ImportPathInfo pathInfo = ImportPathInfo.init)
     {
         //printf("Module::load(ident = '%s')\n", ident.toChars());
         // Build module filename by turning:
@@ -638,7 +638,7 @@ extern (C++) final class Module : Package
      * Params:
      *  loc = The location at which the file read originated (e.g. import)
      */
-    private void onFileReadError(const ref Loc loc)
+    private void onFileReadError(Loc loc)
     {
         const name = srcfile.toString();
         if (FileName.equals(name, "object.d"))
@@ -695,7 +695,7 @@ extern (C++) final class Module : Package
      *
      * Returns: `true` if successful
      */
-    bool read(const ref Loc loc)
+    bool read(Loc loc)
     {
         if (this.src)
             return true; // already read
@@ -969,7 +969,7 @@ extern (C++) final class Module : Package
      *  sc = the scope into which we are imported
      *  loc = the location of the import statement
      */
-    void checkImportDeprecation(const ref Loc loc, Scope* sc)
+    void checkImportDeprecation(Loc loc, Scope* sc)
     {
         if (md && md.isdeprecated && !sc.isDeprecated)
         {
@@ -1294,7 +1294,7 @@ extern (C++) struct ModuleDeclaration
     bool isdeprecated;      // if it is a deprecated module
     Expression msg;
 
-    extern (D) this(const ref Loc loc, Identifier[] packages, Identifier id, Expression msg, bool isdeprecated) @safe
+    extern (D) this(Loc loc, Identifier[] packages, Identifier id, Expression msg, bool isdeprecated) @safe
     {
         this.loc = loc;
         this.packages = packages;

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -382,7 +382,7 @@ extern (C++) struct Scope
      *   loc = for error messages
      *   ctorflow = flow results to merge in
      */
-    extern (D) void merge(const ref Loc loc, const ref CtorFlow ctorflow)
+    extern (D) void merge(Loc loc, const ref CtorFlow ctorflow)
     {
         if (!mergeCallSuper(this.ctorflow.callSuper, ctorflow.callSuper))
             error(loc, "one path skips constructor");
@@ -422,7 +422,7 @@ extern (C++) struct Scope
      * Returns:
      *  symbol if found, null if not
      */
-    extern (C++) Dsymbol search(const ref Loc loc, Identifier ident, out Dsymbol pscopesym, SearchOptFlags flags = SearchOpt.all)
+    extern (C++) Dsymbol search(Loc loc, Identifier ident, out Dsymbol pscopesym, SearchOptFlags flags = SearchOpt.all)
     {
         version (LOGSEARCH)
         {

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -116,7 +116,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     import dmd.common.bitfields : generateBitFields;
     mixin(generateBitFields!(BitFields, ushort));
 
-    extern (D) this(const ref Loc loc, Identifier id, bool inObject)
+    extern (D) this(Loc loc, Identifier id, bool inObject)
     {
         super(loc, id);
         zeroInit = false; // assume false until we do semantic processing
@@ -131,7 +131,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         }
     }
 
-    static StructDeclaration create(const ref Loc loc, Identifier id, bool inObject)
+    static StructDeclaration create(Loc loc, Identifier id, bool inObject)
     {
         return new StructDeclaration(loc, id, inObject);
     }
@@ -540,7 +540,7 @@ bool _isZeroInit(Expression exp)
  */
 extern (C++) final class UnionDeclaration : StructDeclaration
 {
-    extern (D) this(const ref Loc loc, Identifier id)
+    extern (D) this(Loc loc, Identifier id)
     {
         super(loc, id, false);
     }

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -285,7 +285,7 @@ extern (C++) class Dsymbol : ASTNode
         this.ident = ident;
     }
 
-    final extern (D) this(const ref Loc loc, Identifier ident) nothrow @safe
+    final extern (D) this(Loc loc, Identifier ident) nothrow @safe
     {
         //printf("Dsymbol::Dsymbol(%p, ident)\n", this);
         this.loc = loc;
@@ -701,7 +701,7 @@ extern (C++) class Dsymbol : ASTNode
      * Returns:
      *  SIZE_INVALID when the size cannot be determined
      */
-    uinteger_t size(const ref Loc loc)
+    uinteger_t size(Loc loc)
     {
         .error(loc, "%s `%s` symbol `%s` has no size", kind, toPrettyChars, toChars());
         return SIZE_INVALID;
@@ -1099,7 +1099,7 @@ public:
         super(ident);
     }
 
-    final extern (D) this(const ref Loc loc, Identifier ident) nothrow @safe
+    final extern (D) this(Loc loc, Identifier ident) nothrow @safe
     {
         super(loc, ident);
     }
@@ -1241,7 +1241,7 @@ public:
         return (members is null);
     }
 
-    static void multiplyDefined(const ref Loc loc, Dsymbol s1, Dsymbol s2)
+    static void multiplyDefined(Loc loc, Dsymbol s1, Dsymbol s2)
     {
         version (none)
         {
@@ -1559,7 +1559,7 @@ extern (C++) final class AliasAssign : Dsymbol
     Dsymbol aliassym; /// replace previous RHS of AliasDeclaration with `aliassym`
                       /// only one of type and aliassym can be != null
 
-    extern (D) this(const ref Loc loc, Identifier ident, Type type, Dsymbol aliassym) nothrow @safe
+    extern (D) this(Loc loc, Identifier ident, Type type, Dsymbol aliassym) nothrow @safe
     {
         super(loc, null);
         this.ident = ident;

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -220,7 +220,7 @@ public:
     virtual Dsymbol *toAlias();                 // resolve real symbol
     virtual Dsymbol *toAlias2();
     virtual bool overloadInsert(Dsymbol *s);
-    virtual uinteger_t size(const Loc &loc);
+    virtual uinteger_t size(Loc loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration *isThis();     // is a 'this' required to access the member
     virtual bool isExport() const;              // is Dsymbol exported?
@@ -329,7 +329,7 @@ public:
     virtual void importScope(Dsymbol *s, Visibility visibility);
     virtual bool isPackageAccessible(Package *p, Visibility visibility, SearchOptFlags flags = (SearchOptFlags)SearchOpt::all);
     bool isforwardRef() override final;
-    static void multiplyDefined(const Loc &loc, Dsymbol *s1, Dsymbol *s2);
+    static void multiplyDefined(Loc loc, Dsymbol *s1, Dsymbol *s2);
     const char *kind() const override;
     virtual Dsymbol *symtabInsert(Dsymbol *s);
     virtual Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
@@ -429,7 +429,7 @@ public:
 namespace dmd
 {
     void addMember(Dsymbol *dsym, Scope *sc, ScopeDsymbol *sds);
-    Dsymbol *search(Dsymbol *d, const Loc &loc, Identifier *ident, SearchOptFlags flags = (SearchOptFlags)SearchOpt::localsOnly);
+    Dsymbol *search(Dsymbol *d, Loc loc, Identifier *ident, SearchOptFlags flags = (SearchOptFlags)SearchOpt::localsOnly);
     Dsymbols *include(Dsymbol *d, Scope *sc);
     void setScope(Dsymbol *d, Scope *sc);
     void importAll(Dsymbol *d, Scope *sc);

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -174,7 +174,7 @@ const(char)* getMessage(DeprecatedDeclaration dd)
     return dd.msgstr;
 }
 
-bool checkDeprecated(Dsymbol d, const ref Loc loc, Scope* sc)
+bool checkDeprecated(Dsymbol d, Loc loc, Scope* sc)
 {
     if (global.params.useDeprecated == DiagnosticReporting.off)
         return false;
@@ -211,7 +211,7 @@ bool checkDeprecated(Dsymbol d, const ref Loc loc, Scope* sc)
 /*********************************
  * Check type to see if it is based on a deprecated symbol.
  */
-private void checkDeprecated(Type type, const ref Loc loc, Scope* sc)
+private void checkDeprecated(Type type, Loc loc, Scope* sc)
 {
     if (Dsymbol s = type.toDsymbol(sc))
     {
@@ -396,7 +396,7 @@ Expression resolveAliasThis(Scope* sc, Expression e, bool gag = false, bool find
  * Returns:
  *   Whether the alias this was reported as deprecated.
  */
-private bool checkDeprecatedAliasThis(AliasThis at, const ref Loc loc, Scope* sc)
+private bool checkDeprecatedAliasThis(AliasThis at, Loc loc, Scope* sc)
 {
     if (global.params.useDeprecated != DiagnosticReporting.off
         && at.isDeprecated() && !sc.isDeprecated())
@@ -5941,7 +5941,7 @@ void adjustLocForMixin(const(char)[] input, Loc loc, ref BaseLoc baseLoc, ref Ou
  *      lines = line count to update
  *      output = sink for output
  */
-private void writeMixin(const(char)[] s, ref const Loc loc, ref int lines, ref OutBuffer buf)
+private void writeMixin(const(char)[] s, Loc loc, ref int lines, ref OutBuffer buf)
 {
     buf.writestring("// expansion at ");
     buf.writestring(loc.toChars());
@@ -5988,7 +5988,7 @@ private void writeMixin(const(char)[] s, ref const Loc loc, ref int lines, ref O
  * Returns:
  *  null if not found
  */
-Dsymbol search(Dsymbol d, const ref Loc loc, Identifier ident, SearchOptFlags flags = SearchOpt.all)
+Dsymbol search(Dsymbol d, Loc loc, Identifier ident, SearchOptFlags flags = SearchOpt.all)
 {
     scope v = new SearchVisitor(loc, ident, flags);
     d.accept(v);
@@ -6035,7 +6035,7 @@ private extern(C++) class SearchVisitor : Visitor
     SearchOptFlags flags;
     Dsymbol result;
 
-    this(const ref Loc loc, Identifier ident, SearchOptFlags flags) @safe
+    this(Loc loc, Identifier ident, SearchOptFlags flags) @safe
     {
         this.loc = loc;
         this.ident = ident;
@@ -6251,7 +6251,7 @@ private extern(C++) class SearchVisitor : Visitor
         VarDeclaration* pvar;
         Expression ce;
 
-        static Dsymbol dollarFromTypeTuple(const ref Loc loc, TypeTuple tt, Scope* sc)
+        static Dsymbol dollarFromTypeTuple(Loc loc, TypeTuple tt, Scope* sc)
         {
 
             /* $ gives the number of type entries in the type tuple
@@ -7834,7 +7834,7 @@ private Expression callScopeDtor(VarDeclaration vd, Scope* sc)
  * Returns:
  *      false if failed to determine the size.
  */
-bool determineSize(AggregateDeclaration ad, const ref Loc loc)
+bool determineSize(AggregateDeclaration ad, Loc loc)
 {
     //printf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
 

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -595,7 +595,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
     Array!Expression lastConstraintNegs; /// its negative parts
     Objects* lastConstraintTiargs; /// template instance arguments for `lastConstraint`
 
-    extern (D) this(const ref Loc loc, Identifier ident, TemplateParameters* parameters, Expression constraint, Dsymbols* decldefs, bool ismixin = false, bool literal = false)
+    extern (D) this(Loc loc, Identifier ident, TemplateParameters* parameters, Expression constraint, Dsymbols* decldefs, bool ismixin = false, bool literal = false)
     {
         super(loc, ident);
         static if (LOG)
@@ -3171,7 +3171,7 @@ extern (C++) class TemplateParameter : ASTNode
     bool dependent;
 
     /* ======================== TemplateParameter =============================== */
-    extern (D) this(const ref Loc loc, Identifier ident) @safe
+    extern (D) this(Loc loc, Identifier ident) @safe
     {
         this.loc = loc;
         this.ident = ident;
@@ -3210,7 +3210,7 @@ extern (C++) class TemplateParameter : ASTNode
 
     abstract RootObject specialization();
 
-    abstract RootObject defaultArg(const ref Loc instLoc, Scope* sc);
+    abstract RootObject defaultArg(Loc instLoc, Scope* sc);
 
     abstract bool hasDefaultArg();
 
@@ -3242,7 +3242,7 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
 
     extern (D) __gshared Type tdummy = null;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Type specType, Type defaultType) @safe
+    extern (D) this(Loc loc, Identifier ident, Type specType, Type defaultType) @safe
     {
         super(loc, ident);
         this.specType = specType;
@@ -3288,7 +3288,7 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
         return specType;
     }
 
-    override final RootObject defaultArg(const ref Loc instLoc, Scope* sc)
+    override final RootObject defaultArg(Loc instLoc, Scope* sc)
     {
         Type t = defaultType;
         if (t)
@@ -3317,7 +3317,7 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
  */
 extern (C++) final class TemplateThisParameter : TemplateTypeParameter
 {
-    extern (D) this(const ref Loc loc, Identifier ident, Type specType, Type defaultType) @safe
+    extern (D) this(Loc loc, Identifier ident, Type specType, Type defaultType) @safe
     {
         super(loc, ident, specType, defaultType);
     }
@@ -3351,7 +3351,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
 
     extern (D) __gshared Expression[void*] edummies;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Type valType,
+    extern (D) this(Loc loc, Identifier ident, Type valType,
         Expression specValue, Expression defaultValue) @safe
     {
         super(loc, ident);
@@ -3408,7 +3408,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
         return specValue;
     }
 
-    override RootObject defaultArg(const ref Loc instLoc, Scope* sc)
+    override RootObject defaultArg(Loc instLoc, Scope* sc)
     {
         Expression e = defaultValue;
         if (!e)
@@ -3467,7 +3467,7 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
 
     extern (D) __gshared Dsymbol sdummy = null;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Type specType, RootObject specAlias, RootObject defaultAlias) @safe
+    extern (D) this(Loc loc, Identifier ident, Type specType, RootObject specAlias, RootObject defaultAlias) @safe
     {
         super(loc, ident);
         this.specType = specType;
@@ -3505,7 +3505,7 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
         return specAlias;
     }
 
-    override RootObject defaultArg(const ref Loc instLoc, Scope* sc)
+    override RootObject defaultArg(Loc instLoc, Scope* sc)
     {
         RootObject da = defaultAlias;
         if (auto ta = isType(defaultAlias))
@@ -3546,7 +3546,7 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
  */
 extern (C++) final class TemplateTupleParameter : TemplateParameter
 {
-    extern (D) this(const ref Loc loc, Identifier ident) @safe
+    extern (D) this(Loc loc, Identifier ident) @safe
     {
         super(loc, ident);
     }
@@ -3600,7 +3600,7 @@ extern (C++) final class TemplateTupleParameter : TemplateParameter
         return null;
     }
 
-    override RootObject defaultArg(const ref Loc instLoc, Scope* sc)
+    override RootObject defaultArg(Loc instLoc, Scope* sc)
     {
         return null;
     }
@@ -3724,7 +3724,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         }
     }
 
-    extern (D) this(const ref Loc loc, Identifier ident, Objects* tiargs) scope
+    extern (D) this(Loc loc, Identifier ident, Objects* tiargs) scope
     {
         super(loc, null);
         static if (LOG)
@@ -3739,7 +3739,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
      * This constructor is only called when we figured out which function
      * template to instantiate.
      */
-    extern (D) this(const ref Loc loc, TemplateDeclaration td, Objects* tiargs) scope
+    extern (D) this(Loc loc, TemplateDeclaration td, Objects* tiargs) scope
     {
         super(loc, null);
         static if (LOG)
@@ -4477,7 +4477,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
      * Returns:
      *      false if one or more arguments have errors.
      */
-    extern (D) static bool semanticTiargs(const ref Loc loc, Scope* sc, Objects* tiargs, int flags, TupleDeclaration atd = null)
+    extern (D) static bool semanticTiargs(Loc loc, Scope* sc, Objects* tiargs, int flags, TupleDeclaration atd = null)
     {
         // Run semantic on each argument, place results in tiargs[]
         //printf("+TemplateInstance.semanticTiargs()\n");
@@ -5477,7 +5477,7 @@ extern (C++) final class TemplateMixin : TemplateInstance
 {
     TypeQualified tqual;
 
-    extern (D) this(const ref Loc loc, Identifier ident, TypeQualified tqual, Objects* tiargs)
+    extern (D) this(Loc loc, Identifier ident, TypeQualified tqual, Objects* tiargs)
     {
         super(loc,
               tqual.idents.length ? cast(Identifier)tqual.idents[tqual.idents.length - 1] : (cast(TypeIdentifier)tqual).ident,

--- a/compiler/src/dmd/dversion.d
+++ b/compiler/src/dmd/dversion.d
@@ -32,12 +32,12 @@ import dmd.visitor;
  */
 extern (C++) final class DebugSymbol : Dsymbol
 {
-    extern (D) this(const ref Loc loc, Identifier ident) @safe
+    extern (D) this(Loc loc, Identifier ident) @safe
     {
         super(loc, ident);
     }
 
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, null);
     }
@@ -73,12 +73,12 @@ extern (C++) final class DebugSymbol : Dsymbol
 extern (C++) final class VersionSymbol : Dsymbol
 {
 
-    extern (D) this(const ref Loc loc, Identifier ident) @safe
+    extern (D) this(Loc loc, Identifier ident) @safe
     {
         super(loc, ident);
     }
 
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, null);
     }

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -322,7 +322,7 @@ Symbol* toStringSymbol(StringExp se)
  *      loc = to get file/line from
  */
 
-void toTraceGC(ref IRState irs, elem* e, const ref Loc loc)
+void toTraceGC(ref IRState irs, elem* e, Loc loc)
 {
     static immutable RTLSYM[2][25] map =
     [
@@ -4354,7 +4354,7 @@ elem* Dsymbol_toElem(Dsymbol s, ref IRState irs)
  * Allocate a static array, and initialize its members with elems[].
  * Return the initialization expression, and the symbol for the static array in *psym.
  */
-elem* ElemsToStaticArray(const ref Loc loc, Type telem, Elems* elems, Symbol **psym)
+elem* ElemsToStaticArray(Loc loc, Type telem, Elems* elems, Symbol **psym)
 {
     // Create a static array of type telem[dim]
     const dim = elems.length;
@@ -4386,7 +4386,7 @@ elem* ElemsToStaticArray(const ref Loc loc, Type telem, Elems* elems, Symbol **p
  * exps[].
  * Return the initialization expression, and the symbol for the static array in *psym.
  */
-elem* ExpressionsToStaticArray(ref IRState irs, const ref Loc loc, Expressions* exps, Symbol **psym, size_t offset = 0, Expression basis = null)
+elem* ExpressionsToStaticArray(ref IRState irs, Loc loc, Expressions* exps, Symbol **psym, size_t offset = 0, Expression basis = null)
 {
     // Create a static array of type telem[dim]
     const dim = exps.length;
@@ -5395,7 +5395,7 @@ elem* useOPstrpar(elem* e)
  * Call a function.
  */
 
-elem* callfunc(const ref Loc loc,
+elem* callfunc(Loc loc,
         ref IRState irs,
         int directcall,         // 1: don't do virtual call
         Type tret,              // return type
@@ -6162,7 +6162,7 @@ elem* array_toDarray(Type t, elem* e)
 /************************************
  */
 
-elem* sarray_toDarray(const ref Loc loc, Type tfrom, Type tto, elem* e)
+elem* sarray_toDarray(Loc loc, Type tfrom, Type tto, elem* e)
 {
     //printf("sarray_toDarray()\n");
     //elem_print(e);
@@ -6847,7 +6847,7 @@ elem* appendDtors(ref IRState irs, elem* er, size_t starti, size_t endi)
  * for insertion into the parameter list.
  */
 
-elem* filelinefunction(ref IRState irs, const ref Loc loc)
+elem* filelinefunction(ref IRState irs, Loc loc)
 {
     const(char)* id = loc.filename;
     size_t len = strlen(id);
@@ -6882,7 +6882,7 @@ elem* filelinefunction(ref IRState irs, const ref Loc loc)
  * Returns:
  *      elem generated
  */
-elem* buildRangeError(ref IRState irs, const ref Loc loc)
+elem* buildRangeError(ref IRState irs, Loc loc)
 {
     final switch (irs.params.checkAction)
     {
@@ -6908,7 +6908,7 @@ elem* buildRangeError(ref IRState irs, const ref Loc loc)
  * Returns:
  *      elem generated
  */
-elem* buildArraySliceError(ref IRState irs, const ref Loc loc, elem* lower, elem* upper, elem* length) {
+elem* buildArraySliceError(ref IRState irs, Loc loc, elem* lower, elem* upper, elem* length) {
     final switch (irs.params.checkAction)
     {
     case CHECKACTION.C:
@@ -6935,7 +6935,7 @@ elem* buildArraySliceError(ref IRState irs, const ref Loc loc, elem* lower, elem
  * Returns:
  *      elem generated
  */
-elem* buildArrayIndexError(ref IRState irs, const ref Loc loc, elem* index, elem* length) {
+elem* buildArrayIndexError(ref IRState irs, Loc loc, elem* index, elem* length) {
     final switch (irs.params.checkAction)
     {
     case CHECKACTION.C:
@@ -6951,7 +6951,7 @@ elem* buildArrayIndexError(ref IRState irs, const ref Loc loc, elem* index, elem
 }
 
 /// Returns: elem representing a C-string (char*) to the filename
-elem* locToFileElem(const ref IRState irs, const ref Loc loc) {
+elem* locToFileElem(const ref IRState irs, Loc loc) {
     elem* efile;
     if (loc.filename)
     {
@@ -6976,7 +6976,7 @@ elem* locToFileElem(const ref IRState irs, const ref Loc loc) {
  * Returns:
  *      generated call
  */
-elem* callCAssert(ref IRState irs, const ref Loc loc, Expression exp, Expression emsg, const(char)* str)
+elem* callCAssert(ref IRState irs, Loc loc, Expression exp, Expression emsg, const(char)* str)
 {
     //printf("callCAssert.toElem() %s\n", e.toChars());
     Module m = cast(Module)irs.blx._module;
@@ -7077,7 +7077,7 @@ elem* callCAssert(ref IRState irs, const ref Loc loc, Expression exp, Expression
  * Returns:
  *      generated instruction
  */
-elem* genHalt(const ref Loc loc)
+elem* genHalt(Loc loc)
 {
     elem* e = el_calloc();
     e.Ety = TYnoreturn;
@@ -7099,7 +7099,7 @@ elem* genHalt(const ref Loc loc)
  *      `ethis2` if successful, null otherwise
  */
 private
-elem* setEthis2(const ref Loc loc, ref IRState irs, FuncDeclaration fd, elem* ethis2, ref elem* ethis, ref elem* eside)
+elem* setEthis2(Loc loc, ref IRState irs, FuncDeclaration fd, elem* ethis2, ref elem* ethis, ref elem* eside)
 {
     if (!fd.hasDualContext())
         return null;

--- a/compiler/src/dmd/enum.h
+++ b/compiler/src/dmd/enum.h
@@ -20,7 +20,7 @@ class Expression;
 namespace dmd
 {
     // in enumsem.d
-    Expression *getDefaultValue(EnumDeclaration *ed, const Loc &loc);
+    Expression *getDefaultValue(EnumDeclaration *ed, Loc loc);
 }
 
 class EnumDeclaration final : public ScopeDsymbol

--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -347,7 +347,7 @@ void enumSemantic(Scope* sc, EnumDeclaration ed)
     //printf("members = %s\n", members.toChars());
 }
 
-Expression getDefaultValue(EnumDeclaration ed, const ref Loc loc)
+Expression getDefaultValue(EnumDeclaration ed, Loc loc)
 {
     Expression handleErrors(){
         ed.defaultval = ErrorExp.get();
@@ -399,7 +399,7 @@ Expression getDefaultValue(EnumDeclaration ed, const ref Loc loc)
     return handleErrors();
 }
 
-Type getMemtype(EnumDeclaration ed, const ref Loc loc)
+Type getMemtype(EnumDeclaration ed, Loc loc)
 {
     if (ed._scope)
     {

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -60,37 +60,37 @@ class ErrorSinkCompiler : ErrorSink
   extern (C++):
   override:
 
-    void verror(const ref Loc loc, const(char)* format, va_list ap)
+    void verror(Loc loc, const(char)* format, va_list ap)
     {
         verrorReport(loc, format, ap, ErrorKind.error);
     }
 
-    void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap)
+    void verrorSupplemental(Loc loc, const(char)* format, va_list ap)
     {
         verrorReportSupplemental(loc, format, ap, ErrorKind.error);
     }
 
-    void vwarning(const ref Loc loc, const(char)* format, va_list ap)
+    void vwarning(Loc loc, const(char)* format, va_list ap)
     {
         verrorReport(loc, format, ap, ErrorKind.warning);
     }
 
-    void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap)
+    void vwarningSupplemental(Loc loc, const(char)* format, va_list ap)
     {
         verrorReportSupplemental(loc, format, ap, ErrorKind.warning);
     }
 
-    void vdeprecation(const ref Loc loc, const(char)* format, va_list ap)
+    void vdeprecation(Loc loc, const(char)* format, va_list ap)
     {
         verrorReport(loc, format, ap, ErrorKind.deprecation);
     }
 
-    void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap)
+    void vdeprecationSupplemental(Loc loc, const(char)* format, va_list ap)
     {
         verrorReportSupplemental(loc, format, ap, ErrorKind.deprecation);
     }
 
-    void vmessage(const ref Loc loc, const(char)* format, va_list ap)
+    void vmessage(Loc loc, const(char)* format, va_list ap)
     {
         verrorReport(loc, format, ap, ErrorKind.message);
     }
@@ -123,9 +123,9 @@ enum Classification : Color
 
 
 static if (__VERSION__ < 2092)
-    private extern (C++) void noop(const ref Loc loc, const(char)* format, ...) {}
+    private extern (C++) void noop(Loc loc, const(char)* format, ...) {}
 else
-    pragma(printf) private extern (C++) void noop(const ref Loc loc, const(char)* format, ...) {}
+    pragma(printf) private extern (C++) void noop(Loc loc, const(char)* format, ...) {}
 
 
 package auto previewErrorFunc(bool isDeprecated, FeatureState featureState) @safe @nogc pure nothrow
@@ -167,7 +167,7 @@ package auto previewSupplementalFunc(bool isDeprecated, FeatureState featureStat
  *      ...    = printf-style variadic arguments
  */
 static if (__VERSION__ < 2092)
-    extern (C++) void error(const ref Loc loc, const(char)* format, ...)
+    extern (C++) void error(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -175,7 +175,7 @@ static if (__VERSION__ < 2092)
         va_end(ap);
     }
 else
-    pragma(printf) extern (C++) void error(const ref Loc loc, const(char)* format, ...)
+    pragma(printf) extern (C++) void error(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -230,7 +230,7 @@ extern(C++) void errorBackend(const(char)* filename, uint linnum, uint charnum, 
  *      ...    = printf-style variadic arguments
  */
 static if (__VERSION__ < 2092)
-    extern (C++) void errorSupplemental(const ref Loc loc, const(char)* format, ...)
+    extern (C++) void errorSupplemental(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -238,7 +238,7 @@ static if (__VERSION__ < 2092)
         va_end(ap);
     }
 else
-    pragma(printf) extern (C++) void errorSupplemental(const ref Loc loc, const(char)* format, ...)
+    pragma(printf) extern (C++) void errorSupplemental(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -254,7 +254,7 @@ else
  *      ...    = printf-style variadic arguments
  */
 static if (__VERSION__ < 2092)
-    extern (C++) void warning(const ref Loc loc, const(char)* format, ...)
+    extern (C++) void warning(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -262,7 +262,7 @@ static if (__VERSION__ < 2092)
         va_end(ap);
     }
 else
-    pragma(printf) extern (C++) void warning(const ref Loc loc, const(char)* format, ...)
+    pragma(printf) extern (C++) void warning(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -279,7 +279,7 @@ else
  *      ...    = printf-style variadic arguments
  */
 static if (__VERSION__ < 2092)
-    extern (C++) void warningSupplemental(const ref Loc loc, const(char)* format, ...)
+    extern (C++) void warningSupplemental(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -287,7 +287,7 @@ static if (__VERSION__ < 2092)
         va_end(ap);
     }
 else
-    pragma(printf) extern (C++) void warningSupplemental(const ref Loc loc, const(char)* format, ...)
+    pragma(printf) extern (C++) void warningSupplemental(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -304,7 +304,7 @@ else
  *      ...    = printf-style variadic arguments
  */
 static if (__VERSION__ < 2092)
-    extern (C++) void deprecation(const ref Loc loc, const(char)* format, ...)
+    extern (C++) void deprecation(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -312,7 +312,7 @@ static if (__VERSION__ < 2092)
         va_end(ap);
     }
 else
-    pragma(printf) extern (C++) void deprecation(const ref Loc loc, const(char)* format, ...)
+    pragma(printf) extern (C++) void deprecation(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -329,7 +329,7 @@ else
  *      ...    = printf-style variadic arguments
  */
 static if (__VERSION__ < 2092)
-    extern (C++) void deprecationSupplemental(const ref Loc loc, const(char)* format, ...)
+    extern (C++) void deprecationSupplemental(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -337,7 +337,7 @@ static if (__VERSION__ < 2092)
         va_end(ap);
     }
 else
-    pragma(printf) extern (C++) void deprecationSupplemental(const ref Loc loc, const(char)* format, ...)
+    pragma(printf) extern (C++) void deprecationSupplemental(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -354,7 +354,7 @@ else
  *      ...    = printf-style variadic arguments
  */
 static if (__VERSION__ < 2092)
-    extern (C++) void message(const ref Loc loc, const(char)* format, ...)
+    extern (C++) void message(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -362,7 +362,7 @@ static if (__VERSION__ < 2092)
         va_end(ap);
     }
 else
-    pragma(printf) extern (C++) void message(const ref Loc loc, const(char)* format, ...)
+    pragma(printf) extern (C++) void message(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -463,7 +463,7 @@ private struct ErrorInfo
  *      p1          = additional message prefix
  *      p2          = additional message prefix
  */
-private extern(C++) void verrorReport(const ref Loc loc, const(char)* format, va_list ap, ErrorKind kind, const(char)* p1 = null, const(char)* p2 = null)
+private extern(C++) void verrorReport(Loc loc, const(char)* format, va_list ap, ErrorKind kind, const(char)* p1 = null, const(char)* p2 = null)
 {
     return verrorReport(loc.SourceLoc, format, ap, kind, p1, p2);
 }
@@ -595,7 +595,7 @@ private extern(C++) void verrorReport(const SourceLoc loc, const(char)* format, 
  *      ap          = printf-style variadic arguments
  *      kind        = kind of error being printed
  */
-private extern(C++) void verrorReportSupplemental(const ref Loc loc, const(char)* format, va_list ap, ErrorKind kind)
+private extern(C++) void verrorReportSupplemental(Loc loc, const(char)* format, va_list ap, ErrorKind kind)
 {
     return verrorReportSupplemental(loc.SourceLoc, format, ap, kind);
 }

--- a/compiler/src/dmd/errors.h
+++ b/compiler/src/dmd/errors.h
@@ -31,15 +31,15 @@ enum class ErrorKind
 #endif
 
 // Print a warning, deprecation, or error, accepts printf-like format specifiers.
-D_ATTRIBUTE_FORMAT(2, 3) void warning(const Loc& loc, const char *format, ...);
-D_ATTRIBUTE_FORMAT(2, 3) void warningSupplemental(const Loc& loc, const char *format, ...);
-D_ATTRIBUTE_FORMAT(2, 3) void deprecation(const Loc& loc, const char *format, ...);
-D_ATTRIBUTE_FORMAT(2, 3) void deprecationSupplemental(const Loc& loc, const char *format, ...);
-D_ATTRIBUTE_FORMAT(2, 3) void error(const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void warning(Loc loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void warningSupplemental(Loc loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void deprecation(Loc loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void deprecationSupplemental(Loc loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void error(Loc loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(4, 5) void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
-D_ATTRIBUTE_FORMAT(2, 3) void errorSupplemental(const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void errorSupplemental(Loc loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(1, 2) void message(const char *format, ...);
-D_ATTRIBUTE_FORMAT(2, 3) void message(const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void message(Loc loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(1, 2) void tip(const char *format, ...);
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -23,15 +23,15 @@ abstract class ErrorSink
   nothrow:
   extern (C++):
 
-    void verror(const ref Loc loc, const(char)* format, va_list ap);
-    void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap);
-    void vwarning(const ref Loc loc, const(char)* format, va_list ap);
-    void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap);
-    void vmessage(const ref Loc loc, const(char)* format, va_list ap);
-    void vdeprecation(const ref Loc loc, const(char)* format, va_list ap);
-    void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap);
+    void verror(Loc loc, const(char)* format, va_list ap);
+    void verrorSupplemental(Loc loc, const(char)* format, va_list ap);
+    void vwarning(Loc loc, const(char)* format, va_list ap);
+    void vwarningSupplemental(Loc loc, const(char)* format, va_list ap);
+    void vmessage(Loc loc, const(char)* format, va_list ap);
+    void vdeprecation(Loc loc, const(char)* format, va_list ap);
+    void vdeprecationSupplemental(Loc loc, const(char)* format, va_list ap);
 
-    void error(const ref Loc loc, const(char)* format, ...)
+    void error(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -39,7 +39,7 @@ abstract class ErrorSink
         va_end(ap);
     }
 
-    void errorSupplemental(const ref Loc loc, const(char)* format, ...)
+    void errorSupplemental(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -47,7 +47,7 @@ abstract class ErrorSink
         va_end(ap);
     }
 
-    void warning(const ref Loc loc, const(char)* format, ...)
+    void warning(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -55,7 +55,7 @@ abstract class ErrorSink
         va_end(ap);
     }
 
-    void warningSupplemental(const ref Loc loc, const(char)* format, ...)
+    void warningSupplemental(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -63,7 +63,7 @@ abstract class ErrorSink
         va_end(ap);
     }
 
-    void message(const ref Loc loc, const(char)* format, ...)
+    void message(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -71,7 +71,7 @@ abstract class ErrorSink
         va_end(ap);
     }
 
-    void deprecation(const ref Loc loc, const(char)* format, ...)
+    void deprecation(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -79,7 +79,7 @@ abstract class ErrorSink
         va_end(ap);
     }
 
-    void deprecationSupplemental(const ref Loc loc, const(char)* format, ...)
+    void deprecationSupplemental(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -106,19 +106,19 @@ class ErrorSinkNull : ErrorSink
   extern (C++):
   override:
 
-    void verror(const ref Loc loc, const(char)* format, va_list ap) { }
+    void verror(Loc loc, const(char)* format, va_list ap) { }
 
-    void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
+    void verrorSupplemental(Loc loc, const(char)* format, va_list ap) { }
 
-    void vwarning(const ref Loc loc, const(char)* format, va_list ap) { }
+    void vwarning(Loc loc, const(char)* format, va_list ap) { }
 
-    void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
+    void vwarningSupplemental(Loc loc, const(char)* format, va_list ap) { }
 
-    void vmessage(const ref Loc loc, const(char)* format, va_list ap) { }
+    void vmessage(Loc loc, const(char)* format, va_list ap) { }
 
-    void vdeprecation(const ref Loc loc, const(char)* format, va_list ap) { }
+    void vdeprecation(Loc loc, const(char)* format, va_list ap) { }
 
-    void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
+    void vdeprecationSupplemental(Loc loc, const(char)* format, va_list ap) { }
 }
 
 /*****************************************
@@ -132,7 +132,7 @@ class ErrorSinkLatch : ErrorSinkNull
 
     bool sawErrors;
 
-    void verror(const ref Loc loc, const(char)* format, va_list ap) { sawErrors = true; }
+    void verror(Loc loc, const(char)* format, va_list ap) { sawErrors = true; }
 }
 
 /*****************************************
@@ -148,7 +148,7 @@ class ErrorSinkStderr : ErrorSink
   extern (C++):
   override:
 
-    void verror(const ref Loc loc, const(char)* format, va_list ap)
+    void verror(Loc loc, const(char)* format, va_list ap)
     {
         fputs("Error: ", stderr);
         const p = loc.toChars();
@@ -162,9 +162,9 @@ class ErrorSinkStderr : ErrorSink
         fputc('\n', stderr);
     }
 
-    void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
+    void verrorSupplemental(Loc loc, const(char)* format, va_list ap) { }
 
-    void vwarning(const ref Loc loc, const(char)* format, va_list ap)
+    void vwarning(Loc loc, const(char)* format, va_list ap)
     {
         fputs("Warning: ", stderr);
         const p = loc.toChars();
@@ -178,9 +178,9 @@ class ErrorSinkStderr : ErrorSink
         fputc('\n', stderr);
     }
 
-    void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
+    void vwarningSupplemental(Loc loc, const(char)* format, va_list ap) { }
 
-    void vdeprecation(const ref Loc loc, const(char)* format, va_list ap)
+    void vdeprecation(Loc loc, const(char)* format, va_list ap)
     {
         fputs("Deprecation: ", stderr);
         const p = loc.toChars();
@@ -194,7 +194,7 @@ class ErrorSinkStderr : ErrorSink
         fputc('\n', stderr);
     }
 
-    void vmessage(const ref Loc loc, const(char)* format, va_list ap)
+    void vmessage(Loc loc, const(char)* format, va_list ap)
     {
         const p = loc.toChars();
         if (*p)
@@ -207,5 +207,5 @@ class ErrorSinkStderr : ErrorSink
         fputc('\n', stderr);
     }
 
-    void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap) { }
+    void vdeprecationSupplemental(Loc loc, const(char)* format, va_list ap) { }
 }

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -203,7 +203,7 @@ TemplateDeclaration getFuncTemplateDecl(Dsymbol s) @safe
  *      (foo).size
  *      cast(foo).size
  */
-DotIdExp typeDotIdExp(const ref Loc loc, Type type, Identifier ident) @safe
+DotIdExp typeDotIdExp(Loc loc, Type type, Identifier ident) @safe
 {
     return new DotIdExp(loc, new TypeExp(loc, type), ident);
 }
@@ -310,7 +310,7 @@ extern (C++) abstract class Expression : ASTNode
     import dmd.common.bitfields;
     mixin(generateBitFields!(BitFields, ubyte));
 
-    extern (D) this(const ref Loc loc, EXP op) scope @safe
+    extern (D) this(Loc loc, EXP op) scope @safe
     {
         //printf("Expression::Expression(op = %d) this = %p\n", op, this);
         this.loc = loc;
@@ -757,7 +757,7 @@ extern (C++) final class IntegerExp : Expression
 {
     private dinteger_t value;
 
-    extern (D) this(const ref Loc loc, dinteger_t value, Type type)
+    extern (D) this(Loc loc, dinteger_t value, Type type)
     {
         super(loc, EXP.int64);
         //printf("IntegerExp(value = %lld, type = '%s')\n", value, type ? type.toChars() : "");
@@ -780,7 +780,7 @@ extern (C++) final class IntegerExp : Expression
         this.value = cast(int)value;
     }
 
-    static IntegerExp create(const ref Loc loc, dinteger_t value, Type type)
+    static IntegerExp create(Loc loc, dinteger_t value, Type type)
     {
         return new IntegerExp(loc, value, type);
     }
@@ -1021,7 +1021,7 @@ extern (C++) final class RealExp : Expression
 {
     real_t value;
 
-    extern (D) this(const ref Loc loc, real_t value, Type type) @safe
+    extern (D) this(Loc loc, real_t value, Type type) @safe
     {
         super(loc, EXP.float64);
         //printf("RealExp::RealExp(%Lg)\n", value);
@@ -1029,7 +1029,7 @@ extern (C++) final class RealExp : Expression
         this.type = type;
     }
 
-    static RealExp create(const ref Loc loc, real_t value, Type type) @safe
+    static RealExp create(Loc loc, real_t value, Type type) @safe
     {
         return new RealExp(loc, value, type);
     }
@@ -1113,7 +1113,7 @@ extern (C++) final class ComplexExp : Expression
 {
     complex_t value;
 
-    extern (D) this(const ref Loc loc, complex_t value, Type type) @safe
+    extern (D) this(Loc loc, complex_t value, Type type) @safe
     {
         super(loc, EXP.complex80);
         this.value = value;
@@ -1121,7 +1121,7 @@ extern (C++) final class ComplexExp : Expression
         //printf("ComplexExp::ComplexExp(%s)\n", toChars());
     }
 
-    static ComplexExp create(const ref Loc loc, complex_t value, Type type) @safe
+    static ComplexExp create(Loc loc, complex_t value, Type type) @safe
     {
         return new ComplexExp(loc, value, type);
     }
@@ -1200,13 +1200,13 @@ extern (C++) class IdentifierExp : Expression
 {
     Identifier ident;
 
-    extern (D) this(const ref Loc loc, Identifier ident) scope @safe
+    extern (D) this(Loc loc, Identifier ident) scope @safe
     {
         super(loc, EXP.identifier);
         this.ident = ident;
     }
 
-    static IdentifierExp create(const ref Loc loc, Identifier ident) @safe
+    static IdentifierExp create(Loc loc, Identifier ident) @safe
     {
         return new IdentifierExp(loc, ident);
     }
@@ -1229,7 +1229,7 @@ extern (C++) class IdentifierExp : Expression
  */
 extern (C++) final class DollarExp : IdentifierExp
 {
-    extern (D) this(const ref Loc loc)
+    extern (D) this(Loc loc)
     {
         super(loc, Id.dollar);
     }
@@ -1248,7 +1248,7 @@ extern (C++) final class DsymbolExp : Expression
     Dsymbol s;
     bool hasOverloads;
 
-    extern (D) this(const ref Loc loc, Dsymbol s, bool hasOverloads = true) @safe
+    extern (D) this(Loc loc, Dsymbol s, bool hasOverloads = true) @safe
     {
         super(loc, EXP.dSymbol);
         this.s = s;
@@ -1273,13 +1273,13 @@ extern (C++) class ThisExp : Expression
 {
     VarDeclaration var;
 
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, EXP.this_);
         //printf("ThisExp::ThisExp() loc = %d\n", loc.linnum);
     }
 
-    this(const ref Loc loc, const EXP tok) @safe
+    this(Loc loc, const EXP tok) @safe
     {
         super(loc, tok);
         //printf("ThisExp::ThisExp() loc = %d\n", loc.linnum);
@@ -1317,7 +1317,7 @@ extern (C++) class ThisExp : Expression
  */
 extern (C++) final class SuperExp : ThisExp
 {
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, EXP.super_);
     }
@@ -1335,7 +1335,7 @@ extern (C++) final class SuperExp : ThisExp
  */
 extern (C++) final class NullExp : Expression
 {
-    extern (D) this(const ref Loc loc, Type type = null) scope @safe
+    extern (D) this(Loc loc, Type type = null) scope @safe
     {
         super(loc, EXP.null_);
         this.type = type;
@@ -1409,7 +1409,7 @@ extern (C++) final class StringExp : Expression
 
     enum char NoPostfix = 0;
 
-    extern (D) this(const ref Loc loc, const(void)[] string) scope
+    extern (D) this(Loc loc, const(void)[] string) scope
     {
         super(loc, EXP.string_);
         this.string = cast(char*)string.ptr; // note that this.string should be const
@@ -1417,7 +1417,7 @@ extern (C++) final class StringExp : Expression
         this.sz = 1;                    // work around LDC bug #1286
     }
 
-    extern (D) this(const ref Loc loc, const(void)[] string, size_t len, ubyte sz, char postfix = NoPostfix) scope
+    extern (D) this(Loc loc, const(void)[] string, size_t len, ubyte sz, char postfix = NoPostfix) scope
     {
         super(loc, EXP.string_);
         this.string = cast(char*)string.ptr; // note that this.string should be const
@@ -1426,12 +1426,12 @@ extern (C++) final class StringExp : Expression
         this.postfix = postfix;
     }
 
-    static StringExp create(const ref Loc loc, const(char)* s)
+    static StringExp create(Loc loc, const(char)* s)
     {
         return new StringExp(loc, s.toDString());
     }
 
-    static StringExp create(const ref Loc loc, const(void)* string, size_t len)
+    static StringExp create(Loc loc, const(void)* string, size_t len)
     {
         return new StringExp(loc, string[0 .. len]);
     }
@@ -1763,7 +1763,7 @@ extern (C++) final class InterpExp : Expression
 
     enum char NoPostfix = 0;
 
-    extern (D) this(const ref Loc loc, InterpolatedSet* set, char postfix = NoPostfix) scope @safe
+    extern (D) this(Loc loc, InterpolatedSet* set, char postfix = NoPostfix) scope @safe
     {
         super(loc, EXP.interpolated);
         this.interpolatedSet = set;
@@ -1798,7 +1798,7 @@ extern (C++) final class TupleExp : Expression
 
     Expressions* exps;
 
-    extern (D) this(const ref Loc loc, Expression e0, Expressions* exps) @safe
+    extern (D) this(Loc loc, Expression e0, Expressions* exps) @safe
     {
         super(loc, EXP.tuple);
         //printf("TupleExp(this = %p)\n", this);
@@ -1806,14 +1806,14 @@ extern (C++) final class TupleExp : Expression
         this.exps = exps;
     }
 
-    extern (D) this(const ref Loc loc, Expressions* exps) @safe
+    extern (D) this(Loc loc, Expressions* exps) @safe
     {
         super(loc, EXP.tuple);
         //printf("TupleExp(this = %p)\n", this);
         this.exps = exps;
     }
 
-    extern (D) this(const ref Loc loc, TupleDeclaration tup)
+    extern (D) this(Loc loc, TupleDeclaration tup)
     {
         super(loc, EXP.tuple);
         this.exps = new Expressions();
@@ -1847,7 +1847,7 @@ extern (C++) final class TupleExp : Expression
         }
     }
 
-    static TupleExp create(const ref Loc loc, Expressions* exps) @safe
+    static TupleExp create(Loc loc, Expressions* exps) @safe
     {
         return new TupleExp(loc, exps);
     }
@@ -1903,14 +1903,14 @@ extern (C++) final class ArrayLiteralExp : Expression
 
     Expressions* elements;
 
-    extern (D) this(const ref Loc loc, Type type, Expressions* elements) @safe
+    extern (D) this(Loc loc, Type type, Expressions* elements) @safe
     {
         super(loc, EXP.arrayLiteral);
         this.type = type;
         this.elements = elements;
     }
 
-    extern (D) this(const ref Loc loc, Type type, Expression e)
+    extern (D) this(Loc loc, Type type, Expression e)
     {
         super(loc, EXP.arrayLiteral);
         this.type = type;
@@ -1918,7 +1918,7 @@ extern (C++) final class ArrayLiteralExp : Expression
         elements.push(e);
     }
 
-    extern (D) this(const ref Loc loc, Type type, Expression basis, Expressions* elements) @safe
+    extern (D) this(Loc loc, Type type, Expression basis, Expressions* elements) @safe
     {
         super(loc, EXP.arrayLiteral);
         this.type = type;
@@ -1926,7 +1926,7 @@ extern (C++) final class ArrayLiteralExp : Expression
         this.elements = elements;
     }
 
-    static ArrayLiteralExp create(const ref Loc loc, Expressions* elements) @safe
+    static ArrayLiteralExp create(Loc loc, Expressions* elements) @safe
     {
         return new ArrayLiteralExp(loc, null, elements);
     }
@@ -2059,7 +2059,7 @@ extern (C++) final class AssocArrayLiteralExp : Expression
     /// Lower to core.internal.newaa for static initializaton
     Expression lowering;
 
-    extern (D) this(const ref Loc loc, Expressions* keys, Expressions* values) @safe
+    extern (D) this(Loc loc, Expressions* keys, Expressions* values) @safe
     {
         super(loc, EXP.assocArrayLiteral);
         assert(keys.length == values.length);
@@ -2166,7 +2166,7 @@ extern (C++) final class StructLiteralExp : Expression
         toCBuffer         = 0x20 /// toCBuffer is running
     }
 
-    extern (D) this(const ref Loc loc, StructDeclaration sd, Expressions* elements, Type stype = null) @safe
+    extern (D) this(Loc loc, StructDeclaration sd, Expressions* elements, Type stype = null) @safe
     {
         super(loc, EXP.structLiteral);
         this.sd = sd;
@@ -2178,7 +2178,7 @@ extern (C++) final class StructLiteralExp : Expression
         //printf("StructLiteralExp::StructLiteralExp(%s)\n", toChars());
     }
 
-    static StructLiteralExp create(const ref Loc loc, StructDeclaration sd, void* elements, Type stype = null)
+    static StructLiteralExp create(Loc loc, StructDeclaration sd, void* elements, Type stype = null)
     {
         return new StructLiteralExp(loc, sd, cast(Expressions*)elements, stype);
     }
@@ -2309,7 +2309,7 @@ extern (C++) final class CompoundLiteralExp : Expression
 {
     Initializer initializer; /// initializer-list
 
-    extern (D) this(const ref Loc loc, Type type_name, Initializer initializer) @safe
+    extern (D) this(Loc loc, Type type_name, Initializer initializer) @safe
     {
         super(loc, EXP.compoundLiteral);
         super.type = type_name;
@@ -2328,7 +2328,7 @@ extern (C++) final class CompoundLiteralExp : Expression
  */
 extern (C++) final class TypeExp : Expression
 {
-    extern (D) this(const ref Loc loc, Type type) @safe
+    extern (D) this(Loc loc, Type type) @safe
     {
         super(loc, EXP.type);
         //printf("TypeExp::TypeExp(%s)\n", type.toChars());
@@ -2364,7 +2364,7 @@ extern (C++) final class ScopeExp : Expression
 {
     ScopeDsymbol sds;
 
-    extern (D) this(const ref Loc loc, ScopeDsymbol sds) @safe
+    extern (D) this(Loc loc, ScopeDsymbol sds) @safe
     {
         super(loc, EXP.scope_);
         //printf("ScopeExp::ScopeExp(sds = '%s')\n", sds.toChars());
@@ -2413,7 +2413,7 @@ extern (C++) final class TemplateExp : Expression
     TemplateDeclaration td;
     FuncDeclaration fd;
 
-    extern (D) this(const ref Loc loc, TemplateDeclaration td, FuncDeclaration fd = null) @safe
+    extern (D) this(Loc loc, TemplateDeclaration td, FuncDeclaration fd = null) @safe
     {
         super(loc, EXP.template_);
         //printf("TemplateExp(): %s\n", td.toChars());
@@ -2459,7 +2459,7 @@ extern (C++) final class NewExp : Expression
     /// The fields are still separate for backwards compatibility
     extern (D) ArgumentList argumentList() { return ArgumentList(arguments, names); }
 
-    extern (D) this(const ref Loc loc, Expression thisexp, Type newtype, Expressions* arguments, Identifiers* names = null) @safe
+    extern (D) this(Loc loc, Expression thisexp, Type newtype, Expressions* arguments, Identifiers* names = null) @safe
     {
         super(loc, EXP.new_);
         this.thisexp = thisexp;
@@ -2468,7 +2468,7 @@ extern (C++) final class NewExp : Expression
         this.names = names;
     }
 
-    static NewExp create(const ref Loc loc, Expression thisexp, Type newtype, Expressions* arguments) @safe
+    static NewExp create(Loc loc, Expression thisexp, Type newtype, Expressions* arguments) @safe
     {
         return new NewExp(loc, thisexp, newtype, arguments);
     }
@@ -2497,7 +2497,7 @@ extern (C++) final class NewAnonClassExp : Expression
     ClassDeclaration cd;    // class being instantiated
     Expressions* arguments; // Array of Expression's to call class constructor
 
-    extern (D) this(const ref Loc loc, Expression thisexp, ClassDeclaration cd, Expressions* arguments) @safe
+    extern (D) this(Loc loc, Expression thisexp, ClassDeclaration cd, Expressions* arguments) @safe
     {
         super(loc, EXP.newAnonymousClass);
         this.thisexp = thisexp;
@@ -2524,7 +2524,7 @@ extern (C++) class SymbolExp : Expression
     Dsymbol originalScope; // original scope before inlining
     bool hasOverloads;
 
-    extern (D) this(const ref Loc loc, EXP op, Declaration var, bool hasOverloads) @safe
+    extern (D) this(Loc loc, EXP op, Declaration var, bool hasOverloads) @safe
     {
         super(loc, op);
         assert(var);
@@ -2545,7 +2545,7 @@ extern (C++) final class SymOffExp : SymbolExp
 {
     dinteger_t offset;
 
-    extern (D) this(const ref Loc loc, Declaration var, dinteger_t offset, bool hasOverloads = true)
+    extern (D) this(Loc loc, Declaration var, dinteger_t offset, bool hasOverloads = true)
     {
         if (auto v = var.isVarDeclaration())
         {
@@ -2580,7 +2580,7 @@ extern (C++) final class SymOffExp : SymbolExp
 extern (C++) final class VarExp : SymbolExp
 {
     bool delegateWasExtracted;
-    extern (D) this(const ref Loc loc, Declaration var, bool hasOverloads = true) @safe
+    extern (D) this(Loc loc, Declaration var, bool hasOverloads = true) @safe
     {
         if (var.isVarDeclaration())
             hasOverloads = false;
@@ -2591,7 +2591,7 @@ extern (C++) final class VarExp : SymbolExp
         this.type = var.type;
     }
 
-    static VarExp create(const ref Loc loc, Declaration var, bool hasOverloads = true) @safe
+    static VarExp create(Loc loc, Declaration var, bool hasOverloads = true) @safe
     {
         return new VarExp(loc, var, hasOverloads);
     }
@@ -2630,7 +2630,7 @@ extern (C++) final class OverExp : Expression
 {
     OverloadSet vars;
 
-    extern (D) this(const ref Loc loc, OverloadSet s)
+    extern (D) this(Loc loc, OverloadSet s)
     {
         super(loc, EXP.overloadSet);
         //printf("OverExp(this = %p, '%s')\n", this, var.toChars());
@@ -2659,7 +2659,7 @@ extern (C++) final class FuncExp : Expression
     TemplateDeclaration td;
     TOK tok;  // TOK.reserved, TOK.delegate_, TOK.function_
 
-    extern (D) this(const ref Loc loc, Dsymbol s)
+    extern (D) this(Loc loc, Dsymbol s)
     {
         super(loc, EXP.function_);
         this.td = s.isTemplateDeclaration();
@@ -2726,7 +2726,7 @@ extern (C++) final class DeclarationExp : Expression
 {
     Dsymbol declaration;
 
-    extern (D) this(const ref Loc loc, Dsymbol declaration) @safe
+    extern (D) this(Loc loc, Dsymbol declaration) @safe
     {
         super(loc, EXP.declaration);
         this.declaration = declaration;
@@ -2759,7 +2759,7 @@ extern (C++) final class TypeidExp : Expression
 {
     RootObject obj;
 
-    extern (D) this(const ref Loc loc, RootObject o) @safe
+    extern (D) this(Loc loc, RootObject o) @safe
     {
         super(loc, EXP.typeid_);
         this.obj = o;
@@ -2784,7 +2784,7 @@ extern (C++) final class TraitsExp : Expression
     Identifier ident;
     Objects* args;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Objects* args) @safe
+    extern (D) this(Loc loc, Identifier ident, Objects* args) @safe
     {
         super(loc, EXP.traits);
         this.ident = ident;
@@ -2809,7 +2809,7 @@ extern (C++) final class TraitsExp : Expression
  */
 extern (C++) final class HaltExp : Expression
 {
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, EXP.halt);
     }
@@ -2833,7 +2833,7 @@ extern (C++) final class IsExp : Expression
     TOK tok;            // ':' or '=='
     TOK tok2;           // 'struct', 'union', etc.
 
-    extern (D) this(const ref Loc loc, Type targ, Identifier id, TOK tok, Type tspec, TOK tok2, TemplateParameters* parameters) scope @safe
+    extern (D) this(Loc loc, Type targ, Identifier id, TOK tok, Type tspec, TOK tok2, TemplateParameters* parameters) scope @safe
     {
         super(loc, EXP.is_);
         this.targ = targ;
@@ -2872,7 +2872,7 @@ extern (C++) abstract class UnaExp : Expression
 {
     Expression e1;
 
-    extern (D) this(const ref Loc loc, EXP op, Expression e1) scope @safe
+    extern (D) this(Loc loc, EXP op, Expression e1) scope @safe
     {
         super(loc, op);
         this.e1 = e1;
@@ -2912,7 +2912,7 @@ extern (C++) abstract class BinExp : Expression
     Expression e1;
     Expression e2;
 
-    extern (D) this(const ref Loc loc, EXP op, Expression e1, Expression e2) scope @safe
+    extern (D) this(Loc loc, EXP op, Expression e1, Expression e2) scope @safe
     {
         super(loc, op);
         this.e1 = e1;
@@ -2953,7 +2953,7 @@ extern (C++) abstract class BinExp : Expression
  */
 extern (C++) class BinAssignExp : BinExp
 {
-    extern (D) this(const ref Loc loc, EXP op, Expression e1, Expression e2) scope @safe
+    extern (D) this(Loc loc, EXP op, Expression e1, Expression e2) scope @safe
     {
         super(loc, op, e1, e2);
     }
@@ -2978,7 +2978,7 @@ extern (C++) final class MixinExp : Expression
 {
     Expressions* exps;
 
-    extern (D) this(const ref Loc loc, Expressions* exps) @safe
+    extern (D) this(Loc loc, Expressions* exps) @safe
     {
         super(loc, EXP.mixin_);
         this.exps = exps;
@@ -3026,7 +3026,7 @@ extern (C++) final class MixinExp : Expression
  */
 extern (C++) final class ImportExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e) @safe
+    extern (D) this(Loc loc, Expression e) @safe
     {
         super(loc, EXP.import_, e);
     }
@@ -3046,7 +3046,7 @@ extern (C++) final class AssertExp : UnaExp
 {
     Expression msg;
 
-    extern (D) this(const ref Loc loc, Expression e, Expression msg = null) @safe
+    extern (D) this(Loc loc, Expression e, Expression msg = null) @safe
     {
         super(loc, EXP.assert_, e);
         this.msg = msg;
@@ -3071,7 +3071,7 @@ extern (C++) final class AssertExp : UnaExp
  */
 extern (C++) final class ThrowExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e)
+    extern (D) this(Loc loc, Expression e)
     {
         super(loc, EXP.throw_, e);
     }
@@ -3096,13 +3096,13 @@ extern (C++) final class DotIdExp : UnaExp
     bool wantsym;       // do not replace Symbol with its initializer during semantic()
     bool arrow;         // ImportC: if -> instead of .
 
-    extern (D) this(const ref Loc loc, Expression e, Identifier ident) @safe
+    extern (D) this(Loc loc, Expression e, Identifier ident) @safe
     {
         super(loc, EXP.dotIdentifier, e);
         this.ident = ident;
     }
 
-    static DotIdExp create(const ref Loc loc, Expression e, Identifier ident) @safe
+    static DotIdExp create(Loc loc, Expression e, Identifier ident) @safe
     {
         return new DotIdExp(loc, e, ident);
     }
@@ -3120,7 +3120,7 @@ extern (C++) final class DotTemplateExp : UnaExp
 {
     TemplateDeclaration td;
 
-    extern (D) this(const ref Loc loc, Expression e, TemplateDeclaration td) @safe
+    extern (D) this(Loc loc, Expression e, TemplateDeclaration td) @safe
     {
         super(loc, EXP.dotTemplateDeclaration, e);
         this.td = td;
@@ -3145,7 +3145,7 @@ extern (C++) final class DotVarExp : UnaExp
     Declaration var;
     bool hasOverloads;
 
-    extern (D) this(const ref Loc loc, Expression e, Declaration var, bool hasOverloads = true) @safe
+    extern (D) this(Loc loc, Expression e, Declaration var, bool hasOverloads = true) @safe
     {
         if (var.isVarDeclaration())
             hasOverloads = false;
@@ -3179,14 +3179,14 @@ extern (C++) final class DotTemplateInstanceExp : UnaExp
 {
     TemplateInstance ti;
 
-    extern (D) this(const ref Loc loc, Expression e, Identifier name, Objects* tiargs)
+    extern (D) this(Loc loc, Expression e, Identifier name, Objects* tiargs)
     {
         super(loc, EXP.dotTemplateInstance, e);
         //printf("DotTemplateInstanceExp()\n");
         this.ti = new TemplateInstance(loc, name, tiargs);
     }
 
-    extern (D) this(const ref Loc loc, Expression e, TemplateInstance ti) @safe
+    extern (D) this(Loc loc, Expression e, TemplateInstance ti) @safe
     {
         super(loc, EXP.dotTemplateInstance, e);
         this.ti = ti;
@@ -3224,7 +3224,7 @@ extern (C++) final class DelegateExp : UnaExp
     bool hasOverloads;
     VarDeclaration vthis2;  // container for multi-context
 
-    extern (D) this(const ref Loc loc, Expression e, FuncDeclaration f, bool hasOverloads = true, VarDeclaration vthis2 = null) @safe
+    extern (D) this(Loc loc, Expression e, FuncDeclaration f, bool hasOverloads = true, VarDeclaration vthis2 = null) @safe
     {
         super(loc, EXP.delegate_, e);
         this.func = f;
@@ -3244,7 +3244,7 @@ extern (C++) final class DotTypeExp : UnaExp
 {
     Dsymbol sym;        // symbol that represents a type
 
-    extern (D) this(const ref Loc loc, Expression e, Dsymbol s) @safe
+    extern (D) this(Loc loc, Expression e, Dsymbol s) @safe
     {
         super(loc, EXP.dotType, e);
         this.sym = s;
@@ -3299,19 +3299,19 @@ extern (C++) final class CallExp : UnaExp
     /// The fields are still separate for backwards compatibility
     extern (D) ArgumentList argumentList() { return ArgumentList(arguments, names); }
 
-    extern (D) this(const ref Loc loc, Expression e, Expressions* exps, Identifiers* names = null) @safe
+    extern (D) this(Loc loc, Expression e, Expressions* exps, Identifiers* names = null) @safe
     {
         super(loc, EXP.call, e);
         this.arguments = exps;
         this.names = names;
     }
 
-    extern (D) this(const ref Loc loc, Expression e) @safe
+    extern (D) this(Loc loc, Expression e) @safe
     {
         super(loc, EXP.call, e);
     }
 
-    extern (D) this(const ref Loc loc, Expression e, Expression earg1)
+    extern (D) this(Loc loc, Expression e, Expression earg1)
     {
         super(loc, EXP.call, e);
         this.arguments = new Expressions();
@@ -3319,7 +3319,7 @@ extern (C++) final class CallExp : UnaExp
             this.arguments.push(earg1);
     }
 
-    extern (D) this(const ref Loc loc, Expression e, Expression earg1, Expression earg2)
+    extern (D) this(Loc loc, Expression e, Expression earg1, Expression earg2)
     {
         super(loc, EXP.call, e);
         auto arguments = new Expressions(2);
@@ -3335,23 +3335,23 @@ extern (C++) final class CallExp : UnaExp
     *       fd    = the declaration of the function to call
     *       earg1 = the function argument
     */
-    extern(D) this(const ref Loc loc, FuncDeclaration fd, Expression earg1)
+    extern(D) this(Loc loc, FuncDeclaration fd, Expression earg1)
     {
         this(loc, new VarExp(loc, fd, false), earg1);
         this.f = fd;
     }
 
-    static CallExp create(const ref Loc loc, Expression e, Expressions* exps) @safe
+    static CallExp create(Loc loc, Expression e, Expressions* exps) @safe
     {
         return new CallExp(loc, e, exps);
     }
 
-    static CallExp create(const ref Loc loc, Expression e) @safe
+    static CallExp create(Loc loc, Expression e) @safe
     {
         return new CallExp(loc, e);
     }
 
-    static CallExp create(const ref Loc loc, Expression e, Expression earg1)
+    static CallExp create(Loc loc, Expression e, Expression earg1)
     {
         return new CallExp(loc, e, earg1);
     }
@@ -3363,7 +3363,7 @@ extern (C++) final class CallExp : UnaExp
     *       fd    = the declaration of the function to call
     *       earg1 = the function argument
     */
-    static CallExp create(const ref Loc loc, FuncDeclaration fd, Expression earg1)
+    static CallExp create(Loc loc, FuncDeclaration fd, Expression earg1)
     {
         return new CallExp(loc, fd, earg1);
     }
@@ -3457,12 +3457,12 @@ FuncDeclaration isFuncAddress(Expression e, bool* hasOverloads = null) @safe
  */
 extern (C++) final class AddrExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e) @safe
+    extern (D) this(Loc loc, Expression e) @safe
     {
         super(loc, EXP.address, e);
     }
 
-    extern (D) this(const ref Loc loc, Expression e, Type t) @safe
+    extern (D) this(Loc loc, Expression e, Type t) @safe
     {
         this(loc, e);
         type = t;
@@ -3479,14 +3479,14 @@ extern (C++) final class AddrExp : UnaExp
  */
 extern (C++) final class PtrExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e) @safe
+    extern (D) this(Loc loc, Expression e) @safe
     {
         super(loc, EXP.star, e);
         //if (e.type)
         //  type = ((TypePointer *)e.type).next;
     }
 
-    extern (D) this(const ref Loc loc, Expression e, Type t) @safe
+    extern (D) this(Loc loc, Expression e, Type t) @safe
     {
         super(loc, EXP.star, e);
         type = t;
@@ -3508,7 +3508,7 @@ extern (C++) final class PtrExp : UnaExp
  */
 extern (C++) final class NegExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e) @safe
+    extern (D) this(Loc loc, Expression e) @safe
     {
         super(loc, EXP.negate, e);
     }
@@ -3524,7 +3524,7 @@ extern (C++) final class NegExp : UnaExp
  */
 extern (C++) final class UAddExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e) scope @safe
+    extern (D) this(Loc loc, Expression e) scope @safe
     {
         super(loc, EXP.uadd, e);
     }
@@ -3540,7 +3540,7 @@ extern (C++) final class UAddExp : UnaExp
  */
 extern (C++) final class ComExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e) @safe
+    extern (D) this(Loc loc, Expression e) @safe
     {
         super(loc, EXP.tilde, e);
     }
@@ -3556,7 +3556,7 @@ extern (C++) final class ComExp : UnaExp
  */
 extern (C++) final class NotExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e) @safe
+    extern (D) this(Loc loc, Expression e) @safe
     {
         super(loc, EXP.not, e);
     }
@@ -3576,7 +3576,7 @@ extern (C++) final class DeleteExp : UnaExp
 {
     bool isRAII;        // true if called automatically as a result of scoped destruction
 
-    extern (D) this(const ref Loc loc, Expression e, bool isRAII) @safe
+    extern (D) this(Loc loc, Expression e, bool isRAII) @safe
     {
         super(loc, EXP.delete_, e);
         this.isRAII = isRAII;
@@ -3601,7 +3601,7 @@ extern (C++) final class CastExp : UnaExp
     ubyte mod = cast(ubyte)~0;  // MODxxxxx
     bool trusted; // assume cast is safe
 
-    extern (D) this(const ref Loc loc, Expression e, Type t) @safe
+    extern (D) this(Loc loc, Expression e, Type t) @safe
     {
         super(loc, EXP.cast_, e);
         this.to = t;
@@ -3609,7 +3609,7 @@ extern (C++) final class CastExp : UnaExp
 
     /* For cast(const) and cast(immutable)
      */
-    extern (D) this(const ref Loc loc, Expression e, ubyte mod) @safe
+    extern (D) this(Loc loc, Expression e, ubyte mod) @safe
     {
         super(loc, EXP.cast_, e);
         this.mod = mod;
@@ -3643,14 +3643,14 @@ extern (C++) final class VectorExp : UnaExp
     uint dim = ~0;      // number of elements in the vector
     OwnedBy ownedByCtfe = OwnedBy.code;
 
-    extern (D) this(const ref Loc loc, Expression e, Type t) @trusted
+    extern (D) this(Loc loc, Expression e, Type t) @trusted
     {
         super(loc, EXP.vector, e);
         assert(t.ty == Tvector);
         to = cast(TypeVector)t;
     }
 
-    static VectorExp create(const ref Loc loc, Expression e, Type t) @safe
+    static VectorExp create(Loc loc, Expression e, Type t) @safe
     {
         return new VectorExp(loc, e, t);
     }
@@ -3673,7 +3673,7 @@ extern (C++) final class VectorExp : UnaExp
  */
 extern (C++) final class VectorArrayExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e1) @safe
+    extern (D) this(Loc loc, Expression e1) @safe
     {
         super(loc, EXP.vectorArray, e1);
     }
@@ -3711,14 +3711,14 @@ extern (C++) final class SliceExp : UnaExp
     mixin(generateBitFields!(BitFields, ubyte));
 
     /************************************************************/
-    extern (D) this(const ref Loc loc, Expression e1, IntervalExp ie) @safe
+    extern (D) this(Loc loc, Expression e1, IntervalExp ie) @safe
     {
         super(loc, EXP.slice, e1);
         this.upr = ie ? ie.upr : null;
         this.lwr = ie ? ie.lwr : null;
     }
 
-    extern (D) this(const ref Loc loc, Expression e1, Expression lwr, Expression upr) @safe
+    extern (D) this(Loc loc, Expression e1, Expression lwr, Expression upr) @safe
     {
         super(loc, EXP.slice, e1);
         this.upr = upr;
@@ -3756,7 +3756,7 @@ extern (C++) final class SliceExp : UnaExp
  */
 extern (C++) final class ArrayLengthExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e1) @safe
+    extern (D) this(Loc loc, Expression e1) @safe
     {
         super(loc, EXP.arrayLength, e1);
     }
@@ -3779,7 +3779,7 @@ extern (C++) final class ArrayExp : UnaExp
     size_t currentDimension;    // for opDollar
     VarDeclaration lengthVar;
 
-    extern (D) this(const ref Loc loc, Expression e1, Expression index = null)
+    extern (D) this(Loc loc, Expression e1, Expression index = null)
     {
         super(loc, EXP.array, e1);
         arguments = new Expressions();
@@ -3787,7 +3787,7 @@ extern (C++) final class ArrayExp : UnaExp
             arguments.push(index);
     }
 
-    extern (D) this(const ref Loc loc, Expression e1, Expressions* args) @safe
+    extern (D) this(Loc loc, Expression e1, Expressions* args) @safe
     {
         super(loc, EXP.array, e1);
         arguments = args;
@@ -3819,7 +3819,7 @@ extern (C++) final class ArrayExp : UnaExp
  */
 extern (C++) final class DotExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.dot, e1, e2);
     }
@@ -3845,7 +3845,7 @@ extern (C++) final class CommaExp : BinExp
     bool allowCommaExp;
 
 
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2, bool generated = true) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2, bool generated = true) @safe
     {
         super(loc, EXP.comma, e1, e2);
         allowCommaExp = isGenerated = generated;
@@ -3896,7 +3896,7 @@ extern (C++) final class IntervalExp : Expression
     Expression lwr;
     Expression upr;
 
-    extern (D) this(const ref Loc loc, Expression lwr, Expression upr) @safe
+    extern (D) this(Loc loc, Expression lwr, Expression upr) @safe
     {
         super(loc, EXP.interval);
         this.lwr = lwr;
@@ -3921,7 +3921,7 @@ extern (C++) final class IntervalExp : Expression
  */
 extern (C++) final class DelegatePtrExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e1) @safe
+    extern (D) this(Loc loc, Expression e1) @safe
     {
         super(loc, EXP.delegatePointer, e1);
     }
@@ -3944,7 +3944,7 @@ extern (C++) final class DelegatePtrExp : UnaExp
  */
 extern (C++) final class DelegateFuncptrExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e1) @safe
+    extern (D) this(Loc loc, Expression e1) @safe
     {
         super(loc, EXP.delegateFunctionPointer, e1);
     }
@@ -3969,13 +3969,13 @@ extern (C++) final class IndexExp : BinExp
     bool modifiable = false;    // assume it is an rvalue
     bool indexIsInBounds;       // true if 0 <= e2 && e2 <= e1.length - 1
 
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.index, e1, e2);
         //printf("IndexExp::IndexExp('%s')\n", toChars());
     }
 
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2, bool indexIsInBounds) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2, bool indexIsInBounds) @safe
     {
         super(loc, EXP.index, e1, e2);
         this.indexIsInBounds = indexIsInBounds;
@@ -4036,7 +4036,7 @@ extern (C++) final class IndexExp : BinExp
  */
 extern (C++) final class PostExp : BinExp
 {
-    extern (D) this(EXP op, const ref Loc loc, Expression e)
+    extern (D) this(EXP op, Loc loc, Expression e)
     {
         super(loc, op, e, IntegerExp.literal!1);
         assert(op == EXP.minusMinus || op == EXP.plusPlus);
@@ -4053,7 +4053,7 @@ extern (C++) final class PostExp : BinExp
  */
 extern (C++) final class PreExp : UnaExp
 {
-    extern (D) this(EXP op, const ref Loc loc, Expression e) @safe
+    extern (D) this(EXP op, Loc loc, Expression e) @safe
     {
         super(loc, op, e);
         assert(op == EXP.preMinusMinus || op == EXP.prePlusPlus);
@@ -4083,12 +4083,12 @@ extern (C++) class AssignExp : BinExp
 
     /************************************************************/
     /* op can be EXP.assign, EXP.construct, or EXP.blit */
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.assign, e1, e2);
     }
 
-    this(const ref Loc loc, EXP tok, Expression e1, Expression e2) @safe
+    this(Loc loc, EXP tok, Expression e1, Expression e2) @safe
     {
         super(loc, tok, e1, e2);
     }
@@ -4136,14 +4136,14 @@ extern (C++) final class LoweredAssignExp : AssignExp
  */
 extern (C++) final class ConstructExp : AssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.construct, e1, e2);
     }
 
     // Internal use only. If `v` is a reference variable, the assignment
     // will become a reference initialization automatically.
-    extern (D) this(const ref Loc loc, VarDeclaration v, Expression e2) @safe
+    extern (D) this(Loc loc, VarDeclaration v, Expression e2) @safe
     {
         auto ve = new VarExp(loc, v);
         assert(v.type && ve.type);
@@ -4165,14 +4165,14 @@ extern (C++) final class ConstructExp : AssignExp
  */
 extern (C++) final class BlitExp : AssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.blit, e1, e2);
     }
 
     // Internal use only. If `v` is a reference variable, the assinment
     // will become a reference rebinding automatically.
-    extern (D) this(const ref Loc loc, VarDeclaration v, Expression e2) @safe
+    extern (D) this(Loc loc, VarDeclaration v, Expression e2) @safe
     {
         auto ve = new VarExp(loc, v);
         assert(v.type && ve.type);
@@ -4194,7 +4194,7 @@ extern (C++) final class BlitExp : AssignExp
  */
 extern (C++) final class AddAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.addAssign, e1, e2);
     }
@@ -4210,7 +4210,7 @@ extern (C++) final class AddAssignExp : BinAssignExp
  */
 extern (C++) final class MinAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.minAssign, e1, e2);
     }
@@ -4226,7 +4226,7 @@ extern (C++) final class MinAssignExp : BinAssignExp
  */
 extern (C++) final class MulAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.mulAssign, e1, e2);
     }
@@ -4242,7 +4242,7 @@ extern (C++) final class MulAssignExp : BinAssignExp
  */
 extern (C++) final class DivAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.divAssign, e1, e2);
     }
@@ -4258,7 +4258,7 @@ extern (C++) final class DivAssignExp : BinAssignExp
  */
 extern (C++) final class ModAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.modAssign, e1, e2);
     }
@@ -4274,7 +4274,7 @@ extern (C++) final class ModAssignExp : BinAssignExp
  */
 extern (C++) final class AndAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.andAssign, e1, e2);
     }
@@ -4290,7 +4290,7 @@ extern (C++) final class AndAssignExp : BinAssignExp
  */
 extern (C++) final class OrAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.orAssign, e1, e2);
     }
@@ -4306,7 +4306,7 @@ extern (C++) final class OrAssignExp : BinAssignExp
  */
 extern (C++) final class XorAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.xorAssign, e1, e2);
     }
@@ -4322,7 +4322,7 @@ extern (C++) final class XorAssignExp : BinAssignExp
  */
 extern (C++) final class PowAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.powAssign, e1, e2);
     }
@@ -4338,7 +4338,7 @@ extern (C++) final class PowAssignExp : BinAssignExp
  */
 extern (C++) final class ShlAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.leftShiftAssign, e1, e2);
     }
@@ -4354,7 +4354,7 @@ extern (C++) final class ShlAssignExp : BinAssignExp
  */
 extern (C++) final class ShrAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.rightShiftAssign, e1, e2);
     }
@@ -4370,7 +4370,7 @@ extern (C++) final class ShrAssignExp : BinAssignExp
  */
 extern (C++) final class UshrAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.unsignedRightShiftAssign, e1, e2);
     }
@@ -4397,12 +4397,12 @@ extern (C++) class CatAssignExp : BinAssignExp
 {
     Expression lowering;    // lowered druntime hook `_d_arrayappend{cTX,T}`
 
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.concatenateAssign, e1, e2);
     }
 
-    extern (D) this(const ref Loc loc, EXP tok, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, EXP tok, Expression e1, Expression e2) @safe
     {
         super(loc, tok, e1, e2);
     }
@@ -4418,7 +4418,7 @@ extern (C++) class CatAssignExp : BinAssignExp
  */
 extern (C++) final class CatElemAssignExp : CatAssignExp
 {
-    extern (D) this(const ref Loc loc, Type type, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Type type, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.concatenateElemAssign, e1, e2);
         this.type = type;
@@ -4435,7 +4435,7 @@ extern (C++) final class CatElemAssignExp : CatAssignExp
  */
 extern (C++) final class CatDcharAssignExp : CatAssignExp
 {
-    extern (D) this(const ref Loc loc, Type type, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Type type, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.concatenateDcharAssign, e1, e2);
         this.type = type;
@@ -4454,7 +4454,7 @@ extern (C++) final class CatDcharAssignExp : CatAssignExp
  */
 extern (C++) final class AddExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.add, e1, e2);
     }
@@ -4472,7 +4472,7 @@ extern (C++) final class AddExp : BinExp
  */
 extern (C++) final class MinExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.min, e1, e2);
     }
@@ -4492,7 +4492,7 @@ extern (C++) final class CatExp : BinExp
 {
     Expression lowering;  // call to druntime hook `_d_arraycatnTX`
 
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) scope @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) scope @safe
     {
         super(loc, EXP.concatenate, e1, e2);
     }
@@ -4510,7 +4510,7 @@ extern (C++) final class CatExp : BinExp
  */
 extern (C++) final class MulExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.mul, e1, e2);
     }
@@ -4528,7 +4528,7 @@ extern (C++) final class MulExp : BinExp
  */
 extern (C++) final class DivExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.div, e1, e2);
     }
@@ -4546,7 +4546,7 @@ extern (C++) final class DivExp : BinExp
  */
 extern (C++) final class ModExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.mod, e1, e2);
     }
@@ -4564,7 +4564,7 @@ extern (C++) final class ModExp : BinExp
  */
 extern (C++) final class PowExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.pow, e1, e2);
     }
@@ -4582,7 +4582,7 @@ extern (C++) final class PowExp : BinExp
  */
 extern (C++) final class ShlExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.leftShift, e1, e2);
     }
@@ -4600,7 +4600,7 @@ extern (C++) final class ShlExp : BinExp
  */
 extern (C++) final class ShrExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.rightShift, e1, e2);
     }
@@ -4618,7 +4618,7 @@ extern (C++) final class ShrExp : BinExp
  */
 extern (C++) final class UshrExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.unsignedRightShift, e1, e2);
     }
@@ -4636,7 +4636,7 @@ extern (C++) final class UshrExp : BinExp
  */
 extern (C++) final class AndExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.and, e1, e2);
     }
@@ -4654,7 +4654,7 @@ extern (C++) final class AndExp : BinExp
  */
 extern (C++) final class OrExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.or, e1, e2);
     }
@@ -4672,7 +4672,7 @@ extern (C++) final class OrExp : BinExp
  */
 extern (C++) final class XorExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.xor, e1, e2);
     }
@@ -4691,7 +4691,7 @@ extern (C++) final class XorExp : BinExp
  */
 extern (C++) final class LogicalExp : BinExp
 {
-    extern (D) this(const ref Loc loc, EXP op, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, EXP op, Expression e1, Expression e2) @safe
     {
         super(loc, op, e1, e2);
         assert(op == EXP.andAnd || op == EXP.orOr);
@@ -4713,7 +4713,7 @@ extern (C++) final class LogicalExp : BinExp
  */
 extern (C++) final class CmpExp : BinExp
 {
-    extern (D) this(EXP op, const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(EXP op, Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, op, e1, e2);
         assert(op == EXP.lessThan || op == EXP.lessOrEqual || op == EXP.greaterThan || op == EXP.greaterOrEqual);
@@ -4734,7 +4734,7 @@ extern (C++) final class CmpExp : BinExp
  */
 extern (C++) final class InExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.in_, e1, e2);
     }
@@ -4752,7 +4752,7 @@ extern (C++) final class InExp : BinExp
  */
 extern (C++) final class RemoveExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+    extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, EXP.remove, e1, e2);
         type = Type.tbool;
@@ -4773,7 +4773,7 @@ extern (C++) final class RemoveExp : BinExp
  */
 extern (C++) final class EqualExp : BinExp
 {
-    extern (D) this(EXP op, const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(EXP op, Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, op, e1, e2);
         assert(op == EXP.equal || op == EXP.notEqual);
@@ -4794,7 +4794,7 @@ extern (C++) final class EqualExp : BinExp
  */
 extern (C++) final class IdentityExp : BinExp
 {
-    extern (D) this(EXP op, const ref Loc loc, Expression e1, Expression e2) @safe
+    extern (D) this(EXP op, Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, op, e1, e2);
         assert(op == EXP.identity || op == EXP.notIdentity);
@@ -4815,7 +4815,7 @@ extern (C++) final class CondExp : BinExp
 {
     Expression econd;
 
-    extern (D) this(const ref Loc loc, Expression econd, Expression e1, Expression e2) scope @safe
+    extern (D) this(Loc loc, Expression econd, Expression e1, Expression e2) scope @safe
     {
         super(loc, EXP.question, e1, e2);
         this.econd = econd;
@@ -4859,7 +4859,7 @@ extern (C++) class DefaultInitExp : Expression
      *  op = EXP.prettyFunction, EXP.functionString, EXP.moduleString,
      *       EXP.line, EXP.file, EXP.fileFullPath
      */
-    extern (D) this(const ref Loc loc, EXP op) @safe
+    extern (D) this(Loc loc, EXP op) @safe
     {
         super(loc, op);
     }
@@ -4875,7 +4875,7 @@ extern (C++) class DefaultInitExp : Expression
  */
 extern (C++) final class FileInitExp : DefaultInitExp
 {
-    extern (D) this(const ref Loc loc, EXP tok) @safe
+    extern (D) this(Loc loc, EXP tok) @safe
     {
         super(loc, tok);
     }
@@ -4891,7 +4891,7 @@ extern (C++) final class FileInitExp : DefaultInitExp
  */
 extern (C++) final class LineInitExp : DefaultInitExp
 {
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, EXP.line);
     }
@@ -4907,7 +4907,7 @@ extern (C++) final class LineInitExp : DefaultInitExp
  */
 extern (C++) final class ModuleInitExp : DefaultInitExp
 {
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, EXP.moduleString);
     }
@@ -4923,7 +4923,7 @@ extern (C++) final class ModuleInitExp : DefaultInitExp
  */
 extern (C++) final class FuncInitExp : DefaultInitExp
 {
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, EXP.functionString);
     }
@@ -4939,7 +4939,7 @@ extern (C++) final class FuncInitExp : DefaultInitExp
  */
 extern (C++) final class PrettyFuncInitExp : DefaultInitExp
 {
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, EXP.prettyFunction);
     }
@@ -4958,7 +4958,7 @@ extern (C++) final class ClassReferenceExp : Expression
 {
     StructLiteralExp value;
 
-    extern (D) this(const ref Loc loc, StructLiteralExp lit, Type type) @safe
+    extern (D) this(Loc loc, StructLiteralExp lit, Type type) @safe
     {
         super(loc, EXP.classReference);
         assert(lit && lit.sd && lit.sd.isClassDeclaration());
@@ -5060,7 +5060,7 @@ extern (C++) final class ThrownExceptionExp : Expression
 {
     ClassReferenceExp thrown;   // the thing being tossed
 
-    extern (D) this(const ref Loc loc, ClassReferenceExp victim) @safe
+    extern (D) this(Loc loc, ClassReferenceExp victim) @safe
     {
         super(loc, EXP.thrownException);
         this.thrown = victim;
@@ -5082,7 +5082,7 @@ extern (C++) final class ObjcClassReferenceExp : Expression
 {
     ClassDeclaration classDeclaration;
 
-    extern (D) this(const ref Loc loc, ClassDeclaration classDeclaration) @safe
+    extern (D) this(Loc loc, ClassDeclaration classDeclaration) @safe
     {
         super(loc, EXP.objcClassReference);
         this.classDeclaration = classDeclaration;
@@ -5104,7 +5104,7 @@ extern (C++) final class GenericExp : Expression
     Types* types;       /// type-names for generic associations (null entry for `default`)
     Expressions* exps;  /// 1:1 mapping of typeNames to exps
 
-    extern (D) this(const ref Loc loc, Expression cntlExp, Types* types, Expressions* exps) @safe
+    extern (D) this(Loc loc, Expression cntlExp, Types* types, Expressions* exps) @safe
     {
         super(loc, EXP._Generic);
         this.cntlExp = cntlExp;

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -51,7 +51,7 @@ namespace dmd
     // in expressionsem.d
     Expression *expressionSemantic(Expression *e, Scope *sc);
     // in typesem.d
-    Expression *defaultInit(Type *mt, const Loc &loc, const bool isCfile = false);
+    Expression *defaultInit(Type *mt, Loc loc, const bool isCfile = false);
 
     // Entry point for CTFE.
     // A compile-time result is required. Give an error if not possible
@@ -233,7 +233,7 @@ class IntegerExp final : public Expression
 public:
     dinteger_t value;
 
-    static IntegerExp *create(const Loc &loc, dinteger_t value, Type *type);
+    static IntegerExp *create(Loc loc, dinteger_t value, Type *type);
     bool equals(const RootObject * const o) const override;
     dinteger_t toInteger() override;
     real_t toReal() override;
@@ -259,7 +259,7 @@ class RealExp final : public Expression
 public:
     real_t value;
 
-    static RealExp *create(const Loc &loc, real_t value, Type *type);
+    static RealExp *create(Loc loc, real_t value, Type *type);
     bool equals(const RootObject * const o) const override;
     bool isIdentical(const Expression *e) const override;
     dinteger_t toInteger() override;
@@ -276,7 +276,7 @@ class ComplexExp final : public Expression
 public:
     complex_t value;
 
-    static ComplexExp *create(const Loc &loc, complex_t value, Type *type);
+    static ComplexExp *create(Loc loc, complex_t value, Type *type);
     bool equals(const RootObject * const o) const override;
     bool isIdentical(const Expression *e) const override;
     dinteger_t toInteger() override;
@@ -293,7 +293,7 @@ class IdentifierExp : public Expression
 public:
     Identifier *ident;
 
-    static IdentifierExp *create(const Loc &loc, Identifier *ident);
+    static IdentifierExp *create(Loc loc, Identifier *ident);
     bool isLvalue() override final;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -353,8 +353,8 @@ public:
     d_bool committed;   // if type is committed
     d_bool hexString;   // if string is parsed from a hex string literal
 
-    static StringExp *create(const Loc &loc, const char *s);
-    static StringExp *create(const Loc &loc, const void *s, d_size_t len);
+    static StringExp *create(Loc loc, const char *s);
+    static StringExp *create(Loc loc, const void *s, d_size_t len);
     bool equals(const RootObject * const o) const override;
     char32_t getCodeUnit(d_size_t i) const;
     dinteger_t getIndex(d_size_t i) const;
@@ -391,7 +391,7 @@ public:
      */
     Expressions *exps;
 
-    static TupleExp *create(const Loc &loc, Expressions *exps);
+    static TupleExp *create(Loc loc, Expressions *exps);
     TupleExp *syntaxCopy() override;
     bool equals(const RootObject * const o) const override;
 
@@ -406,7 +406,7 @@ public:
     Expression *basis;
     Expressions *elements;
 
-    static ArrayLiteralExp *create(const Loc &loc, Expressions *elements);
+    static ArrayLiteralExp *create(Loc loc, Expressions *elements);
     ArrayLiteralExp *syntaxCopy() override;
     bool equals(const RootObject * const o) const override;
     Expression *getElement(d_size_t i);
@@ -472,7 +472,7 @@ public:
     StructLiteralExp *origin;
 
 
-    static StructLiteralExp *create(const Loc &loc, StructDeclaration *sd, void *elements, Type *stype = nullptr);
+    static StructLiteralExp *create(Loc loc, StructDeclaration *sd, void *elements, Type *stype = nullptr);
     bool equals(const RootObject * const o) const override;
     StructLiteralExp *syntaxCopy() override;
 
@@ -526,7 +526,7 @@ public:
 
     Expression *lowering;       // lowered druntime hook: `_d_newclass`
 
-    static NewExp *create(const Loc &loc, Expression *thisexp, Type *newtype, Expressions *arguments);
+    static NewExp *create(Loc loc, Expression *thisexp, Type *newtype, Expressions *arguments);
     NewExp *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -573,7 +573,7 @@ class VarExp final : public SymbolExp
 {
 public:
     d_bool delegateWasExtracted;
-    static VarExp *create(const Loc &loc, Declaration *var, bool hasOverloads = true);
+    static VarExp *create(Loc loc, Declaration *var, bool hasOverloads = true);
     bool equals(const RootObject * const o) const override;
     bool isLvalue() override;
 
@@ -736,7 +736,7 @@ public:
     d_bool wantsym;       // do not replace Symbol with its initializer during semantic()
     d_bool arrow;         // ImportC: if -> instead of .
 
-    static DotIdExp *create(const Loc &loc, Expression *e, Identifier *ident);
+    static DotIdExp *create(Loc loc, Expression *e, Identifier *ident);
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -815,10 +815,10 @@ public:
     d_bool isUfcsRewrite;       // the first argument was pushed in here by a UFCS rewrite
     VarDeclaration *vthis2;     // container for multi-context
 
-    static CallExp *create(const Loc &loc, Expression *e, Expressions *exps);
-    static CallExp *create(const Loc &loc, Expression *e);
-    static CallExp *create(const Loc &loc, Expression *e, Expression *earg1);
-    static CallExp *create(const Loc &loc, FuncDeclaration *fd, Expression *earg1);
+    static CallExp *create(Loc loc, Expression *e, Expressions *exps);
+    static CallExp *create(Loc loc, Expression *e);
+    static CallExp *create(Loc loc, Expression *e, Expression *earg1);
+    static CallExp *create(Loc loc, FuncDeclaration *fd, Expression *earg1);
 
     CallExp *syntaxCopy() override;
     bool isLvalue() override;
@@ -892,7 +892,7 @@ public:
     unsigned dim;               // number of elements in the vector
     OwnedBy ownedByCtfe;
 
-    static VectorExp *create(const Loc &loc, Expression *e, Type *t);
+    static VectorExp *create(Loc loc, Expression *e, Type *t);
     VectorExp *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1564,7 +1564,7 @@ Expression resolvePropertiesOnly(Scope* sc, Expression e1)
  * Returns:
  *      `s` turned into an expression, `ErrorExp` if an error occurred
  */
-Expression symbolToExp(Dsymbol s, const ref Loc loc, Scope* sc, bool hasOverloads)
+Expression symbolToExp(Dsymbol s, Loc loc, Scope* sc, bool hasOverloads)
 {
     static if (LOGSEMANTIC)
     {
@@ -1793,7 +1793,7 @@ Lagain:
  * Returns:
  *      Expression representing the `this` for the var
  */
-private Expression getRightThis(const ref Loc loc, Scope* sc, AggregateDeclaration ad, Expression e1, Dsymbol var, int flag = 0)
+private Expression getRightThis(Loc loc, Scope* sc, AggregateDeclaration ad, Expression e1, Dsymbol var, int flag = 0)
 {
     //printf("\ngetRightThis(e1 = %s, ad = %s, var = %s)\n", e1.toChars(), ad.toChars(), var.toChars());
 L1:
@@ -1960,7 +1960,7 @@ private bool haveSameThis(FuncDeclaration outerFunc, FuncDeclaration calledFunc)
  * we can only call other pure functions.
  * Returns true if error occurs.
  */
-private bool checkPurity(FuncDeclaration f, const ref Loc loc, Scope* sc)
+private bool checkPurity(FuncDeclaration f, Loc loc, Scope* sc)
 {
     if (!sc.func)
         return false;
@@ -2001,7 +2001,7 @@ private bool checkPurity(FuncDeclaration f, const ref Loc loc, Scope* sc)
  *   check = current check (e.g. whether it's pure)
  *   checkName = the kind of check (e.g. `"pure"`)
  */
-void checkOverriddenDtor(FuncDeclaration f, Scope* sc, const ref Loc loc,
+void checkOverriddenDtor(FuncDeclaration f, Scope* sc, Loc loc,
             scope bool function(DtorDeclaration) check, const string checkName)
 {
     auto dd = f.isDtorDeclaration();
@@ -2122,7 +2122,7 @@ public void errorSupplementalInferredAttr(FuncDeclaration fd, int maxDepth, bool
  * Check for purity and safety violations.
  * Returns true if error occurs.
  */
-private bool checkPurity(VarDeclaration v, const ref Loc loc, Scope* sc)
+private bool checkPurity(VarDeclaration v, Loc loc, Scope* sc)
 {
     //printf("v = %s %s\n", v.type.toChars(), v.toChars());
     /* Look for purity and safety violations when accessing variable v
@@ -2794,7 +2794,7 @@ private Type arrayExpressionToCommonType(Scope* sc, ref Expressions exps)
     return t0;
 }
 
-private Expression opAssignToOp(const ref Loc loc, EXP op, Expression e1, Expression e2) @safe
+private Expression opAssignToOp(Loc loc, EXP op, Expression e1, Expression e2) @safe
 {
     Expression e;
     switch (op)
@@ -2979,7 +2979,7 @@ private bool checkDefCtor(Loc loc, Type t)
  * Returns:
  *      true    errors happened
  */
-private bool functionParameters(const ref Loc loc, Scope* sc,
+private bool functionParameters(Loc loc, Scope* sc,
     TypeFunction tf, Expression ethis, Type tthis, ArgumentList argumentList, FuncDeclaration fd,
     Type* prettype, Expression* peprefix)
 {
@@ -13902,7 +13902,7 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
         // symbol.mangleof
 
         // return mangleof as an Expression
-        static Expression dotMangleof(const ref Loc loc, Scope* sc, Dsymbol ds, bool hasOverloads)
+        static Expression dotMangleof(Loc loc, Scope* sc, Dsymbol ds, bool hasOverloads)
         {
             Expression e;
 
@@ -15111,7 +15111,7 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
 /****************************************
  * Resolve __FILE__, __LINE__, __MODULE__, __FUNCTION__, __PRETTY_FUNCTION__, __FILE_FULL_PATH__ to loc.
  */
-Expression resolveLoc(Expression exp, const ref Loc loc, Scope* sc)
+Expression resolveLoc(Expression exp, Loc loc, Scope* sc)
 {
     // Don't replace the special keywords, while we are inside a default
     // argument. They are replaced later when copied to the call site.
@@ -16186,7 +16186,7 @@ private bool checkFunctionAttributes(Expression exp, Scope* sc, FuncDeclaration 
  * Returns:
  *      Expression representing the `this` for the var
  */
-Expression getThisSkipNestedFuncs(const ref Loc loc, Scope* sc, Dsymbol s, AggregateDeclaration ad, Expression e1, Type t, Dsymbol var, bool flag = false)
+Expression getThisSkipNestedFuncs(Loc loc, Scope* sc, Dsymbol s, AggregateDeclaration ad, Expression e1, Type t, Dsymbol var, bool flag = false)
 {
     int n = 0;
     while (s && s.isFuncDeclaration())
@@ -16247,7 +16247,7 @@ Expression getThisSkipNestedFuncs(const ref Loc loc, Scope* sc, Dsymbol s, Aggre
  *      newly created variable such that a closure is made for the variable when
  *      the address of `fd` is taken.
  */
-private VarDeclaration makeThis2Argument(const ref Loc loc, Scope* sc, FuncDeclaration fd)
+private VarDeclaration makeThis2Argument(Loc loc, Scope* sc, FuncDeclaration fd)
 {
     Type tthis2 = Type.tvoidptr.sarrayOf(2);
     VarDeclaration vthis2 = new VarDeclaration(loc, tthis2, Identifier.generateId("__this"), null);
@@ -16273,7 +16273,7 @@ private VarDeclaration makeThis2Argument(const ref Loc loc, Scope* sc, FuncDecla
  * Returns:
  *      a `bool` indicating if the hook is present.
  */
-bool verifyHookExist(const ref Loc loc, ref Scope sc, Identifier id, string description, Identifier module_ = Id.object)
+bool verifyHookExist(Loc loc, ref Scope sc, Identifier id, string description, Identifier module_ = Id.object)
 {
     Dsymbol pscopesym;
     auto rootSymbol = sc.search(loc, Id.empty, pscopesym);
@@ -16297,7 +16297,7 @@ bool verifyHookExist(const ref Loc loc, ref Scope sc, Identifier id, string desc
  *      false if any errors occur,
  *      otherwise true and elements[] are rewritten for the output.
  */
-private bool fit(StructDeclaration sd, const ref Loc loc, Scope* sc, Expressions* elements, Type stype)
+private bool fit(StructDeclaration sd, Loc loc, Scope* sc, Expressions* elements, Type stype)
 {
     if (!elements)
         return true;
@@ -16408,7 +16408,7 @@ private bool fit(StructDeclaration sd, const ref Loc loc, Scope* sc, Expressions
  * Returns:
  *     VarExp referenceing `em` or ErrorExp if `em` if disabled/deprecated
  */
-Expression getVarExp(EnumMember em, const ref Loc loc, Scope* sc)
+Expression getVarExp(EnumMember em, Loc loc, Scope* sc)
 {
     dsymbolSemantic(em, sc);
     if (em.errors)
@@ -17257,7 +17257,7 @@ private bool needsTypeInference(TemplateInstance ti, Scope* sc, int flag = 0)
  *      false if any errors occur.
  *      Otherwise, returns true and the missing arguments will be pushed in elements[].
  */
-bool fill(StructDeclaration sd, const ref Loc loc, ref Expressions elements, bool ctorinit)
+bool fill(StructDeclaration sd, Loc loc, ref Expressions elements, bool ctorinit)
 {
     //printf("AggregateDeclaration::fill() %s\n", toChars());
     assert(sd.sizeok == Sizeok.done);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -493,7 +493,7 @@ public:
     virtual Dsymbol* toAlias();
     virtual Dsymbol* toAlias2();
     virtual bool overloadInsert(Dsymbol* s);
-    virtual uinteger_t size(const Loc& loc);
+    virtual uinteger_t size(Loc loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration* isThis();
     virtual bool isExport() const;
@@ -619,7 +619,7 @@ public:
     virtual void importScope(Dsymbol* s, Visibility visibility);
     virtual bool isPackageAccessible(Package* p, Visibility visibility, uint32_t flags = 0u);
     bool isforwardRef() final override;
-    static void multiplyDefined(const Loc& loc, Dsymbol* s1, Dsymbol* s2);
+    static void multiplyDefined(Loc loc, Dsymbol* s1, Dsymbol* s2);
     const char* kind() const override;
     virtual Dsymbol* symtabInsert(Dsymbol* s);
     virtual Dsymbol* symtabLookup(Dsymbol* s, Identifier* id);
@@ -1538,7 +1538,7 @@ public:
     virtual bool declareParameter(Scope* sc) = 0;
     virtual void print(RootObject* oarg, RootObject* oded) = 0;
     virtual RootObject* specialization() = 0;
-    virtual RootObject* defaultArg(const Loc& instLoc, Scope* sc) = 0;
+    virtual RootObject* defaultArg(Loc instLoc, Scope* sc) = 0;
     virtual bool hasDefaultArg() = 0;
     const char* toChars() const override;
     DYNCAST dyncast() const override;
@@ -1556,7 +1556,7 @@ public:
     bool declareParameter(Scope* sc) override;
     void print(RootObject* oarg, RootObject* oded) override;
     RootObject* specialization() override;
-    RootObject* defaultArg(const Loc& instLoc, Scope* sc) override;
+    RootObject* defaultArg(Loc instLoc, Scope* sc) override;
     bool hasDefaultArg() override;
     void accept(Visitor* v) override;
 };
@@ -1710,7 +1710,7 @@ public:
     bool declareParameter(Scope* sc) final override;
     void print(RootObject* oarg, RootObject* oded) final override;
     RootObject* specialization() final override;
-    RootObject* defaultArg(const Loc& instLoc, Scope* sc) final override;
+    RootObject* defaultArg(Loc instLoc, Scope* sc) final override;
     bool hasDefaultArg() final override;
     void accept(Visitor* v) override;
 };
@@ -1731,7 +1731,7 @@ public:
     bool declareParameter(Scope* sc) override;
     void print(RootObject* oarg, RootObject* oded) override;
     RootObject* specialization() override;
-    RootObject* defaultArg(const Loc& instLoc, Scope* sc) override;
+    RootObject* defaultArg(Loc instLoc, Scope* sc) override;
     bool hasDefaultArg() override;
     void accept(Visitor* v) override;
 };
@@ -1747,7 +1747,7 @@ public:
     bool declareParameter(Scope* sc) override;
     void print(RootObject* oarg, RootObject* oded) override;
     RootObject* specialization() override;
-    RootObject* defaultArg(const Loc& instLoc, Scope* sc) override;
+    RootObject* defaultArg(Loc instLoc, Scope* sc) override;
     bool hasDefaultArg() override;
     void accept(Visitor* v) override;
 };
@@ -1959,7 +1959,7 @@ public:
     virtual uint8_t deduceWild(Type* t, bool isRef);
     virtual ClassDeclaration* isClassHandle();
     virtual structalign_t alignment();
-    virtual Expression* defaultInitLiteral(const Loc& loc);
+    virtual Expression* defaultInitLiteral(Loc loc);
     virtual int32_t hasWild() const;
     virtual bool hasVoidInitPointers();
     virtual bool hasUnsafeBitpatterns();
@@ -2457,7 +2457,7 @@ public:
     bool onstack;
     Expression* basis;
     Array<Expression* >* elements;
-    static ArrayLiteralExp* create(const Loc& loc, Array<Expression* >* elements);
+    static ArrayLiteralExp* create(Loc loc, Array<Expression* >* elements);
     ArrayLiteralExp* syntaxCopy() override;
     bool equals(const RootObject* const o) const override;
     Expression* getElement(size_t i);
@@ -2485,7 +2485,7 @@ class AssignExp : public BinExp
 {
 public:
     MemorySet memset;
-    AssignExp(const Loc& loc, EXP tok, Expression* e1, Expression* e2);
+    AssignExp(Loc loc, EXP tok, Expression* e1, Expression* e2);
     bool isLvalue() final override;
     void accept(Visitor* v) override;
 };
@@ -2524,10 +2524,10 @@ public:
     bool ignoreAttributes;
     bool isUfcsRewrite;
     VarDeclaration* vthis2;
-    static CallExp* create(const Loc& loc, Expression* e, Array<Expression* >* exps);
-    static CallExp* create(const Loc& loc, Expression* e);
-    static CallExp* create(const Loc& loc, Expression* e, Expression* earg1);
-    static CallExp* create(const Loc& loc, FuncDeclaration* fd, Expression* earg1);
+    static CallExp* create(Loc loc, Expression* e, Array<Expression* >* exps);
+    static CallExp* create(Loc loc, Expression* e);
+    static CallExp* create(Loc loc, Expression* e, Expression* earg1);
+    static CallExp* create(Loc loc, FuncDeclaration* fd, Expression* earg1);
     CallExp* syntaxCopy() override;
     bool isLvalue() override;
     void accept(Visitor* v) override;
@@ -2607,7 +2607,7 @@ class ComplexExp final : public Expression
 {
 public:
     complex_t value;
-    static ComplexExp* create(const Loc& loc, complex_t value, Type* type);
+    static ComplexExp* create(Loc loc, complex_t value, Type* type);
     bool equals(const RootObject* const o) const override;
     bool isIdentical(const Expression* const e) const override;
     dinteger_t toInteger() override;
@@ -2702,7 +2702,7 @@ class IdentifierExp : public Expression
 {
 public:
     Identifier* ident;
-    static IdentifierExp* create(const Loc& loc, Identifier* ident);
+    static IdentifierExp* create(Loc loc, Identifier* ident);
     bool isLvalue() final override;
     void accept(Visitor* v) override;
 };
@@ -2726,7 +2726,7 @@ public:
     bool noderef;
     bool wantsym;
     bool arrow;
-    static DotIdExp* create(const Loc& loc, Expression* e, Identifier* ident);
+    static DotIdExp* create(Loc loc, Expression* e, Identifier* ident);
     void accept(Visitor* v) override;
 };
 
@@ -3089,7 +3089,7 @@ class IntegerExp final : public Expression
 {
     dinteger_t value;
 public:
-    static IntegerExp* create(const Loc& loc, dinteger_t value, Type* type);
+    static IntegerExp* create(Loc loc, dinteger_t value, Type* type);
     bool equals(const RootObject* const o) const override;
     dinteger_t toInteger() override;
     _d_real toReal() override;
@@ -3235,7 +3235,7 @@ public:
     bool onstack;
     bool thrownew;
     Expression* lowering;
-    static NewExp* create(const Loc& loc, Expression* thisexp, Type* newtype, Array<Expression* >* arguments);
+    static NewExp* create(Loc loc, Expression* thisexp, Type* newtype, Array<Expression* >* arguments);
     NewExp* syntaxCopy() override;
     void accept(Visitor* v) override;
 };
@@ -3323,7 +3323,7 @@ class RealExp final : public Expression
 {
 public:
     _d_real value;
-    static RealExp* create(const Loc& loc, _d_real value, Type* type);
+    static RealExp* create(Loc loc, _d_real value, Type* type);
     bool equals(const RootObject* const o) const override;
     bool isIdentical(const Expression* const e) const override;
     dinteger_t toInteger() override;
@@ -3433,8 +3433,8 @@ public:
     bool hexString;
     enum : char { NoPostfix = 0u };
 
-    static StringExp* create(const Loc& loc, const char* s);
-    static StringExp* create(const Loc& loc, const void* string, size_t len);
+    static StringExp* create(Loc loc, const char* s);
+    static StringExp* create(Loc loc, const void* string, size_t len);
     bool equals(const RootObject* const o) const override;
     size_t numberOfCodeUnits(int32_t tynto = 0) const;
     void writeTo(void* dest, bool zero, int32_t tyto = 0) const;
@@ -3498,7 +3498,7 @@ public:
         toCBuffer = 32u,
     };
 
-    static StructLiteralExp* create(const Loc& loc, StructDeclaration* sd, void* elements, Type* stype = nullptr);
+    static StructLiteralExp* create(Loc loc, StructDeclaration* sd, void* elements, Type* stype = nullptr);
     bool equals(const RootObject* const o) const override;
     StructLiteralExp* syntaxCopy() override;
     void accept(Visitor* v) override;
@@ -3508,7 +3508,7 @@ class ThisExp : public Expression
 {
 public:
     VarDeclaration* var;
-    ThisExp(const Loc& loc, const EXP tok);
+    ThisExp(Loc loc, const EXP tok);
     ThisExp* syntaxCopy() override;
     Optional<bool > toBool() override;
     bool isLvalue() final override;
@@ -3576,7 +3576,7 @@ class TupleExp final : public Expression
 public:
     Expression* e0;
     Array<Expression* >* exps;
-    static TupleExp* create(const Loc& loc, Array<Expression* >* exps);
+    static TupleExp* create(Loc loc, Array<Expression* >* exps);
     TupleExp* syntaxCopy() override;
     bool equals(const RootObject* const o) const override;
     void accept(Visitor* v) override;
@@ -3620,7 +3620,7 @@ class VarExp final : public SymbolExp
 {
 public:
     bool delegateWasExtracted;
-    static VarExp* create(const Loc& loc, Declaration* var, bool hasOverloads = true);
+    static VarExp* create(Loc loc, Declaration* var, bool hasOverloads = true);
     bool equals(const RootObject* const o) const override;
     bool isLvalue() override;
     void accept(Visitor* v) override;
@@ -3639,7 +3639,7 @@ public:
     TypeVector* to;
     uint32_t dim;
     OwnedBy ownedByCtfe;
-    static VectorExp* create(const Loc& loc, Expression* e, Type* t);
+    static VectorExp* create(Loc loc, Expression* e, Type* t);
     VectorExp* syntaxCopy() override;
     void accept(Visitor* v) override;
 };
@@ -3850,7 +3850,7 @@ private:
     uint32_t bitFields;
 public:
     ObjcFuncDeclaration objc;
-    static FuncDeclaration* create(const Loc& loc, const Loc& endloc, Identifier* id, StorageClass storage_class, Type* type, bool noreturn = false);
+    static FuncDeclaration* create(Loc loc, Loc endloc, Identifier* id, StorageClass storage_class, Type* type, bool noreturn = false);
     Array<Statement* >* frequires();
     Array<Ensure >* fensures();
     Statement* frequire();
@@ -3871,7 +3871,7 @@ public:
     bool equals(const RootObject* const o) const final override;
     bool overloadInsert(Dsymbol* s) override;
     bool inUnittest();
-    LabelDsymbol* searchLabel(Identifier* ident, const Loc& loc);
+    LabelDsymbol* searchLabel(Identifier* ident, Loc loc);
     enum : int32_t { LevelError = -2 };
 
     const char* toPrettyChars(bool QualifyTypes = false) override;
@@ -4233,7 +4233,7 @@ public:
     Identifier* ident;
     Expression* defaultArg;
     UserAttributeDeclaration* userAttribDecl;
-    static Parameter* create(const Loc& loc, StorageClass storageClass, Type* type, Identifier* ident, Expression* defaultArg, UserAttributeDeclaration* userAttribDecl);
+    static Parameter* create(Loc loc, StorageClass storageClass, Type* type, Identifier* ident, Expression* defaultArg, UserAttributeDeclaration* userAttribDecl);
     Parameter* syntaxCopy();
     Type* isLazyArray();
     bool isLazy() const;
@@ -4411,7 +4411,7 @@ class TypeError final : public Type
 public:
     const char* kind() const override;
     TypeError* syntaxCopy() override;
-    Expression* defaultInitLiteral(const Loc& loc) override;
+    Expression* defaultInitLiteral(Loc loc) override;
     void accept(Visitor* v) override;
 };
 
@@ -4547,7 +4547,7 @@ class TypeIdentifier final : public TypeQualified
 public:
     Identifier* ident;
     Dsymbol* originalSymbol;
-    static TypeIdentifier* create(const Loc& loc, Identifier* ident);
+    static TypeIdentifier* create(Loc loc, Identifier* ident);
     const char* kind() const override;
     TypeIdentifier* syntaxCopy() override;
     void accept(Visitor* v) override;
@@ -4628,7 +4628,7 @@ public:
     uint32_t alignsize() override;
     bool isString() override;
     structalign_t alignment() override;
-    Expression* defaultInitLiteral(const Loc& loc) override;
+    Expression* defaultInitLiteral(Loc loc) override;
     bool hasUnsafeBitpatterns() override;
     bool hasVoidInitPointers() override;
     bool hasInvariant() override;
@@ -4659,7 +4659,7 @@ public:
     uint32_t alignsize() override;
     TypeStruct* syntaxCopy() override;
     structalign_t alignment() override;
-    Expression* defaultInitLiteral(const Loc& loc) override;
+    Expression* defaultInitLiteral(Loc loc) override;
     bool isAssignable() override;
     bool isBoolean() override;
     bool needsDestruction() override;
@@ -4737,7 +4737,7 @@ public:
     bool isScalar() override;
     bool isUnsigned() override;
     bool isBoolean() override;
-    Expression* defaultInitLiteral(const Loc& loc) override;
+    Expression* defaultInitLiteral(Loc loc) override;
     TypeBasic* elementType();
     void accept(Visitor* v) override;
 };
@@ -4917,7 +4917,7 @@ class CompoundStatement : public Statement
 {
 public:
     Array<Statement* >* statements;
-    static CompoundStatement* create(const Loc& loc, Statement* s1, Statement* s2);
+    static CompoundStatement* create(Loc loc, Statement* s1, Statement* s2);
     CompoundStatement* syntaxCopy() override;
     ReturnStatement* endsWithReturnStatement() final override;
     Statement* last() final override;
@@ -4990,7 +4990,7 @@ class ExpStatement : public Statement
 {
 public:
     Expression* exp;
-    static ExpStatement* create(const Loc& loc, Expression* exp);
+    static ExpStatement* create(Loc loc, Expression* exp);
     ExpStatement* syntaxCopy() override;
     void accept(Visitor* v) override;
 };
@@ -5318,7 +5318,7 @@ public:
     Statement* finalbody;
     Statement* tryBody;
     bool bodyFallsThru;
-    static TryFinallyStatement* create(const Loc& loc, Statement* _body, Statement* finalbody);
+    static TryFinallyStatement* create(Loc loc, Statement* _body, Statement* finalbody);
     TryFinallyStatement* syntaxCopy() override;
     bool hasBreak() const override;
     bool hasContinue() const override;
@@ -6252,7 +6252,7 @@ public:
     Sizeok sizeok;
     virtual Scope* newScope(Scope* sc);
     virtual void finalizeSize() = 0;
-    uinteger_t size(const Loc& loc) final override;
+    uinteger_t size(Loc loc) final override;
     Type* getType() final override;
     bool isDeprecated() const final override;
     bool isNested() const;
@@ -6349,7 +6349,7 @@ class LinkDeclaration final : public AttribDeclaration
 {
 public:
     LINK linkage;
-    static LinkDeclaration* create(const Loc& loc, LINK p, Array<Dsymbol* >* decl);
+    static LinkDeclaration* create(Loc loc, LINK p, Array<Dsymbol* >* decl);
     LinkDeclaration* syntaxCopy(Dsymbol* s) override;
     void accept(Visitor* v) override;
 };
@@ -6483,7 +6483,7 @@ public:
 
 extern BUILTIN isBuiltin(FuncDeclaration* fd);
 
-extern Expression* eval_builtin(const Loc& loc, FuncDeclaration* fd, Array<Expression* >* arguments);
+extern Expression* eval_builtin(Loc loc, FuncDeclaration* fd, Array<Expression* >* arguments);
 
 extern bool includeImports;
 
@@ -6562,7 +6562,7 @@ public:
     StaticIfCondition* isStaticIfCondition() override;
 };
 
-extern DArray<uint8_t > preprocess(FileName csrcfile, const Loc& loc, OutBuffer& defines);
+extern DArray<uint8_t > preprocess(FileName csrcfile, Loc loc, OutBuffer& defines);
 
 struct BaseClass final
 {
@@ -6607,7 +6607,7 @@ public:
     Baseok baseok;
     ObjcClassDeclaration objc;
     Symbol* cpp_type_info_ptr_sym;
-    static ClassDeclaration* create(const Loc& loc, Identifier* id, Array<BaseClass* >* baseclasses, Array<Dsymbol* >* members, bool inObject);
+    static ClassDeclaration* create(Loc loc, Identifier* id, Array<BaseClass* >* baseclasses, Array<Dsymbol* >* members, bool inObject);
     const char* toPrettyChars(bool qualifyTypes = false) override;
     ClassDeclaration* syntaxCopy(Dsymbol* s) override;
     Scope* newScope(Scope* sc) override;
@@ -6670,7 +6670,7 @@ public:
 
     _d_dynamicArray< const char > mangleOverride;
     const char* kind() const override;
-    uinteger_t size(const Loc& loc) final override;
+    uinteger_t size(Loc loc) final override;
     bool isStatic() const;
     LINK resolvedLinkage() const;
     virtual bool isDelete();
@@ -6724,7 +6724,7 @@ public:
     Dsymbol* aliassym;
     Dsymbol* overnext;
     Dsymbol* _import_;
-    static AliasDeclaration* create(const Loc& loc, Identifier* id, Type* type);
+    static AliasDeclaration* create(Loc loc, Identifier* id, Type* type);
     AliasDeclaration* syntaxCopy(Dsymbol* s) override;
     bool overloadInsert(Dsymbol* s) override;
     const char* kind() const override;
@@ -6805,7 +6805,7 @@ private:
 public:
     int8_t canassign;
     uint8_t isdataseg;
-    static VarDeclaration* create(const Loc& loc, Type* type, Identifier* ident, Initializer* _init, StorageClass storage_class = static_cast<StorageClass>(STC::undefined_));
+    static VarDeclaration* create(Loc loc, Type* type, Identifier* ident, Initializer* _init, StorageClass storage_class = static_cast<StorageClass>(STC::undefined_));
     VarDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
     AggregateDeclaration* isThis() final override;
@@ -7113,12 +7113,12 @@ public:
     size_t namelen;
     static Module* create(const char* filename, Identifier* ident, int32_t doDocComment, int32_t doHdrGen);
     static const char* find(const char* filename);
-    static Module* load(const Loc& loc, Array<Identifier* >* packages, Identifier* ident);
+    static Module* load(Loc loc, Array<Identifier* >* packages, Identifier* ident);
     const char* kind() const override;
-    bool read(const Loc& loc);
+    bool read(Loc loc);
     Module* parse();
     int32_t needModuleInfo();
-    void checkImportDeprecation(const Loc& loc, Scope* sc);
+    void checkImportDeprecation(Loc loc, Scope* sc);
     bool isPackageAccessible(Package* p, Visibility visibility, uint32_t flags = 0u) override;
     Dsymbol* symtabInsert(Dsymbol* s) override;
     static void runDeferredSemantic();
@@ -7233,7 +7233,7 @@ public:
     Identifier* prevAnchor;
     AliasDeclaration* aliasAsg;
     StructDeclaration* argStruct;
-    Dsymbol* search(const Loc& loc, Identifier* ident, Dsymbol*& pscopesym, uint32_t flags = 0u);
+    Dsymbol* search(Loc loc, Identifier* ident, Dsymbol*& pscopesym, uint32_t flags = 0u);
     Scope() :
         enclosing(),
         _module(),
@@ -7366,7 +7366,7 @@ public:
 private:
     uint16_t bitFields;
 public:
-    static StructDeclaration* create(const Loc& loc, Identifier* id, bool inObject);
+    static StructDeclaration* create(Loc loc, Identifier* id, bool inObject);
     StructDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
     void finalizeSize() final override;
@@ -7636,7 +7636,7 @@ public:
     void deinitialize();
     uint32_t alignsize(Type* type);
     uint32_t fieldalign(Type* type);
-    Type* va_listType(const Loc& loc, Scope* sc);
+    Type* va_listType(Loc loc, Scope* sc);
     int32_t isVectorTypeSupported(int32_t sz, Type* type);
     bool isVectorOpSupported(Type* type, EXP op, Type* t2 = nullptr);
     LINK systemLinkage();
@@ -7654,7 +7654,7 @@ private:
     };
 
 public:
-    Expression* getTargetInfo(const char* name, const Loc& loc);
+    Expression* getTargetInfo(const char* name, Loc loc);
     bool isCalleeDestroyingArgs(TypeFunction* tf);
     bool libraryObjectMonitors(FuncDeclaration* fd, Statement* fbody);
     bool supportsLinkerDirective() const;
@@ -7717,7 +7717,7 @@ public:
 
 extern Target target;
 
-extern Type* getTypeInfoType(const Loc& loc, Type* t, Scope* sc);
+extern Type* getTypeInfoType(Loc loc, Type* t, Scope* sc);
 
 class SemanticTimeTransitiveVisitor : public SemanticTimePermissiveVisitor
 {
@@ -8180,23 +8180,23 @@ extern bool c_isxdigit(const int32_t c);
 
 extern bool c_isalnum(const int32_t c);
 
-extern void error(const Loc& loc, const char* format, ...);
+extern void error(Loc loc, const char* format, ...);
 
 extern void error(const char* filename, uint32_t linnum, uint32_t charnum, const char* format, ...);
 
 extern void errorBackend(const char* filename, uint32_t linnum, uint32_t charnum, const char* format, ...);
 
-extern void errorSupplemental(const Loc& loc, const char* format, ...);
+extern void errorSupplemental(Loc loc, const char* format, ...);
 
-extern void warning(const Loc& loc, const char* format, ...);
+extern void warning(Loc loc, const char* format, ...);
 
-extern void warningSupplemental(const Loc& loc, const char* format, ...);
+extern void warningSupplemental(Loc loc, const char* format, ...);
 
-extern void deprecation(const Loc& loc, const char* format, ...);
+extern void deprecation(Loc loc, const char* format, ...);
 
-extern void deprecationSupplemental(const Loc& loc, const char* format, ...);
+extern void deprecationSupplemental(Loc loc, const char* format, ...);
 
-extern void message(const Loc& loc, const char* format, ...);
+extern void message(Loc loc, const char* format, ...);
 
 extern void message(const char* format, ...);
 
@@ -8631,7 +8631,7 @@ struct Global final
 
     ErrorSink* errorSink;
     ErrorSink* errorSinkNull;
-    DArray<uint8_t >(*preprocess)(FileName , const Loc& , OutBuffer& );
+    DArray<uint8_t >(*preprocess)(FileName , Loc , OutBuffer& );
     uint32_t startGagging();
     bool endGagging(uint32_t oldGagged);
     void increaseErrorCount();
@@ -8665,7 +8665,7 @@ struct Global final
         preprocess()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<ImportPathInfo > path = Array<ImportPathInfo >(), Array<const char* > importPaths = Array<const char* >(), Array<const char* > filePath = Array<const char* >(), CompileEnv compileEnv = CompileEnv(), Param params = Param(), uint32_t errors = 0u, uint32_t deprecations = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* > versionids = Array<Identifier* >(), Array<Identifier* > debugids = Array<Identifier* >(), bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, ErrorSink* errorSink = nullptr, ErrorSink* errorSinkNull = nullptr, DArray<uint8_t >(*preprocess)(FileName , const Loc& , OutBuffer& ) = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<ImportPathInfo > path = Array<ImportPathInfo >(), Array<const char* > importPaths = Array<const char* >(), Array<const char* > filePath = Array<const char* >(), CompileEnv compileEnv = CompileEnv(), Param params = Param(), uint32_t errors = 0u, uint32_t deprecations = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* > versionids = Array<Identifier* >(), Array<Identifier* > debugids = Array<Identifier* >(), bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, ErrorSink* errorSink = nullptr, ErrorSink* errorSinkNull = nullptr, DArray<uint8_t >(*preprocess)(FileName , Loc , OutBuffer& ) = nullptr) :
         inifilename(inifilename),
         copyright(copyright),
         written(written),

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -296,7 +296,7 @@ extern (C++) class FuncDeclaration : Declaration
      */
     ObjcFuncDeclaration objc;
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, Identifier ident, StorageClass storage_class, Type type, bool noreturn = false)
+    extern (D) this(Loc loc, Loc endloc, Identifier ident, StorageClass storage_class, Type type, bool noreturn = false)
     {
         super(loc, ident);
         //.printf("FuncDeclaration(id = '%s', type = %s)\n", ident.toChars(), type.toChars());
@@ -320,7 +320,7 @@ extern (C++) class FuncDeclaration : Declaration
             this.inferRetType = true;
     }
 
-    static FuncDeclaration create(const ref Loc loc, const ref Loc endloc, Identifier id, StorageClass storage_class, Type type, bool noreturn = false)
+    static FuncDeclaration create(Loc loc, Loc endloc, Identifier id, StorageClass storage_class, Type type, bool noreturn = false)
     {
         return new FuncDeclaration(loc, endloc, id, storage_class, type, noreturn);
     }
@@ -504,7 +504,7 @@ extern (C++) class FuncDeclaration : Declaration
      *
      * Returns: the `LabelDsymbol` for `ident`
      */
-    final LabelDsymbol searchLabel(Identifier ident, const ref Loc loc)
+    final LabelDsymbol searchLabel(Identifier ident, Loc loc)
     {
         Dsymbol s;
         if (!labtab)
@@ -1290,7 +1290,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
     // backend
     bool deferToObj;
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, StorageClass storage_class = STC.undefined_)
+    extern (D) this(Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, StorageClass storage_class = STC.undefined_)
     {
         super(loc, endloc, null, storage_class, type);
         this.ident = id ? id : Id.empty;
@@ -1371,7 +1371,7 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
 {
     bool isCpCtor;    // copy constructor
     bool isMoveCtor;  // move constructor (aka rvalue constructor)
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Type type)
+    extern (D) this(Loc loc, Loc endloc, StorageClass stc, Type type)
     {
         super(loc, endloc, Id.ctor, stc, type);
         //printf("CtorDeclaration(loc = %s) %s %p\n", loc.toChars(), toChars(), this);
@@ -1420,7 +1420,7 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
  */
 extern (C++) final class PostBlitDeclaration : FuncDeclaration
 {
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Identifier id)
+    extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id)
     {
         super(loc, endloc, id, stc, null);
     }
@@ -1468,12 +1468,12 @@ extern (C++) final class PostBlitDeclaration : FuncDeclaration
  */
 extern (C++) final class DtorDeclaration : FuncDeclaration
 {
-    extern (D) this(const ref Loc loc, const ref Loc endloc)
+    extern (D) this(Loc loc, Loc endloc)
     {
         super(loc, endloc, Id.dtor, STC.undefined_, null);
     }
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Identifier id)
+    extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id)
     {
         super(loc, endloc, id, stc, null);
     }
@@ -1528,12 +1528,12 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
  */
 extern (C++) class StaticCtorDeclaration : FuncDeclaration
 {
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc("_staticCtor", loc), STC.static_ | stc, null);
     }
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, string name, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, string name, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
     }
@@ -1589,7 +1589,7 @@ extern (C++) final class SharedStaticCtorDeclaration : StaticCtorDeclaration
     /// Exclude this constructor from cyclic dependency check
     bool standalone;
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, "_sharedStaticCtor", stc);
     }
@@ -1619,12 +1619,12 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
 {
     VarDeclaration vgate; // 'gate' variable
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc("_staticDtor", loc), STC.static_ | stc, null);
     }
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, string name, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, string name, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
     }
@@ -1677,7 +1677,7 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
  */
 extern (C++) final class SharedStaticDtorDeclaration : StaticDtorDeclaration
 {
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, "_sharedStaticDtor", stc);
     }
@@ -1705,7 +1705,7 @@ extern (C++) final class SharedStaticDtorDeclaration : StaticDtorDeclaration
  */
 extern (C++) final class InvariantDeclaration : FuncDeclaration
 {
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Identifier id, Statement fbody)
+    extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id, Statement fbody)
     {
         // Make a unique invariant for now; we'll fix it up as we add it to the aggregate invariant list.
         super(loc, endloc, id ? id : Identifier.generateId("__invariant"), stc, null);
@@ -1765,7 +1765,7 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
     // toObjFile() these nested functions after this one
     FuncDeclarations deferredNested;
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, char* codedoc)
+    extern (D) this(Loc loc, Loc endloc, StorageClass stc, char* codedoc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc("__unittest", loc), stc, null);
         this.codedoc = codedoc;
@@ -1814,7 +1814,7 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
  */
 extern (C++) final class NewDeclaration : FuncDeclaration
 {
-    extern (D) this(const ref Loc loc, StorageClass stc)
+    extern (D) this(Loc loc, StorageClass stc)
     {
         super(loc, Loc.initial, Id.classNew, STC.static_ | stc, null);
     }
@@ -1875,9 +1875,9 @@ struct AttributeViolation
 
     string action;   /// Action that made the attribute fail to get inferred
 
-    this(ref Loc loc, FuncDeclaration fd) { this.loc = loc; this.fd = fd; }
+    this(Loc loc, FuncDeclaration fd) { this.loc = loc; this.fd = fd; }
 
-    this(ref Loc loc, const(char)* fmt, RootObject[] args)
+    this(Loc loc, const(char)* fmt, RootObject[] args)
     {
         this.loc = loc;
         assert(args.length <= 4); // expand if necessary

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1333,7 +1333,7 @@ extern (D) void declareThis(FuncDeclaration fd, Scope* sc)
  * Check that this function type is properly resolved.
  * If not, report "forward reference error" and return true.
  */
-extern (D) bool checkForwardRef(FuncDeclaration fd, const ref Loc loc)
+extern (D) bool checkForwardRef(FuncDeclaration fd, Loc loc)
 {
     if (!functionSemantic(fd))
         return true;
@@ -1526,7 +1526,7 @@ enum FuncResolveFlag : ubyte
  * Returns:
  *      if match is found, then function symbol, else null
  */
-FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
+FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
     Objects* tiargs, Type tthis, ArgumentList argumentList, FuncResolveFlag flags)
 {
     //printf("resolveFuncCall() %s\n", s.toChars());
@@ -1809,7 +1809,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
  *      declaration =    the declaration to print overload candidates for
  *      showDeprecated = If `false`, `deprecated` function won't be shown
  */
-private void printCandidates(Decl)(const ref Loc loc, Decl declaration, bool showDeprecated)
+private void printCandidates(Decl)(Loc loc, Decl declaration, bool showDeprecated)
 {
     // max num of overloads to print (-v or -verror-supplements overrides this).
     const uint DisplayLimit = global.params.v.errorSupplementCount();
@@ -2146,7 +2146,7 @@ L1:
  * 4. If there's no candidates, it's "no match" and returns null with error report.
  *      e.g. If 'tthis' is const but there's no const methods.
  */
-FuncDeclaration overloadModMatch(FuncDeclaration thisfd, const ref Loc loc, Type tthis, ref bool hasOverloads)
+FuncDeclaration overloadModMatch(FuncDeclaration thisfd, Loc loc, Type tthis, ref bool hasOverloads)
 {
     //printf("FuncDeclaration::overloadModMatch('%s')\n", toChars());
     MatchAccumulator m;
@@ -2246,7 +2246,7 @@ FuncDeclaration overloadModMatch(FuncDeclaration thisfd, const ref Loc loc, Type
  *      -1      increase nesting by 1 (`target` is nested within 'fd')
  *      LevelError  error
  */
-int getLevelAndCheck(FuncDeclaration fd, const ref Loc loc, Scope* sc, FuncDeclaration target,
+int getLevelAndCheck(FuncDeclaration fd, Loc loc, Scope* sc, FuncDeclaration target,
                      Declaration decl)
 {
     int level = fd.getLevel(target, sc.intypeof);
@@ -2315,7 +2315,7 @@ bool canInferAttributes(FuncDeclaration fd, Scope* sc)
  *    then mark it as a delegate.
  * Returns true if error occurs.
  */
-bool checkNestedFuncReference(FuncDeclaration fd, Scope* sc, const ref Loc loc)
+bool checkNestedFuncReference(FuncDeclaration fd, Scope* sc, Loc loc)
 {
     //printf("FuncDeclaration::checkNestedFuncReference() %s\n", toPrettyChars());
     if (auto fld = fd.isFuncLiteralDeclaration())

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -326,7 +326,7 @@ extern (C++) struct Global
     ErrorSink errorSink;       /// where the error messages go
     ErrorSink errorSinkNull;   /// where the error messages are ignored
 
-    extern (C++) DArray!ubyte function(FileName, ref const Loc, ref OutBuffer) preprocess;
+    extern (C++) DArray!ubyte function(FileName, Loc, ref OutBuffer) preprocess;
 
   nothrow:
 

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -349,7 +349,7 @@ struct Global
     ErrorSink* errorSink;       // where the error messages go
     ErrorSink* errorSinkNull;   // where the error messages disappear
 
-    DArray<unsigned char> (*preprocess)(FileName, const Loc&, OutBuffer&);
+    DArray<unsigned char> (*preprocess)(FileName, Loc, OutBuffer&);
 
     /* Start gagging. Return the current number of gagged errors
      */
@@ -442,7 +442,7 @@ public:
     const char *toChars(
         bool showColumns = Loc::showColumns,
         MessageStyle messageStyle = Loc::messageStyle) const;
-    bool equals(const Loc& loc) const;
+    bool equals(Loc loc) const;
 };
 
 enum class LINK : uint8_t

--- a/compiler/src/dmd/identifier.d
+++ b/compiler/src/dmd/identifier.d
@@ -221,7 +221,7 @@ nothrow:
      *      Identifier (inside Identifier.idPool) with deterministic name based
      *      on the source location.
      */
-    extern (D) static Identifier generateIdWithLoc(string prefix, const ref Loc loc, string parent = "")
+    extern (D) static Identifier generateIdWithLoc(string prefix, Loc loc, string parent = "")
     {
         // generate `<prefix>_L<line>_C<col>`
         auto sl = SourceLoc(loc);

--- a/compiler/src/dmd/init.d
+++ b/compiler/src/dmd/init.d
@@ -46,7 +46,7 @@ extern (C++) class Initializer : ASTNode
     }
 
 
-    extern (D) this(const ref Loc loc, InitKind kind) @safe
+    extern (D) this(Loc loc, InitKind kind) @safe
     {
         this.loc = loc;
         this.kind = kind;
@@ -100,7 +100,7 @@ extern (C++) final class VoidInitializer : Initializer
 {
     Type type;      // type that this will initialize to
 
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, InitKind.void_);
     }
@@ -118,7 +118,7 @@ extern (C++) final class DefaultInitializer : Initializer
 {
     Type type;      // type that this will initialize to
 
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, InitKind.default_);
     }
@@ -151,7 +151,7 @@ extern (C++) final class StructInitializer : Initializer
     Identifiers field;      // of Identifier *'s
     Initializers value;     // parallel array of Initializer *'s
 
-    extern (D) this(const ref Loc loc)
+    extern (D) this(Loc loc)
     {
         super(loc, InitKind.struct_);
     }
@@ -179,7 +179,7 @@ extern (C++) final class ArrayInitializer : Initializer
     Type type;              // type that array will be used to initialize
     bool isCarray;          // C array semantics
 
-    extern (D) this(const ref Loc loc)
+    extern (D) this(Loc loc)
     {
         super(loc, InitKind.array);
     }
@@ -215,7 +215,7 @@ extern (C++) final class ExpInitializer : Initializer
     bool expandTuples;
     Expression exp;
 
-    extern (D) this(const ref Loc loc, Expression exp) @safe
+    extern (D) this(Loc loc, Expression exp) @safe
     {
         super(loc, InitKind.exp);
         this.exp = exp;
@@ -257,7 +257,7 @@ extern (C++) final class CInitializer : Initializer
     DesigInits initializerList; /// initializer-list
     Type type;              /// type that array will be used to initialize
 
-    extern (D) this(const ref Loc loc)
+    extern (D) this(Loc loc)
     {
         super(loc, InitKind.C_);
     }

--- a/compiler/src/dmd/json.d
+++ b/compiler/src/dmd/json.d
@@ -347,7 +347,7 @@ public:
         }
     }
 
-    extern(D) void property(const char[] linename, const char[] charname, const ref Loc loc)
+    extern(D) void property(const char[] linename, const char[] charname, Loc loc)
     {
         if (loc.isValid())
         {

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -1464,7 +1464,7 @@ class Lexer
      * Returns:
      *  the escape sequence as a single character
      */
-    private dchar escapeSequence(const ref Loc loc, ref const(char)* sequence, bool Ccompile, out dchar c2)
+    private dchar escapeSequence(Loc loc, ref const(char)* sequence, bool Ccompile, out dchar c2)
     {
         const(char)* p = sequence; // cache sequence reference on stack
         scope(exit) sequence = p;
@@ -3163,7 +3163,7 @@ class Lexer
         eSink.error(token.loc, format, args);
     }
 
-    void error(T...)(const ref Loc loc, const(char)* format, T args)
+    void error(T...)(Loc loc, const(char)* format, T args)
     {
         eSink.error(loc, format, args);
     }
@@ -3173,12 +3173,12 @@ class Lexer
         eSink.errorSupplemental(token.loc, format, args);
     }
 
-    void deprecation(T...)(const ref Loc loc, const(char)* format, T args)
+    void deprecation(T...)(Loc loc, const(char)* format, T args)
     {
         eSink.deprecation(loc, format, args);
     }
 
-    void warning(T...)(const ref Loc loc, const(char)* format, T args)
+    void warning(T...)(Loc loc, const(char)* format, T args)
     {
         eSink.warning(loc, format, args);
     }
@@ -3678,7 +3678,7 @@ unittest
         string expectedSupplemental;
         bool gotError;
 
-        void verror(const ref Loc loc, const(char)* format, va_list ap)
+        void verror(Loc loc, const(char)* format, va_list ap)
         {
             gotError = true;
             char[100] buffer = void;
@@ -3686,7 +3686,7 @@ unittest
             assert(expected == actual);
         }
 
-        void errorSupplemental(const ref Loc loc, const(char)* format, ...)
+        void errorSupplemental(Loc loc, const(char)* format, ...)
         {
             gotError = true;
             char[128] buffer = void;

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -948,7 +948,7 @@ public int runProgram(const char[] exefile, const char*[] runargs, bool verbose,
  * Returns:
  *    error status, 0 for success
  */
-public int runPreprocessor(ref const Loc loc, const(char)[] cpp, const(char)[] filename, const(char)* importc_h, ref Array!(const(char)*) cppswitches,
+public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, const(char)* importc_h, ref Array!(const(char)*) cppswitches,
     bool verbose, ErrorSink eSink, ref OutBuffer defines, out DArray!ubyte text)
 {
     //printf("runPreprocessor() cpp: %.*s filename: %.*s\n", cast(int)cpp.length, cpp.ptr, cast(int)filename.length, filename.ptr);
@@ -1577,7 +1577,7 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)
 
         extern(C++): override:
 
-        void verror(const ref Loc loc, const(char)* format, va_list ap)
+        void verror(Loc loc, const(char)* format, va_list ap)
         {
             assert(format[0 .. strlen(format)] == expectedFormat);
             const expectedSymbol = expectedSymbols[errorCount++];
@@ -1586,7 +1586,7 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)
             assert(actualSymbol == expectedSymbol, "expected " ~ expectedSymbol ~ ", not " ~ actualSymbol);
         }
 
-        void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap)
+        void verrorSupplemental(Loc loc, const(char)* format, va_list ap)
         {
             assert(format.startsWith("perhaps") || format.startsWith("referenced from "));
         }

--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -41,7 +41,7 @@ struct Loc
     version (DigitalMars) version (linux) version (X86)
         private uint dummy;
 
-    static immutable Loc initial; /// use for default initialization of const ref Loc's
+    static immutable Loc initial; /// use for default initialization of Loc's
 
     extern (C++) __gshared bool showColumns;
     extern (C++) __gshared MessageStyle messageStyle;

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -464,7 +464,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     /* Read ddoc macro files named by the DDOCFILE environment variable and command line
      * and concatenate the text into ddocbuf
      */
-    void readDdocFiles(ref const Loc loc, ref const Strings ddocfiles, ref OutBuffer ddocbuf)
+    void readDdocFiles(Loc loc, ref const Strings ddocfiles, ref OutBuffer ddocbuf)
     {
         foreach (file; ddocfiles)
         {

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -123,10 +123,10 @@ public:
 
     static Module* create(const char *arg, Identifier *ident, int doDocComment, int doHdrGen);
     static const char *find(const char *filename);
-    static Module *load(const Loc &loc, Identifiers *packages, Identifier *ident);
+    static Module *load(Loc loc, Identifiers *packages, Identifier *ident);
 
     const char *kind() const override;
-    bool read(const Loc &loc); // read file, returns 'true' if succeed, 'false' otherwise.
+    bool read(Loc loc); // read file, returns 'true' if succeed, 'false' otherwise.
     Module *parse();    // syntactic parse
     int needModuleInfo();
     bool isPackageAccessible(Package *p, Visibility visibility, SearchOptFlags flags = (SearchOptFlags)SearchOpt::all) override;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1327,7 +1327,7 @@ extern (C++) abstract class Type : ASTNode
      * Use when we prefer the default initializer to be a literal,
      * rather than a global immutable variable.
      */
-    Expression defaultInitLiteral(const ref Loc loc)
+    Expression defaultInitLiteral(Loc loc)
     {
         static if (LOGDEFAULTINIT)
         {
@@ -1572,7 +1572,7 @@ extern (C++) final class TypeError : Type
         return this;
     }
 
-    override Expression defaultInitLiteral(const ref Loc loc)
+    override Expression defaultInitLiteral(Loc loc)
     {
         return ErrorExp.get();
     }
@@ -2118,7 +2118,7 @@ extern (C++) final class TypeVector : Type
         return false;
     }
 
-    override Expression defaultInitLiteral(const ref Loc loc)
+    override Expression defaultInitLiteral(Loc loc)
     {
         //printf("TypeVector::defaultInitLiteral()\n");
         assert(basetype.ty == Tsarray);
@@ -2219,7 +2219,7 @@ extern (C++) final class TypeSArray : TypeArray
         return next.alignment();
     }
 
-    override Expression defaultInitLiteral(const ref Loc loc)
+    override Expression defaultInitLiteral(Loc loc)
     {
         static if (LOGDEFAULTINIT)
         {
@@ -2814,7 +2814,7 @@ extern (C++) final class TypeTraits : Type
     /// Cached type/symbol after semantic analysis.
     RootObject obj;
 
-    final extern (D) this(const ref Loc loc, TraitsExp exp) @safe
+    final extern (D) this(Loc loc, TraitsExp exp) @safe
     {
         super(Ttraits);
         this.loc = loc;
@@ -2851,7 +2851,7 @@ extern (C++) final class TypeMixin : Type
     Expressions* exps;
     RootObject obj; // cached result of semantic analysis.
 
-    extern (D) this(const ref Loc loc, Expressions* exps) @safe
+    extern (D) this(Loc loc, Expressions* exps) @safe
     {
         super(Tmixin);
         this.loc = loc;
@@ -2962,13 +2962,13 @@ extern (C++) final class TypeIdentifier : TypeQualified
     // The symbol representing this identifier, before alias resolution
     Dsymbol originalSymbol;
 
-    extern (D) this(const ref Loc loc, Identifier ident)
+    extern (D) this(Loc loc, Identifier ident)
     {
         super(Tident, loc);
         this.ident = ident;
     }
 
-    static TypeIdentifier create(const ref Loc loc, Identifier ident)
+    static TypeIdentifier create(Loc loc, Identifier ident)
     {
         return new TypeIdentifier(loc, ident);
     }
@@ -2999,7 +2999,7 @@ extern (C++) final class TypeInstance : TypeQualified
 {
     TemplateInstance tempinst;
 
-    extern (D) this(const ref Loc loc, TemplateInstance tempinst)
+    extern (D) this(Loc loc, TemplateInstance tempinst)
     {
         super(Tinstance, loc);
         this.tempinst = tempinst;
@@ -3032,7 +3032,7 @@ extern (C++) final class TypeTypeof : TypeQualified
     Expression exp;
     int inuse;
 
-    extern (D) this(const ref Loc loc, Expression exp)
+    extern (D) this(Loc loc, Expression exp)
     {
         super(Ttypeof, loc);
         this.exp = exp;
@@ -3062,7 +3062,7 @@ extern (C++) final class TypeTypeof : TypeQualified
  */
 extern (C++) final class TypeReturn : TypeQualified
 {
-    extern (D) this(const ref Loc loc)
+    extern (D) this(Loc loc)
     {
         super(Treturn, loc);
     }
@@ -3132,7 +3132,7 @@ extern (C++) final class TypeStruct : Type
      * Use when we prefer the default initializer to be a literal,
      * rather than a global immutable variable.
      */
-    override Expression defaultInitLiteral(const ref Loc loc)
+    override Expression defaultInitLiteral(Loc loc)
     {
         static if (LOGDEFAULTINIT)
         {
@@ -3769,7 +3769,7 @@ extern (C++) final class TypeTag : Type
                             ///   struct S { int a; } s1, *s2;
     MOD mod;                /// modifiers to apply after type is resolved (only MODFlags.const_ at the moment)
 
-    extern (D) this(const ref Loc loc, TOK tok, Identifier id, structalign_t packalign, Type base, Dsymbols* members) @safe
+    extern (D) this(Loc loc, TOK tok, Identifier id, structalign_t packalign, Type base, Dsymbols* members) @safe
     {
         //printf("TypeTag ctor %s %p\n", id ? id.toChars() : "null".ptr, this);
         super(Ttag);
@@ -3917,7 +3917,7 @@ extern (C++) final class Parameter : ASTNode
     Expression defaultArg;
     UserAttributeDeclaration userAttribDecl; // user defined attributes
 
-    extern (D) this(const ref Loc loc, StorageClass storageClass, Type type, Identifier ident, Expression defaultArg, UserAttributeDeclaration userAttribDecl) @safe
+    extern (D) this(Loc loc, StorageClass storageClass, Type type, Identifier ident, Expression defaultArg, UserAttributeDeclaration userAttribDecl) @safe
     {
         this.loc = loc;
         this.type = type;
@@ -3927,7 +3927,7 @@ extern (C++) final class Parameter : ASTNode
         this.userAttribDecl = userAttribDecl;
     }
 
-    static Parameter create(const ref Loc loc, StorageClass storageClass, Type type, Identifier ident, Expression defaultArg, UserAttributeDeclaration userAttribDecl) @safe
+    static Parameter create(Loc loc, StorageClass storageClass, Type type, Identifier ident, Expression defaultArg, UserAttributeDeclaration userAttribDecl) @safe
     {
         return new Parameter(loc, storageClass, type, ident, defaultArg, userAttribDecl);
     }

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -42,7 +42,7 @@ typedef struct TYPE type;
 
 namespace dmd
 {
-    Type *typeSemantic(Type *t, const Loc &loc, Scope *sc);
+    Type *typeSemantic(Type *t, Loc loc, Scope *sc);
     Type *merge(Type *type);
 }
 
@@ -268,7 +268,7 @@ public:
 
     virtual ClassDeclaration *isClassHandle();
     virtual structalign_t alignment();
-    virtual Expression *defaultInitLiteral(const Loc &loc);
+    virtual Expression *defaultInitLiteral(Loc loc);
     virtual int hasWild() const;
     virtual bool hasVoidInitPointers();
     virtual bool hasUnsafeBitpatterns();
@@ -318,7 +318,7 @@ public:
     const char *kind() override;
     TypeError *syntaxCopy() override;
 
-    Expression *defaultInitLiteral(const Loc &loc) override;
+    Expression *defaultInitLiteral(Loc loc) override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -379,7 +379,7 @@ public:
     bool isScalar() override;
     bool isUnsigned() override;
     bool isBoolean() override;
-    Expression *defaultInitLiteral(const Loc &loc) override;
+    Expression *defaultInitLiteral(Loc loc) override;
     TypeBasic *elementType();
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -403,7 +403,7 @@ public:
     unsigned alignsize() override;
     bool isString() override;
     structalign_t alignment() override;
-    Expression *defaultInitLiteral(const Loc &loc) override;
+    Expression *defaultInitLiteral(Loc loc) override;
     bool hasUnsafeBitpatterns() override;
     bool hasVoidInitPointers() override;
     bool hasInvariant() override;
@@ -498,7 +498,7 @@ public:
     Expression *defaultArg;
     UserAttributeDeclaration *userAttribDecl;   // user defined attributes
 
-    static Parameter *create(const Loc &loc, StorageClass storageClass, Type *type, Identifier *ident,
+    static Parameter *create(Loc loc, StorageClass storageClass, Type *type, Identifier *ident,
                              Expression *defaultArg, UserAttributeDeclaration *userAttribDecl);
     Parameter *syntaxCopy();
     Type *isLazyArray();
@@ -632,7 +632,7 @@ public:
     Identifier *ident;
     Dsymbol *originalSymbol; // The symbol representing this identifier, before alias resolution
 
-    static TypeIdentifier *create(const Loc &loc, Identifier *ident);
+    static TypeIdentifier *create(Loc loc, Identifier *ident);
     const char *kind() override;
     TypeIdentifier *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
@@ -693,7 +693,7 @@ public:
     unsigned alignsize() override;
     TypeStruct *syntaxCopy() override;
     structalign_t alignment() override;
-    Expression *defaultInitLiteral(const Loc &loc) override;
+    Expression *defaultInitLiteral(Loc loc) override;
     bool isAssignable() override;
     bool isBoolean() override;
     bool needsDestruction() override;
@@ -715,7 +715,7 @@ public:
     const char *kind() override;
     TypeEnum *syntaxCopy() override;
     unsigned alignsize() override;
-    Type *memType(const Loc &loc);
+    Type *memType(Loc loc);
     bool isIntegral() override;
     bool isFloating() override;
     bool isReal() override;
@@ -825,8 +825,8 @@ namespace dmd
     bool equivalent(Type *src, Type *t);
     Covariant covariant(Type *, Type *, StorageClass * = nullptr, bool = false);
     bool isBaseOf(Type *tthis, Type *t, int *poffset);
-    bool isZeroInit(Type *t, const Loc &loc = Loc());
-    Type *trySemantic(Type *type, const Loc &loc, Scope *sc);
+    bool isZeroInit(Type *t, Loc loc = Loc());
+    Type *trySemantic(Type *type, Loc loc, Scope *sc);
     Type *pointerTo(Type *type);
     Type *referenceTo(Type *type);
     Type *merge2(Type *type);
@@ -850,7 +850,7 @@ namespace dmd
     Type *addStorageClass(Type *type, StorageClass stc);
     Type *substWildTo(Type *type, unsigned mod);
     uinteger_t size(Type *type);
-    uinteger_t size(Type *type, const Loc &loc);
+    uinteger_t size(Type *type, Loc loc);
     MATCH implicitConvTo(Type* from, Type* to);
     MATCH constConv(Type* from, Type* to);
 }

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -242,7 +242,7 @@ Expression checkGC(Scope* sc, Expression e)
     return e;
 }
 
-extern (D) void printGCUsage(FuncDeclaration fd, const ref Loc loc, const(char)* warn)
+extern (D) void printGCUsage(FuncDeclaration fd, Loc loc, const(char)* warn)
 {
     if (!global.params.v.gc)
         return;

--- a/compiler/src/dmd/nspace.d
+++ b/compiler/src/dmd/nspace.d
@@ -62,7 +62,7 @@ extern (C++) final class Nspace : ScopeDsymbol
      */
     Expression identExp;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members)
+    extern (D) this(Loc loc, Identifier ident, Expression identExp, Dsymbols* members)
     {
         super(loc, ident);
         //printf("Nspace::Nspace(ident = %s)\n", ident.toChars());

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -1336,7 +1336,7 @@ void genKill(ref ObState obstate, ObNode* ob)
         }
     }
 
-    void dgReadVar(const ref Loc loc, ObNode* ob, VarDeclaration v, bool mutable)
+    void dgReadVar(Loc loc, ObNode* ob, VarDeclaration v, bool mutable)
     {
         if (log)
             printf("dgReadVar() %s %d\n", v.toChars(), mutable);
@@ -1351,12 +1351,12 @@ void genKill(ref ObState obstate, ObNode* ob)
         {
             alias visit = typeof(super).visit;
             extern (D) void delegate(ObNode*, VarDeclaration, Expression, bool) dgWriteVar;
-            extern (D) void delegate(const ref Loc loc, ObNode* ob, VarDeclaration v, bool mutable) dgReadVar;
+            extern (D) void delegate(Loc loc, ObNode* ob, VarDeclaration v, bool mutable) dgReadVar;
             ObNode* ob;
             ObState* obstate;
 
             extern (D) this(void delegate(ObNode*, VarDeclaration, Expression, bool) dgWriteVar,
-                            void delegate(const ref Loc loc, ObNode* ob, VarDeclaration v, bool mutable) dgReadVar,
+                            void delegate(Loc loc, ObNode* ob, VarDeclaration v, bool mutable) dgReadVar,
                             ObNode* ob, ref ObState obstate) scope
             {
                 this.dgWriteVar = dgWriteVar;
@@ -2085,7 +2085,7 @@ void checkObErrors(ref ObState obstate)
         }
     }
 
-    void dgReadVar(const ref Loc loc, ObNode* ob, VarDeclaration v, bool mutable, PtrVarState[] gen)
+    void dgReadVar(Loc loc, ObNode* ob, VarDeclaration v, bool mutable, PtrVarState[] gen)
     {
         if (log) printf("dgReadVar() %s\n", v.toChars());
         const vi = obstate.vars.find(v);
@@ -2103,12 +2103,12 @@ void checkObErrors(ref ObState obstate)
         {
             alias visit = typeof(super).visit;
             extern (D) void delegate(ObNode*, PtrVarState[], VarDeclaration, Expression) dgWriteVar;
-            extern (D) void delegate(const ref Loc loc, ObNode* ob, VarDeclaration v, bool mutable, PtrVarState[]) dgReadVar;
+            extern (D) void delegate(Loc loc, ObNode* ob, VarDeclaration v, bool mutable, PtrVarState[]) dgReadVar;
             PtrVarState[] cpvs;
             ObNode* ob;
             ObState* obstate;
 
-            extern (D) this(void delegate(const ref Loc loc, ObNode* ob, VarDeclaration v, bool mutable, PtrVarState[]) dgReadVar,
+            extern (D) this(void delegate(Loc loc, ObNode* ob, VarDeclaration v, bool mutable, PtrVarState[]) dgReadVar,
                             void delegate(ObNode*, PtrVarState[], VarDeclaration, Expression) dgWriteVar,
                             PtrVarState[] cpvs, ObNode* ob, ref ObState obstate) scope
             {

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1157,7 +1157,7 @@ private Expression compare_overload(BinExp e, Scope* sc, Identifier id, ref EXP 
 /***********************************
  * Utility to build a function call out of this reference and argument.
  */
-Expression build_overload(const ref Loc loc, Scope* sc, Expression ethis, Expression earg, Dsymbol d)
+Expression build_overload(Loc loc, Scope* sc, Expression ethis, Expression earg, Dsymbol d)
 {
     assert(d);
     Expression e;

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -1002,7 +1002,7 @@ Expression optimize(Expression e, int result, bool keepLvalue = false)
         }
     }
 
-    extern (D) void shift_optimize(BinExp e, UnionExp function(const ref Loc, Type, Expression, Expression) shift)
+    extern (D) void shift_optimize(BinExp e, UnionExp function(Loc, Type, Expression, Expression) shift)
     {
         if (binOptimize(e, result))
             return;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -54,7 +54,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Input:
      *      loc = location in source file of mixin
      */
-    extern (D) this(const ref Loc loc, AST.Module _module, const(char)[] input, bool doDocComment,
+    extern (D) this(Loc loc, AST.Module _module, const(char)[] input, bool doDocComment,
         ErrorSink errorSink, const CompileEnv* compileEnv, const bool doUnittests) scope
     {
         //printf("Parser::Parser()1 %d\n", doUnittests);
@@ -1311,7 +1311,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             return 0;
         }
 
-        AST.Expression templateArgToExp(RootObject o, const ref Loc loc)
+        AST.Expression templateArgToExp(RootObject o, Loc loc)
         {
             switch (o.dyncast)
             {

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -70,7 +70,7 @@ import dmd.backend.type;
 alias StmtState = dmd.stmtstate.StmtState!block;
 
 
-void elem_setLoc(elem* e, const ref Loc loc) nothrow
+void elem_setLoc(elem* e, Loc loc) nothrow
 {
     srcpos_setLoc(e.Esrcpos, loc);
 }
@@ -1708,12 +1708,12 @@ void insertFinallyBlockGotos(block* startblock)
     }
 }
 
-private void block_setLoc(block* b, const ref Loc loc) nothrow
+private void block_setLoc(block* b, Loc loc) nothrow
 {
     srcpos_setLoc(b.Bsrcpos, loc);
 }
 
-private void srcpos_setLoc(ref Srcpos s, const ref Loc loc) nothrow
+private void srcpos_setLoc(ref Srcpos s, Loc loc) nothrow
 {
     SourceLoc sl = SourceLoc(loc);
     s.set(sl.filename.ptr, sl.line, sl.column);
@@ -1760,7 +1760,7 @@ private block* block_calloc(BlockState* blx) @safe
  * Add in code to increment usage count for linnum.
  */
 
-private void incUsage(ref IRState irs, const ref Loc loc)
+private void incUsage(ref IRState irs, Loc loc)
 {
 
     if (irs.params.cov && loc.linnum)

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -142,5 +142,5 @@ struct Scope final
                                 // do not set wasRead for it
     StructDeclaration *argStruct; // elimiate recursion when looking for rvalue construction
 
-    Dsymbol *search(const Loc &loc, Identifier *ident, Dsymbol *&pscopesym, SearchOptFlags flags = (SearchOptFlags)SearchOpt::all);
+    Dsymbol *search(Loc loc, Identifier *ident, Dsymbol *&pscopesym, SearchOptFlags flags = (SearchOptFlags)SearchOpt::all);
 };

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -47,7 +47,7 @@ extern (C++) abstract class Statement : ASTNode
         return DYNCAST.statement;
     }
 
-    final extern (D) this(const ref Loc loc, STMT stmt) @safe
+    final extern (D) this(Loc loc, STMT stmt) @safe
     {
         this.loc = loc;
         this.stmt = stmt;
@@ -371,25 +371,25 @@ extern (C++) class ExpStatement : Statement
 {
     Expression exp;
 
-    final extern (D) this(const ref Loc loc, Expression exp) @safe
+    final extern (D) this(Loc loc, Expression exp) @safe
     {
         super(loc, STMT.Exp);
         this.exp = exp;
     }
 
-    final extern (D) this(const ref Loc loc, Expression exp, STMT stmt) @safe
+    final extern (D) this(Loc loc, Expression exp, STMT stmt) @safe
     {
         super(loc, stmt);
         this.exp = exp;
     }
 
-    final extern (D) this(const ref Loc loc, Dsymbol declaration) @safe
+    final extern (D) this(Loc loc, Dsymbol declaration) @safe
     {
         super(loc, STMT.Exp);
         this.exp = new DeclarationExp(loc, declaration);
     }
 
-    static ExpStatement create(const ref Loc loc, Expression exp) @safe
+    static ExpStatement create(Loc loc, Expression exp) @safe
     {
         return new ExpStatement(loc, exp);
     }
@@ -412,7 +412,7 @@ extern (C++) final class DtorExpStatement : ExpStatement
     // Wraps an expression that is the destruction of 'var'
     VarDeclaration var;
 
-    extern (D) this(const ref Loc loc, Expression exp, VarDeclaration var) @safe
+    extern (D) this(Loc loc, Expression exp, VarDeclaration var) @safe
     {
         super(loc, exp, STMT.DtorExp);
         this.var = var;
@@ -437,14 +437,14 @@ extern (C++) final class MixinStatement : Statement
 {
     Expressions* exps;
 
-    extern (D) this(const ref Loc loc, Expression exp)
+    extern (D) this(Loc loc, Expression exp)
     {
         Expressions* exps = new Expressions();
         exps.push(exp);
         this(loc, exps);
     }
 
-    extern (D) this(const ref Loc loc, Expressions* exps) @safe
+    extern (D) this(Loc loc, Expressions* exps) @safe
     {
         super(loc, STMT.Mixin);
         this.exps = exps;
@@ -475,13 +475,13 @@ extern (C++) class CompoundStatement : Statement
      *   loc = Instantiation information
      *   statements   = An array of `Statement`s, that will referenced by this class
      */
-    final extern (D) this(const ref Loc loc, Statements* statements) @safe
+    final extern (D) this(Loc loc, Statements* statements) @safe
     {
         super(loc, STMT.Compound);
         this.statements = statements;
     }
 
-    final extern (D) this(const ref Loc loc, Statements* statements, STMT stmt) @safe
+    final extern (D) this(Loc loc, Statements* statements, STMT stmt) @safe
     {
         super(loc, stmt);
         this.statements = statements;
@@ -495,7 +495,7 @@ extern (C++) class CompoundStatement : Statement
      *   sts   = A variadic array of `Statement`s, that will copied in this class
      *         The entries themselves will not be copied.
      */
-    final extern (D) this(const ref Loc loc, Statement[] sts...)
+    final extern (D) this(Loc loc, Statement[] sts...)
     {
         super(loc, STMT.Compound);
         statements = new Statements();
@@ -504,7 +504,7 @@ extern (C++) class CompoundStatement : Statement
             statements.push(s);
     }
 
-    static CompoundStatement create(const ref Loc loc, Statement s1, Statement s2)
+    static CompoundStatement create(Loc loc, Statement s1, Statement s2)
     {
         return new CompoundStatement(loc, s1, s2);
     }
@@ -553,7 +553,7 @@ extern (C++) class CompoundStatement : Statement
  */
 extern (C++) final class CompoundDeclarationStatement : CompoundStatement
 {
-    extern (D) this(const ref Loc loc, Statements* statements) @safe
+    extern (D) this(Loc loc, Statements* statements) @safe
     {
         super(loc, statements, STMT.CompoundDeclaration);
     }
@@ -577,7 +577,7 @@ extern (C++) final class UnrolledLoopStatement : Statement
 {
     Statements* statements;
 
-    extern (D) this(const ref Loc loc, Statements* statements) @safe
+    extern (D) this(Loc loc, Statements* statements) @safe
     {
         super(loc, STMT.UnrolledLoop);
         this.statements = statements;
@@ -611,7 +611,7 @@ extern (C++) final class ScopeStatement : Statement
     Statement statement;
     Loc endloc;                 // location of closing curly bracket
 
-    extern (D) this(const ref Loc loc, Statement statement, Loc endloc) @safe
+    extern (D) this(Loc loc, Statement statement, Loc endloc) @safe
     {
         super(loc, STMT.Scope);
         this.statement = statement;
@@ -661,7 +661,7 @@ extern (C++) final class ForwardingStatement : Statement
     /// The wrapped statement.
     Statement statement;
 
-    extern (D) this(const ref Loc loc, ForwardingScopeDsymbol sym, Statement statement) @safe
+    extern (D) this(Loc loc, ForwardingScopeDsymbol sym, Statement statement) @safe
     {
         super(loc, STMT.Forwarding);
         this.sym = sym;
@@ -669,7 +669,7 @@ extern (C++) final class ForwardingStatement : Statement
         this.statement = statement;
     }
 
-    extern (D) this(const ref Loc loc, Statement statement) @safe
+    extern (D) this(Loc loc, Statement statement) @safe
     {
         auto sym = new ForwardingScopeDsymbol();
         sym.symtab = new DsymbolTable();
@@ -698,7 +698,7 @@ extern (C++) final class WhileStatement : Statement
     Statement _body;
     Loc endloc;             // location of closing curly bracket
 
-    extern (D) this(const ref Loc loc, Expression condition, Statement _body, Loc endloc, Parameter param = null) @safe
+    extern (D) this(Loc loc, Expression condition, Statement _body, Loc endloc, Parameter param = null) @safe
     {
         super(loc, STMT.While);
         this.condition = condition;
@@ -740,7 +740,7 @@ extern (C++) final class DoStatement : Statement
     Expression condition;
     Loc endloc;                 // location of ';' after while
 
-    extern (D) this(const ref Loc loc, Statement _body, Expression condition, Loc endloc) @safe
+    extern (D) this(Loc loc, Statement _body, Expression condition, Loc endloc) @safe
     {
         super(loc, STMT.Do);
         this._body = _body;
@@ -788,7 +788,7 @@ extern (C++) final class ForStatement : Statement
     // treat that label as referring to this loop.
     Statement relatedLabeled;
 
-    extern (D) this(const ref Loc loc, Statement _init, Expression condition, Expression increment, Statement _body, Loc endloc) @safe
+    extern (D) this(Loc loc, Statement _init, Expression condition, Expression increment, Statement _body, Loc endloc) @safe
     {
         super(loc, STMT.For);
         this._init = _init;
@@ -849,7 +849,7 @@ extern (C++) final class ForeachStatement : Statement
     Statements* cases;          // put breaks, continues, gotos and returns here
     ScopeStatements* gotos;     // forward referenced goto's go here
 
-    extern (D) this(const ref Loc loc, TOK op, Parameters* parameters, Expression aggr, Statement _body, Loc endloc) @safe
+    extern (D) this(Loc loc, TOK op, Parameters* parameters, Expression aggr, Statement _body, Loc endloc) @safe
     {
         super(loc, STMT.Foreach);
         this.op = op;
@@ -898,7 +898,7 @@ extern (C++) final class ForeachRangeStatement : Statement
 
     VarDeclaration key;
 
-    extern (D) this(const ref Loc loc, TOK op, Parameter param, Expression lwr, Expression upr, Statement _body, Loc endloc) @safe
+    extern (D) this(Loc loc, TOK op, Parameter param, Expression lwr, Expression upr, Statement _body, Loc endloc) @safe
     {
         super(loc, STMT.ForeachRange);
         this.op = op;
@@ -942,7 +942,7 @@ extern (C++) final class IfStatement : Statement
     VarDeclaration match;   // for MatchExpression results
     Loc endloc;                 // location of closing curly bracket
 
-    extern (D) this(const ref Loc loc, Parameter param, Expression condition, Statement ifbody, Statement elsebody, Loc endloc) @safe
+    extern (D) this(Loc loc, Parameter param, Expression condition, Statement ifbody, Statement elsebody, Loc endloc) @safe
     {
         super(loc, STMT.If);
         this.param = param;
@@ -987,7 +987,7 @@ extern (C++) final class ConditionalStatement : Statement
     Statement ifbody;
     Statement elsebody;
 
-    extern (D) this(const ref Loc loc, Condition condition, Statement ifbody, Statement elsebody) @safe
+    extern (D) this(Loc loc, Condition condition, Statement ifbody, Statement elsebody) @safe
     {
         super(loc, STMT.Conditional);
         this.condition = condition;
@@ -1022,7 +1022,7 @@ extern (C++) final class StaticForeachStatement : Statement
 {
     StaticForeach sfe;
 
-    extern (D) this(const ref Loc loc, StaticForeach sfe) @safe
+    extern (D) this(Loc loc, StaticForeach sfe) @safe
     {
         super(loc, STMT.StaticForeach);
         this.sfe = sfe;
@@ -1048,7 +1048,7 @@ extern (C++) final class PragmaStatement : Statement
     Expressions* args;      // array of Expression's
     Statement _body;
 
-    extern (D) this(const ref Loc loc, const Identifier ident, Expressions* args, Statement _body) @safe
+    extern (D) this(Loc loc, const Identifier ident, Expressions* args, Statement _body) @safe
     {
         super(loc, STMT.Pragma);
         this.ident = ident;
@@ -1111,7 +1111,7 @@ extern (C++) final class SwitchStatement : Statement
     CaseStatements* cases;          /// array of CaseStatement's
     VarDeclaration lastVar;         /// last observed variable declaration in this statement
 
-    extern (D) this(const ref Loc loc, Parameter param, Expression condition, Statement _body, bool isFinal, Loc endloc)
+    extern (D) this(Loc loc, Parameter param, Expression condition, Statement _body, bool isFinal, Loc endloc)
     {
         super(loc, STMT.Switch);
         this.param = param;
@@ -1154,7 +1154,7 @@ extern (C++) final class CaseStatement : Statement
     VarDeclaration lastVar;
     void* extra;            // for use by Statement_toIR()
 
-    extern (D) this(const ref Loc loc, Expression exp, Statement statement) @safe
+    extern (D) this(Loc loc, Expression exp, Statement statement) @safe
     {
         super(loc, STMT.Case);
         this.exp = exp;
@@ -1181,7 +1181,7 @@ extern (C++) final class CaseRangeStatement : Statement
     Expression last;
     Statement statement;
 
-    extern (D) this(const ref Loc loc, Expression first, Expression last, Statement statement) @safe
+    extern (D) this(Loc loc, Expression first, Expression last, Statement statement) @safe
     {
         super(loc, STMT.CaseRange);
         this.first = first;
@@ -1209,7 +1209,7 @@ extern (C++) final class DefaultStatement : Statement
 
     VarDeclaration lastVar;
 
-    extern (D) this(const ref Loc loc, Statement statement) @safe
+    extern (D) this(Loc loc, Statement statement) @safe
     {
         super(loc, STMT.Default);
         this.statement = statement;
@@ -1233,7 +1233,7 @@ extern (C++) final class GotoDefaultStatement : Statement
 {
     SwitchStatement sw;
 
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, STMT.GotoDefault);
     }
@@ -1258,7 +1258,7 @@ extern (C++) final class GotoCaseStatement : Statement
 
     CaseStatement cs;   // case statement it resolves to
 
-    extern (D) this(const ref Loc loc, Expression exp) @safe
+    extern (D) this(Loc loc, Expression exp) @safe
     {
         super(loc, STMT.GotoCase);
         this.exp = exp;
@@ -1281,12 +1281,12 @@ extern (C++) final class SwitchErrorStatement : Statement
 {
     Expression exp;
 
-    extern (D) this(const ref Loc loc) @safe
+    extern (D) this(Loc loc) @safe
     {
         super(loc, STMT.SwitchError);
     }
 
-    final extern (D) this(const ref Loc loc, Expression exp) @safe
+    final extern (D) this(Loc loc, Expression exp) @safe
     {
         super(loc, STMT.SwitchError);
         this.exp = exp;
@@ -1306,7 +1306,7 @@ extern (C++) final class ReturnStatement : Statement
     Expression exp;
     size_t caseDim;
 
-    extern (D) this(const ref Loc loc, Expression exp) @safe
+    extern (D) this(Loc loc, Expression exp) @safe
     {
         super(loc, STMT.Return);
         this.exp = exp;
@@ -1335,7 +1335,7 @@ extern (C++) final class BreakStatement : Statement
 {
     Identifier ident;
 
-    extern (D) this(const ref Loc loc, Identifier ident) @safe
+    extern (D) this(Loc loc, Identifier ident) @safe
     {
         super(loc, STMT.Break);
         this.ident = ident;
@@ -1359,7 +1359,7 @@ extern (C++) final class ContinueStatement : Statement
 {
     Identifier ident;
 
-    extern (D) this(const ref Loc loc, Identifier ident) @safe
+    extern (D) this(Loc loc, Identifier ident) @safe
     {
         super(loc, STMT.Continue);
         this.ident = ident;
@@ -1384,7 +1384,7 @@ extern (C++) final class SynchronizedStatement : Statement
     Expression exp;
     Statement _body;
 
-    extern (D) this(const ref Loc loc, Expression exp, Statement _body) @safe
+    extern (D) this(Loc loc, Expression exp, Statement _body) @safe
     {
         super(loc, STMT.Synchronized);
         this.exp = exp;
@@ -1422,7 +1422,7 @@ extern (C++) final class WithStatement : Statement
     VarDeclaration wthis;
     Loc endloc;
 
-    extern (D) this(const ref Loc loc, Expression exp, Statement _body, Loc endloc) @safe
+    extern (D) this(Loc loc, Expression exp, Statement _body, Loc endloc) @safe
     {
         super(loc, STMT.With);
         this.exp = exp;
@@ -1451,7 +1451,7 @@ extern (C++) final class TryCatchStatement : Statement
 
     Statement tryBody;   /// set to enclosing TryCatchStatement or TryFinallyStatement if in _body portion
 
-    extern (D) this(const ref Loc loc, Statement _body, Catches* catches) @safe
+    extern (D) this(Loc loc, Statement _body, Catches* catches) @safe
     {
         super(loc, STMT.TryCatch);
         this._body = _body;
@@ -1495,7 +1495,7 @@ extern (C++) final class Catch : RootObject
     // was generated by the compiler, wasn't present in source code
     bool internalCatch;
 
-    extern (D) this(const ref Loc loc, Type type, Identifier ident, Statement handler) @safe
+    extern (D) this(Loc loc, Type type, Identifier ident, Statement handler) @safe
     {
         //printf("Catch(%s, loc = %s)\n", id.toChars(), loc.toChars());
         this.loc = loc;
@@ -1523,7 +1523,7 @@ extern (C++) final class TryFinallyStatement : Statement
     Statement tryBody;   /// set to enclosing TryCatchStatement or TryFinallyStatement if in _body portion
     bool bodyFallsThru;  /// true if _body falls through to finally
 
-    extern (D) this(const ref Loc loc, Statement _body, Statement finalbody) @safe
+    extern (D) this(Loc loc, Statement _body, Statement finalbody) @safe
     {
         super(loc, STMT.TryFinally);
         this._body = _body;
@@ -1531,7 +1531,7 @@ extern (C++) final class TryFinallyStatement : Statement
         this.bodyFallsThru = true;      // assume true until statementSemantic()
     }
 
-    static TryFinallyStatement create(const ref Loc loc, Statement _body, Statement finalbody) @safe
+    static TryFinallyStatement create(Loc loc, Statement _body, Statement finalbody) @safe
     {
         return new TryFinallyStatement(loc, _body, finalbody);
     }
@@ -1565,7 +1565,7 @@ extern (C++) final class ScopeGuardStatement : Statement
     TOK tok;
     Statement statement;
 
-    extern (D) this(const ref Loc loc, TOK tok, Statement statement) @safe
+    extern (D) this(Loc loc, TOK tok, Statement statement) @safe
     {
         super(loc, STMT.ScopeGuard);
         this.tok = tok;
@@ -1593,7 +1593,7 @@ extern (C++) final class ThrowStatement : Statement
     // was generated by the compiler, wasn't present in source code
     bool internalThrow;
 
-    extern (D) this(const ref Loc loc, Expression exp) @safe
+    extern (D) this(Loc loc, Expression exp) @safe
     {
         super(loc, STMT.Throw);
         this.exp = exp;
@@ -1618,7 +1618,7 @@ extern (C++) final class DebugStatement : Statement
 {
     Statement statement;
 
-    extern (D) this(const ref Loc loc, Statement statement) @safe
+    extern (D) this(Loc loc, Statement statement) @safe
     {
         super(loc, STMT.Debug);
         this.statement = statement;
@@ -1648,7 +1648,7 @@ extern (C++) final class GotoStatement : Statement
     VarDeclaration lastVar;
     bool inCtfeBlock;               /// set if goto is inside an `if (__ctfe)` block
 
-    extern (D) this(const ref Loc loc, Identifier ident) @safe
+    extern (D) this(Loc loc, Identifier ident) @safe
     {
         super(loc, STMT.Goto);
         this.ident = ident;
@@ -1682,7 +1682,7 @@ extern (C++) final class LabelStatement : Statement
     bool breaks;                // someone did a 'break ident'
     bool inCtfeBlock;           // inside a block dominated by `if (__ctfe)`
 
-    extern (D) this(const ref Loc loc, Identifier ident, Statement statement) @safe
+    extern (D) this(Loc loc, Identifier ident, Statement statement) @safe
     {
         super(loc, STMT.Label);
         this.ident = ident;
@@ -1713,7 +1713,7 @@ extern (C++) final class LabelDsymbol : Dsymbol
     // can be removed if generic error message deduplication is implemented
     bool duplicated;
 
-    extern (D) this(Identifier ident, const ref Loc loc = Loc.initial) @safe
+    extern (D) this(Identifier ident, Loc loc = Loc.initial) @safe
     {
         super(loc, ident);
     }
@@ -1743,13 +1743,13 @@ extern (C++) class AsmStatement : Statement
     Token* tokens;
     bool caseSensitive;  // for register names
 
-    extern (D) this(const ref Loc loc, Token* tokens) @safe
+    extern (D) this(Loc loc, Token* tokens) @safe
     {
         super(loc, STMT.Asm);
         this.tokens = tokens;
     }
 
-    extern (D) this(const ref Loc loc, Token* tokens, STMT stmt) @safe
+    extern (D) this(Loc loc, Token* tokens, STMT stmt) @safe
     {
         super(loc, stmt);
         this.tokens = tokens;
@@ -1777,7 +1777,7 @@ extern (C++) final class InlineAsmStatement : AsmStatement
     bool refparam;  // true if function parameter is referenced
     bool naked;     // true if function is to be naked
 
-    extern (D) this(const ref Loc loc, Token* tokens) @safe
+    extern (D) this(Loc loc, Token* tokens) @safe
     {
         super(loc, tokens, STMT.InlineAsm);
     }
@@ -1809,7 +1809,7 @@ extern (C++) final class GccAsmStatement : AsmStatement
     Identifiers* labels;        // list of goto labels
     GotoStatements* gotos;      // of the goto labels, the equivalent statements they represent
 
-    extern (D) this(const ref Loc loc, Token* tokens) @safe
+    extern (D) this(Loc loc, Token* tokens) @safe
     {
         super(loc, tokens, STMT.GccAsm);
     }
@@ -1832,7 +1832,7 @@ extern (C++) final class CompoundAsmStatement : CompoundStatement
 {
     StorageClass stc; // postfix attributes like nothrow/pure/@trusted
 
-    extern (D) this(const ref Loc loc, Statements* statements, StorageClass stc) @safe
+    extern (D) this(Loc loc, Statements* statements, StorageClass stc) @safe
     {
         super(loc, statements, STMT.CompoundAsm);
         this.stc = stc;
@@ -1856,7 +1856,7 @@ extern (C++) final class ImportStatement : Statement
 {
     Dsymbols* imports;      // Array of Import's
 
-    extern (D) this(const ref Loc loc, Dsymbols* imports) @safe
+    extern (D) this(Loc loc, Dsymbols* imports) @safe
     {
         super(loc, STMT.Import);
         this.imports = imports;

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -181,7 +181,7 @@ class ExpStatement : public Statement
 public:
     Expression *exp;
 
-    static ExpStatement *create(const Loc &loc, Expression *exp);
+    static ExpStatement *create(Loc loc, Expression *exp);
     ExpStatement *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -213,7 +213,7 @@ class CompoundStatement : public Statement
 public:
     Statements *statements;
 
-    static CompoundStatement *create(const Loc &loc, Statement *s1, Statement *s2);
+    static CompoundStatement *create(Loc loc, Statement *s1, Statement *s2);
     CompoundStatement *syntaxCopy() override;
     ReturnStatement *endsWithReturnStatement() override final;
     Statement *last() override final;
@@ -613,7 +613,7 @@ public:
     Statement *tryBody;   // set to enclosing TryCatchStatement or TryFinallyStatement if in _body portion
     d_bool bodyFallsThru;   // true if _body falls through to finally
 
-    static TryFinallyStatement *create(const Loc &loc, Statement *body, Statement *finalbody);
+    static TryFinallyStatement *create(Loc loc, Statement *body, Statement *finalbody);
     TryFinallyStatement *syntaxCopy() override;
     bool hasBreak() const override;
     bool hasContinue() const override;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3696,7 +3696,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
  *
  * Returns: true if the `throw` is valid, or false if an error was found
  */
-public bool throwSemantic(const ref Loc loc, ref Expression exp, Scope* sc)
+public bool throwSemantic(Loc loc, ref Expression exp, Scope* sc)
 {
     if (!global.params.useExceptions)
     {
@@ -3945,7 +3945,7 @@ private extern(D) Expression applyAssocArray(ForeachStatement fs, Expression fld
     return ec;
 }
 
-private extern(D) Statement loopReturn(Expression e, Statements* cases, const ref Loc loc)
+private extern(D) Statement loopReturn(Expression e, Statements* cases, Loc loc)
 {
     if (!cases.length)
     {

--- a/compiler/src/dmd/staticassert.d
+++ b/compiler/src/dmd/staticassert.d
@@ -28,7 +28,7 @@ extern (C++) final class StaticAssert : Dsymbol
     Expression exp;
     Expressions* msgs;
 
-    extern (D) this(const ref Loc loc, Expression exp, Expression msg)
+    extern (D) this(Loc loc, Expression exp, Expression msg)
     {
         super(loc, Id.empty);
         this.exp = exp;
@@ -36,7 +36,7 @@ extern (C++) final class StaticAssert : Dsymbol
         (*this.msgs)[0] = msg;
     }
 
-    extern (D) this(const ref Loc loc, Expression exp, Expressions* msgs)
+    extern (D) this(Loc loc, Expression exp, Expressions* msgs)
     {
         super(loc, Id.empty);
         this.exp = exp;

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -632,7 +632,7 @@ extern (C++) struct Target
      * Returns:
      *      `Type` that represents `va_list`.
      */
-    extern (C++) Type va_listType(const ref Loc loc, Scope* sc)
+    extern (C++) Type va_listType(Loc loc, Scope* sc)
     {
         if (tvalist)
             return tvalist;
@@ -1241,7 +1241,7 @@ extern (C++) struct Target
      * Returns:
      *  Expression for the requested targetInfo
      */
-    extern (C++) Expression getTargetInfo(const(char)* name, const ref Loc loc)
+    extern (C++) Expression getTargetInfo(const(char)* name, Loc loc)
     {
         import dmd.dmdparams : driverParams;
         import dmd.expression : IntegerExp, StringExp;

--- a/compiler/src/dmd/target.h
+++ b/compiler/src/dmd/target.h
@@ -197,7 +197,7 @@ public:
     // Type sizes and support.
     unsigned alignsize(Type *type);
     unsigned fieldalign(Type *type);
-    Type *va_listType(const Loc &loc, Scope *sc);  // get type of va_list
+    Type *va_listType(Loc loc, Scope *sc);  // get type of va_list
     int isVectorTypeSupported(int sz, Type *type);
     bool isVectorOpSupported(Type *type, EXP op, Type *t2 = nullptr);
     // ABI and backend.
@@ -205,7 +205,7 @@ public:
     TypeTuple *toArgTypes(Type *t);
     bool isReturnOnStack(TypeFunction *tf, bool needsThis);
     bool preferPassByRef(Type *t);
-    Expression *getTargetInfo(const char* name, const Loc& loc);
+    Expression *getTargetInfo(const char* name, Loc loc);
     bool isCalleeDestroyingArgs(TypeFunction* tf);
     bool libraryObjectMonitors(FuncDeclaration *fd, Statement *fbody);
     bool supportsLinkerDirective() const;

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -127,7 +127,7 @@ public:
     virtual bool declareParameter(Scope *sc) = 0;
     virtual void print(RootObject *oarg, RootObject *oded) = 0;
     virtual RootObject *specialization() = 0;
-    virtual RootObject *defaultArg(const Loc &instLoc, Scope *sc) = 0;
+    virtual RootObject *defaultArg(Loc instLoc, Scope *sc) = 0;
     virtual bool hasDefaultArg() = 0;
 
     DYNCAST dyncast() const override { return DYNCAST_TEMPLATEPARAMETER; }
@@ -149,7 +149,7 @@ public:
     bool declareParameter(Scope *sc) override final;
     void print(RootObject *oarg, RootObject *oded) override final;
     RootObject *specialization() override final;
-    RootObject *defaultArg(const Loc &instLoc, Scope *sc) override final;
+    RootObject *defaultArg(Loc instLoc, Scope *sc) override final;
     bool hasDefaultArg() override final;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -180,7 +180,7 @@ public:
     bool declareParameter(Scope *sc) override;
     void print(RootObject *oarg, RootObject *oded) override;
     RootObject *specialization() override;
-    RootObject *defaultArg(const Loc &instLoc, Scope *sc) override;
+    RootObject *defaultArg(Loc instLoc, Scope *sc) override;
     bool hasDefaultArg() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -200,7 +200,7 @@ public:
     bool declareParameter(Scope *sc) override;
     void print(RootObject *oarg, RootObject *oded) override;
     RootObject *specialization() override;
-    RootObject *defaultArg(const Loc &instLoc, Scope *sc) override;
+    RootObject *defaultArg(Loc instLoc, Scope *sc) override;
     bool hasDefaultArg() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -216,7 +216,7 @@ public:
     bool declareParameter(Scope *sc) override;
     void print(RootObject *oarg, RootObject *oded) override;
     RootObject *specialization() override;
-    RootObject *defaultArg(const Loc &instLoc, Scope *sc) override;
+    RootObject *defaultArg(Loc instLoc, Scope *sc) override;
     bool hasDefaultArg() override;
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -162,7 +162,7 @@ struct IRState
  * References:
  * https://dlang.org/dmd-windows.html#switch-cov
  */
-extern (D) elem* incUsageElem(ref IRState irs, const ref Loc loc)
+extern (D) elem* incUsageElem(ref IRState irs, Loc loc)
 {
     uint linnum = loc.linnum;
 
@@ -203,7 +203,7 @@ extern (D) elem* incUsageElem(ref IRState irs, const ref Loc loc)
  * 'origSc' is the original scope we inlined from.
  * This routine is critical for implementing nested functions.
  */
-elem* getEthis(const ref Loc loc, ref IRState irs, Dsymbol fd, Dsymbol fdp = null, Dsymbol origSc = null)
+elem* getEthis(Loc loc, ref IRState irs, Dsymbol fd, Dsymbol fdp = null, Dsymbol origSc = null)
 {
     elem* ethis;
     FuncDeclaration thisfd = irs.getFunc();
@@ -435,7 +435,7 @@ elem* fixEthis2(elem* ethis, FuncDeclaration fd, bool ctxt2 = false)
  * Returns:
  *      *(ey + (ethis2 ? ad.vthis2 : ad.vthis).offset) = this;
  */
-elem* setEthis(const ref Loc loc, ref IRState irs, elem* ey, AggregateDeclaration ad, bool setthis2 = false)
+elem* setEthis(Loc loc, ref IRState irs, elem* ey, AggregateDeclaration ad, bool setthis2 = false)
 {
     elem* ethis;
     FuncDeclaration thisfd = irs.getFunc();

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -281,7 +281,7 @@ void write_instance_pointers(Type type, Symbol* s, uint offset)
  *      loc = the location for reporting line numbers in errors
  *      t   = the type to generate the `TypeInfo` object for
  */
-void TypeInfo_toObjFile(Expression e, const ref Loc loc, Type t)
+void TypeInfo_toObjFile(Expression e, Loc loc, Type t)
 {
     // printf("TypeInfo_toObjFIle() %s\n", torig.toChars());
     if (genTypeInfo(e, loc, t, null))

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -83,7 +83,7 @@ import dmd.tokens;
  *      ps = set if s[oindex] is a Dsymbol, otherwise null
  *      oindex = index into s
  */
-private void resolveTupleIndex(const ref Loc loc, Scope* sc, Dsymbol s, out Expression pe, out Type pt, out Dsymbol ps, RootObject oindex)
+private void resolveTupleIndex(Loc loc, Scope* sc, Dsymbol s, out Expression pe, out Type pt, out Dsymbol ps, RootObject oindex)
 {
     auto tup = s.isTupleDeclaration();
 
@@ -153,7 +153,7 @@ private void resolveTupleIndex(const ref Loc loc, Scope* sc, Dsymbol s, out Expr
  *      ps = set if symbol otherwise null
  *      typeid = set if in TypeidExpression https://dlang.org/spec/expression.html#TypeidExpression
  */
-private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymbol s, Dsymbol scopesym,
+private void resolveHelper(TypeQualified mt, Loc loc, Scope* sc, Dsymbol s, Dsymbol scopesym,
     out Expression pe, out Type pt, out Dsymbol ps, bool intypeid = false)
 {
     version (none)
@@ -388,7 +388,7 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
  * Returns:
  *      symbol found, NULL if not
  */
-private Dsymbol searchX(Dsymbol dsym, const ref Loc loc, Scope* sc, RootObject id, SearchOptFlags flags)
+private Dsymbol searchX(Dsymbol dsym, Loc loc, Scope* sc, RootObject id, SearchOptFlags flags)
 {
     //printf("Dsymbol::searchX(this=%p,%s, ident='%s')\n", this, toChars(), ident.toChars());
     Dsymbol s = dsym.toAlias();
@@ -615,7 +615,7 @@ Expression typeToExpression(Type t)
  *  loc = The source location.
  *  sc = scope of the type
  */
-extern (D) bool checkComplexTransition(Type type, const ref Loc loc, Scope* sc)
+extern (D) bool checkComplexTransition(Type type, Loc loc, Scope* sc)
 {
     if (sc.isDeprecated())
         return false;
@@ -1365,7 +1365,7 @@ uinteger_t size(Type t)
     return size(t, Loc.initial);
 }
 
-uinteger_t size(Type t, const ref Loc loc)
+uinteger_t size(Type t, Loc loc)
 {
 
     uinteger_t visitType(Type t)
@@ -1673,7 +1673,7 @@ MATCH constConv(Type from, Type to)
  *      `Type` with completed semantic analysis, `Terror` if errors
  *      were encountered
  */
-Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
+Type typeSemantic(Type type, Loc loc, Scope* sc)
 {
     static Type error()
     {
@@ -3205,7 +3205,7 @@ Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
     }
 }
 
-Type trySemantic(Type type, const ref Loc loc, Scope* sc)
+Type trySemantic(Type type, Loc loc, Scope* sc)
 {
     //printf("+trySemantic(%s) %d\n", toChars(), global.errors);
 
@@ -3340,7 +3340,7 @@ Type merge2(Type type)
  * Returns:
  *      expression representing the property, or null if not a property and (flag & 1)
  */
-Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier ident, int flag,
+Expression getProperty(Type t, Scope* scope_, Loc loc, Identifier ident, int flag,
     Expression src = null)
 {
     Expression visitType(Type mt)
@@ -3825,7 +3825,7 @@ private void resolveExp(Expression exp, out Type t, out Expression e, out Dsymbo
  *  ps = is set if t is a symbol
  *  intypeid = true if in type id
  */
-void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type pt, out Dsymbol ps, bool intypeid = false)
+void resolve(Type mt, Loc loc, Scope* sc, out Expression pe, out Type pt, out Dsymbol ps, bool intypeid = false)
 {
     void returnExp(Expression e)
     {
@@ -5800,7 +5800,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
 }
 
 // if initializer is 0
-bool isZeroInit(Type t, const ref Loc loc)
+bool isZeroInit(Type t, Loc loc)
 {
     bool visitType(Type _)
     {
@@ -5878,7 +5878,7 @@ bool isZeroInit(Type t, const ref Loc loc)
  * Returns:
  *  The initialization expression for the type.
  */
-Expression defaultInit(Type mt, const ref Loc loc, const bool isCfile = false)
+Expression defaultInit(Type mt, Loc loc, const bool isCfile = false)
 {
     Expression visitBasic(TypeBasic mt)
     {
@@ -6254,7 +6254,7 @@ Type addStorageClass(Type type, StorageClass stc)
  *      Complex!float, Complex!double, Complex!real or null for error
  */
 
-Type getComplexLibraryType(const ref Loc loc, Scope* sc, TY ty)
+Type getComplexLibraryType(Loc loc, Scope* sc, TY ty)
 {
     // singleton
     __gshared Type complex_float;
@@ -7561,7 +7561,7 @@ MATCH implicitConvToThroughAliasThis(TypeStruct from, Type to)
  * Returns:
  *  number of elements, uint.max on overflow
  */
-uint numberOfElems(Type t, const ref Loc loc)
+uint numberOfElems(Type t, Loc loc)
 {
     //printf("Type::numberOfElems()\n");
     uinteger_t n = 1;
@@ -7580,7 +7580,7 @@ uint numberOfElems(Type t, const ref Loc loc)
     return cast(uint)n;
 }
 
-bool checkRetType(TypeFunction tf, const ref Loc loc)
+bool checkRetType(TypeFunction tf, Loc loc)
 {
     Type tb = tf.next.toBasetype();
     if (tb.ty == Tfunction)
@@ -7820,11 +7820,11 @@ Type stripDefaultArgs(Type t)
  * Returns:
  *      corresponding value of .max/.min
  */
-Expression getMaxMinValue(EnumDeclaration ed, const ref Loc loc, Identifier id)
+Expression getMaxMinValue(EnumDeclaration ed, Loc loc, Identifier id)
 {
     //printf("EnumDeclaration::getMaxValue()\n");
 
-    static Expression pvalToResult(Expression e, const ref Loc loc)
+    static Expression pvalToResult(Expression e, Loc loc)
     {
         if (e.op != EXP.error)
         {
@@ -7931,7 +7931,7 @@ Expression getMaxMinValue(EnumDeclaration ed, const ref Loc loc, Identifier id)
  * Return:
  *      null if error, else RootObject AST as parsed
  */
-RootObject compileTypeMixin(TypeMixin tm, ref const Loc loc, Scope* sc)
+RootObject compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
 {
     OutBuffer buf;
     if (expressionsToString(buf, sc, tm.exps, tm.loc, null, true))

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -35,7 +35,7 @@ import core.stdc.stdio;
  * Returns:
  *      true if `TypeInfo` was generated and needs compiling to object file
  */
-bool genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc)
+bool genTypeInfo(Expression e, Loc loc, Type torig, Scope* sc)
 {
     // printf("genTypeInfo() %s\n", torig.toChars());
 
@@ -103,7 +103,7 @@ bool genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc)
  * Returns:
  *      The type of the `TypeInfo` object associated with `t`
  */
-extern (C++) Type getTypeInfoType(const ref Loc loc, Type t, Scope* sc)
+extern (C++) Type getTypeInfoType(Loc loc, Type t, Scope* sc)
 {
     assert(t.ty != Terror);
     if (genTypeInfo(null, loc, t, sc))

--- a/compiler/src/dmd/typinf.h
+++ b/compiler/src/dmd/typinf.h
@@ -18,8 +18,8 @@ struct Scope;
 
 namespace dmd
 {
-    bool genTypeInfo(Expression *e, const Loc &loc, Type *torig, Scope *sc);
+    bool genTypeInfo(Expression *e, Loc loc, Type *torig, Scope *sc);
     bool isSpeculativeType(Type *t);
     bool builtinTypeInfo(Type *t);
 }
-Type *getTypeInfoType(const Loc &loc, Type *t, Scope *sc);
+Type *getTypeInfoType(Loc loc, Type *t, Scope *sc);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1730,7 +1730,7 @@ void argtypes_h(Type *t)
     //dmd::isHFVA(t);
 }
 
-void declaration_h(FuncDeclaration *fd, const Loc &loc, Expressions* args)
+void declaration_h(FuncDeclaration *fd, Loc loc, Expressions* args)
 {
     dmd::functionSemantic(fd);
     dmd::functionSemantic3(fd);
@@ -1744,7 +1744,7 @@ void doc_h(Module *m, const char *ptr, d_size_t length, const char *date,
     dmd::gendocfile(m, ptr, length, date, sink, buf);
 }
 
-void dsymbol_h(Dsymbol *d, Scope *sc, ScopeDsymbol *sds, const Loc &loc, Identifier *ident)
+void dsymbol_h(Dsymbol *d, Scope *sc, ScopeDsymbol *sds, Loc loc, Identifier *ident)
 {
     dmd::dsymbolSemantic(d, sc);
     dmd::semantic2(d, sc);
@@ -1755,7 +1755,7 @@ void dsymbol_h(Dsymbol *d, Scope *sc, ScopeDsymbol *sds, const Loc &loc, Identif
     dmd::importAll(d, sc);
 }
 
-void expression_h(Expression *e, Scope *sc, Type *t, const Loc &loc, Expressions *es)
+void expression_h(Expression *e, Scope *sc, Type *t, Loc loc, Expressions *es)
 {
     dmd::expressionSemantic(e, sc);
     dmd::defaultInit(t, loc);
@@ -1808,7 +1808,7 @@ void module_h(Module *m, Array<ClassDeclaration* >& acs, ScopeDsymbol *sds)
     dmd::findGetMembers(sds);
 }
 
-void mtype_h(Type *t1, Type *t2, const Loc &loc, Scope *sc, int *p)
+void mtype_h(Type *t1, Type *t2, Loc loc, Scope *sc, int *p)
 {
     dmd::typeSemantic(t1, loc, sc);
     dmd::merge(t1);
@@ -1862,7 +1862,7 @@ void template_h(TemplateParameter *tp, Scope *sc, TemplateParameters *tps,
     dmd::printTemplateStats(true, sink);
 }
 
-void typinf_h(Expression *e, const Loc &loc, Type *t, Scope *sc)
+void typinf_h(Expression *e, Loc loc, Type *t, Scope *sc)
 {
     dmd::genTypeInfo(e, loc, t, sc);
     ::getTypeInfoType(loc, t, sc);

--- a/compiler/test/unit/frontend.d
+++ b/compiler/test/unit/frontend.d
@@ -33,7 +33,7 @@ unittest
 
             bool created = false;
 
-            extern (D) this(const ref Loc loc, Identifier id, BaseClasses* baseclasses)
+            extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses)
             {
                 super(loc, id, baseclasses, null, false);
                 created = true;


### PR DESCRIPTION
Since it's no longer larger than 8 bytes, it can just be passed as a value parameter instead of `const ref`.