### PR TITLE
Move Dsymbol.hasStaticCtorOrDtor to dsymbolsem

### DIFF
--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -115,11 +115,6 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         return this.include(null).foreachDsymbol( (s) { return s.hasPointers(); } ) != 0;
     }
 
-    override final bool hasStaticCtorOrDtor()
-    {
-        return this.include(null).foreachDsymbol( (s) { return s.hasStaticCtorOrDtor(); } ) != 0;
-    }
-
     /****************************************
      */
     override final void addObjcSymbols(ClassDeclarations* classes, ClassDeclarations* categories)

--- a/compiler/src/dmd/attrib.h
+++ b/compiler/src/dmd/attrib.h
@@ -30,8 +30,6 @@ public:
     Dsymbols *decl;     // array of Dsymbol's
     const char *kind() const override;
     bool hasPointers() override final;
-    bool hasStaticCtorOrDtor() override final;
-
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -813,7 +813,6 @@ public:
     bool isVirtual() const override final;
     bool addPreInvariant() override final;
     bool addPostInvariant() override final;
-    bool hasStaticCtorOrDtor() override final;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -835,7 +834,6 @@ public:
     StaticDtorDeclaration *syntaxCopy(Dsymbol *) override;
     AggregateDeclaration *isThis() override final;
     bool isVirtual() const override final;
-    bool hasStaticCtorOrDtor() override final;
     bool addPreInvariant() override final;
     bool addPostInvariant() override final;
 

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -972,12 +972,6 @@ extern (C++) class Dsymbol : ASTNode
         return false;
     }
 
-    bool hasStaticCtorOrDtor()
-    {
-        //printf("Dsymbol::hasStaticCtorOrDtor() %s\n", toChars());
-        return false;
-    }
-
     void addObjcSymbols(ClassDeclarations* classes, ClassDeclarations* categories)
     {
     }
@@ -1489,24 +1483,6 @@ public:
     Dsymbol symtabLookup(Dsymbol s, Identifier id) nothrow
     {
         return symtab.lookup(id);
-    }
-
-    /****************************************
-     * Return true if any of the members are static ctors or static dtors, or if
-     * any members have members that are.
-     */
-    override bool hasStaticCtorOrDtor()
-    {
-        if (members)
-        {
-            for (size_t i = 0; i < members.length; i++)
-            {
-                Dsymbol member = (*members)[i];
-                if (member.hasStaticCtorOrDtor())
-                    return true;
-            }
-        }
-        return false;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -244,7 +244,6 @@ public:
     virtual Visibility visible();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     virtual bool hasPointers();
-    virtual bool hasStaticCtorOrDtor();
     virtual void addObjcSymbols(ClassDeclarations *, ClassDeclarations *) { }
 
     virtual void addComment(const utf8_t *comment);
@@ -337,7 +336,6 @@ public:
     const char *kind() const override;
     virtual Dsymbol *symtabInsert(Dsymbol *s);
     virtual Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
-    bool hasStaticCtorOrDtor() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -432,4 +430,5 @@ namespace dmd
     void importAll(Dsymbol *d, Scope *sc);
     void addComment(Dsymbol *d, const char *comment);
     bool oneMember(Dsymbol *d, Dsymbol *&ps, Identifier *ident);
+    bool hasStaticCtorOrDtor(Dsymbol *d);
 }

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -53,7 +53,7 @@ import dmd.dinterpret;
 import dmd.dmodule;
 import dmd.dscope;
 import dmd.dsymbol;
-import dmd.dsymbolsem : dsymbolSemantic, checkDeprecated, aliasSemantic, search, search_correct, setScope, importAll, include;
+import dmd.dsymbolsem : dsymbolSemantic, checkDeprecated, aliasSemantic, search, search_correct, setScope, importAll, include, hasStaticCtorOrDtor;
 import dmd.errors;
 import dmd.errorsink;
 import dmd.expression;
@@ -742,11 +742,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             printf("\ttrue: no conflict\n");
         }
         return true;
-    }
-
-    override bool hasStaticCtorOrDtor()
-    {
-        return false; // don't scan uninstantiated templates
     }
 
     override const(char)* kind() const

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -602,7 +602,6 @@ public:
     virtual Visibility visible();
     virtual Dsymbol* syntaxCopy(Dsymbol* s);
     virtual bool hasPointers();
-    virtual bool hasStaticCtorOrDtor();
     virtual void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories);
     virtual void addComment(const char* comment);
     const char* comment();
@@ -712,7 +711,6 @@ public:
     const char* kind() const override;
     virtual Dsymbol* symtabInsert(Dsymbol* s);
     virtual Dsymbol* symtabLookup(Dsymbol* s, Identifier* id);
-    bool hasStaticCtorOrDtor() override;
     void accept(Visitor* v) override;
 };
 
@@ -1738,7 +1736,6 @@ public:
     Array<RootObject* >* lastConstraintTiargs;
     TemplateDeclaration* syntaxCopy(Dsymbol* __param_0_) override;
     bool overloadInsert(Dsymbol* s) override;
-    bool hasStaticCtorOrDtor() override;
     const char* kind() const override;
     const char* toCharsNoConstraints() const;
     Visibility visible() override;
@@ -4153,7 +4150,6 @@ public:
     bool isVirtual() const final override;
     bool addPreInvariant() final override;
     bool addPostInvariant() final override;
-    bool hasStaticCtorOrDtor() final override;
     void accept(Visitor* v) override;
 };
 
@@ -4172,7 +4168,6 @@ public:
     StaticDtorDeclaration* syntaxCopy(Dsymbol* s) override;
     AggregateDeclaration* isThis() final override;
     bool isVirtual() const final override;
-    bool hasStaticCtorOrDtor() final override;
     bool addPreInvariant() final override;
     bool addPostInvariant() final override;
     void accept(Visitor* v) override;
@@ -6398,7 +6393,6 @@ public:
     Array<Dsymbol* >* decl;
     const char* kind() const override;
     bool hasPointers() final override;
-    bool hasStaticCtorOrDtor() final override;
     void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories) final override;
     void accept(Visitor* v) override;
 };
@@ -7549,6 +7543,8 @@ public:
     void visit(ConditionalDeclaration* cd) override;
     void visit(StaticForeachDeclaration* sfd) override;
 };
+
+extern bool hasStaticCtorOrDtor(Dsymbol* d);
 
 extern void lowerNonArrayAggregate(StaticForeach* sfe, Scope* sc);
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1544,11 +1544,6 @@ extern (C++) class StaticCtorDeclaration : FuncDeclaration
         return false;
     }
 
-    override final bool hasStaticCtorOrDtor() @nogc nothrow pure @safe
-    {
-        return true;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1616,11 +1611,6 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
     override final bool isVirtual() const
     {
         return false;
-    }
-
-    override final bool hasStaticCtorOrDtor()
-    {
-        return true;
     }
 
     override final bool addPreInvariant()

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -77,7 +77,6 @@ public:
 
     TemplateDeclaration *syntaxCopy(Dsymbol *) override;
     bool overloadInsert(Dsymbol *s) override;
-    bool hasStaticCtorOrDtor() override;
     const char *kind() const override;
 
     Visibility visible() override;

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -35,7 +35,7 @@ import dmd.dmodule;
 import dmd.dscope;
 import dmd.dstruct;
 import dmd.dsymbol;
-import dmd.dsymbolsem : include;
+import dmd.dsymbolsem : include, hasStaticCtorOrDtor;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.errorsink;


### PR DESCRIPTION
Part of the project to separate semantic routines from AST nodes: https://github.com/dlang/project-ideas/blob/master/separate-semantic-routines-from-ast-nodes/description.md

@RazvanN7 