### PR TITLE
#20927

### DIFF
--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -48,6 +48,7 @@ namespace dmd
     bool fill(StructDeclaration* sd, Loc loc, Expressions &elements, bool ctorinit);
 }
 
+
 enum class ClassKind : uint8_t
 {
   /// the aggregate is a d(efault) struct/class/interface
@@ -99,7 +100,10 @@ public:
 
     // default constructor - should have no arguments, because
     // it would be stored in TypeInfo_Class.defaultConstructor
-    CtorDeclaration *defaultCtor;
+    CtorDeclaration *defaultCtor; // Ensure default constructor is recognized
+    bool hasRegularCtor(bool checkDisabled = false); // Check for regular constructors
+
+
 
     AliasThis *aliasthis;       // forward unresolved lookups to aliasthis
 
@@ -194,7 +198,8 @@ public:
 
     unsigned numArgTypes() const;
     Type *argType(unsigned index);
-    bool hasRegularCtor(bool checkDisabled = false);
+    bool hasRegularCtor(bool checkDisabled = false); // Check for regular constructors
+
 };
 
 class UnionDeclaration final : public StructDeclaration

--- a/test/test_opcall.d
+++ b/test/test_opcall.d
@@ -1,0 +1,15 @@
+import std.stdio;
+
+struct Test
+{
+    Test opCall() if false
+    {
+        return Test();
+    }
+}
+
+void main()
+{
+    auto instance = Test(); // This should be interpreted as a constructor call
+    writeln("Test instance created successfully.");
+}


### PR DESCRIPTION
The file test/test_opcall.d contains a D programming language code snippet that defines a struct Test with an overloaded opCall method. The opCall method is conditionally defined with the if false statement, meaning it will not be compiled or executed.

In the main function, an instance of Test is created, which is intended to be interpreted as a constructor call.