### PR TITLE
Fix #21065 - classInstanceSize is not a multiple of its classInstanceAlignment

### DIFF
--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -269,6 +269,7 @@ public:
     TypeInfoClassDeclaration *vclassinfo;       // the ClassInfo object for this ClassDeclaration
     d_bool com;                           // true if this is a COM class (meaning it derives from IUnknown)
     d_bool stack;                         // true if this is a scope class
+    uint32_t derivedClassOffset;        // The starting offset position for fields that are derived from this class
     int cppDtorVtblIndex;               // slot reserved for the virtual destructor [extern(C++)]
     d_bool inuse;                         // to prevent recursive attempts
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5537,23 +5537,23 @@ struct UnionExp final
 private:
     union _AnonStruct_u
     {
-        char exp[22LLU];
+        char exp[24LLU];
         char integerexp[32LLU];
-        char errorexp[22LLU];
+        char errorexp[24LLU];
         char realexp[48LLU];
         char complexexp[64LLU];
         char symoffexp[56LLU];
-        char stringexp[43LLU];
+        char stringexp[48LLU];
         char arrayliteralexp[40LLU];
         char assocarrayliteralexp[48LLU];
         char structliteralexp[64LLU];
         char compoundliteralexp[32LLU];
-        char nullexp[22LLU];
-        char dotvarexp[41LLU];
+        char nullexp[24LLU];
+        char dotvarexp[48LLU];
         char addrexp[32LLU];
-        char indexexp[50LLU];
-        char sliceexp[57LLU];
-        char vectorexp[45LLU];
+        char indexexp[56LLU];
+        char sliceexp[64LLU];
+        char vectorexp[48LLU];
     };
     #pragma pack(pop)
 
@@ -6166,7 +6166,7 @@ struct TargetCPP final
     const char* typeMangle(Type* t);
     Type* parameterType(Type* t);
     bool fundamentalType(const Type* const t, bool& isFundamental);
-    uint32_t derivedClassOffset(ClassDeclaration* baseClass);
+    uint32_t derivedClassOffset(ClassDeclaration* cd);
     TargetCPP() :
         reverseOverloads(),
         exceptions(),
@@ -6683,6 +6683,7 @@ public:
     TypeInfoClassDeclaration* vclassinfo;
     bool com;
     bool stack;
+    uint32_t derivedClassOffset;
     int32_t cppDtorVtblIndex;
     bool inuse;
     ThreeState isabstract;

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -1635,17 +1635,17 @@ struct TargetCPP
      * Get the starting offset position for fields of an `extern(C++)` class
      * that is derived from the given base class.
      * Params:
-     *      baseClass = base class with C++ linkage
+     *      cd = class with C++ linkage
      * Returns:
      *      starting offset to lay out derived class fields
      */
-    extern (C++) uint derivedClassOffset(ClassDeclaration baseClass)
+    extern (C++) uint derivedClassOffset(ClassDeclaration cd)
     {
         // MSVC adds padding between base and derived fields if required.
         if (target.os == Target.OS.Windows)
-            return (baseClass.structsize + baseClass.alignsize - 1) & ~(baseClass.alignsize - 1);
+            return (cd.structsize + cd.alignsize - 1) & ~(cd.alignsize - 1);
 
-        return baseClass.structsize;
+        return cd.structsize;
     }
 }
 

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -769,7 +769,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
             for (ClassDeclaration c = cdb.baseClass; c; c = c.baseClass)
                 index += c.fields.length;
             membersToDt(cdb, dtb, elements, index, concreteType, null);
-            offset = cdb.structsize;
+            offset = cdb.derivedClassOffset;
         }
         else if (InterfaceDeclaration id = cd.isInterfaceDeclaration())
         {
@@ -1036,7 +1036,14 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
 
     finishInFlightBitField();
 
-    if (offset < ad.structsize)
+    // Finish padding at end of instance type.
+    if (cd)
+    {
+        const cdsize = cd is concreteType ? cd.structsize : cd.derivedClassOffset;
+        if (offset < cdsize)
+            dtb.nzeros(cdsize - offset);
+    }
+    else if (offset < ad.structsize)
         dtb.nzeros(ad.structsize - offset);
     //printf("-dtb.length: %d\n", dtb.length);
 }

--- a/compiler/test/compilable/aggr_alignment.d
+++ b/compiler/test/compilable/aggr_alignment.d
@@ -25,7 +25,7 @@ class C2 // overall alignment: max(vtbl.alignof, monitor.alignof, 1, 2)
 enum payloadOffset = C2.bytes.offsetof;
 static assert(C2.int1.offsetof == payloadOffset + 8);
 static assert(__traits(classInstanceAlignment, C2) == size_t.sizeof);
-static assert(__traits(classInstanceSize, C2) == payloadOffset + 12); // no tail padding
+static assert(__traits(classInstanceSize, C2) == payloadOffset + 12 + 4); // with tail padding
 
 align(8) struct PaddedStruct
 {
@@ -44,7 +44,7 @@ class AlignedPayloadClass
 
 static assert(AlignedPayloadClass.field.offsetof == 64); // vtbl, monitor, alignment padding
 static assert(__traits(classInstanceAlignment, AlignedPayloadClass) == 64);
-static assert(__traits(classInstanceSize, AlignedPayloadClass) == 68);
+static assert(__traits(classInstanceSize, AlignedPayloadClass) == 128);
 
 align(1) struct UglyStruct
 {

--- a/compiler/test/compilable/noreturn3.d
+++ b/compiler/test/compilable/noreturn3.d
@@ -207,8 +207,9 @@ class AlignedClass
 }
 
 enum offset = (objectMemberSize + 4 + 16) & ~15;
+enum alignsize = __traits(classInstanceAlignment, AlignedClass);
 
-static assert(__traits(classInstanceSize, AlignedClass) == offset + 8);
+static assert(__traits(classInstanceSize, AlignedClass) == ((offset + 8 + alignsize - 1) & ~(alignsize - 1)));
 
 static assert(AlignedClass.firstInt.offsetof == objectMemberSize + 0);
 static assert(AlignedClass.noRet.offsetof == offset);

--- a/compiler/test/compilable/test21065.d
+++ b/compiler/test/compilable/test21065.d
@@ -1,0 +1,36 @@
+// https://github.com/dlang/dmd/issues/21065
+
+extern(C++) class CXX
+{
+    int method();
+    ubyte[4] not_multiple_of_8;
+}
+static assert(__traits(classInstanceAlignment, CXX) == 8);
+static assert(__traits(classInstanceSize, CXX) == 16);
+
+////////////////////////////////////////////
+
+extern(C++) class CXX2 : CXX
+{
+    ubyte[4] also_not_multiple;
+}
+version (Posix) static assert(__traits(classInstanceAlignment, CXX2) == 8);
+version (Posix) static assert(__traits(classInstanceSize, CXX2) == 16);
+
+////////////////////////////////////////////
+
+extern(D) class D
+{
+    ubyte[4] not_multiple_of_8;
+}
+static assert(__traits(classInstanceAlignment, D) == 8);
+static assert(__traits(classInstanceSize, D) == 24);
+
+////////////////////////////////////////////
+
+extern(D) class D2 : D
+{
+    ubyte[4] also_not_multiple;
+}
+static assert(__traits(classInstanceAlignment, D) == 8);
+static assert(__traits(classInstanceSize, D) == 24);

--- a/compiler/test/compilable/testfwdref.d
+++ b/compiler/test/compilable/testfwdref.d
@@ -340,8 +340,8 @@ class E12984b(T) : D12984b!int
     }
 }
 
-static assert(__traits(classInstanceSize, B12984b) == (void*).sizeof * 2 + int.sizeof);
-static assert(__traits(classInstanceSize, C12984b) == (void*).sizeof * 2 + int.sizeof * 2);
+static assert(__traits(classInstanceSize, B12984b) == (void*).sizeof * 2 + int.sizeof * 2); // 4 bytes tail padding
+static assert(__traits(classInstanceSize, C12984b) == (void*).sizeof * 2 + int.sizeof * 2); // no tail padding
 
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=14390

--- a/compiler/test/runnable/test12.d
+++ b/compiler/test/runnable/test12.d
@@ -786,7 +786,7 @@ void test36()
     printf("%d\n", a.d);
 
     version(D_LP64)
-        assert(a.classinfo.initializer.length == 36);
+        assert(a.classinfo.initializer.length == 40);
     else
         assert(a.classinfo.initializer.length == 28);
     assert(a.s == 1);

--- a/compiler/test/runnable/testconst.d
+++ b/compiler/test/runnable/testconst.d
@@ -627,8 +627,8 @@ class C42
 void test42()
 {
     printf("%zd\n", C42.classinfo.initializer.length);
-    assert(C42.classinfo.initializer.length == 12 + (void*).sizeof +
-        (void*).sizeof);
+    assert(C42.classinfo.initializer.length ==
+           ((12 + (void*).sizeof + (void*).sizeof + (void*).alignof - 1) & ~((void*).alignof - 1)));
     C42 c = new C42;
     assert(c.a == 1);
     assert(c.b == 2);


### PR DESCRIPTION
Introduces new field `derivedClassOffset` to distinguish between a class instances struct size, and the offset that derived classes start their field members from.

Closes: #21065


[Depends on https://github.com/dlang/phobos/pull/10717]