### PR TITLE
[RFC] ctonly: new annotation to mark functions that are intended to be only used during compile time.

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -3946,6 +3946,7 @@ struct ASTBase
             incomplete      = 0x0200, // return type or default arguments removed
             inoutParam      = 0x0400, // inout on the parameters
             inoutQual       = 0x0800, // inout on the qualifier
+            isCtonly        = 0x1000, // is @ctonly
         }
 
         LINK linkage;               // calling convention
@@ -3987,6 +3988,9 @@ struct ASTBase
                 this.trust = TRUST.system;
             else if (stc & STC.trusted)
                 this.trust = TRUST.trusted;
+
+            if (stc & STC.ctonly)
+                this.isCtonly = true;
         }
 
         override TypeFunction syntaxCopy()
@@ -4006,6 +4010,7 @@ struct ASTBase
             t.isScopeInferred = isScopeInferred;
             t.isInOutParam = isInOutParam;
             t.isInOutQual = isInOutQual;
+            t.isCtonly = isCtonly;
             t.trust = trust;
             t.fargs = fargs;
             return t;
@@ -4158,6 +4163,18 @@ struct ASTBase
         bool iswild() const pure nothrow @safe @nogc
         {
             return (funcFlags & (FunctionFlag.inoutParam | FunctionFlag.inoutQual)) != 0;
+        }
+
+        /// set or get if the function is @ctonly
+        bool isCtonly() const pure nothrow @safe @nogc
+        {
+            return (funcFlags & FunctionFlag.isCtonly) != 0;
+        }
+        /// ditto
+        void isCtonly(bool v) pure nothrow @safe @nogc
+        {
+            if (v) funcFlags |= FunctionFlag.isCtonly;
+            else funcFlags &= ~FunctionFlag.isCtonly;
         }
 
         override void accept(Visitor v)
@@ -6917,6 +6934,7 @@ struct ASTBase
             SCstring(STC.disable, "@disable"),
             SCstring(STC.future, "@__future"),
             SCstring(STC.local, "__local"),
+            SCstring(STC.ctonly, "@ctonly"),
         ];
         foreach (ref entry; table)
         {

--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -119,6 +119,7 @@ enum STC : ulong  // transfer changes to declaration.h
     live                = 0x10_0000_0000_0000,   /// function `@live` attribute
     register            = 0x20_0000_0000_0000,   /// `register` storage class (ImportC)
     volatile_           = 0x40_0000_0000_0000,   /// destined for volatile in the back end
+    ctonly              = 0x80_0000_0000_0000,   /// function that is only called during compile time
 
     safeGroup = STC.safe | STC.trusted | STC.system,
     IOR  = STC.constscoperef | STC.in_ | STC.ref_ | STC.out_,
@@ -132,7 +133,7 @@ enum STC : ulong  // transfer changes to declaration.h
         (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ |
          STC.deprecated_ | STC.future | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest |
          STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared |
-         STC.property | STC.safeGroup | STC.disable | STC.local | STC.live),
+         STC.property | STC.safeGroup | STC.disable | STC.local | STC.live | STC.ctonly),
 
     /* These storage classes "flow through" to the inner scope of a Dsymbol
      */

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -109,9 +109,10 @@ namespace dmd
     #define STClive               0x10000000000000ULL    /// function `@live` attribute
     #define STCregister           0x20000000000000ULL    /// `register` storage class (ImportC)
     #define STCvolatile           0x40000000000000ULL    /// destined for volatile in the back end
+    #define STCctonly             0x80000000000000ULL    /// function that is only called during compile time
 
 #define STC_TYPECTOR    (STCconst | STCimmutable | STCshared | STCwild)
-#define STC_FUNCATTR    (STCref | STCnothrow | STCnogc | STCpure | STCproperty | STCsafe | STCtrusted | STCsystem)
+#define STC_FUNCATTR    (STCref | STCnothrow | STCnogc | STCpure | STCproperty | STCsafe | STCtrusted | STCsystem | STCctonly)
 
 /**************************************************************/
 

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -3307,6 +3307,7 @@ string stcToString(ref StorageClass stc) @safe
         SCstring(STC.disable, "@disable"),
         SCstring(STC.future, "@__future"),
         SCstring(STC.local, "__local"),
+        SCstring(STC.ctonly, "@ctonly"),
     ];
     foreach (ref entry; table)
     {

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -214,6 +214,7 @@ immutable Msgtable[] msgtable =
     { "trusted" },
     { "system" },
     { "disable" },
+    { "ctonly" },
 
     // For inline assembler
     { "___out", "out" },

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2488,6 +2488,7 @@ extern (C++) final class TypeFunction : TypeNext
         bool isInOutQual;      /// inout on the qualifier
         bool isCtor;           /// the function is a constructor
         bool isReturnScope;    /// `this` is returned by value
+        bool isCtonly;         /// is @ctonly
     }
 
     import dmd.common.bitfields : generateBitFields;
@@ -2518,6 +2519,8 @@ extern (C++) final class TypeFunction : TypeNext
             this.isProperty = true;
         if (stc & STC.live)
             this.isLive = true;
+        if (stc & STC.ctonly)
+            this.isCtonly = true;
 
         if (stc & STC.ref_)
             this.isRef = true;
@@ -2572,6 +2575,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.trust = trust;
         t.inferenceArguments = inferenceArguments;
         t.isCtor = isCtor;
+        t.isCtonly = isCtonly;
         return t;
     }
 
@@ -4298,6 +4302,8 @@ void attributesApply(const TypeFunction tf, void delegate(string) dg, TRUSTforma
         dg("scope");
     if (tf.isLive)
         dg("@live");
+    if (tf.isCtonly)
+        dg("@ctonly");
 
     TRUST trustAttrib = tf.trust;
 

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -31,6 +31,7 @@ import dmd.enumsem;
 import dmd.errors;
 import dmd.expression;
 import dmd.dsymbolsem : determineSize;
+import dmd.func : FuncDeclaration;
 import dmd.globals;
 import dmd.hdrgen;
 import dmd.id;
@@ -2489,6 +2490,7 @@ extern (C++) final class TypeFunction : TypeNext
         bool isCtor;           /// the function is a constructor
         bool isReturnScope;    /// `this` is returned by value
         bool isCtonly;         /// is @ctonly
+        bool isCtonlyInferred; /// was @ctonly inferred
     }
 
     import dmd.common.bitfields : generateBitFields;
@@ -2499,6 +2501,7 @@ extern (C++) final class TypeFunction : TypeNext
     PURE purity = PURE.impure;
     byte inuse;
     ArgumentList inferenceArguments; // function arguments to determine `auto ref` in type semantic
+    FuncDeclaration ctOnlyInferReason = null;
 
     extern (D) this(ParameterList pl, Type treturn, LINK linkage, StorageClass stc = 0) @safe
     {

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -572,6 +572,8 @@ public:
     bool isInOutQual() const;
     void isInOutQual(bool v);
     bool iswild() const;
+    bool isCtonly() const;
+    void isCtonly(bool v);
 
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -9570,6 +9570,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                (ident == Id.live)     ? STC.live     :
                (ident == Id.future)   ? STC.future   :
                (ident == Id.disable)  ? STC.disable  :
+               (ident == Id.ctonly)   ? STC.ctonly   :
                0;
     }
 

--- a/compiler/test/compilable/ctonly_basic.d
+++ b/compiler/test/compilable/ctonly_basic.d
@@ -1,0 +1,24 @@
+int f(int x, int y) @ctonly {
+    return x + y;
+}
+
+int g(int x)(int y) @ctonly {
+    return x + y;
+}
+
+alias gf = g!2;
+
+/* enums are fine */
+enum e = g!4(2);
+/* globals initializers are fine */
+int z = f(2, 5);
+
+void main() {
+    /* enums are fine */
+    enum x = f(2, 4);
+    enum y = gf(4);
+    /* static asserts are fine */
+    static assert (f(2, 2) == g!4(0));
+    /* array indeces are fine */
+    int[g!10(0)] arr;
+}

--- a/compiler/test/compilable/ctonly_class.d
+++ b/compiler/test/compilable/ctonly_class.d
@@ -1,0 +1,28 @@
+
+class C {
+    int v;
+    this(int v_) { v = v_; }
+    int f(int x) const @ctonly { return x + v; }
+    static int g(int x) @ctonly { return x + 2; }
+}
+
+class CtOnly {
+    int v;
+    this(int v_) @ctonly { v = v_; }
+    int f(int x) const { return x + v; }
+    static int g(int x) { return x + 2; }
+}
+
+// can do this
+enum v = new C(1).f(0);
+// or this
+static const c = new C(2);
+enum v2 = c.f(2);
+
+void main() {
+    C i = new C(2);
+    // or this
+    enum v = C.g(2);
+    // or this
+    enum e = new CtOnly(5).f(5);
+}

--- a/compiler/test/compilable/ctonly_simple_map.d
+++ b/compiler/test/compilable/ctonly_simple_map.d
@@ -1,0 +1,51 @@
+
+import std.algorithm.searching;
+import std.range;
+import std.traits;
+
+/// Checks is a function is @ctonly
+enum isCtOnly(alias f) = canFind(only(__traits(getFunctionAttributes, f)), "@ctonly");
+
+/// Simplified @ctonly-aware version of `map`
+auto simple_map(alias fun, Range)(Range r) {
+    return SimpleMapResult!(fun, Range)(r);
+}
+
+private struct SimpleMapResult(alias fun, Range) {
+    alias R = Unqual!Range;
+    enum funIsCtOnly = isCtOnly!fun;
+    R _input;
+    this(R input) {
+        _input = input;
+    }
+    void popFront() {
+        _input.popFront();
+    }
+    @property bool empty() {
+        return _input.empty;
+    }
+    static if (funIsCtOnly) {
+        /// If `fun` is @ctonly, `front` must be @ctonly too
+        @property auto ref front() @ctonly {
+            return fun(_input.front);
+        }
+    } else {
+        @property auto ref front() {
+            return fun(_input.front);
+        }
+    }
+}
+
+int f(int x) @ctonly {
+    return x + 1;
+}
+
+import std.algorithm.iteration;
+import std.array;
+
+void main() {
+    enum f2 = f(2);
+    // enum a = map!f([1, 2, 3]).array; // doesn't work
+    enum a2 = simple_map!f([1, 2, 3]); // that works
+    enum a2f = a2.front; // that works too, even though `a2.array` won't work, since `array` must be @ctonly-aware as well
+}

--- a/compiler/test/compilable/ctonly_templates.d
+++ b/compiler/test/compilable/ctonly_templates.d
@@ -1,0 +1,15 @@
+import std.algorithm.iteration;
+import std.array;
+
+int f(int x) @ctonly
+{
+    return x + 1;
+}
+
+enum a = map!f([1, 2, 3]).array;
+
+import std.stdio;
+
+void main() {
+    writeln(a);
+}

--- a/compiler/test/fail_compilation/ctonly_basic.d
+++ b/compiler/test/fail_compilation/ctonly_basic.d
@@ -1,0 +1,24 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/ctonly_basic.d(23): Error: cannot call @ctonly function ctonly_basic.f from non-@ctonly function D main
+fail_compilation/ctonly_basic.d(23): Error: cannot call @ctonly function ctonly_basic.g!2.g from non-@ctonly function D main
+fail_compilation/ctonly_basic.d(23): Error: cannot take address of @ctonly function `f`
+fail_compilation/ctonly_basic.d(23): Error: cannot take address of @ctonly function `g`
+---
+*/
+
+int f(int x, int y) @ctonly {
+    return x + y;
+}
+
+int g(int x)(int y) @ctonly {
+    return x + y;
+}
+
+alias gf = g!2;
+
+import std.stdio;
+
+void main() {
+    writeln(f(2, 4), gf(0), &f, &gf);
+}

--- a/compiler/test/fail_compilation/ctonly_class.d
+++ b/compiler/test/fail_compilation/ctonly_class.d
@@ -1,0 +1,28 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/ctonly_class.d(24): Error: cannot call @ctonly function ctonly_class.C.f from non-@ctonly function D main
+fail_compilation/ctonly_class.d(25): Error: cannot call @ctonly function ctonly_class.C.g from non-@ctonly function D main
+fail_compilation/ctonly_class.d(27): Error: cannot call @ctonly function ctonly_class.CtOnly.this from non-@ctonly function D main
+---
+*/
+class C {
+    int v;
+    this(int v_) { v = v_; }
+    int f(int x) const @ctonly { return x + v; }
+    static int g(int x) @ctonly { return x + 2; }
+}
+
+class CtOnly {
+    int v;
+    this(int v_) @ctonly { v = v_; }
+    int f(int x) const { return x + v; }
+    static int g(int x) { return x + 2; }
+}
+
+void main() {
+    C i = new C(1);
+    int a = i.f(3);
+    int v = C.g(2);
+
+    auto cl = new CtOnly(5);
+}

--- a/compiler/test/fail_compilation/ctonly_templates.d
+++ b/compiler/test/fail_compilation/ctonly_templates.d
@@ -1,0 +1,22 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/ctonly_templates.d(21): Error: cannot call @ctonly function std.array.array!(MapResult!(f, int[])).array from non-@ctonly function D main
+fail_compilation/ctonly_templates.d(21):        std.array.array!(MapResult!(f, int[])).array was inferred to be @ctonly because it calls std.algorithm.iteration.MapResult!(f, int[]).MapResult.front
+---
+*/
+import std.algorithm.iteration;
+import std.array;
+
+int f(int x) @ctonly
+{
+    return x + 1;
+}
+
+enum a = map!f([1, 2, 3]);
+
+import std.stdio;
+
+void main() {
+    // That fails, because `f` is called internally.
+    writeln(a.array);
+}


### PR DESCRIPTION
This is mostly a RFC and an invitation for discussion, the implementation is hacky and I guess I need to go via the official feature proposal process before the implementation could be merge (please advise!).

## Motivation

My motivation is two-fold.

1. We have some functions that we know we intend to only use during compile time. Yet it’s really easy to write `auto v = f(x);`  instead of `enum v = f(x);` , so the function call shifts to run time. We could hope for some constant fold/partial evaluation optimization to kick in the later stages of the compilation, such that it still gets pre-computed at compile time. But why should we rely on that, while D gives us all the controls? Marking `f` as `@ctonly` will easily uncover this unintended usages.
2. If a function is marked `@ctonly`, backends can skip codegen for that function (currently I’ve only implemented that for LDC in my local branch, but the implementation is really straightforward). That might seem like a micro optimization at first glance, but if a `@ctonly` function is templated and instantiated widely, code generation cost for it becomes non-trivial.

## Implementation Ideas

Basically, what we need is to check is that `@ctonly` functions are never called outside from CTFE context and that we never take addresses of these functions.

### New function attribute

Let’s add a new function attribute `@ctonly` to mark CT only functions.

This doesn’t require mangling change, since the feature is essentially frontend-only. It also doesn’t make much sense to have both `@ctonly` and non `@ctonly` versions of a function with the same signature, so I suggest to **not** count the new attribute when comparing function attributes for equality.

This is implemented in the first commit of the PR.

### Basic check rules

1. In semantic check of `CallExp`, make sure that if the callee function is `@ctonly`, either the caller function is also `@ctonly` or the call is in CTFE context.
2. Fail on taking the address of `@ctonly` functions.

Basic rules are implemented in the second commit, and the third commit adds some tests to showcase accepted and rejected code snippets.

### Basic rules limitations

Though this works in simple cases, unfortunately there is at least one case, where it doesn’t work as I would like. Consider this code:

```d
int f(int x) @ctonly { return x + 1; }
enum a = map!f([1, 2, 3]).array;
```

There is nothing wrong with it, `f` is only called during compile time. But with only the basic rules, the compiler fails to understand that. The problem with the basic rules is they require explicit `@ctonly` everywhere. Which I think is good for the most part. Except for this case with templates from the standard library (or any other library actually).

There is a way to write `MapResult` implementation such that it checks if a function it gets via its template parameter is `@ctonly` and adjusts all callers to also be `@ctonly`... but that’s going to result in a lot of code duplication and, probably more importantly, will require changes to the stdlib.

So what if we enable inference for template instance functions?

### Additional rules

1. Add an extra bit marking if `@ctonly` was inferred.
2. If `f` is `@ctonly` **and** `f` is called from `g` **and** `g` is a template instance function **and** `f` is an alias parameter somewhere in `g`'s instantiation stack, mark `g` as inferred `@ctonly` with an inference reason `f`.
3. If `f` is inferred `@ctonly` with reason `r` **and** `f` is called from `g` **and** `g` is a template instance function **and** `r` is an alias parameter somewhere in `g`'s instantiation stack, mark `g` as inferred `@ctonly` with an inference reason `r`.

A hackier version of these rules is implemented in the fourth commit. In particular I only look at the first level of template parameters for initial inference step. And don’t look at template parameters at all for subsequent steps, instead promoting further as long as the caller is a template instance function. This is suboptimal and could be improved.