### PR TITLE
Extracted Dsymbol.oneMember to a visitor in dsymbolsem

### DIFF
--- a/compiler/src/dmd/attrib.h
+++ b/compiler/src/dmd/attrib.h
@@ -29,7 +29,6 @@ class AttribDeclaration : public Dsymbol
 public:
     Dsymbols *decl;     // array of Dsymbol's
     const char *kind() const override;
-    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     bool hasPointers() override final;
     bool hasStaticCtorOrDtor() override final;
     AttribDeclaration *isAttribDeclaration() override { return this; }
@@ -43,7 +42,6 @@ public:
     StorageClass stc;
 
     StorageClassDeclaration *syntaxCopy(Dsymbol *s) override;
-    bool oneMember(Dsymbol *&ps, Identifier *ident) override final;
     StorageClassDeclaration *isStorageClassDeclaration() override { return this; }
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -142,7 +140,6 @@ public:
     Dsymbols *elsedecl; // array of Dsymbol's for else block
 
     ConditionalDeclaration *syntaxCopy(Dsymbol *s) override;
-    bool oneMember(Dsymbol *&ps, Identifier *ident) override final;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -169,7 +166,6 @@ public:
     Dsymbols *cache;
 
     StaticForeachDeclaration *syntaxCopy(Dsymbol *s) override;
-    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     const char *kind() const override;
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/denum.d
+++ b/compiler/src/dmd/denum.d
@@ -81,13 +81,6 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         return ed;
     }
 
-    override bool oneMember(out Dsymbol ps, Identifier ident)
-    {
-        if (isAnonymous())
-            return Dsymbol.oneMembers(members, ps, ident);
-        return Dsymbol.oneMember(ps, ident);
-    }
-
     override Type getType()
     {
         return type;

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -51,6 +51,7 @@ import dmd.statement;
 import dmd.staticassert;
 import dmd.tokens;
 import dmd.visitor;
+import dmd.dsymbolsem;
 
 import dmd.common.outbuffer;
 
@@ -820,20 +821,6 @@ extern (C++) class Dsymbol : ASTNode
         assert(0);
     }
 
-    /**************************************
-     * Determine if this symbol is only one.
-     * Returns:
-     *      false, ps = null: There are 2 or more symbols
-     *      true,  ps = null: There are zero symbols
-     *      true,  ps = symbol: The one and only one symbol
-     */
-    bool oneMember(out Dsymbol ps, Identifier ident)
-    {
-        //printf("Dsymbol::oneMember()\n");
-        ps = this;
-        return true;
-    }
-
     /*****************************************
      * Same as Dsymbol::oneMember(), but look at an array of Dsymbols.
      */
@@ -850,7 +837,7 @@ extern (C++) class Dsymbol : ASTNode
         for (size_t i = 0; i < members.length; i++)
         {
             Dsymbol sx = (*members)[i];
-            bool x = sx.oneMember(ps, ident);
+            bool x = sx.oneMember(ps, ident); //MYTODO: this temporarily creates a new dependency to dsymbolsem, will need to extract oneMembers() later
             //printf("\t[%d] kind %s = %d, s = %p\n", i, sx.kind(), x, *ps);
             if (!x)
             {

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -237,7 +237,6 @@ public:
     virtual bool needThis();                    // need a 'this' pointer?
     virtual Visibility visible();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
-    virtual bool oneMember(Dsymbol *&ps, Identifier *ident);
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
     virtual void addObjcSymbols(ClassDeclarations *, ClassDeclarations *) { }
@@ -433,4 +432,5 @@ namespace dmd
     void setScope(Dsymbol *d, Scope *sc);
     void importAll(Dsymbol *d, Scope *sc);
     void addComment(Dsymbol *d, const char *comment);
+    bool oneMember(Dsymbol *d, Dsymbol *&ps, Identifier *ident);
 }

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -3823,12 +3823,6 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         return "template instance";
     }
 
-    override bool oneMember(out Dsymbol ps, Identifier ident)
-    {
-        ps = null;
-        return true;
-    }
-
     override final const(char)* toPrettyCharsHelper()
     {
         OutBuffer buf;
@@ -5503,11 +5497,6 @@ extern (C++) final class TemplateMixin : TemplateInstance
     override const(char)* kind() const
     {
         return "mixin";
-    }
-
-    override bool oneMember(out Dsymbol ps, Identifier ident)
-    {
-        return Dsymbol.oneMember(ps, ident);
     }
 
     override bool hasPointers()

--- a/compiler/src/dmd/enum.h
+++ b/compiler/src/dmd/enum.h
@@ -52,7 +52,6 @@ public:
     bool inuse(bool v);
 
     EnumDeclaration *syntaxCopy(Dsymbol *s) override;
-    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     Type *getType() override;
     const char *kind() const override;
     bool isDeprecated() const override;       // is Dsymbol deprecated?

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -510,7 +510,6 @@ public:
     virtual bool needThis();
     virtual Visibility visible();
     virtual Dsymbol* syntaxCopy(Dsymbol* s);
-    virtual bool oneMember(Dsymbol*& ps, Identifier* ident);
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
     virtual void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories);
@@ -1632,7 +1631,6 @@ public:
     TemplateInstance* syntaxCopy(Dsymbol* s) override;
     Dsymbol* toAlias() final override;
     const char* kind() const override;
-    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     const char* toPrettyCharsHelper() final override;
     Identifier* getIdent() final override;
     bool equalsx(TemplateInstance* ti);
@@ -1657,7 +1655,6 @@ public:
     TypeQualified* tqual;
     TemplateInstance* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     bool hasPointers() override;
     TemplateMixin* isTemplateMixin() override;
     void accept(Visitor* v) override;
@@ -5378,7 +5375,6 @@ public:
     Expression* exp;
     Array<Expression* >* msgs;
     StaticAssert* syntaxCopy(Dsymbol* s) override;
-    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     const char* kind() const override;
     StaticAssert* isStaticAssert() override;
     void accept(Visitor* v) override;
@@ -6330,7 +6326,6 @@ class AttribDeclaration : public Dsymbol
 public:
     Array<Dsymbol* >* decl;
     const char* kind() const override;
-    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     bool hasPointers() final override;
     bool hasStaticCtorOrDtor() final override;
     void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories) final override;
@@ -6343,7 +6338,6 @@ class StorageClassDeclaration : public AttribDeclaration
 public:
     StorageClass stc;
     StorageClassDeclaration* syntaxCopy(Dsymbol* s) override;
-    bool oneMember(Dsymbol*& ps, Identifier* ident) final override;
     StorageClassDeclaration* isStorageClassDeclaration() override;
     void accept(Visitor* v) override;
 };
@@ -6433,7 +6427,6 @@ public:
     Condition* condition;
     Array<Dsymbol* >* elsedecl;
     ConditionalDeclaration* syntaxCopy(Dsymbol* s) override;
-    bool oneMember(Dsymbol*& ps, Identifier* ident) final override;
     void accept(Visitor* v) override;
 };
 
@@ -6458,7 +6451,6 @@ public:
     bool cached;
     Array<Dsymbol* >* cache;
     StaticForeachDeclaration* syntaxCopy(Dsymbol* s) override;
-    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     const char* kind() const override;
     void accept(Visitor* v) override;
 };
@@ -7011,7 +7003,6 @@ private:
 public:
     Symbol* sinit;
     EnumDeclaration* syntaxCopy(Dsymbol* s) override;
-    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     Type* getType() override;
     const char* kind() const override;
     bool isDeprecated() const override;

--- a/compiler/src/dmd/staticassert.d
+++ b/compiler/src/dmd/staticassert.d
@@ -49,13 +49,6 @@ extern (C++) final class StaticAssert : Dsymbol
         return new StaticAssert(loc, exp.syntaxCopy(), msgs ? Expression.arraySyntaxCopy(msgs) : null);
     }
 
-    override bool oneMember(out Dsymbol ps, Identifier ident)
-    {
-        //printf("StaticAssert::oneMember())\n");
-        ps = null;
-        return true;
-    }
-
     override const(char)* kind() const
     {
         return "static assert";

--- a/compiler/src/dmd/staticassert.h
+++ b/compiler/src/dmd/staticassert.h
@@ -21,7 +21,6 @@ public:
     Expressions *msg;
 
     StaticAssert *syntaxCopy(Dsymbol *s) override;
-    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     const char *kind() const override;
     StaticAssert *isStaticAssert() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -270,7 +270,6 @@ public:
     TemplateInstance *syntaxCopy(Dsymbol *) override;
     Dsymbol *toAlias() override final;   // resolve real symbol
     const char *kind() const override;
-    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     const char* toPrettyCharsHelper() override final;
     Identifier *getIdent() override final;
 
@@ -288,7 +287,6 @@ public:
 
     TemplateMixin *syntaxCopy(Dsymbol *s) override;
     const char *kind() const override;
-    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     bool hasPointers() override;
 
     TemplateMixin *isTemplateMixin() override { return this; }


### PR DESCRIPTION
Part of the [project ](https://github.com/dlang/project-ideas/blob/master/separate-semantic-routines-from-ast-nodes/description.md)to separate semantic routines from AST nodes. @RazvanN7 