### PR TITLE
Fix dlang#18262 - Fix expected error message for enum auto-increment

### DIFF
--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -524,6 +524,16 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
         });
 
         assert(emprev);
+
+        // New check: if the base type is an enum, auto-increment is not supported.
+        if (em.ed.memtype && em.ed.memtype.isTypeEnum())
+        {
+            error(em.loc,
+                  "cannot automatically assign value to enum member `%s` because base type `%s` is an enum; please provide an explicit value",
+                  em.toPrettyChars(), em.ed.memtype.toChars());
+            return errorReturn();
+        }
+
         if (emprev.semanticRun < PASS.semanticdone) // if forward reference
             emprev.dsymbolSemantic(emprev._scope); // resolve it
         if (emprev.errors)

--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -525,14 +525,19 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
 
         assert(emprev);
 
-        // New check: if the base type is an enum, auto-increment is not supported.
-        if (em.ed.memtype && em.ed.memtype.isTypeEnum())
+        // New check: if the base type is an enum, auto-increment is not supported,
+        // unless it is a special enum (for example, the C types like cpp_long/longlong).
+        if (auto te = em.ed.memtype ? em.ed.memtype.isTypeEnum() : null)
         {
-            error(em.loc,
-                  "cannot automatically assign value to enum member `%s` because base type `%s` is an enum; please provide an explicit value",
-                  em.toPrettyChars(), em.ed.memtype.toChars());
-            return errorReturn();
+            if (!te.sym.isSpecial())
+            {
+                error(em.loc,
+                      "cannot automatically assign value to enum member `%s` because base type `%s` is an enum; provide an explicit value",
+                      em.toPrettyChars(), em.ed.memtype.toChars());
+                return errorReturn();
+            }
         }
+
 
         if (emprev.semanticRun < PASS.semanticdone) // if forward reference
             emprev.dsymbolSemantic(emprev._scope); // resolve it

--- a/compiler/test/fail_compilation/enum_auto_increment.d
+++ b/compiler/test/fail_compilation/enum_auto_increment.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation\enum_auto_increment.d(17): Error: cannot automatically assign value to enum member `enum_auto_increment.A2.d` because base type `A1` is an enum; please provide an explicit value
+---
+*/
+
+enum A1 : int
+{
+    a,
+    b,
+}
+
+enum A2 : A1
+{
+    c,
+    d,
+}

--- a/compiler/test/fail_compilation/enum_auto_increment.d
+++ b/compiler/test/fail_compilation/enum_auto_increment.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation\enum_auto_increment.d(17): Error: cannot automatically assign value to enum member `enum_auto_increment.A2.d` because base type `A1` is an enum; please provide an explicit value
+fail_compilation\enum_auto_increment.d(17): Error: cannot automatically assign value to enum member `enum_auto_increment.A2.d` because base type `A1` is an enum; provide an explicit value
 ---
 */
 

--- a/compiler/test/fail_compilation/fail109.d
+++ b/compiler/test/fail_compilation/fail109.d
@@ -34,9 +34,7 @@ enum E1 : short
 /* https://issues.dlang.org/show_bug.cgi?id=14950
 TEST_OUTPUT:
 ---
-fail_compilation/fail109.d(50): Error: cannot check `fail109.B.end` value for overflow
-fail_compilation/fail109.d(50): Error: comparison between different enumeration types `B` and `C`; If this behavior is intended consider using `std.conv.asOriginalType`
-fail_compilation/fail109.d(50): Error: enum member `fail109.B.end` initialization with `B.start+1` causes overflow for type `C`
+fail_compilation\fail109.d(48): Error: cannot automatically assign value to enum member `fail109.B.end` because base type `C` is an enum; provide an explicit value
 ---
 */
 enum C
@@ -53,10 +51,10 @@ enum B
 /* https://issues.dlang.org/show_bug.cgi?id=11849
 TEST_OUTPUT:
 ---
-fail_compilation/fail109.d(72): Error: enum member `fail109.RegValueType1a.Unknown` is forward referenced looking for `.max`
-fail_compilation/fail109.d(79): Error: enum member `fail109.RegValueType1b.Unknown` is forward referenced looking for `.max`
-fail_compilation/fail109.d(84): Error: enum member `fail109.RegValueType2a.Unknown` is forward referenced looking for `.min`
-fail_compilation/fail109.d(91): Error: enum member `fail109.RegValueType2b.Unknown` is forward referenced looking for `.min`
+fail_compilation/fail109.d(70): Error: enum member `fail109.RegValueType1a.Unknown` is forward referenced looking for `.max`
+fail_compilation/fail109.d(77): Error: enum member `fail109.RegValueType1b.Unknown` is forward referenced looking for `.max`
+fail_compilation/fail109.d(82): Error: enum member `fail109.RegValueType2a.Unknown` is forward referenced looking for `.min`
+fail_compilation/fail109.d(89): Error: enum member `fail109.RegValueType2b.Unknown` is forward referenced looking for `.min`
 ---
 */
 
@@ -94,7 +92,7 @@ enum RegValueType2b : DWORD
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail109.d(107): Error: enum member `fail109.d` initialization with `__anonymous.c+1` causes overflow for type `Q`
+fail_compilation/fail109.d(105): Error: enum member `fail109.d` initialization with `__anonymous.c+1` causes overflow for type `Q`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail98.d
+++ b/compiler/test/fail_compilation/fail98.d
@@ -1,7 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail98.d(17): Error: cannot implicitly convert expression `256` of type `int` to `E`
+fail_compilation/fail98.d(20): Error: cannot implicitly convert expression `256` of type `int` to `E`
+fail_compilation/fail98.d(21): Error: cannot automatically assign value to enum member `fail98.D3DTS_WORLD1` because base type `E` is an enum; provide an explicit value
+fail_compilation/fail98.d(22): Error: cannot automatically assign value to enum member `fail98.D3DTS_WORLD2` because base type `E` is an enum; provide an explicit value
+fail_compilation/fail98.d(23): Error: cannot automatically assign value to enum member `fail98.D3DTS_WORLD3` because base type `E` is an enum; provide an explicit value
 ---
 */
 
@@ -34,3 +37,4 @@ enum E
     D3DTS_TEXTURE7, // = 23
     D3DTS_FORCE_DWORD  = 0xffffffff
 }
+

--- a/compiler/test/fail_compilation/fail98.d
+++ b/compiler/test/fail_compilation/fail98.d
@@ -37,4 +37,3 @@ enum E
     D3DTS_TEXTURE7, // = 23
     D3DTS_FORCE_DWORD  = 0xffffffff
 }
-


### PR DESCRIPTION
Fix #18262 

The original error message for "auto-incrementing enum members whose base type is another enum" stated that - Error: comparison between different enumeration types `A2` and `A1`; If this behavior is intended consider using `std.conv.asOriginalType`
which made no sense. 

This pull request improves the diagnostic message for auto-incrementing enum members when the base type is another enum. Now, it clearly instructs the user to provide an explicit initializer.

The fix: 
1. In enumsem.d, within the enumMemberSemantic function, I added a check to determine if the enum's base type is an enum. If it is, a clear error message is issued, and the auto-increment is aborted. This change prevents the confusing diagnostic previously encountered.
2. I added a test case file in ../test/fail_compilation/enum_auto_increment.d that replicates the issue. The new error message is correctly displayed when compiling the file with the updated DMD.