### PR TITLE
Improve error for failing opDispatch instantiation

### DIFF
--- a/compiler/test/fail_compilation/diag14145.d
+++ b/compiler/test/fail_compilation/diag14145.d
@@ -1,11 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag14145.d(16): Error: no property `i` for `_` of type `diag14145.main.Capture!(i)`
-fail_compilation/diag14145.d(16):        potentially malformed `opDispatch`. Use an explicit instantiation to get a better error message
-fail_compilation/diag14145.d(26):        struct `Capture` defined here
-fail_compilation/diag14145.d(35): Error: expression `*this.ptr` of type `shared(int)` is not implicitly convertible to return type `ref int`
-fail_compilation/diag14145.d(17): Error: template instance `diag14145.main.Capture!(i).Capture.opDispatch!"i"` error instantiating
+fail_compilation/diag14145.d(14): Error: no property `i` for `_` of type `diag14145.main.Capture!(i)`
+fail_compilation/diag14145.d(33): Error: expression `*this.ptr` of type `shared(int)` is not implicitly convertible to return type `ref int`
+fail_compilation/diag14145.d(14): Error: template instance `diag14145.main.Capture!(i).Capture.opDispatch!"i"` error instantiating
 ---
 */
 

--- a/compiler/test/fail_compilation/fail18970.d
+++ b/compiler/test/fail_compilation/fail18970.d
@@ -2,11 +2,11 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail18970.d(26): Error: no property `y` for `S()` of type `fail18970.S`
-fail_compilation/fail18970.d(26):        potentially malformed `opDispatch`. Use an explicit instantiation to get a better error message
-fail_compilation/fail18970.d(15):        struct `S` defined here
+fail_compilation/fail18970.d(19): Error: undefined identifier `x`
+fail_compilation/fail18970.d(26): Error: template instance `fail18970.S.opDispatch!"y"` error instantiating
 fail_compilation/fail18970.d(33): Error: no property `yyy` for `this` of type `fail18970.S2`
-fail_compilation/fail18970.d(33):        potentially malformed `opDispatch`. Use an explicit instantiation to get a better error message
-fail_compilation/fail18970.d(29):        struct `S2` defined here
+fail_compilation/fail18970.d(38): Error: undefined identifier `x`
+fail_compilation/fail18970.d(33): Error: template instance `fail18970.S2.opDispatch!"yyy"` error instantiating
 ---
 */
 

--- a/compiler/test/fail_compilation/fail22054.d
+++ b/compiler/test/fail_compilation/fail22054.d
@@ -3,12 +3,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22054.d(23): Error: no property `what` for type `fail22054.exception`
-fail_compilation/fail22054.d(18):        `class fail22054.exception` is opaque and has no members.
-fail_compilation/fail22054.d(18):        class `exception` defined here
-fail_compilation/fail22054.d(24): Error: no property `what` for type `fail22054.exception2`
-fail_compilation/fail22054.d(19):        `struct fail22054.exception2` is opaque and has no members.
-fail_compilation/fail22054.d(19):        struct `exception2` defined here
+fail_compilation/fail22054.d(21): Error: no property `what` for type `fail22054.exception`
+fail_compilation/fail22054.d(16):        `class fail22054.exception` is opaque and has no members.
+fail_compilation/fail22054.d(22): Error: no property `what` for type `fail22054.exception2`
+fail_compilation/fail22054.d(17):        `struct fail22054.exception2` is opaque and has no members.
 ---
 */
 

--- a/compiler/test/fail_compilation/ice10938.d
+++ b/compiler/test/fail_compilation/ice10938.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice10938.d(14): Error: no property `opts` for `this` of type `ice10938.C`
-fail_compilation/ice10938.d(14):        potentially malformed `opDispatch`. Use an explicit instantiation to get a better error message
-fail_compilation/ice10938.d(10):        class `C` defined here
+fail_compilation/ice10938.d(19): Error: forward reference to inferred return type of function call `this.opDispatch()`
+fail_compilation/ice10938.d(14): Error: template instance `ice10938.C.opDispatch!"opts"` error instantiating
 ---
 */
 

--- a/compiler/test/fail_compilation/test16188.d
+++ b/compiler/test/fail_compilation/test16188.d
@@ -2,8 +2,8 @@
  * TEST_OUTPUT:
 ---
 fail_compilation/test16188.d(101): Error: no property `name` for `Where()` of type `test16188.Where`
-fail_compilation/test16188.d(101):        potentially malformed `opDispatch`. Use an explicit instantiation to get a better error message
-fail_compilation/test16188.d(103):        struct `Where` defined here
+fail_compilation/test16188.d(107): Error: undefined identifier `getMember`
+fail_compilation/test16188.d(101): Error: template instance `test16188.Where.opDispatch!"name"` error instantiating
 ---
  */
 


### PR DESCRIPTION
Instead of saying "Use an explicit instantiation to get a better error message", just do let the compiler do the instantiation for you :slightly_smiling_face: 