### PR TITLE
Fix #21105: Is-expressions should not generate unnecessary code for lowerings

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -64,7 +64,7 @@ private extern (D) struct BitFields
     bool inTemplateConstraint; /// inside template constraint
     Contract contract;
     bool ctfe;              /// inside a ctfe-only expression
-    bool traitsCompiles;    /// inside __traits(compile)
+    bool traitsCompiles;    /// inside __traits(compile) or is-expression
     /// ignore symbol visibility
     /// https://issues.dlang.org/show_bug.cgi?id=15907
     bool ignoresymbolvisibility;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7304,6 +7304,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             sc2.tinst = null;
             sc2.minst = null;
             sc2.fullinst = true;
+            sc2.traitsCompiles = true;
             Type t = dmd.typesem.trySemantic(e.targ, e.loc, sc2);
             sc2.pop();
             if (!t) // errors, so condition is false

--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -106,6 +106,8 @@ template imported()
 	import imported = imports.vcg_ast_import;
 }
 alias myImport = vcg_ast_import;
+enum bool compiles = true;
+enum bool isexp = true;
 R!int
 {
 	struct _R

--- a/compiler/test/compilable/vcg-ast.d
+++ b/compiler/test/compilable/vcg-ast.d
@@ -75,3 +75,14 @@ template imported()
 }
 
 alias myImport = imported!();
+
+// https://github.com/dlang/dmd/issues/21105
+
+enum compiles = __traits(compiles,{
+    int[] arr;
+    arr ~= 1;
+});
+enum isexp = is(typeof({
+    int[] arr;
+    arr ~= 1;
+}));


### PR DESCRIPTION
treat as if compiling with __traits(compiles)

This also avoids https://github.com/dlang/dmd/pull/21066 from running into https://github.com/dlang/dmd/issues/21104