### PR TITLE
Make `StorageClass` typed `STC` instead of `ulong`

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -96,7 +96,7 @@ struct MangleOverride
 extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 {
     Type type;                  ///
-    StorageClass storage_class; ///
+    STC storage_class;          ///
     uint structsize;            /// size of struct
     uint alignsize;             /// size of struct for alignment purposes
     VarDeclarations fields;     /// VarDeclaration fields including flattened AnonDeclaration members

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -318,7 +318,7 @@ struct ASTBase
         final extern (D) this(Identifier id)
         {
             super(id);
-            storage_class = STC.undefined_;
+            storage_class = STC.none;
             visibility = Visibility(Visibility.Kind.undefined);
             linkage = LINK.default_;
         }
@@ -509,7 +509,7 @@ struct ASTBase
         uint ctfeAdrOnStack;
         uint sequenceNumber;
 
-        final extern (D) this(Loc loc, Type type, Identifier id, Initializer _init, StorageClass st = STC.undefined_)
+        final extern (D) this(Loc loc, Type type, Identifier id, Initializer _init, StorageClass st = STC.none)
         {
             super(id);
             this.type = type;
@@ -539,7 +539,7 @@ struct ASTBase
 
         final extern (D) this(Loc loc, Type type, Identifier id, Expression width)
         {
-            super(loc, type, id, cast(Initializer)null, cast(StorageClass)STC.undefined_);
+            super(loc, type, id, cast(Initializer)null, cast(StorageClass)STC.none);
 
             this.width = width;
             this.storage_class |= STC.field;
@@ -663,7 +663,7 @@ struct ASTBase
     {
         TOK tok;
 
-        extern (D) this(Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, StorageClass storage_class = STC.undefined_)
+        extern (D) this(Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, StorageClass storage_class = STC.none)
         {
             super(loc, endloc, null, storage_class, type);
             this.ident = id ? id : Id.empty;
@@ -717,7 +717,7 @@ struct ASTBase
     {
         extern (D) this(Loc loc, Loc endloc)
         {
-            super(loc, endloc, Id.dtor, STC.undefined_, null);
+            super(loc, endloc, Id.dtor, STC.none, null);
         }
         extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id)
         {
@@ -1687,7 +1687,7 @@ struct ASTBase
         StorageClass stc;                   // storage class of ...
         VarArg varargs = VarArg.none;
 
-        this(Parameters* parameters, VarArg varargs = VarArg.none, StorageClass stc = 0)
+        this(Parameters* parameters, VarArg varargs = VarArg.none, StorageClass stc = STC.none)
         {
             this.parameters = parameters;
             this.varargs = varargs;
@@ -2555,7 +2555,7 @@ struct ASTBase
      */
     static StorageClass ModToStc(uint mod) pure nothrow @nogc @safe
     {
-        StorageClass stc = 0;
+        StorageClass stc = STC.none;
         if (mod & MODFlags.immutable_)
             stc |= STC.immutable_;
         if (mod & MODFlags.const_)
@@ -3703,7 +3703,7 @@ struct ASTBase
                     Expression e = (*exps)[i];
                     if (e.type.ty == Ttuple)
                         error(e.loc, "cannot form sequence of sequences");
-                    auto arg = new Parameter(e.loc, STC.undefined_, e.type, null, null, null);
+                    auto arg = new Parameter(e.loc, STC.none, e.type, null, null, null);
                     (*arguments)[i] = arg;
                 }
             }
@@ -3955,7 +3955,7 @@ struct ASTBase
         byte inuse;
         Expressions* fargs;         // function arguments
 
-        extern (D) this(ParameterList pl, Type treturn, LINK linkage, StorageClass stc = 0)
+        extern (D) this(ParameterList pl, Type treturn, LINK linkage, StorageClass stc = STC.none)
         {
             super(Tfunction, treturn);
             assert(VarArg.none <= pl.varargs && pl.varargs <= VarArg.max);

--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -50,7 +50,7 @@ alias MOD = ubyte;
 
 enum STC : ulong  // transfer changes to declaration.h
 {
-    undefined_          = 0,
+    none                = 0,
 
     static_             = 1,   /// `static`
     extern_             = 2,   /// `extern`
@@ -143,7 +143,7 @@ enum STC : ulong  // transfer changes to declaration.h
 
 }
 
-alias StorageClass = ulong;
+alias StorageClass = STC;
 
 /********
  * Determine if it's the ambigous case of where `return` attaches to.

--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -143,7 +143,10 @@ enum STC : ulong  // transfer changes to declaration.h
 
 }
 
-alias StorageClass = STC;
+// Alias for C++ interface functions which use plain integer instead of enum class,
+// since C++ enum class doesn't support | & and conversion to bool. Maybe this can
+// be refactored to a struct with operator overloads or bit fields at some point.
+alias StorageClass = ulong;
 
 /********
  * Determine if it's the ambigous case of where `return` attaches to.

--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -79,7 +79,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
      * If the returned scope != sc, the caller should pop
      * the scope after it used.
      */
-    extern (D) static Scope* createNewScope(Scope* sc, StorageClass stc, LINK linkage,
+    extern (D) static Scope* createNewScope(Scope* sc, STC stc, LINK linkage,
         CPPMANGLE cppmangle, Visibility visibility, int explicitVisibility,
         AlignDeclaration aligndecl, PragmaDeclaration inlining)
     {
@@ -140,16 +140,16 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
  */
 extern (C++) class StorageClassDeclaration : AttribDeclaration
 {
-    StorageClass stc;
+    STC stc;
 
-    extern (D) this(StorageClass stc, Dsymbols* decl) @safe
+    extern (D) this(STC stc, Dsymbols* decl) @safe
     {
         super(decl);
         this.stc = stc;
         this.dsym = DSYM.storageClassDeclaration;
     }
 
-    extern (D) this(Loc loc, StorageClass stc, Dsymbols* decl) @safe
+    extern (D) this(Loc loc, STC stc, Dsymbols* decl) @safe
     {
         super(loc, decl);
         this.stc = stc;

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -51,11 +51,11 @@ import dmd.tokens;
  * Returns:
  *      merged storage class
  */
-StorageClass mergeFuncAttrs(StorageClass s1, const FuncDeclaration f) pure @safe
+STC mergeFuncAttrs(STC s1, const FuncDeclaration f) pure @safe
 {
     if (!f)
         return s1;
-    StorageClass s2 = (f.storage_class & STC.disable);
+    STC s2 = (f.storage_class & STC.disable);
 
     auto tf = f.type.isTypeFunction();
     if (tf.trust == TRUST.safe)
@@ -75,7 +75,7 @@ StorageClass mergeFuncAttrs(StorageClass s1, const FuncDeclaration f) pure @safe
     const sa = s1 & s2;
     const so = s1 | s2;
 
-    StorageClass stc = (sa & (STC.pure_ | STC.nothrow_ | STC.nogc)) | (so & STC.disable);
+    STC stc = (sa & (STC.pure_ | STC.nothrow_ | STC.nogc)) | (so & STC.disable);
 
     if (so & STC.system)
         stc |= STC.system;
@@ -269,7 +269,7 @@ FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
         return null;
 
     //printf("StructDeclaration::buildOpAssign() %s\n", sd.toChars());
-    StorageClass stc = STC.safe;
+    STC stc = STC.safe;
     Loc declLoc = sd.loc;
     Loc loc; // internal code should have no loc to prevent coverage
 
@@ -905,7 +905,7 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
     if (ad.isUnionDeclaration())
         return;                    // unions don't have destructors
 
-    StorageClass stc = STC.safe | STC.nothrow_ | STC.pure_ | STC.nogc;
+    STC stc = STC.safe | STC.nothrow_ | STC.pure_ | STC.nogc;
     Loc declLoc = ad.userDtors.length ? ad.userDtors[0].loc : ad.loc;
     Loc loc; // internal code should have no loc to prevent coverage
     FuncDeclaration xdtor_fwd = null;
@@ -1224,8 +1224,8 @@ FuncDeclaration buildInv(AggregateDeclaration ad, Scope* sc)
 
     default:
         Expression e = null;
-        StorageClass stcx = STC.none;
-        StorageClass stc = STC.safe | STC.nothrow_ | STC.pure_ | STC.nogc;
+        STC stcx = STC.none;
+        STC stc = STC.safe | STC.nothrow_ | STC.pure_ | STC.nogc;
         foreach (i, inv; ad.invs)
         {
             stc = mergeFuncAttrs(stc, inv);
@@ -1278,7 +1278,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
     const hasUserDefinedPosblit = sd.postblits.length && !sd.postblits[0].isDisabled ? true : false;
 
     // by default, the storage class of the created postblit
-    StorageClass stc = STC.safe;
+    STC stc = STC.safe;
     Loc declLoc = sd.postblits.length ? sd.postblits[0].loc : sd.loc;
     Loc loc; // internal code should have no loc to prevent coverage
 
@@ -1559,11 +1559,11 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
  * Returns:
  *  The copy constructor declaration for struct `sd`.
  */
-private CtorDeclaration generateCtorDeclaration(StructDeclaration sd, const StorageClass paramStc, const StorageClass funcStc, bool move)
+private CtorDeclaration generateCtorDeclaration(StructDeclaration sd, const STC paramStc, const STC funcStc, bool move)
 {
     auto fparams = new Parameters();
     auto structType = sd.type;
-    StorageClass stc = move ? STC.none : STC.ref_;     // the only difference between copy or move
+    STC stc = move ? STC.none : STC.ref_;     // the only difference between copy or move
     fparams.push(new Parameter(Loc.initial, paramStc | stc, structType, Id.p, null, null));
     ParameterList pList = ParameterList(fparams);
     auto tf = new TypeFunction(pList, structType, LINK.d, STC.ref_);

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -387,7 +387,7 @@ FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
     sd.hasIdentityAssign = true; // temporary mark identity assignable
     const errors = global.startGagging(); // Do not report errors, even if the template opAssign fbody makes it.
     Scope* sc2 = sc.push();
-    sc2.stc = 0;
+    sc2.stc = STC.none;
     sc2.linkage = LINK.d;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
@@ -607,7 +607,7 @@ FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     auto tf = new TypeFunction(ParameterList(parameters), Type.tbool, LINK.d, STC.const_);
     tf = tf.addSTC(STC.const_).toTypeFunction();
     Identifier id = Id.xopEquals;
-    auto fop = new FuncDeclaration(declLoc, Loc.initial, id, 0, tf);
+    auto fop = new FuncDeclaration(declLoc, Loc.initial, id, STC.none, tf);
     fop.isGenerated = true;
     fop.parent = sd;
     Expression e1 = new IdentifierExp(loc, Id.This);
@@ -616,7 +616,7 @@ FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     fop.fbody = new ReturnStatement(loc, e);
     const errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
-    sc2.stc = 0;
+    sc2.stc = STC.none;
     sc2.linkage = LINK.d;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
@@ -731,7 +731,7 @@ FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     auto tf = new TypeFunction(ParameterList(parameters), Type.tint32, LINK.d, STC.const_);
     tf = tf.addSTC(STC.const_).toTypeFunction();
     Identifier id = Id.xopCmp;
-    auto fop = new FuncDeclaration(declLoc, Loc.initial, id, 0, tf);
+    auto fop = new FuncDeclaration(declLoc, Loc.initial, id, STC.none, tf);
     fop.isGenerated = true;
     fop.parent = sd;
     Expression e1 = new IdentifierExp(loc, Id.This);
@@ -740,7 +740,7 @@ FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     fop.fbody = new ReturnStatement(loc, e);
     const errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
-    sc2.stc = 0;
+    sc2.stc = STC.none;
     sc2.linkage = LINK.d;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
@@ -877,7 +877,7 @@ FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
         "return h;";
     fop.fbody = new MixinStatement(loc, new StringExp(loc, code));
     Scope* sc2 = sc.push();
-    sc2.stc = 0;
+    sc2.stc = STC.none;
     sc2.linkage = LINK.d;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
@@ -1109,7 +1109,7 @@ private DtorDeclaration buildWindowsCppDtor(AggregateDeclaration ad, DtorDeclara
     //   // TODO: if (del) delete (char*)this;
     //   return (void*) this;
     // }
-    Parameter delparam = new Parameter(Loc.initial, STC.undefined_, Type.tuns32, Identifier.idPool("del"), new IntegerExp(dtor.loc, 0, Type.tuns32), null);
+    Parameter delparam = new Parameter(Loc.initial, STC.none, Type.tuns32, Identifier.idPool("del"), new IntegerExp(dtor.loc, 0, Type.tuns32), null);
     Parameters* params = new Parameters;
     params.push(delparam);
     const stc = dtor.storage_class & ~STC.scope_; // because we add the `return this;` later
@@ -1224,7 +1224,7 @@ FuncDeclaration buildInv(AggregateDeclaration ad, Scope* sc)
 
     default:
         Expression e = null;
-        StorageClass stcx = 0;
+        StorageClass stcx = STC.none;
         StorageClass stc = STC.safe | STC.nothrow_ | STC.pure_ | STC.nogc;
         foreach (i, inv; ad.invs)
         {
@@ -1234,7 +1234,7 @@ FuncDeclaration buildInv(AggregateDeclaration ad, Scope* sc)
                 // What should do?
             }
             const stcy = (inv.storage_class & STC.synchronized_) |
-                         (inv.type.mod & MODFlags.shared_ ? STC.shared_ : 0);
+                         (inv.type.mod & MODFlags.shared_ ? STC.shared_ : STC.none);
             if (i == 0)
                 stcx = stcy;
             else if (stcx ^ stcy)
@@ -1563,7 +1563,7 @@ private CtorDeclaration generateCtorDeclaration(StructDeclaration sd, const Stor
 {
     auto fparams = new Parameters();
     auto structType = sd.type;
-    StorageClass stc = move ? 0 : STC.ref_;     // the only difference between copy or move
+    StorageClass stc = move ? STC.none : STC.ref_;     // the only difference between copy or move
     fparams.push(new Parameter(Loc.initial, paramStc | stc, structType, Id.p, null, null));
     ParameterList pList = ParameterList(fparams);
     auto tf = new TypeFunction(pList, structType, LINK.d, STC.ref_);
@@ -1773,7 +1773,7 @@ void buildCopyOrMoveCtor(StructDeclaration sd, Scope* sc, bool move)
     ccd.addMember(sc, sd);
     const errors = global.startGagging();
     Scope* sc2 = sc.push();
-    sc2.stc = 0;
+    sc2.stc = STC.none;
     sc2.linkage = LINK.d;
     ccd.dsymbolSemantic(sc2);
     ccd.semantic2(sc2);

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -200,7 +200,7 @@ extern (C++) final class StaticForeach : RootObject
      */
     private extern(D) Expression wrapAndCall(Loc loc, Statement s)
     {
-        auto tf = new TypeFunction(ParameterList(), null, LINK.default_, 0);
+        auto tf = new TypeFunction(ParameterList(), null, LINK.default_, STC.none);
         auto fd = new FuncLiteralDeclaration(loc, loc, tf, TOK.reserved, null);
         fd.fbody = s;
         auto fe = new FuncExp(loc, fd);
@@ -262,7 +262,7 @@ extern (C++) final class StaticForeach : RootObject
         sdecl.members = new Dsymbols();
         auto fid = Identifier.idPool(tupleFieldName);
         auto ty = new TypeTypeof(loc, new TupleExp(loc, e));
-        sdecl.members.push(new VarDeclaration(loc, ty, fid, null, 0));
+        sdecl.members.push(new VarDeclaration(loc, ty, fid, null, STC.none));
         auto r = cast(TypeStruct)sdecl.type;
         if (global.params.useTypeInfo && Type.dtypeinfo)
             r.vtinfo = TypeInfoStructDeclaration.create(r); // prevent typeinfo from going to object file

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1686,7 +1686,7 @@ final class CParser(AST) : Parser!AST
     private AST.Expression cparseStatementExpression()
     {
         AST.ParameterList parameterList;
-        StorageClass stc = 0;
+        StorageClass stc = STC.none;
         const loc = token.loc;
         auto symbolsSave = symbols;
         symbols = new AST.Dsymbols();
@@ -1710,7 +1710,7 @@ final class CParser(AST) : Parser!AST
         }
 
         auto tf = new AST.TypeFunction(parameterList, null, LINK.d, stc);
-        auto fd = new AST.FuncLiteralDeclaration(loc, token.loc, tf, TOK.delegate_, null, null, 0);
+        auto fd = new AST.FuncLiteralDeclaration(loc, token.loc, tf, TOK.delegate_, null, null, STC.none);
         fd.fbody = fbody;
 
         auto fe = new AST.FuncExp(loc, fd);
@@ -3018,7 +3018,7 @@ final class CParser(AST) : Parser!AST
 
                         auto parameterList = cparseParameterList();
                         const lkg = specifier.mod & MOD.x__stdcall ? LINK.windows : linkage;
-                        StorageClass stc = specifier._nothrow ? STC.nothrow_ : 0;
+                        StorageClass stc = specifier._nothrow ? STC.nothrow_ : STC.none;
                         if (specifier._pure)
                             stc |= STC.pure_;
                         stc |= defaultStorageClasses;
@@ -3537,7 +3537,7 @@ final class CParser(AST) : Parser!AST
             break;
         }
         nextToken();
-        auto s = new AST.CompoundAsmStatement(loc, statements, 0);
+        auto s = new AST.CompoundAsmStatement(loc, statements, STC.none);
         return s;
     }
 
@@ -3922,7 +3922,7 @@ final class CParser(AST) : Parser!AST
                     cparseGnuAttributes(specifierx);
                 }
 
-                auto em = new AST.EnumMember(mloc, ident, value, null, 0, null, null);
+                auto em = new AST.EnumMember(mloc, ident, value, null, STC.none, null, null);
                 members.push(em);
 
                 if (token.value == TOK.comma)
@@ -6205,7 +6205,7 @@ final class CParser(AST) : Parser!AST
                             if (token.value != TOK.endOfFile)
                                 break;
                             auto ret = new AST.ReturnStatement(exp.loc, exp);
-                            auto parameterList = AST.ParameterList(new AST.Parameters(), VarArg.none, 0);
+                            auto parameterList = AST.ParameterList(new AST.Parameters(), VarArg.none, STC.none);
                             StorageClass stc = STC.auto_;
                             auto tf = new AST.TypeFunction(parameterList, null, LINK.d, stc);
                             auto fd = new AST.FuncDeclaration(exp.loc, exp.loc, id, stc, tf, 0);
@@ -6251,7 +6251,7 @@ final class CParser(AST) : Parser!AST
 
                                 if (token.value != TOK.identifier)
                                     break Lswitch;
-                                auto param = new AST.Parameter(token.loc, 0, null, token.ident, null, null);
+                                auto param = new AST.Parameter(token.loc, STC.none, null, token.ident, null, null);
                                 parameters.push(param);
                                 nextToken();
                                 if (token.value == TOK.comma)
@@ -6266,7 +6266,7 @@ final class CParser(AST) : Parser!AST
 
                             //auto pstart = p;
                             nextToken();
-                            auto parameterList = AST.ParameterList(parameters, varargs, 0);
+                            auto parameterList = AST.ParameterList(parameters, varargs, STC.none);
                             /* Create a type for each parameter. Add it to the template parameter list,
                              * and the parameter list.
                              */

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1686,7 +1686,7 @@ final class CParser(AST) : Parser!AST
     private AST.Expression cparseStatementExpression()
     {
         AST.ParameterList parameterList;
-        StorageClass stc = STC.none;
+        STC stc = STC.none;
         const loc = token.loc;
         auto symbolsSave = symbols;
         symbols = new AST.Dsymbols();
@@ -2046,7 +2046,7 @@ final class CParser(AST) : Parser!AST
                         error("no initializer for function declaration");
                     if (specifier.scw & SCW.x_Thread_local)
                         error("functions cannot be `_Thread_local`"); // C11 6.7.1-4
-                    StorageClass stc = specifiersToSTC(level, specifier);
+                    STC stc = specifiersToSTC(level, specifier);
                     stc &= ~STC.gshared;        // no gshared functions
                     auto fd = new AST.FuncDeclaration(token.loc, Loc.initial, id, stc, dt, specifier.noreturn);
                     specifiersToFuncDeclaration(fd, specifier);
@@ -2233,7 +2233,7 @@ final class CParser(AST) : Parser!AST
         auto body = cparseStatement(ParseStatementFlags.curly);  // don't start a new scope; continue with parameter scope
         typedefTab.pop();                                        // end of function scope
 
-        StorageClass stc = specifiersToSTC(LVL.global, specifier);
+        STC stc = specifiersToSTC(LVL.global, specifier);
         stc &= ~STC.gshared;    // no gshared functions
         auto fd = new AST.FuncDeclaration(locFunc, prevloc, id, stc, ft, specifier.noreturn);
         specifiersToFuncDeclaration(fd, specifier);
@@ -3018,7 +3018,7 @@ final class CParser(AST) : Parser!AST
 
                         auto parameterList = cparseParameterList();
                         const lkg = specifier.mod & MOD.x__stdcall ? LINK.windows : linkage;
-                        StorageClass stc = specifier._nothrow ? STC.nothrow_ : STC.none;
+                        STC stc = specifier._nothrow ? STC.nothrow_ : STC.none;
                         if (specifier._pure)
                             stc |= STC.pure_;
                         stc |= defaultStorageClasses;
@@ -3174,7 +3174,7 @@ final class CParser(AST) : Parser!AST
     {
         auto parameters = new AST.Parameters();
         AST.VarArg varargs = AST.VarArg.none;
-        StorageClass varargsStc;
+        STC varargsStc;
 
         check(TOK.leftParenthesis);
         if (token.value == TOK.void_ && peekNext() == TOK.rightParenthesis) // func(void)
@@ -5162,9 +5162,9 @@ final class CParser(AST) : Parser!AST
      * Returns:
      *  corresponding D storage class
      */
-    StorageClass specifiersToSTC(LVL level, const ref Specifier specifier)
+    STC specifiersToSTC(LVL level, const ref Specifier specifier)
     {
-        StorageClass stc;
+        STC stc;
         if (specifier.scw & SCW.x_Thread_local)
         {
             if (level == LVL.global)
@@ -6206,7 +6206,7 @@ final class CParser(AST) : Parser!AST
                                 break;
                             auto ret = new AST.ReturnStatement(exp.loc, exp);
                             auto parameterList = AST.ParameterList(new AST.Parameters(), VarArg.none, STC.none);
-                            StorageClass stc = STC.auto_;
+                            STC stc = STC.auto_;
                             auto tf = new AST.TypeFunction(parameterList, null, LINK.d, stc);
                             auto fd = new AST.FuncDeclaration(exp.loc, exp.loc, id, stc, tf, 0);
                             fd.fbody = ret;
@@ -6297,7 +6297,7 @@ final class CParser(AST) : Parser!AST
 
                             // Generate function
                             auto ret = new AST.ReturnStatement(exp.loc, exp);
-                            StorageClass stc = STC.auto_;
+                            STC stc = STC.auto_;
                             auto tf = new AST.TypeFunction(parameterList, null, LINK.d, stc);
                             auto fd = new AST.FuncDeclaration(exp.loc, exp.loc, id, stc, tf, 0);
                             fd.fbody = ret;

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -510,7 +510,7 @@ Covariant covariant(Type src, Type t, StorageClass* pstc = null, bool
                     cppCovariant = false)
 {
     import dmd.typesem;
-    return dmd.typesem.covariant(src, t, pstc, cppCovariant);
+    return dmd.typesem.covariant(src, t, cast(STC*) pstc, cppCovariant);
 }
 
 bool isZeroInit(Type t, Loc loc)
@@ -642,7 +642,7 @@ Type addMod(Type type, MOD mod)
 Type addStorageClass(Type type, StorageClass stc)
 {
     import dmd.typesem;
-    return dmd.typesem.addStorageClass(type, stc);
+    return dmd.typesem.addStorageClass(type, cast(STC) stc);
 }
 
 Type pointerTo(Type type)

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -87,7 +87,7 @@ extern (C++) abstract class Declaration : Dsymbol
 {
     Type type;
     Type originalType;  // before semantic analysis
-    StorageClass storage_class = STC.none;
+    STC storage_class = STC.none;
     // overridden symbol with pragma(mangle, "...")
     const(char)[] mangleOverride;
     Visibility visibility;
@@ -867,7 +867,7 @@ extern (C++) class VarDeclaration : Declaration
     byte canassign;                 // it can be assigned to
     ubyte isdataseg;                // private data for isDataseg 0 unset, 1 true, 2 false
 
-    final extern (D) this(Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.none)
+    final extern (D) this(Loc loc, Type type, Identifier ident, Initializer _init, STC storage_class = STC.none)
     in
     {
         assert(ident);
@@ -894,7 +894,7 @@ extern (C++) class VarDeclaration : Declaration
 
     static VarDeclaration create(Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.none)
     {
-        return new VarDeclaration(loc, type, ident, _init, storage_class);
+        return new VarDeclaration(loc, type, ident, _init, cast(STC) storage_class);
     }
 
     override VarDeclaration syntaxCopy(Dsymbol s)

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -87,7 +87,7 @@ extern (C++) abstract class Declaration : Dsymbol
 {
     Type type;
     Type originalType;  // before semantic analysis
-    StorageClass storage_class = STC.undefined_;
+    StorageClass storage_class = STC.none;
     // overridden symbol with pragma(mangle, "...")
     const(char)[] mangleOverride;
     Visibility visibility;
@@ -345,7 +345,7 @@ extern (C++) final class TupleDeclaration : Declaration
                 }
                 else
                 {
-                    auto arg = new Parameter(Loc.initial, 0, t, null, null, null);
+                    auto arg = new Parameter(Loc.initial, STC.none, t, null, null, null);
                 }
                 (*args)[i] = arg;
                 if (!t.deco)
@@ -867,7 +867,7 @@ extern (C++) class VarDeclaration : Declaration
     byte canassign;                 // it can be assigned to
     ubyte isdataseg;                // private data for isDataseg 0 unset, 1 true, 2 false
 
-    final extern (D) this(Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
+    final extern (D) this(Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.none)
     in
     {
         assert(ident);
@@ -892,7 +892,7 @@ extern (C++) class VarDeclaration : Declaration
         this.storage_class = storage_class;
     }
 
-    static VarDeclaration create(Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
+    static VarDeclaration create(Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.none)
     {
         return new VarDeclaration(loc, type, ident, _init, storage_class);
     }

--- a/compiler/src/dmd/denum.d
+++ b/compiler/src/dmd/denum.d
@@ -152,7 +152,7 @@ extern (C++) final class EnumMember : VarDeclaration
     }
 
     extern(D) this(Loc loc, Identifier id, Expression value, Type memtype,
-        StorageClass stc, UserAttributeDeclaration uad, DeprecatedDeclaration dd)
+        STC stc, UserAttributeDeclaration uad, DeprecatedDeclaration dd)
     {
         this(loc, id, value, memtype);
         storage_class = stc;

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -176,7 +176,7 @@ extern (C++) struct Scope
     Visibility visibility = Visibility(Visibility.Kind.public_);
     int explicitVisibility;         /// set if in an explicit visibility attribute
 
-    StorageClass stc;               /// storage class
+    STC stc;                        /// storage class
 
     DeprecatedDeclaration depdecl;  /// customized deprecation message
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -896,7 +896,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 else
                     ti = dsym._init ? dsym._init.syntaxCopy() : null;
 
-                StorageClass storage_class = STC.temp | dsym.storage_class;
+                STC storage_class = STC.temp | dsym.storage_class;
                 if ((dsym.storage_class & STC.parameter) && (arg.storageClass & STC.parameter))
                     storage_class |= arg.storageClass;
                 auto v = new VarDeclaration(dsym.loc, arg.type, id, ti, storage_class);
@@ -935,7 +935,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         else if (dsym.type.isWild())
             dsym.storage_class |= STC.wild;
 
-        if (StorageClass stc = dsym.storage_class & (STC.synchronized_ | STC.override_ | STC.abstract_ | STC.final_))
+        if (STC stc = dsym.storage_class & (STC.synchronized_ | STC.override_ | STC.abstract_ | STC.final_))
         {
             if (stc == STC.final_)
                 .error(dsym.loc, "%s `%s` cannot be `final`, perhaps you meant `const`?", dsym.kind, dsym.toPrettyChars);
@@ -955,7 +955,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (dsym.storage_class & STC.scope_)
         {
-            StorageClass stc = dsym.storage_class & (STC.static_ | STC.extern_ | STC.manifest | STC.gshared);
+            STC stc = dsym.storage_class & (STC.static_ | STC.extern_ | STC.manifest | STC.gshared);
             if (stc)
             {
                 OutBuffer buf;
@@ -4835,7 +4835,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
             continue;
         Type t = isType((*tempinst.tiargs)[i]);
         assert(t);
-        if (StorageClass stc = ModToStc(t.mod))
+        if (STC stc = ModToStc(t.mod))
         {
             //printf("t = %s, stc = x%llx\n", t.toChars(), stc);
             auto s = new Dsymbols();
@@ -7415,7 +7415,7 @@ private extern(C++) class NewScopeVisitor : Visitor
 
     override void visit(StorageClassDeclaration swt)
     {
-        StorageClass scstc = sc.stc;
+        STC scstc = sc.stc;
         /* These sets of storage classes are mutually exclusive,
          * so choose the innermost or most recent one.
          */

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -812,7 +812,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     }
                     else if (isAliasThisTuple(e))
                     {
-                        auto v = copyToTemp(0, "__tup", e);
+                        auto v = copyToTemp(STC.none, "__tup", e);
                         v.dsymbolSemantic(sc);
                         auto ve = new VarExp(dsym.loc, v);
                         ve.type = e.type;
@@ -1024,7 +1024,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 }
                 // If it's a member template
                 AggregateDeclaration ad2 = ti.tempdecl.isMember();
-                if (ad2 && dsym.storage_class != STC.undefined_)
+                if (ad2 && dsym.storage_class != STC.none)
                 {
                     .error(dsym.loc, "%s `%s` - cannot use template to add field to aggregate `%s`", dsym.kind, dsym.toPrettyChars, ad2.toChars());
                 }
@@ -2679,7 +2679,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
              */
 
             auto v = new VarDeclaration(Loc.initial, Type.tint32, Id.gate, null);
-            v.storage_class = STC.temp | STC.static_ | (isShared ? STC.shared_ : 0);
+            v.storage_class = STC.temp | STC.static_ | (isShared ? STC.shared_ : STC.none);
 
             auto sa = new Statements();
             Statement s = new ExpStatement(Loc.initial, v);
@@ -3684,7 +3684,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 // This is required if other lowerings add code to the generated constructor which
                 // is less strict (e.g. `preview=dtorfields` might introduce a call to a less qualified dtor)
 
-                auto ctor = new CtorDeclaration(cldec.loc, Loc.initial, 0, tf);
+                auto ctor = new CtorDeclaration(cldec.loc, Loc.initial, STC.none, tf);
                 ctor.storage_class |= STC.inference | (fd.storage_class & STC.scope_);
                 ctor.isGenerated = true;
                 ctor.fbody = new CompoundStatement(Loc.initial, new Statements());
@@ -4863,11 +4863,11 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     _scope = _scope.push(tempinst.argsym);
     _scope.tinst = tempinst;
     _scope.minst = tempinst.minst;
-    //scope.stc = 0;
+    //scope.stc = STC.none;
 
     // Declare each template parameter as an alias for the argument type
     Scope* paramscope = _scope.push();
-    paramscope.stc = 0;
+    paramscope.stc = STC.none;
     paramscope.visibility = Visibility(Visibility.Kind.public_); // https://issues.dlang.org/show_bug.cgi?id=14169
                                               // template parameters should be public
     tempinst.declareParameters(paramscope);
@@ -5200,7 +5200,7 @@ void aliasSeqInstanceSemantic(TemplateInstance tempinst, Scope* sc, TemplateDecl
 {
     //printf("[%s] aliasSeqInstance.dsymbolSemantic('%s')\n", tempinst.loc.toChars(), tempinst.toChars());
     Scope* paramscope = sc.push();
-    paramscope.stc = 0;
+    paramscope.stc = STC.none;
     paramscope.visibility = Visibility(Visibility.Kind.public_);
 
     TemplateTupleParameter ttp = (*tempdecl.parameters)[0].isTemplateTupleParameter();
@@ -5225,7 +5225,7 @@ void aliasInstanceSemantic(TemplateInstance tempinst, Scope* sc, TemplateDeclara
 {
     //printf("[%s] aliasInstance.dsymbolSemantic('%s')\n", tempinst.loc.toChars(), tempinst.toChars());
     Scope* paramscope = sc.push();
-    paramscope.stc = 0;
+    paramscope.stc = STC.none;
     paramscope.visibility = Visibility(Visibility.Kind.public_);
 
     TemplateTypeParameter ttp = (*tempdecl.parameters)[0].isTemplateTypeParameter();

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -1863,9 +1863,9 @@ void escapeExp(Expression e, ref scope EscapeByResults er, int deref)
  * Returns:
  *      storage class for fd's `this`
  */
-StorageClass getThisStorageClass(FuncDeclaration fd)
+STC getThisStorageClass(FuncDeclaration fd)
 {
-    StorageClass stc;
+    STC stc;
     auto tf = fd.type.toBasetype().isTypeFunction();
     if (tf.isReturn)
         stc |= STC.return_;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3324,7 +3324,7 @@ private bool functionParameters(Loc loc, Scope* sc,
                 {   /* allow rvalues to be passed to ref parameters by copying
                      * them to a temp, then pass the temp as the argument
                      */
-                    auto v = copyToTemp(0, "__rvalue", arg);
+                    auto v = copyToTemp(STC.none, "__rvalue", arg);
                     Expression ev = new DeclarationExp(arg.loc, v);
                     ev = new CommaExp(arg.loc, ev, new VarExp(arg.loc, v));
                     arg = ev.expressionSemantic(sc);
@@ -3406,7 +3406,7 @@ private bool functionParameters(Loc loc, Scope* sc,
                 {
                     // allocate the array literal as temporary static array on the stack
                     ale.type = ale.type.nextOf().sarrayOf(ale.elements.length);
-                    auto tmp = copyToTemp(0, "__arrayliteral_on_stack", ale);
+                    auto tmp = copyToTemp(STC.none, "__arrayliteral_on_stack", ale);
                     tmp.storage_class |= STC.exptemp;
                     auto declareTmp = new DeclarationExp(ale.loc, tmp);
                     auto castToSlice = new CastExp(ale.loc, new VarExp(ale.loc, tmp),
@@ -6369,7 +6369,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 tthis = ue.e1.type;
                 if (!(exp.f.type.ty == Tfunction && (cast(TypeFunction)exp.f.type).isScopeQual))
                 {
-                    if (checkParamArgumentEscape(*sc, exp.f, Id.This, exp.f.vthis, STC.undefined_, ethis, false, false))
+                    if (checkParamArgumentEscape(*sc, exp.f, Id.This, exp.f.vthis, STC.none, ethis, false, false))
                         return setError();
                 }
             }
@@ -6851,10 +6851,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Loc loc = exp.loc;
 
                 auto vptr = new DotIdExp(loc, new ThisExp(loc), Id.__vptr);
-                auto vptrTmpDecl = copyToTemp(0, "__vptrTmp", vptr);
+                auto vptrTmpDecl = copyToTemp(STC.none, "__vptrTmp", vptr);
                 auto declareVptrTmp = new DeclarationExp(loc, vptrTmpDecl);
 
-                auto superTmpDecl = copyToTemp(0, "__superTmp", result);
+                auto superTmpDecl = copyToTemp(STC.none, "__superTmp", result);
                 auto declareSuperTmp = new DeclarationExp(loc, superTmpDecl);
 
                 auto declareTmps = new CommaExp(loc, declareVptrTmp, declareSuperTmp);
@@ -7871,7 +7871,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         return res.expressionSemantic(sc);
                     }
 
-                    const stc = op.isLvalue() ? STC.ref_ : 0;
+                    const stc = op.isLvalue() ? STC.ref_ : STC.none;
                     auto tmp = copyToTemp(stc, "__assertOp", op);
                     tmp.dsymbolSemantic(sc);
 
@@ -8039,7 +8039,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.msg = resolveProperties(sc, exp.msg);
             exp.msg = exp.msg.implicitCastTo(sc, Type.tchar.constOf().arrayOf());
             exp.msg = exp.msg.optimize(WANTvalue);
-            checkParamArgumentEscape(*sc, null, null, null, STC.undefined_, exp.msg, true, false);
+            checkParamArgumentEscape(*sc, null, null, null, STC.none, exp.msg, true, false);
         }
 
         if (exp.msg && exp.msg.op == EXP.error)
@@ -10149,7 +10149,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             /* Rewrite as:
              * auto tmp = e1; ++e1; tmp
              */
-            auto tmp = copyToTemp(0, "__pitmp", exp.e1);
+            auto tmp = copyToTemp(STC.none, "__pitmp", exp.e1);
             Expression ea = new DeclarationExp(exp.loc, tmp);
 
             Expression eb = exp.e1.syntaxCopy();
@@ -14611,7 +14611,7 @@ MATCH matchType(FuncExp funcExp, Type to, Scope* sc, FuncExp* presult, ErrorSink
         convertMatch = true;
 
         auto tfy = new TypeFunction(tfx.parameterList, tof.next,
-                    tfx.linkage, STC.undefined_);
+                    tfx.linkage, STC.none);
         tfy.mod = tfx.mod;
         tfy.trust = tfx.trust;
         tfy.isNothrow = tfx.isNothrow;
@@ -15332,7 +15332,7 @@ Expression addDtorHook(Expression e, Scope* sc)
             buf[0 .. prefix.length] = prefix;
             buf[prefix.length .. len] = ident[0 .. len - prefix.length];
 
-            auto tmp = copyToTemp(0, buf[0 .. len], exp);
+            auto tmp = copyToTemp(STC.none, buf[0 .. len], exp);
             Expression ae = new DeclarationExp(exp.loc, tmp);
             Expression e = new CommaExp(exp.loc, ae, new VarExp(exp.loc, tmp));
             e = e.expressionSemantic(sc);
@@ -15365,7 +15365,7 @@ Expression addDtorHook(Expression e, Scope* sc)
                 /* Type needs destruction, so declare a tmp
                  * which the back end will recognize and call dtor on
                  */
-                auto tmp = copyToTemp(0, Id.__tmpfordtor.toString(), exp);
+                auto tmp = copyToTemp(STC.none, Id.__tmpfordtor.toString(), exp);
                 auto de = new DeclarationExp(exp.loc, tmp);
                 auto ve = new VarExp(exp.loc, tmp);
                 Expression e = new CommaExp(exp.loc, de, ve);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11677,7 +11677,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // `__assigntmp` will be destroyed together with the array `ae.e1`.
             // When `ae.e2` is a variadic arg array, it is also `scope`, so
             // `__assigntmp` may also be scope.
-            StorageClass stc = STC.nodtor;
+            STC stc = STC.nodtor;
             if (isArrayAssign)
                 stc |= STC.rvalue | STC.scope_;
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -964,6 +964,8 @@ struct ObjcClassDeclaration final
     }
 };
 
+typedef uint64_t StorageClass;
+
 enum class PKG
 {
     unknown = 0,
@@ -4002,7 +4004,7 @@ private:
     uint32_t bitFields;
 public:
     ObjcFuncDeclaration objc;
-    static FuncDeclaration* create(Loc loc, Loc endloc, Identifier* id, STC storage_class, Type* type, bool noreturn = false);
+    static FuncDeclaration* create(Loc loc, Loc endloc, Identifier* id, StorageClass storage_class, Type* type, bool noreturn = false);
     Array<Statement* >* frequires();
     Array<Ensure >* fensures();
     Statement* frequire();
@@ -4378,7 +4380,7 @@ public:
     Identifier* ident;
     Expression* defaultArg;
     UserAttributeDeclaration* userAttribDecl;
-    static Parameter* create(Loc loc, STC storageClass, Type* type, Identifier* ident, Expression* defaultArg, UserAttributeDeclaration* userAttribDecl);
+    static Parameter* create(Loc loc, StorageClass storageClass, Type* type, Identifier* ident, Expression* defaultArg, UserAttributeDeclaration* userAttribDecl);
     Parameter* syntaxCopy();
     Type* isLazyArray();
     bool isLazy() const;
@@ -4669,7 +4671,7 @@ public:
     PURE purity;
     int8_t inuse;
     ArgumentList inferenceArguments;
-    static TypeFunction* create(Array<Parameter* >* parameters, Type* treturn, uint8_t varargs, LINK linkage, STC stc = (STC)0LLU);
+    static TypeFunction* create(Array<Parameter* >* parameters, Type* treturn, uint8_t varargs, LINK linkage, StorageClass stc = static_cast<StorageClass>(STC::none));
     const char* kind() const override;
     TypeFunction* syntaxCopy() override;
     bool hasLazyParameters();
@@ -6865,7 +6867,7 @@ private:
 public:
     int8_t canassign;
     uint8_t isdataseg;
-    static VarDeclaration* create(Loc loc, Type* type, Identifier* ident, Initializer* _init, STC storage_class = (STC)0LLU);
+    static VarDeclaration* create(Loc loc, Type* type, Identifier* ident, Initializer* _init, StorageClass storage_class = static_cast<StorageClass>(STC::none));
     VarDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
     AggregateDeclaration* isThis() final override;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -716,7 +716,70 @@ public:
     void accept(Visitor* v) override;
 };
 
-typedef uint64_t StorageClass;
+enum class STC : uint64_t
+{
+    none = 0LLU,
+    static_ = 1LLU,
+    extern_ = 2LLU,
+    const_ = 4LLU,
+    final_ = 8LLU,
+    abstract_ = 16LLU,
+    parameter = 32LLU,
+    field = 64LLU,
+    override_ = 128LLU,
+    auto_ = 256LLU,
+    synchronized_ = 512LLU,
+    deprecated_ = 1024LLU,
+    in_ = 2048LLU,
+    out_ = 4096LLU,
+    lazy_ = 8192LLU,
+    foreach_ = 16384LLU,
+    variadic = 32768LLU,
+    constscoperef = 65536LLU,
+    templateparameter = 131072LLU,
+    ref_ = 262144LLU,
+    scope_ = 524288LLU,
+    scopeinferred = 2097152LLU,
+    return_ = 4194304LLU,
+    returnScope = 8388608LLU,
+    returninferred = 16777216LLU,
+    immutable_ = 33554432LLU,
+    manifest = 134217728LLU,
+    nodtor = 268435456LLU,
+    nothrow_ = 536870912LLU,
+    pure_ = 1073741824LLU,
+    tls = 2147483648LLU,
+    alias_ = 4294967296LLU,
+    shared_ = 8589934592LLU,
+    gshared = 17179869184LLU,
+    wild = 34359738368LLU,
+    property = 68719476736LLU,
+    safe = 137438953472LLU,
+    trusted = 274877906944LLU,
+    system = 549755813888LLU,
+    ctfe = 1099511627776LLU,
+    disable = 2199023255552LLU,
+    result = 4398046511104LLU,
+    nodefaultctor = 8796093022208LLU,
+    temp = 17592186044416LLU,
+    rvalue = 35184372088832LLU,
+    nogc = 70368744177664LLU,
+    autoref = 140737488355328LLU,
+    inference = 281474976710656LLU,
+    exptemp = 562949953421312LLU,
+    future = 1125899906842624LLU,
+    local = 2251799813685248LLU,
+    live = 4503599627370496LLU,
+    register_ = 9007199254740992LLU,
+    volatile_ = 18014398509481984LLU,
+    safeGroup = 962072674304LLU,
+    IOR = 333824LLU,
+    TYPECTOR = 42983227396LLU,
+    FUNCATTR = 4575000774574080LLU,
+    visibleStorageClasses = 7954966262857631LLU,
+    flowThruAggregate = 962072674304LLU,
+    flowThruFunction = 18446742978991225440LLU,
+};
 
 template <typename T>
 struct Array final
@@ -3813,15 +3876,14 @@ enum class VarArg : uint8_t
 struct ParameterList final
 {
     Array<Parameter* >* parameters;
-    StorageClass stc;
+    STC stc;
     VarArg varargs;
     bool hasIdentifierList;
-    ParameterList(Array<Parameter* >* parameters, VarArg varargs = (VarArg)0u, StorageClass stc = 0);
+    ParameterList(Array<Parameter* >* parameters, VarArg varargs = (VarArg)0u, STC stc = (STC)0LLU);
     size_t length();
     Parameter* opIndex(size_t i);
     ParameterList() :
         parameters(),
-        stc(),
         varargs((VarArg)0u),
         hasIdentifierList()
     {
@@ -3857,7 +3919,7 @@ public:
     ForeachStatement* fes;
     BaseClass* interfaceVirtual;
     Type* tintro;
-    StorageClass storage_class2;
+    STC storage_class2;
     VarDeclaration* nrvo_var;
     Symbol* shidden;
     Array<ReturnStatement* >* returns;
@@ -3940,7 +4002,7 @@ private:
     uint32_t bitFields;
 public:
     ObjcFuncDeclaration objc;
-    static FuncDeclaration* create(Loc loc, Loc endloc, Identifier* id, StorageClass storage_class, Type* type, bool noreturn = false);
+    static FuncDeclaration* create(Loc loc, Loc endloc, Identifier* id, STC storage_class, Type* type, bool noreturn = false);
     Array<Statement* >* frequires();
     Array<Ensure >* fensures();
     Statement* frequire();
@@ -3989,8 +4051,8 @@ public:
     bool needsClosure();
     bool hasNestedFrameRefs();
     ParameterList getParameterList();
-    static FuncDeclaration* genCfunc(Array<Parameter* >* fparams, Type* treturn, const char* name, StorageClass stc = 0);
-    static FuncDeclaration* genCfunc(Array<Parameter* >* fparams, Type* treturn, Identifier* id, StorageClass stc = 0);
+    static FuncDeclaration* genCfunc(Array<Parameter* >* fparams, Type* treturn, const char* name, STC stc = (STC)0LLU);
+    static FuncDeclaration* genCfunc(Array<Parameter* >* fparams, Type* treturn, Identifier* id, STC stc = (STC)0LLU);
     virtual FuncDeclaration* toAliasFunc();
     void accept(Visitor* v) override;
 };
@@ -4311,12 +4373,12 @@ class Parameter final : public ASTNode
 {
 public:
     Loc loc;
-    StorageClass storageClass;
+    STC storageClass;
     Type* type;
     Identifier* ident;
     Expression* defaultArg;
     UserAttributeDeclaration* userAttribDecl;
-    static Parameter* create(Loc loc, StorageClass storageClass, Type* type, Identifier* ident, Expression* defaultArg, UserAttributeDeclaration* userAttribDecl);
+    static Parameter* create(Loc loc, STC storageClass, Type* type, Identifier* ident, Expression* defaultArg, UserAttributeDeclaration* userAttribDecl);
     Parameter* syntaxCopy();
     Type* isLazyArray();
     bool isLazy() const;
@@ -4607,7 +4669,7 @@ public:
     PURE purity;
     int8_t inuse;
     ArgumentList inferenceArguments;
-    static TypeFunction* create(Array<Parameter* >* parameters, Type* treturn, uint8_t varargs, LINK linkage, StorageClass stc = 0);
+    static TypeFunction* create(Array<Parameter* >* parameters, Type* treturn, uint8_t varargs, LINK linkage, STC stc = (STC)0LLU);
     const char* kind() const override;
     TypeFunction* syntaxCopy() override;
     bool hasLazyParameters();
@@ -5008,7 +5070,7 @@ public:
 class CompoundAsmStatement final : public CompoundStatement
 {
 public:
-    StorageClass stc;
+    STC stc;
     CompoundAsmStatement* syntaxCopy() override;
     void accept(Visitor* v) override;
 };
@@ -5154,7 +5216,7 @@ public:
 class GccAsmStatement final : public AsmStatement
 {
 public:
-    StorageClass stc;
+    STC stc;
     Expression* insn;
     Array<Expression* >* args;
     uint32_t outputargs;
@@ -5494,71 +5556,6 @@ enum class MODFlags
     wild = 8,
     wildconst = 9,
     mutable_ = 16,
-};
-
-enum class STC : uint64_t
-{
-    undefined_ = 0LLU,
-    static_ = 1LLU,
-    extern_ = 2LLU,
-    const_ = 4LLU,
-    final_ = 8LLU,
-    abstract_ = 16LLU,
-    parameter = 32LLU,
-    field = 64LLU,
-    override_ = 128LLU,
-    auto_ = 256LLU,
-    synchronized_ = 512LLU,
-    deprecated_ = 1024LLU,
-    in_ = 2048LLU,
-    out_ = 4096LLU,
-    lazy_ = 8192LLU,
-    foreach_ = 16384LLU,
-    variadic = 32768LLU,
-    constscoperef = 65536LLU,
-    templateparameter = 131072LLU,
-    ref_ = 262144LLU,
-    scope_ = 524288LLU,
-    scopeinferred = 2097152LLU,
-    return_ = 4194304LLU,
-    returnScope = 8388608LLU,
-    returninferred = 16777216LLU,
-    immutable_ = 33554432LLU,
-    manifest = 134217728LLU,
-    nodtor = 268435456LLU,
-    nothrow_ = 536870912LLU,
-    pure_ = 1073741824LLU,
-    tls = 2147483648LLU,
-    alias_ = 4294967296LLU,
-    shared_ = 8589934592LLU,
-    gshared = 17179869184LLU,
-    wild = 34359738368LLU,
-    property = 68719476736LLU,
-    safe = 137438953472LLU,
-    trusted = 274877906944LLU,
-    system = 549755813888LLU,
-    ctfe = 1099511627776LLU,
-    disable = 2199023255552LLU,
-    result = 4398046511104LLU,
-    nodefaultctor = 8796093022208LLU,
-    temp = 17592186044416LLU,
-    rvalue = 35184372088832LLU,
-    nogc = 70368744177664LLU,
-    autoref = 140737488355328LLU,
-    inference = 281474976710656LLU,
-    exptemp = 562949953421312LLU,
-    future = 1125899906842624LLU,
-    local = 2251799813685248LLU,
-    live = 4503599627370496LLU,
-    register_ = 9007199254740992LLU,
-    volatile_ = 18014398509481984LLU,
-    safeGroup = 962072674304LLU,
-    IOR = 333824LLU,
-    TYPECTOR = 42983227396LLU,
-    FUNCATTR = 4575000774574080LLU,
-    visibleStorageClasses = 7954966262857631LLU,
-    flowThruAggregate = 962072674304LLU,
-    flowThruFunction = 18446742978991225440LLU,
 };
 
 struct ASTCodegen final
@@ -6304,7 +6301,7 @@ class AggregateDeclaration : public ScopeDsymbol
 {
 public:
     Type* type;
-    StorageClass storage_class;
+    STC storage_class;
     uint32_t structsize;
     uint32_t alignsize;
     Array<VarDeclaration* > fields;
@@ -6405,7 +6402,7 @@ public:
 class StorageClassDeclaration : public AttribDeclaration
 {
 public:
-    StorageClass stc;
+    STC stc;
     StorageClassDeclaration* syntaxCopy(Dsymbol* s) override;
     void accept(Visitor* v) override;
 };
@@ -6717,7 +6714,7 @@ class Declaration : public Dsymbol
 public:
     Type* type;
     Type* originalType;
-    StorageClass storage_class;
+    STC storage_class;
     _d_dynamicArray< const char > mangleOverride;
     Visibility visibility;
     int16_t inuse;
@@ -6868,7 +6865,7 @@ private:
 public:
     int8_t canassign;
     uint8_t isdataseg;
-    static VarDeclaration* create(Loc loc, Type* type, Identifier* ident, Initializer* _init, StorageClass storage_class = static_cast<StorageClass>(STC::undefined_));
+    static VarDeclaration* create(Loc loc, Type* type, Identifier* ident, Initializer* _init, STC storage_class = (STC)0LLU);
     VarDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
     AggregateDeclaration* isThis() final override;
@@ -7247,7 +7244,7 @@ struct Scope final
     PragmaDeclaration* inlining;
     Visibility visibility;
     int32_t explicitVisibility;
-    StorageClass stc;
+    STC stc;
     DeprecatedDeclaration* depdecl;
     bool ctor() const;
     bool ctor(bool v);
@@ -7319,7 +7316,6 @@ public:
         inlining(),
         visibility(Visibility((Visibility::Kind)5u, nullptr)),
         explicitVisibility(),
-        stc(),
         depdecl(),
         bitFields(0u),
         previews(),
@@ -7330,7 +7326,7 @@ public:
         argStruct()
     {
     }
-    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* switchStatement = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tryFinally = nullptr, ScopeGuardStatement* scopeGuard = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, bool inDefaultArg = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, uint64_t stc = 0LLU, DeprecatedDeclaration* depdecl = nullptr, uint16_t bitFields = 0u, Previews previews = Previews(), UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr, StructDeclaration* argStruct = nullptr) :
+    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* switchStatement = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tryFinally = nullptr, ScopeGuardStatement* scopeGuard = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, bool inDefaultArg = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, STC stc = (STC)0LLU, DeprecatedDeclaration* depdecl = nullptr, uint16_t bitFields = 0u, Previews previews = Previews(), UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr, StructDeclaration* argStruct = nullptr) :
         enclosing(enclosing),
         _module(_module),
         scopesym(scopesym),

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1006,12 +1006,12 @@ extern (C++) class FuncDeclaration : Declaration
     /**********************************
      * Generate a FuncDeclaration for a runtime library function.
      */
-    static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, const(char)* name, StorageClass stc = 0)
+    static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, const(char)* name, StorageClass stc = STC.none)
     {
         return genCfunc(fparams, treturn, Identifier.idPool(name[0 .. strlen(name)]), stc);
     }
 
-    static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, Identifier id, StorageClass stc = 0)
+    static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, Identifier id, StorageClass stc = STC.none)
     {
         FuncDeclaration fd;
         TypeFunction tf;
@@ -1281,7 +1281,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
     // backend
     bool deferToObj;
 
-    extern (D) this(Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, StorageClass storage_class = STC.undefined_)
+    extern (D) this(Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, StorageClass storage_class = STC.none)
     {
         super(loc, endloc, null, storage_class, type);
         this.dsym = DSYM.funcLiteralDeclaration;
@@ -1449,7 +1449,7 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
 {
     extern (D) this(Loc loc, Loc endloc)
     {
-        super(loc, endloc, Id.dtor, STC.undefined_, null);
+        super(loc, endloc, Id.dtor, STC.none, null);
         this.dsym = DSYM.dtorDeclaration;
     }
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -235,7 +235,7 @@ extern (C++) class FuncDeclaration : Declaration
     */
     Type tintro;
 
-    StorageClass storage_class2;        /// storage class for template onemember's
+    STC storage_class2;        /// storage class for template onemember's
 
     // Things that should really go into Scope
 
@@ -296,7 +296,7 @@ extern (C++) class FuncDeclaration : Declaration
      */
     ObjcFuncDeclaration objc;
 
-    extern (D) this(Loc loc, Loc endloc, Identifier ident, StorageClass storage_class, Type type, bool noreturn = false)
+    extern (D) this(Loc loc, Loc endloc, Identifier ident, STC storage_class, Type type, bool noreturn = false)
     {
         super(DSYM.funcDeclaration, loc, ident);
         //.printf("FuncDeclaration(id = '%s', type = %s)\n", ident.toChars(), type.toChars());
@@ -322,7 +322,7 @@ extern (C++) class FuncDeclaration : Declaration
 
     static FuncDeclaration create(Loc loc, Loc endloc, Identifier id, StorageClass storage_class, Type type, bool noreturn = false)
     {
-        return new FuncDeclaration(loc, endloc, id, storage_class, type, noreturn);
+        return new FuncDeclaration(loc, endloc, id, cast(STC) storage_class, type, noreturn);
     }
 
     final nothrow pure @safe
@@ -1006,12 +1006,12 @@ extern (C++) class FuncDeclaration : Declaration
     /**********************************
      * Generate a FuncDeclaration for a runtime library function.
      */
-    static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, const(char)* name, StorageClass stc = STC.none)
+    static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, const(char)* name, STC stc = STC.none)
     {
         return genCfunc(fparams, treturn, Identifier.idPool(name[0 .. strlen(name)]), stc);
     }
 
-    static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, Identifier id, StorageClass stc = STC.none)
+    static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, Identifier id, STC stc = STC.none)
     {
         FuncDeclaration fd;
         TypeFunction tf;
@@ -1281,7 +1281,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
     // backend
     bool deferToObj;
 
-    extern (D) this(Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, StorageClass storage_class = STC.none)
+    extern (D) this(Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null, STC storage_class = STC.none)
     {
         super(loc, endloc, null, storage_class, type);
         this.dsym = DSYM.funcLiteralDeclaration;
@@ -1358,7 +1358,7 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
 {
     bool isCpCtor;    // copy constructor
     bool isMoveCtor;  // move constructor (aka rvalue constructor)
-    extern (D) this(Loc loc, Loc endloc, StorageClass stc, Type type)
+    extern (D) this(Loc loc, Loc endloc, STC stc, Type type)
     {
         super(loc, endloc, Id.ctor, stc, type);
         this.dsym = DSYM.ctorDeclaration;
@@ -1403,7 +1403,7 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
  */
 extern (C++) final class PostBlitDeclaration : FuncDeclaration
 {
-    extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id)
+    extern (D) this(Loc loc, Loc endloc, STC stc, Identifier id)
     {
         super(loc, endloc, id, stc, null);
         this.dsym = DSYM.postBlitDeclaration;
@@ -1453,7 +1453,7 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
         this.dsym = DSYM.dtorDeclaration;
     }
 
-    extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id)
+    extern (D) this(Loc loc, Loc endloc, STC stc, Identifier id)
     {
         super(loc, endloc, id, stc, null);
         this.dsym = DSYM.dtorDeclaration;
@@ -1504,13 +1504,13 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
  */
 extern (C++) class StaticCtorDeclaration : FuncDeclaration
 {
-    extern (D) this(Loc loc, Loc endloc, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, STC stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc("_staticCtor", loc), STC.static_ | stc, null);
         this.dsym = DSYM.staticCtorDeclaration;
     }
 
-    extern (D) this(Loc loc, Loc endloc, string name, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, string name, STC stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
         this.dsym = DSYM.staticCtorDeclaration;
@@ -1562,7 +1562,7 @@ extern (C++) final class SharedStaticCtorDeclaration : StaticCtorDeclaration
     /// Exclude this constructor from cyclic dependency check
     bool standalone;
 
-    extern (D) this(Loc loc, Loc endloc, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, STC stc)
     {
         super(loc, endloc, "_sharedStaticCtor", stc);
         this.dsym = DSYM.sharedStaticCtorDeclaration;
@@ -1588,13 +1588,13 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
 {
     VarDeclaration vgate; // 'gate' variable
 
-    extern (D) this(Loc loc, Loc endloc, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, STC stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc("_staticDtor", loc), STC.static_ | stc, null);
         this.dsym = DSYM.staticDtorDeclaration;
     }
 
-    extern (D) this(Loc loc, Loc endloc, string name, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, string name, STC stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
         this.dsym = DSYM.staticDtorDeclaration;
@@ -1643,7 +1643,7 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
  */
 extern (C++) final class SharedStaticDtorDeclaration : StaticDtorDeclaration
 {
-    extern (D) this(Loc loc, Loc endloc, StorageClass stc)
+    extern (D) this(Loc loc, Loc endloc, STC stc)
     {
         super(loc, endloc, "_sharedStaticDtor", stc);
         this.dsym = DSYM.sharedStaticDtorDeclaration;
@@ -1667,7 +1667,7 @@ extern (C++) final class SharedStaticDtorDeclaration : StaticDtorDeclaration
  */
 extern (C++) final class InvariantDeclaration : FuncDeclaration
 {
-    extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id, Statement fbody)
+    extern (D) this(Loc loc, Loc endloc, STC stc, Identifier id, Statement fbody)
     {
         // Make a unique invariant for now; we'll fix it up as we add it to the aggregate invariant list.
         super(loc, endloc, id ? id : Identifier.generateId("__invariant"), stc, null);
@@ -1723,7 +1723,7 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
     // toObjFile() these nested functions after this one
     FuncDeclarations deferredNested;
 
-    extern (D) this(Loc loc, Loc endloc, StorageClass stc, char* codedoc)
+    extern (D) this(Loc loc, Loc endloc, STC stc, char* codedoc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc("__unittest", loc), stc, null);
         this.codedoc = codedoc;
@@ -1768,7 +1768,7 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
  */
 extern (C++) final class NewDeclaration : FuncDeclaration
 {
-    extern (D) this(Loc loc, StorageClass stc)
+    extern (D) this(Loc loc, STC stc)
     {
         super(loc, Loc.initial, Id.classNew, STC.static_ | stc, null);
         this.dsym = DSYM.newDeclaration;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1370,7 +1370,7 @@ int findVtblIndex(FuncDeclaration fd, Dsymbol[] vtbl)
     import dmd.typesem : covariant;
 
     FuncDeclaration mismatch = null;
-    StorageClass mismatchstc = STC.none;
+    STC mismatchstc = STC.none;
     int mismatchvi = -1;
     int exactvi = -1;
     int bestvi = -1;
@@ -1402,7 +1402,7 @@ int findVtblIndex(FuncDeclaration fd, Dsymbol[] vtbl)
             continue;
         }
 
-        StorageClass stc = STC.none;
+        STC stc = STC.none;
         const cov = fd.type.covariant(fdv.type, &stc);
         //printf("\tbaseclass cov = %d\n", cov);
         final switch (cov)
@@ -1429,7 +1429,7 @@ int findVtblIndex(FuncDeclaration fd, Dsymbol[] vtbl)
     }
     if (fd._linkage == LINK.cpp && bestvi != -1)
     {
-        StorageClass stc = STC.none;
+        STC stc = STC.none;
         FuncDeclaration fdv = vtbl[bestvi].isFuncDeclaration();
         assert(fdv && fdv.ident == fd.ident);
         if (fd.type.covariant(fdv.type, &stc, /*cppCovariant=*/true) == Covariant.no)

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1370,7 +1370,7 @@ int findVtblIndex(FuncDeclaration fd, Dsymbol[] vtbl)
     import dmd.typesem : covariant;
 
     FuncDeclaration mismatch = null;
-    StorageClass mismatchstc = 0;
+    StorageClass mismatchstc = STC.none;
     int mismatchvi = -1;
     int exactvi = -1;
     int bestvi = -1;
@@ -1402,7 +1402,7 @@ int findVtblIndex(FuncDeclaration fd, Dsymbol[] vtbl)
             continue;
         }
 
-        StorageClass stc = 0;
+        StorageClass stc = STC.none;
         const cov = fd.type.covariant(fdv.type, &stc);
         //printf("\tbaseclass cov = %d\n", cov);
         final switch (cov)
@@ -1429,7 +1429,7 @@ int findVtblIndex(FuncDeclaration fd, Dsymbol[] vtbl)
     }
     if (fd._linkage == LINK.cpp && bestvi != -1)
     {
-        StorageClass stc = 0;
+        StorageClass stc = STC.none;
         FuncDeclaration fdv = vtbl[bestvi].isFuncDeclaration();
         assert(fdv && fdv.ident == fd.ident);
         if (fd.type.covariant(fdv.type, &stc, /*cppCovariant=*/true) == Covariant.no)
@@ -2649,7 +2649,7 @@ void buildEnsureRequire(FuncDeclaration thisfd)
         tf.isNogc = f.isNogc;
         tf.purity = f.purity;
         tf.trust = f.trust;
-        auto fd = new FuncDeclaration(loc, loc, Id.require, STC.undefined_, tf);
+        auto fd = new FuncDeclaration(loc, loc, Id.require, STC.none, tf);
         fd.fbody = thisfd.frequire;
         Statement s1 = new ExpStatement(loc, fd);
         Expression e = new CallExp(loc, new VarExp(loc, fd, false), thisfd.fdrequireParams);
@@ -2690,7 +2690,7 @@ void buildEnsureRequire(FuncDeclaration thisfd)
         tf.isNogc = f.isNogc;
         tf.purity = f.purity;
         tf.trust = f.trust;
-        auto fd = new FuncDeclaration(loc, loc, Id.ensure, STC.undefined_, tf);
+        auto fd = new FuncDeclaration(loc, loc, Id.ensure, STC.none, tf);
         fd.fbody = thisfd.fensure;
         Statement s1 = new ExpStatement(loc, fd);
         Expression e = new CallExp(loc, new VarExp(loc, fd, false), thisfd.fdensureParams);

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -429,7 +429,7 @@ private void statementToBuffer(Statement s, ref OutBuffer buf, ref HdrGenState h
         if (p)
         {
             // Print condition assignment
-            StorageClass stc = p.storageClass;
+            STC stc = p.storageClass;
             if (!p.type && !stc)
                 stc = STC.auto_;
             if (stcToBuffer(buf, stc))
@@ -3283,7 +3283,7 @@ void toCBuffer(const Initializer iz, ref OutBuffer buf, ref HdrGenState hgs)
     initializerToBuffer(cast() iz, buf, hgs);
 }
 
-bool stcToBuffer(ref OutBuffer buf, StorageClass stc) @safe
+bool stcToBuffer(ref OutBuffer buf, STC stc) @safe
 {
     //printf("stc: %llx\n", stc);
     bool result = false;
@@ -3349,11 +3349,11 @@ bool stcToBuffer(ref OutBuffer buf, StorageClass stc) @safe
  * and return a string representation of it.
  * stc is reduced by the one picked.
  */
-string stcToString(ref StorageClass stc) @safe
+string stcToString(ref STC stc) @safe
 {
     static struct SCstring
     {
-        StorageClass stc;
+        STC stc;
         string id;
     }
 
@@ -3396,7 +3396,7 @@ string stcToString(ref StorageClass stc) @safe
     ];
     foreach (ref entry; table)
     {
-        const StorageClass tbl = entry.stc;
+        const STC tbl = entry.stc;
         assert(tbl & STC.visibleStorageClasses);
         if (stc & tbl)
         {
@@ -3629,7 +3629,7 @@ private void parameterToBuffer(Parameter p, ref OutBuffer buf, ref HdrGenState h
     if (p.storageClass & STC.auto_)
         buf.writestring("auto ");
 
-    StorageClass stc = p.storageClass;
+    STC stc = p.storageClass;
     if (p.storageClass & STC.in_)
     {
         buf.writestring("in ");

--- a/compiler/src/dmd/json.d
+++ b/compiler/src/dmd/json.d
@@ -333,7 +333,7 @@ public:
         }
     }
 
-    extern(D) void propertyStorageClass(const char[] name, StorageClass stc)
+    extern(D) void propertyStorageClass(const char[] name, STC stc)
     {
         stc &= STC.visibleStorageClasses;
         if (stc)

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -451,7 +451,7 @@ void mangleParameter(Parameter p, ref OutBuffer buf, ref Backref backref)
 
     switch (stc & ((STC.IOR | STC.lazy_) & ~STC.constscoperef))
     {
-    case 0:
+    case STC.none:
         break;
     case STC.in_:
         buf.writeByte('I');

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -232,9 +232,9 @@ unittest
 /************************************
  * Convert MODxxxx to STCxxx
  */
-StorageClass ModToStc(uint mod) pure nothrow @nogc @safe
+STC ModToStc(uint mod) pure nothrow @nogc @safe
 {
-    StorageClass stc = STC.none;
+    STC stc = STC.none;
     if (mod & MODFlags.immutable_)
         stc |= STC.immutable_;
     if (mod & MODFlags.const_)
@@ -1108,7 +1108,7 @@ extern (C++) abstract class Type : ASTNode
      * Apply STCxxxx bits to existing type.
      * Use *before* semantic analysis is run.
      */
-    extern (D) final Type addSTC(StorageClass stc)
+    extern (D) final Type addSTC(STC stc)
     {
         Type t = this;
         if (t.isImmutable())
@@ -2499,7 +2499,7 @@ extern (C++) final class TypeFunction : TypeNext
     byte inuse;
     ArgumentList inferenceArguments; // function arguments to determine `auto ref` in type semantic
 
-    extern (D) this(ParameterList pl, Type treturn, LINK linkage, StorageClass stc = STC.none) @safe
+    extern (D) this(ParameterList pl, Type treturn, LINK linkage, STC stc = STC.none) @safe
     {
         super(Tfunction, treturn);
         //if (!treturn) *(char*)0=0;
@@ -2543,7 +2543,7 @@ extern (C++) final class TypeFunction : TypeNext
 
     static TypeFunction create(Parameters* parameters, Type treturn, ubyte varargs, LINK linkage, StorageClass stc = STC.none) @safe
     {
-        return new TypeFunction(ParameterList(parameters, cast(VarArg)varargs), treturn, linkage, stc);
+        return new TypeFunction(ParameterList(parameters, cast(VarArg)varargs), treturn, linkage, cast(STC) stc);
     }
 
     override const(char)* kind() const
@@ -3806,11 +3806,11 @@ extern (C++) struct ParameterList
 {
     /// The raw (unexpanded) formal parameters, possibly containing tuples.
     Parameters* parameters;
-    StorageClass stc;                   // storage class of ...
+    STC stc;                   // storage class of ...
     VarArg varargs = VarArg.none;
     bool hasIdentifierList;             // true if C identifier-list style
 
-    this(Parameters* parameters, VarArg varargs = VarArg.none, StorageClass stc = STC.none) @safe
+    this(Parameters* parameters, VarArg varargs = VarArg.none, STC stc = STC.none) @safe
     {
         this.parameters = parameters;
         this.varargs = varargs;
@@ -3909,13 +3909,13 @@ extern (C++) final class Parameter : ASTNode
     import dmd.attrib : UserAttributeDeclaration;
 
     Loc loc;
-    StorageClass storageClass;
+    STC storageClass;
     Type type;
     Identifier ident;
     Expression defaultArg;
     UserAttributeDeclaration userAttribDecl; // user defined attributes
 
-    extern (D) this(Loc loc, StorageClass storageClass, Type type, Identifier ident, Expression defaultArg, UserAttributeDeclaration userAttribDecl) @safe
+    extern (D) this(Loc loc, STC storageClass, Type type, Identifier ident, Expression defaultArg, UserAttributeDeclaration userAttribDecl) @safe
     {
         this.loc = loc;
         this.type = type;
@@ -3927,7 +3927,7 @@ extern (C++) final class Parameter : ASTNode
 
     static Parameter create(Loc loc, StorageClass storageClass, Type type, Identifier ident, Expression defaultArg, UserAttributeDeclaration userAttribDecl) @safe
     {
-        return new Parameter(loc, storageClass, type, ident, defaultArg, userAttribDecl);
+        return new Parameter(loc, cast(STC) storageClass, type, ident, defaultArg, userAttribDecl);
     }
 
     Parameter syntaxCopy()
@@ -4153,7 +4153,7 @@ extern (C++) final class Parameter : ASTNode
         return isCovariantScope(returnByRef, thisSTC, otherSTC);
     }
 
-    extern (D) static bool isCovariantScope(bool returnByRef, StorageClass from, StorageClass to) pure nothrow @nogc @safe
+    extern (D) static bool isCovariantScope(bool returnByRef, STC from, STC to) pure nothrow @nogc @safe
     {
         // Workaround for failing covariance when finding a common type of delegates,
         // some of which have parameters with inferred scope
@@ -4340,13 +4340,13 @@ bool isIndexableNonAggregate(Type t)
 
 /***************************************
  * Computes how a parameter may be returned.
- * Shrinking the representation is necessary because StorageClass is so wide
+ * Shrinking the representation is necessary because STC is so wide
  * Params:
  *   stc = storage class of parameter
  * Returns:
  *   value from enum ScopeRef
  */
-ScopeRef buildScopeRef(StorageClass stc) pure nothrow @nogc @safe
+ScopeRef buildScopeRef(STC stc) pure nothrow @nogc @safe
 {
     if (stc & STC.out_)
         stc |= STC.ref_;        // treat `out` and `ref` the same

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -536,7 +536,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     }
                     // Workaround 14894. Add an empty unittest declaration to keep
                     // the number of symbols in this scope independent of -unittest.
-                    s = new AST.UnitTestDeclaration(loc, token.loc, STC.undefined_, null);
+                    s = new AST.UnitTestDeclaration(loc, token.loc, STC.none, null);
                 }
                 break;
 
@@ -744,7 +744,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                 a = parseBlock(pLastDecl, pAttrs);
                 auto stc2 = getStorageClass!AST(pAttrs);
-                if (stc2 != STC.undefined_)
+                if (stc2 != STC.none)
                 {
                     s = new AST.StorageClassDeclaration(scdLoc, stc2, a);
                 }
@@ -1332,7 +1332,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (udas is null)
                 udas = new AST.Expressions();
             udas.push(exp);
-            return 0;
+            return STC.none;
         }
 
         AST.Expression templateArgToExp(RootObject o, Loc loc)
@@ -1359,7 +1359,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             auto args = parseTemplateArgumentList();
             foreach (arg; *args)
                 udas.push(templateArgToExp(arg, token.loc));
-            return 0;
+            return STC.none;
         }
 
         if (auto o = parseTemplateSingleArgument())
@@ -1367,7 +1367,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (udas is null)
                 udas = new AST.Expressions();
             udas.push(templateArgToExp(o, token.loc));
-            return 0;
+            return STC.none;
         }
 
         if (token.isKeyword())
@@ -1375,7 +1375,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         else
             error("`@identifier` or `@(ArgumentList)` expected, not `@%s`", token.toChars());
 
-        return 0;
+        return STC.none;
     }
 
     /***********************************************
@@ -1460,7 +1460,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
     private StorageClass parseTypeCtor()
     {
-        StorageClass storageClass = STC.undefined_;
+        StorageClass storageClass = STC.none;
 
         while (1)
         {
@@ -2802,7 +2802,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         {
             Identifier ai = null;
             AST.Type at;
-            StorageClass storageClass = 0;
+            StorageClass storageClass = STC.none;
             StorageClass stc;
             AST.Expression ae;
             AST.Expressions* udas = null;
@@ -3499,7 +3499,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
          *        shared inout type
          *  shared inout const type
          */
-        StorageClass stc = 0;
+        StorageClass stc = STC.none;
         while (1)
         {
             switch (token.value)
@@ -3983,7 +3983,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                     auto parameterList = parseParameterList(null);
 
-                    StorageClass stc = parsePostfix(STC.undefined_, null);
+                    StorageClass stc = parsePostfix(STC.none, null);
                     auto tf = new AST.TypeFunction(parameterList, t, linkage, stc);
                     if (stc & (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild | STC.return_))
                     {
@@ -4019,7 +4019,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Reference: https://dlang.org/spec/declaration.html#Declarator
      */
     private AST.Type parseDeclarator(AST.Type t, ref int palt, Identifier* pident,
-        AST.TemplateParameters** tpl = null, StorageClass storageClass = 0,
+        AST.TemplateParameters** tpl = null, StorageClass storageClass = STC.none,
         bool* pdisable = null, AST.Expressions** pudas = null)
     {
         //printf("parseDeclarator(tpl = %p)\n", tpl);
@@ -4369,7 +4369,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      */
     private AST.Dsymbols* parseDeclarations(bool autodecl, PrefixAttributes!AST* pAttrs, const(char)* comment)
     {
-        StorageClass storage_class = STC.undefined_;
+        StorageClass storage_class = STC.none;
         LINK link = linkage;
         Loc linkloc = this.linkLoc;
         bool setAlignment = false;
@@ -4500,7 +4500,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         if (pAttrs)
         {
             storage_class |= pAttrs.storageClass;
-            //pAttrs.storageClass = STC.undefined_;
+            //pAttrs.storageClass = STC.none;
         }
 
         AST.Type tfirst = null;
@@ -4606,9 +4606,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                 AST.Expression constraint = null;
                 //printf("%s funcdecl t = %s, storage_class = x%lx\n", loc.toChars(), t.toChars(), storage_class);
-                auto f = new AST.FuncDeclaration(loc, Loc.initial, ident, storage_class | (disable ? STC.disable : 0), t);
+                auto f = new AST.FuncDeclaration(loc, Loc.initial, ident, storage_class | (disable ? STC.disable : STC.none), t);
                 if (pAttrs)
-                    pAttrs.storageClass = STC.undefined_;
+                    pAttrs.storageClass = STC.none;
                 if (tpl)
                     constraint = parseConstraint();
                 AST.Dsymbol s = parseContracts(f, !!tpl);
@@ -4644,7 +4644,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     auto tempdecl = new AST.TemplateDeclaration(loc, tplIdent, tpl, constraint, decldefs);
                     s = tempdecl;
 
-                    StorageClass stc2 = STC.undefined_;
+                    StorageClass stc2 = STC.none;
                     if (storage_class & STC.static_)
                     {
                         assert(f.storage_class & STC.static_);
@@ -4657,7 +4657,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         f.storage_class &= ~STC.deprecated_;
                         stc2 |= STC.deprecated_;
                     }
-                    if (stc2 != STC.undefined_)
+                    if (stc2 != STC.none)
                     {
                         auto ax = new AST.Dsymbols();
                         ax.push(s);
@@ -4697,7 +4697,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     auto v = new AST.VarDeclaration(loc, t, ident, _init);
                     v.storage_class = storage_class;
                     if (pAttrs)
-                        pAttrs.storageClass = STC.undefined_;
+                        pAttrs.storageClass = STC.none;
                     s = v;
                 }
 
@@ -4812,7 +4812,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         Loc linkloc = this.linkLoc;
         AST.Expressions* udas;
         LINK link = linkage;
-        StorageClass storage_class = STC.undefined_;
+        StorageClass storage_class = STC.none;
         AST.Expression ealign;
         bool setAlignment = false;
 
@@ -4870,7 +4870,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         return;
                     hasParsedAttributes = true;
                     udas = null;
-                    storage_class = STC.undefined_;
+                    storage_class = STC.none;
                     link = linkage;
                     linkloc = this.linkLoc;
                     setAlignment = false;
@@ -5058,7 +5058,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         AST.TemplateParameters* tpl = null;
         AST.ParameterList parameterList;
         AST.Type tret = null;
-        StorageClass stc = 0;
+        StorageClass stc = STC.none;
         TOK save = TOK.reserved;
 
         switch (token.value)
@@ -5485,8 +5485,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             AST.Type at;
             Loc aloc;
 
-            StorageClass storageClass = 0;
-            StorageClass stc = 0;
+            StorageClass storageClass = STC.none;
+            StorageClass stc = STC.none;
         Lagain:
             if (stc)
             {
@@ -5663,8 +5663,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     AST.Parameter parseAssignCondition()
     {
         AST.Parameter param = null;
-        StorageClass storageClass = 0;
-        StorageClass stc = 0;
+        StorageClass storageClass = STC.none;
+        StorageClass stc = STC.none;
     Lwhile:
         while (1)
         {
@@ -7005,7 +7005,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         Loc labelloc;
 
         nextToken();
-        StorageClass stc = parsePostfix(STC.undefined_, null);  // optional FunctionAttributes
+        StorageClass stc = parsePostfix(STC.none, null);  // optional FunctionAttributes
         if (stc & (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild))
             error("`const`/`immutable`/`shared`/`inout` attributes are not allowed on `asm` blocks");
 
@@ -9600,7 +9600,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                (ident == Id.live)     ? STC.live     :
                (ident == Id.future)   ? STC.future   :
                (ident == Id.disable)  ? STC.disable  :
-               0;
+               STC.none;
     }
 
     enum StorageClass atAttrGroup =
@@ -9854,11 +9854,11 @@ private enum CARRAYDECL = 1;
  */
 private StorageClass getStorageClass(AST)(PrefixAttributes!(AST)* pAttrs)
 {
-    StorageClass stc = STC.undefined_;
+    StorageClass stc = STC.none;
     if (pAttrs)
     {
         stc = pAttrs.storageClass;
-        pAttrs.storageClass = STC.undefined_;
+        pAttrs.storageClass = STC.none;
     }
     return stc;
 }

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -327,7 +327,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 pAttrs.comment = token.blockComment.ptr;
             }
             AST.Visibility.Kind prot;
-            StorageClass stc;
+            STC stc;
             AST.Condition condition;
 
             linkage = linksave;
@@ -1101,7 +1101,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Starts with token on the first ident.
      * Ends with scanner past closing ';'
      */
-    private AST.Dsymbols* parseAutoDeclarations(StorageClass storageClass, const(char)* comment)
+    private AST.Dsymbols* parseAutoDeclarations(STC storageClass, const(char)* comment)
     {
         //printf("parseAutoDeclarations\n");
         auto a = new AST.Dsymbols();
@@ -1216,9 +1216,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Returns:
      *   The combination of both storage classes (`orig | added`).
      */
-    private StorageClass appendStorageClass(StorageClass orig, StorageClass added)
+    private STC appendStorageClass(STC orig, STC added)
     {
-        void checkConflictSTCGroup(bool at = false)(StorageClass group)
+        void checkConflictSTCGroup(bool at = false)(STC group)
         {
             if (added & group && orig & group & ((orig & group) - 1))
                 error(
@@ -1308,13 +1308,13 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      *   If the attribute is builtin, the return value will be non-zero.
      *   Otherwise, 0 is returned, and `pudas` will be appended to.
      */
-    private StorageClass parseAttribute(ref AST.Expressions* udas)
+    private STC parseAttribute(ref AST.Expressions* udas)
     {
         nextToken();
         if (token.value == TOK.identifier)
         {
             // If we find a builtin attribute, we're done, return immediately.
-            if (StorageClass stc = isBuiltinAtAttribute(token.ident))
+            if (STC stc = isBuiltinAtAttribute(token.ident))
                 return stc;
 
             // Allow identifier, template instantiation, or function call
@@ -1381,11 +1381,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     /***********************************************
      * Parse const/immutable/shared/inout/nothrow/pure postfix
      */
-    private StorageClass parsePostfix(StorageClass storageClass, AST.Expressions** pudas)
+    private STC parsePostfix(STC storageClass, AST.Expressions** pudas)
     {
         while (1)
         {
-            StorageClass stc;
+            STC stc;
             switch (token.value)
             {
             case TOK.const_:
@@ -1458,16 +1458,16 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         }
     }
 
-    private StorageClass parseTypeCtor()
+    private STC parseTypeCtor()
     {
-        StorageClass storageClass = STC.none;
+        STC storageClass = STC.none;
 
         while (1)
         {
             if (peekNext() == TOK.leftParenthesis)
                 return storageClass;
 
-            StorageClass stc;
+            STC stc;
             switch (token.value)
             {
             case TOK.const_:
@@ -2411,7 +2411,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         AST.Expressions* udas = null;
         const loc = token.loc;
-        StorageClass stc = getStorageClass!AST(pAttrs);
+        STC stc = getStorageClass!AST(pAttrs);
 
         nextToken();
         if (token.value == TOK.leftParenthesis && peekNext() == TOK.this_ && peekNext2() == TOK.rightParenthesis)
@@ -2462,7 +2462,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (stc & STC.static_)
                 error(loc, "constructor cannot be static");
         }
-        else if (StorageClass ss = stc & (STC.shared_ | STC.static_)) // this()
+        else if (STC ss = stc & (STC.shared_ | STC.static_)) // this()
         {
             if (ss == STC.static_)
                 error(loc, "use `static this()` to declare a static constructor");
@@ -2504,7 +2504,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         AST.Expressions* udas = null;
         const loc = token.loc;
-        StorageClass stc = getStorageClass!AST(pAttrs);
+        STC stc = getStorageClass!AST(pAttrs);
 
         nextToken();
         check(TOK.this_);
@@ -2512,7 +2512,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         check(TOK.rightParenthesis);
 
         stc = parsePostfix(stc, &udas);
-        if (StorageClass ss = stc & (STC.shared_ | STC.static_))
+        if (STC ss = stc & (STC.shared_ | STC.static_))
         {
             if (ss == STC.static_)
                 error(loc, "use `static ~this()` to declare a static destructor");
@@ -2540,7 +2540,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         //Expressions *udas = NULL;
         const loc = token.loc;
-        StorageClass stc = getStorageClass!AST(pAttrs);
+        STC stc = getStorageClass!AST(pAttrs);
 
         nextToken();
         nextToken();
@@ -2552,7 +2552,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             error(loc, "use `shared static this()` to declare a shared static constructor");
         else if (stc & STC.static_)
             appendStorageClass(stc, STC.static_); // complaint for the redundancy
-        else if (StorageClass modStc = stc & STC.TYPECTOR)
+        else if (STC modStc = stc & STC.TYPECTOR)
         {
             OutBuffer buf;
             AST.stcToBuffer(buf, modStc);
@@ -2574,7 +2574,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         AST.Expressions* udas = null;
         const loc = token.loc;
-        StorageClass stc = getStorageClass!AST(pAttrs);
+        STC stc = getStorageClass!AST(pAttrs);
 
         nextToken();
         nextToken();
@@ -2587,7 +2587,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             error(loc, "use `shared static ~this()` to declare a shared static destructor");
         else if (stc & STC.static_)
             appendStorageClass(stc, STC.static_); // complaint for the redundancy
-        else if (StorageClass modStc = stc & STC.TYPECTOR)
+        else if (STC modStc = stc & STC.TYPECTOR)
         {
             OutBuffer buf;
             AST.stcToBuffer(buf, modStc);
@@ -2615,7 +2615,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         //Expressions *udas = NULL;
         const loc = token.loc;
-        StorageClass stc = getStorageClass!AST(pAttrs);
+        STC stc = getStorageClass!AST(pAttrs);
 
         nextToken();
         nextToken();
@@ -2624,9 +2624,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         check(TOK.rightParenthesis);
 
         stc = parsePostfix(stc & ~STC.TYPECTOR, null) | stc;
-        if (StorageClass ss = stc & (STC.shared_ | STC.static_))
+        if (STC ss = stc & (STC.shared_ | STC.static_))
             appendStorageClass(stc, ss); // complaint for the redundancy
-        else if (StorageClass modStc = stc & STC.TYPECTOR)
+        else if (STC modStc = stc & STC.TYPECTOR)
         {
             OutBuffer buf;
             AST.stcToBuffer(buf, modStc);
@@ -2648,7 +2648,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         AST.Expressions* udas = null;
         const loc = token.loc;
-        StorageClass stc = getStorageClass!AST(pAttrs);
+        STC stc = getStorageClass!AST(pAttrs);
 
         nextToken();
         nextToken();
@@ -2658,9 +2658,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         check(TOK.rightParenthesis);
 
         stc = parsePostfix(stc & ~STC.TYPECTOR, &udas) | stc;
-        if (StorageClass ss = stc & (STC.shared_ | STC.static_))
+        if (STC ss = stc & (STC.shared_ | STC.static_))
             appendStorageClass(stc, ss); // complaint for the redundancy
-        else if (StorageClass modStc = stc & STC.TYPECTOR)
+        else if (STC modStc = stc & STC.TYPECTOR)
         {
             OutBuffer buf;
             AST.stcToBuffer(buf, modStc);
@@ -2689,7 +2689,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     private AST.Dsymbol parseInvariant(PrefixAttributes!AST* pAttrs)
     {
         const loc = token.loc;
-        StorageClass stc = getStorageClass!AST(pAttrs);
+        STC stc = getStorageClass!AST(pAttrs);
 
         nextToken();
         if (token.value == TOK.leftParenthesis) // optional () or invariant (expression);
@@ -2731,7 +2731,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     private AST.Dsymbol parseUnitTest(PrefixAttributes!AST* pAttrs)
     {
         const loc = token.loc;
-        StorageClass stc = getStorageClass!AST(pAttrs);
+        STC stc = getStorageClass!AST(pAttrs);
 
         nextToken();
 
@@ -2773,7 +2773,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     private AST.Dsymbol parseNewDeclaration(PrefixAttributes!AST* pAttrs)
     {
         const loc = token.loc;
-        StorageClass stc = getStorageClass!AST(pAttrs);
+        STC stc = getStorageClass!AST(pAttrs);
         if (!(stc & STC.disable))
         {
             error("`new` allocator must be annotated with `@disabled`");
@@ -2792,7 +2792,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         auto parameters = new AST.Parameters();
         VarArg varargs = VarArg.none;
-        StorageClass varargsStc;
+        STC varargsStc;
 
         // Attributes allowed for ...
         enum VarArgsStc = STC.const_ | STC.immutable_ | STC.shared_ | STC.scope_ | STC.return_ | STC.returnScope;
@@ -2802,8 +2802,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         {
             Identifier ai = null;
             AST.Type at;
-            StorageClass storageClass = STC.none;
-            StorageClass stc;
+            STC storageClass = STC.none;
+            STC stc;
             AST.Expression ae;
             AST.Expressions* udas = null;
             for (; 1; nextToken())
@@ -2855,7 +2855,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 case TOK.at:
                     {
                         AST.Expressions* exps = null;
-                        StorageClass stc2 = parseAttribute(exps);
+                        STC stc2 = parseAttribute(exps);
                         if (stc2 & atAttrGroup)
                         {
                             error("`@%s` attribute for function parameter is not supported", token.toChars());
@@ -2961,7 +2961,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         if (token.value == TOK.at)
                         {
                             AST.Expressions* exps = null;
-                            StorageClass stc2 = parseAttribute(exps);
+                            STC stc2 = parseAttribute(exps);
                             if (stc2 & atAttrGroup)
                             {
                                 error("`@%s` attribute for function parameter is not supported", token.toChars());
@@ -3059,7 +3059,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 Identifier ident = null;
 
                 AST.Expressions* udas;
-                StorageClass stc;
+                STC stc;
                 AST.Expression deprecationMessage;
                 enum attributeErrorMessage = "`%s` is not a valid attribute for enum members";
             Lattrs:
@@ -3068,7 +3068,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     switch (token.value)
                     {
                         case TOK.at:
-                            if (StorageClass _stc = parseAttribute(udas))
+                            if (STC _stc = parseAttribute(udas))
                             {
                                 if (_stc == STC.disable)
                                     stc |= _stc;
@@ -3499,7 +3499,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
          *        shared inout type
          *  shared inout const type
          */
-        StorageClass stc = STC.none;
+        STC stc = STC.none;
         while (1)
         {
             switch (token.value)
@@ -3983,7 +3983,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                     auto parameterList = parseParameterList(null);
 
-                    StorageClass stc = parsePostfix(STC.none, null);
+                    STC stc = parsePostfix(STC.none, null);
                     auto tf = new AST.TypeFunction(parameterList, t, linkage, stc);
                     if (stc & (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild | STC.return_))
                     {
@@ -4019,7 +4019,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Reference: https://dlang.org/spec/declaration.html#Declarator
      */
     private AST.Type parseDeclarator(AST.Type t, ref int palt, Identifier* pident,
-        AST.TemplateParameters** tpl = null, StorageClass storageClass = STC.none,
+        AST.TemplateParameters** tpl = null, STC storageClass = STC.none,
         bool* pdisable = null, AST.Expressions** pudas = null)
     {
         //printf("parseDeclarator(tpl = %p)\n", tpl);
@@ -4160,7 +4160,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     /* Parse const/immutable/shared/inout/nothrow/pure/return postfix
                      */
                     // merge prefix storage classes
-                    StorageClass stc = parsePostfix(storageClass, pudas);
+                    STC stc = parsePostfix(storageClass, pudas);
 
                     AST.Type tf = new AST.TypeFunction(parameterList, t, linkage, stc);
                     tf = tf.addSTC(stc);
@@ -4187,11 +4187,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         return ts;
     }
 
-    private void parseStorageClasses(ref StorageClass storage_class, ref LINK link,
+    private void parseStorageClasses(ref STC storage_class, ref LINK link,
         ref bool setAlignment, ref AST.Expression ealign, ref AST.Expressions* udas,
         out Loc linkloc)
     {
-        StorageClass stc;
+        STC stc;
         bool sawLinkage = false; // seen a linkage declaration
 
         linkloc = Loc.initial;
@@ -4369,7 +4369,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      */
     private AST.Dsymbols* parseDeclarations(bool autodecl, PrefixAttributes!AST* pAttrs, const(char)* comment)
     {
-        StorageClass storage_class = STC.none;
+        STC storage_class = STC.none;
         LINK link = linkage;
         Loc linkloc = this.linkLoc;
         bool setAlignment = false;
@@ -4644,7 +4644,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     auto tempdecl = new AST.TemplateDeclaration(loc, tplIdent, tpl, constraint, decldefs);
                     s = tempdecl;
 
-                    StorageClass stc2 = STC.none;
+                    STC stc2 = STC.none;
                     if (storage_class & STC.static_)
                     {
                         assert(f.storage_class & STC.static_);
@@ -4812,7 +4812,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         Loc linkloc = this.linkLoc;
         AST.Expressions* udas;
         LINK link = linkage;
-        StorageClass storage_class = STC.none;
+        STC storage_class = STC.none;
         AST.Expression ealign;
         bool setAlignment = false;
 
@@ -4885,7 +4885,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 AST.Dsymbol s;
 
                 bool attributesAppended;
-                const StorageClass funcStc = parseTypeCtor();
+                const STC funcStc = parseTypeCtor();
                 Token* tk;
                 // function literal?
                 if (token.value == TOK.function_ ||
@@ -5058,7 +5058,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         AST.TemplateParameters* tpl = null;
         AST.ParameterList parameterList;
         AST.Type tret = null;
-        StorageClass stc = STC.none;
+        STC stc = STC.none;
         TOK save = TOK.reserved;
 
         switch (token.value)
@@ -5137,7 +5137,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 // (parameters) { statements... }
                 parameterList = parseParameterList(&tpl);
                 stc = parsePostfix(stc, null);
-                if (StorageClass modStc = stc & STC.TYPECTOR)
+                if (STC modStc = stc & STC.TYPECTOR)
                 {
                     if (save == TOK.function_)
                     {
@@ -5485,8 +5485,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             AST.Type at;
             Loc aloc;
 
-            StorageClass storageClass = STC.none;
-            StorageClass stc = STC.none;
+            STC storageClass = STC.none;
+            STC stc = STC.none;
         Lagain:
             if (stc)
             {
@@ -5663,8 +5663,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     AST.Parameter parseAssignCondition()
     {
         AST.Parameter param = null;
-        StorageClass storageClass = STC.none;
-        StorageClass stc = STC.none;
+        STC storageClass = STC.none;
+        STC stc = STC.none;
     Lwhile:
         while (1)
         {
@@ -7005,7 +7005,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         Loc labelloc;
 
         nextToken();
-        StorageClass stc = parsePostfix(STC.none, null);  // optional FunctionAttributes
+        STC stc = parsePostfix(STC.none, null);  // optional FunctionAttributes
         if (stc & (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild))
             error("`const`/`immutable`/`shared`/`inout` attributes are not allowed on `asm` blocks");
 
@@ -8773,7 +8773,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         case TOK.const_:
         case TOK.immutable_: // immutable(type)(arguments) / immutable(type).init
             {
-                StorageClass stc = parseTypeCtor();
+                STC stc = parseTypeCtor();
 
                 AST.Type t = parseBasicType();
                 t = t.addSTC(stc);
@@ -9590,7 +9590,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Returns:
      *  storage class for attribute, 0 if not
      */
-    static StorageClass isBuiltinAtAttribute(Identifier ident)
+    static STC isBuiltinAtAttribute(Identifier ident)
     {
         return (ident == Id.property) ? STC.property :
                (ident == Id.nogc)     ? STC.nogc     :
@@ -9603,7 +9603,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                STC.none;
     }
 
-    enum StorageClass atAttrGroup =
+    enum STC atAttrGroup =
                 STC.property |
                 STC.nogc     |
                 STC.safe     |
@@ -9800,7 +9800,7 @@ enum ParseStatementFlags : int
 
 struct PrefixAttributes(AST)
 {
-    StorageClass storageClass;
+    STC storageClass;
     AST.Expression depmsg;
     LINK link;
     AST.Visibility visibility;
@@ -9852,9 +9852,9 @@ private enum CARRAYDECL = 1;
 /*****************************
  * Destructively extract storage class from pAttrs.
  */
-private StorageClass getStorageClass(AST)(PrefixAttributes!(AST)* pAttrs)
+private STC getStorageClass(AST)(PrefixAttributes!(AST)* pAttrs)
 {
-    StorageClass stc = STC.none;
+    STC stc = STC.none;
     if (pAttrs)
     {
         stc = pAttrs.storageClass;

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -478,7 +478,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 foreach (i, fparam; f.parameterList)
                 {
                     Identifier id = fparam.ident;
-                    StorageClass stc = 0;
+                    StorageClass stc = STC.none;
                     if (!id)
                     {
                         /* Generate identifier for un-named parameter,
@@ -1349,7 +1349,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             sc = sc.push();
             if (funcdecl.isCtorDeclaration()) // https://issues.dlang.org/show_bug.cgi?id=#15665
                 f.isCtor = true;
-            sc.stc = 0;
+            sc.stc = STC.none;
             sc.linkage = funcdecl._linkage; // https://issues.dlang.org/show_bug.cgi?id=8496
             funcdecl.type = f.typeSemantic(funcdecl.loc, sc);
             sc = sc.pop();
@@ -1489,9 +1489,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 // storage_class is apparently not set for dtor & ctor
                 OutBuffer ob;
                 stcToBuffer(ob,
-                    (ngErr ? STC.nogc : 0) |
-                    (puErr ? STC.pure_ : 0) |
-                    (saErr ? STC.system : 0)
+                    (ngErr ? STC.nogc : STC.none) |
+                    (puErr ? STC.pure_ : STC.none) |
+                    (saErr ? STC.system : STC.none)
                 );
                 ctor.loc.error("`%s` has stricter attributes than its destructor (`%s`)", ctor.toPrettyChars(), ob.peekChars());
                 ctor.loc.errorSupplemental("The destructor will be called if an exception is thrown");

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -478,7 +478,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 foreach (i, fparam; f.parameterList)
                 {
                     Identifier id = fparam.ident;
-                    StorageClass stc = STC.none;
+                    STC stc = STC.none;
                     if (!id)
                     {
                         /* Generate identifier for un-named parameter,

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -374,7 +374,7 @@ bool discardValue(Expression e)
  * Returns:
  *  Newly created temporary variable.
  */
-VarDeclaration copyToTemp(StorageClass stc, const char[] name, Expression e)
+VarDeclaration copyToTemp(STC stc, const char[] name, Expression e)
 {
     assert(name[0] == '_' && name[1] == '_');
     auto vd = new VarDeclaration(e.loc, e.type,

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -413,7 +413,7 @@ Expression extractSideEffect(Scope* sc, const char[] name,
         (sc.ctfe ? !hasSideEffect(e) : isTrivialExp(e)))
         return e;
 
-    auto vd = copyToTemp(0, name, e);
+    auto vd = copyToTemp(STC.none, name, e);
     vd.storage_class |= e.isLvalue() ? STC.ref_ : STC.rvalue;
 
     e0 = Expression.combine(e0, new DeclarationExp(vd.loc, vd)

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1799,7 +1799,7 @@ extern (C++) final class InlineAsmStatement : AsmStatement
  */
 extern (C++) final class GccAsmStatement : AsmStatement
 {
-    StorageClass stc;           // attributes of the asm {} block
+    STC stc;           // attributes of the asm {} block
     Expression insn;            // string expression that is the template for assembler code
     Expressions* args;          // input and output operands of the statement
     uint outputargs;            // of the operands in 'args', the number of output operands
@@ -1830,9 +1830,9 @@ extern (C++) final class GccAsmStatement : AsmStatement
  */
 extern (C++) final class CompoundAsmStatement : CompoundStatement
 {
-    StorageClass stc; // postfix attributes like nothrow/pure/@trusted
+    STC stc; // postfix attributes like nothrow/pure/@trusted
 
-    extern (D) this(Loc loc, Statements* statements, StorageClass stc) @safe
+    extern (D) this(Loc loc, Statements* statements, STC stc) @safe
     {
         super(loc, statements, STMT.CompoundAsm);
         this.stc = stc;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3990,7 +3990,7 @@ private FuncExp foreachBodyToFunction(Scope* sc, ForeachStatement fs, TypeFuncti
     auto params = new Parameters();
     foreach (i, p; *fs.parameters)
     {
-        StorageClass stc = STC.ref_ | (p.storageClass & STC.scope_);
+        STC stc = STC.ref_ | (p.storageClass & STC.scope_);
         Identifier id;
 
         p.type = p.type.typeSemantic(fs.loc, sc);
@@ -4034,7 +4034,7 @@ private FuncExp foreachBodyToFunction(Scope* sc, ForeachStatement fs, TypeFuncti
     }
     // https://issues.dlang.org/show_bug.cgi?id=13840
     // Throwable nested function inside nothrow function is acceptable.
-    StorageClass stc = mergeFuncAttrs(STC.safe | STC.pure_ | STC.nogc, fs.func);
+    STC stc = mergeFuncAttrs(STC.safe | STC.pure_ | STC.nogc, fs.func);
     auto tf = new TypeFunction(ParameterList(params), Type.tint32, LINK.d, stc);
     fs.cases = new Statements();
     fs.gotos = new ScopeStatements();
@@ -4099,7 +4099,7 @@ void catchSemantic(Catch c, Scope* sc)
         return;
     }
 
-    StorageClass stc;
+    STC stc;
     auto cd = c.type.toBasetype().isClassHandle();
     if (!cd)
     {
@@ -4449,7 +4449,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
          * Returns:
          *     `true` iff the declaration was successful.
          */
-        bool declareVariable(StorageClass storageClass, Type type, Identifier ident, Expression e, Type t)
+        bool declareVariable(STC storageClass, Type type, Identifier ident, Expression e, Type t)
         {
             if (storageClass & (STC.out_ | STC.lazy_) ||
                 storageClass & STC.ref_ && !te)

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1291,7 +1291,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 }
                 else
                 {
-                    r = copyToTemp(0, "__r", fs.aggr);
+                    r = copyToTemp(STC.none, "__r", fs.aggr);
                     r.dsymbolSemantic(sc);
                     _init = new ExpStatement(loc, r);
                     if (vinit)
@@ -3074,14 +3074,14 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                  *  _d_monitorenter(tmp);
                  *  try { body } finally { _d_monitorexit(tmp); }
                  */
-                auto tmp = copyToTemp(0, "__sync", ss.exp);
+                auto tmp = copyToTemp(STC.none, "__sync", ss.exp);
                 tmp.dsymbolSemantic(sc);
 
                 auto cs = new Statements();
                 cs.push(new ExpStatement(ss.loc, tmp));
 
                 auto args = new Parameters();
-                args.push(new Parameter(Loc.initial, 0, ClassDeclaration.object.type, null, null, null));
+                args.push(new Parameter(Loc.initial, STC.none, ClassDeclaration.object.type, null, null, null));
 
                 FuncDeclaration fdenter = FuncDeclaration.genCfunc(args, Type.tvoid, Id.monitorenter);
                 Expression e = new CallExp(ss.loc, fdenter, new VarExp(ss.loc, tmp));
@@ -3123,7 +3123,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             cs.push(new ExpStatement(ss.loc, v));
 
             auto enterArgs = new Parameters();
-            enterArgs.push(new Parameter(Loc.initial, 0, t.pointerTo(), null, null, null));
+            enterArgs.push(new Parameter(Loc.initial, STC.none, t.pointerTo(), null, null, null));
 
             FuncDeclaration fdenter = FuncDeclaration.genCfunc(enterArgs, Type.tvoid, Id.criticalenter, STC.nothrow_);
             Expression e = new AddrExp(ss.loc, tmpExp);
@@ -3133,7 +3133,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             cs.push(new ExpStatement(ss.loc, e));
 
             auto exitArgs = new Parameters();
-            exitArgs.push(new Parameter(Loc.initial, 0, t, null, null, null));
+            exitArgs.push(new Parameter(Loc.initial, STC.none, t, null, null, null));
 
             FuncDeclaration fdexit = FuncDeclaration.genCfunc(exitArgs, Type.tvoid, Id.criticalexit, STC.nothrow_);
             e = new CallExp(ss.loc, fdexit, tmpExp);
@@ -3220,7 +3220,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                      *   }
                      * }
                      */
-                    auto tmp = copyToTemp(0, "__withtmp", ws.exp);
+                    auto tmp = copyToTemp(STC.none, "__withtmp", ws.exp);
                     tmp.dsymbolSemantic(sc);
                     auto es = new ExpStatement(ws.loc, tmp);
                     ws.exp = new VarExp(ws.loc, tmp);
@@ -3847,11 +3847,11 @@ private extern(D) Expression applyArray(ForeachStatement fs, Expression flde,
     auto params = new Parameters();
     params.push(new Parameter(Loc.initial, STC.in_, tn.arrayOf(), null, null, null));
     auto dgparams = new Parameters();
-    dgparams.push(new Parameter(Loc.initial, 0, Type.tvoidptr, null, null, null));
+    dgparams.push(new Parameter(Loc.initial, STC.none, Type.tvoidptr, null, null, null));
     if (dim == 2)
-        dgparams.push(new Parameter(Loc.initial, 0, Type.tvoidptr, null, null, null));
+        dgparams.push(new Parameter(Loc.initial, STC.none, Type.tvoidptr, null, null, null));
     dgty = new TypeDelegate(new TypeFunction(ParameterList(dgparams), Type.tint32, LINK.d));
-    params.push(new Parameter(Loc.initial, 0, dgty, null, null, null));
+    params.push(new Parameter(Loc.initial, STC.none, dgty, null, null, null));
     fdapply = FuncDeclaration.genCfunc(params, Type.tint32, fdname.ptr);
 
     if (tab.isTypeSArray())
@@ -3912,14 +3912,14 @@ private extern(D) Expression applyAssocArray(ForeachStatement fs, Expression fld
     if (!fdapply[i])
     {
         auto params = new Parameters();
-        params.push(new Parameter(Loc.initial, 0, Type.tvoid.pointerTo(), null, null, null));
+        params.push(new Parameter(Loc.initial, STC.none, Type.tvoid.pointerTo(), null, null, null));
         params.push(new Parameter(Loc.initial, STC.const_, Type.tsize_t, null, null, null));
         auto dgparams = new Parameters();
-        dgparams.push(new Parameter(Loc.initial, 0, Type.tvoidptr, null, null, null));
+        dgparams.push(new Parameter(Loc.initial, STC.none, Type.tvoidptr, null, null, null));
         if (dim == 2)
-            dgparams.push(new Parameter(Loc.initial, 0, Type.tvoidptr, null, null, null));
+            dgparams.push(new Parameter(Loc.initial, STC.none, Type.tvoidptr, null, null, null));
         fldeTy[i] = new TypeDelegate(new TypeFunction(ParameterList(dgparams), Type.tint32, LINK.d));
-        params.push(new Parameter(Loc.initial, 0, fldeTy[i], null, null, null));
+        params.push(new Parameter(Loc.initial, STC.none, fldeTy[i], null, null, null));
         fdapply[i] = FuncDeclaration.genCfunc(params, Type.tint32, i ? Id._aaApply2 : Id._aaApply);
     }
 
@@ -4256,7 +4256,7 @@ Statement scopeCode(Statement statement, Scope* sc, out Statement sentry, out St
                  *  sexception:    x = true;
                  *  sfinally: if (!x) statement;
                  */
-                auto v = copyToTemp(0, "__os", IntegerExp.createBool(false));
+                auto v = copyToTemp(STC.none, "__os", IntegerExp.createBool(false));
                 v.dsymbolSemantic(sc);
                 sentry = new ExpStatement(statement.loc, v);
 
@@ -4590,7 +4590,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
             {   // expand tuples into multiple `static foreach` variables.
                 assert(e && !t);
                 auto ident = Identifier.generateId("__value");
-                declareVariable(0, e.type, ident, e, null);
+                declareVariable(STC.none, e.type, ident, e, null);
                 import dmd.cond: StaticForeach;
                 auto field = Identifier.idPool(StaticForeach.tupleFieldName.ptr,StaticForeach.tupleFieldName.length);
                 Expression access = new DotIdExp(loc, e, field);

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -905,7 +905,7 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
         // Match attributes of tthis against attributes of fd
         if (fd.type && !fd.isCtorDeclaration() && !(td._scope.stc & STC.static_))
         {
-            StorageClass stc = td._scope.stc | fd.storage_class2;
+            STC stc = td._scope.stc | fd.storage_class2;
             // Propagate parent storage class, https://issues.dlang.org/show_bug.cgi?id=5504
             Dsymbol p = td.parent;
             while (p.isTemplateDeclaration() || p.isTemplateInstance())

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -120,7 +120,7 @@ void templateDeclarationSemantic(Scope* sc, TemplateDeclaration tempdecl)
     auto paramsym = new ScopeDsymbol();
     paramsym.parent = tempdecl.parent;
     Scope* paramscope = sc.push(paramsym);
-    paramscope.stc = 0;
+    paramscope.stc = STC.none;
 
     if (global.params.ddoc.doOutput)
     {
@@ -603,7 +603,7 @@ Scope* createScopeForTemplateParameters(TemplateDeclaration td, TemplateInstance
     paramscope.tinst = ti;
     paramscope.minst = sc.minst;
     paramscope.callsc = sc;
-    paramscope.stc = 0;
+    paramscope.stc = STC.none;
     return paramscope;
 }
 

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1523,7 +1523,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!fparams.parameters)
             return ErrorExp.get();
 
-        StorageClass stc;
+        STC stc;
 
         // Set stc to storage class of the ith parameter
         auto ex = isExpression((*e.args)[1]);

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -2348,7 +2348,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             /* Create a scope for evaluating the default arguments for the parameters
              */
             Scope* argsc = sc.push();
-            argsc.stc = 0; // don't inherit storage class
+            argsc.stc = STC.none; // don't inherit storage class
             argsc.visibility = Visibility(Visibility.Kind.public_);
             argsc.func = null;
 
@@ -2409,7 +2409,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                             StorageClass stc2 =   narg.storageClass & (STC.ref_ | STC.out_ | STC.lazy_);
                             if (stc1 && stc2 && stc1 != stc2)
                             {
-                                OutBuffer buf1;  stcToBuffer(buf1, stc1 | ((stc1 & STC.ref_) ? (fparam.storageClass & STC.auto_) : 0));
+                                OutBuffer buf1;  stcToBuffer(buf1, stc1 | ((stc1 & STC.ref_) ? (fparam.storageClass & STC.auto_) : STC.none));
                                 OutBuffer buf2;  stcToBuffer(buf2, stc2);
 
                                 .error(loc, "incompatible parameter storage classes `%s` and `%s`",
@@ -2994,7 +2994,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         {
             /* struct S s, *p;
              */
-            return returnType(mtype.resolved.addSTC(mtype.mod));
+            return returnType(mtype.resolved.addSTC(cast(STC) mtype.mod));
         }
 
         /* Find the current scope by skipping tag scopes.
@@ -3067,7 +3067,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         {
             mtype.id = Identifier.generateId("__tag"[]);
             declareTag();
-            return returnType(mtype.resolved.addSTC(mtype.mod));
+            return returnType(mtype.resolved.addSTC(cast(STC) mtype.mod));
         }
 
         /* look for pre-existing declaration
@@ -3080,7 +3080,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             if (mtype.tok == TOK.enum_ && !mtype.members)
                 .error(mtype.loc, "`enum %s` is incomplete without members", mtype.id.toChars()); // C11 6.7.2.3-3
             declareTag();
-            return returnType(mtype.resolved.addSTC(mtype.mod));
+            return returnType(mtype.resolved.addSTC(cast(STC) mtype.mod));
         }
 
         /* A redeclaration only happens if both declarations are in
@@ -3180,7 +3180,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                 declareTag();
             }
         }
-        return returnType(mtype.resolved.addSTC(mtype.mod));
+        return returnType(mtype.resolved.addSTC(cast(STC) mtype.mod));
     }
 
     switch (type.ty)
@@ -6214,7 +6214,7 @@ Type addStorageClass(Type type, StorageClass stc)
             (stc & STC.safe && t.trust < TRUST.trusted))
         {
             // Klunky to change these
-            auto tf = new TypeFunction(t.parameterList, t.next, t.linkage, 0);
+            auto tf = new TypeFunction(t.parameterList, t.next, t.linkage, STC.none);
             tf.mod = t.mod;
             tf.inferenceArguments = tf_src.inferenceArguments;
             tf.purity = t.purity;
@@ -6355,8 +6355,8 @@ Covariant covariant(Type src, Type t, StorageClass* pstc = null, bool cppCovaria
         printf("mod = %x, %x\n", src.mod, t.mod);
     }
     if (pstc)
-        *pstc = 0;
-    StorageClass stc = 0;
+        *pstc = STC.none;
+    StorageClass stc = STC.none;
 
     bool notcovariant = false;
 
@@ -6506,8 +6506,8 @@ Lcovariant:
 
     if (!t1.isRef && (t1.isScopeQual || t2.isScopeQual))
     {
-        StorageClass stc1 = t1.isScopeQual ? STC.scope_ : 0;
-        StorageClass stc2 = t2.isScopeQual ? STC.scope_ : 0;
+        StorageClass stc1 = t1.isScopeQual ? STC.scope_ : STC.none;
+        StorageClass stc2 = t2.isScopeQual ? STC.scope_ : STC.none;
         if (t1.isReturn)
         {
             stc1 |= STC.return_;

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -2404,9 +2404,9 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                             // https://issues.dlang.org/show_bug.cgi?id=12744
                             // If the storage classes of narg
                             // conflict with the ones in fparam, it's ignored.
-                            StorageClass stc  = fparam.storageClass | narg.storageClass;
-                            StorageClass stc1 = fparam.storageClass & (STC.ref_ | STC.out_ | STC.lazy_);
-                            StorageClass stc2 =   narg.storageClass & (STC.ref_ | STC.out_ | STC.lazy_);
+                            STC stc  = fparam.storageClass | narg.storageClass;
+                            STC stc1 = fparam.storageClass & (STC.ref_ | STC.out_ | STC.lazy_);
+                            STC stc2 =   narg.storageClass & (STC.ref_ | STC.out_ | STC.lazy_);
                             if (stc1 && stc2 && stc1 != stc2)
                             {
                                 OutBuffer buf1;  stcToBuffer(buf1, stc1 | ((stc1 & STC.ref_) ? (fparam.storageClass & STC.auto_) : STC.none));
@@ -6182,7 +6182,7 @@ Dsymbol toDsymbol(Type type, Scope* sc)
 /************************************
  * Add storage class modifiers to type.
  */
-Type addStorageClass(Type type, StorageClass stc)
+Type addStorageClass(Type type, STC stc)
 {
     Type visitType(Type t)
     {
@@ -6345,7 +6345,7 @@ Type getComplexLibraryType(Loc loc, Scope* sc, TY ty)
  * Returns:
  *     An enum value of either `Covariant.yes` or a reason it's not covariant.
  */
-Covariant covariant(Type src, Type t, StorageClass* pstc = null, bool cppCovariant = false)
+Covariant covariant(Type src, Type t, STC* pstc = null, bool cppCovariant = false)
 {
     version (none)
     {
@@ -6356,7 +6356,7 @@ Covariant covariant(Type src, Type t, StorageClass* pstc = null, bool cppCovaria
     }
     if (pstc)
         *pstc = STC.none;
-    StorageClass stc = STC.none;
+    STC stc = STC.none;
 
     bool notcovariant = false;
 
@@ -6506,8 +6506,8 @@ Lcovariant:
 
     if (!t1.isRef && (t1.isScopeQual || t2.isScopeQual))
     {
-        StorageClass stc1 = t1.isScopeQual ? STC.scope_ : STC.none;
-        StorageClass stc2 = t2.isScopeQual ? STC.scope_ : STC.none;
+        STC stc1 = t1.isScopeQual ? STC.scope_ : STC.none;
+        STC stc2 = t2.isScopeQual ? STC.scope_ : STC.none;
         if (t1.isReturn)
         {
             stc1 |= STC.return_;
@@ -6605,7 +6605,7 @@ Lnotcovariant:
  * Returns:
  *  storage class with STC.scope_ or STC.return_ OR'd in
  */
-StorageClass parameterStorageClass(TypeFunction tf, Type tthis, Parameter p, VarDeclarations* outerVars = null,
+STC parameterStorageClass(TypeFunction tf, Type tthis, Parameter p, VarDeclarations* outerVars = null,
     bool indirect = false)
 {
     //printf("parameterStorageClass(p: %s)\n", p.toChars());

--- a/compiler/test/unit/semantic/covariance.d
+++ b/compiler/test/unit/semantic/covariance.d
@@ -857,7 +857,7 @@ void testCovariant(Type base, Type target, in Result expected, const size_t line
     assert(base);
     assert(target);
 
-    StorageClass actualStc;
+    STC actualStc;
     const actual = base.covariant(target, &actualStc);
     enforce(!global.errors, line, "`covariant` raised an error!");
 


### PR DESCRIPTION
Adds more type safety, preventing raw integers / other enums being converted to `StorageClass`.

Rename `STC.undefined_` and `0` to `STC.none`, which is more descriptive and consistent with `MODFlags`.