### PR TITLE
Fix "DWARF2 reader: Badly formed extended line op encountered"

### DIFF
--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -72,7 +72,7 @@ alias StmtState = dmd.stmtstate.StmtState!block;
 
 void elem_setLoc(elem* e, Loc loc) nothrow
 {
-    srcpos_setLoc(e.Esrcpos, loc);
+    e.Esrcpos = toSrcpos(loc);
 }
 
 void Statement_toIR(Statement s, ref IRState irs)
@@ -1710,13 +1710,7 @@ void insertFinallyBlockGotos(block* startblock)
 
 private void block_setLoc(block* b, Loc loc) nothrow
 {
-    srcpos_setLoc(b.Bsrcpos, loc);
-}
-
-private void srcpos_setLoc(ref Srcpos s, Loc loc) nothrow
-{
-    SourceLoc sl = SourceLoc(loc);
-    s.set(sl.filename.ptr, sl.line, sl.column);
+    b.Bsrcpos = toSrcpos(loc);
 }
 
 private bool isAssertFalse(const Expression e) nothrow

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -880,8 +880,11 @@ Symbol* toSymbol(Type t)
  * Returns:
  *      Srcpos backend struct corresponding to the given location
  */
-Srcpos toSrcpos(Loc loc)
+Srcpos toSrcpos(Loc loc) nothrow
 {
     SourceLoc sl = SourceLoc(loc);
-    return Srcpos.create(sl.filename.ptr, sl.line, sl.column);
+    if (sl.filename.length > 0)
+        return Srcpos.create(sl.filename.ptr, sl.line, sl.column);
+    else
+        return Srcpos.create(null, 0, 0);
 }


### PR DESCRIPTION
See: https://github.com/dlang/dmd/pull/20777#issuecomment-2651987443

The problem is that __xToHash uses a mixin with Loc.initial. The parser then generates locations with a null filename but non-zero column entries. Formerly the line number would be 0, which I think short-circuits Dwarf location generation somewhere, but after the Loc refactoring the first line would automatically be set to 1, which messes up the line info.