### PR TITLE
Improve UFCS/property error message

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -3444,8 +3444,16 @@ Expression getProperty(Type t, Scope* scope_, Loc loc, Identifier ident, int fla
                 auto s2 = scope_.search_correct(ident);
                 // UFCS
                 if (s2 && s2.isFuncDeclaration)
-                    errorSupplemental(loc, "did you mean %s `%s`?",
-                        s2.kind(), s2.toChars());
+                {
+                    if (s2.ident == ident)
+                    {
+                        errorSupplemental(s2.loc, "cannot call %s `%s` with UFCS because it is not declared at module scope",
+                            s2.kind(), s2.toChars());
+                    }
+                    else
+                        errorSupplemental(s2.loc, "did you mean %s `%s`?",
+                            s2.kind(), s2.toChars());
+                }
                 else if (src.type.ty == Tpointer)
                 {
                     // structPtr.field
@@ -3454,7 +3462,7 @@ Expression getProperty(Type t, Scope* scope_, Loc loc, Identifier ident, int fla
                     {
                         if (auto s3 = as.search_correct(ident))
                         {
-                            errorSupplemental(loc, "did you mean %s `%s`?",
+                            errorSupplemental(s3.loc, "did you mean %s `%s`?",
                                 s3.kind(), s3.toChars());
                         }
                     }

--- a/compiler/test/fail_compilation/fail347.d
+++ b/compiler/test/fail_compilation/fail347.d
@@ -5,10 +5,10 @@ TEST_OUTPUT:
 fail_compilation/fail347.d(26): Error: undefined identifier `bbr`, did you mean variable `bar`?
 fail_compilation/fail347.d(27): Error: no property `ofo` for type `S`, did you mean `fail347.S.foo`?
 fail_compilation/fail347.d(29): Error: no property `fool` for `sp` of type `fail347.S*`
-fail_compilation/fail347.d(29):        did you mean variable `foo`?
+fail_compilation/fail347.d(20):        did you mean variable `foo`?
 fail_compilation/fail347.d(30): Error: undefined identifier `strlenx`, did you mean function `strlen`?
 fail_compilation/fail347.d(31): Error: no property `strlenx` for `"hello"` of type `string`
-fail_compilation/fail347.d(31):        did you mean function `strlen`?
+fail_compilation/imports/fail347a.d(3):        did you mean function `strlen`?
 ---
 */
 

--- a/compiler/test/fail_compilation/ufcs.d
+++ b/compiler/test/fail_compilation/ufcs.d
@@ -1,22 +1,27 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ufcs.d(26): Error: no property `regularF` for `s` of type `S`
-fail_compilation/ufcs.d(26):        the following error occured while looking for a UFCS match
-fail_compilation/ufcs.d(26): Error: function `regularF` is not callable using argument types `(S)`
-fail_compilation/ufcs.d(26):        expected 0 argument(s), not 1
-fail_compilation/ufcs.d(31):        `ufcs.regularF()` declared here
-fail_compilation/ufcs.d(27): Error: no property `templateF` for `s` of type `S`
-fail_compilation/ufcs.d(27):        the following error occured while looking for a UFCS match
-fail_compilation/ufcs.d(27): Error: template `templateF` is not callable using argument types `!()(S)`
-fail_compilation/ufcs.d(32):        Candidate is: `templateF()()`
-fail_compilation/ufcs.d(28): Error: no property `templateO` for `s` of type `S`
-fail_compilation/ufcs.d(28):        the following error occured while looking for a UFCS match
-fail_compilation/ufcs.d(28): Error: none of the overloads of template `ufcs.templateO` are callable using argument types `!()(S)`
-fail_compilation/ufcs.d(34):        Candidates are: `templateO()(int x)`
-fail_compilation/ufcs.d(35):                        `templateO()(float y)`
+fail_compilation/ufcs.d(31): Error: no property `regularF` for `s` of type `S`
+fail_compilation/ufcs.d(31):        the following error occured while looking for a UFCS match
+fail_compilation/ufcs.d(31): Error: function `regularF` is not callable using argument types `(S)`
+fail_compilation/ufcs.d(31):        expected 0 argument(s), not 1
+fail_compilation/ufcs.d(39):        `ufcs.regularF()` declared here
+fail_compilation/ufcs.d(32): Error: no property `templateF` for `s` of type `S`
+fail_compilation/ufcs.d(32):        the following error occured while looking for a UFCS match
+fail_compilation/ufcs.d(32): Error: template `templateF` is not callable using argument types `!()(S)`
+fail_compilation/ufcs.d(40):        Candidate is: `templateF()()`
+fail_compilation/ufcs.d(33): Error: no property `templateO` for `s` of type `S`
+fail_compilation/ufcs.d(33):        the following error occured while looking for a UFCS match
+fail_compilation/ufcs.d(33): Error: none of the overloads of template `ufcs.templateO` are callable using argument types `!()(S)`
+fail_compilation/ufcs.d(42):        Candidates are: `templateO()(int x)`
+fail_compilation/ufcs.d(43):                        `templateO()(float y)`
+fail_compilation/ufcs.d(36): Error: no property `local` for `s` of type `ufcs.S`
+fail_compilation/ufcs.d(35):        cannot call function `local` with UFCS because it is not declared at module scope
+fail_compilation/ufcs.d(26):        struct `S` defined here
 ---
 */
+
+
 
 struct S { }
 
@@ -26,6 +31,9 @@ void f()
     s.regularF();
     s.templateF();
     s.templateO();
+
+    void local(S) {}
+    s.local();
 }
 
 void regularF();


### PR DESCRIPTION
Improves on https://github.com/dlang/dmd/pull/16673 by using the location of the suggested symbol, and considering that local functions aren't eligible for UFCS instead of making a nonsensical suggestion ("no property foo, did you mean foo?").