### PR TITLE
Remove version (tracegc) blocks

### DIFF
--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -53,18 +53,6 @@ version (D_ProfileGC)
             string name = } ~ "`" ~ Type ~ "`;" ~ q{
 
             // FIXME: use rt.tracegc.accumulator when it is accessable in the future.
-            version (tracegc)
-        } ~ "{\n" ~ q{
-                import core.stdc.stdio : printf;
-
-                printf("%sTrace file = '%.*s' line = %d function = '%.*s' type = %.*s\n",
-                } ~ "\"" ~ Hook ~ "\".ptr," ~ q{
-                    file.length, file.ptr,
-                    line,
-                    funcname.length, funcname.ptr,
-                    name.length, name.ptr
-                );
-            } ~ "}\n" ~ q{
             ulong currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
 
             scope(exit)

--- a/druntime/src/rt/tracegc.d
+++ b/druntime/src/rt/tracegc.d
@@ -15,8 +15,6 @@
 
 module rt.tracegc;
 
-// version = tracegc;
-
 extern (C) void _d_callfinalizer(void* p);
 extern (C) void _d_callinterfacefinalizer(void *p);
 extern (C) void _d_delclass(Object* p);
@@ -68,19 +66,6 @@ enum accumulator = q{
         string name = "closure";
     else
         string name = "";
-
-    version (tracegc)
-    {
-        import core.stdc.stdio : printf;
-
-        printf("%s file = '%.*s' line = %d function = '%.*s' type = %.*s\n",
-            __FUNCTION__.ptr,
-            file.length, file.ptr,
-            line,
-            funcname.length, funcname.ptr,
-            name.length, name.ptr
-        );
-    }
 
     ulong currentlyAllocated = GC.allocatedInCurrentThread;
 


### PR DESCRIPTION
It's confusing that there's an actual `version (D_ProfileGC)` and a phony `version(tracegc)`, the latter being tracing of the... tracing...

It's not tested and unsurprisingly, trying `-version=tracegc` results in printf-deprecations and purity errors, so it's best to just keep `accumulate()` doing the actual thing.