### PR TITLE
Translate `_d_arrayliteralTX` to a template

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -4181,11 +4181,13 @@ elem* toElem(Expression e, ref IRState irs)
                 * Avoids the whole variadic arg mess.
                 */
 
-                // call _d_arrayliteralTX(ti, dim)
-                e = el_bin(OPcall, TYnptr,
-                    el_var(getRtlsym(RTLSYM.ARRAYLITERALTX)),
-                    el_param(el_long(TYsize_t, dim), getTypeInfo(ale, ale.type, irs)));
-                toTraceGC(irs, e, ale.loc);
+                if (!ale.lowering)
+                {
+                    fprintf(stderr, "Internal Error: array literal %s at %s should have been lowered to a _d_arrayliteralTX template\n",
+                        ale.toChars(), ale.loc.toChars());
+                    assert(0);
+                }
+                e = toElem(ale.lowering, irs);
 
                 Symbol* stmp = symbol_genauto(Type_toCtype(Type.tvoid.pointerTo()));
                 e = el_bin(OPeq, TYnptr, el_var(stmp), e);

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -1906,6 +1906,8 @@ extern (C++) final class ArrayLiteralExp : Expression
 
     Expressions* elements;
 
+    Expression lowering;
+
     extern (D) this(Loc loc, Type type, Expressions* elements) @safe
     {
         super(loc, EXP.arrayLiteral);

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -407,6 +407,7 @@ public:
     d_bool onstack;
     Expression *basis;
     Expressions *elements;
+    Expression *lowering;
 
     static ArrayLiteralExp *create(Loc loc, Expressions *elements);
     ArrayLiteralExp *syntaxCopy() override;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11899,14 +11899,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression ce = new CallExp(ae.loc, id, arguments);
         res = Expression.combine(eValue2, ce).expressionSemantic(sc);
         if (isArrayAssign)
-            res = Expression.combine(res, ae.e1).expressionSemantic(sc);
+            res = Expression.combine(res, ae.e1).expressionSemantic(sc).checkGC(sc);
 
         if (global.params.v.verbose)
             message("lowered   %s =>\n          %s", ae.toChars(), res.toChars());
 
         res = new LoweredAssignExp(ae, res);
         res.type = ae.type;
-        res = res.checkGC(sc);
 
         return res;
     }
@@ -12542,7 +12541,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         auto tiargs = new Objects(exp.type);
         id = new DotTemplateInstanceExp(exp.loc, id, hook, tiargs);
         id = new CallExp(exp.loc, id, arguments);
-        return id.expressionSemantic(sc);
+        return id.expressionSemantic(sc).checkGC(sc);
     }
 
     void trySetCatExpLowering(Expression exp)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2667,6 +2667,7 @@ public:
     bool onstack;
     Expression* basis;
     Array<Expression* >* elements;
+    Expression* lowering;
     static ArrayLiteralExp* create(Loc loc, Array<Expression* >* elements);
     ArrayLiteralExp* syntaxCopy() override;
     bool equals(const RootObject* const o) const override;
@@ -5589,7 +5590,7 @@ private:
         char complexexp[64LLU];
         char symoffexp[56LLU];
         char stringexp[44LLU];
-        char arrayliteralexp[40LLU];
+        char arrayliteralexp[48LLU];
         char assocarrayliteralexp[48LLU];
         char structliteralexp[64LLU];
         char compoundliteralexp[32LLU];
@@ -8971,6 +8972,8 @@ struct Id final
     static Identifier* _d_newarrayTTrace;
     static Identifier* _d_newarraymTX;
     static Identifier* _d_newarraymTXTrace;
+    static Identifier* _d_arrayliteralTX;
+    static Identifier* _d_arrayliteralTXTrace;
     static Identifier* _d_assert_fail;
     static Identifier* dup;
     static Identifier* _aaApply;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -280,6 +280,8 @@ immutable Msgtable[] msgtable =
     { "_d_newarrayTTrace" },
     { "_d_newarraymTX" },
     { "_d_newarraymTXTrace" },
+    { "_d_arrayliteralTX" },
+    { "_d_arrayliteralTXTrace" },
     { "_d_assert_fail" },
     { "dup" },
     { "_aaApply" },

--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -163,6 +163,15 @@ values!(__c_wchar_t)
 	}
 
 }
+_d_arrayliteralTX!(__c_wchar_t[])
+{
+	pure nothrow @trusted void* _d_arrayliteralTX(ulong length)
+	{
+		return _d_arrayliteralTX(typeid(__c_wchar_t[]), length);
+	}
+
+}
+static __gshared TypeInfo_Array _D28TypeInfo_AE3vcg11__c_wchar_t6__initZ;
 RTInfo!(_R)
 {
 	enum immutable(void)* RTInfo = null;

--- a/compiler/test/compilable/vcg-ast.d
+++ b/compiler/test/compilable/vcg-ast.d
@@ -4,6 +4,8 @@ PERMUTE_ARGS:
 OUTPUT_FILES: compilable/vcg-ast.d.cg
 EXTRA_FILES: imports/vcg_ast_import.d
 TEST_OUTPUT_FILE: extra-files/vcg-ast.d.cg
+// size_t currently must be ulong in this test, not uint
+DISABLED: freebsd32 openbsd32 linux32 osx32 win32
 */
 
 module vcg;

--- a/compiler/test/fail_compilation/test21477.d
+++ b/compiler/test/fail_compilation/test21477.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -betterC
 TEST_OUTPUT:
 ---
-fail_compilation/test21477.d(103): Error: expression `[1]` uses the GC and cannot be used with switch `-betterC`
+fail_compilation/test21477.d(103): Error: this array literal requires the GC and cannot be used with `-betterC`
 ---
 */
 

--- a/compiler/test/fail_compilation/test23710.d
+++ b/compiler/test/fail_compilation/test23710.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -betterC
 TEST_OUTPUT:
 ---
-fail_compilation/test23710.d(111): Error: array concatenation of expression `foo ~ [1, 2, 3]` requires the GC which is not available with -betterC
+fail_compilation/test23710.d(112): Error: array concatenation of expression `foo ~ cast(int[])a` requires the GC which is not available with -betterC
 ---
  */
 // https://issues.dlang.org/show_bug.cgi?id=23710
@@ -12,13 +12,14 @@ int test(int i)
 {
     int j;
     int[] foo;
+    int[3] a = [1,2,3];
     if (0)
     {
         for (;;)
         {
             import core.stdc.stdio;
             printf("start body\n");
-            foo = foo ~ [1,2,3];
+            foo = foo ~ a;
 L1:
             printf("foo.length = %zu\n", foo.length);
 	    j += foo.length;

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -4782,6 +4782,7 @@ version (D_ProfileGC)
     public import core.internal.array.construction : _d_newarrayTTrace;
     public import core.internal.array.construction : _d_newarraymTXTrace;
     public import core.internal.array.capacity: _d_arraysetlengthTTrace;
+    public import core.internal.array.construction : _d_arrayliteralTXTrace;
 }
 public import core.internal.array.appending : _d_arrayappendcTX;
 public import core.internal.array.comparison : __cmp;
@@ -4792,6 +4793,7 @@ public import core.internal.array.construction : _d_arrayctor;
 public import core.internal.array.construction : _d_arraysetctor;
 public import core.internal.array.construction : _d_newarrayT;
 public import core.internal.array.construction : _d_newarraymTX;
+public import core.internal.array.construction : _d_arrayliteralTX;
 public import core.internal.array.arrayassign : _d_arrayassign_l;
 public import core.internal.array.arrayassign : _d_arrayassign_r;
 public import core.internal.array.arrayassign : _d_arraysetassign;


### PR DESCRIPTION
Adds a lowering field to `ArrayLiteralExp`, and builds on https://github.com/dlang/dmd/pull/21058 to set the `.lowering` in NOGCVisitor. At some point `checkGC` and `nogc.d` should be renamed to `gcSemantic` or something, but to keep this PR small, I'll clean up the code in a follow up PR if this gets merged. 

The template hook still only calls the old TypeInfo version. That can be improved later as well.