### PR TITLE
Fix issue #17503 - Associative Arrays improperly register a GC-allocated TypeInfo for element cleanup

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -2832,6 +2832,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                 (*ae.keys)[i] = ex;
             }
             ae.type = t;
+            semanticTypeInfo(sc, ae.type);
             return ae;
         }
         return visit(e);

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1548,6 +1548,8 @@ extern (C++) final class TypeInfoStaticArrayDeclaration : TypeInfoDeclaration
  */
 extern (C++) final class TypeInfoAssociativeArrayDeclaration : TypeInfoDeclaration
 {
+    Type entry; // type of TypeInfo_AssociativeArray.Entry!(t.index, t.next)
+
     extern (D) this(Type tinfo)
     {
         super(tinfo);

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -397,6 +397,8 @@ public:
 class TypeInfoAssociativeArrayDeclaration final : public TypeInfoDeclaration
 {
 public:
+    Type* entry;
+
     static TypeInfoAssociativeArrayDeclaration *create(Type *tinfo);
 
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -13317,7 +13317,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.e1.type.toBasetype().ty == Taarray)
         {
             semanticTypeInfo(sc, exp.e1.type.toBasetype());
-            getTypeInfoType(exp.loc, exp.e1.type, sc);
         }
 
         if (!target.isVectorOpSupported(t1, exp.op, t2))

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -13075,7 +13075,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.e1 = exp.e1.implicitCastTo(sc, ta.index);
                 }
 
-                semanticTypeInfo(sc, ta.index);
+                // even though the glue layer only needs the type info of the index,
+                // this might be the first time an AA literal is accessed, so check
+                // the full type info
+                semanticTypeInfo(sc, ta);
 
                 // Return type is pointer to value
                 exp.type = ta.nextOf().pointerTo();

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11168,6 +11168,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.e2 = e2x;
             t1 = e1x.type.toBasetype();
         }
+        else if (t1.ty == Taarray)
+        {
+            // when assigning a constant, the need for TypeInfo might change
+            semanticTypeInfo(sc, t1);
+        }
         /* Check the mutability of e1.
          */
         if (auto ale = exp.e1.isArrayLengthExp())
@@ -13307,8 +13312,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         if (exp.e1.type.toBasetype().ty == Taarray)
+        {
             semanticTypeInfo(sc, exp.e1.type.toBasetype());
-
+            getTypeInfoType(exp.loc, exp.e1.type, sc);
+        }
 
         if (!target.isVectorOpSupported(t1, exp.op, t2))
         {
@@ -16849,6 +16856,9 @@ void semanticTypeInfo(Scope* sc, Type t)
     {
         semanticTypeInfo(sc, t.index);
         semanticTypeInfo(sc, t.next);
+
+        if (global.params.useTypeInfo)
+            getTypeInfoType(t.loc, t, sc);
     }
 
     void visitStruct(TypeStruct t)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6912,6 +6912,7 @@ public:
 class TypeInfoAssociativeArrayDeclaration final : public TypeInfoDeclaration
 {
 public:
+    Type* entry;
     static TypeInfoAssociativeArrayDeclaration* create(Type* tinfo);
     void accept(Visitor* v) override;
 };
@@ -8791,6 +8792,7 @@ struct Id final
     static Identifier* xopEquals;
     static Identifier* xopCmp;
     static Identifier* xtoHash;
+    static Identifier* Entry;
     static Identifier* LINE;
     static Identifier* FILE;
     static Identifier* MODULE;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -166,6 +166,7 @@ immutable Msgtable[] msgtable =
     { "xopCmp", "__xopCmp" },
     { "xtoHash", "__xtoHash" },
     { "__tmpfordtor" },
+    { "Entry" },
 
     { "LINE", "__LINE__" },
     { "FILE", "__FILE__" },

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -852,6 +852,8 @@ private extern(C++) final class StaticAAVisitor : SemanticTimeTransitiveVisitor
         loweredExp = loweredExp.ctfeInterpret();
 
         aaExp.lowering = loweredExp;
+
+        semanticTypeInfo(sc, loweredExp.type);
     }
 
     // https://issues.dlang.org/show_bug.cgi?id=24602

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -1348,7 +1348,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoAssociativeArrayDeclaration d)
     {
         //printf("TypeInfoAssociativeArrayDeclaration.toDt()\n");
-        verifyStructSize(Type.typeinfoassociativearray, 4 * target.ptrsize);
+        verifyStructSize(Type.typeinfoassociativearray, 5 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoassociativearray), 0); // vtbl for TypeInfo_AssociativeArray
         if (Type.typeinfoassociativearray.hasMonitor())
@@ -1361,6 +1361,9 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         TypeInfo_toObjFile(null, d.loc, tc.index);
         dtb.xoff(toSymbol(tc.index.vtinfo), 0);  // TypeInfo for array of type
+
+        TypeInfo_toObjFile(null, d.loc, d.entry);
+        dtb.xoff(toSymbol(d.entry.vtinfo), 0);  // TypeInfo for key,value-pair
     }
 
     override void visit(TypeInfoFunctionDeclaration d)

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -7023,6 +7023,39 @@ Type sharedWildConstOf(Type type)
     return t;
 }
 
+Type nakedOf(Type type)
+{
+    //printf("Type::nakedOf() %p, %s\n", type, type.toChars());
+    if (type.mod == 0)
+        return type;
+    if (type.mcache) with(type.mcache)
+    {
+        // the cache has the naked type at the "identity" position, try to find it
+        if (cto && cto.mod == 0)
+            return cto;
+        if (ito && ito.mod == 0)
+            return ito;
+        if (sto && sto.mod == 0)
+            return sto;
+        if (scto && scto.mod == 0)
+            return scto;
+        if (wto && wto.mod == 0)
+            return wto;
+        if (wcto && wcto.mod == 0)
+            return wcto;
+        if (swto && swto.mod == 0)
+            return swto;
+        if (swcto && swcto.mod == 0)
+            return swcto;
+    }
+    Type t = type.nullAttributes();
+    t.mod = 0;
+    t = t.merge();
+    t.fixTo(type);
+    //printf("\t%p %s\n", t, t.toChars());
+    return t;
+}
+
 Type unqualify(Type type, uint m)
 {
     Type t = type.mutableOf().unSharedOf();

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -200,17 +200,18 @@ TypeInfoDeclaration getTypeInfoAssocArrayDeclaration(TypeAArray t, Scope* sc)
 }
 
 /******************************************
-* Find or create a TypeAArray with index and next without any modifiers
-*
-* Params:
-*      t = TypeAArray to convert
-* Returns:
-*      t = found type
-*/
+ * Find or create a TypeAArray with index and next without
+ * any head modifiers, tail `inout` is replaced with `const`
+ *
+ * Params:
+ *      t = TypeAArray to convert
+ * Returns:
+ *      t = found type
+ */
 Type makeNakedAssociativeArray(TypeAArray t)
 {
-    Type tindex = t.index.toBasetype().nakedOf();
-    Type tnext = t.next.toBasetype().nakedOf();
+    Type tindex = t.index.toBasetype().nakedOf().substWildTo(MODFlags.const_);
+    Type tnext = t.next.toBasetype().nakedOf().substWildTo(MODFlags.const_);
     if (tindex == t.index && tnext == t.next)
         return t;
 

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -22,6 +22,7 @@ import dmd.expression;
 import dmd.globals;
 import dmd.location;
 import dmd.mtype;
+import dmd.typesem;
 import core.stdc.stdio;
 
 /****************************************************
@@ -67,6 +68,9 @@ bool genTypeInfo(Expression e, Loc loc, Type torig, Scope* sc)
 
     import dmd.typesem : merge2;
     Type t = torig.merge2(); // do this since not all Type's are merge'd
+    if (t.ty == Taarray)
+        t = makeNakedAssociativeArray(cast(TypeAArray)t);
+
     bool needsCodegen = false;
     if (!t.vtinfo)
     {
@@ -79,7 +83,7 @@ bool genTypeInfo(Expression e, Loc loc, Type torig, Scope* sc)
         else if (t.isWild())
             t.vtinfo = TypeInfoWildDeclaration.create(t);
         else
-            t.vtinfo = getTypeInfoDeclaration(t);
+            t.vtinfo = getTypeInfoDeclaration(t, sc);
         assert(t.vtinfo);
 
         // ClassInfos are generated as part of ClassDeclaration codegen
@@ -115,7 +119,7 @@ extern (C++) Type getTypeInfoType(Loc loc, Type t, Scope* sc)
     return t.vtinfo.type;
 }
 
-private TypeInfoDeclaration getTypeInfoDeclaration(Type t)
+private TypeInfoDeclaration getTypeInfoDeclaration(Type t, Scope* sc)
 {
     //printf("Type::getTypeInfoDeclaration() %s\n", t.toChars());
     switch (t.ty)
@@ -127,7 +131,7 @@ private TypeInfoDeclaration getTypeInfoDeclaration(Type t)
     case Tsarray:
         return TypeInfoStaticArrayDeclaration.create(t);
     case Taarray:
-        return TypeInfoAssociativeArrayDeclaration.create(t);
+        return getTypeInfoAssocArrayDeclaration(cast(TypeAArray)t, sc);
     case Tstruct:
         return TypeInfoStructDeclaration.create(t);
     case Tvector:
@@ -149,6 +153,69 @@ private TypeInfoDeclaration getTypeInfoDeclaration(Type t)
     default:
         return TypeInfoDeclaration.create(t);
     }
+}
+
+/******************************************
+ * Instantiate TypeInfoAssociativeArrayDeclaration and fill
+ * the entry with TypeInfo_AssociativeArray.Entry!(t.index, t.next)
+ *
+ * Params:
+ *      t = TypeAArray to generate TypeInfo_AssociativeArray for
+ *      sc = context
+ * Returns:
+ *      a TypeInfoAssociativeArrayDeclaration with field entry initialized
+ */
+TypeInfoDeclaration getTypeInfoAssocArrayDeclaration(TypeAArray t, Scope* sc)
+{
+    import dmd.arraytypes;
+    import dmd.expressionsem;
+    import dmd.id;
+
+    assert(sc); // must not be called in the code generation phase
+
+    auto ti = TypeInfoAssociativeArrayDeclaration.create(t);
+    t.vtinfo = ti; // assign it early to avoid recursion in expressionSemantic
+    Loc loc = t.loc;
+    auto tiargs = new Objects();
+    tiargs.push(t.index); // always called with naked types
+    tiargs.push(t.next);
+
+    Expression id = new IdentifierExp(loc, Id.empty);
+    id = new DotIdExp(loc, id, Id.object);
+    id = new DotIdExp(loc, id, Id.TypeInfo_AssociativeArray);
+    auto tempinst = new DotTemplateInstanceExp(loc, id, Id.Entry, tiargs);
+    auto e = expressionSemantic(tempinst, sc);
+    assert(e.type);
+    ti.entry = e.type;
+    if (auto ts = ti.entry.isTypeStruct())
+    {
+        ts.sym.requestTypeInfo = true;
+        if (auto tmpl = ts.sym.isInstantiated())
+            tmpl.minst = sc._module.importedFrom; // ensure it get's emitted
+    }
+    getTypeInfoType(loc, ti.entry, sc);
+    assert(ti.entry.vtinfo);
+
+    return ti;
+}
+
+/******************************************
+* Find or create a TypeAArray with index and next without any modifiers
+*
+* Params:
+*      t = TypeAArray to convert
+* Returns:
+*      t = found type
+*/
+Type makeNakedAssociativeArray(TypeAArray t)
+{
+    Type tindex = t.index.toBasetype().nakedOf();
+    Type tnext = t.next.toBasetype().nakedOf();
+    if (tindex == t.index && tnext == t.next)
+        return t;
+
+    t = new TypeAArray(tnext, tindex);
+    return t.merge();
 }
 
 /**************************************************

--- a/compiler/test/runnable/testaa2.d
+++ b/compiler/test/runnable/testaa2.d
@@ -287,6 +287,19 @@ struct PropertyTable10106
 }
 
 /************************************************/
+// strip inout in key and value types
+void testinout()
+{
+    inout(long) func1(inout(long[][int]) aa)
+    {
+        return aa[0][0];
+    }
+    long[][int] a = [ 0 : [42] ];
+    long b = func1(a);
+    assert(b == 42);
+}
+
+/************************************************/
 
 int main()
 {
@@ -295,6 +308,7 @@ int main()
     test4523();
     test3825();
     test3825x();
+    testinout();
 
     printf("Success\n");
     return 0;

--- a/compiler/test/runnable/testaa2.d
+++ b/compiler/test/runnable/testaa2.d
@@ -300,6 +300,14 @@ void testinout()
 }
 
 /************************************************/
+// type info generated for enum creation in InExp?
+void testinenum()
+{
+    enum string[string] aa = [ "one" : "un", "two" : "deux" ];
+    assert("one" in aa);
+}
+
+/************************************************/
 
 int main()
 {
@@ -309,6 +317,7 @@ int main()
     test3825();
     test3825x();
     testinout();
+    testinenum();
 
     printf("Success\n");
     return 0;

--- a/druntime/src/core/internal/newaa.d
+++ b/druntime/src/core/internal/newaa.d
@@ -44,7 +44,7 @@ struct Impl
     Bucket[] buckets;
     uint used;
     uint deleted;
-    TypeInfo_Struct entryTI;
+    const(TypeInfo) entryTI;
     uint firstUsed;
     immutable uint keysz;
     immutable uint valsz;

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -1324,8 +1324,16 @@ class TypeInfo_AssociativeArray : TypeInfo
     override @property inout(TypeInfo) next() nothrow pure inout { return value; }
     override @property uint flags() nothrow pure const { return 1; }
 
+    // TypeInfo entry is generated from the type of this template to help rt/aaA.d
+    static struct Entry(K, V)
+    {
+        K key;
+        V value;
+    }
+
     TypeInfo value;
     TypeInfo key;
+    TypeInfo entry;
 
     override @property size_t talign() nothrow pure const
     {

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -1587,16 +1587,13 @@ deprecated unittest
     GC.free(blkinf.base);
 
     // associative arrays
-    import rt.aaA : entryDtor;
-    // throw away all existing AA entries with dtor
-    GC.runFinalizers((cast(char*)&entryDtor)[0..1]);
-
     S1[int] aa1;
     aa1[0] = S1(0);
     aa1[1] = S1(1);
     dtorCount = 0;
     aa1 = null;
-    GC.runFinalizers((cast(char*)&entryDtor)[0..1]);
+    auto dtor1 = typeid(TypeInfo_AssociativeArray.Entry!(int, S1)).xdtor;
+    GC.runFinalizers((cast(char*)dtor1)[0..1]);
     assert(dtorCount == 2);
 
     int[S1] aa2;
@@ -1605,7 +1602,8 @@ deprecated unittest
     aa2[S1(2)] = 2;
     dtorCount = 0;
     aa2 = null;
-    GC.runFinalizers((cast(char*)&entryDtor)[0..1]);
+    auto dtor2 = typeid(TypeInfo_AssociativeArray.Entry!(S1, int)).xdtor;
+    GC.runFinalizers((cast(char*)dtor2)[0..1]);
     assert(dtorCount == 3);
 
     S1[2][int] aa3;
@@ -1613,7 +1611,8 @@ deprecated unittest
     aa3[1] = [S1(1),S1(3)];
     dtorCount = 0;
     aa3 = null;
-    GC.runFinalizers((cast(char*)&entryDtor)[0..1]);
+    auto dtor3 = typeid(TypeInfo_AssociativeArray.Entry!(int, S1[2])).xdtor;
+    GC.runFinalizers((cast(char*)dtor3)[0..1]);
     assert(dtorCount == 4);
 }
 

--- a/druntime/test/aa/src/test_aa.d
+++ b/druntime/test/aa/src/test_aa.d
@@ -40,6 +40,7 @@ void main()
     testZeroSizedValue();
     testTombstonePurging();
     testClear();
+    testTypeInfoCollect();
 }
 
 void testKeysValues1()
@@ -904,4 +905,45 @@ void testClear()
     aa2[5] = 6;
     assert(aa.length == 1);
     assert(aa[5] == 6);
+}
+
+// https://github.com/dlang/dmd/issues/17503
+void testTypeInfoCollect()
+{
+    import core.memory;
+
+    static struct S
+    {
+        int x;
+        ~this() {}
+    }
+
+    static struct AAHolder
+    {
+        S[int] aa;
+    }
+
+    static S* getBadS()
+    {
+        auto aaholder = new AAHolder;
+        aaholder.aa[0] = S();
+        auto s = 0 in aaholder.aa; // keep a pointer to the entry
+        GC.free(aaholder); // but not a pointer to the AA.
+        return s;
+    }
+
+    static void stackStomp()
+    {
+        import core.stdc.string : memset;
+        ubyte[4 * 4096] x;
+        memset(x.ptr, 0, x.sizeof);
+    }
+
+    auto s = getBadS();
+    stackStomp(); // destroy any stale references to the AA or s except in the current frame;
+    GC.collect(); // BUG: this used to invalidate the fake type info, should no longer do this.
+    foreach(i; 0 .. 1000) // try to reallocate the freed type info
+        auto p = new void*[1];
+    s = null; // clear any reference to the entry
+    GC.collect(); // used to segfault.
 }

--- a/druntime/test/profile/myprofilegc.log.freebsd.32.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.32.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            256	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            160	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
             128	              1	float profilegc.main src/profilegc.d:18
             128	              1	int profilegc.main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56

--- a/druntime/test/profile/myprofilegc.log.freebsd.64.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.64.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            496	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            320	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
             160	              1	float profilegc.main src/profilegc.d:18
             160	              1	int profilegc.main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56

--- a/druntime/test/profile/myprofilegc.log.linux.32.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.32.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            256	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            160	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
             128	              1	float profilegc.main src/profilegc.d:18
             128	              1	int profilegc.main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56

--- a/druntime/test/profile/myprofilegc.log.linux.64.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.64.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            496	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            320	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
             160	              1	float profilegc.main src/profilegc.d:18
             160	              1	int profilegc.main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56

--- a/druntime/test/profile/myprofilegc.log.osx.32.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.32.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            176	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            160	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
             128	              1	float profilegc.main src/profilegc.d:18
             128	              1	int profilegc.main src/profilegc.d:15
              64	              1	float[] profilegc.main src/profilegc.d:42

--- a/druntime/test/profile/myprofilegc.log.osx.64.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.64.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            496	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            320	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
             160	              1	float profilegc.main src/profilegc.d:18
             160	              1	int profilegc.main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56

--- a/druntime/test/profile/myprofilegc.log.windows.32.exp
+++ b/druntime/test/profile/myprofilegc.log.windows.32.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            256	              1	immutable(char)[][int] profilegc.main src\profilegc.d:23
+            160	              1	immutable(char)[][int] profilegc.main src\profilegc.d:23
             128	              1	float profilegc.main src\profilegc.d:18
             128	              1	int profilegc.main src\profilegc.d:15
              64	              1	double[] profilegc.main src\profilegc.d:56

--- a/druntime/test/profile/myprofilegc.log.windows.64.exp
+++ b/druntime/test/profile/myprofilegc.log.windows.64.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            496	              1	immutable(char)[][int] profilegc.main src\profilegc.d:23
+            320	              1	immutable(char)[][int] profilegc.main src\profilegc.d:23
             160	              1	float profilegc.main src\profilegc.d:18
             160	              1	int profilegc.main src\profilegc.d:15
              64	              1	double[] profilegc.main src\profilegc.d:56


### PR DESCRIPTION
let the compiler generate type info for the AA entry defined by TypeInfo_AssociativeArray.Entry(K, V) and add it to TypeInfo_AssociativeArray.

@schveiguy Here's my attempt for getting rid of the fake TypeInfo. I guess more logic regarding the dtor can be removed as it should all be there in the Entry TypeInfo.