### PR TITLE
Fix #20075 - Improve error message for immutable constructor type mismatch

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1713,8 +1713,14 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
             OutBuffer buf;
             buf.argExpTypesToCBuffer(fargs);
             if (fd.isCtorDeclaration())
-                .error(loc, "none of the overloads of `%s` can construct a %sobject with argument types `(%s)`",
-                    fd.toChars(), thisBuf.peekChars(), buf.peekChars());
+            {
+                if (tthis.mod & MODFlags.immutable_)
+                    .error(loc, "none of the overloads of `%s` can construct an immutable object with argument types `(%s)`. Expected `immutable(%s)`",
+                        fd.toChars(), buf.peekChars(), buf.peekChars());
+                else
+                    .error(loc, "none of the overloads of `%s` can construct a %sobject with argument types `(%s)`",
+                        fd.toChars(), thisBuf.peekChars(), buf.peekChars());
+            }
             else
                 .error(loc, "none of the overloads of `%s` are callable using a %sobject with argument types `(%s)`",
                     fd.toChars(), thisBuf.peekChars(), buf.peekChars());

--- a/compiler/test/fail_compilation/fix20075.d
+++ b/compiler/test/fail_compilation/fix20075.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fix20075.d(15): Error: none of the overloads of `this` can construct an immutable object with argument types `(int*)`. Expected `immutable(int*)`
+fail_compilation/fix20075.d(11):        Candidate is: `fix20075.Foo.this(immutable(int*) a) immutable`
+---
+*/
+
+struct Foo {
+    @disable this();
+    immutable this(immutable int* a) {}
+}
+
+immutable(Foo) getFoo(int* a) {
+    return immutable Foo(a);
+}
+
+void main() {
+    int x;
+    auto foo = getFoo(&x);
+}

--- a/compiler/test/fail_compilation/testrvaluecpctor.d
+++ b/compiler/test/fail_compilation/testrvaluecpctor.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/testrvaluecpctor.d(16): Error: cannot define both an rvalue constructor and a copy constructor for `struct Foo`
 fail_compilation/testrvaluecpctor.d(24):        Template instance `testrvaluecpctor.Foo!int.Foo.__ctor!(immutable(Foo!int), immutable(Foo!int))` creates an rvalue constructor for `struct Foo`
-fail_compilation/testrvaluecpctor.d(24): Error: none of the overloads of `this` can construct a `immutable` object with argument types `(immutable(Foo!int))`
+fail_compilation/testrvaluecpctor.d(24): Error: none of the overloads of `this` can construct an immutable object with argument types `(immutable(Foo!int))`. Expected `immutable(immutable(Foo!int))`
 fail_compilation/testrvaluecpctor.d(18):        Candidates are: `testrvaluecpctor.Foo!int.Foo.this(ref scope Foo!int rhs)`
 fail_compilation/testrvaluecpctor.d(16):                        `this(Rhs, this This)(scope Rhs rhs)`
 ---


### PR DESCRIPTION
Fix : https://github.com/dlang/dmd/issues/20075

The original error message incorrectly implied that:
    There were no overloads taking an immutable object, when there actually was one
     A mutable object was used, when the real issue was providing a mutable argument to an immutable constructor

The fix:
1. Changes the error message to clearly state the attempted operation: constructing an immutable object
2. Shows what argument type was provided vs what was expected
3. Makes the error message more actionable by showing the exact type mismatch
I added the testcase in compiler/test/fail_compilation/fix20075.d
I think now it is more clear error msg.