### PR TITLE
Fix #17481 - free ctors before returning

### DIFF
--- a/druntime/src/rt/minfo.d
+++ b/druntime/src/rt/minfo.d
@@ -492,7 +492,10 @@ struct ModuleGroup
                 if (!bt(ctordone, idx))
                 {
                     if (!processMod(idx))
+                    {
+                        .free(ctors);
                         return false;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #17481 by properly freeing the `ctors` array before returning false from `doSort`