### PR TITLE
add floating support to tstresult()

### DIFF
--- a/compiler/src/dmd/backend/arm/disasmarm.d
+++ b/compiler/src/dmd/backend/arm/disasmarm.d
@@ -2048,7 +2048,7 @@ void disassemble(uint c) @trusted
         {
             p1 = opcode2 & 0x10 ? "fcmpe" : "fcmp";
             p2 =                    fregString(rbuf[0..4],"sd h"[ftype],Rn);
-            p3 = (Rm == 0 && (opcode2 & 0x18) == 0x18) ? "#0.0" : fregString(rbuf[4..8],"sd h"[ftype],Rm);
+            p3 = (Rm == 0 && (opcode2 & 8)) ? "#0.0" : fregString(rbuf[4..8],"sd h"[ftype],Rm);
         }
     }
 

--- a/compiler/src/dmd/backend/arm/instr.d
+++ b/compiler/src/dmd/backend/arm/instr.d
@@ -761,6 +761,15 @@ struct INSTR
         return floatcmp(0, 0, ftype, Vm & 31, 0, Vn & 31, opcode2);
     }
 
+    /* FCMP Vn,Vm https://www.scs.stanford.edu/~zyedidia/arm64/fcmp_float.html
+     * FCMP Vn,#0.0
+     */
+    static uint fcmp_float(uint ftype, reg_t Vm, reg_t Vn)
+    {
+        uint opcode2 = Vm == 0 ? 8 : 0;  // Vm is 0 for FCMP Vn,#0.0
+        return floatcmp(0, 0, ftype, Vm & 31, 0, Vn & 31, opcode2);
+    }
+
     /* Floating-point immediate
      * FMOV (scalar, immediate)
      * FMOV <Vd>,#<imm> https://www.scs.stanford.edu/~zyedidia/arm64/fmov_float_imm.html


### PR DESCRIPTION
Much simpler than on X86_64, though of course this doesn't do vector ops yet.