### PR TITLE
Put more types in Mcache

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1828,6 +1828,9 @@ public:
         Type* wcto;
         Type* swto;
         Type* swcto;
+        Type* pto;
+        Type* rto;
+        Type* arrayof;
         Mcache() :
             cto(),
             ito(),
@@ -1836,10 +1839,13 @@ public:
             wto(),
             wcto(),
             swto(),
-            swcto()
+            swcto(),
+            pto(),
+            rto(),
+            arrayof()
         {
         }
-        Mcache(Type* cto, Type* ito = nullptr, Type* sto = nullptr, Type* scto = nullptr, Type* wto = nullptr, Type* wcto = nullptr, Type* swto = nullptr, Type* swcto = nullptr) :
+        Mcache(Type* cto, Type* ito = nullptr, Type* sto = nullptr, Type* scto = nullptr, Type* wto = nullptr, Type* wcto = nullptr, Type* swto = nullptr, Type* swcto = nullptr, Type* pto = nullptr, Type* rto = nullptr, Type* arrayof = nullptr) :
             cto(cto),
             ito(ito),
             sto(sto),
@@ -1847,14 +1853,14 @@ public:
             wto(wto),
             wcto(wcto),
             swto(swto),
-            swcto(swcto)
+            swcto(swcto),
+            pto(pto),
+            rto(rto),
+            arrayof(arrayof)
             {}
     };
 
     Mcache* mcache;
-    Type* pto;
-    Type* rto;
-    Type* arrayof;
     TypeInfoDeclaration* vtinfo;
     void* ctype;
     static Type* tvoid;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -299,12 +299,11 @@ extern (C++) abstract class Type : ASTNode
         Type wcto;      // MODFlags.wildconst
         Type swto;      // MODFlags.shared_ | MODFlags.wild
         Type swcto;     // MODFlags.shared_ | MODFlags.wildconst
+        Type pto;       // merged pointer to this type
+        Type rto;       // reference to this type
+        Type arrayof;   // array of this type
     }
     Mcache* mcache;
-
-    Type pto;       // merged pointer to this type
-    Type rto;       // reference to this type
-    Type arrayof;   // array of this type
 
     TypeInfoDeclaration vtinfo;     // TypeInfo object for this Type
 
@@ -762,9 +761,6 @@ extern (C++) abstract class Type : ASTNode
         memcpy(cast(void*)t, cast(void*)this, sz);
         // t.mod = NULL;  // leave mod unchanged
         t.deco = null;
-        t.arrayof = null;
-        t.pto = null;
-        t.rto = null;
         t.vtinfo = null;
         t.ctype = null;
         t.mcache = null;

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -146,9 +146,6 @@ public:
     MOD mod;  // modifiers MODxxxx
     char *deco;
     void* mcache;
-    Type *pto;          // merged pointer to this type
-    Type *rto;          // reference to this type
-    Type *arrayof;      // array of this type
     TypeInfoDeclaration *vtinfo;        // TypeInfo object for this Type
 
     type *ctype;        // for back end

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -6715,30 +6715,32 @@ Type pointerTo(Type type)
 {
     if (type.ty == Terror)
         return type;
-    if (!type.pto)
+    auto mcache = type.getMcache();
+    if (!mcache.pto)
     {
         Type t = new TypePointer(type);
         if (type.ty == Tfunction)
         {
             t.deco = t.merge().deco;
-            type.pto = t;
+            mcache.pto = t;
         }
         else
-            type.pto = t.merge();
+            mcache.pto = t.merge();
     }
-    return type.pto;
+    return mcache.pto;
 }
 
 Type referenceTo(Type type)
 {
     if (type.ty == Terror)
         return type;
-    if (!type.rto)
+    auto mcache = type.getMcache();
+    if (!mcache.rto)
     {
         Type t = new TypeReference(type);
-        type.rto = t.merge();
+        mcache.rto = t.merge();
     }
-    return type.rto;
+    return mcache.rto;
 }
 
 // Make corresponding static array type without semantic
@@ -6756,12 +6758,13 @@ Type arrayOf(Type type)
 {
     if (type.ty == Terror)
         return type;
-    if (!type.arrayof)
+    auto mcache = type.getMcache();
+    if (!mcache.arrayof)
     {
         Type t = new TypeDArray(type);
-        type.arrayof = t.merge();
+        mcache.arrayof = t.merge();
     }
-    return type.arrayof;
+    return mcache.arrayof;
 }
 
 /********************************


### PR DESCRIPTION
I don't know why these were left out of https://github.com/dlang/dmd/pull/11363, but compiling Phobos unittests before & after:
```
        User time (seconds): 26.69
        Maximum resident set size (kbytes): 15010436
        Minor (reclaiming a frame) page faults: 3252591
---
        User time (seconds): 26.34
        Maximum resident set size (kbytes): 14662144
        Minor (reclaiming a frame) page faults: 3161353
```
