### PR TITLE
Use fileOffset in generateIdWithLoc

### DIFF
--- a/compiler/test/compilable/extra-files/json.json
+++ b/compiler/test/compilable/extra-files/json.json
@@ -10,7 +10,7 @@
                 "endline": 8,
                 "kind": "shared static constructor",
                 "line": 8,
-                "name": "_sharedStaticCtor_L8_C1",
+                "name": "_sharedStaticCtor263",
                 "protection": "public",
                 "storageClass": [
                     "static"
@@ -36,7 +36,7 @@
                 "endline": 10,
                 "kind": "shared static destructor",
                 "line": 10,
-                "name": "_sharedStaticDtor_L10_C1",
+                "name": "_sharedStaticDtor304",
                 "protection": "public",
                 "storageClass": [
                     "static"
@@ -66,7 +66,7 @@
                         "endline": 15,
                         "kind": "shared static constructor",
                         "line": 15,
-                        "name": "_sharedStaticCtor_L15_C5",
+                        "name": "_sharedStaticCtor368",
                         "storageClass": [
                             "static"
                         ]
@@ -88,7 +88,7 @@
                         "endline": 17,
                         "kind": "shared static destructor",
                         "line": 17,
-                        "name": "_sharedStaticDtor_L17_C5",
+                        "name": "_sharedStaticDtor417",
                         "storageClass": [
                             "static"
                         ]
@@ -134,7 +134,7 @@
                         "endline": 25,
                         "kind": "shared static constructor",
                         "line": 25,
-                        "name": "_sharedStaticCtor_L25_C5",
+                        "name": "_sharedStaticCtor511",
                         "protection": "public",
                         "storageClass": [
                             "static"
@@ -160,7 +160,7 @@
                         "endline": 27,
                         "kind": "shared static destructor",
                         "line": 27,
-                        "name": "_sharedStaticDtor_L27_C5",
+                        "name": "_sharedStaticDtor560",
                         "protection": "public",
                         "storageClass": [
                             "static"

--- a/compiler/test/compilable/test21330.d
+++ b/compiler/test/compilable/test21330.d
@@ -2,8 +2,8 @@
 REQUIRED_ARGS: -unittest
 TEST_OUTPUT:
 ---
-AliasSeq!(__unittest_L14_C5_1, __unittest_L14_C5_2)
-AliasSeq!(__unittest_L14_C5_2)
+AliasSeq!(__unittest221_1, __unittest221_2)
+AliasSeq!(__unittest221_2)
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=21330

--- a/compiler/test/fail_compilation/diag15411.d
+++ b/compiler/test/fail_compilation/diag15411.d
@@ -2,9 +2,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag15411.d(17): Error: function `diag15411.test15411.__funcliteral_L17_C15` cannot access variable `i` in frame of function `diag15411.test15411`
+fail_compilation/diag15411.d(17): Error: function `diag15411.test15411.__funcliteral783` cannot access variable `i` in frame of function `diag15411.test15411`
 fail_compilation/diag15411.d(16):        `i` declared here
-fail_compilation/diag15411.d(18): Error: function `diag15411.test15411.__funcliteral_L18_C15` cannot access variable `i` in frame of function `diag15411.test15411`
+fail_compilation/diag15411.d(18): Error: function `diag15411.test15411.__funcliteral826` cannot access variable `i` in frame of function `diag15411.test15411`
 fail_compilation/diag15411.d(16):        `i` declared here
 fail_compilation/diag15411.d(26): Error: `static` function `diag15411.testNestedFunction.myFunc2` cannot access function `myFunc1` in frame of function `diag15411.testNestedFunction`
 fail_compilation/diag15411.d(25):        `myFunc1` declared here

--- a/compiler/test/fail_compilation/diag20268.d
+++ b/compiler/test/fail_compilation/diag20268.d
@@ -3,8 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag20268.d(12): Error: template `__lambda_L11_C1` is not callable using argument types `!()(int)`
-fail_compilation/diag20268.d(11):        Candidate is: `__lambda_L11_C1(__T1, __T2)(x, y)`
+fail_compilation/diag20268.d(12): Error: template `__lambda278` is not callable using argument types `!()(int)`
+fail_compilation/diag20268.d(11):        Candidate is: `__lambda278(__T1, __T2)(x, y)`
 ---
 */
 

--- a/compiler/test/fail_compilation/diag9831.d
+++ b/compiler/test/fail_compilation/diag9831.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9831.d(13): Error: function `diag9831.main.__lambda_L13_C12(__T1)(x)` cannot access variable `c` in frame of function `D main`
+fail_compilation/diag9831.d(13): Error: function `diag9831.main.__lambda305(__T1)(x)` cannot access variable `c` in frame of function `D main`
 fail_compilation/diag9831.d(11):        `c` declared here
 ---
 */

--- a/compiler/test/fail_compilation/fail12236.d
+++ b/compiler/test/fail_compilation/fail12236.d
@@ -6,8 +6,8 @@ fail_compilation/fail12236.d(16):        while evaluating `pragma(msg, f1.mangle
 fail_compilation/fail12236.d(21): Error: forward reference to inferred return type of function `f2`
 fail_compilation/fail12236.d(21):        while evaluating `pragma(msg, f2(T)(T).mangleof)`
 fail_compilation/fail12236.d(27): Error: template instance `fail12236.f2!int` error instantiating
-fail_compilation/fail12236.d(31): Error: forward reference to inferred return type of function `__lambda_L29_C5`
-fail_compilation/fail12236.d(31):        while evaluating `pragma(msg, __lambda_L29_C5(__T1)(a).mangleof)`
+fail_compilation/fail12236.d(31): Error: forward reference to inferred return type of function `__lambda911`
+fail_compilation/fail12236.d(31):        while evaluating `pragma(msg, __lambda911(__T1)(a).mangleof)`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail12378.d
+++ b/compiler/test/fail_compilation/fail12378.d
@@ -5,7 +5,7 @@ fail_compilation/fail12378.d(18): Error: undefined identifier `ANYTHING`
 fail_compilation/fail12378.d(18): Error: undefined identifier `GOES`
 fail_compilation/fail12378.d(91):        instantiated from here: `MapResultS!((x0) => ANYTHING - GOES, Result)`
 fail_compilation/fail12378.d(17):        instantiated from here: `mapS!(Result)`
-fail_compilation/fail12378.d(100):        instantiated from here: `__lambda_L16_C19!int`
+fail_compilation/fail12378.d(100):        instantiated from here: `__lambda708!int`
 fail_compilation/fail12378.d(91):        instantiated from here: `MapResultS!((y0) => iota(2).mapS!((x0) => ANYTHING - GOES), Result)`
 fail_compilation/fail12378.d(16):        instantiated from here: `mapS!(Result)`
 ---
@@ -27,7 +27,7 @@ fail_compilation/fail12378.d(40): Error: undefined identifier `ANYTHING`
 fail_compilation/fail12378.d(40): Error: undefined identifier `GOES`
 fail_compilation/fail12378.d(112):        instantiated from here: `MapResultC!((x0) => ANYTHING - GOES, Result)`
 fail_compilation/fail12378.d(39):        instantiated from here: `mapC!(Result)`
-fail_compilation/fail12378.d(123):        instantiated from here: `__lambda_L38_C19!int`
+fail_compilation/fail12378.d(123):        instantiated from here: `__lambda1499!int`
 fail_compilation/fail12378.d(112):        instantiated from here: `MapResultC!((y0) => iota(2).mapC!((x0) => ANYTHING - GOES), Result)`
 fail_compilation/fail12378.d(38):        instantiated from here: `mapC!(Result)`
 ---
@@ -49,7 +49,7 @@ fail_compilation/fail12378.d(64): Error: undefined identifier `ANYTHING`
 fail_compilation/fail12378.d(64): Error: undefined identifier `GOES`
 fail_compilation/fail12378.d(135):        instantiated from here: `MapResultI!((x0) => ANYTHING - GOES, Result)`
 fail_compilation/fail12378.d(63):        instantiated from here: `mapI!(Result)`
-fail_compilation/fail12378.d(143):        instantiated from here: `__lambda_L62_C19!int`
+fail_compilation/fail12378.d(143):        instantiated from here: `__lambda2292!int`
 fail_compilation/fail12378.d(135):        instantiated from here: `MapResultI!((y0) => iota(2).mapI!((x0) => ANYTHING - GOES), Result)`
 fail_compilation/fail12378.d(62):        instantiated from here: `mapI!(Result)`
 ---

--- a/compiler/test/fail_compilation/fail12908.d
+++ b/compiler/test/fail_compilation/fail12908.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12908.d(14): Error: `pure` delegate `fail12908.main.__foreachbody_L12_C5` cannot call impure function `fail12908.g`
+fail_compilation/fail12908.d(14): Error: `pure` delegate `fail12908.main.__foreachbody197` cannot call impure function `fail12908.g`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail13120.d
+++ b/compiler/test/fail_compilation/fail13120.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13120.d(13): Error: `pure` delegate `fail13120.g1.__foreachbody_L12_C5` cannot call impure function `fail13120.f1`
-fail_compilation/fail13120.d(13): Error: `@nogc` delegate `fail13120.g1.__foreachbody_L12_C5` cannot call non-@nogc function `fail13120.f1`
+fail_compilation/fail13120.d(13): Error: `pure` delegate `fail13120.g1.__foreachbody344` cannot call impure function `fail13120.f1`
+fail_compilation/fail13120.d(13): Error: `@nogc` delegate `fail13120.g1.__foreachbody344` cannot call non-@nogc function `fail13120.f1`
 ---
 */
 void f1() {}

--- a/compiler/test/fail_compilation/fail17969.d
+++ b/compiler/test/fail_compilation/fail17969.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail17969.d(10): Error: no property `sum` for type `fail17969.__lambda_L10_C1!(int[]).__lambda_L10_C1.MapResult2!((b) => b)`
+fail_compilation/fail17969.d(10): Error: no property `sum` for type `fail17969.__lambda288!(int[]).__lambda288.MapResult2!((b) => b)`
 fail_compilation/fail17969.d(16):        struct `MapResult2` defined here
 ---
  * https://issues.dlang.org/show_bug.cgi?id=17969

--- a/compiler/test/fail_compilation/fail39.d
+++ b/compiler/test/fail_compilation/fail39.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail39.d(12): Error: function `fail39.main.__funcliteral_L12_C27` cannot access function `foo` in frame of function `D main`
+fail_compilation/fail39.d(12): Error: function `fail39.main.__funcliteral281` cannot access function `foo` in frame of function `D main`
 fail_compilation/fail39.d(11):        `foo` declared here
 ---
 */

--- a/compiler/test/fail_compilation/fail7848.d
+++ b/compiler/test/fail_compilation/fail7848.d
@@ -3,12 +3,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7848.d(27): Error: `pure` function `fail7848.C.__unittest_L25_C30` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(27): Error: `@safe` function `fail7848.C.__unittest_L25_C30` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(27): Error: `pure` function `fail7848.C.__unittest1414` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(27): Error: `@safe` function `fail7848.C.__unittest1414` cannot call `@system` function `fail7848.func`
 fail_compilation/fail7848.d(21):        `fail7848.func` is declared here
-fail_compilation/fail7848.d(27): Error: `@nogc` function `fail7848.C.__unittest_L25_C30` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(27): Error: `@nogc` function `fail7848.C.__unittest1414` cannot call non-@nogc function `fail7848.func`
 fail_compilation/fail7848.d(27): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(25): Error: function `fail7848.C.__unittest_L25_C30` may throw but is marked as `nothrow`
+fail_compilation/fail7848.d(25): Error: function `fail7848.C.__unittest1414` may throw but is marked as `nothrow`
 fail_compilation/fail7848.d(32): Error: `pure` function `fail7848.C.invariant` cannot call impure function `fail7848.func`
 fail_compilation/fail7848.d(32): Error: `@safe` function `fail7848.C.invariant` cannot call `@system` function `fail7848.func`
 fail_compilation/fail7848.d(21):        `fail7848.func` is declared here

--- a/compiler/test/fail_compilation/iasm1.d
+++ b/compiler/test/fail_compilation/iasm1.d
@@ -117,7 +117,7 @@ void test5()
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/iasm1.d(615): Error: delegate `iasm1.test6.__foreachbody_L611_C5` label `L1` is undefined
+fail_compilation/iasm1.d(615): Error: delegate `iasm1.test6.__foreachbody2319` label `L1` is undefined
 ---
 */
 

--- a/compiler/test/fail_compilation/ice10922.d
+++ b/compiler/test/fail_compilation/ice10922.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10922.d(11): Error: function `(in uint n) { enum self = __lambda_L10_C12; return n < 2 ? n : self(n - 1) + ...` is not callable using argument types `()`
+fail_compilation/ice10922.d(11): Error: function `(in uint n) { enum self = __lambda378; return n < 2 ? n : self(n - 1) + self(...` is not callable using argument types `()`
 fail_compilation/ice10922.d(11):        too few arguments, expected 1, got 0
-fail_compilation/ice10922.d(10):        `ice10922.__lambda_L10_C12(in uint n)` declared here
+fail_compilation/ice10922.d(10):        `ice10922.__lambda378(in uint n)` declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/ice11822.d
+++ b/compiler/test/fail_compilation/ice11822.d
@@ -5,8 +5,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11822.d(33): Deprecation: function `ice11822.d` is deprecated
-fail_compilation/ice11822.d(16):        instantiated from here: `__lambda_L33_C15!int`
-fail_compilation/ice11822.d(22):        instantiated from here: `S!(__lambda_L33_C15)`
+fail_compilation/ice11822.d(16):        instantiated from here: `__lambda589!int`
+fail_compilation/ice11822.d(22):        instantiated from here: `S!(__lambda589)`
 fail_compilation/ice11822.d(33):        instantiated from here: `g!((n) => d(i))`
 ---
 */

--- a/compiler/test/fail_compilation/ice11850.d
+++ b/compiler/test/fail_compilation/ice11850.d
@@ -3,7 +3,7 @@ EXTRA_FILES: imports/a11850.d
 TEST_OUTPUT:
 ---
 fail_compilation/ice11850.d(15): Error: incompatible types for `(a) < ([0])`: `uint[]` and `int[]`
-fail_compilation/imports/a11850.d(9):        instantiated from here: `FilterResult!(__lambda_L15_C13, uint[][])`
+fail_compilation/imports/a11850.d(9):        instantiated from here: `FilterResult!(__lambda408, uint[][])`
 fail_compilation/ice11850.d(15):        instantiated from here: `filter!(uint[][])`
 ---
 */

--- a/compiler/test/fail_compilation/ice12235.d
+++ b/compiler/test/fail_compilation/ice12235.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12235.d(14): Error: forward reference to inferred return type of function `__lambda_L12_C5`
-fail_compilation/ice12235.d(15): Error: forward reference to inferred return type of function `__lambda_L12_C5`
-fail_compilation/ice12235.d(15):        while evaluating `pragma(msg, __lambda_L12_C5.mangleof)`
+fail_compilation/ice12235.d(14): Error: forward reference to inferred return type of function `__lambda355`
+fail_compilation/ice12235.d(15): Error: forward reference to inferred return type of function `__lambda355`
+fail_compilation/ice12235.d(15):        while evaluating `pragma(msg, __lambda355.mangleof)`
 ---
 */
 

--- a/compiler/test/fail_compilation/ice14424.d
+++ b/compiler/test/fail_compilation/ice14424.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14424.d(13): Error: `AliasSeq!(__unittest_L3_C1)` has no effect
+fail_compilation/ice14424.d(13): Error: `AliasSeq!(__unittest24)` has no effect
 ---
 */
 

--- a/compiler/test/fail_compilation/test15306.d
+++ b/compiler/test/fail_compilation/test15306.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test15306.d(15): Error: `immutable` delegate `test15306.main.__dgliteral_L15_C16` cannot access mutable data `i`
-fail_compilation/test15306.d(19): Error: `shared` delegate `test15306.main.__dgliteral_L19_C16` cannot access non-shared data `p`
+fail_compilation/test15306.d(15): Error: `immutable` delegate `test15306.main.__dgliteral413` cannot access mutable data `i`
+fail_compilation/test15306.d(19): Error: `shared` delegate `test15306.main.__dgliteral530` cannot access non-shared data `p`
 ---
 */
 

--- a/compiler/test/fail_compilation/test17451.d
+++ b/compiler/test/fail_compilation/test17451.d
@@ -2,7 +2,7 @@
 ---
 fail_compilation/test17451.d(22): Error: undefined identifier `allocator`
 fail_compilation/test17451.d(23): Error: `false` has no effect
-fail_compilation/test17451.d(30): Error: variable `test17451.HashMap!(ThreadSlot).HashMap.__lambda_L30_C20.v` - size of type `ThreadSlot` is invalid
+fail_compilation/test17451.d(30): Error: variable `test17451.HashMap!(ThreadSlot).HashMap.__lambda796.v` - size of type `ThreadSlot` is invalid
 fail_compilation/test17451.d(44): Error: template instance `test17451.HashMap!(ThreadSlot)` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/test20626.d
+++ b/compiler/test/fail_compilation/test20626.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -check=invariant=off
 TEST_OUTPUT:
 ----
-fail_compilation/test20626.d(2): Error: expression `__unittest_L1_C1` has no type
+fail_compilation/test20626.d(2): Error: undefined identifier `__unittest_L1_C1`
 _error_
 const void()
 ----

--- a/compiler/test/fail_compilation/test20719.d
+++ b/compiler/test/fail_compilation/test20719.d
@@ -2,7 +2,7 @@
 ---
 fail_compilation/test20719.d(14): Error: struct `test20719.SumType` no size because of forward reference
 fail_compilation/test20719.d(17):        error on member `test20719.SumType.storage`
-fail_compilation/test20719.d(33): Error: variable `test20719.isCopyable!(SumType).__lambda_L33_C22.foo` - size of type `SumType` is invalid
+fail_compilation/test20719.d(33): Error: variable `test20719.isCopyable!(SumType).__lambda904.foo` - size of type `SumType` is invalid
 fail_compilation/test20719.d(19): Error: template instance `test20719.isCopyable!(SumType)` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/test23170.d
+++ b/compiler/test/fail_compilation/test23170.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test23170.d(10): Error: this array literal causes a GC allocation in `@nogc` delegate `__lambda_L10_C15`
+fail_compilation/test23170.d(10): Error: this array literal causes a GC allocation in `@nogc` delegate `__lambda225`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=23170

--- a/compiler/test/runnable/mangle.d
+++ b/compiler/test/runnable/mangle.d
@@ -449,10 +449,12 @@ void test11776()
         {
             auto s = S11776!(a => 1)();
             enum expected = "S"~"6mangle"~tl!("56")~
-                ("__T"~"6S11776"~"S"~tl!("42")~
-                 (id!("6mangle","Qs")~"9test11776"~"FZ"~"17__lambda_L444_C14MFZ17__lambda_L450_C30")~"Z"
-                 )~id!("6S11776", "QCm");
-            static assert(typeof(s).mangleof == expected);
+                "__T"~"6S11776"~"S"~tl!("42")~
+                 id!("6mangle","Qs")~"9test11776"~"FZ";
+
+            // "17__lambda_L444_C14MFZ17__lambda_L450_C30")~
+            enum expectedEnd = "Z"~id!("6S11776", "QCm");
+            static assert(typeof(s).mangleof.startsWith(expected));
         }
     };
 }
@@ -508,22 +510,22 @@ void test12217() {}
 void func12231a()()
 if (is(typeof({
         class C {}
-        static assert(C.mangleof ==
-            "C6mangle"~tl!("16")~"__U10func12231aZ"~id!("10func12231a","Qn")~"FZ17__lambda_L509_C15MFZ1C");
+        static assert(C.mangleof.startsWith(
+            "C6mangle"~tl!("16")~"__U10func12231aZ"~id!("10func12231a","Qn")));
             //         ###            L                       #
     })))
 {}
 
 void func12231b()()
 if (is(typeof({
-        class C {}        static assert(C.mangleof ==
-            "C6mangle"~tl!("16")~"__U10func12231bZ"~id!("10func12231b","Qn")~"FZ17__lambda_L518_C15MFZ1C");
+        class C {}        static assert(C.mangleof.startsWith(
+            "C6mangle"~tl!("16")~"__U10func12231bZ"~id!("10func12231b","Qn")));
             //         L__L           L                       LL
       })) &&
     is(typeof({
         class C {}
-        static assert(C.mangleof ==
-            "C6mangle"~tl!("16")~"__U10func12231bZ"~id!("10func12231b","Qn")~"FZ17__lambda_L523_C15MFZ1C");
+        static assert(C.mangleof.startsWith(
+            "C6mangle"~tl!("16")~"__U10func12231bZ"~id!("10func12231b","Qn")));
             //         L__L           L                       LL
     })))
 {}
@@ -531,15 +533,15 @@ if (is(typeof({
 void func12231c()()
 if (is(typeof({
         class C {}
-        static assert(C.mangleof ==
-            "C6mangle"~tl!("16")~"__U10func12231cZ"~id!("10func12231c","Qn")~"FZ17__lambda_L532_C15MFZ1C");
+        static assert(C.mangleof.startsWith(
+            "C6mangle"~tl!("16")~"__U10func12231cZ"~id!("10func12231c","Qn")));
             //         L__L           L                       LL
     })))
 {
     (){
         class C {}
-        static assert(C.mangleof ==
-            "C6mangle"~tl!("16")~"__T10func12231cZ"~id!("10func12231c","Qn")~"FZ16__lambda_L539_C5MFZ1C");
+        static assert(C.mangleof.startsWith(
+            "C6mangle"~tl!("16")~"__T10func12231cZ"~id!("10func12231c","Qn")));
             //         L__L           L                       LL
     }();
 }
@@ -547,15 +549,15 @@ if (is(typeof({
 void func12231c(X)()
 if (is(typeof({
         class C {}
-    static assert(C.mangleof ==
-            "C6mangle"~tl!("20")~"__U10func12231cTAyaZ"~id!("10func12231c","Qr")~"FZ17__lambda_L548_C15MFZ1C");
+    static assert(C.mangleof.startsWith(
+            "C6mangle"~tl!("20")~"__U10func12231cTAyaZ"~id!("10func12231c","Qr")));
             //         L__L           L___L                       LL
     })))
 {
     (){
         class C {}
-        static assert(C.mangleof ==
-            "C6mangle"~tl!("20")~"__T10func12231cTAyaZ"~id!("10func12231c","Qr")~"FZ16__lambda_L555_C5MFZ1C");
+        static assert(C.mangleof.startsWith(
+            "C6mangle"~tl!("20")~"__T10func12231cTAyaZ"~id!("10func12231c","Qr")));
             //         L__L           L___L                       LL
     }();
 }
@@ -569,7 +571,7 @@ void test12231()
     func12231c();
     func12231c!string();
 }
-
+bool startsWith(string s, string prefix) => s.length > prefix.length && s[0 .. prefix.length] == prefix[];
 /***************************************************/
 
 class CC
@@ -612,12 +614,11 @@ int funcd(fpd);
 static assert(funcd.mangleof == "_D6mangle5funcdFPFZNnZi");
 
 /***************************************************/
-
+enum intToString(int t) = t.stringof;
 struct S21753 { void function() f1; }
 void fun21753(S21753 v)() {}
 alias fl21753 = (){};
-static assert((fun21753!(S21753(fl21753))).mangleof == "_D6mangle__T8fun21753VSQv6S21753S1f_DQBj16" ~ fl21753.stringof ~ "MFNaNbNiNfZvZQChQp");
-
+static assert((fun21753!(S21753(fl21753))).mangleof == "_D6mangle__T8fun21753VSQv6S21753S1f_DQBj" ~ intToString!(fl21753.stringof.length - 0) ~ fl21753.stringof ~ "MFNaNbNiNfZvZQCeQp");
 /***************************************************/
 void main()
 {

--- a/compiler/test/runnable/testkeyword.d
+++ b/compiler/test/runnable/testkeyword.d
@@ -30,19 +30,19 @@ enum thisFile = "runnable"~sep~"testkeyword.d";
 enum thisMod  = "testkeyword";
 
 static assert(getFuncArgFile()  == thisFile);
-static assert(getFuncArgLine()  == 33);
+static assert(getFuncArgLine()  == __LINE__);
 static assert(getFuncArgMod()   == thisMod);
 static assert(getFuncArgFunc()  == "");
 static assert(getFuncArgFunc2() == "");
 
 static assert(getFuncTiargFile()  == thisFile);
-static assert(getFuncTiargLine()  == 39);
+static assert(getFuncTiargLine()  == __LINE__);
 static assert(getFuncTiargMod()   == thisMod);
 static assert(getFuncTiargFunc()  == "");
 static assert(getFuncTiargFunc2() == "");
 
 static assert(getInstTiargFile!()  == thisFile);
-static assert(getInstTiargLine!()  == 45);
+static assert(getInstTiargLine!()  == __LINE__);
 static assert(getInstTiargMod!()   == thisMod);
 static assert(getInstTiargFunc!()  == "");
 static assert(getInstTiargFunc2!() == "");
@@ -53,19 +53,19 @@ void main(string[] args) nothrow
     enum thisFunc2 = "void testkeyword.main(string[] args) nothrow";
 
     static assert(getFuncArgFile()  == thisFile);
-    static assert(getFuncArgLine()  == 56);
+    static assert(getFuncArgLine()  == __LINE__);
     static assert(getFuncArgMod()   == thisMod);
     static assert(getFuncArgFunc()  == thisFunc);
     static assert(getFuncArgFunc2() == thisFunc2);
 
     static assert(getFuncTiargFile()  == thisFile);
-    static assert(getFuncTiargLine()  == 62);
+    static assert(getFuncTiargLine()  == __LINE__);
     static assert(getFuncTiargMod()   == thisMod);
     static assert(getFuncTiargFunc()  == thisFunc);
     static assert(getFuncTiargFunc2() == thisFunc2);
 
     static assert(getInstTiargFile!()  == thisFile);
-    static assert(getInstTiargLine!()  == 68);
+    static assert(getInstTiargLine!()  == __LINE__);
     static assert(getInstTiargMod!()   == thisMod);
     static assert(getInstTiargFunc!()  == thisFunc);
     static assert(getInstTiargFunc2!() == thisFunc2);
@@ -76,19 +76,19 @@ void main(string[] args) nothrow
         enum thisFunc2 = "void testkeyword.main.nested(int x, float y) nothrow";
 
         static assert(getFuncArgFile()  == thisFile);
-        static assert(getFuncArgLine()  == 79);
+        static assert(getFuncArgLine()  == __LINE__);
         static assert(getFuncArgMod()   == thisMod);
         static assert(getFuncArgFunc()  == thisFunc);
         static assert(getFuncArgFunc2() == thisFunc2);
 
         static assert(getFuncTiargFile()  == thisFile);
-        static assert(getFuncTiargLine()  == 85);
+        static assert(getFuncTiargLine()  == __LINE__);
         static assert(getFuncTiargMod()   == thisMod);
         static assert(getFuncTiargFunc()  == thisFunc);
         static assert(getFuncTiargFunc2() == thisFunc2);
 
         static assert(getInstTiargFile!()  == thisFile);
-        static assert(getInstTiargLine!()  == 91);
+        static assert(getInstTiargLine!()  == __LINE__);
         static assert(getInstTiargMod!()   == thisMod);
         static assert(getInstTiargFunc!()  == thisFunc);
         static assert(getInstTiargFunc2!() == thisFunc2);
@@ -97,26 +97,17 @@ void main(string[] args) nothrow
 
     auto funcLiteral = (int x, int y)
     {
-        enum thisFunc  = "testkeyword.main.__lambda_L98_C24";
-        enum thisFunc2 = "testkeyword.main.__lambda_L98_C24(int x, int y)";
-
         static assert(getFuncArgFile()  == thisFile);
-        static assert(getFuncArgLine()  == 104);
+        static assert(getFuncArgLine()  == __LINE__);
         static assert(getFuncArgMod()   == thisMod);
-        static assert(getFuncArgFunc()  == thisFunc);
-        static assert(getFuncArgFunc2() == thisFunc2);
 
         static assert(getFuncTiargFile()  == thisFile);
-        static assert(getFuncTiargLine()  == 110);
+        static assert(getFuncTiargLine()  == __LINE__);
         static assert(getFuncTiargMod()   == thisMod);
-        static assert(getFuncTiargFunc()  == thisFunc);
-        static assert(getFuncTiargFunc2() == thisFunc2);
 
         static assert(getInstTiargFile!()  == thisFile);
-        static assert(getInstTiargLine!()  == 116);
+        static assert(getInstTiargLine!()  == __LINE__);
         static assert(getInstTiargMod!()   == thisMod);
-        static assert(getInstTiargFunc!()  == thisFunc);
-        static assert(getInstTiargFunc2!() == thisFunc2);
     };
     funcLiteral(1, 2);
 
@@ -128,19 +119,19 @@ void main(string[] args) nothrow
             enum thisFunc2 = `void testkeyword.main.S.func!("foo", int, symbol, int[], float[]).func(int x) const`;
 
             static assert(getFuncArgFile()  == thisFile);
-            static assert(getFuncArgLine()  == 131);
+            static assert(getFuncArgLine()  == __LINE__);
             static assert(getFuncArgMod()   == thisMod);
             static assert(getFuncArgFunc()  == thisFunc);
             static assert(getFuncArgFunc2() == thisFunc2);
 
             static assert(getFuncTiargFile()  == thisFile);
-            static assert(getFuncTiargLine()  == 137);
+            static assert(getFuncTiargLine()  == __LINE__);
             static assert(getFuncTiargMod()   == thisMod);
             static assert(getFuncTiargFunc()  == thisFunc);
             static assert(getFuncTiargFunc2() == thisFunc2);
 
             static assert(getInstTiargFile!()  == thisFile);
-            static assert(getInstTiargLine!()  == 143);
+            static assert(getInstTiargLine!()  == __LINE__);
             static assert(getInstTiargMod!()   == thisMod);
             static assert(getInstTiargFunc!()  == thisFunc);
             static assert(getInstTiargFunc2!() == thisFunc2);

--- a/compiler/test/runnable/traits.d
+++ b/compiler/test/runnable/traits.d
@@ -10,7 +10,7 @@ Creating library {{RESULTS_DIR}}/runnable/traits_0.lib and object {{RESULTS_DIR}
 TRANSFORM_OUTPUT: remove_lines("Creating library")
 TEST_OUTPUT:
 ---
-__lambda_L1073_C5
+__lambda34612
 ---
 */
 


### PR DESCRIPTION
Remove the GC string concatenation, and use `loc.fileOffset` instead, which is more robust since it doesn't get affected by `#line` directives (which a preprocessed ImportC file tends to have a lot of). Unfortunately many tests still expose the internal name, but I made the ones which can't be `AUTO_UPDATE`'d less reliant on hard-coded line/column numbers.