### PR TITLE
Add support to disable ModuleInfo generation based upon import path

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -358,10 +358,12 @@ extern (C++) final class Module : Package
     Edition edition;            // language edition that this module is compiled with
     Package pkg;                // if isPackageFile is true, the Package that contains this package.d
     Strings contentImportedFiles; // array of files whose content was imported
-    int needmoduleinfo;
     private ThreeState selfimports;
     private ThreeState rootimports;
     Dsymbol[void*] tagSymTab;   /// ImportC: tag symbols that conflict with other symbols used as the index
+
+    bool needmoduleinfo;         // is ModuleInfo required for all code in module to work correctly
+    bool moduleinfodisabled;     // has ModuleInfo generation been disabled
 
     private OutBuffer defines;  // collect all the #define lines here
 
@@ -533,6 +535,7 @@ extern (C++) final class Module : Package
         auto m = new Module(loc, filename, ident, 0, 0);
 
         // TODO: apply import path information (pathInfo) on to module
+        m.moduleinfodisabled = pathInfo.moduleInfoDisabled;
 
         if (!m.read(loc))
             return null;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1715,7 +1715,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (imp.mod.needmoduleinfo)
         {
             //printf("module4 %s because of %s\n", importer.toChars(), imp.mod.toChars());
-            importer.needmoduleinfo = 1;
+            importer.needmoduleinfo = true;
         }
 
         sc = sc.push(imp.mod);
@@ -2733,7 +2733,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             m = sc._module;
         if (m)
         {
-            m.needmoduleinfo = 1;
+            m.needmoduleinfo = true;
             //printf("module2 %s needs moduleinfo\n", m.toChars());
         }
     }
@@ -2852,7 +2852,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (m)
             {
                 //printf("module3 %s needs moduleinfo\n", m.toChars());
-                m.needmoduleinfo = 1;
+                m.needmoduleinfo = true;
             }
         }
     }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7131,12 +7131,13 @@ public:
     Edition edition;
     Package* pkg;
     Array<const char* > contentImportedFiles;
-    int32_t needmoduleinfo;
 private:
     ThreeState selfimports;
     ThreeState rootimports;
 public:
     void* tagSymTab;
+    bool needmoduleinfo;
+    bool moduleinfodisabled;
 private:
     OutBuffer defines;
 public:
@@ -8379,12 +8380,15 @@ struct Verbose final
 struct ImportPathInfo final
 {
     const char* path;
+    bool moduleInfoDisabled;
     ImportPathInfo() :
-        path()
+        path(),
+        moduleInfoDisabled()
     {
     }
-    ImportPathInfo(const char* path) :
-        path(path)
+    ImportPathInfo(const char* path, bool moduleInfoDisabled = false) :
+        path(path),
+        moduleInfoDisabled(moduleInfoDisabled)
         {}
 };
 

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -153,6 +153,7 @@ extern(C++) struct Verbose
 
 extern (C++) struct ImportPathInfo {
     const(char)* path; // char*'s of where to look for import modules
+    bool moduleInfoDisabled;
 }
 
 /// Put command line switches in here

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -158,9 +158,10 @@ struct Verbose
 struct ImportPathInfo
 {
     const char* path;
+    bool moduleInfoDisabled;
 
-    ImportPathInfo() : path(NULL) { }
-    ImportPathInfo(const char* p) : path(p) { }
+    ImportPathInfo() : path(NULL), moduleInfoDisabled() { }
+    ImportPathInfo(const char* p, bool moduleInfoDisabled = false) : path(p), moduleInfoDisabled(moduleInfoDisabled) { }
 };
 
 // Put command line switches in here

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -84,10 +84,13 @@ public:
     Edition edition;    // language edition that this module is compiled with
     Package *pkg;       // if isPackageFile is true, the Package that contains this package.d
     Strings contentImportedFiles;  // array of files whose content was imported
-    int needmoduleinfo;
     ThreeState selfimports;
     ThreeState rootimports;
     void* tagSymTab;            // ImportC: tag symbols that conflict with other symbols used as the index
+
+    d_bool needmoduleinfo;      // is ModuleInfo required for all code in module to work correctly
+    d_bool moduleinfodisabled;  // has ModuleInfo generation been disabled
+
     OutBuffer defines;          // collect all the #define lines here
     bool selfImports();         // returns true if module imports itself
 

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -489,7 +489,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         {
             //printf("module5 %s because of %s\n", sc._module.toChars(), mod.toChars());
             if (sc)
-                sc._module.needmoduleinfo = 1;
+                sc._module.needmoduleinfo = true;
         }
     }
 

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -91,6 +91,10 @@ void genModuleInfo(Module m)
         ObjectNotFound(m.loc, Id.ModuleInfo);
     }
 
+    // If ModuleInfo generation has been disabled selectively, don't emit it.
+    if (m.moduleinfodisabled)
+        return;
+
     Symbol* msym = toSymbol(m);
 
     //////////////////////////////////////////////
@@ -108,7 +112,7 @@ void genModuleInfo(Module m)
     for (size_t i = 0; i < m.aimports.length; i++)
     {
         Module mod = m.aimports[i];
-        if (!mod.needmoduleinfo)
+        if (!mod.needmoduleinfo || mod.moduleinfodisabled)
             aimports_dim--;
     }
 
@@ -177,7 +181,7 @@ void genModuleInfo(Module m)
         {
             Module mod = m.aimports[i];
 
-            if (!mod.needmoduleinfo)
+            if (!mod.needmoduleinfo || mod.moduleinfodisabled)
                 continue;
 
             Symbol* s = toSymbol(mod);


### PR DESCRIPTION
Preference to merging should go to: https://github.com/dlang/dmd/pull/20899
I need it a lot more.

This is a preparation PR, to make ModuleInfo generation be dependent on the import path switch.

It is to help codebases that are mixed -betterC and full D.

See any of the bindbc codebases for why it is absolutely abhorrent that it is an all or nothing switch, rather than recognizing its pay as you go runtime scale nature.

https://github.com/BindBC/bindbc-sdl/blob/master/dub.json