### PR TITLE
[stable] C++ header fixes for declaration, expression, and typinf

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -16,6 +16,7 @@ import dmd.astenums;
 import dmd.attrib;
 import dmd.common.outbuffer : OutBuffer;
 import dmd.dclass : ClassDeclaration;
+import dmd.declaration : TypeInfoDeclaration;
 import dmd.denum : EnumDeclaration;
 import dmd.dmodule /*: Module*/;
 import dmd.dscope : Scope;
@@ -726,6 +727,18 @@ bool builtinTypeInfo(Type t)
 {
     import dmd.typinf;
     return dmd.typinf.builtinTypeInfo(t);
+}
+
+Type makeNakedAssociativeArray(TypeAArray t)
+{
+    import dmd.typinf;
+    return dmd.typinf.makeNakedAssociativeArray(t);
+}
+
+TypeInfoDeclaration getTypeInfoAssocArrayDeclaration(TypeAArray t, Scope* sc)
+{
+    import dmd.typinf;
+    return dmd.typinf.getTypeInfoAssocArrayDeclaration(t, sc);
 }
 
 version (IN_LLVM)

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -37,6 +37,8 @@ namespace dmd
     bool checkClosure(FuncDeclaration* fd);
     MATCH leastAsSpecialized(FuncDeclaration *f, FuncDeclaration *g, Identifiers *names);
     PURE isPure(FuncDeclaration *f);
+    FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);
+    FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc=0);
 }
 
 //enum STC : ulong from astenums.d:
@@ -729,9 +731,6 @@ public:
     virtual FuncDeclaration *toAliasFunc() { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
-
-FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);
-FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc=0);
 
 class FuncAliasDeclaration final : public FuncDeclaration
 {

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -40,6 +40,7 @@ class OverloadSet;
 class StringExp;
 class InterpExp;
 class LoweredAssignExp;
+class StaticForeach;
 #ifdef IN_GCC
 typedef union tree_node Symbol;
 #else

--- a/compiler/src/dmd/typinf.h
+++ b/compiler/src/dmd/typinf.h
@@ -14,6 +14,8 @@
 
 class Expression;
 class Type;
+class TypeAArray;
+class TypeInfoDeclaration;
 struct Scope;
 
 namespace dmd
@@ -21,5 +23,7 @@ namespace dmd
     bool genTypeInfo(Expression *e, Loc loc, Type *torig, Scope *sc);
     bool isSpeculativeType(Type *t);
     bool builtinTypeInfo(Type *t);
+    Type *makeNakedAssociativeArray(TypeAArray *t);
+    TypeInfoDeclaration *getTypeInfoAssocArrayDeclaration(TypeAArray *t, Scope *sc);
 }
 Type *getTypeInfoType(Loc loc, Type *t, Scope *sc);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1730,12 +1730,14 @@ void argtypes_h(Type *t)
     //dmd::isHFVA(t);
 }
 
-void declaration_h(FuncDeclaration *fd, Loc loc, Expressions* args)
+void declaration_h(FuncDeclaration *fd, Loc loc, Expressions* args, Parameters* params)
 {
     dmd::functionSemantic(fd);
     dmd::functionSemantic3(fd);
     ::eval_builtin(loc, fd, args);
     ::isBuiltin(fd);
+    dmd::genCfunc(params, fd->type, "test");
+    dmd::genCfunc(params, fd->type, Identifier::idPool("test"));
 }
 
 void doc_h(Module *m, const char *ptr, d_size_t length, const char *date,
@@ -1868,4 +1870,6 @@ void typinf_h(Expression *e, Loc loc, Type *t, Scope *sc)
     ::getTypeInfoType(loc, t, sc);
     dmd::isSpeculativeType(t);
     dmd::builtinTypeInfo(t);
+    dmd::makeNakedAssociativeArray(t->isTypeAArray());
+    dmd::getTypeInfoAssocArrayDeclaration(t->isTypeAArray(), sc);
 }


### PR DESCRIPTION
Seen either from compilation errors or missing symbols at link time.