### PR TITLE
Reset global Loc table in initDMD

### DIFF
--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -152,6 +152,7 @@ void initDMD(
     Module._init();
     Expression._init();
     Objc._init();
+    Loc._init();
     EscapeState.reset();
 
     addDefaultVersionIdentifiers(global.params, target);

--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -48,6 +48,15 @@ struct Loc
 
 nothrow:
 
+    /// Reset global (Base)Loc tables, invalidating every existing `Loc` out there
+    /// and giving room to create new `Loc`s
+    static void _init()
+    {
+        locIndex = 1;
+        locFileTable = null;
+        lastFileTableIndex = 0;
+    }
+
     /*******************************
      * Configure how display is done
      * Params:
@@ -272,9 +281,7 @@ private size_t fileTableIndex(uint index) nothrow @nogc
     // To speed up linear find, we cache the last hit and compare that first,
     // since usually we stay in the same file for some time when resolving source locations.
     // If it's a different file now, either scan forwards / backwards
-    __gshared size_t lastI = 0; // index of last found hit
-
-    size_t i = lastI;
+    size_t i = lastFileTableIndex;
     if (index >= locFileTable[i].startIndex)
     {
         while (i + 1 < locFileTable.length && index >= locFileTable[i+1].startIndex)
@@ -286,7 +293,7 @@ private size_t fileTableIndex(uint index) nothrow @nogc
             i--;
     }
 
-    lastI = i;
+    lastFileTableIndex = i;
     return i;
 }
 
@@ -459,3 +466,6 @@ private __gshared uint locIndex = 1;
 
 // Global mapping of Loc indices to source file offset/line/column, see `BaseLoc`
 private __gshared BaseLoc*[] locFileTable;
+
+// Index of last found hit in locFileTable, for optimization
+private __gshared size_t lastFileTableIndex = 0;

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -376,6 +376,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     Module._init();
     Expression._init();
     Objc._init();
+    Loc._init();
 
     reconcileLinkRunLib(params, files.length, target.obj_ext);
     version(CRuntime_Microsoft)


### PR DESCRIPTION
To prevent you running out of location indices after repeated initialization