### PR TITLE
Fix #20982 - wrong line number in iasmgcc

### DIFF
--- a/compiler/src/dmd/iasmgcc.d
+++ b/compiler/src/dmd/iasmgcc.d
@@ -55,7 +55,8 @@ public Statement gccAsmSemantic(GccAsmStatement s, Scope* sc)
         *ptoklist = null;
     }
     p.token = *toklist;
-    p.scanloc = s.loc;
+    p.baseLoc.startLine = s.loc.linnum;
+    p.linnum = s.loc.linnum;
 
     // Parse the gcc asm statement.
     const errors = global.errors;


### PR DESCRIPTION
Still need to test this, the unittest in this module calls `parseGccAsm` but not `gccAsmSemantic`.