### PR TITLE
 Fix error when struct initializer isn't accepted 

### DIFF
--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -196,7 +196,7 @@ public:
 
     unsigned numArgTypes() const;
     Type *argType(unsigned index);
-    bool hasRegularCtor(bool checkDisabled = false);
+    bool hasRegularCtor(bool ignoreDisabled = false);
 };
 
 class UnionDeclaration final : public StructDeclaration

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -401,13 +401,12 @@ extern (C++) class StructDeclaration : AggregateDeclaration
      * is not disabled.
      *
      * Params:
-     *      checkDisabled = if the struct has a regular
-                            non-disabled constructor
+     *      ignoreDisabled = true to ignore disabled constructors
      * Returns:
      *      true, if the struct has a regular (optionally,
      *      not disabled) constructor, false otherwise.
      */
-    final bool hasRegularCtor(bool checkDisabled = false)
+    final bool hasRegularCtor(bool ignoreDisabled = false)
     {
         if (!ctor)
             return false;
@@ -417,7 +416,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         {
             if (auto td = s.isTemplateDeclaration())
             {
-                if (checkDisabled && td.onemember)
+                if (ignoreDisabled && td.onemember)
                 {
                     if (auto ctorDecl = td.onemember.isCtorDeclaration())
                     {
@@ -430,7 +429,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             }
             if (auto ctorDecl = s.isCtorDeclaration())
             {
-                if (!ctorDecl.isCpCtor && (!checkDisabled || !(ctorDecl.storage_class & STC.disable)))
+                if (!ctorDecl.isCpCtor && (!ignoreDisabled || !(ctorDecl.storage_class & STC.disable)))
                 {
                     result = true;
                     return 1;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7281,7 +7281,7 @@ public:
     void accept(Visitor* v) override;
     uint32_t numArgTypes() const;
     Type* argType(uint32_t index);
-    bool hasRegularCtor(bool checkDisabled = false);
+    bool hasRegularCtor(bool ignoreDisabled = false);
 };
 
 class UnionDeclaration final : public StructDeclaration

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -153,10 +153,10 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             // that is not disabled.
             if (sd.hasRegularCtor(true))
             {
-                error(i.loc, "%s `%s` has a constructor, cannot use %s initializer syntax",
-					sd.kind(), sd.toChars(), sd.kind());
+                error(i.loc, "Cannot use %s initializer syntax for %s `%s` because it has a constructor",
+                    sd.kind(), sd.kind(), sd.toChars());
                 errorSupplemental(i.loc, "Use `%s( arguments )` instead of `{ initializers }`",
-					sd.toChars());
+                    sd.toChars());
                 return err();
             }
             sd.size(i.loc);

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -153,7 +153,10 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             // that is not disabled.
             if (sd.hasRegularCtor(true))
             {
-                error(i.loc, "%s `%s` has constructors, cannot use `{ initializers }`, use `%s( initializers )` instead", sd.kind(), sd.toChars(), sd.toChars());
+                error(i.loc, "%s `%s` has a constructor, cannot use %s initializer syntax",
+					sd.kind(), sd.toChars(), sd.kind());
+                errorSupplemental(i.loc, "Use `%s( arguments )` instead of `{ initializers }`",
+					sd.toChars());
                 return err();
             }
             sd.size(i.loc);

--- a/compiler/test/fail_compilation/fail21547.d
+++ b/compiler/test/fail_compilation/fail21547.d
@@ -3,8 +3,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail21547.d(32): Error: struct `Bar` has constructors, cannot use `{ initializers }`, use `Bar( initializers )` instead
-fail_compilation/fail21547.d(33): Error: struct `Bar1` has constructors, cannot use `{ initializers }`, use `Bar1( initializers )` instead
+fail_compilation/fail21547.d(34): Error: Cannot use struct initializer syntax for struct `Bar` because it has a constructor
+fail_compilation/fail21547.d(34):        Use `Bar( arguments )` instead of `{ initializers }`
+fail_compilation/fail21547.d(35): Error: Cannot use struct initializer syntax for struct `Bar1` because it has a constructor
+fail_compilation/fail21547.d(35):        Use `Bar1( arguments )` instead of `{ initializers }`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail336.d
+++ b/compiler/test/fail_compilation/fail336.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail336.d(16): Error: struct `S` has constructors, cannot use `{ initializers }`, use `S( initializers )` instead
+fail_compilation/fail336.d(17): Error: Cannot use struct initializer syntax for struct `S` because it has a constructor
+fail_compilation/fail336.d(17):        Use `S( arguments )` instead of `{ initializers }`
 ---
 */
 


### PR DESCRIPTION
Suggested `S( initializers )` syntax is not valid grammar, only expressions can be passed to a struct literal.
Break message into 2 lines.
Also rename confusing parameter of `StructDeclaration.hasRegularCtor` to `ignoreDisabled`.