### PR TITLE
Fix importc_compare test on Windows

### DIFF
--- a/druntime/test/importc_compare/Makefile
+++ b/druntime/test/importc_compare/Makefile
@@ -11,3 +11,7 @@ endif
 include ../common.mak
 
 extra_dflags += -d
+
+ifeq ($(OS),windows)
+    extra_dflags += -P=/std:c11
+endif

--- a/druntime/test/importc_compare/src/importc_includes.c
+++ b/druntime/test/importc_compare/src/importc_includes.c
@@ -93,7 +93,7 @@
 #if __has_include(<sys/eventfd.h>)
 #include <sys/eventfd.h>
 #endif
-#if __has_include(<stdatomic.h>)
+#if __has_include(<stdatomic.h>) && !defined(__STDC_NO_ATOMICS__)
 #include <stdatomic.h>
 #endif
 #if __has_include(<ifaddrs.h>)


### PR DESCRIPTION
MSVC does not support C11 atomics, but it still provides a "stub" version of stdatomic.h, which aborts compilation with an #error directive when included.

To avoid this error, explicitly set the C standard to C11 when invoking the C preprocessor on Windows, and check for the C11 macro `__STDC_NO_ATOMICS__` before including stdatomic.h.

---

Found in https://github.com/dlang/phobos/pull/10650#issuecomment-2688375024