### PR TITLE
[stable] Add C++ header for `dmd.timetrace`

### DIFF
--- a/compiler/src/dmd/timetrace.d
+++ b/compiler/src/dmd/timetrace.d
@@ -34,7 +34,7 @@ TimeTraceProfiler* timeTraceProfiler = null;
  *   timeGranularityUs = minimum event size in microseconds
  *   processName = name of this executable
  */
-extern (C++)
+extern (C++, "dmd")
 void initializeTimeTrace(uint timeGranularityUs, const(char)* processName)
 {
     assert(timeTraceProfiler is null, "Double initialization of timeTraceProfiler");
@@ -46,7 +46,7 @@ void initializeTimeTrace(uint timeGranularityUs, const(char)* processName)
  *
  * After this, no more calls to timeTrace functions can be made.
  */
-extern (C++)
+extern (C++, "dmd")
 void deinitializeTimeTrace()
 {
     if (timeTraceProfilerEnabled())
@@ -60,7 +60,7 @@ void deinitializeTimeTrace()
  * Returns: Whether time tracing is enabled.
  */
 pragma(inline, true)
-extern (C++)
+extern (C++, "dmd")
 bool timeTraceProfilerEnabled()
 {
     version (LDC)
@@ -80,7 +80,7 @@ bool timeTraceProfilerEnabled()
  * Params:
  *   buf = output buffer to write JSON into
  */
-extern (C++)
+extern (C++, "dmd")
 void writeTimeTraceProfile(OutBuffer* buf)
 {
     timeTraceProfiler.writeToBuffer(*buf);
@@ -94,7 +94,7 @@ void writeTimeTraceProfile(OutBuffer* buf)
  *   detail_ptr = further details, visible when this event is selected
  *   loc = source location corresponding to this event
  */
-extern (C++)
+extern (C++, "dmd")
 void timeTraceBeginEvent(scope const(char)* name_ptr, scope const(char)* detail_ptr, Loc loc)
 {
     import dmd.root.rmem : xarraydup;
@@ -117,7 +117,7 @@ void timeTraceBeginEvent(scope const(char)* name_ptr, scope const(char)* detail_
  *   eventType = what compilation stage the event belongs to
  *      (redundant with the eventType of `timeTraceEndEvent` but used by GDC)
  */
-extern (C++)
+extern (C++, "dmd")
 void timeTraceBeginEvent(TimeTraceEventType eventType)
 {
     if (timeTraceProfilerEnabled)
@@ -135,7 +135,7 @@ void timeTraceBeginEvent(TimeTraceEventType eventType)
  *   e = Expression which was analyzed, used to generate 'name' and 'detail'
  *   detail = custom lazy string for 'detail' of event
  */
-extern (C++)
+extern (C++, "dmd")
 void timeTraceEndEvent(TimeTraceEventType eventType)
 {
     if (timeTraceProfilerEnabled)
@@ -157,7 +157,7 @@ void timeTraceEndEvent(TimeTraceEventType eventType, Dsymbol sym, scope const(ch
 }
 
 /// ditto
-extern (C++)
+extern (C++, "dmd")
 void timeTraceEndEvent(TimeTraceEventType eventType, Expression e)
 {
     if (timeTraceProfilerEnabled)

--- a/compiler/src/dmd/timetrace.h
+++ b/compiler/src/dmd/timetrace.h
@@ -1,0 +1,81 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
+ * written by Walter Bright
+ * https://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * https://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/compiler/src/dmd/timetrace.h
+ */
+
+#pragma once
+
+#include "dmd/globals.h"
+
+class Expression;
+class OutBuffer;
+
+enum class TimeTraceEventType
+{
+    generic,
+    parseGeneral,
+    parse,
+    semaGeneral,
+    sema1Import,
+    sema1Module,
+    sema2,
+    sema3,
+    ctfe,
+    ctfeCall,
+    codegenGlobal,
+    codegenModule,
+    codegenFunction,
+    link
+};
+
+namespace dmd
+{
+    void initializeTimeTrace(unsigned timeGranularityUs, const char *processName);
+    void deinitializeTimeTrace();
+    bool timeTraceProfilerEnabled();
+    void writeTimeTraceProfile(OutBuffer *buf);
+
+    void timeTraceBeginEvent(const char *name_ptr, const char *detail_ptr, Loc loc);
+    void timeTraceBeginEvent(TimeTraceEventType eventType);
+
+    void timeTraceEndEvent(TimeTraceEventType eventType);
+    void timeTraceEndEvent(TimeTraceEventType eventType, Expression *e);
+
+
+    /// RAII helper class to call the begin and end functions of the time trace
+    /// profiler.  When the object is constructed, it begins the event; and when
+    /// it is destroyed, it stops it.
+    /// The strings pointed to are copied (pointers are not stored).
+    struct TimeTraceScope
+    {
+        TimeTraceScope() = delete;
+        TimeTraceScope(const TimeTraceScope &) = delete;
+        TimeTraceScope &operator=(const TimeTraceScope &) = delete;
+        TimeTraceScope(TimeTraceScope &&) = delete;
+        TimeTraceScope &operator=(TimeTraceScope &&) = delete;
+
+        TimeTraceScope(const char *name, const char *detail = nullptr, Loc loc = Loc())
+            : TimeTraceScope(TimeTraceEventType::generic, name, detail, loc)
+        {}
+        TimeTraceScope(TimeTraceEventType type, const char *name = nullptr, const char *detail = nullptr, Loc loc = Loc())
+            : type(type)
+        {
+            if (timeTraceProfilerEnabled())
+                timeTraceBeginEvent(name, detail, loc);
+        }
+
+        ~TimeTraceScope()
+        {
+            if (timeTraceProfilerEnabled())
+                timeTraceEndEvent(type);
+        }
+
+    private:
+        TimeTraceEventType type = TimeTraceEventType::generic;
+    };
+}


### PR DESCRIPTION
Incl. moving the free-standing functions into the `dmd` C++ namespace.