### PR TITLE
druntime fix for systems where ucontext_t is available

### DIFF
--- a/druntime/src/core/thread/fiber/base.d
+++ b/druntime/src/core/thread/fiber/base.d
@@ -13,6 +13,7 @@ module core.thread.fiber.base;
 
 package:
 
+version (Posix) import core.sys.posix.ucontext : ucontext_t;
 import core.thread.fiber;
 import core.thread.threadbase;
 import core.thread.threadgroup;


### PR DESCRIPTION
Related: https://github.com/dlang/dmd/pull/16850