### PR TITLE
Add external import path switch

### DIFF
--- a/changelog/dmd.external-import-path.dd
+++ b/changelog/dmd.external-import-path.dd
@@ -1,0 +1,8 @@
+External import path switch
+
+A new switch is added, the external import path (``-extI``).
+It is similar to the import path switch (``-I``) except it indicates that a module found from it is external to the currently compiling binary.
+
+It is used on Windows when the ``dllimport`` override switch is set to anything other than ``none`` to force an external module's symbols as DllImport.
+
+If a build system supports the external import path switch, it is recommend to **not** use the ``all`` option for the ``dllimport`` override switch which applies to symbols that should not be getting DllImport'd.

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -337,11 +337,12 @@ dmd -cov -unittest myprog.d
             (only imports).`,
         ),
         Option("dllimport=<value>",
-            "Windows only: select symbols to dllimport (none/defaultLibsOnly/all)",
-            `Which global variables to dllimport implicitly if not defined in a root module
+            "Windows only: select symbols to dllimport (none/defaultLibsOnly/externalOnly/all)",
+            `Which symbols to dllimport implicitly if not defined in a module that is being compiled
             $(UL
                 $(LI $(I none): None)
-                $(LI $(I defaultLibsOnly): Only druntime/Phobos symbols)
+                $(LI $(I defaultLibsOnly): Only druntime/Phobos symbols and any from a module that is marked as external to binary)
+                $(LI $(I externalOnly): Only symbols found from a module that is marked as external to binary)
                 $(LI $(I all): All)
             )`,
         ),
@@ -459,6 +460,9 @@ dmd -cov -unittest myprog.d
         ),
         Option("I=<directory>",
             "look for imports also in directory"
+        ),
+        Option("extI=<directory>",
+            "look for imports that are out of the currently compiling binary, used to set the module as DllImport"
         ),
         Option("i[=<pattern>]",
             "include imported modules in the compilation",

--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -34,6 +34,7 @@ enum SymImport : ubyte
 {
     none,               /// no symbols
     defaultLibsOnly,    /// only druntime/phobos symbols
+    externalOnly,       /// any module that is known to be external to binary (-extI)
     all,                /// all non-root symbols
 }
 

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -417,6 +417,8 @@ extern (C++) final class Module : Package
     SearchOptFlags searchCacheFlags;       // cached flags
     bool insearch;
 
+    bool isExplicitlyOutOfBinary; // Is this module known to be out of binary, and must be DllImport'd?
+
     /**
      * A root module is one that will be compiled all the way to
      * object code.  This field holds the root module that caused
@@ -536,6 +538,7 @@ extern (C++) final class Module : Package
         auto m = new Module(loc, filename, ident, 0, 0);
 
         // TODO: apply import path information (pathInfo) on to module
+        m.isExplicitlyOutOfBinary = importPathThatFindUs.isOutOfBinary;
 
         if (!m.read(loc))
             return null;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7111,6 +7111,7 @@ public:
     Dsymbol* searchCacheSymbol;
     uint32_t searchCacheFlags;
     bool insearch;
+    bool isExplicitlyOutOfBinary;
     Module* importedFrom;
     Array<Dsymbol* >* decldefs;
     Array<Module* > aimports;
@@ -8349,12 +8350,15 @@ struct Verbose final
 struct ImportPathInfo final
 {
     const char* path;
+    bool isOutOfBinary;
     ImportPathInfo() :
-        path()
+        path(),
+        isOutOfBinary()
     {
     }
-    ImportPathInfo(const char* path) :
-        path(path)
+    ImportPathInfo(const char* path, bool isOutOfBinary = false) :
+        path(path),
+        isOutOfBinary(isOutOfBinary)
         {}
 };
 

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -153,6 +153,7 @@ extern(C++) struct Verbose
 
 extern (C++) struct ImportPathInfo {
     const(char)* path; // char*'s of where to look for import modules
+    bool isOutOfBinary; // Will any module found from this path be out of binary?
 }
 
 /// Put command line switches in here

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -158,9 +158,17 @@ struct Verbose
 struct ImportPathInfo
 {
     const char* path;
+    d_bool isOutOfBinary;
 
-    ImportPathInfo() : path(NULL) { }
-    ImportPathInfo(const char* p) : path(p) { }
+    ImportPathInfo() :
+        path(),
+        isOutOfBinary()
+    {
+    }
+    ImportPathInfo(const char* path, d_bool isOutOfBinary = false) :
+        path(path),
+        isOutOfBinary(isOutOfBinary)
+        {}
 };
 
 // Put command line switches in here

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -829,11 +829,14 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                 case "defaultLibsOnly":
                     driverParams.symImport = SymImport.defaultLibsOnly;
                     break;
+                case "externalOnly":
+                    driverParams.symImport = SymImport.externalOnly;
+                    break;
                 case "all":
                     driverParams.symImport = SymImport.all;
                     break;
                 default:
-                    error("unknown dllimport '%.*s', must be 'none', 'defaultLibsOnly' or 'all'", cast(int) imp.length, imp.ptr);
+                    error("unknown dllimport '%.*s', must be 'none', 'defaultLibsOnly', 'externalOnly' or 'all'", cast(int) imp.length, imp.ptr);
             }
         }
         else if (arg == "-fIBT")
@@ -1572,6 +1575,13 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         else if (p[1] == 'I')              // https://dlang.org/dmd.html#switch-I
         {
             params.imppath.push(ImportPathInfo(p + 2 + (p[2] == '=')));
+        }
+        else if (startsWith(p + 1, "extI"))
+        {
+            // External import path switch -extI
+            auto importPathInfo = ImportPathInfo(p + 5 + (p[5] == '='));
+            importPathInfo.isOutOfBinary = true;
+            params.imppath.push(importPathInfo);
         }
         else if (p[1] == 'm' && p[2] == 'v' && p[3] == '=') // https://dlang.org/dmd.html#switch-mv
         {

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -100,6 +100,8 @@ public:
     SearchOptFlags searchCacheFlags;       // cached flags
     d_bool insearch;
 
+    d_bool isExplicitlyOutOfBinary; // Is this module known to be out of binary, and must be DllImport'd?
+
     // module from command line we're imported from,
     // i.e. a module that will be taken all the
     // way to an object file

--- a/compiler/test/dshell/dll_cxx.d
+++ b/compiler/test/dshell/dll_cxx.d
@@ -27,7 +27,7 @@ int main()
         Vars.set(`DLL_LIB`, `$OUTPUT_BASE${SEP}mydll.lib`);
         // CXX should be cl
         dllCmd ~= [`/LD`, `/nologo`, `/Fe` ~ Vars.DLL];
-        mainExtra = `$DLL_LIB`;
+        mainExtra = `$DLL_LIB -dllimport=externalOnly`;
     }
     else version(OSX)
     {
@@ -44,7 +44,7 @@ int main()
     // The arguments have to be passed as an array, because run would replace '/' with '\\' otherwise.
     run(dllCmd);
 
-    run(`$DMD -m$MODEL -g -od=$OUTPUT_BASE -of=$EXE_NAME $SRC/testdll.d ` ~ mainExtra);
+    run(`$DMD -m$MODEL -g -od=$OUTPUT_BASE -of=$EXE_NAME -extI=$EXTRA_FILES${SEP}dll_cxx${SEP}external $SRC/testdll.d ` ~ mainExtra);
 
     run(`$EXE_NAME`, stdout, stderr, [`LD_LIBRARY_PATH`: Vars.OUTPUT_BASE]);
 

--- a/compiler/test/dshell/extra-files/dll_cxx/external/binding.d
+++ b/compiler/test/dshell/extra-files/dll_cxx/external/binding.d
@@ -1,0 +1,3 @@
+module binding;
+
+extern (C) __gshared extern int testExternalImportVar;

--- a/compiler/test/dshell/extra-files/dll_cxx/mydll.cpp
+++ b/compiler/test/dshell/extra-files/dll_cxx/mydll.cpp
@@ -73,3 +73,9 @@ EXPORT int getSomeValueCPP19660(void)
 {
     return someValueCPP19660;
 }
+
+extern "C"
+{
+    // tests -extI switch for variables
+    EXPORT int testExternalImportVar = 0xF1234;
+}

--- a/compiler/test/dshell/extra-files/dll_cxx/testdll.d
+++ b/compiler/test/dshell/extra-files/dll_cxx/testdll.d
@@ -107,4 +107,7 @@ void main()
 {
     test22323();
     test19660();
+
+    import binding;
+    assert(testExternalImportVar == 0xF1234);
 }


### PR DESCRIPTION
Before I attempt to add the switch itself, let's make sure I didn't break anything with my refactoring of the DllImport detection logic.

Based upon this logic, I can see that the ``-dllimport=externalOnly`` option wouldn't be required.

I cannot foresee a reason why you would want to set the explicitly external flag on a module, without also wanting it to be DllImport.