### PR TITLE
Fix fail_compilation/retscope TEST_OUTPUT blocks

### DIFF
--- a/compiler/test/fail_compilation/retscope.d
+++ b/compiler/test/fail_compilation/retscope.d
@@ -164,6 +164,7 @@ class C11
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope.d(177): Error: assigning address of variable `i` to `p` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 
@@ -180,6 +181,7 @@ void foo11() @safe
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope.d(197): Error: returning scope variable `e` is not allowed in a `@safe` function
 ---
 */
 
@@ -199,8 +201,6 @@ void* escapeDg1(scope void* d) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(176): Error: assigning address of variable `i` to `p` with longer lifetime is not allowed in a `@safe` function
-fail_compilation/retscope.d(195): Error: returning scope variable `e` is not allowed in a `@safe` function
 fail_compilation/retscope.d(212): Error: assigning scope variable `p` to non-scope `e.e` is not allowed in a `@safe` function
 ---
 */
@@ -254,6 +254,7 @@ void escape4() @safe
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope.d(266): Error: taking address of `scope` variable `p` with pointers is not allowed in a `@safe` function
 ---
 */
 
@@ -270,7 +271,6 @@ void escape5() @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(265): Error: taking address of `scope` variable `p` with pointers is not allowed in a `@safe` function
 fail_compilation/retscope.d(286): Error: escaping a reference to local variable `b` by returning `foo6(& b)`  is not allowed in a `@safe` function
 ---
 */
@@ -323,6 +323,7 @@ ref int[3] asStatic2(      scope int[] p) @safe { return p[0 .. 3]; }
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope.d(335): Error: assigning reference to local variable `i` to non-scope `f` is not allowed in a `@safe` function
 ---
 */
 
@@ -346,7 +347,6 @@ int* bar10( scope int** ptr ) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(334): Error: assigning reference to local variable `i` to non-scope `f` is not allowed in a `@safe` function
 fail_compilation/retscope.d(358): Error: taking address of `scope` variable `aa` with pointers is not allowed in a `@safe` function
 ---
 */
@@ -399,6 +399,7 @@ struct Foo12
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope.d(1103): Error: returning scope variable `f` is not allowed in a `@safe` function
 ---
 */
 
@@ -418,6 +419,7 @@ class Foo13
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope.d(1205): Error: scope variable `f14` calling non-scope member function `Foo14.foo()` is not allowed in a `@safe` function
 ---
 */
 
@@ -440,6 +442,7 @@ struct Foo14
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope.d(1311): Error: assigning scope variable `u2` to `ek` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 
@@ -467,6 +470,7 @@ TEST_OUTPUT:
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope.d(1405): Error: assigning reference to local variable `buf` to non-scope anonymous parameter calling `myprintf` is not allowed in a `@safe` function
 ---
 */
 
@@ -484,10 +488,6 @@ TEST_OUTPUT:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1103): Error: returning scope variable `f` is not allowed in a `@safe` function
-fail_compilation/retscope.d(1205): Error: scope variable `f14` calling non-scope member function `Foo14.foo()` is not allowed in a `@safe` function
-fail_compilation/retscope.d(1311): Error: assigning scope variable `u2` to `ek` with longer lifetime is not allowed in a `@safe` function
-fail_compilation/retscope.d(1405): Error: assigning reference to local variable `buf` to non-scope anonymous parameter calling `myprintf` is not allowed in a `@safe` function
 fail_compilation/retscope.d(1509): Error: assigning reference to stack allocated value returned by `(*fp15)()` to non-scope anonymous parameter is not allowed in a `@safe` function
 ---
 */

--- a/compiler/test/fail_compilation/retscope2.d
+++ b/compiler/test/fail_compilation/retscope2.d
@@ -2,6 +2,8 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
+fail_compilation/retscope2.d(102): Error: assigning scope variable `s` to `ref` variable `p` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/retscope2.d(107): Error: assigning address of variable `s` to `p` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 
@@ -34,6 +36,7 @@ void test200()
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope2.d(302): Error: assigning scope variable `a` to return scope `b` is not allowed in a `@safe` function
 ---
 */
 
@@ -49,6 +52,7 @@ TEST_OUTPUT:
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope2.d(403): Error: assigning scope variable `a` to return scope `c` is not allowed in a `@safe` function
 ---
 */
 
@@ -65,6 +69,7 @@ TEST_OUTPUT:
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope2.d(504): Error: returning scope variable `c` is not allowed in a `@safe` function
 ---
 */
 
@@ -81,11 +86,6 @@ TEST_OUTPUT:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(102): Error: assigning scope variable `s` to `ref` variable `p` with longer lifetime is not allowed in a `@safe` function
-fail_compilation/retscope2.d(107): Error: assigning address of variable `s` to `p` with longer lifetime is not allowed in a `@safe` function
-fail_compilation/retscope2.d(302): Error: assigning scope variable `a` to return scope `b` is not allowed in a `@safe` function
-fail_compilation/retscope2.d(403): Error: assigning scope variable `a` to return scope `c` is not allowed in a `@safe` function
-fail_compilation/retscope2.d(504): Error: returning scope variable `c` is not allowed in a `@safe` function
 fail_compilation/retscope2.d(604): Error: assigning scope variable `__param_0` to non-scope anonymous parameter calling `foo600` is not allowed in a `@safe` function
 fail_compilation/retscope2.d(604): Error: assigning scope variable `__param_1` to non-scope anonymous parameter calling `foo600` is not allowed in a `@safe` function
 fail_compilation/retscope2.d(614): Error: template instance `retscope2.test600!(int*, int*)` error instantiating
@@ -115,6 +115,8 @@ fail_compilation/retscope2.d(614): Error: template instance `retscope2.test600!(
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope2.d(719): Error: returning `get2(s)` escapes a reference to local variable `s`
+fail_compilation/retscope2.d(721): Error: returning `s.get1()` escapes a reference to local variable `s`
 ---
 */
 
@@ -148,6 +150,7 @@ S700* escape700(int i) @safe
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope2.d(804): Error: throwing scope variable `e` is not allowed in a `@safe` function
 ---
 */
 
@@ -164,6 +167,7 @@ void foo800() @safe
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope2.d(907): Error: assigning address of variable `this` to `p17568` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 
@@ -184,6 +188,9 @@ struct T17568
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope2.d(1005): Error: assigning scope variable `p` to non-scope `this._p` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(1021): Error: assigning scope variable `p` to non-scope `c._p` is not allowed in a `@safe` function
+fail_compilation/retscope2.d(1024): Error: assigning scope variable `p` to non-scope `d._p` is not allowed in a `@safe` function
 ---
 */
 
@@ -222,6 +229,7 @@ void test17428() @safe
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope2.d(1107): Error: returning scope variable `dg` is not allowed in a `@safe` function
 ---
 */
 
@@ -241,6 +249,8 @@ void delegate() test17430() @safe
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope2.d(1216): Error: returning `s.foo()` escapes a reference to local variable `s`
+fail_compilation/retscope2.d(1233): Error: returning `t.foo()` escapes a reference to local variable `t`
 ---
 */
 
@@ -286,16 +296,6 @@ struct T17388
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(719): Error: returning `get2(s)` escapes a reference to local variable `s`
-fail_compilation/retscope2.d(721): Error: returning `s.get1()` escapes a reference to local variable `s`
-fail_compilation/retscope2.d(804): Error: throwing scope variable `e` is not allowed in a `@safe` function
-fail_compilation/retscope2.d(907): Error: assigning address of variable `this` to `p17568` with longer lifetime is not allowed in a `@safe` function
-fail_compilation/retscope2.d(1005): Error: assigning scope variable `p` to non-scope `this._p` is not allowed in a `@safe` function
-fail_compilation/retscope2.d(1021): Error: assigning scope variable `p` to non-scope `c._p` is not allowed in a `@safe` function
-fail_compilation/retscope2.d(1024): Error: assigning scope variable `p` to non-scope `d._p` is not allowed in a `@safe` function
-fail_compilation/retscope2.d(1107): Error: returning scope variable `dg` is not allowed in a `@safe` function
-fail_compilation/retscope2.d(1216): Error: returning `s.foo()` escapes a reference to local variable `s`
-fail_compilation/retscope2.d(1233): Error: returning `t.foo()` escapes a reference to local variable `t`
 fail_compilation/retscope2.d(1306): Error: escaping a reference to local variable `i` by copying `& i` into allocated memory is not allowed in a `@safe` function
 ---
 */

--- a/compiler/test/fail_compilation/retscope3.d
+++ b/compiler/test/fail_compilation/retscope3.d
@@ -5,6 +5,8 @@ REQUIRED_ARGS: -preview=dip1000
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/retscope3.d(2008): Error: escaping a reference to local variable `i` by copying `& i` into allocated memory is not allowed in a `@safe` function
+fail_compilation/retscope3.d(2017): Error: escaping a reference to local variable `i` by copying `S2000(& i)` into allocated memory is not allowed in a `@safe` function
 ---
 */
 
@@ -51,8 +53,6 @@ void bar4()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope3.d(2008): Error: escaping a reference to local variable `i` by copying `& i` into allocated memory is not allowed in a `@safe` function
-fail_compilation/retscope3.d(2017): Error: escaping a reference to local variable `i` by copying `S2000(& i)` into allocated memory is not allowed in a `@safe` function
 fail_compilation/retscope3.d(4003): Error: escaping a reference to parameter `u` by copying `u[]` into allocated memory is not allowed in a `@safe` function
 fail_compilation/retscope3.d(4016): Error: storing reference to outer local variable `i` into allocated memory causes it to escape
 fail_compilation/retscope3.d(4025): Error: escaping reference to stack allocated value returned by `makeSA()` into allocated memory


### PR DESCRIPTION
The TEST_OUTPUT blocks accidentally got merged before I fixed AUTO_UPDATE to intertwine the additions/deletions in the diff