### PR TITLE
Improve fix: #20867 ICE on final switch forward referencing its enum.

### DIFF
--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -751,6 +751,8 @@ void cEnumSemantic(Scope* sc, EnumDeclaration ed)
     }
 
     ed.memtype = commonType;
-    ed.semanticRun = PASS.semanticdone;
+    // Set semantic2done to mark C enums as fully processed
+    // Prevents issues with final switch statements that reference C enums
+    ed.semanticRun = PASS.semantic2done;
     return;
 }

--- a/compiler/test/compilable/imports/cstuff3.c
+++ b/compiler/test/compilable/imports/cstuff3.c
@@ -4,3 +4,16 @@ int squared(int a)
 {
     return a * a;
 }
+
+/* test case for issue #21094 */
+typedef enum upng_error {
+    UPNG_EOK            = 0, /* success (no error) */
+    UPNG_ENOMEM         = 1, /* memory allocation failed */
+    UPNG_ENOTFOUND      = 2, /* resource not found (file missing) */
+    UPNG_ENOTPNG        = 3, /* image data does not have a PNG header */
+    UPNG_EMALFORMED     = 4, /* image data is not a valid PNG image */
+    UPNG_EUNSUPPORTED   = 5, /* critical PNG chunk type is not supported */
+    UPNG_EUNINTERLACED  = 6, /* image interlacing is not supported */
+    UPNG_EUNFORMAT      = 7, /* image color format is not supported */
+    UPNG_EPARAM         = 8  /* invalid parameter to method call */
+} upng_error;

--- a/compiler/test/compilable/testcstuff3.d
+++ b/compiler/test/compilable/testcstuff3.d
@@ -2,3 +2,22 @@
 import imports.cstuff3;
 
 static assert(squared(4) == 16);
+
+/* test case for issue #21094 */
+string enum_to_str(E)(E v) if (is(E == enum))
+{
+    final switch (v) with(E)
+    {
+        static foreach (m; __traits(allMembers, E))
+        {
+    case mixin(m):
+            return m;
+        }
+    }
+}
+
+void testEnumSwitch()
+{
+    auto str = enum_to_str(UPNG_EOK);
+    assert(str == "UPNG_EOK");
+}


### PR DESCRIPTION
Fix: https://github.com/dlang/dmd/issues/21094 
Improve the PR: https://github.com/dlang/dmd/pull/21001 (Fix: Prevent ICE on final switch forward referencing its enum)
I set `ed.semanticRun = PASS.semantic2done` at the end of the C enum processing