### PR TITLE
Remove redundant GC allocation for _d_newarraymTX.dims

### DIFF
--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -505,7 +505,7 @@ version (D_ProfileGC)
  * Returns:
  *    newly allocated array
  */
-Tarr _d_newarraymTX(Tarr : U[], T, U)(size_t[] dims, bool isShared=false) @trusted
+Tarr _d_newarraymTX(Tarr : U[], T, U)(scope size_t[] dims, bool isShared=false) @trusted
 {
     debug(PRINTF) printf("_d_newarraymTX(dims.length = %zd)\n", dims.length);
 
@@ -602,7 +602,7 @@ version (D_ProfileGC)
     /**
     * TraceGC wrapper around $(REF _d_newarraymT, core,internal,array,construction).
     */
-    Tarr _d_newarraymTXTrace(Tarr : U[], T, U)(size_t[] dims, bool isShared=false, string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
+    Tarr _d_newarraymTXTrace(Tarr : U[], T, U)(scope size_t[] dims, bool isShared=false, string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
     {
         version (D_TypeInfo)
         {

--- a/druntime/test/profile/myprofilegc.log.freebsd.32.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.32.exp
@@ -14,8 +14,6 @@ bytes allocated, allocations, type, function, file:line
              16	              1	float profilegc.main src/profilegc.d:17
              16	              1	int profilegc.main src/profilegc.d:13
              16	              1	int profilegc.main src/profilegc.d:14
-             16	              1	uint[] profilegc.main src/profilegc.d:15
-             16	              1	uint[] profilegc.main src/profilegc.d:18
              16	              1	int[] profilegc.main src/profilegc.d:22
              16	              1	int[] profilegc.main src/profilegc.d:37
              16	              1	wchar[] profilegc.main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.freebsd.64.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.64.exp
@@ -6,8 +6,6 @@ bytes allocated, allocations, type, function, file:line
              48	              1	float[] profilegc.main src/profilegc.d:42
              48	              1	int[] profilegc.main src/profilegc.d:41
              32	              1	C profilegc.main src/profilegc.d:12
-             32	              1	ulong[] profilegc.main src/profilegc.d:15
-             32	              1	ulong[] profilegc.main src/profilegc.d:18
              32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] profilegc.main src/profilegc.d:34
              16	              1	char[] profilegc.main src/profilegc.d:36

--- a/druntime/test/profile/myprofilegc.log.linux.32.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.32.exp
@@ -16,6 +16,4 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int profilegc.main src/profilegc.d:14
              16	              1	int[] profilegc.main src/profilegc.d:22
              16	              1	int[] profilegc.main src/profilegc.d:37
-             16	              1	uint[] profilegc.main src/profilegc.d:15
-             16	              1	uint[] profilegc.main src/profilegc.d:18
              16	              1	wchar[] profilegc.main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.linux.64.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.64.exp
@@ -6,8 +6,6 @@ bytes allocated, allocations, type, function, file:line
              48	              1	float[] profilegc.main src/profilegc.d:42
              48	              1	int[] profilegc.main src/profilegc.d:41
              32	              1	C profilegc.main src/profilegc.d:12
-             32	              1	ulong[] profilegc.main src/profilegc.d:15
-             32	              1	ulong[] profilegc.main src/profilegc.d:18
              32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] profilegc.main src/profilegc.d:34
              16	              1	char[] profilegc.main src/profilegc.d:36

--- a/druntime/test/profile/myprofilegc.log.osx.32.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.32.exp
@@ -14,8 +14,6 @@ bytes allocated, allocations, type, function, file:line
              16	              1	float profilegc.main src/profilegc.d:17
              16	              1	int profilegc.main src/profilegc.d:13
              16	              1	int profilegc.main src/profilegc.d:14
-             16	              1	uint[] profilegc.main src/profilegc.d:15
-             16	              1	uint[] profilegc.main src/profilegc.d:18
              16	              1	int[] profilegc.main src/profilegc.d:22
              16	              1	int[] profilegc.main src/profilegc.d:37
              16	              1	wchar[] profilegc.main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.osx.64.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.64.exp
@@ -6,8 +6,6 @@ bytes allocated, allocations, type, function, file:line
              48	              1	float[] profilegc.main src/profilegc.d:42
              48	              1	int[] profilegc.main src/profilegc.d:41
              32	              1	C profilegc.main src/profilegc.d:12
-             32	              1	ulong[] profilegc.main src/profilegc.d:15
-             32	              1	ulong[] profilegc.main src/profilegc.d:18
              32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] profilegc.main src/profilegc.d:34
              16	              1	char[] profilegc.main src/profilegc.d:36

--- a/druntime/test/profile/myprofilegc.log.windows.32.exp
+++ b/druntime/test/profile/myprofilegc.log.windows.32.exp
@@ -16,6 +16,4 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int profilegc.main src\profilegc.d:14
              16	              1	int[] profilegc.main src\profilegc.d:22
              16	              1	int[] profilegc.main src\profilegc.d:37
-             16	              1	uint[] profilegc.main src\profilegc.d:15
-             16	              1	uint[] profilegc.main src\profilegc.d:18
              16	              1	wchar[] profilegc.main src\profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.windows.64.exp
+++ b/druntime/test/profile/myprofilegc.log.windows.64.exp
@@ -6,8 +6,6 @@ bytes allocated, allocations, type, function, file:line
              48	              1	float[] profilegc.main src\profilegc.d:42
              48	              1	int[] profilegc.main src\profilegc.d:41
              32	              1	C profilegc.main src\profilegc.d:12
-             32	              1	ulong[] profilegc.main src\profilegc.d:15
-             32	              1	ulong[] profilegc.main src\profilegc.d:18
              32	              1	void[] profilegc.main src\profilegc.d:55
              16	              1	char[] profilegc.main src\profilegc.d:34
              16	              1	char[] profilegc.main src\profilegc.d:36


### PR DESCRIPTION
I found that when you run `int[][] a = new int[][](2, 8);`, it actually puts [2, 8] on the heap! scope inference fails on the `dims` parameter, so make it explicit.