### PR TITLE
Fix #20985 - runnable\exe1.c heisenbugs on Win64

### DIFF
--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -513,7 +513,7 @@ void build_syment_table(bool bigobj)
 
         write_sym(&sym, bigobj);
 
-        auxent aux = void;
+        auxent aux;
         memset(&aux, 0, (aux).sizeof);
 
         // s_size is not set yet
@@ -555,7 +555,7 @@ void build_syment_table(bool bigobj)
 
         SymbolTable32 sym;
 
-        char[DEST_LEN+1] dest = void;
+        char[DEST_LEN+1] dest;
         char* destr = obj_mangle2(s, dest.ptr);
         syment_set_name(&sym, destr);
 
@@ -647,8 +647,8 @@ void MsCoffObj_term(const(char)[] objfilename)
 
     // Write out the bytes for the header
 
-    BIGOBJ_HEADER header = void;
-    IMAGE_FILE_HEADER header_old = void;
+    BIGOBJ_HEADER header;
+    IMAGE_FILE_HEADER header_old;
 
     time_t f_timedat = 0;
     time(&f_timedat);
@@ -1176,7 +1176,7 @@ void MsCoffObj_ehtables(Symbol* sfunc,uint size,Symbol* ehsym)
 @trusted
 private void emitSectionBrace(const(char)* segname, const(char)* symname, int attr, bool coffZeroBytes)
 {
-    char[16] name = void;
+    char[16] name;
     strcat(strcpy(name.ptr, segname), "$A");
     const int seg_bg = MsCoffObj_getsegment(name.ptr, attr);
 
@@ -1762,7 +1762,7 @@ debug
 @trusted
 void MsCoffObj_export_symbol(Symbol* s,uint argsize)
 {
-    char[DEST_LEN+1] dest = void;
+    char[DEST_LEN+1] dest;
     char* destr = obj_mangle2(s, dest.ptr);
 
     int seg = MsCoffObj_seg_drectve();
@@ -2112,7 +2112,7 @@ void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol* targsym,
         symbuf.write((&targsym)[0 .. 1]);
     }
 
-    Relocation rel = void;
+    Relocation rel;
     rel.offset = offset;
     rel.targsym = targsym;
     rel.targseg = targseg;


### PR DESCRIPTION
I narrowed it down to void initialization in this module. There's padding gaps in `struct Relocation` which don't get filled, and then the whole `rel` variable gets written out, including uninitialized bytes, which is suspicious. But just removing the `rel = void` was not sufficient, so I still need to narrow it down a bit further. Bisecting this was quite hard, since you have to build dmd with LDC -O3, and then run the runnable/exe1.c test 100 times before you can say it's not there anymore, which is a slow process. This current patch removing 7 void initializations has run succesfully 650 times.