### PR TITLE
Fix hidden base constructor supplemental message

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1765,10 +1765,15 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
                     functionResolve(mErr, baseFunction, loc, sc, tiargs, baseClass.type, argumentList);
                     if (mErr.last > MATCH.nomatch && mErr.lastf)
                     {
-                        errorSupplemental(loc, "%s `%s` hides base class function `%s`",
-                                fd.kind, fd.toPrettyChars(), mErr.lastf.toPrettyChars());
-                        errorSupplemental(loc, "add `alias %s = %s` to `%s`'s body to merge the overload sets",
-                                fd.toChars(), mErr.lastf.toPrettyChars(), tthis.toChars());
+                        errorSupplemental(loc, "Note: %s `%s` hides base class %s `%s`",
+                            fd.kind, fd.toPrettyChars(),
+                            mErr.lastf.kind, mErr.lastf.toPrettyChars());
+
+                        if (!fd.isCtorDeclaration)
+                        {
+                            errorSupplemental(loc, "Add `alias %s = %s;` to `%s`'s body to merge the overload sets",
+                                    fd.toChars(), mErr.lastf.toPrettyChars(), tthis.toChars());
+                        }
                         return null;
                     }
                 }

--- a/compiler/test/fail_compilation/diag23384.d
+++ b/compiler/test/fail_compilation/diag23384.d
@@ -4,8 +4,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag23384.d(28): Error: function `diag23384.Derived.fun(B b)` is not callable using argument types `(A)`
-fail_compilation/diag23384.d(28):        function `diag23384.Derived.fun` hides base class function `diag23384.Base.fun`
-fail_compilation/diag23384.d(28):        add `alias fun = diag23384.Base.fun` to `diag23384.Derived`'s body to merge the overload sets
+fail_compilation/diag23384.d(28):        Note: function `diag23384.Derived.fun` hides base class function `diag23384.Base.fun`
+fail_compilation/diag23384.d(28):        Add `alias fun = diag23384.Base.fun;` to `diag23384.Derived`'s body to merge the overload sets
 ---
 */
 

--- a/compiler/test/fail_compilation/hidden_ctor.d
+++ b/compiler/test/fail_compilation/hidden_ctor.d
@@ -1,0 +1,27 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/hidden_ctor.d(25): Error: constructor `hidden_ctor.B.this(string s)` is not callable using argument types `()`
+fail_compilation/hidden_ctor.d(25):        Note: constructor `hidden_ctor.B.this` hides base class constructor `hidden_ctor.A.this`
+---
+*/
+
+class A {
+    int a;
+
+    this() {
+        this.a = 1;
+    }
+}
+class B : A {
+    string b;
+
+    this(string s) {
+        super();
+        this.b = s;
+    }
+}
+void main() {
+    auto b = new B();
+    b = new B("Hi, Mom!");
+}


### PR DESCRIPTION
Fixes #21068.
Also say base class *constructor* in supplemental message. 