### PR TITLE
Don't parse lambda as UDA without parentheses

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1319,7 +1319,21 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
             // Allow identifier, template instantiation, or function call
             // for `@Argument` (single UDA) form.
-            AST.Expression exp = parsePrimaryExp();
+            AST.Expression exp;
+
+            {
+                const loc = token.loc;
+                Identifier id = token.ident;
+                nextToken();
+                if (token.value == TOK.not)
+                {
+                    auto tempinst = new AST.TemplateInstance(loc, id, parseTemplateArguments());
+                    exp = new AST.ScopeExp(loc, tempinst);
+                }
+                else
+                    exp = new AST.IdentifierExp(loc, id);
+            }
+
             if (token.value == TOK.leftParenthesis)
             {
                 const loc = token.loc;

--- a/compiler/test/compilable/uda_lambda.d
+++ b/compiler/test/compilable/uda_lambda.d
@@ -1,0 +1,3 @@
+enum UDA;
+int fun() @UDA => 7;
+static assert(fun() == 7);

--- a/compiler/test/fail_compilation/uda_lambda.d
+++ b/compiler/test/fail_compilation/uda_lambda.d
@@ -1,0 +1,7 @@
+/+
+TEST_OUTPUT:
+---
+fail_compilation/uda_lambda.d(7): Error: declaration expected, not `=>`
+---
++/
+@a => 7 int b;


### PR DESCRIPTION
This brings the compiler's behavior in line with the language spec.

Fixes dlang/dlang.org#4137