### PR TITLE
Fix #20929 - #line directives mess up -verrors=context

### DIFF
--- a/compiler/test/compilable/test21177.d
+++ b/compiler/test/compilable/test21177.d
@@ -1,5 +1,6 @@
 // https://issues.dlang.org/show_bug.cgi?id=21177
 /*
+REQUIRED_ARGS: -verrors=simple
 DISABLED: win
 TEST_OUTPUT:
 ---

--- a/compiler/test/fail_compilation/fail21849.d
+++ b/compiler/test/fail_compilation/fail21849.d
@@ -29,6 +29,10 @@ void fail21849c()
     string s = "
 ß-utf"; undefined_identifier;
 }
+
+// Test correct context with line directive present
+// https://github.com/dlang/dmd/issues/20929
+#line 32
 void fail21849d()
 {
     string s = "


### PR DESCRIPTION
Closes #20929

Use the newly available `Loc.fileOffset` instead of counting lines, which is inaccurate when using `#line` directives.