### PR TITLE
Devirtualize Dsymbol.isXXX functions

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -495,11 +495,6 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     // Back end
     void* sinit;  /// initializer symbol
 
-    override final inout(AggregateDeclaration) isAggregateDeclaration() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -135,7 +135,6 @@ public:
     // Back end
     void *sinit;
 
-    AggregateDeclaration *isAggregateDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -191,7 +190,6 @@ public:
     bool requestTypeInfo() const;
     bool requestTypeInfo(bool v);
 
-    StructDeclaration *isStructDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 
     unsigned numArgTypes() const;
@@ -205,7 +203,6 @@ public:
     UnionDeclaration *syntaxCopy(Dsymbol *s) override;
     const char *kind() const override;
 
-    UnionDeclaration *isUnionDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -305,7 +302,6 @@ public:
     Dsymbol *vtblsym;
     Dsymbol *vtblSymbol();
 
-    ClassDeclaration *isClassDeclaration() override final { return (ClassDeclaration *)this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -320,6 +316,5 @@ public:
     bool isCPPinterface() const override;
     bool isCOMinterface() const override;
 
-    InterfaceDeclaration *isInterfaceDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/aliasthis.d
+++ b/compiler/src/dmd/aliasthis.d
@@ -33,7 +33,7 @@ extern (C++) final class AliasThis : Dsymbol
 
     extern (D) this(Loc loc, Identifier ident) @safe
     {
-        super(loc, null);    // it's anonymous (no identifier)
+        super(DSYM.aliasThis, loc, null);    // it's anonymous (no identifier)
         this.ident = ident;
     }
 

--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -57,18 +57,19 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     extern (D) this(Dsymbols* decl) @safe
     {
+        super(DSYM.attribDeclaration);
         this.decl = decl;
     }
 
     extern (D) this(Loc loc, Dsymbols* decl) @safe
     {
-        super(loc, null);
+        super(DSYM.attribDeclaration, loc, null);
         this.decl = decl;
     }
 
     extern (D) this(Loc loc, Identifier ident, Dsymbols* decl) @safe
     {
-        super(loc, ident);
+        super(DSYM.attribDeclaration, loc, ident);
         this.decl = decl;
     }
 
@@ -126,11 +127,6 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         objc.addSymbols(this, classes, categories);
     }
 
-    override inout(AttribDeclaration) isAttribDeclaration() inout pure @safe
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -150,23 +146,20 @@ extern (C++) class StorageClassDeclaration : AttribDeclaration
     {
         super(decl);
         this.stc = stc;
+        this.dsym = DSYM.storageClassDeclaration;
     }
 
     extern (D) this(Loc loc, StorageClass stc, Dsymbols* decl) @safe
     {
         super(loc, decl);
         this.stc = stc;
+        this.dsym = DSYM.storageClassDeclaration;
     }
 
     override StorageClassDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new StorageClassDeclaration(stc, Dsymbol.arraySyntaxCopy(decl));
-    }
-
-    override inout(StorageClassDeclaration) isStorageClassDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -221,6 +214,7 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
         super(loc, null, decl);
         //printf("LinkDeclaration(linkage = %d, decl = %p)\n", linkage, decl);
         this.linkage = linkage;
+        this.dsym = DSYM.linkDeclaration;
     }
 
     static LinkDeclaration create(Loc loc, LINK p, Dsymbols* decl) @safe
@@ -257,6 +251,7 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
         super(loc, null, decl);
         //printf("CPPMangleDeclaration(cppmangle = %d, decl = %p)\n", cppmangle, decl);
         this.cppmangle = cppmangle;
+        this.dsym = DSYM.cppMangleDeclaration;
     }
 
     override CPPMangleDeclaration syntaxCopy(Dsymbol s)
@@ -302,11 +297,13 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
     extern (D) this(Loc loc, Identifier ident, Dsymbols* decl) @safe
     {
         super(loc, ident, decl);
+        this.dsym = DSYM.cppNamespaceDeclaration;
     }
 
     extern (D) this(Loc loc, Expression exp, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
+        this.dsym = DSYM.cppNamespaceDeclaration;
         this.exp = exp;
     }
 
@@ -314,6 +311,7 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
                     CPPNamespaceDeclaration parent) @safe
     {
         super(loc, ident, decl);
+        this.dsym = DSYM.cppNamespaceDeclaration;
         this.exp = exp;
         this.cppnamespace = parent;
     }
@@ -329,8 +327,6 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
     {
         v.visit(this);
     }
-
-    override inout(CPPNamespaceDeclaration) isCPPNamespaceDeclaration() inout { return this; }
 }
 
 /***********************************************************
@@ -353,6 +349,7 @@ extern (C++) final class VisibilityDeclaration : AttribDeclaration
     extern (D) this(Loc loc, Visibility visibility, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
+        this.dsym = DSYM.visibilityDeclaration;
         this.visibility = visibility;
         //printf("decl = %p\n", decl);
     }
@@ -366,6 +363,7 @@ extern (C++) final class VisibilityDeclaration : AttribDeclaration
     extern (D) this(Loc loc, Identifier[] pkg_identifiers, Dsymbols* decl)
     {
         super(loc, null, decl);
+        this.dsym = DSYM.visibilityDeclaration;
         this.visibility.kind = Visibility.Kind.package_;
         this.pkg_identifiers = pkg_identifiers;
         if (pkg_identifiers.length > 0)
@@ -399,11 +397,6 @@ extern (C++) final class VisibilityDeclaration : AttribDeclaration
         return buf.extractChars();
     }
 
-    override inout(VisibilityDeclaration) isVisibilityDeclaration() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -428,6 +421,7 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
     extern (D) this(Loc loc, Expression exp, Dsymbols* decl)
     {
         super(loc, null, decl);
+        this.dsym = DSYM.alignDeclaration;
         if (exp)
         {
             exps = new Expressions();
@@ -438,12 +432,14 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
     extern (D) this(Loc loc, Expressions* exps, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
+        this.dsym = DSYM.alignDeclaration;
         this.exps = exps;
     }
 
     extern (D) this(Loc loc, structalign_t salign, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
+        this.dsym = DSYM.alignDeclaration;
         this.salign = salign;
     }
 
@@ -475,6 +471,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
     extern (D) this(Loc loc, bool isunion, Dsymbols* decl) @safe
     {
         super(loc, null, decl);
+        this.dsym = DSYM.anonDeclaration;
         this.isunion = isunion;
     }
 
@@ -487,11 +484,6 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
     override const(char)* kind() const
     {
         return (isunion ? "anonymous union" : "anonymous struct");
-    }
-
-    override inout(AnonDeclaration) isAnonDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -513,6 +505,7 @@ extern (C++) final class PragmaDeclaration : AttribDeclaration
     extern (D) this(Loc loc, Identifier ident, Expressions* args, Dsymbols* decl) @safe
     {
         super(loc, ident, decl);
+        this.dsym = DSYM.pragmaDeclaration;
         this.args = args;
     }
 
@@ -548,6 +541,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
     extern (D) this(Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl) @safe
     {
         super(loc, null, decl);
+        this.dsym = DSYM.conditionalDeclaration;
         //printf("ConditionalDeclaration::ConditionalDeclaration()\n");
         this.condition = condition;
         this.elsedecl = elsedecl;
@@ -579,6 +573,7 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
     extern (D) this(Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl) @safe
     {
         super(loc, condition, decl, elsedecl);
+        this.dsym = DSYM.staticIfDeclaration;
         //printf("StaticIfDeclaration::StaticIfDeclaration()\n");
     }
 
@@ -591,11 +586,6 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
     override const(char)* kind() const
     {
         return "static if";
-    }
-
-    override inout(StaticIfDeclaration) isStaticIfDeclaration() inout pure @safe
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -628,6 +618,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
     extern (D) this(StaticForeach sfe, Dsymbols* decl) @safe
     {
         super(sfe.loc, null, decl);
+        this.dsym = DSYM.staticForeachDeclaration;
         this.sfe = sfe;
     }
 
@@ -683,14 +674,9 @@ extern(C++) final class ForwardingAttribDeclaration : AttribDeclaration
     this(Dsymbols* decl) @safe
     {
         super(decl);
+        this.dsym = DSYM.forwardingAttribDeclaration;
         sym = new ForwardingScopeDsymbol();
         sym.symtab = new DsymbolTable();
-    }
-
-
-    override inout(ForwardingAttribDeclaration) isForwardingAttribDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -715,6 +701,7 @@ extern (C++) final class MixinDeclaration : AttribDeclaration
     {
         super(loc, null, null);
         //printf("MixinDeclaration(loc = %d)\n", loc.linnum);
+        this.dsym = DSYM.mixinDeclaration;
         this.exps = exps;
     }
 
@@ -727,11 +714,6 @@ extern (C++) final class MixinDeclaration : AttribDeclaration
     override const(char)* kind() const
     {
         return "mixin";
-    }
-
-    override inout(MixinDeclaration) isMixinDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -752,6 +734,7 @@ extern (C++) final class UserAttributeDeclaration : AttribDeclaration
     extern (D) this(Expressions* atts, Dsymbols* decl) @safe
     {
         super(decl);
+        this.dsym = DSYM.userAttributeDeclaration;
         this.atts = atts;
     }
 

--- a/compiler/src/dmd/attrib.h
+++ b/compiler/src/dmd/attrib.h
@@ -31,7 +31,6 @@ public:
     const char *kind() const override;
     bool hasPointers() override final;
     bool hasStaticCtorOrDtor() override final;
-    AttribDeclaration *isAttribDeclaration() override { return this; }
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -42,7 +41,6 @@ public:
     StorageClass stc;
 
     StorageClassDeclaration *syntaxCopy(Dsymbol *s) override;
-    StorageClassDeclaration *isStorageClassDeclaration() override { return this; }
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -94,7 +92,6 @@ public:
     VisibilityDeclaration *syntaxCopy(Dsymbol *s) override;
     const char *kind() const override;
     const char *toPrettyChars(bool unused) override;
-    VisibilityDeclaration *isVisibilityDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -119,7 +116,6 @@ public:
 
     AnonDeclaration *syntaxCopy(Dsymbol *s) override;
     const char *kind() const override;
-    AnonDeclaration *isAnonDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -151,7 +147,6 @@ public:
     d_bool onStack;
 
     StaticIfDeclaration *syntaxCopy(Dsymbol *s) override;
-    StaticIfDeclaration *isStaticIfDeclaration() override { return this; }
     const char *kind() const override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -175,7 +170,6 @@ class ForwardingAttribDeclaration final : public AttribDeclaration
 public:
     ForwardingScopeDsymbol *sym;
 
-    ForwardingAttribDeclaration *isForwardingAttribDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/cond.h
+++ b/compiler/src/dmd/cond.h
@@ -71,7 +71,6 @@ public:
     static void addGlobalIdent(const char *ident);
 
     int include(Scope *sc) override;
-    DebugCondition *isDebugCondition() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -82,7 +81,6 @@ public:
     static void addPredefinedGlobalIdent(const char *ident);
 
     int include(Scope *sc) override;
-    VersionCondition *isVersionCondition() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -206,6 +206,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             id = Identifier.generateAnonymousId("class");
 
         super(loc, id);
+        this.dsym = DSYM.classDeclaration;
 
         static immutable msg = "only object.d can define this reserved class name";
 
@@ -941,11 +942,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         return errorException && (this == errorException || errorException.isBaseOf(this, null));
     }
 
-    override final inout(ClassDeclaration) isClassDeclaration() inout @nogc nothrow pure @safe
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -959,6 +955,7 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
     extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses)
     {
         super(loc, id, baseclasses, null, false);
+        this.dsym = DSYM.interfaceDeclaration;
         if (id == Id.IUnknown) // IUnknown is the root of all COM interfaces
         {
             com = true;
@@ -1056,11 +1053,6 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
     override bool isCOMinterface() const
     {
         return com;
-    }
-
-    override inout(InterfaceDeclaration) isInterfaceDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -106,15 +106,15 @@ extern (C++) abstract class Declaration : Dsymbol
     import dmd.common.bitfields;
     mixin(generateBitFields!(BitFields, ubyte));
 
-    final extern (D) this(Identifier ident) @safe
+    final extern (D) this(DSYM tag, Identifier ident) @safe
     {
-        super(ident);
+        super(tag, ident);
         visibility = Visibility(Visibility.Kind.undefined);
     }
 
-    final extern (D) this(Loc loc, Identifier ident) @safe
+    final extern (D) this(DSYM tag, Loc loc, Identifier ident) @safe
     {
-        super(loc, ident);
+        super(tag, loc, ident);
         visibility = Visibility(Visibility.Kind.undefined);
     }
 
@@ -274,11 +274,6 @@ extern (C++) abstract class Declaration : Dsymbol
         return visibility;
     }
 
-    override final inout(Declaration) isDeclaration() inout pure nothrow @nogc @safe
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -296,7 +291,7 @@ extern (C++) final class TupleDeclaration : Declaration
 
     extern (D) this(Loc loc, Identifier ident, Objects* objects) @safe
     {
-        super(loc, ident);
+        super(DSYM.tupleDeclaration, loc, ident);
         this.objects = objects;
     }
 
@@ -424,11 +419,6 @@ extern (C++) final class TupleDeclaration : Declaration
         return 0;
     }
 
-    override inout(TupleDeclaration) isTupleDeclaration() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -447,7 +437,7 @@ extern (C++) final class AliasDeclaration : Declaration
 
     extern (D) this(Loc loc, Identifier ident, Type type) @safe
     {
-        super(loc, ident);
+        super(DSYM.aliasDeclaration, loc, ident);
         //debug printf("AliasDeclaration(id = '%s', type = `%s`, %p)\n", ident.toChars(), dmd.hdrgen.toChars(type), type.isTypeIdentifier());
         this.type = type;
         assert(type);
@@ -455,7 +445,7 @@ extern (C++) final class AliasDeclaration : Declaration
 
     extern (D) this(Loc loc, Identifier ident, Dsymbol s) @safe
     {
-        super(loc, ident);
+        super(DSYM.aliasDeclaration, loc, ident);
         //debug printf("AliasDeclaration(id = '%s', s = `%s`)\n", ident.toChars(), s.toChars());
         assert(s != this);
         this.aliassym = s;
@@ -732,11 +722,6 @@ extern (C++) final class AliasDeclaration : Declaration
             aliassym && aliassym.isOverloadable();
     }
 
-    override inout(AliasDeclaration) isAliasDeclaration() inout
-    {
-        return this;
-    }
-
     /** Returns: `true` if this instance was created to make a template parameter
     visible in the scope of a template body, `false` otherwise */
     extern (D) bool isAliasedTemplateParameter() const
@@ -759,7 +744,7 @@ extern (C++) final class OverDeclaration : Declaration
 
     extern (D) this(Identifier ident, Dsymbol s) @safe
     {
-        super(ident);
+        super(DSYM.overDeclaration, ident);
         this.aliassym = s;
     }
 
@@ -815,11 +800,6 @@ extern (C++) final class OverDeclaration : Declaration
             }
         });
         return result;
-    }
-
-    override inout(OverDeclaration) isOverDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -895,7 +875,7 @@ extern (C++) class VarDeclaration : Declaration
     do
     {
         //printf("VarDeclaration('%s')\n", ident.toChars());
-        super(loc, ident);
+        super(DSYM.varDeclaration, loc, ident);
         debug
         {
             if (!type && !_init)
@@ -1217,12 +1197,6 @@ extern (C++) class VarDeclaration : Declaration
         return s;
     }
 
-    // Eliminate need for dynamic_cast
-    override final inout(VarDeclaration) isVarDeclaration() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1242,7 +1216,7 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
     final extern (D) this(Loc loc, Type type, Identifier ident, Expression width)
     {
         super(loc, type, ident, null);
-
+        this.dsym = DSYM.bitFieldDeclaration;
         this.width = width;
         this.storage_class |= STC.field;
     }
@@ -1254,11 +1228,6 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
         auto bf = new BitFieldDeclaration(loc, type ? type.syntaxCopy() : null, ident, width.syntaxCopy());
         bf.comment = comment;
         return bf;
-    }
-
-    override final inout(BitFieldDeclaration) isBitFieldDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -1302,15 +1271,9 @@ extern (C++) final class SymbolDeclaration : Declaration
 
     extern (D) this(Loc loc, AggregateDeclaration dsym) @safe
     {
-        super(loc, dsym.ident);
+        super(DSYM.symbolDeclaration, loc, dsym.ident);
         this.dsym = dsym;
         storage_class |= STC.const_;
-    }
-
-    // Eliminate need for dynamic_cast
-    override inout(SymbolDeclaration) isSymbolDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -1357,6 +1320,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
     final extern (D) this(Type tinfo)
     {
         super(Loc.initial, Type.dtypeinfo.type, tinfo.getTypeInfoIdent(), null);
+        this.dsym = DSYM.typeInfoDeclaration;
         this.tinfo = tinfo;
         storage_class = STC.static_ | STC.gshared;
         visibility = Visibility(Visibility.Kind.public_);
@@ -1372,11 +1336,6 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
     override final TypeInfoDeclaration syntaxCopy(Dsymbol s)
     {
         assert(0); // should never be produced by syntax
-    }
-
-    override final inout(TypeInfoDeclaration) isTypeInfoDeclaration() inout @nogc nothrow pure @safe
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -1795,17 +1754,13 @@ extern (C++) final class ThisDeclaration : VarDeclaration
     extern (D) this(Loc loc, Type t)
     {
         super(loc, t, Id.This, null);
+        this.dsym = DSYM.thisDeclaration;
         storage_class |= STC.nodtor;
     }
 
     override ThisDeclaration syntaxCopy(Dsymbol s)
     {
         assert(0); // should never be produced by syntax
-    }
-
-    override inout(ThisDeclaration) isThisDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -160,7 +160,6 @@ public:
 
     Visibility visible() override final;
 
-    Declaration *isDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -180,7 +179,6 @@ public:
     Dsymbol *toAlias2() override;
     bool needThis() override;
 
-    TupleDeclaration *isTupleDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -202,7 +200,6 @@ public:
     Dsymbol *toAlias2() override;
     bool isOverloadable() const override;
 
-    AliasDeclaration *isAliasDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -222,7 +219,6 @@ public:
     Dsymbol *isUnique();
     bool isOverloadable() const override;
 
-    OverDeclaration *isOverDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -300,7 +296,6 @@ public:
     bool needsScopeDtor();
     Dsymbol *toAlias() override final;
     // Eliminate need for dynamic_cast
-    VarDeclaration *isVarDeclaration() override final { return (VarDeclaration *)this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -315,7 +310,6 @@ public:
     unsigned bitOffset;
 
     BitFieldDeclaration *syntaxCopy(Dsymbol *) override;
-    BitFieldDeclaration *isBitFieldDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -329,7 +323,6 @@ public:
     AggregateDeclaration *dsym;
 
     // Eliminate need for dynamic_cast
-    SymbolDeclaration *isSymbolDeclaration() override { return (SymbolDeclaration *)this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -341,7 +334,6 @@ public:
     static TypeInfoDeclaration *create(Type *tinfo);
     TypeInfoDeclaration *syntaxCopy(Dsymbol *) override final;
 
-    TypeInfoDeclaration *isTypeInfoDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -481,7 +473,6 @@ class ThisDeclaration final : public VarDeclaration
 {
 public:
     ThisDeclaration *syntaxCopy(Dsymbol *) override;
-    ThisDeclaration *isThisDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -738,8 +729,6 @@ public:
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc=0);
 
-    FuncDeclaration *isFuncDeclaration() override final { return this; }
-
     virtual FuncDeclaration *toAliasFunc() { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -750,7 +739,6 @@ public:
     FuncDeclaration *funcalias;
     d_bool hasOverloads;
 
-    FuncAliasDeclaration *isFuncAliasDeclaration() override { return this; }
     const char *kind() const override;
 
     FuncDeclaration *toAliasFunc() override;
@@ -773,7 +761,6 @@ public:
     bool addPreInvariant() override;
     bool addPostInvariant() override;
 
-    FuncLiteralDeclaration *isFuncLiteralDeclaration() override { return this; }
     const char *kind() const override;
     const char *toPrettyChars(bool QualifyTypes = false) override;
     void accept(Visitor *v) override { v->visit(this); }
@@ -790,7 +777,6 @@ public:
     bool addPreInvariant() override;
     bool addPostInvariant() override;
 
-    CtorDeclaration *isCtorDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -803,7 +789,6 @@ public:
     bool addPostInvariant() override;
     bool overloadInsert(Dsymbol *s) override;
 
-    PostBlitDeclaration *isPostBlitDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -817,7 +802,6 @@ public:
     bool addPostInvariant() override;
     bool overloadInsert(Dsymbol *s) override;
 
-    DtorDeclaration *isDtorDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -831,7 +815,6 @@ public:
     bool addPostInvariant() override final;
     bool hasStaticCtorOrDtor() override final;
 
-    StaticCtorDeclaration *isStaticCtorDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -841,7 +824,6 @@ public:
     bool standalone;
     SharedStaticCtorDeclaration *syntaxCopy(Dsymbol *) override;
 
-    SharedStaticCtorDeclaration *isSharedStaticCtorDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -857,7 +839,6 @@ public:
     bool addPreInvariant() override final;
     bool addPostInvariant() override final;
 
-    StaticDtorDeclaration *isStaticDtorDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -866,7 +847,6 @@ class SharedStaticDtorDeclaration final : public StaticDtorDeclaration
 public:
     SharedStaticDtorDeclaration *syntaxCopy(Dsymbol *) override;
 
-    SharedStaticDtorDeclaration *isSharedStaticDtorDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -878,7 +858,6 @@ public:
     bool addPreInvariant() override;
     bool addPostInvariant() override;
 
-    InvariantDeclaration *isInvariantDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -896,7 +875,6 @@ public:
     bool addPreInvariant() override;
     bool addPostInvariant() override;
 
-    UnitTestDeclaration *isUnitTestDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -909,6 +887,5 @@ public:
     bool addPreInvariant() override;
     bool addPostInvariant() override;
 
-    NewDeclaration *isNewDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/denum.d
+++ b/compiler/src/dmd/denum.d
@@ -70,6 +70,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         //printf("EnumDeclaration() %p %s : %s\n", this, toChars(), memtype.toChars());
         type = new TypeEnum(this);
         this.memtype = memtype;
+        this.dsym = DSYM.enumDeclaration;
         visibility = Visibility(Visibility.Kind.undefined);
     }
 
@@ -113,11 +114,6 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         return isSpecialEnumIdent(ident) && memtype;
     }
 
-    override inout(EnumDeclaration) isEnumDeclaration() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -152,6 +148,7 @@ extern (C++) final class EnumMember : VarDeclaration
         super(loc, null, id ? id : Id.empty, new ExpInitializer(loc, value));
         this.origValue = value;
         this.origType = origType;
+        this.dsym = DSYM.enumMember;
     }
 
     extern(D) this(Loc loc, Identifier id, Expression value, Type memtype,
@@ -178,11 +175,6 @@ extern (C++) final class EnumMember : VarDeclaration
     override const(char)* kind() const
     {
         return "enum member";
-    }
-
-    override inout(EnumMember) isEnumMember() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -59,7 +59,7 @@ extern (C++) final class Import : Dsymbol
             return id;
         }
 
-        super(loc, selectIdent());
+        super(DSYM.import_, loc, selectIdent());
 
         assert(id);
         version (none)
@@ -159,11 +159,6 @@ extern (C++) final class Import : Dsymbol
             return false;
         const imp = s.isImport();
         return imp && !imp.aliasId;
-    }
-
-    override inout(Import) isImport() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -180,6 +180,7 @@ extern (C++) class Package : ScopeDsymbol
         super(loc, ident);
         __gshared uint packageTag;
         this.tag = packageTag++;
+        this.dsym = DSYM.package_;
     }
 
     override const(char)* kind() const nothrow
@@ -251,11 +252,6 @@ extern (C++) class Package : ScopeDsymbol
         if (pparent)
             *pparent = parent;
         return dst;
-    }
-
-    override final inout(Package) isPackage() inout
-    {
-        return this;
     }
 
     /**
@@ -445,6 +441,7 @@ extern (C++) final class Module : Package
     extern (D) this(Loc loc, const(char)[] filename, Identifier ident, int doDocComment, int doHdrGen)
     {
         super(loc, ident);
+        this.dsym = DSYM.module_;
         const(char)[] srcfilename;
         //printf("Module::Module(filename = '%.*s', ident = '%s')\n", cast(int)filename.length, filename.ptr, ident.toChars());
         this.arg = filename;
@@ -1177,11 +1174,6 @@ extern (C++) final class Module : Package
     Symbol* sfilename; // symbol for filename
 
     uint[uint] ctfe_cov; /// coverage information from ctfe execution_count[line]
-
-    override inout(Module) isModule() inout nothrow
-    {
-        return this;
-    }
 
     override void accept(Visitor v)
     {

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -119,6 +119,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     extern (D) this(Loc loc, Identifier id, bool inObject)
     {
         super(loc, id);
+        this.dsym = DSYM.structDeclaration;
         zeroInit = false; // assume false until we do semantic processing
         ispod = ThreeState.none;
         // For forward references
@@ -374,11 +375,6 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         return postblit || hasCopyCtor;
     }
 
-    override final inout(StructDeclaration) isStructDeclaration() inout @nogc nothrow pure @safe
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -543,6 +539,7 @@ extern (C++) final class UnionDeclaration : StructDeclaration
     extern (D) this(Loc loc, Identifier id)
     {
         super(loc, id, false);
+        this.dsym = DSYM.unionDeclaration;
     }
 
     override UnionDeclaration syntaxCopy(Dsymbol s)
@@ -556,11 +553,6 @@ extern (C++) final class UnionDeclaration : StructDeclaration
     override const(char)* kind() const
     {
         return "union";
-    }
-
-    override inout(UnionDeclaration) isUnionDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -259,6 +259,76 @@ private struct DsymbolAttributes
     UserAttributeDeclaration userAttribDecl;
 }
 
+enum DSYM : ubyte
+{
+    none,
+    dsymbol,
+    linkDeclaration,
+    cppMangleDeclaration,
+    alignDeclaration,
+    pragmaDeclaration,
+    conditionalDeclaration,
+    staticForeachDeclaration,
+    userAttributeDeclaration,
+    labelDsymbol,
+    aliasThis,
+    package_,
+    module_,
+    enumMember,
+    templateDeclaration,
+    templateInstance,
+    templateMixin,
+    forwardingAttribDeclaration,
+    nspace,
+    declaration,
+    storageClassDeclaration,
+    expressionDsymbol,
+    aliasAssign,
+    thisDeclaration,
+    bitFieldDeclaration,
+    typeInfoDeclaration,
+    tupleDeclaration,
+    aliasDeclaration,
+    aggregateDeclaration,
+    funcDeclaration,
+    funcAliasDeclaration,
+    overDeclaration,
+    funcLiteralDeclaration,
+    ctorDeclaration,
+    postBlitDeclaration,
+    dtorDeclaration,
+    staticCtorDeclaration,
+    staticDtorDeclaration,
+    sharedStaticCtorDeclaration,
+    sharedStaticDtorDeclaration,
+    invariantDeclaration,
+    unitTestDeclaration,
+    newDeclaration,
+    varDeclaration,
+    versionSymbol,
+    debugSymbol,
+    classDeclaration,
+    structDeclaration,
+    unionDeclaration,
+    interfaceDeclaration,
+    scopeDsymbol,
+    forwardingScopeDsymbol,
+    withScopeSymbol,
+    arrayScopeSymbol,
+    import_,
+    enumDeclaration,
+    symbolDeclaration,
+    attribDeclaration,
+    anonDeclaration,
+    cppNamespaceDeclaration,
+    visibilityDeclaration,
+    overloadSet,
+    mixinDeclaration,
+    staticAssert,
+    staticIfDeclaration,
+    cAsmDeclaration
+}
+
 /***********************************************************
  */
 extern (C++) class Dsymbol : ASTNode
@@ -269,33 +339,42 @@ extern (C++) class Dsymbol : ASTNode
     Scope* _scope;          // !=null means context to use for semantic()
     private DsymbolAttributes* atts; /// attached attribute declarations
     const Loc loc;          // where defined
-    bool errors;            // this symbol failed to pass semantic()
-    PASS semanticRun = PASS.initial;
     ushort localNum;        /// perturb mangled name to avoid collisions with those in FuncDeclaration.localsymtab
+    static struct BitFields
+    {
+        bool errors;            // this symbol failed to pass semantic()
+        PASS semanticRun = PASS.initial;
+    }
+    import dmd.common.bitfields;
+    mixin(generateBitFields!(BitFields, ubyte));
+    DSYM dsym;
 
-    final extern (D) this() nothrow @safe
+    final extern (D) this(DSYM tag) nothrow @safe
     {
         //printf("Dsymbol::Dsymbol(%p)\n", this);
+        this.dsym = tag;
         loc = Loc.initial;
     }
 
-    final extern (D) this(Identifier ident) nothrow @safe
+    final extern (D) this(DSYM tag, Identifier ident) nothrow @safe
     {
         //printf("Dsymbol::Dsymbol(%p, ident)\n", this);
+        this.dsym = tag;
         this.loc = Loc.initial;
         this.ident = ident;
     }
 
-    final extern (D) this(Loc loc, Identifier ident) nothrow @safe
+    final extern (D) this(DSYM tag, Loc loc, Identifier ident) nothrow @safe
     {
         //printf("Dsymbol::Dsymbol(%p, ident)\n", this);
+        this.dsym = tag;
         this.loc = loc;
         this.ident = ident;
     }
 
     static Dsymbol create(Identifier ident) nothrow @safe
     {
-        return new Dsymbol(ident);
+        return new Dsymbol(DSYM.dsymbol, ident);
     }
 
     final override const(char)* toChars() const
@@ -995,64 +1074,181 @@ extern (C++) class Dsymbol : ASTNode
         v.visit(this);
     }
 
-  pure nothrow @safe @nogc:
+  pure nothrow @trusted @nogc final:
 
-    // Eliminate need for dynamic_cast
-    inout(Package)                     isPackage()                     inout { return null; }
-    inout(Module)                      isModule()                      inout { return null; }
-    inout(EnumMember)                  isEnumMember()                  inout { return null; }
-    inout(TemplateDeclaration)         isTemplateDeclaration()         inout { return null; }
-    inout(TemplateInstance)            isTemplateInstance()            inout { return null; }
-    inout(TemplateMixin)               isTemplateMixin()               inout { return null; }
-    inout(ForwardingAttribDeclaration) isForwardingAttribDeclaration() inout { return null; }
-    inout(Nspace)                      isNspace()                      inout { return null; }
-    inout(Declaration)                 isDeclaration()                 inout { return null; }
-    inout(StorageClassDeclaration)     isStorageClassDeclaration()     inout { return null; }
-    inout(ExpressionDsymbol)           isExpressionDsymbol()           inout { return null; }
-    inout(AliasAssign)                 isAliasAssign()                 inout { return null; }
-    inout(ThisDeclaration)             isThisDeclaration()             inout { return null; }
-    inout(BitFieldDeclaration)         isBitFieldDeclaration()         inout { return null; }
-    inout(TypeInfoDeclaration)         isTypeInfoDeclaration()         inout { return null; }
-    inout(TupleDeclaration)            isTupleDeclaration()            inout { return null; }
-    inout(AliasDeclaration)            isAliasDeclaration()            inout { return null; }
-    inout(AggregateDeclaration)        isAggregateDeclaration()        inout { return null; }
-    inout(FuncDeclaration)             isFuncDeclaration()             inout { return null; }
-    inout(FuncAliasDeclaration)        isFuncAliasDeclaration()        inout { return null; }
-    inout(OverDeclaration)             isOverDeclaration()             inout { return null; }
-    inout(FuncLiteralDeclaration)      isFuncLiteralDeclaration()      inout { return null; }
-    inout(CtorDeclaration)             isCtorDeclaration()             inout { return null; }
-    inout(PostBlitDeclaration)         isPostBlitDeclaration()         inout { return null; }
-    inout(DtorDeclaration)             isDtorDeclaration()             inout { return null; }
-    inout(StaticCtorDeclaration)       isStaticCtorDeclaration()       inout { return null; }
-    inout(StaticDtorDeclaration)       isStaticDtorDeclaration()       inout { return null; }
-    inout(SharedStaticCtorDeclaration) isSharedStaticCtorDeclaration() inout { return null; }
-    inout(SharedStaticDtorDeclaration) isSharedStaticDtorDeclaration() inout { return null; }
-    inout(InvariantDeclaration)        isInvariantDeclaration()        inout { return null; }
-    inout(UnitTestDeclaration)         isUnitTestDeclaration()         inout { return null; }
-    inout(NewDeclaration)              isNewDeclaration()              inout { return null; }
-    inout(VarDeclaration)              isVarDeclaration()              inout { return null; }
-    inout(VersionSymbol)               isVersionSymbol()               inout { return null; }
-    inout(DebugSymbol)                 isDebugSymbol()                 inout { return null; }
-    inout(ClassDeclaration)            isClassDeclaration()            inout { return null; }
-    inout(StructDeclaration)           isStructDeclaration()           inout { return null; }
-    inout(UnionDeclaration)            isUnionDeclaration()            inout { return null; }
-    inout(InterfaceDeclaration)        isInterfaceDeclaration()        inout { return null; }
-    inout(ScopeDsymbol)                isScopeDsymbol()                inout { return null; }
-    inout(ForwardingScopeDsymbol)      isForwardingScopeDsymbol()      inout { return null; }
-    inout(WithScopeSymbol)             isWithScopeSymbol()             inout { return null; }
-    inout(ArrayScopeSymbol)            isArrayScopeSymbol()            inout { return null; }
-    inout(Import)                      isImport()                      inout { return null; }
-    inout(EnumDeclaration)             isEnumDeclaration()             inout { return null; }
-    inout(SymbolDeclaration)           isSymbolDeclaration()           inout { return null; }
-    inout(AttribDeclaration)           isAttribDeclaration()           inout { return null; }
-    inout(AnonDeclaration)             isAnonDeclaration()             inout { return null; }
-    inout(CPPNamespaceDeclaration)     isCPPNamespaceDeclaration()     inout { return null; }
-    inout(VisibilityDeclaration)       isVisibilityDeclaration()       inout { return null; }
-    inout(OverloadSet)                 isOverloadSet()                 inout { return null; }
-    inout(MixinDeclaration)            isMixinDeclaration()            inout { return null; }
-    inout(StaticAssert)                isStaticAssert()                inout { return null; }
-    inout(StaticIfDeclaration)         isStaticIfDeclaration()         inout { return null; }
-    inout(CAsmDeclaration)             isCAsmDeclaration()             inout { return null; }
+    inout(Package)                     isPackage()                     inout { return (dsym == DSYM.package_ || dsym == DSYM.module_) ? cast(inout(Package)) cast(void*) this : null; }
+    inout(Module)                      isModule()                      inout { return dsym == DSYM.module_ ? cast(inout(Module)) cast(void*) this : null; }
+    inout(EnumMember)                  isEnumMember()                  inout { return dsym == DSYM.enumMember ? cast(inout(EnumMember)) cast(void*) this : null; }
+    inout(TemplateDeclaration)         isTemplateDeclaration()         inout { return dsym == DSYM.templateDeclaration ? cast(inout(TemplateDeclaration)) cast(void*) this : null; }
+    inout(TemplateInstance)            isTemplateInstance()            inout { return (dsym == DSYM.templateInstance || dsym == DSYM.templateMixin) ? cast(inout(TemplateInstance)) cast(void*) this : null; }
+    inout(TemplateMixin)               isTemplateMixin()               inout { return dsym == DSYM.templateMixin ? cast(inout(TemplateMixin)) cast(void*) this : null; }
+    inout(ForwardingAttribDeclaration) isForwardingAttribDeclaration() inout { return dsym == DSYM.forwardingAttribDeclaration ? cast(inout(ForwardingAttribDeclaration)) cast(void*) this : null; }
+    inout(Nspace)                      isNspace()                      inout { return dsym == DSYM.nspace ? cast(inout(Nspace)) cast(void*) this : null; }
+    inout(Declaration)                 isDeclaration()                 inout {
+        switch (dsym)
+        {
+        case DSYM.tupleDeclaration:
+        case DSYM.aliasDeclaration:
+        case DSYM.overDeclaration:
+        case DSYM.varDeclaration:
+            case DSYM.bitFieldDeclaration:
+            case DSYM.typeInfoDeclaration:
+            case DSYM.thisDeclaration:
+            case DSYM.enumMember:
+        case DSYM.symbolDeclaration:
+        case DSYM.funcDeclaration:
+            case DSYM.funcAliasDeclaration:
+            case DSYM.funcLiteralDeclaration:
+            case DSYM.ctorDeclaration:
+            case DSYM.postBlitDeclaration:
+            case DSYM.dtorDeclaration:
+            case DSYM.staticCtorDeclaration:
+                case DSYM.sharedStaticCtorDeclaration:
+            case DSYM.staticDtorDeclaration:
+                case DSYM.sharedStaticDtorDeclaration:
+            case DSYM.invariantDeclaration:
+            case DSYM.unitTestDeclaration:
+            case DSYM.newDeclaration:
+            return cast(inout(Declaration)) cast(void*) this;
+        default:
+            return null;
+        }
+    }
+    inout(StorageClassDeclaration)     isStorageClassDeclaration()     inout { return dsym == DSYM.storageClassDeclaration ? cast(inout(StorageClassDeclaration)) cast(void*) this : null; }
+    inout(ExpressionDsymbol)           isExpressionDsymbol()           inout { return dsym == DSYM.expressionDsymbol ? cast(inout(ExpressionDsymbol)) cast(void*) this : null; }
+    inout(AliasAssign)                 isAliasAssign()                 inout { return dsym == DSYM.aliasAssign ? cast(inout(AliasAssign)) cast(void*) this : null; }
+    inout(ThisDeclaration)             isThisDeclaration()             inout { return dsym == DSYM.thisDeclaration ? cast(inout(ThisDeclaration)) cast(void*) this : null; }
+    inout(BitFieldDeclaration)         isBitFieldDeclaration()         inout { return dsym == DSYM.bitFieldDeclaration ? cast(inout(BitFieldDeclaration)) cast(void*) this : null; }
+    inout(TypeInfoDeclaration)         isTypeInfoDeclaration()         inout { return dsym == DSYM.typeInfoDeclaration ? cast(inout(TypeInfoDeclaration)) cast(void*) this : null; }
+    inout(TupleDeclaration)            isTupleDeclaration()            inout { return dsym == DSYM.tupleDeclaration ? cast(inout(TupleDeclaration)) cast(void*) this : null; }
+    inout(AliasDeclaration)            isAliasDeclaration()            inout { return dsym == DSYM.aliasDeclaration ? cast(inout(AliasDeclaration)) cast(void*) this : null; }
+    inout(AggregateDeclaration)        isAggregateDeclaration()        inout {
+        switch (dsym)
+        {
+        case DSYM.aggregateDeclaration:
+        case DSYM.structDeclaration:
+        case DSYM.unionDeclaration:
+        case DSYM.classDeclaration:
+        case DSYM.interfaceDeclaration:
+            return cast(inout(AggregateDeclaration)) cast(void*) this;
+        default:
+            return null;
+        }
+    }
+    inout(FuncDeclaration)             isFuncDeclaration()             inout {
+        switch (dsym)
+        {
+        case DSYM.funcDeclaration:
+            case DSYM.funcAliasDeclaration:
+            case DSYM.funcLiteralDeclaration:
+            case DSYM.ctorDeclaration:
+            case DSYM.postBlitDeclaration:
+            case DSYM.dtorDeclaration:
+            case DSYM.staticCtorDeclaration:
+                case DSYM.sharedStaticCtorDeclaration:
+            case DSYM.staticDtorDeclaration:
+                case DSYM.sharedStaticDtorDeclaration:
+            case DSYM.invariantDeclaration:
+            case DSYM.unitTestDeclaration:
+            case DSYM.newDeclaration:
+            return cast(inout(FuncDeclaration)) cast(void*) this;
+        default:
+            return null;
+        }
+    }
+    inout(FuncAliasDeclaration)        isFuncAliasDeclaration()        inout { return dsym == DSYM.funcAliasDeclaration ? cast(inout(FuncAliasDeclaration)) cast(void*) this : null; }
+    inout(OverDeclaration)             isOverDeclaration()             inout { return dsym == DSYM.overDeclaration ? cast(inout(OverDeclaration)) cast(void*) this : null; }
+    inout(FuncLiteralDeclaration)      isFuncLiteralDeclaration()      inout { return dsym == DSYM.funcLiteralDeclaration ? cast(inout(FuncLiteralDeclaration)) cast(void*) this : null; }
+    inout(CtorDeclaration)             isCtorDeclaration()             inout { return dsym == DSYM.ctorDeclaration ? cast(inout(CtorDeclaration)) cast(void*) this : null; }
+    inout(PostBlitDeclaration)         isPostBlitDeclaration()         inout { return dsym == DSYM.postBlitDeclaration ? cast(inout(PostBlitDeclaration)) cast(void*) this : null; }
+    inout(DtorDeclaration)             isDtorDeclaration()             inout { return dsym == DSYM.dtorDeclaration ? cast(inout(DtorDeclaration)) cast(void*) this : null; }
+    inout(StaticCtorDeclaration)       isStaticCtorDeclaration()       inout { return (dsym == DSYM.staticCtorDeclaration || dsym == DSYM.sharedStaticCtorDeclaration) ? cast(inout(StaticCtorDeclaration)) cast(void*) this : null; }
+    inout(StaticDtorDeclaration)       isStaticDtorDeclaration()       inout { return (dsym == DSYM.staticDtorDeclaration || dsym == DSYM.sharedStaticDtorDeclaration) ? cast(inout(StaticDtorDeclaration)) cast(void*) this : null; }
+    inout(SharedStaticCtorDeclaration) isSharedStaticCtorDeclaration() inout { return dsym == DSYM.sharedStaticCtorDeclaration ? cast(inout(SharedStaticCtorDeclaration)) cast(void*) this : null; }
+    inout(SharedStaticDtorDeclaration) isSharedStaticDtorDeclaration() inout { return dsym == DSYM.sharedStaticDtorDeclaration ? cast(inout(SharedStaticDtorDeclaration)) cast(void*) this : null; }
+    inout(InvariantDeclaration)        isInvariantDeclaration()        inout { return dsym == DSYM.invariantDeclaration ? cast(inout(InvariantDeclaration)) cast(void*) this : null; }
+    inout(UnitTestDeclaration)         isUnitTestDeclaration()         inout { return dsym == DSYM.unitTestDeclaration ? cast(inout(UnitTestDeclaration)) cast(void*) this : null; }
+    inout(NewDeclaration)              isNewDeclaration()              inout { return dsym == DSYM.newDeclaration ? cast(inout(NewDeclaration)) cast(void*) this : null; }
+    inout(VarDeclaration)              isVarDeclaration()              inout {
+        switch (dsym)
+        {
+        case DSYM.varDeclaration:
+            case DSYM.bitFieldDeclaration:
+            case DSYM.typeInfoDeclaration:
+            case DSYM.thisDeclaration:
+            case DSYM.enumMember:
+            return cast(inout(VarDeclaration)) cast(void*) this;
+        default:
+            return null;
+        }
+    }
+    inout(VersionSymbol)               isVersionSymbol()               inout { return dsym == DSYM.versionSymbol ? cast(inout(VersionSymbol)) cast(void*) this : null; }
+    inout(DebugSymbol)                 isDebugSymbol()                 inout { return dsym == DSYM.debugSymbol ? cast(inout(DebugSymbol)) cast(void*) this : null; }
+    inout(ClassDeclaration)            isClassDeclaration()            inout { return (dsym == DSYM.classDeclaration || dsym == DSYM.interfaceDeclaration) ? cast(inout(ClassDeclaration)) cast(void*) this : null; }
+    inout(StructDeclaration)           isStructDeclaration()           inout { return (dsym == DSYM.structDeclaration || dsym == DSYM.unionDeclaration) ? cast(inout(StructDeclaration)) cast(void*) this : null; }
+    inout(UnionDeclaration)            isUnionDeclaration()            inout { return dsym == DSYM.unionDeclaration ? cast(inout(UnionDeclaration)) cast(void*) this : null; }
+    inout(InterfaceDeclaration)        isInterfaceDeclaration()        inout { return dsym == DSYM.interfaceDeclaration ? cast(inout(InterfaceDeclaration)) cast(void*) this : null; }
+    inout(ScopeDsymbol)                isScopeDsymbol()                inout {
+        switch (dsym)
+        {
+        case DSYM.enumDeclaration:
+        case DSYM.scopeDsymbol:
+        case DSYM.package_:
+            case DSYM.module_:
+        case DSYM.nspace:
+        case DSYM.templateInstance:
+            case DSYM.templateMixin:
+        case DSYM.templateDeclaration:
+        case DSYM.aggregateDeclaration:
+            case DSYM.structDeclaration:
+                case DSYM.unionDeclaration:
+            case DSYM.classDeclaration:
+                case DSYM.interfaceDeclaration:
+        case DSYM.withScopeSymbol:
+        case DSYM.arrayScopeSymbol:
+        case DSYM.forwardingScopeDsymbol:
+            return cast(inout(ScopeDsymbol)) cast(void*) this;
+        default:
+            return null;
+        }
+    }
+    inout(ForwardingScopeDsymbol)      isForwardingScopeDsymbol()      inout { return dsym == DSYM.forwardingScopeDsymbol ? cast(inout(ForwardingScopeDsymbol)) cast(void*) this : null; }
+    inout(WithScopeSymbol)             isWithScopeSymbol()             inout { return dsym == DSYM.withScopeSymbol ? cast(inout(WithScopeSymbol)) cast(void*) this : null; }
+    inout(ArrayScopeSymbol)            isArrayScopeSymbol()            inout { return dsym == DSYM.arrayScopeSymbol ? cast(inout(ArrayScopeSymbol)) cast(void*) this : null; }
+    inout(Import)                      isImport()                      inout { return dsym == DSYM.import_ ? cast(inout(Import)) cast(void*) this : null; }
+    inout(EnumDeclaration)             isEnumDeclaration()             inout { return dsym == DSYM.enumDeclaration ? cast(inout(EnumDeclaration)) cast(void*) this : null; }
+    inout(SymbolDeclaration)           isSymbolDeclaration()           inout { return dsym == DSYM.symbolDeclaration ? cast(inout(SymbolDeclaration)) cast(void*) this : null; }
+    inout(AttribDeclaration)           isAttribDeclaration()           inout {
+        switch (dsym)
+        {
+        case DSYM.attribDeclaration:
+        case DSYM.storageClassDeclaration:
+        case DSYM.linkDeclaration:
+        case DSYM.cppMangleDeclaration:
+        case DSYM.cppNamespaceDeclaration:
+        case DSYM.visibilityDeclaration:
+        case DSYM.alignDeclaration:
+        case DSYM.anonDeclaration:
+        case DSYM.pragmaDeclaration:
+        case DSYM.conditionalDeclaration:
+            case DSYM.staticIfDeclaration:
+        case DSYM.staticForeachDeclaration:
+        case DSYM.forwardingAttribDeclaration:
+        case DSYM.mixinDeclaration:
+        case DSYM.userAttributeDeclaration:
+            return cast(inout(AttribDeclaration)) cast(void*) this;
+        default:
+            return null;
+        }
+    }
+    inout(AnonDeclaration)             isAnonDeclaration()             inout { return dsym == DSYM.anonDeclaration ? cast(inout(AnonDeclaration)) cast(void*) this : null; }
+    inout(CPPNamespaceDeclaration)     isCPPNamespaceDeclaration()     inout { return dsym == DSYM.cppNamespaceDeclaration ? cast(inout(CPPNamespaceDeclaration)) cast(void*) this : null; }
+    inout(VisibilityDeclaration)       isVisibilityDeclaration()       inout { return dsym == DSYM.visibilityDeclaration ? cast(inout(VisibilityDeclaration)) cast(void*) this : null; }
+    inout(OverloadSet)                 isOverloadSet()                 inout { return dsym == DSYM.overloadSet ? cast(inout(OverloadSet)) cast(void*) this : null; }
+    inout(MixinDeclaration)            isMixinDeclaration()            inout { return dsym == DSYM.mixinDeclaration ? cast(inout(MixinDeclaration)) cast(void*) this : null; }
+    inout(StaticAssert)                isStaticAssert()                inout { return dsym == DSYM.staticAssert ? cast(inout(StaticAssert)) cast(void*) this : null; }
+    inout(StaticIfDeclaration)         isStaticIfDeclaration()         inout { return dsym == DSYM.staticIfDeclaration ? cast(inout(StaticIfDeclaration)) cast(void*) this : null; }
+    inout(CAsmDeclaration)             isCAsmDeclaration()             inout { return dsym == DSYM.cAsmDeclaration ? cast(inout(CAsmDeclaration)) cast(void*) this : null; }
 }
 
 /***********************************************************
@@ -1075,16 +1271,17 @@ private:
 public:
     final extern (D) this() nothrow @safe
     {
+        super(DSYM.scopeDsymbol);
     }
 
     final extern (D) this(Identifier ident) nothrow @safe
     {
-        super(ident);
+        super(DSYM.scopeDsymbol, ident);
     }
 
     final extern (D) this(Loc loc, Identifier ident) nothrow @safe
     {
-        super(loc, ident);
+        super(DSYM.scopeDsymbol, loc, ident);
     }
 
     override ScopeDsymbol syntaxCopy(Dsymbol s)
@@ -1312,11 +1509,6 @@ public:
         return false;
     }
 
-    override final inout(ScopeDsymbol) isScopeDsymbol() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1333,11 +1525,7 @@ extern (C++) final class WithScopeSymbol : ScopeDsymbol
     extern (D) this(WithStatement withstate) nothrow @safe
     {
         this.withstate = withstate;
-    }
-
-    override inout(WithScopeSymbol) isWithScopeSymbol() inout
-    {
-        return this;
+        this.dsym = DSYM.withScopeSymbol;
     }
 
     override void accept(Visitor v)
@@ -1361,6 +1549,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
         assert(exp.op == EXP.index || exp.op == EXP.slice || exp.op == EXP.array);
         this._scope = sc;
         this.arrayContent = exp;
+        this.dsym = DSYM.arrayScopeSymbol;
     }
 
     extern (D) this(Scope* sc, TypeTuple type) nothrow @safe
@@ -1373,11 +1562,6 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
     {
         this._scope = sc;
         this.arrayContent = td;
-    }
-
-    override inout(ArrayScopeSymbol) isArrayScopeSymbol() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -1395,7 +1579,7 @@ extern (C++) final class OverloadSet : Dsymbol
 
     extern (D) this(Identifier ident, OverloadSet os = null) nothrow
     {
-        super(ident);
+        super(DSYM.overloadSet, ident);
         if (os)
         {
             a.pushSlice(os.a[]);
@@ -1405,11 +1589,6 @@ extern (C++) final class OverloadSet : Dsymbol
     void push(Dsymbol s) nothrow
     {
         a.push(s);
-    }
-
-    override inout(OverloadSet) isOverloadSet() inout
-    {
-        return this;
     }
 
     override const(char)* kind() const
@@ -1434,6 +1613,7 @@ extern (C++) final class ForwardingScopeDsymbol : ScopeDsymbol
     extern (D) this() nothrow @safe
     {
         super();
+        this.dsym = DSYM.forwardingScopeDsymbol;
     }
 
     override Dsymbol symtabInsert(Dsymbol s) nothrow
@@ -1502,11 +1682,6 @@ extern (C++) final class ForwardingScopeDsymbol : ScopeDsymbol
 
     override const(char)* kind()const{ return "local scope"; }
 
-    override inout(ForwardingScopeDsymbol) isForwardingScopeDsymbol() inout nothrow
-    {
-        return this;
-    }
-
 }
 
 /**
@@ -1519,13 +1694,8 @@ extern (C++) final class ExpressionDsymbol : Dsymbol
     Expression exp;
     this(Expression exp) nothrow @safe
     {
-        super();
+        super(DSYM.expressionDsymbol);
         this.exp = exp;
-    }
-
-    override inout(ExpressionDsymbol) isExpressionDsymbol() inout nothrow
-    {
-        return this;
     }
 }
 
@@ -1544,7 +1714,7 @@ extern (C++) final class AliasAssign : Dsymbol
 
     extern (D) this(Loc loc, Identifier ident, Type type, Dsymbol aliassym) nothrow @safe
     {
-        super(loc, null);
+        super(DSYM.aliasAssign, loc, null);
         this.ident = ident;
         this.type = type;
         this.aliassym = aliassym;
@@ -1557,11 +1727,6 @@ extern (C++) final class AliasAssign : Dsymbol
                 type     ? type.syntaxCopy()         : null,
                 aliassym ? aliassym.syntaxCopy(null) : null);
         return aa;
-    }
-
-    override inout(AliasAssign) isAliasAssign() inout
-    {
-        return this;
     }
 
     override const(char)* kind() const
@@ -1656,13 +1821,8 @@ extern (C++) final class CAsmDeclaration : Dsymbol
     Expression code;
     extern (D) this(Expression e) nothrow @safe
     {
-        super();
+        super(DSYM.cAsmDeclaration);
         this.code = e;
-    }
-
-    override inout(CAsmDeclaration) isCAsmDeclaration() inout nothrow
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -183,9 +183,15 @@ private:
     DsymbolAttributes* atts;
 public:
     Loc loc;                    // where defined
-    d_bool errors;                // this symbol failed to pass semantic()
-    PASS semanticRun;
     unsigned short localNum;        // perturb mangled name to avoid collisions with those in FuncDeclaration.localsymtab
+
+    bool errors() const;
+    PASS semanticRun() const;
+    PASS semanticRun(PASS v);
+private:
+    unsigned char bitfields;
+    unsigned char dsym;
+public:
     static Dsymbol *create(Identifier *);
     const char *toChars() const final override;
     DeprecatedDeclaration* depdecl();
@@ -250,61 +256,61 @@ public:
     bool inNonRoot();
 
     // Eliminate need for dynamic_cast
-    virtual Package *isPackage() { return nullptr; }
-    virtual Module *isModule() { return nullptr; }
-    virtual EnumMember *isEnumMember() { return nullptr; }
-    virtual TemplateDeclaration *isTemplateDeclaration() { return nullptr; }
-    virtual TemplateInstance *isTemplateInstance() { return nullptr; }
-    virtual TemplateMixin *isTemplateMixin() { return nullptr; }
-    virtual ForwardingAttribDeclaration *isForwardingAttribDeclaration() { return nullptr; }
-    virtual Nspace *isNspace() { return nullptr; }
-    virtual Declaration *isDeclaration() { return nullptr; }
-    virtual StorageClassDeclaration *isStorageClassDeclaration(){ return nullptr; }
-    virtual ExpressionDsymbol *isExpressionDsymbol() { return nullptr; }
-    virtual AliasAssign *isAliasAssign() { return nullptr; }
-    virtual ThisDeclaration *isThisDeclaration() { return nullptr; }
-    virtual BitFieldDeclaration *isBitFieldDeclaration() { return nullptr; }
-    virtual TypeInfoDeclaration *isTypeInfoDeclaration() { return nullptr; }
-    virtual TupleDeclaration *isTupleDeclaration() { return nullptr; }
-    virtual AliasDeclaration *isAliasDeclaration() { return nullptr; }
-    virtual AggregateDeclaration *isAggregateDeclaration() { return nullptr; }
-    virtual FuncDeclaration *isFuncDeclaration() { return nullptr; }
-    virtual FuncAliasDeclaration *isFuncAliasDeclaration() { return nullptr; }
-    virtual OverDeclaration *isOverDeclaration() { return nullptr; }
-    virtual FuncLiteralDeclaration *isFuncLiteralDeclaration() { return nullptr; }
-    virtual CtorDeclaration *isCtorDeclaration() { return nullptr; }
-    virtual PostBlitDeclaration *isPostBlitDeclaration() { return nullptr; }
-    virtual DtorDeclaration *isDtorDeclaration() { return nullptr; }
-    virtual StaticCtorDeclaration *isStaticCtorDeclaration() { return nullptr; }
-    virtual StaticDtorDeclaration *isStaticDtorDeclaration() { return nullptr; }
-    virtual SharedStaticCtorDeclaration *isSharedStaticCtorDeclaration() { return nullptr; }
-    virtual SharedStaticDtorDeclaration *isSharedStaticDtorDeclaration() { return nullptr; }
-    virtual InvariantDeclaration *isInvariantDeclaration() { return nullptr; }
-    virtual UnitTestDeclaration *isUnitTestDeclaration() { return nullptr; }
-    virtual NewDeclaration *isNewDeclaration() { return nullptr; }
-    virtual VarDeclaration *isVarDeclaration() { return nullptr; }
-    virtual VersionSymbol *isVersionSymbol() { return nullptr; }
-    virtual DebugSymbol *isDebugSymbol() { return nullptr; }
-    virtual ClassDeclaration *isClassDeclaration() { return nullptr; }
-    virtual StructDeclaration *isStructDeclaration() { return nullptr; }
-    virtual UnionDeclaration *isUnionDeclaration() { return nullptr; }
-    virtual InterfaceDeclaration *isInterfaceDeclaration() { return nullptr; }
-    virtual ScopeDsymbol *isScopeDsymbol() { return nullptr; }
-    virtual ForwardingScopeDsymbol *isForwardingScopeDsymbol() { return nullptr; }
-    virtual WithScopeSymbol *isWithScopeSymbol() { return nullptr; }
-    virtual ArrayScopeSymbol *isArrayScopeSymbol() { return nullptr; }
-    virtual Import *isImport() { return nullptr; }
-    virtual EnumDeclaration *isEnumDeclaration() { return nullptr; }
-    virtual SymbolDeclaration *isSymbolDeclaration() { return nullptr; }
-    virtual AttribDeclaration *isAttribDeclaration() { return nullptr; }
-    virtual AnonDeclaration *isAnonDeclaration() { return nullptr; }
-    virtual CPPNamespaceDeclaration *isCPPNamespaceDeclaration() { return nullptr; }
-    virtual VisibilityDeclaration *isVisibilityDeclaration() { return nullptr; }
-    virtual OverloadSet *isOverloadSet() { return nullptr; }
-    virtual MixinDeclaration *isMixinDeclaration() { return nullptr; }
-    virtual StaticAssert *isStaticAssert() { return nullptr; }
-    virtual StaticIfDeclaration *isStaticIfDeclaration() { return nullptr; }
-    virtual CAsmDeclaration *isCAsmDeclaration() { return nullptr; }
+    Package *isPackage();
+    Module *isModule();
+    EnumMember *isEnumMember();
+    TemplateDeclaration *isTemplateDeclaration();
+    TemplateInstance *isTemplateInstance();
+    TemplateMixin *isTemplateMixin();
+    ForwardingAttribDeclaration *isForwardingAttribDeclaration();
+    Nspace *isNspace();
+    Declaration *isDeclaration();
+    StorageClassDeclaration *isStorageClassDeclaration();
+    ExpressionDsymbol *isExpressionDsymbol();
+    AliasAssign *isAliasAssign();
+    ThisDeclaration *isThisDeclaration();
+    BitFieldDeclaration *isBitFieldDeclaration();
+    TypeInfoDeclaration *isTypeInfoDeclaration();
+    TupleDeclaration *isTupleDeclaration();
+    AliasDeclaration *isAliasDeclaration();
+    AggregateDeclaration *isAggregateDeclaration();
+    FuncDeclaration *isFuncDeclaration();
+    FuncAliasDeclaration *isFuncAliasDeclaration();
+    OverDeclaration *isOverDeclaration();
+    FuncLiteralDeclaration *isFuncLiteralDeclaration();
+    CtorDeclaration *isCtorDeclaration();
+    PostBlitDeclaration *isPostBlitDeclaration();
+    DtorDeclaration *isDtorDeclaration();
+    StaticCtorDeclaration *isStaticCtorDeclaration();
+    StaticDtorDeclaration *isStaticDtorDeclaration();
+    SharedStaticCtorDeclaration *isSharedStaticCtorDeclaration();
+    SharedStaticDtorDeclaration *isSharedStaticDtorDeclaration();
+    InvariantDeclaration *isInvariantDeclaration();
+    UnitTestDeclaration *isUnitTestDeclaration();
+    NewDeclaration *isNewDeclaration();
+    VarDeclaration *isVarDeclaration();
+    VersionSymbol *isVersionSymbol();
+    DebugSymbol *isDebugSymbol();
+    ClassDeclaration *isClassDeclaration();
+    StructDeclaration *isStructDeclaration();
+    UnionDeclaration *isUnionDeclaration();
+    InterfaceDeclaration *isInterfaceDeclaration();
+    ScopeDsymbol *isScopeDsymbol();
+    ForwardingScopeDsymbol *isForwardingScopeDsymbol();
+    WithScopeSymbol *isWithScopeSymbol();
+    ArrayScopeSymbol *isArrayScopeSymbol();
+    Import *isImport();
+    EnumDeclaration *isEnumDeclaration();
+    SymbolDeclaration *isSymbolDeclaration();
+    AttribDeclaration *isAttribDeclaration();
+    AnonDeclaration *isAnonDeclaration();
+    CPPNamespaceDeclaration *isCPPNamespaceDeclaration();
+    VisibilityDeclaration *isVisibilityDeclaration();
+    OverloadSet *isOverloadSet();
+    MixinDeclaration *isMixinDeclaration();
+    StaticAssert *isStaticAssert();
+    StaticIfDeclaration *isStaticIfDeclaration();
+    CAsmDeclaration *isCAsmDeclaration();
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -333,7 +339,6 @@ public:
     virtual Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
     bool hasStaticCtorOrDtor() override;
 
-    ScopeDsymbol *isScopeDsymbol() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -345,7 +350,6 @@ public:
     WithStatement *withstate;
 
 
-    WithScopeSymbol *isWithScopeSymbol() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -356,7 +360,6 @@ class ArrayScopeSymbol final : public ScopeDsymbol
 public:
     RootObject *arrayContent;
 
-    ArrayScopeSymbol *isArrayScopeSymbol() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -368,7 +371,6 @@ public:
     Dsymbols a;         // array of Dsymbols
 
     void push(Dsymbol *s);
-    OverloadSet *isOverloadSet() override { return this; }
     const char *kind() const override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -383,7 +385,6 @@ public:
     void importScope(Dsymbol *s, Visibility visibility) override;
     const char *kind() const override;
 
-    ForwardingScopeDsymbol *isForwardingScopeDsymbol() override { return this; }
 };
 
 class ExpressionDsymbol final : public Dsymbol
@@ -391,7 +392,6 @@ class ExpressionDsymbol final : public Dsymbol
 public:
     Expression *exp;
 
-    ExpressionDsymbol *isExpressionDsymbol() override { return this; }
 };
 
 class CAsmDeclaration final : public Dsymbol
@@ -399,7 +399,6 @@ class CAsmDeclaration final : public Dsymbol
 public:
     Expression *code;   // string expression
 
-    CAsmDeclaration *isCAsmDeclaration() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1775,7 +1775,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             s.dsymbolSemantic(sc2);
             errors |= s.errors;
         }
-        ad.errors |= errors;
+        if (errors)
+            ad.errors = true;
         if (sc2 != sc)
             sc2.pop();
 
@@ -2962,7 +2963,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
          */
         sd.members.foreachDsymbol( s => s.setScope(sc2) );
         sd.members.foreachDsymbol( s => s.importAll(sc2) );
-        sd.members.foreachDsymbol( (s) { s.dsymbolSemantic(sc2); sd.errors |= s.errors; } );
+        sd.members.foreachDsymbol( (s) { s.dsymbolSemantic(sc2); if (sd.errors) s.errors = true; } );
 
         if (sd.errors)
             sd.type = Type.terror;

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -605,6 +605,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
     extern (D) this(Loc loc, Identifier ident, TemplateParameters* parameters, Expression constraint, Dsymbols* decldefs, bool ismixin = false, bool literal = false)
     {
         super(loc, ident);
+        this.dsym = DSYM.templateDeclaration;
         static if (LOG)
         {
             printf("TemplateDeclaration(this = %p, id = '%s')\n", this, ident.toChars());
@@ -888,11 +889,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         auto tibox = TemplateInstanceBox(ti);
         debug (FindExistingInstance) ++nRemoved;
         instances.remove(tibox);
-    }
-
-    override inout(TemplateDeclaration) isTemplateDeclaration() inout
-    {
-        return this;
     }
 
     /**
@@ -3738,6 +3734,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         {
             printf("TemplateInstance(this = %p, ident = '%s')\n", this, ident ? ident.toChars() : "null");
         }
+        this.dsym = DSYM.templateInstance;
         this.name = ident;
         this.tiargs = tiargs;
     }
@@ -3753,6 +3750,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         {
             printf("TemplateInstance(this = %p, tempdecl = '%s')\n", this, td.toChars());
         }
+        this.dsym = DSYM.templateInstance;
         this.name = td.ident;
         this.tiargs = tiargs;
         this.tempdecl = td;
@@ -5336,11 +5334,6 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         --nest;
     }
 
-    override final inout(TemplateInstance) isTemplateInstance() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -5484,6 +5477,7 @@ extern (C++) final class TemplateMixin : TemplateInstance
               tqual.idents.length ? cast(Identifier)tqual.idents[tqual.idents.length - 1] : (cast(TypeIdentifier)tqual).ident,
               tiargs ? tiargs : new Objects());
         //printf("TemplateMixin(ident = '%s')\n", ident ? ident.toChars() : "");
+        this.dsym = DSYM.templateMixin;
         this.ident = ident;
         this.tqual = tqual;
     }
@@ -5577,11 +5571,6 @@ extern (C++) final class TemplateMixin : TemplateInstance
                 return false;
         }
         return true;
-    }
-
-    override inout(TemplateMixin) isTemplateMixin() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/dversion.d
+++ b/compiler/src/dmd/dversion.d
@@ -34,12 +34,12 @@ extern (C++) final class DebugSymbol : Dsymbol
 {
     extern (D) this(Loc loc, Identifier ident) @safe
     {
-        super(loc, ident);
+        super(DSYM.debugSymbol, loc, ident);
     }
 
     extern (D) this(Loc loc) @safe
     {
-        super(loc, null);
+        super(DSYM.aliasDeclaration, loc, null);
     }
 
     override DebugSymbol syntaxCopy(Dsymbol s)
@@ -53,11 +53,6 @@ extern (C++) final class DebugSymbol : Dsymbol
     override const(char)* kind() const nothrow
     {
         return "debug";
-    }
-
-    override inout(DebugSymbol) isDebugSymbol() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -75,12 +70,12 @@ extern (C++) final class VersionSymbol : Dsymbol
 
     extern (D) this(Loc loc, Identifier ident) @safe
     {
-        super(loc, ident);
+        super(DSYM.versionSymbol, loc, ident);
     }
 
     extern (D) this(Loc loc) @safe
     {
-        super(loc, null);
+        super(DSYM.versionSymbol, loc, null);
     }
 
     override VersionSymbol syntaxCopy(Dsymbol s)
@@ -94,11 +89,6 @@ extern (C++) final class VersionSymbol : Dsymbol
     override const(char)* kind() const nothrow
     {
         return "version";
-    }
-
-    override inout(VersionSymbol) isVersionSymbol() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/enum.h
+++ b/compiler/src/dmd/enum.h
@@ -58,7 +58,6 @@ public:
     Visibility visible() override;
     bool isSpecial() const;
 
-    EnumDeclaration *isEnumDeclaration() override { return this; }
 
     Symbol *sinit;
     void accept(Visitor *v) override { v->visit(this); }
@@ -86,6 +85,5 @@ public:
     EnumMember *syntaxCopy(Dsymbol *s) override;
     const char *kind() const override;
 
-    EnumMember *isEnumMember() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -414,6 +414,76 @@ enum class PASS : uint8_t
     obj = 9u,
 };
 
+enum class DSYM : uint8_t
+{
+    none = 0u,
+    dsymbol = 1u,
+    linkDeclaration = 2u,
+    cppMangleDeclaration = 3u,
+    alignDeclaration = 4u,
+    pragmaDeclaration = 5u,
+    conditionalDeclaration = 6u,
+    staticForeachDeclaration = 7u,
+    userAttributeDeclaration = 8u,
+    labelDsymbol = 9u,
+    aliasThis = 10u,
+    package_ = 11u,
+    module_ = 12u,
+    enumMember = 13u,
+    templateDeclaration = 14u,
+    templateInstance = 15u,
+    templateMixin = 16u,
+    forwardingAttribDeclaration = 17u,
+    nspace = 18u,
+    declaration = 19u,
+    storageClassDeclaration = 20u,
+    expressionDsymbol = 21u,
+    aliasAssign = 22u,
+    thisDeclaration = 23u,
+    bitFieldDeclaration = 24u,
+    typeInfoDeclaration = 25u,
+    tupleDeclaration = 26u,
+    aliasDeclaration = 27u,
+    aggregateDeclaration = 28u,
+    funcDeclaration = 29u,
+    funcAliasDeclaration = 30u,
+    overDeclaration = 31u,
+    funcLiteralDeclaration = 32u,
+    ctorDeclaration = 33u,
+    postBlitDeclaration = 34u,
+    dtorDeclaration = 35u,
+    staticCtorDeclaration = 36u,
+    staticDtorDeclaration = 37u,
+    sharedStaticCtorDeclaration = 38u,
+    sharedStaticDtorDeclaration = 39u,
+    invariantDeclaration = 40u,
+    unitTestDeclaration = 41u,
+    newDeclaration = 42u,
+    varDeclaration = 43u,
+    versionSymbol = 44u,
+    debugSymbol = 45u,
+    classDeclaration = 46u,
+    structDeclaration = 47u,
+    unionDeclaration = 48u,
+    interfaceDeclaration = 49u,
+    scopeDsymbol = 50u,
+    forwardingScopeDsymbol = 51u,
+    withScopeSymbol = 52u,
+    arrayScopeSymbol = 53u,
+    import_ = 54u,
+    enumDeclaration = 55u,
+    symbolDeclaration = 56u,
+    attribDeclaration = 57u,
+    anonDeclaration = 58u,
+    cppNamespaceDeclaration = 59u,
+    visibilityDeclaration = 60u,
+    overloadSet = 61u,
+    mixinDeclaration = 62u,
+    staticAssert = 63u,
+    staticIfDeclaration = 64u,
+    cAsmDeclaration = 65u,
+};
+
 struct Ungag final
 {
     uint32_t oldgag;
@@ -459,9 +529,30 @@ private:
     DsymbolAttributes* atts;
 public:
     const Loc loc;
-    bool errors;
-    PASS semanticRun;
     uint16_t localNum;
+    struct BitFields final
+    {
+        bool errors;
+        PASS semanticRun;
+        BitFields() :
+            errors(),
+            semanticRun((PASS)0u)
+        {
+        }
+        BitFields(bool errors, PASS semanticRun = (PASS)0u) :
+            errors(errors),
+            semanticRun(semanticRun)
+            {}
+    };
+
+    bool errors() const;
+    bool errors(bool v);
+    PASS semanticRun() const;
+    PASS semanticRun(PASS v);
+private:
+    uint8_t bitFields;
+public:
+    DSYM dsym;
     static Dsymbol* create(Identifier* ident);
     const char* toChars() const final override;
     DeprecatedDeclaration* depdecl();
@@ -521,61 +612,61 @@ public:
     bool inNonRoot();
     static void deinitialize();
     void accept(Visitor* v) override;
-    virtual Package* isPackage();
-    virtual Module* isModule();
-    virtual EnumMember* isEnumMember();
-    virtual TemplateDeclaration* isTemplateDeclaration();
-    virtual TemplateInstance* isTemplateInstance();
-    virtual TemplateMixin* isTemplateMixin();
-    virtual ForwardingAttribDeclaration* isForwardingAttribDeclaration();
-    virtual Nspace* isNspace();
-    virtual Declaration* isDeclaration();
-    virtual StorageClassDeclaration* isStorageClassDeclaration();
-    virtual ExpressionDsymbol* isExpressionDsymbol();
-    virtual AliasAssign* isAliasAssign();
-    virtual ThisDeclaration* isThisDeclaration();
-    virtual BitFieldDeclaration* isBitFieldDeclaration();
-    virtual TypeInfoDeclaration* isTypeInfoDeclaration();
-    virtual TupleDeclaration* isTupleDeclaration();
-    virtual AliasDeclaration* isAliasDeclaration();
-    virtual AggregateDeclaration* isAggregateDeclaration();
-    virtual FuncDeclaration* isFuncDeclaration();
-    virtual FuncAliasDeclaration* isFuncAliasDeclaration();
-    virtual OverDeclaration* isOverDeclaration();
-    virtual FuncLiteralDeclaration* isFuncLiteralDeclaration();
-    virtual CtorDeclaration* isCtorDeclaration();
-    virtual PostBlitDeclaration* isPostBlitDeclaration();
-    virtual DtorDeclaration* isDtorDeclaration();
-    virtual StaticCtorDeclaration* isStaticCtorDeclaration();
-    virtual StaticDtorDeclaration* isStaticDtorDeclaration();
-    virtual SharedStaticCtorDeclaration* isSharedStaticCtorDeclaration();
-    virtual SharedStaticDtorDeclaration* isSharedStaticDtorDeclaration();
-    virtual InvariantDeclaration* isInvariantDeclaration();
-    virtual UnitTestDeclaration* isUnitTestDeclaration();
-    virtual NewDeclaration* isNewDeclaration();
-    virtual VarDeclaration* isVarDeclaration();
-    virtual VersionSymbol* isVersionSymbol();
-    virtual DebugSymbol* isDebugSymbol();
-    virtual ClassDeclaration* isClassDeclaration();
-    virtual StructDeclaration* isStructDeclaration();
-    virtual UnionDeclaration* isUnionDeclaration();
-    virtual InterfaceDeclaration* isInterfaceDeclaration();
-    virtual ScopeDsymbol* isScopeDsymbol();
-    virtual ForwardingScopeDsymbol* isForwardingScopeDsymbol();
-    virtual WithScopeSymbol* isWithScopeSymbol();
-    virtual ArrayScopeSymbol* isArrayScopeSymbol();
-    virtual Import* isImport();
-    virtual EnumDeclaration* isEnumDeclaration();
-    virtual SymbolDeclaration* isSymbolDeclaration();
-    virtual AttribDeclaration* isAttribDeclaration();
-    virtual AnonDeclaration* isAnonDeclaration();
-    virtual CPPNamespaceDeclaration* isCPPNamespaceDeclaration();
-    virtual VisibilityDeclaration* isVisibilityDeclaration();
-    virtual OverloadSet* isOverloadSet();
-    virtual MixinDeclaration* isMixinDeclaration();
-    virtual StaticAssert* isStaticAssert();
-    virtual StaticIfDeclaration* isStaticIfDeclaration();
-    virtual CAsmDeclaration* isCAsmDeclaration();
+    Package* isPackage();
+    Module* isModule();
+    EnumMember* isEnumMember();
+    TemplateDeclaration* isTemplateDeclaration();
+    TemplateInstance* isTemplateInstance();
+    TemplateMixin* isTemplateMixin();
+    ForwardingAttribDeclaration* isForwardingAttribDeclaration();
+    Nspace* isNspace();
+    Declaration* isDeclaration();
+    StorageClassDeclaration* isStorageClassDeclaration();
+    ExpressionDsymbol* isExpressionDsymbol();
+    AliasAssign* isAliasAssign();
+    ThisDeclaration* isThisDeclaration();
+    BitFieldDeclaration* isBitFieldDeclaration();
+    TypeInfoDeclaration* isTypeInfoDeclaration();
+    TupleDeclaration* isTupleDeclaration();
+    AliasDeclaration* isAliasDeclaration();
+    AggregateDeclaration* isAggregateDeclaration();
+    FuncDeclaration* isFuncDeclaration();
+    FuncAliasDeclaration* isFuncAliasDeclaration();
+    OverDeclaration* isOverDeclaration();
+    FuncLiteralDeclaration* isFuncLiteralDeclaration();
+    CtorDeclaration* isCtorDeclaration();
+    PostBlitDeclaration* isPostBlitDeclaration();
+    DtorDeclaration* isDtorDeclaration();
+    StaticCtorDeclaration* isStaticCtorDeclaration();
+    StaticDtorDeclaration* isStaticDtorDeclaration();
+    SharedStaticCtorDeclaration* isSharedStaticCtorDeclaration();
+    SharedStaticDtorDeclaration* isSharedStaticDtorDeclaration();
+    InvariantDeclaration* isInvariantDeclaration();
+    UnitTestDeclaration* isUnitTestDeclaration();
+    NewDeclaration* isNewDeclaration();
+    VarDeclaration* isVarDeclaration();
+    VersionSymbol* isVersionSymbol();
+    DebugSymbol* isDebugSymbol();
+    ClassDeclaration* isClassDeclaration();
+    StructDeclaration* isStructDeclaration();
+    UnionDeclaration* isUnionDeclaration();
+    InterfaceDeclaration* isInterfaceDeclaration();
+    ScopeDsymbol* isScopeDsymbol();
+    ForwardingScopeDsymbol* isForwardingScopeDsymbol();
+    WithScopeSymbol* isWithScopeSymbol();
+    ArrayScopeSymbol* isArrayScopeSymbol();
+    Import* isImport();
+    EnumDeclaration* isEnumDeclaration();
+    SymbolDeclaration* isSymbolDeclaration();
+    AttribDeclaration* isAttribDeclaration();
+    AnonDeclaration* isAnonDeclaration();
+    CPPNamespaceDeclaration* isCPPNamespaceDeclaration();
+    VisibilityDeclaration* isVisibilityDeclaration();
+    OverloadSet* isOverloadSet();
+    MixinDeclaration* isMixinDeclaration();
+    StaticAssert* isStaticAssert();
+    StaticIfDeclaration* isStaticIfDeclaration();
+    CAsmDeclaration* isCAsmDeclaration();
 };
 
 struct BitArray final
@@ -622,7 +713,6 @@ public:
     virtual Dsymbol* symtabInsert(Dsymbol* s);
     virtual Dsymbol* symtabLookup(Dsymbol* s, Identifier* id);
     bool hasStaticCtorOrDtor() override;
-    ScopeDsymbol* isScopeDsymbol() final override;
     void accept(Visitor* v) override;
 };
 
@@ -1588,7 +1678,6 @@ public:
     const char* toCharsNoConstraints() const;
     Visibility visible() override;
     const char* getConstraintEvalError(const char*& tip);
-    TemplateDeclaration* isTemplateDeclaration() override;
     bool isDeprecated() const override;
     bool isOverloadable() const override;
     void accept(Visitor* v) override;
@@ -1636,7 +1725,6 @@ public:
     bool equalsx(TemplateInstance* ti);
     bool isDiscardable();
     bool needsCodegen();
-    TemplateInstance* isTemplateInstance() final override;
     void accept(Visitor* v) override;
 };
 
@@ -1656,7 +1744,6 @@ public:
     TemplateInstance* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
     bool hasPointers() override;
-    TemplateMixin* isTemplateMixin() override;
     void accept(Visitor* v) override;
 };
 
@@ -2020,7 +2107,6 @@ class DebugSymbol final : public Dsymbol
 public:
     DebugSymbol* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    DebugSymbol* isDebugSymbol() override;
     void accept(Visitor* v) override;
 };
 
@@ -2029,7 +2115,6 @@ class VersionSymbol final : public Dsymbol
 public:
     VersionSymbol* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    VersionSymbol* isVersionSymbol() override;
     void accept(Visitor* v) override;
 };
 
@@ -3906,7 +3991,6 @@ public:
     ParameterList getParameterList();
     static FuncDeclaration* genCfunc(Array<Parameter* >* fparams, Type* treturn, const char* name, StorageClass stc = 0);
     static FuncDeclaration* genCfunc(Array<Parameter* >* fparams, Type* treturn, Identifier* id, StorageClass stc = 0);
-    FuncDeclaration* isFuncDeclaration() final override;
     virtual FuncDeclaration* toAliasFunc();
     void accept(Visitor* v) override;
 };
@@ -3921,7 +4005,6 @@ public:
     bool isVirtual() const override;
     bool addPreInvariant() override;
     bool addPostInvariant() override;
-    CtorDeclaration* isCtorDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -3934,7 +4017,6 @@ public:
     bool addPreInvariant() override;
     bool addPostInvariant() override;
     bool overloadInsert(Dsymbol* s) override;
-    DtorDeclaration* isDtorDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -3943,7 +4025,6 @@ class FuncAliasDeclaration final : public FuncDeclaration
 public:
     FuncDeclaration* funcalias;
     bool hasOverloads;
-    FuncAliasDeclaration* isFuncAliasDeclaration() override;
     const char* kind() const override;
     FuncDeclaration* toAliasFunc() override;
     void accept(Visitor* v) override;
@@ -3961,7 +4042,6 @@ public:
     bool isVirtual() const override;
     bool addPreInvariant() override;
     bool addPostInvariant() override;
-    FuncLiteralDeclaration* isFuncLiteralDeclaration() override;
     const char* kind() const override;
     const char* toPrettyChars(bool QualifyTypes = false) override;
     void accept(Visitor* v) override;
@@ -3974,7 +4054,6 @@ public:
     bool isVirtual() const override;
     bool addPreInvariant() override;
     bool addPostInvariant() override;
-    InvariantDeclaration* isInvariantDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -3986,7 +4065,6 @@ public:
     bool isVirtual() const override;
     bool addPreInvariant() override;
     bool addPostInvariant() override;
-    NewDeclaration* isNewDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -3998,7 +4076,6 @@ public:
     bool addPreInvariant() override;
     bool addPostInvariant() override;
     bool overloadInsert(Dsymbol* s) override;
-    PostBlitDeclaration* isPostBlitDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -4011,7 +4088,6 @@ public:
     bool addPreInvariant() final override;
     bool addPostInvariant() final override;
     bool hasStaticCtorOrDtor() final override;
-    StaticCtorDeclaration* isStaticCtorDeclaration() final override;
     void accept(Visitor* v) override;
 };
 
@@ -4020,7 +4096,6 @@ class SharedStaticCtorDeclaration final : public StaticCtorDeclaration
 public:
     bool standalone;
     SharedStaticCtorDeclaration* syntaxCopy(Dsymbol* s) override;
-    SharedStaticCtorDeclaration* isSharedStaticCtorDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -4034,7 +4109,6 @@ public:
     bool hasStaticCtorOrDtor() final override;
     bool addPreInvariant() final override;
     bool addPostInvariant() final override;
-    StaticDtorDeclaration* isStaticDtorDeclaration() final override;
     void accept(Visitor* v) override;
 };
 
@@ -4042,7 +4116,6 @@ class SharedStaticDtorDeclaration final : public StaticDtorDeclaration
 {
 public:
     SharedStaticDtorDeclaration* syntaxCopy(Dsymbol* s) override;
-    SharedStaticDtorDeclaration* isSharedStaticDtorDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -4056,7 +4129,6 @@ public:
     bool isVirtual() const override;
     bool addPreInvariant() override;
     bool addPostInvariant() override;
-    UnitTestDeclaration* isUnitTestDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -4759,7 +4831,6 @@ public:
     Nspace* syntaxCopy(Dsymbol* s) override;
     bool hasPointers() override;
     const char* kind() const override;
-    Nspace* isNspace() override;
     void accept(Visitor* v) override;
 };
 
@@ -5376,7 +5447,6 @@ public:
     Array<Expression* >* msgs;
     StaticAssert* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    StaticAssert* isStaticAssert() override;
     void accept(Visitor* v) override;
 };
 
@@ -5592,6 +5662,7 @@ struct ASTCodegen final
     using AliasAssign = ::AliasAssign;
     using ArrayScopeSymbol = ::ArrayScopeSymbol;
     using CAsmDeclaration = ::CAsmDeclaration;
+    using DSYM = ::DSYM;
     using Dsymbol = ::Dsymbol;
     using DsymbolTable = ::DsymbolTable;
     using ExpressionDsymbol = ::ExpressionDsymbol;
@@ -6270,7 +6341,6 @@ public:
     Type* handleType();
     bool hasInvariant();
     void* sinit;
-    AggregateDeclaration* isAggregateDeclaration() final override;
     void accept(Visitor* v) override;
 };
 
@@ -6329,7 +6399,6 @@ public:
     bool hasPointers() final override;
     bool hasStaticCtorOrDtor() final override;
     void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories) final override;
-    AttribDeclaration* isAttribDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6338,7 +6407,6 @@ class StorageClassDeclaration : public AttribDeclaration
 public:
     StorageClass stc;
     StorageClassDeclaration* syntaxCopy(Dsymbol* s) override;
-    StorageClassDeclaration* isStorageClassDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6374,7 +6442,6 @@ public:
     Expression* exp;
     CPPNamespaceDeclaration* syntaxCopy(Dsymbol* s) override;
     void accept(Visitor* v) override;
-    CPPNamespaceDeclaration* isCPPNamespaceDeclaration() override;
 };
 
 class VisibilityDeclaration final : public AttribDeclaration
@@ -6385,7 +6452,6 @@ public:
     VisibilityDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
     const char* toPrettyChars(bool __param_0_) override;
-    VisibilityDeclaration* isVisibilityDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6408,7 +6474,6 @@ public:
     uint32_t anonalignsize;
     AnonDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    AnonDeclaration* isAnonDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6438,7 +6503,6 @@ public:
     bool onStack;
     StaticIfDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    StaticIfDeclaration* isStaticIfDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6460,7 +6524,6 @@ class ForwardingAttribDeclaration final : public AttribDeclaration
 public:
     ForwardingScopeDsymbol* sym;
     ForwardingAttribDeclaration(Array<Dsymbol* >* decl);
-    ForwardingAttribDeclaration* isForwardingAttribDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6472,7 +6535,6 @@ public:
     bool compiled;
     MixinDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    MixinDeclaration* isMixinDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6634,7 +6696,6 @@ public:
     void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories) final override;
     Dsymbol* vtblsym;
     Dsymbol* vtblSymbol();
-    ClassDeclaration* isClassDeclaration() final override;
     void accept(Visitor* v) override;
 };
 
@@ -6648,7 +6709,6 @@ public:
     int32_t vtblOffset() const override;
     bool isCPPinterface() const override;
     bool isCOMinterface() const override;
-    InterfaceDeclaration* isInterfaceDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6705,7 +6765,6 @@ public:
     bool isReference() const;
     bool isFuture() const;
     Visibility visible() final override;
-    Declaration* isDeclaration() final override;
     void accept(Visitor* v) override;
 };
 
@@ -6721,7 +6780,6 @@ public:
     Type* getType() override;
     Dsymbol* toAlias2() override;
     bool needThis() override;
-    TupleDeclaration* isTupleDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6739,7 +6797,6 @@ public:
     Dsymbol* toAlias() override;
     Dsymbol* toAlias2() override;
     bool isOverloadable() const override;
-    AliasDeclaration* isAliasDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6753,7 +6810,6 @@ public:
     bool overloadInsert(Dsymbol* s) override;
     bool isOverloadable() const override;
     Dsymbol* isUnique();
-    OverDeclaration* isOverDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6828,7 +6884,6 @@ public:
     bool canTakeAddressOf();
     bool needsScopeDtor();
     Dsymbol* toAlias() final override;
-    VarDeclaration* isVarDeclaration() final override;
     void accept(Visitor* v) override;
 };
 
@@ -6839,7 +6894,6 @@ public:
     uint32_t fieldWidth;
     uint32_t bitOffset;
     BitFieldDeclaration* syntaxCopy(Dsymbol* s) override;
-    BitFieldDeclaration* isBitFieldDeclaration() final override;
     void accept(Visitor* v) override;
     uint64_t getMinMax(Identifier* id);
 };
@@ -6848,7 +6902,6 @@ class SymbolDeclaration final : public Declaration
 {
 public:
     AggregateDeclaration* dsym;
-    SymbolDeclaration* isSymbolDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -6858,7 +6911,6 @@ public:
     Type* tinfo;
     static TypeInfoDeclaration* create(Type* tinfo);
     TypeInfoDeclaration* syntaxCopy(Dsymbol* s) final override;
-    TypeInfoDeclaration* isTypeInfoDeclaration() final override;
     void accept(Visitor* v) override;
 };
 
@@ -6979,7 +7031,6 @@ class ThisDeclaration final : public VarDeclaration
 {
 public:
     ThisDeclaration* syntaxCopy(Dsymbol* s) override;
-    ThisDeclaration* isThisDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -7008,7 +7059,6 @@ public:
     bool isDeprecated() const override;
     Visibility visible() override;
     bool isSpecial() const;
-    EnumDeclaration* isEnumDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -7021,7 +7071,6 @@ public:
     EnumDeclaration* ed;
     EnumMember* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    EnumMember* isEnumMember() override;
     void accept(Visitor* v) override;
 };
 
@@ -7043,7 +7092,6 @@ public:
     Import* syntaxCopy(Dsymbol* s) override;
     Dsymbol* toAlias() override;
     bool overloadInsert(Dsymbol* s) override;
-    Import* isImport() override;
     void accept(Visitor* v) override;
 };
 
@@ -7057,7 +7105,6 @@ public:
     Module* mod;
     const char* kind() const override;
     bool equals(const RootObject* const o) const override;
-    Package* isPackage() final override;
     bool isAncestorPackageOf(const Package* const pkg) const;
     void accept(Visitor* v) override;
     Module* isPackageMod();
@@ -7144,7 +7191,6 @@ public:
     Symbol* stest;
     Symbol* sfilename;
     void* ctfe_cov;
-    Module* isModule() override;
     void accept(Visitor* v) override;
     void fullyQualifiedName(OutBuffer& buf);
 };
@@ -7378,7 +7424,6 @@ public:
     void finalizeSize() final override;
     bool isPOD();
     bool hasCopyConstruction();
-    StructDeclaration* isStructDeclaration() final override;
     void accept(Visitor* v) override;
     uint32_t numArgTypes() const;
     Type* argType(uint32_t index);
@@ -7390,7 +7435,6 @@ class UnionDeclaration final : public StructDeclaration
 public:
     UnionDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    UnionDeclaration* isUnionDeclaration() override;
     void accept(Visitor* v) override;
 };
 
@@ -7398,7 +7442,6 @@ class WithScopeSymbol final : public ScopeDsymbol
 {
 public:
     WithStatement* withstate;
-    WithScopeSymbol* isWithScopeSymbol() override;
     void accept(Visitor* v) override;
 };
 
@@ -7406,7 +7449,6 @@ class ArrayScopeSymbol final : public ScopeDsymbol
 {
 public:
     RootObject* arrayContent;
-    ArrayScopeSymbol* isArrayScopeSymbol() override;
     void accept(Visitor* v) override;
 };
 
@@ -7415,7 +7457,6 @@ class OverloadSet final : public Dsymbol
 public:
     Array<Dsymbol* > a;
     void push(Dsymbol* s);
-    OverloadSet* isOverloadSet() override;
     const char* kind() const override;
     void accept(Visitor* v) override;
 };
@@ -7427,7 +7468,6 @@ public:
     Dsymbol* symtabLookup(Dsymbol* s, Identifier* id) override;
     void importScope(Dsymbol* s, Visibility visibility) override;
     const char* kind() const override;
-    ForwardingScopeDsymbol* isForwardingScopeDsymbol() override;
 };
 
 class ExpressionDsymbol final : public Dsymbol
@@ -7435,7 +7475,6 @@ class ExpressionDsymbol final : public Dsymbol
 public:
     Expression* exp;
     ExpressionDsymbol(Expression* exp);
-    ExpressionDsymbol* isExpressionDsymbol() override;
 };
 
 class AliasAssign final : public Dsymbol
@@ -7445,7 +7484,6 @@ public:
     Type* type;
     Dsymbol* aliassym;
     AliasAssign* syntaxCopy(Dsymbol* s) override;
-    AliasAssign* isAliasAssign() override;
     const char* kind() const override;
     void accept(Visitor* v) override;
 };
@@ -7466,7 +7504,6 @@ class CAsmDeclaration final : public Dsymbol
 {
 public:
     Expression* code;
-    CAsmDeclaration* isCAsmDeclaration() override;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -298,7 +298,7 @@ extern (C++) class FuncDeclaration : Declaration
 
     extern (D) this(Loc loc, Loc endloc, Identifier ident, StorageClass storage_class, Type type, bool noreturn = false)
     {
-        super(loc, ident);
+        super(DSYM.funcDeclaration, loc, ident);
         //.printf("FuncDeclaration(id = '%s', type = %s)\n", ident.toChars(), type.toChars());
         //.printf("storage_class = x%llx\n", storage_class);
         this.storage_class = storage_class;
@@ -1043,11 +1043,6 @@ extern (C++) class FuncDeclaration : Declaration
         return fd;
     }
 
-    override final inout(FuncDeclaration) isFuncDeclaration() inout
-    {
-        return this;
-    }
-
     inout(FuncDeclaration) toAliasFunc() inout @safe
     {
         return this;
@@ -1243,6 +1238,7 @@ extern (C++) final class FuncAliasDeclaration : FuncDeclaration
         super(funcalias.loc, funcalias.endloc, ident, funcalias.storage_class, funcalias.type);
         assert(funcalias != this);
         this.funcalias = funcalias;
+        this.dsym = DSYM.funcAliasDeclaration;
 
         this.hasOverloads = hasOverloads;
         if (hasOverloads)
@@ -1257,11 +1253,6 @@ extern (C++) final class FuncAliasDeclaration : FuncDeclaration
             this.hasOverloads = false;
         }
         userAttribDecl = funcalias.userAttribDecl;
-    }
-
-    override inout(FuncAliasDeclaration) isFuncAliasDeclaration() inout
-    {
-        return this;
     }
 
     override const(char)* kind() const
@@ -1293,6 +1284,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
     extern (D) this(Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, StorageClass storage_class = STC.undefined_)
     {
         super(loc, endloc, null, storage_class, type);
+        this.dsym = DSYM.funcLiteralDeclaration;
         this.ident = id ? id : Id.empty;
         this.tok = tok;
         this.fes = fes;
@@ -1338,11 +1330,6 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
         return false;
     }
 
-    override inout(FuncLiteralDeclaration) isFuncLiteralDeclaration() inout
-    {
-        return this;
-    }
-
     override const(char)* kind() const
     {
         // GCC requires the (char*) casts
@@ -1374,6 +1361,7 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
     extern (D) this(Loc loc, Loc endloc, StorageClass stc, Type type)
     {
         super(loc, endloc, Id.ctor, stc, type);
+        this.dsym = DSYM.ctorDeclaration;
         //printf("CtorDeclaration(loc = %s) %s %p\n", loc.toChars(), toChars(), this);
     }
 
@@ -1405,11 +1393,6 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
         return (isThis() && vthis && global.params.useInvariants == CHECKENABLE.on);
     }
 
-    override inout(CtorDeclaration) isCtorDeclaration() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1423,6 +1406,7 @@ extern (C++) final class PostBlitDeclaration : FuncDeclaration
     extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id)
     {
         super(loc, endloc, id, stc, null);
+        this.dsym = DSYM.postBlitDeclaration;
     }
 
     override PostBlitDeclaration syntaxCopy(Dsymbol s)
@@ -1453,11 +1437,6 @@ extern (C++) final class PostBlitDeclaration : FuncDeclaration
         return false; // cannot overload postblits
     }
 
-    override inout(PostBlitDeclaration) isPostBlitDeclaration() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1471,11 +1450,13 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
     extern (D) this(Loc loc, Loc endloc)
     {
         super(loc, endloc, Id.dtor, STC.undefined_, null);
+        this.dsym = DSYM.dtorDeclaration;
     }
 
     extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id)
     {
         super(loc, endloc, id, stc, null);
+        this.dsym = DSYM.dtorDeclaration;
     }
 
     override DtorDeclaration syntaxCopy(Dsymbol s)
@@ -1513,11 +1494,6 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
         return false; // cannot overload destructors
     }
 
-    override inout(DtorDeclaration) isDtorDeclaration() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1531,11 +1507,13 @@ extern (C++) class StaticCtorDeclaration : FuncDeclaration
     extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc("_staticCtor", loc), STC.static_ | stc, null);
+        this.dsym = DSYM.staticCtorDeclaration;
     }
 
     extern (D) this(Loc loc, Loc endloc, string name, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
+        this.dsym = DSYM.staticCtorDeclaration;
     }
 
     override StaticCtorDeclaration syntaxCopy(Dsymbol s)
@@ -1571,11 +1549,6 @@ extern (C++) class StaticCtorDeclaration : FuncDeclaration
         return true;
     }
 
-    override final inout(StaticCtorDeclaration) isStaticCtorDeclaration() inout @nogc nothrow pure @safe
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1592,6 +1565,7 @@ extern (C++) final class SharedStaticCtorDeclaration : StaticCtorDeclaration
     extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, "_sharedStaticCtor", stc);
+        this.dsym = DSYM.sharedStaticCtorDeclaration;
     }
 
     override SharedStaticCtorDeclaration syntaxCopy(Dsymbol s)
@@ -1600,11 +1574,6 @@ extern (C++) final class SharedStaticCtorDeclaration : StaticCtorDeclaration
         auto scd = new SharedStaticCtorDeclaration(loc, endloc, storage_class);
         FuncDeclaration.syntaxCopy(scd);
         return scd;
-    }
-
-    override inout(SharedStaticCtorDeclaration) isSharedStaticCtorDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -1622,11 +1591,13 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
     extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc("_staticDtor", loc), STC.static_ | stc, null);
+        this.dsym = DSYM.staticDtorDeclaration;
     }
 
     extern (D) this(Loc loc, Loc endloc, string name, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
+        this.dsym = DSYM.staticDtorDeclaration;
     }
 
     override StaticDtorDeclaration syntaxCopy(Dsymbol s)
@@ -1662,11 +1633,6 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
         return false;
     }
 
-    override final inout(StaticDtorDeclaration) isStaticDtorDeclaration() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1680,6 +1646,7 @@ extern (C++) final class SharedStaticDtorDeclaration : StaticDtorDeclaration
     extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, "_sharedStaticDtor", stc);
+        this.dsym = DSYM.sharedStaticDtorDeclaration;
     }
 
     override SharedStaticDtorDeclaration syntaxCopy(Dsymbol s)
@@ -1688,11 +1655,6 @@ extern (C++) final class SharedStaticDtorDeclaration : StaticDtorDeclaration
         auto sdd = new SharedStaticDtorDeclaration(loc, endloc, storage_class);
         FuncDeclaration.syntaxCopy(sdd);
         return sdd;
-    }
-
-    override inout(SharedStaticDtorDeclaration) isSharedStaticDtorDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -1710,6 +1672,7 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
         // Make a unique invariant for now; we'll fix it up as we add it to the aggregate invariant list.
         super(loc, endloc, id ? id : Identifier.generateId("__invariant"), stc, null);
         this.fbody = fbody;
+        this.dsym = DSYM.invariantDeclaration;
     }
 
     override InvariantDeclaration syntaxCopy(Dsymbol s)
@@ -1733,11 +1696,6 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
     override bool addPostInvariant()
     {
         return false;
-    }
-
-    override inout(InvariantDeclaration) isInvariantDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)
@@ -1769,6 +1727,7 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
     {
         super(loc, endloc, Identifier.generateIdWithLoc("__unittest", loc), stc, null);
         this.codedoc = codedoc;
+        this.dsym = DSYM.unitTestDeclaration;
     }
 
     override UnitTestDeclaration syntaxCopy(Dsymbol s)
@@ -1799,11 +1758,6 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
         return false;
     }
 
-    override inout(UnitTestDeclaration) isUnitTestDeclaration() inout
-    {
-        return this;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1817,6 +1771,7 @@ extern (C++) final class NewDeclaration : FuncDeclaration
     extern (D) this(Loc loc, StorageClass stc)
     {
         super(loc, Loc.initial, Id.classNew, STC.static_ | stc, null);
+        this.dsym = DSYM.newDeclaration;
     }
 
     override NewDeclaration syntaxCopy(Dsymbol s)
@@ -1845,11 +1800,6 @@ extern (C++) final class NewDeclaration : FuncDeclaration
     override bool addPostInvariant()
     {
         return false;
-    }
-
-    override inout(NewDeclaration) isNewDeclaration() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1275,6 +1275,7 @@ extern (D) void declareThis(FuncDeclaration fd, Scope* sc)
     const bool dualCtx = (fd.toParent2() != fd.toParentLocal());
     if (dualCtx)
         fd.hasDualContext = true;
+
     auto ad = fd.isThis();
     if (!dualCtx && !ad && !fd.isNested())
     {

--- a/compiler/src/dmd/import.h
+++ b/compiler/src/dmd/import.h
@@ -44,6 +44,5 @@ public:
     Dsymbol *toAlias() override;
     bool overloadInsert(Dsymbol *s) override;
 
-    Import *isImport() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -47,8 +47,6 @@ public:
 
     bool equals(const RootObject * const o) const override;
 
-    Package *isPackage() override final { return this; }
-
     bool isAncestorPackageOf(const Package * const pkg) const;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -158,7 +156,6 @@ public:
 
     void *ctfe_cov;             // stores coverage information from ctfe
 
-    Module *isModule() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/nspace.d
+++ b/compiler/src/dmd/nspace.d
@@ -66,6 +66,7 @@ extern (C++) final class Nspace : ScopeDsymbol
     {
         super(loc, ident);
         //printf("Nspace::Nspace(ident = %s)\n", ident.toChars());
+        this.dsym = DSYM.nspace;
         this.members = members;
         this.identExp = identExp;
     }
@@ -86,11 +87,6 @@ extern (C++) final class Nspace : ScopeDsymbol
     override const(char)* kind() const
     {
         return "namespace";
-    }
-
-    override inout(Nspace) isNspace() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/nspace.h
+++ b/compiler/src/dmd/nspace.h
@@ -23,6 +23,5 @@ class Nspace final : public ScopeDsymbol
     Nspace *syntaxCopy(Dsymbol *s) override;
     bool hasPointers() override;
     const char *kind() const override;
-    Nspace *isNspace() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1715,7 +1715,7 @@ extern (C++) final class LabelDsymbol : Dsymbol
 
     extern (D) this(Identifier ident, Loc loc = Loc.initial) @safe
     {
-        super(loc, ident);
+        super(DSYM.labelDsymbol, loc, ident);
     }
 
     static LabelDsymbol create(Identifier ident) @safe

--- a/compiler/src/dmd/staticassert.d
+++ b/compiler/src/dmd/staticassert.d
@@ -30,7 +30,7 @@ extern (C++) final class StaticAssert : Dsymbol
 
     extern (D) this(Loc loc, Expression exp, Expression msg)
     {
-        super(loc, Id.empty);
+        super(DSYM.staticAssert, loc, Id.empty);
         this.exp = exp;
         this.msgs = new Expressions(1);
         (*this.msgs)[0] = msg;
@@ -38,7 +38,7 @@ extern (C++) final class StaticAssert : Dsymbol
 
     extern (D) this(Loc loc, Expression exp, Expressions* msgs)
     {
-        super(loc, Id.empty);
+        super(DSYM.staticAssert, loc, Id.empty);
         this.exp = exp;
         this.msgs = msgs;
     }
@@ -52,11 +52,6 @@ extern (C++) final class StaticAssert : Dsymbol
     override const(char)* kind() const
     {
         return "static assert";
-    }
-
-    override inout(StaticAssert) isStaticAssert() inout
-    {
-        return this;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/staticassert.h
+++ b/compiler/src/dmd/staticassert.h
@@ -22,6 +22,5 @@ public:
 
     StaticAssert *syntaxCopy(Dsymbol *s) override;
     const char *kind() const override;
-    StaticAssert *isStaticAssert() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -82,7 +82,6 @@ public:
 
     Visibility visible() override;
 
-    TemplateDeclaration *isTemplateDeclaration() override { return this; }
 
     bool isDeprecated() const override;
     bool isOverloadable() const override;
@@ -276,7 +275,6 @@ public:
     bool isDiscardable();
     bool needsCodegen();
 
-    TemplateInstance *isTemplateInstance() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -289,7 +287,6 @@ public:
     const char *kind() const override;
     bool hasPointers() override;
 
-    TemplateMixin *isTemplateMixin() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -2491,7 +2491,7 @@ private extern(C++) class DummyArgVisitor : Visitor
             return;
         }
         if (!tap.sdummy)
-            tap.sdummy = new Dsymbol();
+            tap.sdummy = new Dsymbol(DSYM.dsymbol);
         result = tap.sdummy;
     }
 

--- a/compiler/src/dmd/version.h
+++ b/compiler/src/dmd/version.h
@@ -18,7 +18,6 @@ public:
     DebugSymbol *syntaxCopy(Dsymbol *) override;
 
     const char *kind() const override;
-    DebugSymbol *isDebugSymbol() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -28,6 +27,5 @@ public:
     VersionSymbol *syntaxCopy(Dsymbol *) override;
 
     const char *kind() const override;
-    VersionSymbol *isVersionSymbol() override;
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1166,7 +1166,7 @@ public:
     void visit(Dsymbol *) override { assert(0); }
     void visit(Module *d) override
     {
-        if (d->semanticRun >= PASS::obj)
+        if (d->semanticRun() >= PASS::obj)
             return;
         if (d->members)
         {
@@ -1192,11 +1192,11 @@ public:
             (void)d->stest;
             (void)d->needmoduleinfo;
         }
-        d->semanticRun = PASS::obj;
+        d->semanticRun(PASS::obj);
     }
     void visit(Import *d) override
     {
-        if (d->semanticRun >= PASS::obj)
+        if (d->semanticRun() >= PASS::obj)
             return;
         if (d->isstatic)
             return;
@@ -1210,7 +1210,7 @@ public:
         }
         else
             d->mod->accept(this);
-        d->semanticRun = PASS::obj;
+        d->semanticRun(PASS::obj);
     }
     void visit(TupleDeclaration *d) override
     {
@@ -1283,7 +1283,7 @@ public:
     }
     void visit(StructDeclaration *d) override
     {
-        if (d->semanticRun >= PASS::obj)
+        if (d->semanticRun() >= PASS::obj)
             return;
         if (d->type->ty == TY::Terror)
             return;
@@ -1304,11 +1304,11 @@ public:
             d->xcmp->accept(this);
         if (d->xhash)
             d->xhash->accept(this);
-        d->semanticRun = PASS::obj;
+        d->semanticRun(PASS::obj);
     }
     void visit(ClassDeclaration *d) override
     {
-        if (d->semanticRun >= PASS::obj)
+        if (d->semanticRun() >= PASS::obj)
             return;
         if (d->type->ty == TY::Terror)
             return;
@@ -1401,11 +1401,11 @@ public:
                 visitDeclaration(fd);
         }
         d->type->accept(this);
-        d->semanticRun = PASS::obj;
+        d->semanticRun(PASS::obj);
     }
     void visit(InterfaceDeclaration *d) override
     {
-        if (d->semanticRun >= PASS::obj)
+        if (d->semanticRun() >= PASS::obj)
             return;
         if (d->type->ty == TY::Terror)
             return;
@@ -1415,13 +1415,13 @@ public:
             (*d->members)[i]->accept(this);
         (void)d->csym;
         d->type->accept(this);
-        d->semanticRun = PASS::obj;
+        d->semanticRun(PASS::obj);
     }
     void visit(EnumDeclaration *d) override
     {
-        if (d->semanticRun >= PASS::obj)
+        if (d->semanticRun() >= PASS::obj)
             return;
-        if (d->errors || d->type->ty == TY::Terror)
+        if (d->errors() || d->type->ty == TY::Terror)
             return;
         if (d->isAnonymous())
             return;
@@ -1432,7 +1432,7 @@ public:
             tc->sym->defaultval->accept(this);
         }
         d->type->accept(this);
-        d->semanticRun = PASS::obj;
+        d->semanticRun(PASS::obj);
     }
     void visitDeclaration(Declaration *decl)
     {
@@ -1525,7 +1525,7 @@ public:
     }
     void visit(VarDeclaration *d) override
     {
-        if (d->semanticRun >= PASS::obj)
+        if (d->semanticRun() >= PASS::obj)
             return;
         if (d->type->ty == TY::Terror)
             return;
@@ -1579,18 +1579,18 @@ public:
             }
         }
         d->type->accept(this);
-        d->semanticRun = PASS::obj;
+        d->semanticRun(PASS::obj);
     }
     void visit(TypeInfoDeclaration *d) override
     {
-        if (d->semanticRun >= PASS::obj)
+        if (d->semanticRun() >= PASS::obj)
             return;
         visitDeclaration(d);
-        d->semanticRun = PASS::obj;
+        d->semanticRun(PASS::obj);
     }
     void visit(FuncDeclaration *d) override
     {
-        if (d->semanticRun >= PASS::obj)
+        if (d->semanticRun() >= PASS::obj)
             return;
         if (d->isUnitTestDeclaration())
             return;
@@ -1613,7 +1613,7 @@ public:
                     return;
             }
         }
-        if (d->semanticRun < PASS::semantic3)
+        if (d->semanticRun() < PASS::semantic3)
         {
             dmd::functionSemantic3(d);
             Module::runDeferredSemantic3();
@@ -1623,8 +1623,8 @@ public:
         visitDeclaration(d);
         if (!d->fbody)
             return;
-        assert(d->semanticRun == PASS::semantic3done);
-        d->semanticRun = PASS::obj;
+        assert(d->semanticRun() == PASS::semantic3done);
+        d->semanticRun(PASS::obj);
         if (d->vthis)
             visitDeclaration(d->vthis);
         if (d->v_arguments)


### PR DESCRIPTION
Profiling showed that `isModule()` and `isPackage()` etc. are hot functions, so this is an attempt to give `Dsymbol` the same treatment as `Type` and `Expression` and use a tag enum to use for `Dsymbol.isXXX` functions instead of overridden virtual functions.

This PR makes compiling Phobos unittests 7% faster.

```
Benchmark 1: dmdmaster -i=std -c -unittest -version=StdUnittest -preview=dip1000 std/package.d
  Time (mean ± σ):     33.528 s ±  0.220 s    [User: 27.367 s, System: 5.869 s]
  Range (min … max):   33.260 s … 33.933 s    10 runs
 
Benchmark 2: dmdbranch -i=std -c -unittest -version=StdUnittest -preview=dip1000 std/package.d
  Time (mean ± σ):     31.444 s ±  0.470 s    [User: 25.133 s, System: 5.965 s]
  Range (min … max):   30.823 s … 32.018 s    10 runs
 
Summary
  dmdbranch -i=std -c -unittest -version=StdUnittest -preview=dip1000 std/package.d ran
    1.07 ± 0.02 times faster than dmdmaster -i=std -c -unittest -version=StdUnittest -preview=dip1000 std/package.d
```