### PR TITLE
Add C++23 to CppStdRevision enum

### DIFF
--- a/changelog/dmd.extern-std-cpp23.dd
+++ b/changelog/dmd.extern-std-cpp23.dd
@@ -1,0 +1,4 @@
+The compiler now accepts `-extern-std=c++23`
+
+The compiler now accepts c++23 as a supported standard for `-extern-std=`.
+Currently this only changes the value of `__traits(getTargetInfo, "cppStd")`.

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -359,6 +359,8 @@ dmd -cov -unittest myprog.d
                     Sets `__traits(getTargetInfo, \"cppStd\")` to `201703`)
                 $(LI $(I c++20): Use C++20 name mangling,
                     Sets `__traits(getTargetInfo, \"cppStd\")` to `202002`)
+                $(LI $(I c++23): Use C++23 name mangling,
+                    Sets `__traits(getTargetInfo, \"cppStd\")` to `202302`)
             )",
         ),
         Option("extern-std=[h|help|?]",
@@ -1122,6 +1124,7 @@ struct CLIUsage
   =c++14                Sets `__traits(getTargetInfo, \"cppStd\")` to `201402`
   =c++17                Sets `__traits(getTargetInfo, \"cppStd\")` to `201703`
   =c++20                Sets `__traits(getTargetInfo, \"cppStd\")` to `202002`
+  =c++23                Sets `__traits(getTargetInfo, \"cppStd\")` to `202302`
 ";
 
     /// Options supported by -HC

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6234,6 +6234,7 @@ enum class CppStdRevision : uint32_t
     cpp14 = 201402u,
     cpp17 = 201703u,
     cpp20 = 202002u,
+    cpp23 = 202302u,
 };
 
 enum class CHECKENABLE : uint8_t

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -62,6 +62,7 @@ enum CppStdRevision : uint
     cpp14 = 2014_02,
     cpp17 = 2017_03,
     cpp20 = 2020_02,
+    cpp23 = 2023_02,
 }
 
 /// Trivalent boolean to represent the state of a `revert`able change

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -73,7 +73,8 @@ enum CppStdRevision
     CppStdRevisionCpp11 = 201103,
     CppStdRevisionCpp14 = 201402,
     CppStdRevisionCpp17 = 201703,
-    CppStdRevisionCpp20 = 202002
+    CppStdRevisionCpp20 = 202002,
+    CppStdRevisionCpp23 = 202302,
 };
 
 /// Trivalent boolean to represent the state of a `revert`able change

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1143,6 +1143,9 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             case "c++20":
                 params.cplusplus = CppStdRevision.cpp20;
                 break;
+            case "c++23":
+                params.cplusplus = CppStdRevision.cpp23;
+                break;
             default:
                 error("switch `%s` is invalid", p);
                 params.help.externStd = true;

--- a/druntime/src/core/stdcpp/xutility.d
+++ b/druntime/src/core/stdcpp/xutility.d
@@ -35,6 +35,7 @@ enum CppStdRevision : uint
     cpp14 = 201402,
     cpp17 = 201703,
     cpp20 = 202002,
+    cpp23 = 202302,
 }
 
 /**


### PR DESCRIPTION
It's past time to add this option, and set CppStdRevision to the specified value for C++23

https://www.iso.org/standard/83626.html

https://eel.is/c++draft/cpp.predefined#1.1.