### PR TITLE
Fix #21054 - No location for array literal sliced from init symbol

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2234,7 +2234,7 @@ extern (C++) final class TypeSArray : TypeArray
         auto elements = new Expressions(d);
         foreach (ref e; *elements)
             e = null;
-        auto ae = new ArrayLiteralExp(Loc.initial, this, elementinit, elements);
+        auto ae = new ArrayLiteralExp(loc, this, elementinit, elements);
         return ae;
     }
 

--- a/compiler/test/fail_compilation/nogc3.d
+++ b/compiler/test/fail_compilation/nogc3.d
@@ -111,3 +111,16 @@ void f() @nogc
     DA da = DA.a;
     int i = *cast(int*)cast(char[4])['0', '0', '0', '0'];
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/nogc3.d(125): Error: this array literal causes a GC allocation in `@nogc` function `g`
+---
+*/
+
+// https://github.com/dlang/dmd/issues/21054
+void g() @nogc
+{
+    int[] x = (int[2]).init[];
+}


### PR DESCRIPTION
Closes #21054 