### PR TITLE
flags not set by complement instruction

### DIFF
--- a/compiler/src/dmd/backend/arm/cod2.d
+++ b/compiler/src/dmd/backend/arm/cod2.d
@@ -470,8 +470,8 @@ void cdcom(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
      */
     uint sf = sz == 8;
     cdb.gen1(INSTR.log_shift(sf, 1, 0, 1, Rm, 0, 31, Rd));
+    //pretregs &= ~mPSW;             // flags not set
 
-    pretregs &= ~mPSW;             // flags already set
     fixresult(cdb,e,retregs,pretregs);
 }
 

--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -1378,7 +1378,7 @@ void assignaddrc(code* c)
                     c.Iop = INSTR.nop;               // remove references to it
                     break;
                 }
-                static if (1)
+                static if (0)
                 {
                     symbol_print(*s);
                     printf("c: %p, x%08x\n", c, c.Iop);
@@ -1432,7 +1432,7 @@ void assignaddrc(code* c)
                 uint opc   = field(ins,23,22);
                 uint shift = field(ins,31,30);        // 0:1 1:2 2:4 3:8 shift for imm12
                 uint op24  = field(ins,25,24);
-printf("offset: %lld localsize: %lld REGSIZE*2: %d\n", offset, localsize, REGSIZE*2);
+//printf("offset: %lld localsize: %lld REGSIZE*2: %d\n", offset, localsize, REGSIZE*2);
                 if (cgstate.hasframe)
                     offset += REGSIZE * 2;
                 offset += localsize;

--- a/compiler/src/dmd/backend/debugprint.d
+++ b/compiler/src/dmd/backend/debugprint.d
@@ -175,7 +175,7 @@ const(char)* tym_str(tym_t ty)
 @trusted
 const(char)* bc_str(uint bc)
 {
-    __gshared const char[10][BC.max + 1] bcs =
+    __gshared const char[11][BC.max + 1] bcs =
         ["BC.unde  ","BC.goto_  ","BC.true  ","BC.ret   ","BC.retexp",
          "BC.exit  ","BC.asm_   ","BC.switch_","BC.ifthen","BC.jmptab",
          "BC.try_   ","BC.catch_ ","BC.jump  ",


### PR DESCRIPTION
I keep forgetting that, unlike the x86_64, very few AArch64 instructions set the flags.