### PR TITLE
Escape backticks in error messages

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1896,8 +1896,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             const sident = se.toStringz();
             if (!sident.length || !Identifier.isValidIdentifier(sident))
             {
-                error(ns.exp.loc, "expected valid identifier for C++ namespace but got `%.*s`",
-                             cast(int)sident.length, sident.ptr);
+                error(ns.exp.loc, "expected valid identifier for C++ namespace but got `%s`", se.toErrMsg());
                 return null;
             }
             else

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -141,13 +141,15 @@ const(char)* toErrMsg(const Dsymbol d)
  */
 private void truncateForError(ref OutBuffer buf, size_t maxLength)
 {
-    // Remove newlines
+    // Remove newlines, escape backticks ` by doubling them
     for (size_t i = 0; i < buf.length; i++)
     {
         if (buf[i] == '\r')
             buf.remove(i, 1);
         if (buf[i] == '\n')
             buf.peekSlice[i] = ' ';
+        if (buf[i] == '`')
+            i = buf.insert(i, "`");
     }
 
     // Strip trailing whitespace

--- a/compiler/test/fail_compilation/cppmangle.d
+++ b/compiler/test/fail_compilation/cppmangle.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/cppmangle.d(11): Error: expected valid identifier for C++ namespace but got ``
-fail_compilation/cppmangle.d(15): Error: expected valid identifier for C++ namespace but got `0num`
+fail_compilation/cppmangle.d(11): Error: expected valid identifier for C++ namespace but got `""`
+fail_compilation/cppmangle.d(15): Error: expected valid identifier for C++ namespace but got `"0num"`
 fail_compilation/cppmangle.d(19): Error: compile time string constant (or sequence) expected, not `2`
-fail_compilation/cppmangle.d(23): Error: expected valid identifier for C++ namespace but got `invalid@namespace`
+fail_compilation/cppmangle.d(23): Error: expected valid identifier for C++ namespace but got `"invalid@namespace"`
 ---
 */
 


### PR DESCRIPTION
Partial fix to #19947, not complete because most errors still use `toChars` instead of `toErrMsg`.