### PR TITLE
[stable] druntime: Add module declaration to rt.invariant, to prevent conflicts with user-provided invariant.d

### DIFF
--- a/compiler/src/dmd/backend/drtlsym.d
+++ b/compiler/src/dmd/backend/drtlsym.d
@@ -89,7 +89,7 @@ Symbol* getRtlsym(RTLSYM i) @trusted
         case RTLSYM.DARRAYP:                symbolz(ps,FL.func,FREGSAVED,"_d_arrayboundsp", SFLexit, t); break;
         case RTLSYM.DARRAY_SLICEP:          symbolz(ps,FL.func,FREGSAVED,"_d_arraybounds_slicep", SFLexit, t); break;
         case RTLSYM.DARRAY_INDEXP:          symbolz(ps,FL.func,FREGSAVED,"_d_arraybounds_indexp", SFLexit, t); break;
-        case RTLSYM.DINVARIANT:             symbolz(ps,FL.func,FREGSAVED,"_D9invariant12_d_invariantFC6ObjectZv", 0, tsdlib); break;
+        case RTLSYM.DINVARIANT:             symbolz(ps,FL.func,FREGSAVED,"_D2rt10invariant_12_d_invariantFC6ObjectZv", 0, tsdlib); break;
         case RTLSYM.MEMCPY:                 symbolz(ps,FL.func,FREGSAVED,"memcpy",    0, t); break;
         case RTLSYM.MEMSET8:                symbolz(ps,FL.func,FREGSAVED,"memset",    0, t); break;
         case RTLSYM.MEMSET16:               symbolz(ps,FL.func,FREGSAVED,"_memset16", 0, t); break;

--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -479,7 +479,7 @@ TESTS_EXTRACTOR=$(ROOT)/tests_extractor$(DOTEXE)
 BETTERCTESTS_DIR=$(ROOT)/betterctests
 
 # macro that returns the module name given the src path
-moduleName=$(subst rt.invariant,invariant,$(subst object_,object,$(subst /,.,$(1))))
+moduleName=$(subst /,.,$(1))
 
 $(ROOT)/unittest/% : $(ROOT)/unittest/test_runner$(DOTEXE)
 	@mkdir -p $(dir $@)

--- a/druntime/mak/DOCS
+++ b/druntime/mak/DOCS
@@ -548,7 +548,7 @@ DOCS=\
 	$(DOCDIR)\rt_deh_win32.html \
 	$(DOCDIR)\rt_deh_win64_posix.html \
 	$(DOCDIR)\rt_ehalloc.html \
-	$(DOCDIR)\rt_invariant.html \
+	$(DOCDIR)\rt_invariant_.html \
 	$(DOCDIR)\rt_llmath.html \
 	$(DOCDIR)\rt_memory.html \
 	$(DOCDIR)\rt_memset.html \

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -573,7 +573,7 @@ SRCS=\
 	src\rt\dmain2.d \
 	src\rt\dwarfeh.d \
 	src\rt\ehalloc.d \
-	src\rt\invariant.d \
+	src\rt\invariant_.d \
 	src\rt\lifetime.d \
 	src\rt\llmath.d \
 	src\rt\memory.d \

--- a/druntime/src/rt/invariant_.d
+++ b/druntime/src/rt/invariant_.d
@@ -4,15 +4,10 @@
  * Copyright: Copyright Digital Mars 2007 - 2010.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
- * Source: $(DRUNTIMESRC rt/_invariant.d)
+ * Source: $(DRUNTIMESRC rt/_invariant_.d)
  */
 
-/*          Copyright Digital Mars 2007 - 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
-
+module rt.invariant_;
 
 /**
  *


### PR DESCRIPTION
Such as (empty) https://github.com/dlang/dmd/blob/master/druntime/test/gc/invariant.d. See https://github.com/ldc-developers/ldc/issues/4879.