### PR TITLE
Fix dub file for dscanner

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -103,12 +103,15 @@ subPackage {
     console,\
     entity,\
     errors,\
+    errorsink,\
     file_manager,\
     globals,\
     id,\
     identifier,\
     lexer,\
+    location,\
     parse,\
+    sarif,\
     tokens,\
     utf,\
     utils,\


### PR DESCRIPTION
Replace libdparse in dscanner PR is currently failing due to multiple definitions of symbols due to the dub file configured to not exclude some lexer modules.

https://github.com/dlang-community/D-Scanner/pull/964