### PR TITLE
Rephrase "no identifier for declarator" parse error

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4531,7 +4531,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (ident)
                 checkCstyleTypeSyntax(loc, t, alt, ident);
             else if (!isThis && (t != AST.Type.terror))
-                noIdentifierForDeclarator(t);
+                noIdentifierForDeclarator(t, token);
 
             if (isAliasDeclaration)
             {
@@ -4757,11 +4757,12 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         return a;
     }
 
-    /// Report an error that a declaration of type `t` is missing an identifier
+    /// Report an error that a declaration of type `t` is missing an identifier and got `tok` instead
     /// The parser is expected to sit on the next token after the type.
-    private void noIdentifierForDeclarator(AST.Type t)
+    private void noIdentifierForDeclarator(AST.Type t, Token tok)
     {
-        error("no identifier for declarator `%s`", t.toChars());
+        error("variable name expected after type `%s`, not `%s`", t.toChars(), tok.toChars);
+
         // A common mistake is to use a reserved keyword as an identifier, e.g. `in` or `out`
         if (token.isKeyword)
         {
@@ -5571,7 +5572,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             }
             at = parseType(&ai);
             if (!ai)
-                noIdentifierForDeclarator(at);
+                noIdentifierForDeclarator(at, token);
         Larg:
             auto p = new AST.Parameter(aloc, storageClass, at, ai, null, null);
             parameters.push(p);

--- a/compiler/test/compilable/testcolor.sh
+++ b/compiler/test/compilable/testcolor.sh
@@ -31,8 +31,8 @@ check()
     compare "$actual" "$3"
 }
 
-expectedWithoutColor='__stdin.d(2): Error: no identifier for declarator `test`'
-expectedWithColor=$'\033[1m__stdin.d(2): \033[1;31mError: \033[mno identifier for declarator `\033[0;36m\033[m\033[1mtest\033[0;36m\033[m`'
+expectedWithoutColor='__stdin.d(2): Error: variable name expected after type `test`, not `End of File`'
+expectedWithColor=$'\E[1m__stdin.d(2): \E[1;31mError: \E[mvariable name expected after type `\E[0;36m\E[m\E[1mtest\E[0;36m\E[m`, not `\E[0;36m\E[m\E[1mEnd\E[0;36m \E[m\E[1mof\E[0;36m \E[m\E[1mFile\E[0;36m\E[m`'
 
 check -c "test" "$expectedWithoutColor"
 check -color=auto "test" "$expectedWithoutColor"

--- a/compiler/test/fail_compilation/e15876_1.d
+++ b/compiler/test/fail_compilation/e15876_1.d
@@ -7,11 +7,11 @@ fail_compilation/e15876_1.d(18): Error: found `End of File` instead of statement
 fail_compilation/e15876_1.d(18): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/e15876_1.d(17):        unmatched `{`
 fail_compilation/e15876_1.d(18): Error: found `End of File` when expecting `]`
-fail_compilation/e15876_1.d(18): Error: no identifier for declarator `o[()
+fail_compilation/e15876_1.d(18): Error: variable name expected after type `o[()
 {
 scope(exit) __error__
 }
-]`
+]`, not `End of File`
 ---
 */
 o[{scope(x

--- a/compiler/test/fail_compilation/e15876_2.d
+++ b/compiler/test/fail_compilation/e15876_2.d
@@ -5,11 +5,11 @@ fail_compilation/e15876_2.d(16): Error: identifier expected following `template`
 fail_compilation/e15876_2.d(16): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/e15876_2.d(15):        unmatched `{`
 fail_compilation/e15876_2.d(16): Error: found `End of File` when expecting `]`
-fail_compilation/e15876_2.d(16): Error: no identifier for declarator `o[()
+fail_compilation/e15876_2.d(16): Error: variable name expected after type `o[()
 {
 ;
 }
-]`
+]`, not `End of File`
 ---
 */
 o[{template

--- a/compiler/test/fail_compilation/e15876_3.d
+++ b/compiler/test/fail_compilation/e15876_3.d
@@ -13,7 +13,7 @@ fail_compilation/e15876_3.d(29): Error: found `End of File` instead of statement
 fail_compilation/e15876_3.d(29): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/e15876_3.d(28):        unmatched `{`
 fail_compilation/e15876_3.d(29): Error: found `End of File` when expecting `)`
-fail_compilation/e15876_3.d(29): Error: no identifier for declarator `d(_error_ = ()
+fail_compilation/e15876_3.d(29): Error: variable name expected after type `d(_error_ = ()
 {
 for (__error__
  __error; __error)
@@ -21,7 +21,7 @@ for (__error__
 __error__
 }
 }
-)`
+)`, not `End of File`
 fail_compilation/e15876_3.d(29): Error: semicolon expected following function declaration, not `End of File`
 ---
 */

--- a/compiler/test/fail_compilation/e15876_4.d
+++ b/compiler/test/fail_compilation/e15876_4.d
@@ -12,7 +12,7 @@ fail_compilation/e15876_4.d(27): Error: found `End of File` instead of statement
 fail_compilation/e15876_4.d(27): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/e15876_4.d(26):        unmatched `{`
 fail_compilation/e15876_4.d(27): Error: found `End of File` when expecting `)`
-fail_compilation/e15876_4.d(27): Error: no identifier for declarator `typeof(()
+fail_compilation/e15876_4.d(27): Error: variable name expected after type `typeof(()
 {
 for (__error__
  __error; __error)
@@ -20,7 +20,7 @@ for (__error__
 __error__
 }
 }
-)`
+)`, not `End of File`
 ---
 */
 typeof){for

--- a/compiler/test/fail_compilation/e15876_5.d
+++ b/compiler/test/fail_compilation/e15876_5.d
@@ -6,11 +6,11 @@ fail_compilation/e15876_5.d(17): Error: semicolon expected to close `alias` decl
 fail_compilation/e15876_5.d(17): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/e15876_5.d(16):        unmatched `{`
 fail_compilation/e15876_5.d(17): Error: found `End of File` when expecting `]`
-fail_compilation/e15876_5.d(17): Error: no identifier for declarator `p[()
+fail_compilation/e15876_5.d(17): Error: variable name expected after type `p[()
 {
 alias ;
 }
-]`
+]`, not `End of File`
 ---
 */
 p[{alias

--- a/compiler/test/fail_compilation/fail11751.d
+++ b/compiler/test/fail_compilation/fail11751.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail11751.d(10): Error: missing exponent
 fail_compilation/fail11751.d(10): Error: semicolon expected following auto declaration, not `ABC`
-fail_compilation/fail11751.d(10): Error: no identifier for declarator `ABC`
+fail_compilation/fail11751.d(10): Error: variable name expected after type `ABC`, not `;`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail16.d
+++ b/compiler/test/fail_compilation/fail16.d
@@ -3,7 +3,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail16.d(19): Error: function declaration without return type. (Note that constructors are always named `this`)
-fail_compilation/fail16.d(19): Error: no identifier for declarator `bar!(typeof(X))(X)`
+fail_compilation/fail16.d(19): Error: variable name expected after type `bar!(typeof(X))(X)`, not `;`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail22.d
+++ b/compiler/test/fail_compilation/fail22.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22.d(13): Error: no identifier for declarator `char`
+fail_compilation/fail22.d(13): Error: variable name expected after type `char`, not `;`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail3673b.d
+++ b/compiler/test/fail_compilation/fail3673b.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/fail3673b.d(12): Error: basic type expected, not `if`
 fail_compilation/fail3673b.d(12): Error: template constraints only allowed for templates
 fail_compilation/fail3673b.d(12): Error: { } expected following `class` declaration
-fail_compilation/fail3673b.d(12): Error: no identifier for declarator `A`
+fail_compilation/fail3673b.d(12): Error: variable name expected after type `A`, not `{`
 fail_compilation/fail3673b.d(12): Error: declaration expected, not `{`
 ---
 */

--- a/compiler/test/fail_compilation/fail4269e.d
+++ b/compiler/test/fail_compilation/fail4269e.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail4269e.d(10): Error: semicolon needed to end declaration of `Y` instead of `X5`
-fail_compilation/fail4269e.d(10): Error: no identifier for declarator `X5`
+fail_compilation/fail4269e.d(10): Error: variable name expected after type `X5`, not `;`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4544.d
+++ b/compiler/test/fail_compilation/fail4544.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail4544.d(15): Error: character constant has multiple characters
 fail_compilation/fail4544.d(16): Error: `0x` isn't a valid integer literal, use `0x0` instead
-fail_compilation/fail4544.d(16): Error: no identifier for declarator `int`
+fail_compilation/fail4544.d(16): Error: variable name expected after type `int`, not `0`
 fail_compilation/fail4544.d(17): Error: unterminated character constant
 fail_compilation/fail4544.d(18): Error: character constant has multiple characters
 ---

--- a/compiler/test/fail_compilation/failcontracts.d
+++ b/compiler/test/fail_compilation/failcontracts.d
@@ -3,7 +3,7 @@
 fail_compilation/failcontracts.d(17): Error: missing `{ ... }` for function literal
 fail_compilation/failcontracts.d(17): Error: semicolon expected following auto declaration, not `bode`
 fail_compilation/failcontracts.d(18): Error: function declaration without return type. (Note that constructors are always named `this`)
-fail_compilation/failcontracts.d(18): Error: no identifier for declarator `test1()`
+fail_compilation/failcontracts.d(18): Error: variable name expected after type `test1()`, not `bode`
 fail_compilation/failcontracts.d(18): Error: semicolon expected following function declaration, not `bode`
 fail_compilation/failcontracts.d(19): Error: semicolon expected following function declaration, not `bode`
 fail_compilation/failcontracts.d(21): Error: unexpected `(` in declarator

--- a/compiler/test/fail_compilation/ice11153.d
+++ b/compiler/test/fail_compilation/ice11153.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11153.d(11): Error: function declaration without return type. (Note that constructors are always named `this`)
-fail_compilation/ice11153.d(11): Error: no identifier for declarator `foo()`
+fail_compilation/ice11153.d(11): Error: variable name expected after type `foo()`, not `{`
 ---
 */
 

--- a/compiler/test/fail_compilation/ice11963.d
+++ b/compiler/test/fail_compilation/ice11963.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/ice11963.d(10): Error: unexpected `(` in declarator
 fail_compilation/ice11963.d(10): Error: identifier expected for template type parameter
-fail_compilation/ice11963.d(10): Error: no identifier for declarator `A`
+fail_compilation/ice11963.d(10): Error: variable name expected after type `A`, not `""`
 fail_compilation/ice11963.d(10): Error: declaration expected, not `""`
 ---
 */

--- a/compiler/test/fail_compilation/ice11965.d
+++ b/compiler/test/fail_compilation/ice11965.d
@@ -1,15 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11965.d(16): Error: no identifier for declarator `b*`
+fail_compilation/ice11965.d(16): Error: variable name expected after type `b*`, not `End of File`
 fail_compilation/ice11965.d(16): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/ice11965.d(15):        unmatched `{`
 fail_compilation/ice11965.d(16): Error: found `End of File` when expecting `]`
-fail_compilation/ice11965.d(16): Error: no identifier for declarator `u[()
+fail_compilation/ice11965.d(16): Error: variable name expected after type `u[()
 {
 b* A;
 }
-]`
+]`, not `End of File`
 ---
 */
 u[{b*A,

--- a/compiler/test/fail_compilation/ice15855.d
+++ b/compiler/test/fail_compilation/ice15855.d
@@ -12,7 +12,7 @@ fail_compilation/ice15855.d(28): Error: found `End of File` instead of statement
 fail_compilation/ice15855.d(28): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/ice15855.d(27):        unmatched `{`
 fail_compilation/ice15855.d(28): Error: found `End of File` when expecting `]`
-fail_compilation/ice15855.d(28): Error: no identifier for declarator `a[()
+fail_compilation/ice15855.d(28): Error: variable name expected after type `a[()
 {
 for (__error__
  __error; __error)
@@ -20,7 +20,7 @@ for (__error__
 __error__
 }
 }
-]`
+]`, not `End of File`
 ---
 */
 

--- a/compiler/test/fail_compilation/parse14285.d
+++ b/compiler/test/fail_compilation/parse14285.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parse14285.d(10): Error: no identifier for declarator `this`
+fail_compilation/parse14285.d(10): Error: variable name expected after type `this`, not `;`
 ---
 */
 

--- a/compiler/test/fail_compilation/test1.d
+++ b/compiler/test/fail_compilation/test1.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test1.d(8): Error: no identifier for declarator `fail`
+fail_compilation/test1.d(8): Error: variable name expected after type `fail`, not `End of File`
 ---
 */
 fail

--- a/compiler/test/fail_compilation/test21062.d
+++ b/compiler/test/fail_compilation/test21062.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test21062.d(16): Error: no identifier for declarator `bool`
+fail_compilation/test21062.d(16): Error: variable name expected after type `bool`, not `synchronized`
 fail_compilation/test21062.d(16):        `synchronized` is a keyword, perhaps append `_` to make it an identifier
-fail_compilation/test21062.d(17): Error: no identifier for declarator `ubyte*`
+fail_compilation/test21062.d(17): Error: variable name expected after type `ubyte*`, not `out`
 fail_compilation/test21062.d(17):        `out` is a keyword, perhaps append `_` to make it an identifier
-fail_compilation/test21062.d(21): Error: no identifier for declarator `uint`
+fail_compilation/test21062.d(21): Error: variable name expected after type `uint`, not `in`
 fail_compilation/test21062.d(21):        `in` is a keyword, perhaps append `_` to make it an identifier
 ---
 */

--- a/compiler/test/fail_compilation/test21096.d
+++ b/compiler/test/fail_compilation/test21096.d
@@ -4,7 +4,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/test21096.d(11): Error: identifier or new keyword expected following `(...)`.
-fail_compilation/test21096.d(11): Error: no identifier for declarator `char[(__error)]`
+fail_compilation/test21096.d(11): Error: variable name expected after type `char[(__error)]`, not `;`
 ---
 */
 

--- a/compiler/test/fail_compilation/test23873.d
+++ b/compiler/test/fail_compilation/test23873.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/imports/import23873.d(1): Error: (expression) expected following `static if`
 fail_compilation/imports/import23873.d(1): Error: declaration expected following attribute, not `;`
-fail_compilation/imports/import23873.d(3): Error: no identifier for declarator `x`
+fail_compilation/imports/import23873.d(3): Error: variable name expected after type `x`, not `End of File`
 ---
 */
 struct Foo

--- a/compiler/test/fail_compilation/testsemi.d
+++ b/compiler/test/fail_compilation/testsemi.d
@@ -1,11 +1,11 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/testsemi.d(102): Error: found `int` when expecting `;` following static assert
-fail_compilation/testsemi.d(102): Error: no identifier for declarator `x`
+fail_compilation/testsemi.d(102): Error: variable name expected after type `x`, not `;`
 fail_compilation/testsemi.d(109): Error: found `alias` when expecting `;` following alias reassignment
 fail_compilation/testsemi.d(112): Error: found `}` when expecting `;` following invariant
 fail_compilation/testsemi.d(117): Error: found `int` when expecting `;` following `alias Identifier this`
-fail_compilation/testsemi.d(117): Error: no identifier for declarator `x`
+fail_compilation/testsemi.d(117): Error: variable name expected after type `x`, not `;`
 fail_compilation/testsemi.d(123): Error: found `int` when expecting `;` following mixin
 fail_compilation/testsemi.d(129): Error: found `int` when expecting `;` following `import` Expression
 fail_compilation/testsemi.d(131): Error: `}` expected following members in `class` declaration

--- a/compiler/test/fail_compilation/traits_alone.d
+++ b/compiler/test/fail_compilation/traits_alone.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/traits_alone.d(11): Error: found `End of File` when expecting `(`
 fail_compilation/traits_alone.d(11): Error: `__traits(identifier, args...)` expected
-fail_compilation/traits_alone.d(11): Error: no identifier for declarator `$r:_?_error_?$`
+fail_compilation/traits_alone.d(11): Error: variable name expected after type `$r:_?_error_?$`, not `End of File`
 ---
 */
 //used to segfault

--- a/compiler/test/fail_compilation/udaparams.d
+++ b/compiler/test/fail_compilation/udaparams.d
@@ -24,7 +24,7 @@ fail_compilation/udaparams.d(57): Error: found `@` when expecting `)`
 fail_compilation/udaparams.d(57): Error: basic type expected, not `3`
 fail_compilation/udaparams.d(57): Error: found `3` when expecting `)`
 fail_compilation/udaparams.d(57): Error: semicolon expected following function declaration, not `)`
-fail_compilation/udaparams.d(57): Error: no identifier for declarator `T`
+fail_compilation/udaparams.d(57): Error: variable name expected after type `T`, not `)`
 fail_compilation/udaparams.d(57): Error: declaration expected, not `)`
 ---
 */

--- a/compiler/test/unit/frontend.d
+++ b/compiler/test/unit/frontend.d
@@ -271,7 +271,7 @@ unittest
         }
     });
 
-    assert(endsWith(diagnosticMessages[0], "no identifier for declarator `temp`"));
+    assert(endsWith(diagnosticMessages[0], "variable name expected after type `temp`, not `==`"));
     assert(endsWith(diagnosticMessages[1], "found `==` instead of statement"));
 }
 


### PR DESCRIPTION
Unless you wrote a C parser, "no identifier for declarator" is a very cryptic message.