### PR TITLE
Fixes compilation of ucontext_t based Fibers implementations

### DIFF
--- a/druntime/src/core/thread/fiber/base.d
+++ b/druntime/src/core/thread/fiber/base.d
@@ -558,7 +558,7 @@ protected:
         //       of the executing thread.
         static ucontext_t       sm_utxt = void;
         ucontext_t              m_utxt  = void;
-        ucontext_t*             m_ucur  = null;
+        package ucontext_t*     m_ucur  = null;
     }
 
 


### PR DESCRIPTION
Fixes issue brought in https://github.com/dlang/dmd/pull/16695 (https://github.com/dlang/dmd/pull/16695#issuecomment-2358432942)

~~But also I found that (probably) CI execution was broken before #16695 for `ucontext_t`-based `Fiber` implementations~~

I have no systems that using `ucontext_t` and I "emulated" them on my x86_64 Linux system by disabling other context switching approaches by using temporary code commenting:
```diff
diff --git a/druntime/src/core/thread/fiber/package.d b/druntime/src/core/thread/fiber/package.d
index 2112e23258..10101c7075 100644
--- a/druntime/src/core/thread/fiber/package.d
+++ b/druntime/src/core/thread/fiber/package.d
@@ -147,12 +147,12 @@ package
 
     version (Posix)
     {
-        version (AsmX86_Windows)    {} else
-        version (AsmX86_Posix)      {} else
-        version (AsmX86_64_Windows) {} else
-        version (AsmX86_64_Posix)   {} else
-        version (AsmExternal)       {} else
-        {
+        //~ version (AsmX86_Windows)    {} else
+        //~ version (AsmX86_Posix)      {} else
+        //~ version (AsmX86_64_Windows) {} else
+        //~ version (AsmX86_64_Posix)   {} else
+        //~ version (AsmExternal)       {} else
+        //~ {
             // NOTE: The ucontext implementation requires architecture specific
             //       data definitions to operate so testing for it must be done
             //       by checking for the existence of ucontext_t rather than by
@@ -160,7 +160,7 @@ package
             //       an obsolescent feature according to the POSIX spec, so a
             //       custom solution is still preferred.
             import core.sys.posix.ucontext : getcontext, makecontext, MINSIGSTKSZ, swapcontext, ucontext_t;
-        }
+        //~ }
     }
 }
 
@@ -330,7 +330,7 @@ package
                 jmp ECX;
             }
         }
-        else version (AsmX86_64_Posix)
+        else version (AsmX86_64_Posix_disabled)
         {
             asm pure nothrow @nogc
             {
```

After that I successfully compiled and run tests by command:
```
$ make druntime-test
```
and got error:
```
****** FAIL debug64 core.thread.fiber.base
core.exception.AssertError@src/core/thread/fiber/base.d(690): Derived fiber increment.
```

But same error I got then compiling commit e3aee6789df74335a7971780a73dc79ae4113275 that was made few days earlier than #16695
