### PR TITLE
fix #20912 lexing problem with #define // comments

### DIFF
--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -867,7 +867,7 @@ class Lexer
                             case 0:
                             case 0x1A:
                                 error(t.loc, "unterminated /* */ comment");
-                                p = end;
+                                //p = end;
                                 t.loc = loc();
                                 t.value = TOK.endOfFile;
                                 return;
@@ -927,7 +927,7 @@ class Lexer
                                 getDocComment(t, lastLine == startLoc.linnum, startLoc.linnum - lastDocLine > 1);
                                 lastDocLine = linnum;
                             }
-                            p = end;
+                            //p = end;
                             t.loc = loc();
                             t.value = TOK.endOfFile;
                             return;
@@ -1003,7 +1003,7 @@ class Lexer
                             case 0:
                             case 0x1A:
                                 error(t.loc, "unterminated /+ +/ comment");
-                                p = end;
+                                //p = end;
                                 t.loc = loc();
                                 t.value = TOK.endOfFile;
                                 return;

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -58,6 +58,9 @@ extern (C)
 	/+enum int __TIMESTAMP__ = 1+/;
 	/+enum int __EOF__ = 1+/;
 	/+enum int __VENDOR__ = 1+/;
+	enum int DEF = 123;
+	enum int SQL_DRIVER_STMT_ATTR_BASE = 16384;
+	enum int ABC = 64;
 }
 ---
  */
@@ -124,3 +127,7 @@ struct Test
 };
 
 int arr[(ULONG) 3];
+
+#define DEF 123
+#define SQL_DRIVER_STMT_ATTR_BASE   0x00004000  // 32-bit
+#define ABC 64


### PR DESCRIPTION
The problem is the current position in the buffer gets advanced to the end when it encounters a 0 in a comment.