### PR TITLE
Makes fiber_entryPoint() noreturn

### DIFF
--- a/druntime/src/core/thread/fiber/base.d
+++ b/druntime/src/core/thread/fiber/base.d
@@ -27,7 +27,7 @@ package
     import core.exception : onOutOfMemoryError;
     import core.stdc.stdlib : abort;
 
-    extern (C) void fiber_entryPoint() nothrow
+    extern (C) noreturn fiber_entryPoint() nothrow
     {
         FiberBase obj = FiberBase.getThis();
         assert( obj );
@@ -51,6 +51,8 @@ package
 
         obj.m_state = Fiber.State.TERM;
         obj.switchOut();
+
+        assert(false, "It is impossible to return from switchOut");
     }
 }
 
@@ -173,8 +175,6 @@ package
  *
  * The ARM implementation is meant to be used as a kind of documented example implementation.
  * Look there for a concrete example.
- *
- * FIXME: fiber_entrypoint might benefit from a @noreturn attribute, but D doesn't have one.
  */
 
 /**

--- a/druntime/src/core/thread/fiber/package.d
+++ b/druntime/src/core/thread/fiber/package.d
@@ -497,8 +497,6 @@ package
  *
  * The ARM implementation is meant to be used as a kind of documented example implementation.
  * Look there for a concrete example.
- *
- * FIXME: fiber_entrypoint might benefit from a @noreturn attribute, but D doesn't have one.
  */
 
 /**


### PR DESCRIPTION
This makes fiber trampoline functions unnecessary? I.e., will this clear the "link register" prior to calling `fiber_entryPoint`?

upd: Most likely not, because this added assertion still needs to be catched somehow