### PR TITLE
backend: Remove some void/unsafe initialization

### DIFF
--- a/compiler/src/dmd/backend/arm/disasmarm.d
+++ b/compiler/src/dmd/backend/arm/disasmarm.d
@@ -260,12 +260,12 @@ void disassemble(uint c) @trusted
     puts("   ");
 
     int i;
-    char[80] p0;
+    char[80] p0 = '\0';
     const(char)[] sep;
     const(char)[] s2;
     const(char)[] s3;
-    char[BUFMAX] buf = void;
-    char[14] rbuf = void;
+    char[BUFMAX] buf = '\0';
+    char[14] rbuf = '\0';
 
     buf[0] = 0;
     sep = ",";
@@ -284,7 +284,7 @@ void disassemble(uint c) @trusted
         }
     }
 
-    char[8+1] p1buf = void;
+    char[8+1] p1buf = '\0';
     const p1len = snprintf(p1buf.ptr,p1buf.length,"%08x", ins);
     if (log) debug printf("ins: %s %d %d\n", p1buf.ptr, field(ins, 28, 24), field(ins, 21, 21));
     const(char)[] p1 = p1buf[0 .. p1len];
@@ -542,7 +542,7 @@ void disassemble(uint c) @trusted
         p2 = regString(sf, Rd);
         if (hw)
         {
-            __gshared char[5 + hw.sizeof * 3 + 1 + 1] P4 = void;
+            __gshared char[5 + hw.sizeof * 3 + 1 + 1] P4 = '\0';
             const n = snprintf(P4.ptr, P4.length, "lsl #%d", hw * 16);
             p4 = P4[0 .. n];
         }
@@ -1430,7 +1430,7 @@ void disassemble(uint c) @trusted
         string[4] shiftstring = [ "", "lsr ", "asr ", "ror " ];
         if (imm6)
         {
-            __gshared char[4 + 3 + imm6.sizeof * 3 + 1 + 1] P5 = void;
+            __gshared char[4 + 3 + imm6.sizeof * 3 + 1 + 1] P5 = '\0';
             const n = snprintf(P5.ptr, P5.length, ((imm6 < 10) ? "%s #%d" : "#0x%X"), shiftstring[shift].ptr, imm6);
             p5 = P5[0 .. n];
         }
@@ -1471,7 +1471,7 @@ void disassemble(uint c) @trusted
         if (immed6) // defaults to 0
         {
             string[4] tab2 = [ "lsl", "lsr", "asr", "reserved" ];
-            __gshared char[1 + 8 + 1 + 3 + immed6.sizeof * 3 + 1 + 1] P5buf = void;
+            __gshared char[1 + 8 + 1 + 3 + immed6.sizeof * 3 + 1 + 1] P5buf = '\0';
             const n = snprintf(P5buf.ptr, P5buf.length, ((immed6 < 10) ? "%s #%d".ptr : "#0x%X".ptr), tab2[shift].ptr, immed6);
             p5 = P5buf[0 .. n];
         }
@@ -1534,7 +1534,7 @@ void disassemble(uint c) @trusted
         else
             p4 = regString(sf, Rm);
 
-        __gshared char[1 + 4 + 1 + 3 + imm3.sizeof * 3 + 1 + 1] P5buf2 = void;
+        __gshared char[1 + 4 + 1 + 3 + imm3.sizeof * 3 + 1 + 1] P5buf2 = '\0';
         if (imm3 == 0)
             p5 = extend;
         else
@@ -1593,7 +1593,7 @@ void disassemble(uint c) @trusted
             p4 = regString(sf, Rm);
             if (imm3)
             {
-                __gshared char[7 + imm3.sizeof * 3 + 1] P5buf3 = void;
+                __gshared char[7 + imm3.sizeof * 3 + 1] P5buf3 = '\0';
                 size_t n = snprintf(P5buf3.ptr, P5buf3.length, ((imm3 < 10) ? "LSL #%d" : "LSL #0x%X"), imm3);
                 assert(n <= P5buf3.length);
                 p5 = P5buf3[0 .. n];

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -650,8 +650,8 @@ union Vconst
         targ_llong      Vllong;
         targ_ullong     Vullong;
         Cent            Vcent;
-        targ_float      Vfloat = void;
-        targ_double     Vdouble = void;
+        targ_float      Vfloat = void; // FIXME: Floats have a void-initializer to give
+        targ_double     Vdouble = void; // the union has an all-zero initializer, see also bugzilla #23841
         targ_ldouble    Vldouble = void;
         Complex_f       Vcfloat = void;   // 2x float
         Complex_d       Vcdouble = void;  // 2x double
@@ -684,8 +684,6 @@ union Vconst
         targ_llong[4]   Vllong4;   // long[4]
         targ_ullong[4]  Vullong4;  // ulong[4]
 }                               // variants for each type of elem
-
-static assert(__traits(isZeroInit, Vconst));
 
 // Symbols
 

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -650,19 +650,19 @@ union Vconst
         targ_llong      Vllong;
         targ_ullong     Vullong;
         Cent            Vcent;
-        targ_float      Vfloat;
-        targ_double     Vdouble;
-        targ_ldouble    Vldouble;
-        Complex_f       Vcfloat;   // 2x float
-        Complex_d       Vcdouble;  // 2x double
-        Complex_ld      Vcldouble; // 2x long double
+        targ_float      Vfloat = void;
+        targ_double     Vdouble = void;
+        targ_ldouble    Vldouble = void;
+        Complex_f       Vcfloat = void;   // 2x float
+        Complex_d       Vcdouble = void;  // 2x double
+        Complex_ld      Vcldouble = void; // 2x long double
         targ_size_t     Vpointer;
         targ_ptrdiff_t  Vptrdiff;
         targ_uchar      Vreg;   // register number for OPreg elems
 
         // 16 byte vector types
-        targ_float[4]   Vfloat4;   // float[4]
-        targ_double[2]  Vdouble2;  // double[2]
+        targ_float[4]   Vfloat4 = void; // float[4]
+        targ_double[2]  Vdouble2 = void; // double[2]
         targ_schar[16]  Vschar16;  // byte[16]
         targ_uchar[16]  Vuchar16;  // ubyte[16]
         targ_short[8]   Vshort8;   // short[8]
@@ -673,8 +673,8 @@ union Vconst
         targ_ullong[2]  Vullong2;  // ulong[2]
 
         // 32 byte vector types
-        targ_float[8]   Vfloat8;   // float[8]
-        targ_double[4]  Vdouble4;  // double[4]
+        targ_float[8]   Vfloat8 = void; // float[8]
+        targ_double[4]  Vdouble4 = void; // double[4]
         targ_schar[32]  Vschar32;  // byte[32]
         targ_uchar[32]  Vuchar32;  // ubyte[32]
         targ_short[16]  Vshort16;  // short[16]
@@ -684,6 +684,8 @@ union Vconst
         targ_llong[4]   Vllong4;   // long[4]
         targ_ullong[4]  Vullong4;  // ulong[4]
 }                               // variants for each type of elem
+
+static assert(__traits(isZeroInit, Vconst));
 
 // Symbols
 

--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -1861,7 +1861,7 @@ private elem* elor(elem* e, Goal goal)
      */
     if (sz == 4 && OPTIMIZER)
     {
-        elem*[4] ops = void;
+        elem*[4] ops;
         size_t opsi = 0;
         if (fillinops(ops, opsi, OPor, e) && opsi == ops.length)
         {

--- a/compiler/src/dmd/backend/cgsched.d
+++ b/compiler/src/dmd/backend/cgsched.d
@@ -72,7 +72,7 @@ struct Cinfo
     // For floating point scheduling
     ubyte fxch_pre;
     ubyte fxch_post;
-    FP fp_op;           /// FPxxxx
+    FP fp_op = FP.none;  /// FPxxxx
 
     ubyte flags;         /// CIFLxxx
 
@@ -2233,12 +2233,10 @@ nothrow:
 
     int fpustackused;           // number of slots in FPU stack that are used
 
-    @trusted
-    void initialize(int fpustackinit)          // initialize scheduler
+    this(int fpustackinit)          // initialize scheduler
     {
         //printf("Schedule::initialize(fpustackinit = %d)\n", fpustackinit);
-        memset(&this, 0, Schedule.sizeof);
-        fpustackused = fpustackinit;
+        this.fpustackused = fpustackinit;
     }
 
     void dtor()
@@ -2803,9 +2801,8 @@ private code* schedule(code* c,regm_t scratch)
 {
     code* cresult = null;
     code** pctail = &cresult;
-    Schedule sch = void;
+    Schedule sch = Schedule(0); // initialize scheduling table
 
-    sch.initialize(0);                  // initialize scheduling table
     while (c)
     {
         if ((c.Iop == NOP ||
@@ -2824,7 +2821,7 @@ private code* schedule(code* c,regm_t scratch)
         }
 
         //printf("init\n");
-        sch.initialize(sch.fpustackused);       // initialize scheduling table
+        sch = Schedule(sch.fpustackused);       // initialize scheduling table
 
         while (c)
         {

--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -310,7 +310,7 @@ idx_t cv_debtyp(debtyp_t* d)
         {
             // Hash consists of the sum of the first 4 bytes with the last 4 bytes
             union U { ubyte* cp; uint* up; }
-            U un = void;
+            U un;
             un.cp = d.data.ptr;
             hash += *un.up;
             un.cp += length - uint.sizeof;
@@ -1887,7 +1887,8 @@ private void cv4_func(Funcsym* s, ref symtab_t symtab)
 
     // Put out function return record
     if (1)
-    {   ubyte[2+2+2+1+1+4] sreturn = void;
+    {
+        ubyte[2+2+2+1+1+4] sreturn;
         ushort flags;
         ubyte style;
         tym_t ty;

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -1240,8 +1240,6 @@ elem* el_convfloat(ref GlobalOptimizer go, elem* e)
 @trusted
 elem* el_convxmm(ref GlobalOptimizer go, elem* e)
 {
-    ubyte[Vconst.sizeof] buffer = void;
-
     // Do not convert if the constants can be loaded with the special XMM instructions
     if (loadxmmconst(e))
         return e;
@@ -1249,7 +1247,7 @@ elem* el_convxmm(ref GlobalOptimizer go, elem* e)
     go.changes++;
     tym_t ty = e.Ety;
     int sz = tysize(ty);
-    assert(sz <= buffer.length);
+    assert(sz <= Vconst.sizeof);
     void* p = &e.EV;
 
     static if (0)
@@ -1564,8 +1562,7 @@ elem* el_ctor_dtor(elem* ec, elem* ed, out elem* pedtor)
         ector.Ety = TYvoid;
 //      ector.ed.Edecl = decl;
 
-        Vconst c = void;
-        memset(&c, 0, c.sizeof);
+        Vconst c = Vconst.init;
         elem* e_flag_0 = el_bin(OPeq, TYvoid, el_var(sflag), el_const(TYbool, c));  // __flag = 0
         er = el_bin(OPinfo, ec ? ec.Ety : TYvoid, ector, el_combine(e_flag_0, ec));
 

--- a/compiler/src/dmd/backend/evalu8.d
+++ b/compiler/src/dmd/backend/evalu8.d
@@ -345,7 +345,7 @@ static if (0)
       debug printf("d1 = %Lg, d2 = %Lg, op = %d, OPne = %d, tym = x%lx\n",d1,d2,op,OPne,tym);
       debug printf("tym1 = x%lx, tym2 = x%lx, e2 = %g\n",tym,tym2,e2.Vdouble);
 
-      Vconst u = void;
+      Vconst u;
       debug printf("d1 = x%16llx\n", (u.Vldouble = d1, u.Vullong));
       debug printf("d2 = x%16llx\n", (u.Vldouble = d2, u.Vullong));
   }

--- a/compiler/src/dmd/backend/gloop.d
+++ b/compiler/src/dmd/backend/gloop.d
@@ -1900,8 +1900,7 @@ private void appendelem(elem* n,elem** pn)
 @trusted
 private void newfamlist(famlist* fl, tym_t ty)
 {
-    Vconst c = void;
-    memset(&c,0,c.sizeof);
+    Vconst c;
 
     fl.FLty = ty;
     switch (tybasic(ty))

--- a/compiler/src/dmd/backend/mach.d
+++ b/compiler/src/dmd/backend/mach.d
@@ -128,7 +128,7 @@ struct segment_command
 {
     uint cmd;
     uint cmdsize;
-    char[16] segname;
+    char[16] segname = 0;
     uint vmaddr;
     uint vmsize;
     uint fileoff;
@@ -143,7 +143,7 @@ struct segment_command_64
 {
     uint cmd;
     uint cmdsize;
-    char[16] segname;
+    char[16] segname = 0;
     ulong vmaddr;
     ulong vmsize;
     ulong fileoff;

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -640,7 +640,7 @@ void MachObj_term(const(char)[] objfilename)
     // Write out the bytes for the header
     if (I64)
     {
-        mach_header_64 header = void;
+        mach_header_64 header;
 
         header.magic = MH_MAGIC_64;
         header.cputype = CPU_TYPE_X86_64;
@@ -665,7 +665,7 @@ void MachObj_term(const(char)[] objfilename)
     }
     else
     {
-        mach_header header = void;
+        mach_header header;
 
         header.magic = MH_MAGIC;
         header.cputype = CPU_TYPE_I386;
@@ -688,15 +688,10 @@ void MachObj_term(const(char)[] objfilename)
         foffset += header.sizeofcmds;
     }
 
-    segment_command segment_cmd = void;
-    segment_command_64 segment_cmd64 = void;
-    symtab_command symtab_cmd = void;
-    dysymtab_command dysymtab_cmd = void;
-
-    memset(&segment_cmd, 0, segment_cmd.sizeof);
-    memset(&segment_cmd64, 0, segment_cmd64.sizeof);
-    memset(&symtab_cmd, 0, symtab_cmd.sizeof);
-    memset(&dysymtab_cmd, 0, dysymtab_cmd.sizeof);
+    segment_command segment_cmd = segment_command.init;
+    segment_command_64 segment_cmd64 = segment_command_64.init;
+    symtab_command symtab_cmd = symtab_command.init;
+    dysymtab_command dysymtab_cmd = dysymtab_command.init;
 
     if (I64)
     {
@@ -1227,7 +1222,7 @@ void MachObj_term(const(char)[] objfilename)
     fobjbuf.reserve(cast(uint)(symtab_cmd.nsyms * (I64 ? nlist_64.sizeof : nlist.sizeof)));
     for (int i = 0; i < dysymtab_cmd.nlocalsym; i++)
     {   Symbol* s = (cast(Symbol**)local_symbuf.buf)[i];
-        nlist_64 sym = void;
+        nlist_64 sym;
         sym.n_strx = mach_addmangled(s);
         sym.n_type = N_SECT;
         sym.n_desc = 0;
@@ -1241,7 +1236,7 @@ void MachObj_term(const(char)[] objfilename)
         }
         else
         {
-            nlist sym32 = void;
+            nlist sym32;
             sym32.n_strx = sym.n_strx;
             sym32.n_value = cast(uint)(s.Soffset + SecHdrTab[SegData[s.Sseg].SDshtidx].addr);
             sym32.n_type = sym.n_type;
@@ -1254,7 +1249,7 @@ void MachObj_term(const(char)[] objfilename)
     {   Symbol* s = (cast(Symbol**)public_symbuf.buf)[i];
 
         //printf("Writing public symbol %d:x%x %s\n", s.Sseg, s.Soffset, s.Sident);
-        nlist_64 sym = void;
+        nlist_64 sym;
         sym.n_strx = mach_addmangled(s);
         sym.n_type = N_EXT | N_SECT;
         if (s.Sflags & SFLhidden)
@@ -1270,7 +1265,7 @@ void MachObj_term(const(char)[] objfilename)
         }
         else
         {
-            nlist sym32 = void;
+            nlist sym32;
             sym32.n_strx = sym.n_strx;
             sym32.n_value = cast(uint)(s.Soffset + SecHdrTab[SegData[s.Sseg].SDshtidx].addr);
             sym32.n_type = sym.n_type;
@@ -1281,7 +1276,7 @@ void MachObj_term(const(char)[] objfilename)
     }
     for (int i = 0; i < nexterns; i++)
     {   Symbol* s = (cast(Symbol**)extern_symbuf.buf)[i];
-        nlist_64 sym = void;
+        nlist_64 sym;
         sym.n_strx = mach_addmangled(s);
         sym.n_value = s.Soffset;
         sym.n_type = N_EXT | N_UNDF;
@@ -1292,7 +1287,7 @@ void MachObj_term(const(char)[] objfilename)
             fobjbuf.write(&sym, sym.sizeof);
         else
         {
-            nlist sym32 = void;
+            nlist sym32;
             sym32.n_strx = sym.n_strx;
             sym32.n_value = cast(uint)sym.n_value;
             sym32.n_type = sym.n_type;
@@ -1303,7 +1298,7 @@ void MachObj_term(const(char)[] objfilename)
     }
     for (int i = 0; i < ncomdefs; i++)
     {   Comdef* c = (cast(Comdef*)comdef_symbuf.buf) + i;
-        nlist_64 sym = void;
+        nlist_64 sym;
         sym.n_strx = mach_addmangled(c.sym);
         sym.n_value = c.size * c.count;
         sym.n_type = N_EXT | N_UNDF;
@@ -1324,7 +1319,7 @@ void MachObj_term(const(char)[] objfilename)
             fobjbuf.write(&sym, sym.sizeof);
         else
         {
-            nlist sym32 = void;
+            nlist sym32;
             sym32.n_strx = sym.n_strx;
             sym32.n_value = cast(uint)sym.n_value;
             sym32.n_type = sym.n_type;
@@ -1335,7 +1330,7 @@ void MachObj_term(const(char)[] objfilename)
     }
     if (extdef)
     {
-        nlist_64 sym = void;
+        nlist_64 sym;
         sym.n_strx = extdef;
         sym.n_value = 0;
         sym.n_type = N_EXT | N_UNDF;
@@ -1345,7 +1340,7 @@ void MachObj_term(const(char)[] objfilename)
             fobjbuf.write(&sym, sym.sizeof);
         else
         {
-            nlist sym32 = void;
+            nlist sym32;
             sym32.n_strx = sym.n_strx;
             sym32.n_value = cast(uint)sym.n_value;
             sym32.n_type = sym.n_type;

--- a/compiler/src/dmd/backend/mscoff.d
+++ b/compiler/src/dmd/backend/mscoff.d
@@ -254,7 +254,7 @@ union auxent
       align (1):
         uint Unused;
         ushort Linenumber;
-        char[6] filler;
+        char[6] filler = '\0';
         uint PointerToNextFunction;
         ushort Zeros;
     }
@@ -293,10 +293,11 @@ union auxent
     }
     S x_section;
 
-    char[18] filler;
+    char[18] filler = void;
 }
 
 static assert(auxent.sizeof == 18);
+static assert(__traits(isZeroInit, auxent));
 
 // auxent.x_section.Zeros
 enum

--- a/compiler/src/dmd/backend/mscoff.d
+++ b/compiler/src/dmd/backend/mscoff.d
@@ -297,7 +297,6 @@ union auxent
 }
 
 static assert(auxent.sizeof == 18);
-static assert(__traits(isZeroInit, auxent));
 
 // auxent.x_section.Zeros
 enum

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -513,8 +513,7 @@ void build_syment_table(bool bigobj)
 
         write_sym(&sym, bigobj);
 
-        auxent aux = void;
-        memset(&aux, 0, (aux).sizeof);
+        auxent aux = auxent.init;
 
         // s_size is not set yet
         //aux.x_section.length = psechdr.s_size;

--- a/compiler/src/dmd/backend/ptrntab.d
+++ b/compiler/src/dmd/backend/ptrntab.d
@@ -5810,7 +5810,7 @@ const(char)* asm_opstr(OP* pop)
 OP* asm_op_lookup(const(char)* s)
 {
     int i;
-    char[20] szBuf = void;
+    char[20] szBuf = '\0';
 
     //printf("asm_op_lookup('%s')\n",s);
     if (strlen(s) >= szBuf.length)

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -3044,7 +3044,7 @@ const(char)* regm_str(regm_t rm)
                     strcat(p, "PSW");
                 else
                 {
-                    char[4] buf = void;
+                    char[4] buf;
                     char c = j < 32 ? 'r' : 'f';
                     sprintf(buf.ptr, "%c%u", c, j);
                     strcat(p, buf.ptr);

--- a/compiler/src/dmd/backend/x86/cgxmm.d
+++ b/compiler/src/dmd/backend/x86/cgxmm.d
@@ -119,7 +119,7 @@ void movxmmconst(ref CodeBuilder cdb, reg_t xreg, tym_t ty, Vconst* pev, regm_t 
         regm_t rm = ALLREGS;
         const r = allocreg(cdb,rm,TYint);         // allocate scratch register
         static union U { targ_size_t s; targ_long[2] l; }
-        U u = void;
+        U u;
         u.l[1] = 0;
         u.s = value;
         targ_long* p = &u.l[0];

--- a/compiler/src/dmd/backend/x86/cod1.d
+++ b/compiler/src/dmd/backend/x86/cod1.d
@@ -343,7 +343,7 @@ void genEEcode()
 uint gensaverestore(regm_t regm,ref CodeBuilder cdbsave,ref CodeBuilder cdbrestore)
 {
     //printf("gensaverestore2(%s)\n", regm_str(regm));
-    code *[regm.sizeof * 8] restore = void;
+    code *[regm.sizeof * 8] restore;
     reg_t i;
     uint stackused = 0;
 
@@ -3525,8 +3525,7 @@ void cdfunc(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
         // https://msdn.microsoft.com/en-US/library/ew5tede7%28v=vs.100%29
     }
 
-    int[XMM7 + 1] regsaved = void;
-    memset(regsaved.ptr, -1, regsaved.sizeof);
+    int[XMM7 + 1] regsaved = ~0;
     CodeBuilder cdbrestore;
     cdbrestore.ctor();
     regm_t saved = 0;


### PR DESCRIPTION
Getting rid of void initialization because it's bug prone: https://github.com/dlang/dmd/pull/21099

There's more, but I picked these ones first because they are:
- redundant (because they were initialized immediately afterwards)
- `__gshared` (so they get 0 initializated anyway)
- small / not performance critical

