### PR TITLE
Fix #20859 - ICE: class with __vtbl field name causes segfault in Sco…

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4137,7 +4137,8 @@ private extern(C++) class AddMemberVisitor : Visitor
             }
 
             // If using C tag/prototype/forward declaration rules
-            if (sc.flags & SCOPE.Cfile && !dsym.isImport())
+            if (sc && sc.flags & SCOPE.Cfile && !dsym.isImport())
+            // When merging master, replace with: if (sc && sc.inCfile && !dsym.isImport())
             {
                 if (handleTagSymbols(*sc, dsym, s2, sds))
                     return;

--- a/compiler/test/fail_compilation/test20859.d
+++ b/compiler/test/fail_compilation/test20859.d
@@ -1,0 +1,11 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/test20859.d(8): Error: variable `test20859.ICE.__vtbl` conflicts with variable `test20859.ICE.__vtbl` at fail_compilation/test20859.d(10)
+---
+*/
+
+class ICE
+{
+    void **__vtbl;
+}


### PR DESCRIPTION
…pe::inCfile

