### PR TITLE
Optimize access to Loc.filename

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -6953,10 +6953,11 @@ elem* buildArrayIndexError(ref IRState irs, Loc loc, elem* index, elem* length) 
 /// Returns: elem representing a C-string (char*) to the filename
 elem* locToFileElem(const ref IRState irs, Loc loc) {
     elem* efile;
-    if (loc.filename)
+
+    if (auto fname = loc.filename)
     {
-        const len = strlen(loc.filename);
-        Symbol* s = toStringSymbol(loc.filename, len, 1);
+        const len = strlen(fname);
+        Symbol* s = toStringSymbol(fname, len, 1);
         efile = el_ptr(s);
     }
     else

--- a/compiler/src/dmd/timetrace.d
+++ b/compiler/src/dmd/timetrace.d
@@ -382,13 +382,14 @@ private struct TimeTraceProfiler
 
         void writeLocation(Loc loc)
         {
-            if (loc.filename())
+            SourceLoc sl = SourceLoc(loc);
+            if (sl.filename.length > 0)
             {
-                writeEscapeJSONString(buf, loc.filename().toDString());
-                if (loc.linnum())
+                writeEscapeJSONString(buf, sl.filename);
+                if (sl.line)
                 {
                     buf.writeByte(':');
-                    buf.print(loc.linnum());
+                    buf.print(sl.line);
                 }
             }
             else


### PR DESCRIPTION
Memoize repeated calls, and don't needlessly resolve line and column when only accessing the filename.