### PR TITLE
Expand `toErrMsg` to other types

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -136,6 +136,13 @@ inout(Parameter) isParameter(inout RootObject o)
     return cast(inout(Parameter))o;
 }
 
+inout(Identifier) isIdentifier(inout RootObject o)
+{
+    if (!o || o.dyncast() != DYNCAST.identifier)
+        return null;
+    return cast(inout(Identifier))o;
+}
+
 inout(TemplateParameter) isTemplateParameter(inout RootObject o)
 {
     if (!o || o.dyncast() != DYNCAST.templateparameter)

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1883,10 +1883,10 @@ struct AttributeViolation
         assert(args.length <= 4); // expand if necessary
         OutBuffer buf;
         buf.printf(fmt,
-            args.length > 0 && args[0] ? args[0].toChars() : "",
-            args.length > 1 && args[1] ? args[1].toChars() : "",
-            args.length > 2 && args[2] ? args[2].toChars() : "",
-            args.length > 3 && args[3] ? args[3].toChars() : "",
+            args.length > 0 && args[0] ? args[0].toErrMsg() : "",
+            args.length > 1 && args[1] ? args[1].toErrMsg() : "",
+            args.length > 2 && args[2] ? args[2].toErrMsg() : "",
+            args.length > 3 && args[3] ? args[3].toErrMsg() : "",
         );
         this.action = buf.extractSlice();
     }

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -98,11 +98,25 @@ void genhdrfile(Module m, bool doFuncBodies, ref OutBuffer buf)
 }
 
 /**
- * Convert `e` to a string for error messages.
+ * Convert `o` to a string for error messages.
  * Params:
- *      e = expression to convert
+ *      e = object to convert
  * Returns: string representation of `e`
  */
+const(char)* toErrMsg(const RootObject o)
+{
+    if (auto e = o.isExpression())
+        return toErrMsg(e);
+    if (auto d = o.isDsymbol())
+        return toErrMsg(d);
+    if (auto t = o.isType())
+        return t.toChars();
+    if (auto id = o.isIdentifier())
+        return id.toChars();
+    assert(0);
+}
+
+/// ditto
 const(char)* toErrMsg(const Expression e)
 {
     HdrGenState hgs;
@@ -119,7 +133,7 @@ const(char)* toErrMsg(const Dsymbol d)
 {
     if (d.isFuncDeclaration() || d.isTemplateInstance())
     {
-        if (d.ident && d.ident.toString.startsWith("__"))
+        if (d.ident && d.ident.toString.startsWith("__") && !d.isCtorDeclaration())
         {
             HdrGenState hgs;
             hgs.errorMsg = true;

--- a/compiler/test/fail_compilation/fail11375.d
+++ b/compiler/test/fail_compilation/fail11375.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail11375.d(18): Error: constructor `fail11375.D!().D.this` is not `nothrow`
-       which calls `this() { return this; }`
+       which calls `this`
 fail_compilation/fail11375.d(16): Error: function `D main` may throw but is marked as `nothrow`
 ---
 */


### PR DESCRIPTION
In order to generalize truncation, backtick escaping (https://github.com/dlang/dmd/pull/20893) etc. 