### PR TITLE
Print function bodies instead of __lambda in error messages

### DIFF
--- a/changelog/dmd.error-messages.dd
+++ b/changelog/dmd.error-messages.dd
@@ -18,6 +18,23 @@ app.d(2):        and `object.Exception` being thrown but not caught makes it fai
 */
 ---
 
+Function literals are now referred to by their (truncated) function body, instead of the internal `__lambda` name.
+
+---
+/*
+BEFORE:
+
+../test/test_.d(3): Error: function literal `__lambda1()` is not callable using argument types `(int)`
+    (() => 42)(1);
+              ^
+AFTER:
+
+../test/test_.d(3): Error: function literal `() => 42` is not callable using argument types `(int)`
+    (() => 42)(1);
+              ^
+*/
+---
+
 Match levels are now mentioned on ambiguous overloads: [#20637](https://github.com/dlang/dmd/pull/20637)
 
 ---

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -150,7 +150,7 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
                 //printf("type %s t %s\n", type.deco, t.deco);
                 auto ts = toAutoQualChars(e.type, t);
                 error(e.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`",
-                    e.toChars(), ts[0], ts[1]);
+                    e.toErrMsg(), ts[0], ts[1]);
             }
         }
         return ErrorExp.get();

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -3884,7 +3884,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         if (n_instantiations <= max_shown)
         {
             for (TemplateInstance cur = this; cur; cur = cur.tinst)
-                printFn(cur.loc, format, cur.toChars());
+                printFn(cur.loc, format, cur.toErrMsg());
         }
         else if (n_instantiations - n_totalrecursions <= max_shown)
         {
@@ -6265,6 +6265,9 @@ void write(ref OutBuffer buf, RootObject obj)
 {
     if (obj)
     {
-        buf.writestring(obj.toChars());
+        if (auto e = isExpression(obj))
+            buf.writestring(e.toErrMsg());
+        else
+            buf.writestring(obj.toChars());
     }
 }

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -383,8 +383,7 @@ extern (C++) abstract class Expression : ASTNode
 
     final override const(char)* toChars() const
     {
-        // FIXME: Test suite relies on lambda's being printed as __lambdaXXX in errors and .stringof
-        // Printing a (truncated) lambda body is more user friendly
+        // FIXME: mangling (see runnable/mangle.d) relies on toChars outputting __lambdaXXX here
         if (auto fe = isFuncExp())
             return fe.fd.toChars();
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -362,11 +362,11 @@ private Expression incompatibleTypes(UnaExp e)
 
     if (e.e1.op == EXP.type)
     {
-        error(e.loc, "incompatible type for `%s(%s)`: cannot use `%s` with types", EXPtoString(e.op).ptr, e.e1.toChars(), EXPtoString(e.op).ptr);
+        error(e.loc, "incompatible type for `%s(%s)`: cannot use `%s` with types", EXPtoString(e.op).ptr, e.e1.toErrMsg(), EXPtoString(e.op).ptr);
     }
     else
     {
-        error(e.loc, "incompatible type for `%s(%s)`: `%s`", EXPtoString(e.op).ptr, e.e1.toChars(), e.e1.type.toChars());
+        error(e.loc, "incompatible type for `%s(%s)`: `%s`", EXPtoString(e.op).ptr, e.e1.toErrMsg(), e.e1.type.toChars());
     }
     return ErrorExp.get();
 }
@@ -393,18 +393,18 @@ extern (D) Expression incompatibleTypes(BinExp e, Scope* sc = null)
     if (e.e1.op == EXP.type || e.e2.op == EXP.type)
     {
         error(e.loc, "incompatible types for `(%s) %s (%s)`: cannot use `%s` with types",
-            e.e1.toChars(), thisOp, e.e2.toChars(), EXPtoString(e.op).ptr);
+            e.e1.toErrMsg(), thisOp, e.e2.toErrMsg(), EXPtoString(e.op).ptr);
     }
     else if (e.e1.type.equals(e.e2.type))
     {
         error(e.loc, "incompatible types for `(%s) %s (%s)`: both operands are of type `%s`",
-            e.e1.toChars(), thisOp, e.e2.toChars(), e.e1.type.toChars());
+            e.e1.toErrMsg(), thisOp, e.e2.toErrMsg(), e.e1.type.toChars());
     }
     else
     {
         auto ts = toAutoQualChars(e.e1.type, e.e2.type);
         error(e.loc, "incompatible types for `(%s) %s (%s)`: `%s` and `%s`",
-            e.e1.toChars(), thisOp, e.e2.toChars(), ts[0], ts[1]);
+            e.e1.toErrMsg(), thisOp, e.e2.toErrMsg(), ts[0], ts[1]);
     }
     return ErrorExp.get();
 }
@@ -731,7 +731,7 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, out Expression pe0)
 
         if (!e.type)
         {
-            error(ae.loc, "`%s` has no value", e.toChars());
+            error(ae.loc, "`%s` has no value", e.toErrMsg());
             e = ErrorExp.get();
         }
         if (e.op == EXP.error)
@@ -768,7 +768,7 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, IntervalExp ie, ref Expressio
         e = resolveProperties(sc, e);
         if (!e.type)
         {
-            error(ae.loc, "`%s` has no value", e.toChars());
+            error(ae.loc, "`%s` has no value", e.toErrMsg());
             errors = true;
         }
         return e;
@@ -2109,7 +2109,7 @@ public void errorSupplementalInferredAttr(FuncDeclaration fd, int maxDepth, bool
     {
         if (maxDepth > 0)
         {
-            errorFunc(s.loc, "which calls `%s`", s.fd.toPrettyChars());
+            errorFunc(s.loc, "which calls `%s`", s.fd.toErrMsg());
             errorSupplementalInferredAttr(s.fd, maxDepth - 1, deprecation, stc, eSink);
         }
     }
@@ -2477,7 +2477,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
             auto tf = fd.type.isTypeFunction();
             if (!tf.isRef && e2)
             {
-                error(loc, "%s is not an lvalue", e1.toChars());
+                error(loc, "%s is not an lvalue", e1.toErrMsg());
                 return ErrorExp.get();
             }
         }
@@ -2645,13 +2645,13 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
 
     if (!e1.type)
     {
-        error(loc, "cannot resolve type for %s", e1.toChars());
+        error(loc, "cannot resolve type for %s", e1.toErrMsg());
         e1 = ErrorExp.get();
     }
     return e1;
 
 Leprop:
-    error(loc, "not a property %s", e1.toChars());
+    error(loc, "not a property %s", e1.toErrMsg());
     return ErrorExp.get();
 }
 
@@ -2715,7 +2715,7 @@ private Type arrayExpressionToCommonType(Scope* sc, ref Expressions exps)
         e = resolveProperties(sc, e);
         if (!e.type)
         {
-            error(e.loc, "`%s` has no value", e.toChars());
+            error(e.loc, "`%s` has no value", e.toErrMsg());
             t0 = Type.terror;
             continue;
         }
@@ -2912,7 +2912,7 @@ private bool preFunctionParameters(Scope* sc, ArgumentList argumentList, ErrorSi
             {
                 if (eSink)
                 {
-                    eSink.error(arg.loc, "cannot pass type `%s` as a function argument", arg.toChars());
+                    eSink.error(arg.loc, "cannot pass type `%s` as a function argument", arg.toErrMsg());
                     arg = ErrorExp.get();
                 }
                 err = true;
@@ -2922,7 +2922,7 @@ private bool preFunctionParameters(Scope* sc, ArgumentList argumentList, ErrorSi
         {
             if (eSink)
             {
-                eSink.error(arg.loc, "cannot pass function `%s` as a function argument", arg.toChars());
+                eSink.error(arg.loc, "cannot pass function `%s` as a function argument", arg.toErrMsg());
                 arg = ErrorExp.get();
             }
             err = true;
@@ -3515,7 +3515,7 @@ private bool functionParameters(Loc loc, Scope* sc,
             {
                 if (se.hasOverloads && !se.var.isFuncDeclaration().isUnique())
                 {
-                    error(arg.loc, "function `%s` is overloaded", arg.toChars());
+                    error(arg.loc, "function `%s` is overloaded", arg.toErrMsg());
                     err = true;
                 }
             }
@@ -4159,7 +4159,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 if (!s)
                 {
-                    error(e.loc, "`%s` is not in a class or struct scope", e.toChars());
+                    error(e.loc, "`%s` is not in a class or struct scope", e.toErrMsg());
                     return setError();
                 }
                 ClassDeclaration cd = s.isClassDeclaration();
@@ -4225,7 +4225,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 if (!s)
                 {
-                    error(e.loc, "`%s` is not in a class scope", e.toChars());
+                    error(e.loc, "`%s` is not in a class scope", e.toErrMsg());
                     return setError();
                 }
                 cd = s.isClassDeclaration();
@@ -4489,7 +4489,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             e = e.expressionSemantic(sc);
             if (!e.type)
             {
-                error(exp.loc, "`%s` has no value", e.toChars());
+                error(exp.loc, "`%s` has no value", e.toErrMsg());
                 err = true;
             }
             else if (e.op == EXP.error)
@@ -4540,7 +4540,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          */
         if (e.elements.length > 0 && t0.ty == Tvoid)
         {
-            error(e.loc, "`%s` of type `%s` has no value", e.toChars(), e.type.toChars());
+            error(e.loc, "`%s` of type `%s` has no value", e.toErrMsg(), e.type.toChars());
             return setError();
         }
 
@@ -5359,9 +5359,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (!global.params.useGC && sc.needsCodegen())
             {
                 version(IN_GCC)
-                    error(exp.loc, "expression `%s` allocates with the GC and cannot be used with switch `-fno-rtti`", exp.toChars());
+                    error(exp.loc, "expression `%s` allocates with the GC and cannot be used with switch `-fno-rtti`", exp.toErrMsg());
                 else
-                    error(exp.loc, "expression `%s` allocates with the GC and cannot be used with switch `-betterC`", exp.toChars());
+                    error(exp.loc, "expression `%s` allocates with the GC and cannot be used with switch `-betterC`", exp.toErrMsg());
                 return setError();
             }
 
@@ -5832,8 +5832,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             OutBuffer buf;
             foreach (idx, ref arg; *arguments)
                 buf.printf("%s%s", (idx ? ", ".ptr : "".ptr), arg.type.toChars());
-            error(exp.loc, "function literal `%s%s` is not callable using argument types `(%s)`",
-                      exp.fd.toChars(), parametersTypeToChars(tfl.parameterList),
+            error(exp.loc, "`%s` is not callable using argument types `(%s)`",
+                      exp.fd.toErrMsg(), // parametersTypeToChars(tfl.parameterList),
                       buf.peekChars());
             errorSupplemental(exp.loc, "too %s arguments, expected %d, got %d",
                                   arguments.length < dim ? "few".ptr : "many".ptr,
@@ -6038,7 +6038,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 __gshared int nest;
                 if (++nest > global.recursionLimit)
                 {
-                    error(exp.loc, "recursive evaluation of `%s`", exp.toChars());
+                    error(exp.loc, "recursive evaluation of `%s`", exp.toErrMsg());
                     --nest;
                     return setError();
                 }
@@ -6331,7 +6331,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return null;
             if (f)
                 return f;
-            .error(loc, "no overload matches for `%s`", exp.toChars());
+            .error(loc, "no overload matches for `%s`", exp.toErrMsg());
             errorSupplemental(loc, "Candidates are:");
             foreach (s; os.a)
             {
@@ -6591,7 +6591,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else if (!t1)
         {
-            error(exp.loc, "function expected before `()`, not `%s`", exp.e1.toChars());
+            error(exp.loc, "function expected before `()`, not `%s`", exp.e1.toErrMsg());
             return setError();
         }
         else if (t1.ty == Terror)
@@ -6674,7 +6674,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else
             {
-                error(exp.loc, "function expected before `()`, not `%s` of type `%s`", exp.e1.toChars(), exp.e1.type.toChars());
+                error(exp.loc, "function expected before `()`, not `%s` of type `%s`", exp.e1.toErrMsg(), exp.e1.type.toChars());
                 return setError();
             }
 
@@ -6688,8 +6688,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     tthis.modToBuffer(buf);
 
                 //printf("tf = %s, args = %s\n", tf.deco, (*arguments)[0].type.deco);
-                .error(exp.loc, "%s `%s%s` is not callable using argument types `%s`",
-                    p, exp.e1.toChars(), parametersTypeToChars(tf.parameterList), buf.peekChars());
+                .error(exp.loc, "%s `%s` is not callable using argument types `%s`",
+                    p, exp.e1.toErrMsg(), buf.peekChars());
                 if (failMessage)
                     errorSupplemental(exp.loc, "%s", failMessage);
             }
@@ -6712,20 +6712,20 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (!tf.purity && sc.func.setImpure(exp.loc, "calling impure `%s`", exp.e1))
                 {
                     error(exp.loc, "`pure` %s `%s` cannot call impure %s `%s`",
-                        sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toChars());
+                        sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toErrMsg());
                     err = true;
                 }
                 if (!tf.isNogc && sc.func.setGC(exp.loc, "calling non-@nogc `%s`", exp.e1))
                 {
                     error(exp.loc, "`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
-                        sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toChars());
+                        sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toErrMsg());
                     err = true;
                 }
                 if (tf.trust <= TRUST.system && sc.setUnsafe(true, exp.loc,
                     "calling `@system` `%s`", exp.e1))
                 {
                     error(exp.loc, "`@safe` %s `%s` cannot call `@system` %s `%s`",
-                        sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toChars());
+                        sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toErrMsg());
                     err = true;
                 }
                 if (err)
@@ -6770,7 +6770,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     }
 
                     .error(exp.loc, "%s `%s` is not callable using argument types `%s`",
-                        exp.f.kind(), exp.f.toChars(), buf.peekChars());
+                        exp.f.kind(), exp.f.toErrMsg(), buf.peekChars());
                     if (failMessage)
                         errorSupplemental(exp.loc, "%s", failMessage);
                     .errorSupplemental(exp.f.loc, "`%s%s` declared here", exp.f.toPrettyChars(), parametersTypeToChars(tf.parameterList));
@@ -6846,7 +6846,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             exp.e1 = e1org; // https://issues.dlang.org/show_bug.cgi?id=10922
                         // avoid recursive expression printing
-            error(exp.loc, "forward reference to inferred return type of function call `%s`", exp.toChars());
+            error(exp.loc, "forward reference to inferred return type of function call `%s`", exp.toErrMsg());
             return setError();
         }
 
@@ -7126,7 +7126,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (!ta)
         {
             //printf("ta %p ea %p sa %p\n", ta, ea, sa);
-            error(exp.loc, "no type for `typeid(%s)`", ea ? ea.toChars() : (sa ? sa.toChars() : ""));
+            error(exp.loc, "no type for `typeid(%s)`", ea ? ea.toErrMsg() : (sa ? sa.toChars() : ""));
             return setError();
         }
 
@@ -7798,7 +7798,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // deprecated in 2.107
             deprecation(e.loc, "assert condition cannot be a string literal");
             deprecationSupplemental(e.loc, "If intentional, use `%s !is null` instead to preserve behaviour",
-                e.toChars());
+                e.toErrMsg());
         }
 
         const generateMsg = !exp.msg &&
@@ -8430,7 +8430,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 MODMatchToBuffer(&thisBuf, e.e1.type.mod, tf.mod);
                 MODMatchToBuffer(&funcBuf, tf.mod, e.e1.type.mod);
                 error(e.loc, "%smethod `%s` is not callable using a %s`%s`",
-                    funcBuf.peekChars(), f.toPrettyChars(), thisBuf.peekChars(), e.e1.toChars());
+                    funcBuf.peekChars(), f.toPrettyChars(), thisBuf.peekChars(), e.e1.toErrMsg());
                 return setError();
             }
         }
@@ -8614,7 +8614,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (!exp.e1.type)
         {
-            error(exp.loc, "cannot take address of `%s`", exp.e1.toChars());
+            error(exp.loc, "cannot take address of `%s`", exp.e1.toErrMsg());
             return setError();
         }
         if (!checkAddressable(exp, sc))
@@ -8638,7 +8638,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     error(exp.loc, "forward reference to %s `%s`", d.kind(), d.toChars());
                 }
                 else
-                    error(exp.loc, "forward reference to type `%s` of expression `%s`", exp.e1.type.toChars(), exp.e1.toChars());
+                    error(exp.loc, "forward reference to type `%s` of expression `%s`", exp.e1.type.toChars(), exp.e1.toErrMsg());
                 return setError();
             }
         }
@@ -8801,7 +8801,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         case Tarray:
             if (isNonAssignmentArrayOp(exp.e1))
                 goto default;
-            error(exp.loc, "using `*` on an array is no longer supported; use `*(%s).ptr` instead", exp.e1.toChars());
+            error(exp.loc, "using `*` on an array is no longer supported; use `*(%s).ptr` instead", exp.e1.toErrMsg());
             exp.type = (cast(TypeArray)tb).next;
             exp.e1 = exp.e1.castTo(sc, exp.type.pointerTo());
             break;
@@ -9111,7 +9111,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (!exp.e1.type)
         {
-            error(exp.loc, "cannot cast `%s`", exp.e1.toChars());
+            error(exp.loc, "cannot cast `%s`", exp.e1.toErrMsg());
             return setError();
         }
 
@@ -9149,7 +9149,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (exp.to.ty == Ttuple)
         {
-            error(exp.loc, "cannot cast `%s` of type `%s` to type sequence `%s`", exp.e1.toChars(), exp.e1.type.toChars(), exp.to.toChars());
+            error(exp.loc, "cannot cast `%s` of type `%s` to type sequence `%s`", exp.e1.toErrMsg(), exp.e1.type.toChars(), exp.to.toChars());
             return setError();
         }
 
@@ -9333,7 +9333,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (elem.isConst() == 1)
                 return false;
 
-             error(exp.loc, "constant expression expected, not `%s`", elem.toChars());
+             error(exp.loc, "constant expression expected, not `%s`", elem.toErrMsg());
              return true;
         }
 
@@ -9393,7 +9393,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (exp.lwr || exp.upr)
             {
-                error(exp.loc, "cannot slice type `%s`", exp.e1.toChars());
+                error(exp.loc, "cannot slice type `%s`", exp.e1.toErrMsg());
                 return setError();
             }
             Expression e = new TypeExp(exp.loc, exp.e1.type.arrayOf());
@@ -9445,7 +9445,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (t1b.isPtrToFunction())
             {
-                error(exp.loc, "cannot slice function pointer `%s`", exp.e1.toChars());
+                error(exp.loc, "cannot slice function pointer `%s`", exp.e1.toErrMsg());
                 return setError();
             }
             if (!exp.lwr || !exp.upr)
@@ -9462,9 +9462,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         {
                             errorSupplemental(exp.loc,
                                 "pointer `%s` points to an aggregate that defines an `%s`, perhaps you meant `(*%s)[]`",
-                                exp.e1.toChars(),
+                                exp.e1.toErrMsg(),
                                 s.ident.toChars(),
-                                exp.e1.toChars()
+                                exp.e1.toErrMsg()
                             );
                         }
 
@@ -9505,7 +9505,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else
         {
-            error(exp.loc, "`%s` cannot be sliced with `[]`", t1b.ty == Tvoid ? exp.e1.toChars() : t1b.toChars());
+            error(exp.loc, "`%s` cannot be sliced with `[]`", t1b.ty == Tvoid ? exp.e1.toErrMsg() : t1b.toChars());
             return setError();
         }
 
@@ -9981,7 +9981,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         case Tpointer:
             if (t1b.isPtrToFunction())
             {
-                error(exp.loc, "cannot index function pointer `%s`", exp.e1.toChars());
+                error(exp.loc, "cannot index function pointer `%s`", exp.e1.toErrMsg());
                 return setError();
             }
             exp.e2 = exp.e2.implicitCastTo(sc, Type.tsize_t);
@@ -10078,7 +10078,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return;
             }
         default:
-            error(exp.loc, "`%s` must be an array or pointer type, not `%s`", exp.e1.toChars(), exp.e1.type.toChars());
+            error(exp.loc, "`%s` must be an array or pointer type, not `%s`", exp.e1.toErrMsg(), exp.e1.type.toChars());
             return setError();
         }
 
@@ -10156,7 +10156,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.e1.op == EXP.slice)
         {
             const(char)* s = exp.op == EXP.plusPlus ? "increment" : "decrement";
-            error(exp.loc, "cannot post-%s array slice `%s`, use pre-%s instead", s, exp.e1.toChars(), s);
+            error(exp.loc, "cannot post-%s array slice `%s`, use pre-%s instead", s, exp.e1.toErrMsg(), s);
             return setError();
         }
 
@@ -10909,7 +10909,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             if (newExp.newtype && newExp.newtype == t1)
                             {
                                 error(exp.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`",
-                                      newExp.toChars(), newExp.type.toChars(), t1.toChars());
+                                      newExp.toErrMsg(), newExp.type.toChars(), t1.toChars());
                                 errorSupplemental(exp.loc, "Perhaps remove the `new` keyword?");
                                 return setError();
                             }
@@ -11282,7 +11282,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (exp.op == EXP.assign && !tn.baseElemOf().isAssignable())
             {
                 error(exp.loc, "slice `%s` is not mutable, struct `%s` has immutable members",
-                    exp.e1.toChars(), tn.baseElemOf().toChars());
+                    exp.e1.toErrMsg(), tn.baseElemOf().toChars());
                 result = ErrorExp.get();
                 return;
             }
@@ -11305,7 +11305,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (tn && !tn.baseElemOf().isAssignable())
                 {
                     error(exp.loc, "array `%s` is not mutable, struct `%s` has immutable members",
-                        exp.e1.toChars(), tn.baseElemOf().toChars());
+                        exp.e1.toErrMsg(), tn.baseElemOf().toChars());
                     result = ErrorExp.get();
                     return;
                 }
@@ -11375,7 +11375,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 uinteger_t dim2 = tsa2.dim.toInteger();
                 if (dim1 != dim2)
                 {
-                    error(exp.loc, "mismatched array lengths %d and %d for assignment `%s`", cast(int)dim1, cast(int)dim2, exp.toChars());
+                    error(exp.loc, "mismatched array lengths %d and %d for assignment `%s`", cast(int)dim1, cast(int)dim2, exp.toErrMsg());
                     return setError();
                 }
             }
@@ -11451,7 +11451,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         // offer more information about the cause of the problem
                         errorSupplemental(exp.loc,
                                           "`%s` is the first assignment of `%s` therefore it represents its initialization",
-                                          exp.toChars(), exp.e1.toChars());
+                                          exp.toErrMsg(), exp.e1.toErrMsg());
                         errorSupplemental(exp.loc,
                                           "`opAssign` methods are not used for initialization, but for subsequent assignments");
                     }
@@ -12796,7 +12796,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Module mmath = Module.loadStdMath();
         if (!mmath)
         {
-            error(e.loc, "`%s` requires `std.math` for `^^` operators", e.toChars());
+            error(e.loc, "`%s` requires `std.math` for `^^` operators", e.toErrMsg());
             return setError();
         }
         e = new ScopeExp(exp.loc, mmath);
@@ -12970,7 +12970,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (e2x.op == EXP.type || e2x.op == EXP.scope_)
         {
-            error(exp.loc, "`%s` is not an expression", exp.e2.toChars());
+            error(exp.loc, "`%s` is not an expression", exp.e2.toErrMsg());
             return setError();
         }
         if (e1x.op == EXP.error || e1x.type.ty == Tnoreturn)
@@ -13152,7 +13152,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             errorSupplemental(exp.loc, "`in` is only allowed on associative arrays");
             const(char)* slice = (t2b.ty == Tsarray) ? "[]" : "";
             errorSupplemental(exp.loc, "perhaps use `std.algorithm.find(%s, %s%s)` instead",
-                exp.e1.toChars(), exp.e2.toChars(), slice);
+                exp.e1.toErrMsg(), exp.e2.toErrMsg(), slice);
             return;
 
         default:
@@ -13998,12 +13998,12 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
     // Template has no built-in properties except for 'stringof'.
     if ((exp.e1.isDotTemplateExp() || exp.e1.isTemplateExp()) && exp.ident != Id.stringof)
     {
-        error(exp.loc, "template `%s` does not have property `%s`", exp.e1.toChars(), exp.ident.toChars());
+        error(exp.loc, "template `%s` does not have property `%s`", exp.e1.toErrMsg(), exp.ident.toChars());
         return ErrorExp.get();
     }
     if (!exp.e1.type)
     {
-        error(exp.loc, "expression `%s` does not have property `%s`", exp.e1.toChars(), exp.ident.toChars());
+        error(exp.loc, "expression `%s` does not have property `%s`", exp.e1.toErrMsg(), exp.ident.toChars());
         return ErrorExp.get();
     }
 
@@ -14405,7 +14405,7 @@ Expression dotTemplateSemanticProp(DotTemplateInstanceExp exp, Scope* sc, bool g
 
     Expression notTemplate()
     {
-        error(exp.loc, "`%s` isn't a template", e.toChars());
+        error(exp.loc, "`%s` isn't a template", e.toErrMsg());
         return errorExp();
     }
 
@@ -14720,7 +14720,7 @@ MATCH matchType(FuncExp funcExp, Type to, Scope* sc, FuncExp* presult, ErrorSink
     {
         auto ts = toAutoQualChars(tx, to);
         eSink.error(loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`",
-            funcExp.toChars(), ts[0], ts[1]);
+            funcExp.toErrMsg(), ts[0], ts[1]);
     }
     return m;
 }
@@ -14733,7 +14733,7 @@ private bool checkScalar(Expression e)
         return true;
     if (!e.type.isScalar())
     {
-        error(e.loc, "`%s` is not a scalar, it is a `%s`", e.toChars(), e.type.toChars());
+        error(e.loc, "`%s` is not a scalar, it is a `%s`", e.toErrMsg(), e.type.toChars());
         return true;
     }
     return e.checkValue();
@@ -14747,7 +14747,7 @@ private bool checkNoBool(Expression e)
         return true;
     if (e.type.toBasetype().ty == Tbool)
     {
-        error(e.loc, "operation not allowed on `bool` `%s`", e.toChars());
+        error(e.loc, "operation not allowed on `bool` `%s`", e.toErrMsg());
         return true;
     }
     return false;
@@ -14761,7 +14761,7 @@ private bool checkIntegral(Expression e)
         return true;
     if (!e.type.isIntegral())
     {
-        error(e.loc, "`%s` is not of integral type, it is a `%s`", e.toChars(), e.type.toChars());
+        error(e.loc, "`%s` is not of integral type, it is a `%s`", e.toErrMsg(), e.type.toChars());
         return true;
     }
     return e.checkValue();
@@ -14779,7 +14779,7 @@ private bool checkArithmetic(Expression e, EXP op)
         const char* msg = e.type.isAggregate() ?
             "operator `%s` is not defined for `%s` of type `%s`" :
             "illegal operator `%s` for `%s` of type `%s`";
-        error(e.loc, msg, EXPtoString(op).ptr, e.toChars(), e.type.toChars());
+        error(e.loc, msg, EXPtoString(op).ptr, e.toErrMsg(), e.type.toChars());
         return true;
     }
 
@@ -14862,7 +14862,7 @@ bool checkValue(Expression e)
 {
     if (auto te = e.isTypeExp())
     {
-        error(e.loc, "type `%s` has no value", e.toChars());
+        error(e.loc, "type `%s` has no value", e.toErrMsg());
         if (!e.type.isOpaqueType)
             errorSupplemental(e.loc, "perhaps use `%s.init`", e.toChars());
         return true;
@@ -14874,7 +14874,7 @@ bool checkValue(Expression e)
             dtie.ti.semantictiargsdone &&
             dtie.ti.semanticRun == PASS.initial)
 
-            error(e.loc, "partial %s `%s` has no value", dtie.ti.kind(), e.toChars());
+            error(e.loc, "partial %s `%s` has no value", dtie.ti.kind(), e.toErrMsg());
         else
             error(e.loc, "%s `%s` has no value", dtie.ti.kind(), dtie.ti.toChars());
         return true;
@@ -14904,13 +14904,13 @@ bool checkValue(Expression e)
 
     if (auto dte = e.isDotTemplateExp())
     {
-        error(e.loc, "%s `%s` has no value", dte.td.kind(), e.toChars());
+        error(e.loc, "%s `%s` has no value", dte.td.kind(), e.toErrMsg());
         return true;
     }
 
     if (e.type && e.type.toBasetype().ty == Tvoid)
     {
-        error(e.loc, "expression `%s` is `void` and has no value", e.toChars());
+        error(e.loc, "expression `%s` is `void` and has no value", e.toErrMsg());
         //print(); assert(0);
         if (!global.gag)
             e.type = Type.terror;
@@ -14970,7 +14970,7 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
         bool sharedError(Expression e)
         {
             // https://dlang.org/phobos/core_atomic.html
-            error(e.loc, "direct access to shared `%s` is not allowed, see `core.atomic`", e.toChars());
+            error(e.loc, "direct access to shared `%s` is not allowed, see `core.atomic`", e.toErrMsg());
             return true;
         }
 
@@ -15494,9 +15494,9 @@ private Expression toLvalueImpl(Expression _this, Scope* sc, const(char)* action
         if (e.op == EXP.type)
             error(_this.loc, "cannot %s type `%s`", action, e.type.toChars());
         else if (e.op == EXP.template_)
-            error(_this.loc, "cannot %s template `%s`, perhaps instantiate it first", action, e.toChars());
+            error(_this.loc, "cannot %s template `%s`, perhaps instantiate it first", action, e.toErrMsg());
         else
-            error(_this.loc, "cannot %s expression `%s` because it is not an lvalue", action, e.toChars());
+            error(_this.loc, "cannot %s expression `%s` because it is not an lvalue", action, e.toErrMsg());
 
         return ErrorExp.get();
     }
@@ -15505,7 +15505,7 @@ private Expression toLvalueImpl(Expression _this, Scope* sc, const(char)* action
     {
         if (!_this.loc.isValid())
             _this.loc = e.loc;
-        error(e.loc, "cannot %s constant `%s`", action, e.toChars());
+        error(e.loc, "cannot %s constant `%s`", action, e.toErrMsg());
         return ErrorExp.get();
     }
 
@@ -15930,12 +15930,12 @@ private Expression modifiableLvalueImpl(Expression _this, Scope* sc, Expression 
                             break;
                         if (!ff.type.isMutable)
                         {
-                            error(exp.loc, "cannot modify `%s` in `%s` function", exp.toChars(), MODtoChars(type.mod));
+                            error(exp.loc, "cannot modify `%s` in `%s` function", exp.toErrMsg(), MODtoChars(type.mod));
                             return ErrorExp.get();
                         }
                     }
                 }
-                error(exp.loc, "cannot modify `%s` expression `%s`", MODtoChars(type.mod), exp.toChars());
+                error(exp.loc, "cannot modify `%s` expression `%s`", MODtoChars(type.mod), exp.toErrMsg());
                 return ErrorExp.get();
             }
             else if (!type.isAssignable())
@@ -15950,7 +15950,7 @@ private Expression modifiableLvalueImpl(Expression _this, Scope* sc, Expression 
 
     Expression visitString(StringExp exp)
     {
-        error(exp.loc, "cannot modify string literal `%s`", exp.toChars());
+        error(exp.loc, "cannot modify string literal `%s`", exp.toErrMsg());
         return ErrorExp.get();
     }
 
@@ -15959,7 +15959,7 @@ private Expression modifiableLvalueImpl(Expression _this, Scope* sc, Expression 
         //printf("VarExp::modifiableLvalue('%s')\n", exp.var.toChars());
         if (exp.var.storage_class & STC.manifest)
         {
-            error(exp.loc, "cannot modify manifest constant `%s`", exp.toChars());
+            error(exp.loc, "cannot modify manifest constant `%s`", exp.toErrMsg());
             return ErrorExp.get();
         }
         // See if this expression is a modifiable lvalue (i.e. not const)
@@ -15988,7 +15988,7 @@ private Expression modifiableLvalueImpl(Expression _this, Scope* sc, Expression 
 
     Expression visitSlice(SliceExp exp)
     {
-        error(exp.loc, "slice expression `%s` is not a modifiable lvalue", exp.toChars());
+        error(exp.loc, "slice expression `%s` is not a modifiable lvalue", exp.toErrMsg());
         return exp;
     }
 
@@ -16030,7 +16030,7 @@ private Expression modifiableLvalueImpl(Expression _this, Scope* sc, Expression 
     {
         if (!exp.e1.isLvalue() && !exp.e2.isLvalue())
         {
-            error(exp.loc, "conditional expression `%s` is not a modifiable lvalue", exp.toChars());
+            error(exp.loc, "conditional expression `%s` is not a modifiable lvalue", exp.toErrMsg());
             return ErrorExp.get();
         }
         exp.e1 = exp.e1.modifiableLvalue(sc);
@@ -16071,7 +16071,7 @@ private bool checkAddressVar(Scope* sc, Expression exp, VarDeclaration v)
 
     if (!v.canTakeAddressOf())
     {
-        error(exp.loc, "cannot take address of `%s`", exp.toChars());
+        error(exp.loc, "cannot take address of `%s`", exp.toErrMsg());
         return false;
     }
     if (sc.func && !sc.intypeof && !v.isDataseg())
@@ -16133,9 +16133,9 @@ bool checkAddressable(Expression e, Scope* sc)
                     if (ex.isVarExp().var.storage_class & STC.register)
                     {
                         if (e.isIndexExp())
-                            error(e.loc, "cannot index through register variable `%s`", ex.toChars());
+                            error(e.loc, "cannot index through register variable `%s`", ex.toErrMsg());
                         else
-                            error(e.loc, "cannot take address of register variable `%s`", ex.toChars());
+                            error(e.loc, "cannot take address of register variable `%s`", ex.toErrMsg());
                         return false;
                     }
                 }
@@ -16629,7 +16629,7 @@ bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool 
         if (opt.isEmpty())
         {
             if (!e.type.isTypeError())
-                error(e.loc, "expression `%s` is not constant", e.toChars());
+                error(e.loc, "expression `%s` is not constant", e.toErrMsg());
             errors = true;
             return false;
         }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4065,6 +4065,7 @@ struct HdrGenState final
     bool vcg_ast;
     bool skipConstraints;
     bool showOneMember;
+    bool errorMsg;
     bool fullQual;
     int32_t tpltMember;
     int32_t autoMember;
@@ -4082,6 +4083,7 @@ struct HdrGenState final
         vcg_ast(),
         skipConstraints(),
         showOneMember(true),
+        errorMsg(),
         fullQual(),
         tpltMember(),
         autoMember(),
@@ -4092,7 +4094,7 @@ struct HdrGenState final
         inEnumDecl()
     {
     }
-    HdrGenState(bool hdrgen, bool ddoc = false, bool fullDump = false, bool importcHdr = false, bool doFuncBodies = false, bool vcg_ast = false, bool skipConstraints = false, bool showOneMember = true, bool fullQual = false, int32_t tpltMember = 0, int32_t autoMember = 0, int32_t forStmtInit = 0, int32_t insideFuncBody = 0, int32_t insideAggregate = 0, bool declstring = false, EnumDeclaration* inEnumDecl = nullptr) :
+    HdrGenState(bool hdrgen, bool ddoc = false, bool fullDump = false, bool importcHdr = false, bool doFuncBodies = false, bool vcg_ast = false, bool skipConstraints = false, bool showOneMember = true, bool errorMsg = false, bool fullQual = false, int32_t tpltMember = 0, int32_t autoMember = 0, int32_t forStmtInit = 0, int32_t insideFuncBody = 0, int32_t insideAggregate = 0, bool declstring = false, EnumDeclaration* inEnumDecl = nullptr) :
         hdrgen(hdrgen),
         ddoc(ddoc),
         fullDump(fullDump),
@@ -4101,6 +4103,7 @@ struct HdrGenState final
         vcg_ast(vcg_ast),
         skipConstraints(skipConstraints),
         showOneMember(showOneMember),
+        errorMsg(errorMsg),
         fullQual(fullQual),
         tpltMember(tpltMember),
         autoMember(autoMember),

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -585,7 +585,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             const errors = global.startGagging();
             i.exp = i.exp.implicitCastTo(sc, t);
             if (global.endGagging(errors))
-                error(currExp.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`", currExp.toChars(), et.toChars(), t.toChars());
+                error(currExp.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`", currExp.toErrMsg(), et.toChars(), t.toChars());
         }
         }
     L1:

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -380,7 +380,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if (!sc.intypeof)
                     {
                         if (fld.tok == TOK.delegate_)
-                            .error(funcdecl.loc, "%s `%s` cannot be %s members", funcdecl.kind, funcdecl.toPrettyChars, ad.kind());
+                            .error(funcdecl.loc, "%s `%s` cannot be %s members", funcdecl.kind, funcdecl.toErrMsg, ad.kind());
                         else
                             fld.tok = TOK.function_;
                     }
@@ -1375,7 +1375,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             }
             if (isCppNonMappableType(f.next.toBasetype()))
             {
-                .error(funcdecl.loc, "%s `%s` cannot return type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toPrettyChars, f.next.toChars());
+                .error(funcdecl.loc, "%s `%s` cannot return type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toErrMsg(), f.next.toChars());
                 if (f.next.isTypeDArray())
                     errorSupplemental(funcdecl.loc, "slices are specific to D and do not have a counterpart representation in C++", f.next.toChars());
                 funcdecl.errors = true;
@@ -1384,7 +1384,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             {
                 if (isCppNonMappableType(param.type.toBasetype(), param))
                 {
-                    .error(funcdecl.loc, "%s `%s` cannot have parameter of type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toPrettyChars, param.type.toChars());
+                    .error(funcdecl.loc, "%s `%s` cannot have parameter of type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toErrMsg(), param.type.toChars());
                     if (param.type.toBasetype().isTypeSArray())
                         errorSupplemental(funcdecl.loc, "perhaps use a `%s*` type instead",
                                           param.type.nextOf().mutableOf().unSharedOf().toChars());
@@ -1741,7 +1741,7 @@ extern (D) bool checkClosure(FuncDeclaration fd)
                     }
                     a.push(f);
                     .errorSupplemental(f.loc, "%s `%s` closes over variable `%s`",
-                        f.kind, f.toPrettyChars(), v.toChars());
+                        f.kind, f.toErrMsg(), v.toChars());
                     if (v.ident != Id.This)
                         .errorSupplemental(v.loc, "`%s` declared here", v.toChars());
 

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -20,6 +20,7 @@ import dmd.expressionsem;
 import dmd.func;
 import dmd.funcsem;
 import dmd.globals;
+import dmd.hdrgen;
 import dmd.id;
 import dmd.identifier;
 import dmd.init;
@@ -346,12 +347,12 @@ bool discardValue(Expression e)
         BinExp tmp = e.isBinExp();
         assert(tmp);
 
-        error(e.loc, "the result of the equality expression `%s` is discarded", e.toChars());
+        error(e.loc, "the result of the equality expression `%s` is discarded", e.toErrMsg());
         bool seenSideEffect = false;
         foreach(expr; [tmp.e1, tmp.e2])
         {
             if (hasSideEffect(expr)) {
-                errorSupplemental(expr.loc, "note that `%s` may have a side effect", expr.toChars());
+                errorSupplemental(expr.loc, "note that `%s` may have a side effect", expr.toErrMsg());
                 seenSideEffect |= true;
             }
         }
@@ -359,7 +360,7 @@ bool discardValue(Expression e)
     default:
         break;
     }
-    error(e.loc, "`%s` has no effect", e.toChars());
+    error(e.loc, "`%s` has no effect", e.toErrMsg());
     return true;
 }
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -664,7 +664,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             const olderrors = global.startGagging();
             discardValue(fs.increment);
             if (global.endGagging(olderrors))
-                deprecation(fs.increment.loc, "`%s` has no effect", fs.increment.toChars());
+                deprecation(fs.increment.loc, "`%s` has no effect", fs.increment.toErrMsg());
             if (checkNonAssignmentArrayOp(fs.increment))
                 fs.increment = ErrorExp.get();
             fs.increment = fs.increment.optimize(WANTvalue);
@@ -2604,7 +2604,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     //errors = true;
                 }
                 if (global.endGagging(olderrors))
-                    deprecation(rs.exp.loc, "`%s` has no effect", rs.exp.toChars());
+                    deprecation(rs.exp.loc, "`%s` has no effect", rs.exp.toErrMsg());
 
                 /* Replace:
                  *      return exp;

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1187,7 +1187,7 @@ private const(char)* getParamError(TypeFunction tf, Expression arg, Parameter pa
     // only mention rvalue if it's relevant
     const rv = !arg.isLvalue() && par.isReference();
     buf.printf("cannot pass %sargument `%s` of type `%s` to parameter `%s`",
-        rv ? "rvalue ".ptr : "".ptr, arg.toChars(), at,
+        rv ? "rvalue ".ptr : "".ptr, arg.toErrMsg(), at,
         parameterToChars(par, tf, qual));
     return buf.extractChars();
 }
@@ -2329,7 +2329,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             {
                 const(char)* errTxt = fparam.storageClass & STC.ref_ ? "ref" : "out";
                 .error(e.loc, "expression `%s` of type `%s` is not implicitly convertible to type `%s %s` of parameter `%s`",
-                      e.toChars(), e.type.toChars(), errTxt, fparam.type.toChars(), fparam.toChars());
+                      e.toErrMsg(), e.type.toChars(), errTxt, fparam.type.toChars(), fparam.toChars());
             }
             e = e.implicitCastTo(sc, fparam.type);
 
@@ -4731,7 +4731,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
         {
             if (e.op == EXP.type)
             {
-                error(e.loc, "`%s` is not an expression", e.toChars());
+                error(e.loc, "`%s` is not an expression", e.toErrMsg());
                 return ErrorExp.get();
             }
             else if (mt.dim.toUInteger() < 1 && checkUnsafeDotExp(sc, e, ident, flag))
@@ -4780,7 +4780,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
         }
         if (e.op == EXP.type && (ident == Id.length || ident == Id.ptr))
         {
-            error(e.loc, "`%s` is not an expression", e.toChars());
+            error(e.loc, "`%s` is not an expression", e.toErrMsg());
             return ErrorExp.get();
         }
         if (ident == Id.length)
@@ -5207,7 +5207,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
         Declaration d = s.isDeclaration();
         if (!d)
         {
-            error(e.loc, "`%s.%s` is not a declaration", e.toChars(), ident.toChars());
+            error(e.loc, "`%s.%s` is not a declaration", e.toErrMsg(), ident.toChars());
             return ErrorExp.get();
         }
 
@@ -5640,7 +5640,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
         Declaration d = s.isDeclaration();
         if (!d)
         {
-            error(e.loc, "`%s.%s` is not a declaration", e.toChars(), ident.toChars());
+            error(e.loc, "`%s.%s` is not a declaration", e.toErrMsg(), ident.toChars());
             return ErrorExp.get();
         }
 

--- a/compiler/test/fail_compilation/attributediagnostic.d
+++ b/compiler/test/fail_compilation/attributediagnostic.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/attributediagnostic.d(21): Error: `@safe` function `attributediagnostic.layer2` cannot call `@system` function `attributediagnostic.layer1`
-fail_compilation/attributediagnostic.d(23):        which calls `attributediagnostic.layer0`
-fail_compilation/attributediagnostic.d(25):        which calls `attributediagnostic.system`
+fail_compilation/attributediagnostic.d(23):        which calls `layer0`
+fail_compilation/attributediagnostic.d(25):        which calls `system`
 fail_compilation/attributediagnostic.d(27):        and executing an `asm` statement without `@trusted` annotation makes it fail to infer `@safe`
 fail_compilation/attributediagnostic.d(22):        `attributediagnostic.layer1` is declared here
 fail_compilation/attributediagnostic.d(43): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system1`

--- a/compiler/test/fail_compilation/attributediagnostic_nogc.d
+++ b/compiler/test/fail_compilation/attributediagnostic_nogc.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/attributediagnostic_nogc.d(21): Error: `@nogc` function `attributediagnostic_nogc.layer2` cannot call non-@nogc function `attributediagnostic_nogc.layer1`
-fail_compilation/attributediagnostic_nogc.d(22):        which calls `attributediagnostic_nogc.layer0`
-fail_compilation/attributediagnostic_nogc.d(23):        which calls `attributediagnostic_nogc.gc`
+fail_compilation/attributediagnostic_nogc.d(22):        which calls `layer0`
+fail_compilation/attributediagnostic_nogc.d(23):        which calls `gc`
 fail_compilation/attributediagnostic_nogc.d(27):        and executing an `asm` statement without `@nogc` annotation makes it fail to infer `@nogc`
 fail_compilation/attributediagnostic_nogc.d(43): Error: `@nogc` function `D main` cannot call non-@nogc function `attributediagnostic_nogc.gc1`
 fail_compilation/attributediagnostic_nogc.d(32):        and allocating with `new` makes it fail to infer `@nogc`

--- a/compiler/test/fail_compilation/attributediagnostic_nothrow.d
+++ b/compiler/test/fail_compilation/attributediagnostic_nothrow.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/attributediagnostic_nothrow.d(19): Error: function `attributediagnostic_nothrow.layer1` is not `nothrow`
-fail_compilation/attributediagnostic_nothrow.d(20):        which calls `attributediagnostic_nothrow.layer0`
-fail_compilation/attributediagnostic_nothrow.d(21):        which calls `attributediagnostic_nothrow.gc`
+fail_compilation/attributediagnostic_nothrow.d(20):        which calls `layer0`
+fail_compilation/attributediagnostic_nothrow.d(21):        which calls `gc`
 fail_compilation/attributediagnostic_nothrow.d(25):        and executing an `asm` statement without a `nothrow` annotation makes it fail to infer `nothrow`
 fail_compilation/attributediagnostic_nothrow.d(19): Error: function `attributediagnostic_nothrow.layer2` may throw but is marked as `nothrow`
 fail_compilation/attributediagnostic_nothrow.d(41): Error: function `attributediagnostic_nothrow.gc1` is not `nothrow`

--- a/compiler/test/fail_compilation/b19523.d
+++ b/compiler/test/fail_compilation/b19523.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ----
 fail_compilation/b19523.d(13): Error: undefined identifier `SomeStruct`
 fail_compilation/b19523.d(14): Error: function `foo` is not callable using argument types `(_error_)`
-fail_compilation/b19523.d(14):        cannot pass argument `__lambda_L14_C6` of type `_error_` to parameter `int delegate() arg`
+fail_compilation/b19523.d(14):        cannot pass argument `__error` of type `_error_` to parameter `int delegate() arg`
 fail_compilation/b19523.d(19):        `b19523.foo(int delegate() arg)` declared here
 ----
 */

--- a/compiler/test/fail_compilation/bug9631.d
+++ b/compiler/test/fail_compilation/bug9631.d
@@ -65,7 +65,7 @@ TEST_OUTPUT:
 fail_compilation/bug9631.d(80): Error: function `f` is not callable using argument types `(int, S)`
 fail_compilation/bug9631.d(80):        cannot pass argument `y` of type `bug9631.tem!().S` to parameter `bug9631.S s`
 fail_compilation/bug9631.d(79):        `bug9631.arg.f(int i, S s)` declared here
-fail_compilation/bug9631.d(81): Error: function literal `__lambda_L81_C5(S s)` is not callable using argument types `(S)`
+fail_compilation/bug9631.d(81): Error: function literal `(S s) { }` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(81):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S s`
 fail_compilation/bug9631.d(87): Error: constructor `bug9631.arg.A.this(S __param_0)` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(87):        cannot pass argument `S(0)` of type `bug9631.tem!().S` to parameter `bug9631.S __param_0`

--- a/compiler/test/fail_compilation/constraints_defs.d
+++ b/compiler/test/fail_compilation/constraints_defs.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 fail_compilation/constraints_defs.d(49): Error: template instance `constraints_defs.main.def!(int, 0, (a) => a)` does not match template declaration `def(T, int i = 5, alias R)()`
   with `T = int,
        i = 0,
-       R = __lambda_L49_C18`
+       R = (a) => a`
   must satisfy the following constraint:
 `       N!T`
 fail_compilation/constraints_defs.d(50): Error: template instance `imports.constraints.defa!int` does not match template declaration `defa(T, U = int)()`

--- a/compiler/test/fail_compilation/constraints_tmpl.d
+++ b/compiler/test/fail_compilation/constraints_tmpl.d
@@ -22,7 +22,7 @@ fail_compilation/constraints_tmpl.d(41): Error: template instance `imports.const
 `       N!T
        N!U`
 fail_compilation/constraints_tmpl.d(43): Error: template instance `constraints_tmpl.main.lambda!((a) => a)` does not match template declaration `lambda(alias pred)()`
-  with `pred = __lambda_L43_C13`
+  with `pred = (a) => a`
   must satisfy the following constraint:
 `       N!int`
 ---

--- a/compiler/test/fail_compilation/cppvar.d
+++ b/compiler/test/fail_compilation/cppvar.d
@@ -9,7 +9,7 @@ fail_compilation/cppvar.d(21): Error: variable `cppvar.staticVar` cannot have `e
 fail_compilation/cppvar.d(21):        perhaps declare it as `__gshared` instead
 fail_compilation/cppvar.d(22): Error: variable `cppvar.sharedVar` cannot have `extern(C++)` linkage because it is `shared`
 fail_compilation/cppvar.d(22):        perhaps declare it as `__gshared` instead
-fail_compilation/cppvar.d(30): Error: delegate `cppvar.__lambda_L30_C46` cannot return type `bool[3]` because its linkage is `extern(C++)`
+fail_compilation/cppvar.d(30): Error: delegate `() { bool[3] a = false; return a; }` cannot return type `bool[3]` because its linkage is `extern(C++)`
 ---
 */
 #line 10

--- a/compiler/test/fail_compilation/diag12829.d
+++ b/compiler/test/fail_compilation/diag12829.d
@@ -2,12 +2,12 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag12829.d(15): Error: function `diag12829.test1` is `@nogc` yet allocates closure for `test1()` with the GC
-fail_compilation/diag12829.d(18):        delegate `diag12829.test1.__lambda_L18_C33` closes over variable `x`
+fail_compilation/diag12829.d(18):        delegate `() { int y = x; }` closes over variable `x`
 fail_compilation/diag12829.d(17):        `x` declared here
-fail_compilation/diag12829.d(22):        function `diag12829.test1.bar` closes over variable `x`
+fail_compilation/diag12829.d(22):        function `bar` closes over variable `x`
 fail_compilation/diag12829.d(17):        `x` declared here
 fail_compilation/diag12829.d(29): Error: function `diag12829.test2` is `@nogc` yet allocates closure for `test2()` with the GC
-fail_compilation/diag12829.d(34):        function `diag12829.test2.S.foo` closes over variable `x`
+fail_compilation/diag12829.d(34):        function `foo` closes over variable `x`
 fail_compilation/diag12829.d(31):        `x` declared here
 ---
 */

--- a/compiler/test/fail_compilation/diag_funclit.d
+++ b/compiler/test/fail_compilation/diag_funclit.d
@@ -1,19 +1,19 @@
 /**
 TEST_OUTPUT:
 ---
-fail_compilation/diag_funclit.d(103): Error: function literal `__lambda_L103_C5(x, y, z)` is not callable using argument types `()`
+fail_compilation/diag_funclit.d(103): Error: function literal `(x, y, z) { return 42; }` is not callable using argument types `()`
 fail_compilation/diag_funclit.d(103):        too few arguments, expected 3, got 0
-fail_compilation/diag_funclit.d(106): Error: function literal `__lambda_L106_C5(x, y, z)` is not callable using argument types `(int, string, int, int)`
+fail_compilation/diag_funclit.d(106): Error: `(x, y, z) { return 42; }` is not callable using argument types `(int, string, int, int)`
 fail_compilation/diag_funclit.d(106):        too many arguments, expected 3, got 4
-fail_compilation/diag_funclit.d(108): Error: function literal `__lambda_L108_C5(x, y, string z = "Hello")` is not callable using argument types `(int, int, string, string)`
+fail_compilation/diag_funclit.d(108): Error: `(x, y, string z = "Hello") { return x; }` is not callable using argument types `(int, int, string, string)`
 fail_compilation/diag_funclit.d(108):        too many arguments, expected 3, got 4
-fail_compilation/diag_funclit.d(110): Error: function literal `__lambda_L110_C5(x, y, string z = "Hello")` is not callable using argument types `(int)`
+fail_compilation/diag_funclit.d(110): Error: `(x, y, string z = "Hello") { return x; }` is not callable using argument types `(int)`
 fail_compilation/diag_funclit.d(110):        too few arguments, expected 3, got 1
-fail_compilation/diag_funclit.d(112): Error: function literal `__lambda_L112_C5(x, y, z)` is not callable using argument types `(int)`
+fail_compilation/diag_funclit.d(112): Error: `(x, y, z) { return x; }` is not callable using argument types `(int)`
 fail_compilation/diag_funclit.d(112):        too few arguments, expected 3, got 1
-fail_compilation/diag_funclit.d(115): Error: function literal `__lambda_L115_C5(x, y, ...)` is not callable using argument types `(int)`
+fail_compilation/diag_funclit.d(115): Error: `(x, y, ...) { return x; }` is not callable using argument types `(int)`
 fail_compilation/diag_funclit.d(115):        too few arguments, expected 2, got 1
-fail_compilation/diag_funclit.d(117): Error: function literal `__lambda_L117_C5(x, y, string z = "Hey", ...)` is not callable using argument types `(int)`
+fail_compilation/diag_funclit.d(117): Error: `(x, y, string z = "Hey", ...) { return x; }` is not callable using argument types `(int)`
 fail_compilation/diag_funclit.d(117):        too few arguments, expected 3, got 1
 ---
  */

--- a/compiler/test/fail_compilation/fail11125.d
+++ b/compiler/test/fail_compilation/fail11125.d
@@ -2,11 +2,11 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail11125.d(26): Error: template instance `fail11125.filter!(function (int a) pure nothrow @nogc @safe => a + 1)` does not match template declaration `filter(alias predfun)`
-  with `predfun = __lambda_L26_C13`
+  with `predfun = (int a) => a + 1`
   must satisfy the following constraint:
 `       is(ReturnType!predfun == bool)`
 fail_compilation/fail11125.d(27): Error: template instance `fail11125.filter!(function (int a) pure nothrow @nogc @safe => a + 1)` does not match template declaration `filter(alias predfun)`
-  with `predfun = __lambda_L27_C17`
+  with `predfun = (int a) => a + 1`
   must satisfy the following constraint:
 `       is(ReturnType!predfun == bool)`
 ---

--- a/compiler/test/fail_compilation/fail11375.d
+++ b/compiler/test/fail_compilation/fail11375.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail11375.d(18): Error: constructor `fail11375.D!().D.this` is not `nothrow`
-       which calls `fail11375.B.this`
+       which calls `this() { return this; }`
 fail_compilation/fail11375.d(16): Error: function `D main` may throw but is marked as `nothrow`
 ---
 */

--- a/compiler/test/fail_compilation/fail117.d
+++ b/compiler/test/fail_compilation/fail117.d
@@ -1,10 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail117.d(37): Error: expression `foo.mixin MGettor!(a) geta;
-` is `void` and has no value
-fail_compilation/fail117.d(38): Error: expression `foo.mixin MGettor!(b) getb;
-` is `void` and has no value
+fail_compilation/fail117.d(35): Error: expression `foo.mixin MGettor!(a) geta;` is `void` and has no value
+fail_compilation/fail117.d(36): Error: expression `foo.mixin MGettor!(b) getb;` is `void` and has no value
 ---
 */
 

--- a/compiler/test/fail_compilation/fail13120.d
+++ b/compiler/test/fail_compilation/fail13120.d
@@ -17,7 +17,7 @@ void g1(char[] s) pure @nogc
 TEST_OUTPUT:
 ---
 fail_compilation/fail13120.d(35): Error: `pure` function `fail13120.h2` cannot call impure function `fail13120.g2!().g2`
-fail_compilation/fail13120.d(30):        which calls `fail13120.f2`
+fail_compilation/fail13120.d(30):        which calls `f2`
 fail_compilation/fail13120.d(35): Error: `@safe` function `fail13120.h2` cannot call `@system` function `fail13120.g2!().g2`
 fail_compilation/fail13120.d(27):        `fail13120.g2!().g2` is declared here
 fail_compilation/fail13120.d(35): Error: `@nogc` function `fail13120.h2` cannot call non-@nogc function `fail13120.g2!().g2`

--- a/compiler/test/fail_compilation/fail13424.d
+++ b/compiler/test/fail_compilation/fail13424.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13424.d(12): Error: delegate `fail13424.S.__lambda_L12_C35` cannot be struct members
-fail_compilation/fail13424.d(17): Error: delegate `fail13424.U.__lambda_L17_C35` cannot be union members
-fail_compilation/fail13424.d(22): Error: delegate `fail13424.C.__lambda_L22_C35` cannot be class members
+fail_compilation/fail13424.d(12): Error: delegate `(dchar) { }` cannot be struct members
+fail_compilation/fail13424.d(17): Error: delegate `(dchar) { }` cannot be union members
+fail_compilation/fail13424.d(22): Error: delegate `(dchar) { }` cannot be class members
 ---
 */
 

--- a/compiler/test/fail_compilation/fail16575.d
+++ b/compiler/test/fail_compilation/fail16575.d
@@ -3,29 +3,29 @@
 REQUIRED_ARGS: -m64
 TEST_OUTPUT:
 ---
-fail_compilation/fail16575.d(10): Error: function `fail16575.immNull` cannot have parameter of type `immutable(typeof(null))*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(11): Error: function `fail16575.shaNull` cannot have parameter of type `shared(typeof(null))*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(20): Error: function `fail16575.immNoReturn` cannot have parameter of type `immutable(noreturn)*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(21): Error: function `fail16575.shaNoReturn` cannot have parameter of type `shared(noreturn)*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(30): Error: function `fail16575.immBasic` cannot have parameter of type `immutable(int)*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(31): Error: function `fail16575.shaBasic` cannot have parameter of type `shared(int)*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(40): Error: function `fail16575.immVector` cannot have parameter of type `immutable(__vector(long[2]))*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(41): Error: function `fail16575.shaVector` cannot have parameter of type `shared(__vector(long[2]))*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(50): Error: function `fail16575.immSArray` cannot have parameter of type `immutable(long[2])` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(10): Error: function `immNull` cannot have parameter of type `immutable(typeof(null))*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(11): Error: function `shaNull` cannot have parameter of type `shared(typeof(null))*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(20): Error: function `immNoReturn` cannot have parameter of type `immutable(noreturn)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(21): Error: function `shaNoReturn` cannot have parameter of type `shared(noreturn)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(30): Error: function `immBasic` cannot have parameter of type `immutable(int)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(31): Error: function `shaBasic` cannot have parameter of type `shared(int)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(40): Error: function `immVector` cannot have parameter of type `immutable(__vector(long[2]))*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(41): Error: function `shaVector` cannot have parameter of type `shared(__vector(long[2]))*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(50): Error: function `immSArray` cannot have parameter of type `immutable(long[2])` because its linkage is `extern(C++)`
 fail_compilation/fail16575.d(50):        perhaps use a `long*` type instead
-fail_compilation/fail16575.d(51): Error: function `fail16575.shaSArray` cannot have parameter of type `shared(long[2])` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(51): Error: function `shaSArray` cannot have parameter of type `shared(long[2])` because its linkage is `extern(C++)`
 fail_compilation/fail16575.d(51):        perhaps use a `long*` type instead
-fail_compilation/fail16575.d(60): Error: function `fail16575.immPointer` cannot have parameter of type `immutable(int*)` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(61): Error: function `fail16575.shaPointer` cannot have parameter of type `shared(int*)` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(71): Error: function `fail16575.immStruct` cannot have parameter of type `immutable(SPP)*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(72): Error: function `fail16575.shaStruct` cannot have parameter of type `shared(SPP)*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(81): Error: function `fail16575.immClass` cannot have parameter of type `immutable(CPP)` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(82): Error: function `fail16575.shaClass` cannot have parameter of type `shared(CPP)` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(91): Error: function `fail16575.immEnum` cannot have parameter of type `immutable(EPP)*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(92): Error: function `fail16575.shaEnum` cannot have parameter of type `shared(EPP)*` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(100): Error: function `fail16575.typeDArray` cannot have parameter of type `int[]` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(101): Error: function `fail16575.typeAArray` cannot have parameter of type `int[int]` because its linkage is `extern(C++)`
-fail_compilation/fail16575.d(102): Error: function `fail16575.typeDelegate` cannot have parameter of type `extern (C++) int delegate()` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(60): Error: function `immPointer` cannot have parameter of type `immutable(int*)` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(61): Error: function `shaPointer` cannot have parameter of type `shared(int*)` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(71): Error: function `immStruct` cannot have parameter of type `immutable(SPP)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(72): Error: function `shaStruct` cannot have parameter of type `shared(SPP)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(81): Error: function `immClass` cannot have parameter of type `immutable(CPP)` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(82): Error: function `shaClass` cannot have parameter of type `shared(CPP)` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(91): Error: function `immEnum` cannot have parameter of type `immutable(EPP)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(92): Error: function `shaEnum` cannot have parameter of type `shared(EPP)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(100): Error: function `typeDArray` cannot have parameter of type `int[]` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(101): Error: function `typeAArray` cannot have parameter of type `int[int]` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(102): Error: function `typeDelegate` cannot have parameter of type `extern (C++) int delegate()` because its linkage is `extern(C++)`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail16689.d
+++ b/compiler/test/fail_compilation/fail16689.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail16689.d(3): Error: static assert:  "false"
-fail_compilation/fail16689.d(6):        instantiated from here: `Issue16689!()`
+fail_compilation/fail16689.d(6):        instantiated from here: `mixin Issue16689!();`
 ---
 */
 #line 1

--- a/compiler/test/fail_compilation/fail16772.d
+++ b/compiler/test/fail_compilation/fail16772.d
@@ -1,7 +1,7 @@
 // https://issues.dlang.org/show_bug.cgi?id=16772
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail16772.d(8): Error: function `fail16772.ice16772` cannot return type `ubyte[]` because its linkage is `extern(C++)`
+fail_compilation/fail16772.d(8): Error: function `ice16772` cannot return type `ubyte[]` because its linkage is `extern(C++)`
 fail_compilation/fail16772.d(8):        slices are specific to D and do not have a counterpart representation in C++
 ---
 */

--- a/compiler/test/fail_compilation/fail19759.d
+++ b/compiler/test/fail_compilation/fail19759.d
@@ -1,7 +1,7 @@
 // https://issues.dlang.org/show_bug.cgi?id=19759
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail19759.d(8): Error: function `fail19759.fail19759` cannot have parameter of type `float[4]` because its linkage is `extern(C++)`
+fail_compilation/fail19759.d(8): Error: function `fail19759` cannot have parameter of type `float[4]` because its linkage is `extern(C++)`
 fail_compilation/fail19759.d(8):        perhaps use a `float*` type instead
 ---
 */

--- a/compiler/test/fail_compilation/fail21206.d
+++ b/compiler/test/fail_compilation/fail21206.d
@@ -1,7 +1,7 @@
 // https://issues.dlang.org/show_bug.cgi?id=21206
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail21206.d(10): Error: function `fail21206.Obj.toString` cannot return type `string` because its linkage is `extern(C++)`
+fail_compilation/fail21206.d(10): Error: function `toString` cannot return type `string` because its linkage is `extern(C++)`
 fail_compilation/fail21206.d(10):        slices are specific to D and do not have a counterpart representation in C++
 ---
 */

--- a/compiler/test/fail_compilation/fail2450.d
+++ b/compiler/test/fail_compilation/fail2450.d
@@ -2,10 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2450.d(22): Error: function expected before `()`, not `this.mixin Event!() clicked;
-` of type `void`
-fail_compilation/fail2450.d(25): Error: function expected before `()`, not `b.mixin Event!() clicked;
-` of type `void`
+fail_compilation/fail2450.d(20): Error: function expected before `()`, not `this.mixin Event!() clicked;` of type `void`
+fail_compilation/fail2450.d(23): Error: function expected before `()`, not `b.mixin Event!() clicked;` of type `void`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail6334.d
+++ b/compiler/test/fail_compilation/fail6334.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail6334.d(13): Error: static assert:  `0` is false
-fail_compilation/fail6334.d(11):        instantiated from here: `T2!()`
+fail_compilation/fail6334.d(11):        instantiated from here: `mixin T2!();`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail99.d
+++ b/compiler/test/fail_compilation/fail99.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail99.d(13): Error: delegate `dg(int)` is not callable using argument types `()`
+fail_compilation/fail99.d(13): Error: delegate `dg` is not callable using argument types `()`
 fail_compilation/fail99.d(13):        too few arguments, expected 1, got 0
 ---
 */

--- a/compiler/test/fail_compilation/ice10922.d
+++ b/compiler/test/fail_compilation/ice10922.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10922.d(11): Error: function `__lambda_L10_C12` is not callable using argument types `()`
+fail_compilation/ice10922.d(11): Error: function `(in uint n) { enum self = __lambda_L10_C12; return n < 2 ? n : self(n - 1) + ...` is not callable using argument types `()`
 fail_compilation/ice10922.d(11):        too few arguments, expected 1, got 0
 fail_compilation/ice10922.d(10):        `ice10922.__lambda_L10_C12(in uint n)` declared here
 ---

--- a/compiler/test/fail_compilation/ice22377.d
+++ b/compiler/test/fail_compilation/ice22377.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice22377.d(8): Error: function `ice22377.foo` cannot have parameter of type `string` because its linkage is `extern(C++)`
+fail_compilation/ice22377.d(8): Error: function `foo` cannot have parameter of type `string` because its linkage is `extern(C++)`
 ---
 */
 

--- a/compiler/test/fail_compilation/ice8309.d
+++ b/compiler/test/fail_compilation/ice8309.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8309.d(10): Error: incompatible types for `(__lambda_L10_C15) : (__lambda_L10_C24)`: `double function() pure nothrow @nogc @safe` and `int function() pure nothrow @nogc @safe`
+fail_compilation/ice8309.d(10): Error: incompatible types for `(() => 1.0) : (() => 1)`: `double function() pure nothrow @nogc @safe` and `int function() pure nothrow @nogc @safe`
 ---
 */
 

--- a/compiler/test/fail_compilation/ice9406.d
+++ b/compiler/test/fail_compilation/ice9406.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9406.d(22): Error: `s1.mixin Mixin!() t1;
-` has no effect
+fail_compilation/ice9406.d(21): Error: `s1.mixin Mixin!() t1;` has no effect
 ---
 */
 

--- a/compiler/test/fail_compilation/misc1.d
+++ b/compiler/test/fail_compilation/misc1.d
@@ -5,7 +5,7 @@ fail_compilation/misc1.d(109): Error: `5` has no effect
 fail_compilation/misc1.d(110): Error: `1 + 2` has no effect
 fail_compilation/misc1.d(111): Error: `x` has no effect
 fail_compilation/misc1.d(117): Deprecation: `1 * 1` has no effect
-fail_compilation/misc1.d(118): Deprecation: `__lambda_L118_C34` has no effect
+fail_compilation/misc1.d(118): Deprecation: `() { j++; d++; }` has no effect
 fail_compilation/misc1.d(124): Deprecation: `false` has no effect
 fail_compilation/misc1.d(127): Deprecation: `*sp++` has no effect
 fail_compilation/misc1.d(128): Deprecation: `j` has no effect

--- a/compiler/test/fail_compilation/nogc3.d
+++ b/compiler/test/fail_compilation/nogc3.d
@@ -44,10 +44,10 @@ fail_compilation/nogc3.d(35): Error: `@nogc` function `nogc3.testCall` cannot ca
 TEST_OUTPUT:
 ---
 fail_compilation/nogc3.d(54): Error: function `nogc3.testClosure1` is `@nogc` yet allocates closure for `testClosure1()` with the GC
-fail_compilation/nogc3.d(57):        function `nogc3.testClosure1.bar` closes over variable `x`
+fail_compilation/nogc3.d(57):        function `bar` closes over variable `x`
 fail_compilation/nogc3.d(56):        `x` declared here
 fail_compilation/nogc3.d(66): Error: function `nogc3.testClosure3` is `@nogc` yet allocates closure for `testClosure3()` with the GC
-fail_compilation/nogc3.d(69):        function `nogc3.testClosure3.bar` closes over variable `x`
+fail_compilation/nogc3.d(69):        function `bar` closes over variable `x`
 fail_compilation/nogc3.d(68):        `x` declared here
 ---
 */

--- a/compiler/test/fail_compilation/opapplyscope.d
+++ b/compiler/test/fail_compilation/opapplyscope.d
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/opapplyscope.d(113): Error: function `opapplyscope.S.opApply(scope int delegate(scope int* ptr) @safe dg)` is not callable using argument types `(int delegate(int* x) nothrow @nogc @safe)`
-fail_compilation/opapplyscope.d(113):        cannot pass argument `__foreachbody_L113_C5` of type `int delegate(int* x) nothrow @nogc @safe` to parameter `scope int delegate(scope int* ptr) @safe dg`
+fail_compilation/opapplyscope.d(113):        cannot pass argument `int(int* x) => 0` of type `int delegate(int* x) nothrow @nogc @safe` to parameter `scope int delegate(scope int* ptr) @safe dg`
 ---
  */
 

--- a/compiler/test/fail_compilation/previewin.d
+++ b/compiler/test/fail_compilation/previewin.d
@@ -3,13 +3,13 @@ REQUIRED_ARGS: -preview=in -preview=dip1000
 TEST_OUTPUT:
 ----
 fail_compilation/previewin.d(4): Error: function `takeFunction` is not callable using argument types `(void function(real x) pure nothrow @nogc @safe)`
-fail_compilation/previewin.d(4):        cannot pass argument `__lambda_L4_C18` of type `void function(real x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
+fail_compilation/previewin.d(4):        cannot pass argument `(real x) { }` of type `void function(real x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
 fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(in real) f)` declared here
 fail_compilation/previewin.d(5): Error: function `takeFunction` is not callable using argument types `(void function(scope const(real) x) pure nothrow @nogc @safe)`
-fail_compilation/previewin.d(5):        cannot pass argument `__lambda_L5_C18` of type `void function(scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
+fail_compilation/previewin.d(5):        cannot pass argument `(scope const(real) x) { }` of type `void function(scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
 fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(in real) f)` declared here
 fail_compilation/previewin.d(6): Error: function `takeFunction` is not callable using argument types `(void function(ref scope const(real) x) pure nothrow @nogc @safe)`
-fail_compilation/previewin.d(6):        cannot pass argument `__lambda_L6_C18` of type `void function(ref scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
+fail_compilation/previewin.d(6):        cannot pass argument `(ref scope const(real) x) { }` of type `void function(ref scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
 fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(in real) f)` declared here
 fail_compilation/previewin.d(15): Error: assigning scope variable `arg` to global variable `myGlobal` is not allowed in a `@safe` function
 fail_compilation/previewin.d(16): Error: assigning scope variable `arg` to global variable `myGlobal` is not allowed in a `@safe` function

--- a/compiler/test/fail_compilation/retscope.d
+++ b/compiler/test/fail_compilation/retscope.d
@@ -55,7 +55,7 @@ void test2(scope int* p, int[] a ...) @safe
 TEST_OUTPUT:
 ---
 fail_compilation/retscope.d(75): Error: function `retscope.HTTP.Impl.onReceive` is `@nogc` yet allocates closure for `onReceive()` with the GC
-fail_compilation/retscope.d(77):        delegate `retscope.HTTP.Impl.onReceive.__lambda_L77_C23` closes over variable `this`
+fail_compilation/retscope.d(77):        delegate `() => this.x` closes over variable `this`
 ---
 */
 
@@ -234,10 +234,10 @@ void* funretscope(scope dg_t ptr) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `__lambda_L248_C21` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
-fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `__lambda_L248_C21` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
-fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda_L249_C21` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
-fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda_L249_C21` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `() => & x` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `() => & x` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `() => & x` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `() => & x` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
 ---
 */
 

--- a/compiler/test/fail_compilation/systemvariables_deprecation.d
+++ b/compiler/test/fail_compilation/systemvariables_deprecation.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
 fail_compilation/systemvariables_deprecation.d(15): Deprecation: `@safe` function `main` calling `middle`
-fail_compilation/systemvariables_deprecation.d(20):        which calls `systemvariables_deprecation.inferred`
+fail_compilation/systemvariables_deprecation.d(20):        which calls `inferred`
 fail_compilation/systemvariables_deprecation.d(26):        and access `@system` variable `x0` makes it fail to infer `@safe`
 ---
 */

--- a/compiler/test/fail_compilation/test14238.d
+++ b/compiler/test/fail_compilation/test14238.d
@@ -3,7 +3,7 @@
 ---
 fail_compilation/test14238.d(22): Error: scope parameter `fn` may not be returned
 fail_compilation/test14238.d(25): Error: function `test14238.bar` is `@nogc` yet allocates closure for `bar()` with the GC
-fail_compilation/test14238.d(27):        function `test14238.bar.baz` closes over variable `x`
+fail_compilation/test14238.d(27):        function `baz` closes over variable `x`
 fail_compilation/test14238.d(26):        `x` declared here
 ---
 */

--- a/compiler/test/fail_compilation/test16193.d
+++ b/compiler/test/fail_compilation/test16193.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test16193.d(39): Error: function `test16193.abc` is `@nogc` yet allocates closure for `abc()` with the GC
-fail_compilation/test16193.d(41):        delegate `test16193.abc.__foreachbody_L41_C5` closes over variable `x`
+fail_compilation/test16193.d(41):        delegate `int(int i) => 0` closes over variable `x`
 fail_compilation/test16193.d(40):        `x` declared here
 ---
 */

--- a/compiler/test/fail_compilation/test19107.d
+++ b/compiler/test/fail_compilation/test19107.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/test19107.d(24): Error: template `all` is not callable using argument types `!((c) => c)(string[])`
 fail_compilation/test19107.d(18):        Candidate is: `all(alias pred, T)(T t)`
-  with `pred = __lambda_L24_C15,
+  with `pred = (c) => c,
        T = string[]`
   must satisfy the following constraint:
 `       is(typeof(I!pred(t)))`

--- a/compiler/test/fail_compilation/test19971.d
+++ b/compiler/test/fail_compilation/test19971.d
@@ -3,7 +3,7 @@
 fail_compilation/test19971.d(16): Error: function `f` is not callable using argument types `(string)`
 fail_compilation/test19971.d(16):        cannot pass argument `"%s"` of type `string` to parameter `int x`
 fail_compilation/test19971.d(13):        `test19971.f(int x)` declared here
-fail_compilation/test19971.d(17): Error: function literal `__lambda_L17_C5(int x)` is not callable using argument types `(string)`
+fail_compilation/test19971.d(17): Error: function literal `(int x) { }` is not callable using argument types `(string)`
 fail_compilation/test19971.d(17):        cannot pass argument `"%s"` of type `string` to parameter `int x`
 ---
 */

--- a/compiler/test/fail_compilation/test21912.d
+++ b/compiler/test/fail_compilation/test21912.d
@@ -3,16 +3,16 @@ PERMUTE_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test21912.d(28): Error: function `test21912.escapeParam` is `@nogc` yet allocates closure for `escapeParam()` with the GC
-fail_compilation/test21912.d(30):        delegate `test21912.escapeParam.__lambda_L30_C21` closes over variable `i`
+fail_compilation/test21912.d(30):        delegate `() => i` closes over variable `i`
 fail_compilation/test21912.d(28):        `i` declared here
 fail_compilation/test21912.d(33): Error: function `test21912.escapeAssign` is `@nogc` yet allocates closure for `escapeAssign()` with the GC
-fail_compilation/test21912.d(35):        delegate `test21912.escapeAssign.__lambda_L35_C10` closes over variable `i`
+fail_compilation/test21912.d(35):        delegate `() => i` closes over variable `i`
 fail_compilation/test21912.d(33):        `i` declared here
 fail_compilation/test21912.d(44): Error: function `test21912.escapeAssignRef` is `@nogc` yet allocates closure for `escapeAssignRef()` with the GC
-fail_compilation/test21912.d(46):        delegate `test21912.escapeAssignRef.__lambda_L46_C10` closes over variable `i`
+fail_compilation/test21912.d(46):        delegate `() => i` closes over variable `i`
 fail_compilation/test21912.d(44):        `i` declared here
 fail_compilation/test21912.d(55): Error: function `test21912.escapeParamInferred` is `@nogc` yet allocates closure for `escapeParamInferred()` with the GC
-fail_compilation/test21912.d(57):        delegate `test21912.escapeParamInferred.__lambda_L57_C29` closes over variable `i`
+fail_compilation/test21912.d(57):        delegate `() => i` closes over variable `i`
 fail_compilation/test21912.d(55):        `i` declared here
 ---
 */

--- a/compiler/test/fail_compilation/test23112.d
+++ b/compiler/test/fail_compilation/test23112.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/test23112.d(106): Error: function `test23112.bar` is `@nogc` yet allocates closure for `bar()` with the GC
-fail_compilation/test23112.d(108):        function `test23112.bar.f` closes over variable `a`
+fail_compilation/test23112.d(108):        function `f` closes over variable `a`
 fail_compilation/test23112.d(106):        `a` declared here
 ---
 */

--- a/compiler/test/fail_compilation/testInference.d
+++ b/compiler/test/fail_compilation/testInference.d
@@ -138,8 +138,8 @@ immutable(void)* g10063(inout int* p) pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(154): Error: `pure` function `testInference.bar14049` cannot call impure function `testInference.foo14049!int.foo14049`
-fail_compilation/testInference.d(149):        which calls `testInference.foo14049!int.foo14049.__lambda_L147_C14`
-fail_compilation/testInference.d(148):        which calls `testInference.impure14049`
+fail_compilation/testInference.d(149):        which calls `() => impure14049()`
+fail_compilation/testInference.d(148):        which calls `impure14049`
 fail_compilation/testInference.d(143):        and accessing mutable static data `i` makes it fail to infer `pure`
 ---
 */
@@ -174,7 +174,7 @@ int* f14160() pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(180): Error: `pure` function `testInference.test12422` cannot call impure function `testInference.test12422.bar12422!().bar12422`
-fail_compilation/testInference.d(179):        which calls `testInference.foo12422`
+fail_compilation/testInference.d(179):        which calls `foo12422`
 ---
 */
 #line 175
@@ -239,7 +239,7 @@ void test17086_call ()
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(238): Error: `pure` function `testInference.test20047_pure_function` cannot call impure function `testInference.test20047_pure_function.bug`
-fail_compilation/testInference.d(237):        which calls `testInference.test20047_impure_function`
+fail_compilation/testInference.d(237):        which calls `test20047_impure_function`
 ---
 */
 #line 234

--- a/compiler/test/fail_compilation/var_func_attr.d
+++ b/compiler/test/fail_compilation/var_func_attr.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/var_func_attr.d(19): Error: cannot implicitly convert expression `__lambda_L19_C27` of type `void function() nothrow @nogc @safe` to `void function() pure`
+fail_compilation/var_func_attr.d(19): Error: cannot implicitly convert expression `() { static int g; g++; }` of type `void function() nothrow @nogc @safe` to `void function() pure`
 ---
 */
 


### PR DESCRIPTION
The overal strategy is to replace `arg.toChars` with `arg.toErrMsg` in all `error()` calls. `toChars` can't be updated directly because it's also used for various other things (debug printf's, `pragma(msg)`, `.stringof` etc.). Having a dedicated function for error messages has several advantages:

- Allows general truncation of very long expressions (e.g. `import("file.txt")`, big array literals)
- Enables a fix for escaping backticks (https://github.com/dlang/dmd/issues/19947)
- Enables a fix for escaping color codes (https://github.com/dlang/dmd/issues/20805)
- Eases transition to `@safe` in the long run, the return type can be changed from `const(char)*` to `string` more easily

This PR doesn't update all of them yet, it's big enough as is.

~~Still todo: Add ddoc to hdrgen.d, improve function and parameter names.~~

Edit: done