### PR TITLE
[stable] Expose SourceLoc to C++ interface

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -377,6 +377,22 @@ enum class MessageStyle : uint8_t
     sarif = 2u,
 };
 
+struct SourceLoc final
+{
+    _d_dynamicArray< const char > filename;
+    uint32_t line;
+    uint32_t column;
+    uint32_t fileOffset;
+    const char* toChars(bool showColumns = Loc::showColumns, MessageStyle messageStyle = Loc::messageStyle) const;
+    SourceLoc() :
+        filename(),
+        line(),
+        column(),
+        fileOffset()
+    {
+    }
+};
+
 struct Loc final
 {
 private:
@@ -390,7 +406,8 @@ public:
     uint32_t linnum() const;
     const char* filename() const;
     const char* toChars(bool showColumns = Loc::showColumns, MessageStyle messageStyle = Loc::messageStyle) const;
-    bool equals(const Loc& loc) const;
+    SourceLoc toSourceLoc() const;
+    bool equals(Loc loc) const;
     Loc() :
         index(0u)
     {

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -413,6 +413,14 @@ typedef unsigned long long uinteger_t;
 #endif
 
 // file location
+struct SourceLoc
+{
+    DString filename;
+    uint32_t line;
+    uint32_t column;
+    uint32_t fileOffset;
+};
+
 struct Loc
 {
 private:
@@ -438,6 +446,7 @@ public:
     uint32_t charnum() const;
     uint32_t linnum() const;
     const char *filename() const;
+    SourceLoc toSourceLoc() const;
 
     const char *toChars(
         bool showColumns = Loc::showColumns,

--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -124,6 +124,12 @@ nothrow:
         return this.index - locFileTable[i].startIndex;
     }
 
+    /// Returns: this location as a SourceLoc
+    extern (C++) SourceLoc toSourceLoc() const @nogc @safe
+    {
+        return SourceLoc(this);
+    }
+
     /**
      * Checks for equivalence by comparing the filename contents (not the pointer) and character location.
      *
@@ -131,7 +137,7 @@ nothrow:
      *  - Uses case-insensitive comparison on Windows
      *  - Ignores `charnum` if `Columns` is false.
      */
-    extern (C++) bool equals(ref const(Loc) loc) const
+    extern (C++) bool equals(Loc loc) const
     {
         SourceLoc lhs = SourceLoc(this);
         SourceLoc rhs = SourceLoc(loc);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -394,6 +394,12 @@ void test_location()
     Loc loc = Loc::singleFilename("app.d");
     assert(strcmp(loc.toChars(true, MessageStyle::digitalmars), "app.d") == 0);
     assert(strcmp(loc.toChars(true, MessageStyle::gnu), "app.d") == 0);
+
+    Loc loc2 = Loc::singleFilename("app2.d");
+    assert(!loc2.equals(loc));
+
+    SourceLoc sloc = loc.toSourceLoc();
+    assert(strcmp(sloc.filename.ptr, loc.filename()) == 0);
 }
 
 /**********************************/


### PR DESCRIPTION
Since `Loc` was make opaque, can't ignore this type anymore.  For example, converting DMD locations to GCC locations, interfacing with GCC diagnostics via own implementation of `verrorReport`.