### PR TITLE
CI: Migrate Win64-DMD-bootstrap job from Azure Pipelines to GHA

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -65,15 +65,9 @@ fi
 # Build DMD (incl. building and running the unittests)
 ################################################################################
 
-# no `-debug` for unittests build with old host compilers (to avoid compile errors)
-disable_debug_for_unittests=()
-if [[ "$HOST_DMD_VERSION" == "2.079.0" ]]; then
-    disable_debug_for_unittests=(ENABLE_DEBUG=0)
-fi
-
 cd "$DMD_DIR"
 "$HOST_DC" -m$MODEL compiler/src/build.d -ofgenerated/build.exe
-generated/build.exe -j$N MODEL=$MODEL HOST_DMD=$HOST_DC BUILD=debug "${disable_debug_for_unittests[@]}" unittest
+generated/build.exe -j$N MODEL=$MODEL HOST_DMD=$HOST_DC BUILD=debug unittest
 generated/build.exe -j$N MODEL=$MODEL HOST_DMD=$HOST_DC DFLAGS="-L-LARGEADDRESSAWARE" ENABLE_RELEASE=1 ENABLE_ASSERTS=1 dmd
 
 DMD_BIN_PATH="$DMD_DIR/generated/windows/release/$MODEL/dmd.exe"
@@ -103,14 +97,8 @@ fi
 
 "$HOST_DC" -m$MODEL -g -i run.d
 
-targets=("all")
 args=('ARGS=-O -inline -g') # no -release for faster builds
-if [ "$HOST_DMD_VERSION" = "2.079.0" ] ; then
-    # skip runnable_cxx and unit_tests with older bootstrap compilers
-    targets=("runnable" "compilable" "fail_compilation" "dshell")
-    args=() # use default set of args
-fi
-./run --environment --jobs=$N "${targets[@]}" "${args[@]}" CC="$CC" CXX="$CXX"
+./run --environment --jobs=$N "${args[@]}" CC="$CC" CXX="$CXX"
 
 ###############################################################################
 # Upload coverage reports and exit if ENABLE_COVERAGE is specified

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,9 +157,6 @@ jobs:
           arch: ${{ env.MODEL == '64' && 'x64' || 'x86' }}
       - name: Build
         run: ${{ matrix.disable_debug_for_dmd_unittests && 'ENABLE_DEBUG=0' || '' }} ci/run.sh build
-        env:
-          # on Windows, `ci/run.sh build` expects the DMD env var to be set to the DMD-CLI-compatible host compiler
-          DMD: ${{ runner.os == 'Windows' && (startsWith(matrix.host_dmd, 'ldc') && 'ldmd2' || 'dmd') || '' }}
       - name: Rebuild dmd (with enabled coverage)
         if: matrix.coverage
         run: ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ci/run.sh rebuild

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,25 +173,6 @@ jobs:
       - name: Test druntime
         if: '!matrix.coverage && (success() || failure())'
         run: ci/run.sh test_druntime
-      - name: 'Windows: Add libcurl.dll to PATH (required for Phobos unittests)'
-        if: runner.os == 'Windows' && !matrix.coverage && (success() || failure())
-        run: |
-          set -euxo pipefail
-          if [[ "$MODEL" == '32' ]]; then
-            # LDC
-            echo "$(dirname "$(which $DC)")/../lib32" >> $GITHUB_PATH
-            # DMD
-            echo "$(dirname "$(which $DC)")/../bin" >> $GITHUB_PATH
-          elif [[ '${{ matrix.host_dmd }}' == 'dmd-2.079.0' ]]; then
-            # libcurl bundled with bootstrap compiler is too old...
-            curl -fsSL https://downloads.dlang.org/other/libcurl-7.65.3-2-WinSSL-zlib-x86-x64.zip -o libcurl.zip
-            mkdir libcurl
-            cd libcurl
-            7z x ../libcurl.zip > /dev/null
-            cp dmd2/windows/bin64/libcurl.dll "$(dirname "$(which $DC)")"/../bin64/
-            cd ..
-            rm -rf libcurl libcurl.zip
-          fi
       - name: Test phobos
         if: '!matrix.coverage && (success() || failure())'
         run: ci/run.sh test_phobos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,10 @@ jobs:
           - job_name: Windows x64, LDC
             os: windows-2022
             host_dmd: ldc-latest
+          - job_name: Windows x64, DMD (bootstrap)
+            os: windows-2022
+            host_dmd: dmd-2.079.0
+            disable_debug_for_dmd_unittests: true # no `-debug` - host frontend too old
           - job_name: Windows x86, DMD (latest)
             os: windows-2022
             host_dmd: dmd-latest
@@ -123,6 +127,9 @@ jobs:
         uses: dlang-community/setup-dlang@v1.3.0
         with:
           compiler: ${{ matrix.host_dmd }}
+      - name: 'Windows: Remove DM make.exe bundled with old DMD bootstrap compiler, shadowing GNU make.exe in PATH'
+        if: runner.os == 'Windows' && matrix.host_dmd == 'dmd-2.079.0'
+        run: rm "$(dirname "$(which $DC)")"/make.exe
 
       - name: Set up repos
         run: |
@@ -143,6 +150,11 @@ jobs:
           fi
 
           ci/run.sh setup_repos "$REPO_BRANCH"
+      - name: 'Windows: Set up MSVC environment early for old DMD bootstrap compiler'
+        if: runner.os == 'Windows' && matrix.host_dmd == 'dmd-2.079.0'
+        uses: seanmiddleditch/gha-setup-vsdevenv@v4
+        with:
+          arch: ${{ env.MODEL == '64' && 'x64' || 'x86' }}
       - name: Build
         run: ${{ matrix.disable_debug_for_dmd_unittests && 'ENABLE_DEBUG=0' || '' }} ci/run.sh build
         env:
@@ -152,7 +164,7 @@ jobs:
         if: matrix.coverage
         run: ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ci/run.sh rebuild
       - name: 'Windows: Set up MSVC environment' # some tests need cl.exe etc. in PATH
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.host_dmd != 'dmd-2.079.0'
         uses: seanmiddleditch/gha-setup-vsdevenv@v4
         with:
           arch: ${{ env.MODEL == '64' && 'x64' || 'x86' }}
@@ -161,13 +173,25 @@ jobs:
       - name: Test druntime
         if: '!matrix.coverage && (success() || failure())'
         run: ci/run.sh test_druntime
-      - name: 'Windows x86: Add 32-bit libcurl.dll to PATH (required for Phobos unittests)'
-        if: runner.os == 'Windows' && env.MODEL == '32' && !matrix.coverage && (success() || failure())
+      - name: 'Windows: Add libcurl.dll to PATH (required for Phobos unittests)'
+        if: runner.os == 'Windows' && !matrix.coverage && (success() || failure())
         run: |
-          # LDC
-          echo "$(dirname "$(which $DC)")/../lib32" >> $GITHUB_PATH
-          # DMD
-          echo "$(dirname "$(which $DC)")/../bin" >> $GITHUB_PATH
+          set -euxo pipefail
+          if [[ "$MODEL" == '32' ]]; then
+            # LDC
+            echo "$(dirname "$(which $DC)")/../lib32" >> $GITHUB_PATH
+            # DMD
+            echo "$(dirname "$(which $DC)")/../bin" >> $GITHUB_PATH
+          elif [[ '${{ matrix.host_dmd }}' == 'dmd-2.079.0' ]]; then
+            # libcurl bundled with bootstrap compiler is too old...
+            curl -fsSL https://downloads.dlang.org/other/libcurl-7.65.3-2-WinSSL-zlib-x86-x64.zip -o libcurl.zip
+            mkdir libcurl
+            cd libcurl
+            7z x ../libcurl.zip > /dev/null
+            cp dmd2/windows/bin64/libcurl.dll "$(dirname "$(which $DC)")"/../bin64/
+            cd ..
+            rm -rf libcurl libcurl.zip
+          fi
       - name: Test phobos
         if: '!matrix.coverage && (success() || failure())'
         run: ci/run.sh test_phobos

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,21 +3,6 @@ variables:
   VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
 
 jobs:
-  - job: Windows_DMD_bootstrap
-    timeoutInMinutes: 60
-    pool:
-      vmImage: 'windows-2019'
-    variables:
-      D_COMPILER: dmd
-      HOST_DMD_VERSION: 2.079.0
-    strategy:
-      matrix:
-        x64:
-          MODEL: 64
-          ARCH: x64
-    steps:
-      - template: .azure-pipelines/windows.yml
-
   - job: Windows_DMD_latest
     timeoutInMinutes: 60
     pool:


### PR DESCRIPTION
Pros:
* 4 virtual CPU cores instead of 2 for the CI runners, and ~doubled RAM presumably too, so ~halved CI job runtime, or even better:
  * ~15 mins here: https://github.com/dlang/dmd/actions/runs/13777446959/job/38529427312?pr=20973
  * ~50 mins for the latest master job: https://dev.azure.com/dlanguage/dmd/_build/results?buildId=46313&view=logs&jobId=47916d67-4a7b-51e4-ebf4-f45083e4cd9e&j=47916d67-4a7b-51e4-ebf4-f45083e4cd9e (and otherwise 30+ mins for other comparable Azure jobs)
  
  There are warnings like  `Free memory is lower than 5%; Currently used: 97.07%` in the output (for other Azure jobs too), so seems like the Azure Pipelines runners run out of memory and start awfully slow swapping.
* Reduced dependency on Azure Pipelines and their separate set of CI scripts

Cons:
* One more GHA job - with the default concurrency limit of 20 jobs