### PR TITLE
Use __FILE__, __LINE__ for templated tracegc hooks

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -6862,7 +6862,7 @@ elem* filelinefunction(ref IRState irs, Loc loc)
     FuncDeclaration fd = irs.getFunc();
     if (fd)
     {
-        s = fd.toPrettyChars();
+        s = fd.Dsymbol.toPrettyChars();
     }
 
     len = strlen(s);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4864,14 +4864,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         id = new DotTemplateInstanceExp(ne.loc, id, hook, tiargs);
 
         auto arguments = new Expressions();
-        if (global.params.tracegc)
-        {
-            auto funcname = (sc.callsc && sc.callsc.func) ?
-                sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
-            arguments.push(new StringExp(ne.loc, ne.loc.filename.toDString()));
-            arguments.push(new IntegerExp(ne.loc, ne.loc.linnum, Type.tint32));
-            arguments.push(new StringExp(ne.loc, funcname.toDString()));
-        }
         id = new CallExp(ne.loc, id, arguments);
 
         ne.lowering = id.expressionSemantic(sc);
@@ -5210,14 +5202,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 tiargs.push(t);
                 id = new DotTemplateInstanceExp(exp.loc, id, hook, tiargs);
                 auto arguments = new Expressions();
-                if (global.params.tracegc)
-                {
-                    auto funcname = (sc.callsc && sc.callsc.func) ?
-                        sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
-                    arguments.push(new StringExp(exp.loc, exp.loc.filename.toDString()));
-                    arguments.push(new IntegerExp(exp.loc, exp.loc.linnum, Type.tint32));
-                    arguments.push(new StringExp(exp.loc, funcname.toDString()));
-                }
                 id = new CallExp(exp.loc, id, arguments);
 
                 exp.lowering = id.expressionSemantic(sc);
@@ -5402,14 +5386,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 lowering = new DotTemplateInstanceExp(exp.loc, lowering, hook, tiargs);
 
                 auto arguments = new Expressions();
-                if (global.params.tracegc)
-                {
-                    auto funcname = (sc.callsc && sc.callsc.func) ?
-                        sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
-                    arguments.push(new StringExp(exp.loc, exp.loc.filename.toDString()));
-                    arguments.push(new IntegerExp(exp.loc, exp.loc.linnum, Type.tint32));
-                    arguments.push(new StringExp(exp.loc, funcname.toDString()));
-                }
                 arguments.push((*exp.arguments)[0]);
                 arguments.push(new IntegerExp(exp.loc, isShared, Type.tbool));
 
@@ -5441,14 +5417,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 lowering = new DotTemplateInstanceExp(exp.loc, lowering, hook, tiargs);
 
                 auto arguments = new Expressions();
-                if (global.params.tracegc)
-                {
-                    auto funcname = (sc.callsc && sc.callsc.func) ?
-                        sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
-                    arguments.push(new StringExp(exp.loc, exp.loc.filename.toDString()));
-                    arguments.push(new IntegerExp(exp.loc, exp.loc.linnum, Type.tint32));
-                    arguments.push(new StringExp(exp.loc, funcname.toDString()));
-                }
 
                 arguments.push(new ArrayLiteralExp(exp.loc, Type.tsize_t.sarrayOf(nargs), exp.arguments));
                 arguments.push(new IntegerExp(exp.loc, tbn.isShared(), Type.tbool));
@@ -11248,14 +11216,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             id = id.expressionSemantic(sc);
 
             auto arguments = new Expressions();
-            arguments.reserve(5);
-            if (global.params.tracegc)
-            {
-                auto funcname = (sc.callsc && sc.callsc.func) ? sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
-                arguments.push(new StringExp(exp.loc, exp.loc.filename.toDString()));
-                arguments.push(new IntegerExp(exp.loc, exp.loc.linnum, Type.tint32));
-                arguments.push(new StringExp(exp.loc, funcname.toDString()));
-            }
             arguments.push(ale.e1);
             arguments.push(exp.e2);
 
@@ -11973,15 +11933,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 id = new DotIdExp(exp.loc, id, hook);
 
                 auto arguments = new Expressions();
-                arguments.reserve(5);
-                if (global.params.tracegc)
-                {
-                    auto funcname = (sc.callsc && sc.callsc.func) ? sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
-                    arguments.push(new StringExp(exp.loc, exp.loc.filename.toDString()));
-                    arguments.push(new IntegerExp(exp.loc, exp.loc.linnum, Type.tint32));
-                    arguments.push(new StringExp(exp.loc, funcname.toDString()));
-                }
-
                 arguments.push(exp.e1);
                 arguments.push(exp.e2);
                 Expression ce = new CallExp(exp.loc, id, arguments);
@@ -12016,15 +11967,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 id = new DotIdExp(exp.loc, id, hook);
 
                 auto arguments = new Expressions();
-                arguments.reserve(5);
-                if (global.params.tracegc)
-                {
-                    auto funcname = (sc.callsc && sc.callsc.func) ? sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
-                    arguments.push(new StringExp(exp.loc, exp.loc.filename.toDString()));
-                    arguments.push(new IntegerExp(exp.loc, exp.loc.linnum, Type.tint32));
-                    arguments.push(new StringExp(exp.loc, funcname.toDString()));
-                }
-
                 Expression eValue1;
                 Expression value1 = extractSideEffect(sc, "__appendtmp", eValue1, exp.e1);
 
@@ -12368,7 +12310,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     if (hook == Id._d_arraycatnTX)
                         arguments.pushSlice((*callExp.arguments)[]);
                     else
-                        arguments.pushSlice((*callExp.arguments)[3 .. $]);
+                        arguments.pushSlice((*callExp.arguments)[0 .. $ - 3]);
                 }
             }
             else
@@ -12376,15 +12318,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         auto arguments = new Expressions();
-        if (useTraceGCHook)
-        {
-            auto funcname = (sc.callsc && sc.callsc.func) ?
-                sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
-            arguments.push(new StringExp(exp.loc, exp.loc.filename.toDString()));
-            arguments.push(new IntegerExp(exp.loc, exp.loc.linnum, Type.tint32));
-            arguments.push(new StringExp(exp.loc, funcname.toDString()));
-        }
-
         handleCatArgument(arguments, exp.e1, exp.type.toBasetype(), false);
         handleCatArgument(arguments, exp.e2, exp.type.toBasetype(), true);
 

--- a/compiler/test/runnable/profilegc_stdout.d
+++ b/compiler/test/runnable/profilegc_stdout.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -profile=gc
 RUN_OUTPUT:
 ---
 bytes allocated, allocations, type, function, file:line
-             96	              1	ubyte D main runnable/profilegc_stdout.d:17
+             96	              1	ubyte profilegc_stdout.main runnable/profilegc_stdout.d:17
 ---
 */
 

--- a/druntime/src/core/internal/array/appending.d
+++ b/druntime/src/core/internal/array/appending.d
@@ -52,7 +52,7 @@ version (D_ProfileGC)
     /**
      * TraceGC wrapper around $(REF _d_arrayappendT, core,internal,array,appending).
      */
-    ref Tarr _d_arrayappendcTXTrace(Tarr : T[], T)(string file, int line, string funcname, return ref scope Tarr px, size_t n) @trusted
+    ref Tarr _d_arrayappendcTXTrace(Tarr : T[], T)(return ref scope Tarr px, size_t n, string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
     {
         version (D_TypeInfo)
         {
@@ -115,7 +115,7 @@ version (D_ProfileGC)
     /**
      * TraceGC wrapper around $(REF _d_arrayappendT, core,internal,array,appending).
      */
-    ref Tarr _d_arrayappendTTrace(Tarr : T[], T)(string file, int line, string funcname, return ref scope Tarr x, scope Tarr y) @trusted
+    ref Tarr _d_arrayappendTTrace(Tarr : T[], T)(return ref scope Tarr x, scope Tarr y, string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
     {
         version (D_TypeInfo)
         {

--- a/druntime/src/core/internal/array/concatenation.d
+++ b/druntime/src/core/internal/array/concatenation.d
@@ -48,7 +48,7 @@ Tret _d_arraycatnTX(Tret, Tarr...)(auto ref Tarr froms) @trusted
     {
         // TODO: forward file, line, name from _d_arraycatnTXTrace
         _d_arraysetlengthTImpl!(typeof(res))._d_arraysetlengthTTrace(
-            __FILE__, __LINE__, "_d_arraycatnTX", res, totalLen);
+            res, totalLen, __FILE__, __LINE__, __FUNCTION__);
     }
     else
     {
@@ -178,7 +178,7 @@ version (D_ProfileGC)
     /**
     * TraceGC wrapper around $(REF _d_arraycatnTX, core,internal,array,concatenation).
     */
-    Tret _d_arraycatnTXTrace(Tret, Tarr...)(string file, int line, string funcname, scope auto ref Tarr froms) @trusted
+    Tret _d_arraycatnTXTrace(Tret, Tarr...)(scope auto ref Tarr froms, string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
     {
         version (D_TypeInfo)
         {

--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -470,7 +470,7 @@ version (D_ProfileGC)
     /**
     * TraceGC wrapper around $(REF _d_newitemT, core,lifetime).
     */
-    T[] _d_newarrayTTrace(T)(string file, int line, string funcname, size_t length, bool isShared) @trusted
+    T[] _d_newarrayTTrace(T)(size_t length, bool isShared, string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
     {
         version (D_TypeInfo)
         {
@@ -602,7 +602,7 @@ version (D_ProfileGC)
     /**
     * TraceGC wrapper around $(REF _d_newarraymT, core,internal,array,construction).
     */
-    Tarr _d_newarraymTXTrace(Tarr : U[], T, U)(string file, int line, string funcname, size_t[] dims, bool isShared=false) @trusted
+    Tarr _d_newarraymTXTrace(Tarr : U[], T, U)(size_t[] dims, bool isShared=false, string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
     {
         version (D_TypeInfo)
         {

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -87,7 +87,7 @@ version (D_ProfileGC)
      *  purity, and throwabilty checks. To prevent breaking existing code, this function template
      *  is temporarily declared `@trusted pure` until the implementation can be brought up to modern D expectations.
     */
-    auto _d_HookTraceImpl(T, alias Hook, string errorMessage)(string file, int line, string funcname, Parameters!Hook parameters) @trusted pure
+    auto _d_HookTraceImpl(T, alias Hook, string errorMessage)(Parameters!Hook parameters, string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted pure
     {
         version (D_TypeInfo)
         {

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -2788,7 +2788,7 @@ if (is(T == class))
 /**
  * TraceGC wrapper around $(REF _d_newclassT, core,lifetime).
  */
-T _d_newclassTTrace(T)(string file, int line, string funcname) @trusted
+T _d_newclassTTrace(T)(string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
 {
     version (D_TypeInfo)
     {
@@ -2985,7 +2985,7 @@ version (D_ProfileGC)
     /**
     * TraceGC wrapper around $(REF _d_newitemT, core,lifetime).
     */
-    T* _d_newitemTTrace(T)(string file, int line, string funcname) @trusted
+    T* _d_newitemTTrace(T)(string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
     {
         version (D_TypeInfo)
         {

--- a/druntime/test/profile/myprofilegc.log.freebsd.32.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.32.exp
@@ -1,21 +1,21 @@
 bytes allocated, allocations, type, function, file:line
-            256	              1	immutable(char)[][int] D main src/profilegc.d:23
-            128	              1	float D main src/profilegc.d:18
-            128	              1	int D main src/profilegc.d:15
+            256	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            128	              1	float profilegc.main src/profilegc.d:18
+            128	              1	int profilegc.main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56
-             48	              1	float[] D main src/profilegc.d:42
-             48	              1	int[] D main src/profilegc.d:41
+             48	              1	float[] profilegc.main src/profilegc.d:42
+             48	              1	int[] profilegc.main src/profilegc.d:41
              32	              1	void[] profilegc.main src/profilegc.d:55
-             16	              1	C D main src/profilegc.d:12
-             16	              1	char[] D main src/profilegc.d:34
-             16	              1	char[] D main src/profilegc.d:36
+             16	              1	C profilegc.main src/profilegc.d:12
+             16	              1	char[] profilegc.main src/profilegc.d:34
+             16	              1	char[] profilegc.main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45
-             16	              1	float D main src/profilegc.d:16
-             16	              1	float D main src/profilegc.d:17
-             16	              1	int D main src/profilegc.d:13
-             16	              1	int D main src/profilegc.d:14
-             16	              1	uint[] D main src/profilegc.d:15
-             16	              1	uint[] D main src/profilegc.d:18
-             16	              1	int[] D main src/profilegc.d:22
-             16	              1	int[] D main src/profilegc.d:37
-             16	              1	wchar[] D main src/profilegc.d:35
+             16	              1	float profilegc.main src/profilegc.d:16
+             16	              1	float profilegc.main src/profilegc.d:17
+             16	              1	int profilegc.main src/profilegc.d:13
+             16	              1	int profilegc.main src/profilegc.d:14
+             16	              1	uint[] profilegc.main src/profilegc.d:15
+             16	              1	uint[] profilegc.main src/profilegc.d:18
+             16	              1	int[] profilegc.main src/profilegc.d:22
+             16	              1	int[] profilegc.main src/profilegc.d:37
+             16	              1	wchar[] profilegc.main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.freebsd.64.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.64.exp
@@ -1,21 +1,21 @@
 bytes allocated, allocations, type, function, file:line
-            496	              1	immutable(char)[][int] D main src/profilegc.d:23
-            160	              1	float D main src/profilegc.d:18
-            160	              1	int D main src/profilegc.d:15
+            496	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            160	              1	float profilegc.main src/profilegc.d:18
+            160	              1	int profilegc.main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56
-             48	              1	float[] D main src/profilegc.d:42
-             48	              1	int[] D main src/profilegc.d:41
-             32	              1	C D main src/profilegc.d:12
-             32	              1	ulong[] D main src/profilegc.d:15
-             32	              1	ulong[] D main src/profilegc.d:18
+             48	              1	float[] profilegc.main src/profilegc.d:42
+             48	              1	int[] profilegc.main src/profilegc.d:41
+             32	              1	C profilegc.main src/profilegc.d:12
+             32	              1	ulong[] profilegc.main src/profilegc.d:15
+             32	              1	ulong[] profilegc.main src/profilegc.d:18
              32	              1	void[] profilegc.main src/profilegc.d:55
-             16	              1	char[] D main src/profilegc.d:34
-             16	              1	char[] D main src/profilegc.d:36
+             16	              1	char[] profilegc.main src/profilegc.d:34
+             16	              1	char[] profilegc.main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45
-             16	              1	float D main src/profilegc.d:16
-             16	              1	float D main src/profilegc.d:17
-             16	              1	int D main src/profilegc.d:13
-             16	              1	int D main src/profilegc.d:14
-             16	              1	int[] D main src/profilegc.d:22
-             16	              1	int[] D main src/profilegc.d:37
-             16	              1	wchar[] D main src/profilegc.d:35
+             16	              1	float profilegc.main src/profilegc.d:16
+             16	              1	float profilegc.main src/profilegc.d:17
+             16	              1	int profilegc.main src/profilegc.d:13
+             16	              1	int profilegc.main src/profilegc.d:14
+             16	              1	int[] profilegc.main src/profilegc.d:22
+             16	              1	int[] profilegc.main src/profilegc.d:37
+             16	              1	wchar[] profilegc.main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.linux.32.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.32.exp
@@ -1,21 +1,21 @@
 bytes allocated, allocations, type, function, file:line
-            256	              1	immutable(char)[][int] D main src/profilegc.d:23
-            128	              1	float D main src/profilegc.d:18
-            128	              1	int D main src/profilegc.d:15
+            256	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            128	              1	float profilegc.main src/profilegc.d:18
+            128	              1	int profilegc.main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56
-             48	              1	float[] D main src/profilegc.d:42
-             48	              1	int[] D main src/profilegc.d:41
+             48	              1	float[] profilegc.main src/profilegc.d:42
+             48	              1	int[] profilegc.main src/profilegc.d:41
              32	              1	void[] profilegc.main src/profilegc.d:55
-             16	              1	C D main src/profilegc.d:12
-             16	              1	char[] D main src/profilegc.d:34
-             16	              1	char[] D main src/profilegc.d:36
+             16	              1	C profilegc.main src/profilegc.d:12
+             16	              1	char[] profilegc.main src/profilegc.d:34
+             16	              1	char[] profilegc.main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45
-             16	              1	float D main src/profilegc.d:16
-             16	              1	float D main src/profilegc.d:17
-             16	              1	int D main src/profilegc.d:13
-             16	              1	int D main src/profilegc.d:14
-             16	              1	int[] D main src/profilegc.d:22
-             16	              1	int[] D main src/profilegc.d:37
-             16	              1	uint[] D main src/profilegc.d:15
-             16	              1	uint[] D main src/profilegc.d:18
-             16	              1	wchar[] D main src/profilegc.d:35
+             16	              1	float profilegc.main src/profilegc.d:16
+             16	              1	float profilegc.main src/profilegc.d:17
+             16	              1	int profilegc.main src/profilegc.d:13
+             16	              1	int profilegc.main src/profilegc.d:14
+             16	              1	int[] profilegc.main src/profilegc.d:22
+             16	              1	int[] profilegc.main src/profilegc.d:37
+             16	              1	uint[] profilegc.main src/profilegc.d:15
+             16	              1	uint[] profilegc.main src/profilegc.d:18
+             16	              1	wchar[] profilegc.main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.linux.64.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.64.exp
@@ -1,21 +1,21 @@
 bytes allocated, allocations, type, function, file:line
-            496	              1	immutable(char)[][int] D main src/profilegc.d:23
-            160	              1	float D main src/profilegc.d:18
-            160	              1	int D main src/profilegc.d:15
+            496	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            160	              1	float profilegc.main src/profilegc.d:18
+            160	              1	int profilegc.main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56
-             48	              1	float[] D main src/profilegc.d:42
-             48	              1	int[] D main src/profilegc.d:41
-             32	              1	C D main src/profilegc.d:12
-             32	              1	ulong[] D main src/profilegc.d:15
-             32	              1	ulong[] D main src/profilegc.d:18
+             48	              1	float[] profilegc.main src/profilegc.d:42
+             48	              1	int[] profilegc.main src/profilegc.d:41
+             32	              1	C profilegc.main src/profilegc.d:12
+             32	              1	ulong[] profilegc.main src/profilegc.d:15
+             32	              1	ulong[] profilegc.main src/profilegc.d:18
              32	              1	void[] profilegc.main src/profilegc.d:55
-             16	              1	char[] D main src/profilegc.d:34
-             16	              1	char[] D main src/profilegc.d:36
+             16	              1	char[] profilegc.main src/profilegc.d:34
+             16	              1	char[] profilegc.main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45
-             16	              1	float D main src/profilegc.d:16
-             16	              1	float D main src/profilegc.d:17
-             16	              1	int D main src/profilegc.d:13
-             16	              1	int D main src/profilegc.d:14
-             16	              1	int[] D main src/profilegc.d:22
-             16	              1	int[] D main src/profilegc.d:37
-             16	              1	wchar[] D main src/profilegc.d:35
+             16	              1	float profilegc.main src/profilegc.d:16
+             16	              1	float profilegc.main src/profilegc.d:17
+             16	              1	int profilegc.main src/profilegc.d:13
+             16	              1	int profilegc.main src/profilegc.d:14
+             16	              1	int[] profilegc.main src/profilegc.d:22
+             16	              1	int[] profilegc.main src/profilegc.d:37
+             16	              1	wchar[] profilegc.main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.osx.32.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.32.exp
@@ -1,21 +1,21 @@
 bytes allocated, allocations, type, function, file:line
-            176	              1	immutable(char)[][int] D main src/profilegc.d:23
-            128	              1	float D main src/profilegc.d:18
-            128	              1	int D main src/profilegc.d:15
-             64	              1	float[] D main src/profilegc.d:42
-             64	              1	int[] D main src/profilegc.d:41
+            176	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            128	              1	float profilegc.main src/profilegc.d:18
+            128	              1	int profilegc.main src/profilegc.d:15
+             64	              1	float[] profilegc.main src/profilegc.d:42
+             64	              1	int[] profilegc.main src/profilegc.d:41
              64	              1	double[] profilegc.main src/profilegc.d:56
              32	              1	void[] profilegc.main src/profilegc.d:55
-             16	              1	C D main src/profilegc.d:12
-             16	              1	char[] D main src/profilegc.d:34
-             16	              1	char[] D main src/profilegc.d:36
+             16	              1	C profilegc.main src/profilegc.d:12
+             16	              1	char[] profilegc.main src/profilegc.d:34
+             16	              1	char[] profilegc.main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45
-             16	              1	float D main src/profilegc.d:16
-             16	              1	float D main src/profilegc.d:17
-             16	              1	int D main src/profilegc.d:13
-             16	              1	int D main src/profilegc.d:14
-             16	              1	uint[] D main src/profilegc.d:15
-             16	              1	uint[] D main src/profilegc.d:18
-             16	              1	int[] D main src/profilegc.d:22
-             16	              1	int[] D main src/profilegc.d:37
-             16	              1	wchar[] D main src/profilegc.d:35
+             16	              1	float profilegc.main src/profilegc.d:16
+             16	              1	float profilegc.main src/profilegc.d:17
+             16	              1	int profilegc.main src/profilegc.d:13
+             16	              1	int profilegc.main src/profilegc.d:14
+             16	              1	uint[] profilegc.main src/profilegc.d:15
+             16	              1	uint[] profilegc.main src/profilegc.d:18
+             16	              1	int[] profilegc.main src/profilegc.d:22
+             16	              1	int[] profilegc.main src/profilegc.d:37
+             16	              1	wchar[] profilegc.main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.osx.64.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.64.exp
@@ -1,21 +1,21 @@
 bytes allocated, allocations, type, function, file:line
-            496	              1	immutable(char)[][int] D main src/profilegc.d:23
-            160	              1	float D main src/profilegc.d:18
-            160	              1	int D main src/profilegc.d:15
+            496	              1	immutable(char)[][int] profilegc.main src/profilegc.d:23
+            160	              1	float profilegc.main src/profilegc.d:18
+            160	              1	int profilegc.main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56
-             48	              1	float[] D main src/profilegc.d:42
-             48	              1	int[] D main src/profilegc.d:41
-             32	              1	C D main src/profilegc.d:12
-             32	              1	ulong[] D main src/profilegc.d:15
-             32	              1	ulong[] D main src/profilegc.d:18
+             48	              1	float[] profilegc.main src/profilegc.d:42
+             48	              1	int[] profilegc.main src/profilegc.d:41
+             32	              1	C profilegc.main src/profilegc.d:12
+             32	              1	ulong[] profilegc.main src/profilegc.d:15
+             32	              1	ulong[] profilegc.main src/profilegc.d:18
              32	              1	void[] profilegc.main src/profilegc.d:55
-             16	              1	char[] D main src/profilegc.d:34
-             16	              1	char[] D main src/profilegc.d:36
+             16	              1	char[] profilegc.main src/profilegc.d:34
+             16	              1	char[] profilegc.main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45
-             16	              1	float D main src/profilegc.d:16
-             16	              1	float D main src/profilegc.d:17
-             16	              1	int D main src/profilegc.d:13
-             16	              1	int D main src/profilegc.d:14
-             16	              1	int[] D main src/profilegc.d:22
-             16	              1	int[] D main src/profilegc.d:37
-             16	              1	wchar[] D main src/profilegc.d:35
+             16	              1	float profilegc.main src/profilegc.d:16
+             16	              1	float profilegc.main src/profilegc.d:17
+             16	              1	int profilegc.main src/profilegc.d:13
+             16	              1	int profilegc.main src/profilegc.d:14
+             16	              1	int[] profilegc.main src/profilegc.d:22
+             16	              1	int[] profilegc.main src/profilegc.d:37
+             16	              1	wchar[] profilegc.main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.windows.32.exp
+++ b/druntime/test/profile/myprofilegc.log.windows.32.exp
@@ -1,21 +1,21 @@
 bytes allocated, allocations, type, function, file:line
-            256	              1	immutable(char)[][int] D main src\profilegc.d:23
-            128	              1	float D main src\profilegc.d:18
-            128	              1	int D main src\profilegc.d:15
+            256	              1	immutable(char)[][int] profilegc.main src\profilegc.d:23
+            128	              1	float profilegc.main src\profilegc.d:18
+            128	              1	int profilegc.main src\profilegc.d:15
              64	              1	double[] profilegc.main src\profilegc.d:56
-             48	              1	float[] D main src\profilegc.d:42
-             48	              1	int[] D main src\profilegc.d:41
+             48	              1	float[] profilegc.main src\profilegc.d:42
+             48	              1	int[] profilegc.main src\profilegc.d:41
              32	              1	void[] profilegc.main src\profilegc.d:55
-             16	              1	C D main src\profilegc.d:12
-             16	              1	char[] D main src\profilegc.d:34
-             16	              1	char[] D main src\profilegc.d:36
+             16	              1	C profilegc.main src\profilegc.d:12
+             16	              1	char[] profilegc.main src\profilegc.d:34
+             16	              1	char[] profilegc.main src\profilegc.d:36
              16	              1	closure profilegc.main.foo src\profilegc.d:45
-             16	              1	float D main src\profilegc.d:16
-             16	              1	float D main src\profilegc.d:17
-             16	              1	int D main src\profilegc.d:13
-             16	              1	int D main src\profilegc.d:14
-             16	              1	int[] D main src\profilegc.d:22
-             16	              1	int[] D main src\profilegc.d:37
-             16	              1	uint[] D main src\profilegc.d:15
-             16	              1	uint[] D main src\profilegc.d:18
-             16	              1	wchar[] D main src\profilegc.d:35
+             16	              1	float profilegc.main src\profilegc.d:16
+             16	              1	float profilegc.main src\profilegc.d:17
+             16	              1	int profilegc.main src\profilegc.d:13
+             16	              1	int profilegc.main src\profilegc.d:14
+             16	              1	int[] profilegc.main src\profilegc.d:22
+             16	              1	int[] profilegc.main src\profilegc.d:37
+             16	              1	uint[] profilegc.main src\profilegc.d:15
+             16	              1	uint[] profilegc.main src\profilegc.d:18
+             16	              1	wchar[] profilegc.main src\profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.windows.64.exp
+++ b/druntime/test/profile/myprofilegc.log.windows.64.exp
@@ -1,21 +1,21 @@
 bytes allocated, allocations, type, function, file:line
-            496	              1	immutable(char)[][int] D main src\profilegc.d:23
-            160	              1	float D main src\profilegc.d:18
-            160	              1	int D main src\profilegc.d:15
+            496	              1	immutable(char)[][int] profilegc.main src\profilegc.d:23
+            160	              1	float profilegc.main src\profilegc.d:18
+            160	              1	int profilegc.main src\profilegc.d:15
              64	              1	double[] profilegc.main src\profilegc.d:56
-             48	              1	float[] D main src\profilegc.d:42
-             48	              1	int[] D main src\profilegc.d:41
-             32	              1	C D main src\profilegc.d:12
-             32	              1	ulong[] D main src\profilegc.d:15
-             32	              1	ulong[] D main src\profilegc.d:18
+             48	              1	float[] profilegc.main src\profilegc.d:42
+             48	              1	int[] profilegc.main src\profilegc.d:41
+             32	              1	C profilegc.main src\profilegc.d:12
+             32	              1	ulong[] profilegc.main src\profilegc.d:15
+             32	              1	ulong[] profilegc.main src\profilegc.d:18
              32	              1	void[] profilegc.main src\profilegc.d:55
-             16	              1	char[] D main src\profilegc.d:34
-             16	              1	char[] D main src\profilegc.d:36
+             16	              1	char[] profilegc.main src\profilegc.d:34
+             16	              1	char[] profilegc.main src\profilegc.d:36
              16	              1	closure profilegc.main.foo src\profilegc.d:45
-             16	              1	float D main src\profilegc.d:16
-             16	              1	float D main src\profilegc.d:17
-             16	              1	int D main src\profilegc.d:13
-             16	              1	int D main src\profilegc.d:14
-             16	              1	int[] D main src\profilegc.d:22
-             16	              1	int[] D main src\profilegc.d:37
-             16	              1	wchar[] D main src\profilegc.d:35
+             16	              1	float profilegc.main src\profilegc.d:16
+             16	              1	float profilegc.main src\profilegc.d:17
+             16	              1	int profilegc.main src\profilegc.d:13
+             16	              1	int profilegc.main src\profilegc.d:14
+             16	              1	int[] profilegc.main src\profilegc.d:22
+             16	              1	int[] profilegc.main src\profilegc.d:37
+             16	              1	wchar[] profilegc.main src\profilegc.d:35


### PR DESCRIPTION
Removes the duplicated logic for pushing file, line and function name arguments.