### PR TITLE
Turn macro translations into template functions

### DIFF
--- a/changelog/druntime.macro-templates.dd
+++ b/changelog/druntime.macro-templates.dd
@@ -1,0 +1,38 @@
+C Macro translations in druntime have been translated to templates
+
+This prevents linking errors when using `-betterC`.
+For example:
+
+---
+import core.sys.posix.stdlib;
+import core.sys.posix.unistd;
+
+extern(C) int main()
+{
+    int status, pid = vfork();
+    if (pid == 0)
+    {
+        // ...
+        return 0;
+    }
+
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status))
+    {
+        // ...
+    }
+    return 0;
+}
+---
+
+This would fail to compile with the `-betterC` flag:
+
+---
+$(CONSOLE
+Error: undefined reference to `core.sys.posix.sys.wait.WIFEXITED(int)`
+       referenced from `main`
+)
+---
+
+The reason is that `WIFEXITED` is a C macro that was translated to a D function in druntime, which requires linking with druntime to use.
+Now that it's a template, it will be lazily instantiated and the program compiles.

--- a/druntime/src/core/stdc/math.d
+++ b/druntime/src/core/stdc/math.d
@@ -1509,51 +1509,51 @@ extern (D)
 {
     //int isgreater(real-floating x, real-floating y);
     ///
-    pure int isgreater(float x, float y)        { return x > y; }
+    pure int isgreater()(float x, float y)        { return x > y; }
     ///
-    pure int isgreater(double x, double y)      { return x > y; }
+    pure int isgreater()(double x, double y)      { return x > y; }
     ///
-    pure int isgreater(real x, real y)          { return x > y; }
+    pure int isgreater()(real x, real y)          { return x > y; }
 
     //int isgreaterequal(real-floating x, real-floating y);
     ///
-    pure int isgreaterequal(float x, float y)   { return x >= y; }
+    pure int isgreaterequal()(float x, float y)   { return x >= y; }
     ///
-    pure int isgreaterequal(double x, double y) { return x >= y; }
+    pure int isgreaterequal()(double x, double y) { return x >= y; }
     ///
-    pure int isgreaterequal(real x, real y)     { return x >= y; }
+    pure int isgreaterequal()(real x, real y)     { return x >= y; }
 
     //int isless(real-floating x, real-floating y);
     ///
-    pure int isless(float x, float y)           { return x < y; }
+    pure int isless()(float x, float y)           { return x < y; }
     ///
-    pure int isless(double x, double y)         { return x < y; }
+    pure int isless()(double x, double y)         { return x < y; }
     ///
-    pure int isless(real x, real y)             { return x < y; }
+    pure int isless()(real x, real y)             { return x < y; }
 
     //int islessequal(real-floating x, real-floating y);
     ///
-    pure int islessequal(float x, float y)      { return x <= y; }
+    pure int islessequal()(float x, float y)      { return x <= y; }
     ///
-    pure int islessequal(double x, double y)    { return x <= y; }
+    pure int islessequal()(double x, double y)    { return x <= y; }
     ///
-    pure int islessequal(real x, real y)        { return x <= y; }
+    pure int islessequal()(real x, real y)        { return x <= y; }
 
     //int islessgreater(real-floating x, real-floating y);
     ///
-    pure int islessgreater(float x, float y)    { return x != y && !isunordered(x, y); }
+    pure int islessgreater()(float x, float y)    { return x != y && !isunordered(x, y); }
     ///
-    pure int islessgreater(double x, double y)  { return x != y && !isunordered(x, y); }
+    pure int islessgreater()(double x, double y)  { return x != y && !isunordered(x, y); }
     ///
-    pure int islessgreater(real x, real y)      { return x != y && !isunordered(x, y); }
+    pure int islessgreater()(real x, real y)      { return x != y && !isunordered(x, y); }
 
     //int isunordered(real-floating x, real-floating y);
     ///
-    pure int isunordered(float x, float y)      { return isnan(x) || isnan(y); }
+    pure int isunordered()(float x, float y)      { return isnan(x) || isnan(y); }
     ///
-    pure int isunordered(double x, double y)    { return isnan(x) || isnan(y); }
+    pure int isunordered()(double x, double y)    { return isnan(x) || isnan(y); }
     ///
-    pure int isunordered(real x, real y)        { return isnan(x) || isnan(y); }
+    pure int isunordered()(real x, real y)        { return isnan(x) || isnan(y); }
 }
 
 /* MS define some functions inline.

--- a/druntime/src/core/sys/linux/linux/if_packet.d
+++ b/druntime/src/core/sys/linux/linux/if_packet.d
@@ -169,7 +169,7 @@ struct tpacket_hdr
 }
 
 enum TPACKET_ALIGNMENT = 16;
-size_t TPACKET_ALIGN(size_t x) { return (x + TPACKET_ALIGNMENT - 1) &~ (TPACKET_ALIGNMENT - 1); }
+size_t TPACKET_ALIGN()(size_t x) { return (x + TPACKET_ALIGNMENT - 1) &~ (TPACKET_ALIGNMENT - 1); }
 enum TPACKET_HDRLEN = TPACKET_ALIGN(tpacket_hdr.sizeof) + sockaddr_ll.sizeof;
 
 struct tpacket2_hdr

--- a/druntime/src/core/sys/linux/netinet/in_.d
+++ b/druntime/src/core/sys/linux/netinet/in_.d
@@ -82,28 +82,28 @@ version (linux_libc)
 
     enum IPPORT_USERRESERVED = 5000;
 
-    extern(D) bool IN_CLASSA(in_addr_t i) pure @safe { return (i & 0x80000000) == 0; }
+    extern(D) bool IN_CLASSA()(in_addr_t i) pure @safe { return (i & 0x80000000) == 0; }
     enum IN_CLASSA_NET    = 0xff000000;
     enum IN_CLASSA_NSHIFT = 24;
     enum IN_CLASSA_HOST   = 0xffffffff & ~IN_CLASSA_NET;
     enum IN_CLASSA_MAX    = 128;
 
-    extern(D) bool IN_CLASSB(in_addr_t i) pure @safe { return (i & 0xc0000000) == 0x80000000; }
+    extern(D) bool IN_CLASSB()(in_addr_t i) pure @safe { return (i & 0xc0000000) == 0x80000000; }
     enum IN_CLASSB_NET    = 0xffff0000;
     enum IN_CLASSB_NSHIFT = 16;
     enum IN_CLASSB_HOST   = 0xffffffff & ~IN_CLASSB_NET;
     enum IN_CLASSB_MAX    = 65536;
 
-    extern(D) bool IN_CLASSC(in_addr_t i) pure @safe { return (i & 0xe0000000) == 0xc0000000; }
+    extern(D) bool IN_CLASSC()(in_addr_t i) pure @safe { return (i & 0xe0000000) == 0xc0000000; }
     enum IN_CLASSC_NET    = 0xffffff00;
     enum IN_CLASSC_NSHIFT = 8;
     enum IN_CLASSC_HOST   = 0xffffffff & ~IN_CLASSC_NET;
 
-    extern(D) bool IN_CLASSD(in_addr_t i) pure @safe { return (i & 0xf0000000) == 0xe0000000; }
-    extern(D) bool IN_MULTICAST(in_addr_t i) { return IN_CLASSD(i); }
+    extern(D) bool IN_CLASSD()(in_addr_t i) pure @safe { return (i & 0xf0000000) == 0xe0000000; }
+    extern(D) bool IN_MULTICAST()(in_addr_t i) { return IN_CLASSD(i); }
 
-    extern(D) bool IN_EXPERIMENTAL(in_addr_t i) pure @safe { return (i & 0xe0000000) == 0xe0000000; }
-    extern(D) bool IN_BADCLASS(in_addr_t i) pure @safe { return (i & 0xf0000000) == 0xf0000000; }
+    extern(D) bool IN_EXPERIMENTAL()(in_addr_t i) pure @safe { return (i & 0xe0000000) == 0xe0000000; }
+    extern(D) bool IN_BADCLASS()(in_addr_t i) pure @safe { return (i & 0xf0000000) == 0xf0000000; }
 
     enum IN_LOOPBACKNET = 127;
 

--- a/druntime/src/core/sys/linux/sched.d
+++ b/druntime/src/core/sys/linux/sched.d
@@ -41,31 +41,31 @@ private // helpers
     /* Macros */
 
     /* Basic access functions.  */
-    size_t __CPUELT(size_t cpu) pure
+    size_t __CPUELT()(size_t cpu) pure
     {
         return cpu / __NCPUBITS;
     }
-    cpu_mask __CPUMASK(size_t cpu) pure
+    cpu_mask __CPUMASK()(size_t cpu) pure
     {
         return 1UL << (cpu % __NCPUBITS);
     }
 
-    cpu_set_t* __CPU_ALLOC(size_t count)
+    cpu_set_t* __CPU_ALLOC()(size_t count)
     {
         return cast(cpu_set_t*) malloc(__CPU_ALLOC_SIZE(count));
     }
 
-    size_t __CPU_ALLOC_SIZE(size_t count) pure
+    size_t __CPU_ALLOC_SIZE()(size_t count) pure
     {
         return ((count + __NCPUBITS - 1) / __NCPUBITS) * cpu_mask.sizeof;
     }
 
-    void __CPU_FREE(cpu_set_t* set)
+    void __CPU_FREE()(cpu_set_t* set)
     {
         free(cast(void*) set);
     }
 
-    cpu_mask __CPU_SET_S(size_t cpu, size_t setsize, cpu_set_t* cpusetp) pure
+    cpu_mask __CPU_SET_S()(size_t cpu, size_t setsize, cpu_set_t* cpusetp) pure
     {
         if (cpu < 8 * setsize)
         {
@@ -76,14 +76,14 @@ private // helpers
         return 0;
     }
 
-    bool __CPU_ISSET_S(size_t cpu, size_t setsize, cpu_set_t* cpusetp) pure
+    bool __CPU_ISSET_S()(size_t cpu, size_t setsize, cpu_set_t* cpusetp) pure
     {
         if (cpu < 8 * setsize)
             return (cpusetp.__bits[__CPUELT(cpu)] & __CPUMASK(cpu)) != 0;
         return false;
     }
 
-    int __CPU_COUNT_S(size_t setsize, cpu_set_t* cpusetp) pure
+    int __CPU_COUNT_S()(size_t setsize, cpu_set_t* cpusetp) pure
     {
         int s = 0;
         foreach (i; cpusetp.__bits[0 .. (setsize / cpu_mask.sizeof)])
@@ -103,37 +103,37 @@ struct cpu_set_t
 
 /// Access macros for 'cpu_set' (missing a lot of them)
 
-cpu_set_t* CPU_ALLOC(size_t count)
+cpu_set_t* CPU_ALLOC()(size_t count)
 {
     return __CPU_ALLOC(count);
 }
 
-size_t CPU_ALLOC_SIZE(size_t count) pure
+size_t CPU_ALLOC_SIZE()(size_t count) pure
 {
     return __CPU_ALLOC_SIZE(count);
 }
 
-void CPU_FREE(cpu_set_t* set)
+void CPU_FREE()(cpu_set_t* set)
 {
     __CPU_FREE(set);
 }
 
-cpu_mask CPU_SET(size_t cpu, cpu_set_t* cpusetp) pure
+cpu_mask CPU_SET()(size_t cpu, cpu_set_t* cpusetp) pure
 {
      return __CPU_SET_S(cpu, cpu_set_t.sizeof, cpusetp);
 }
 
-bool CPU_ISSET(size_t cpu, cpu_set_t* cpusetp) pure
+bool CPU_ISSET()(size_t cpu, cpu_set_t* cpusetp) pure
 {
     return __CPU_ISSET_S(cpu, cpu_set_t.sizeof, cpusetp);
 }
 
-int CPU_COUNT(cpu_set_t* cpusetp) pure
+int CPU_COUNT()(cpu_set_t* cpusetp) pure
 {
     return __CPU_COUNT_S(cpu_set_t.sizeof, cpusetp);
 }
 
-int CPU_COUNT_S(size_t setsize, cpu_set_t* cpusetp) pure
+int CPU_COUNT_S()(size_t setsize, cpu_set_t* cpusetp) pure
 {
     return __CPU_COUNT_S(setsize, cpusetp);
 }

--- a/druntime/src/core/sys/linux/sys/time.d
+++ b/druntime/src/core/sys/linux/sys/time.d
@@ -23,7 +23,7 @@ version (linux):
  */
 extern (D) pure @safe @nogc nothrow {
 
-    void timeradd(const timeval* a, const timeval* b,
+    void timeradd()(const timeval* a, const timeval* b,
             timeval* result)
     {
         result.tv_sec = a.tv_sec + b.tv_sec;
@@ -35,7 +35,7 @@ extern (D) pure @safe @nogc nothrow {
         }
     }
 
-    void timersub(const timeval* a, const timeval* b,
+    void timersub()(const timeval* a, const timeval* b,
             timeval *result)
     {
         result.tv_sec = a.tv_sec - b.tv_sec;
@@ -46,12 +46,12 @@ extern (D) pure @safe @nogc nothrow {
         }
     }
 
-    void timerclear(timeval* tvp)
+    void timerclear()(timeval* tvp)
     {
         (tvp.tv_sec = tvp.tv_usec = 0);
     }
 
-    int timerisset(timeval* tvp)
+    int timerisset()(timeval* tvp)
     {
         return cast(int) (tvp.tv_sec || tvp.tv_usec);
     }

--- a/druntime/src/core/sys/posix/netdb.d
+++ b/druntime/src/core/sys/posix/netdb.d
@@ -153,7 +153,7 @@ version (CRuntime_Glibc)
         int     h_addrtype;
         int     h_length;
         char**  h_addr_list;
-        char*   h_addr() @property { return h_addr_list[0]; } // non-standard
+        char*   h_addr()() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent
@@ -237,7 +237,7 @@ else version (Darwin)
         int     h_addrtype;
         int     h_length;
         char**  h_addr_list;
-        char*   h_addr() @property { return h_addr_list[0]; } // non-standard
+        char*   h_addr()() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent
@@ -321,7 +321,7 @@ else version (FreeBSD)
         int     h_addrtype;
         int     h_length;
         char**  h_addr_list;
-        extern (D) char* h_addr() @property { return h_addr_list[0]; } // non-standard
+        extern (D) char* h_addr()() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent
@@ -405,7 +405,7 @@ else version (NetBSD)
         int     h_addrtype;
         int     h_length;
         char**  h_addr_list;
-        extern (D) char* h_addr() @property { return h_addr_list[0]; } // non-standard
+        extern (D) char* h_addr()() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent
@@ -512,7 +512,7 @@ else version (OpenBSD)
         int       h_addrtype;
         int       h_length;
         char**    h_addr_list;
-        extern (D) char* h_addr() @property { return h_addr_list[0]; } // non-standard
+        extern (D) char* h_addr()() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent
@@ -608,7 +608,7 @@ else version (DragonFlyBSD)
         int     h_addrtype;
         int     h_length;
         char**  h_addr_list;
-        extern (D) char* h_addr() @property { return h_addr_list[0]; } // non-standard
+        extern (D) char* h_addr()() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent
@@ -706,7 +706,7 @@ else version (Solaris)
         int h_length;
         char** h_addr_list;
 
-        extern (D) char* h_addr() @property { return h_addr_list[0]; } // non-standard
+        extern (D) char* h_addr()() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent
@@ -793,7 +793,7 @@ else version (CRuntime_Bionic)
         int     h_addrtype;
         int     h_length;
         char**  h_addr_list;
-        extern (D) char* h_addr() @property { return h_addr_list[0]; } // non-standard
+        extern (D) char* h_addr()() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent
@@ -874,7 +874,7 @@ else version (CRuntime_Musl)
         int     h_addrtype;
         int     h_length;
         char**  h_addr_list;
-        char*   h_addr() @property { return h_addr_list[0]; } // non-standard
+        char*   h_addr()() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent
@@ -952,7 +952,7 @@ else version (CRuntime_UClibc)
         int     h_addrtype;
         int     h_length;
         char**  h_addr_list;
-        extern (D) char* h_addr() @property { return h_addr_list[0]; } // non-standard
+        extern (D) char* h_addr()() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent

--- a/druntime/src/core/sys/posix/netinet/in_.d
+++ b/druntime/src/core/sys/posix/netinet/in_.d
@@ -547,7 +547,7 @@ version (CRuntime_Glibc)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED()(const scope in6_addr* add) pure
     {
         return (cast(uint32_t*) addr)[0] == 0 &&
                (cast(uint32_t*) addr)[1] == 0 &&
@@ -555,7 +555,7 @@ version (CRuntime_Glibc)
                (cast(uint32_t*) addr)[3] == 0;
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK()(const scope in6_addr* add) pure
     {
         return (cast(uint32_t*) addr)[0] == 0  &&
                (cast(uint32_t*) addr)[1] == 0  &&
@@ -563,29 +563,29 @@ version (CRuntime_Glibc)
                (cast(uint32_t*) addr)[3] == htonl( 1 );
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST()(const scope in6_addr* add) pure
     {
         return (cast(uint8_t*) addr)[0] == 0xff;
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL()(const scope in6_addr* add) pure
     {
         return ((cast(uint32_t*) addr)[0] & htonl( 0xffc00000 )) == htonl( 0xfe800000 );
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL()(const scope in6_addr* add) pure
     {
         return ((cast(uint32_t*) addr)[0] & htonl( 0xffc00000 )) == htonl( 0xfec00000 );
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED()(const scope in6_addr* add) pure
     {
         return (cast(uint32_t*) addr)[0] == 0 &&
                (cast(uint32_t*) addr)[1] == 0 &&
                (cast(uint32_t*) addr)[2] == htonl( 0xffff );
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT()(const scope in6_addr* add) pure
     {
         return (cast(uint32_t*) addr)[0] == 0 &&
                (cast(uint32_t*) addr)[1] == 0 &&
@@ -593,31 +593,31 @@ version (CRuntime_Glibc)
                ntohl( (cast(uint32_t*) addr)[3] ) > 1;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL()(const scope in6_addr* add) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr ) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x1;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL()(const scope in6_addr* add) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr ) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x2;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL()(const scope in6_addr* add) pure
     {
         return IN6_IS_ADDR_MULTICAST(addr) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x5;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL()(const scope in6_addr* add) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x8;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL()(const scope in6_addr* add) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr ) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0xe;
@@ -670,7 +670,7 @@ else version (Darwin)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED()(const scope in6_addr* add) pure
     {
         return (cast(uint32_t*) addr)[0] == 0 &&
                (cast(uint32_t*) addr)[1] == 0 &&
@@ -678,7 +678,7 @@ else version (Darwin)
                (cast(uint32_t*) addr)[3] == 0;
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK()(const scope in6_addr* add) pure
     {
         return (cast(uint32_t*) addr)[0] == 0  &&
                (cast(uint32_t*) addr)[1] == 0  &&
@@ -686,29 +686,29 @@ else version (Darwin)
                (cast(uint32_t*) addr)[3] == ntohl( 1 );
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST()(const scope in6_addr* add) pure
     {
         return addr.s6_addr[0] == 0xff;
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL()(const scope in6_addr* add) pure
     {
         return addr.s6_addr[0] == 0xfe && (addr.s6_addr[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL()(const scope in6_addr* add) pure
     {
         return addr.s6_addr[0] == 0xfe && (addr.s6_addr[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED()(const scope in6_addr* add) pure
     {
         return (cast(uint32_t*) addr)[0] == 0 &&
                (cast(uint32_t*) addr)[1] == 0 &&
                (cast(uint32_t*) addr)[2] == ntohl( 0x0000ffff );
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT()(const scope in6_addr* add) pure
     {
         return (cast(uint32_t*) addr)[0] == 0 &&
                (cast(uint32_t*) addr)[1] == 0 &&
@@ -717,31 +717,31 @@ else version (Darwin)
                (cast(uint32_t*) addr)[3] != ntohl( 1 );
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL()(const scope in6_addr* add) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr ) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x1;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL()(const scope in6_addr* add) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr ) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x2;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL()(const scope in6_addr* add) pure
     {
         return IN6_IS_ADDR_MULTICAST(addr) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x5;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL()(const scope in6_addr* add) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x8;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL()(const scope in6_addr* add) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr ) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0xe;
@@ -804,7 +804,7 @@ else version (FreeBSD)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -812,7 +812,7 @@ else version (FreeBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -820,7 +820,7 @@ else version (FreeBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -829,58 +829,58 @@ else version (FreeBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xff;
     }
 
-    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( const scope in6_addr* a ) pure
+    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE()( const scope in6_addr* a) pure
     {
         return a.s6_addr[1] & 0x0f;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_NODELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_LINKLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_SITELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_ORGLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
@@ -943,7 +943,7 @@ else version (NetBSD)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -951,7 +951,7 @@ else version (NetBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -959,7 +959,7 @@ else version (NetBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -968,58 +968,58 @@ else version (NetBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xff;
     }
 
-    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( const scope in6_addr* a ) pure
+    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE()( const scope in6_addr* a) pure
     {
         return a.s6_addr[1] & 0x0f;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_NODELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_LINKLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_SITELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_ORGLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
@@ -1082,7 +1082,7 @@ else version (OpenBSD)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1090,7 +1090,7 @@ else version (OpenBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1098,7 +1098,7 @@ else version (OpenBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1107,58 +1107,58 @@ else version (OpenBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xff;
     }
 
-    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( const scope in6_addr* a ) pure
+    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE()( const scope in6_addr* a) pure
     {
         return a.s6_addr[1] & 0x0f;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_NODELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_LINKLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_SITELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_ORGLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
@@ -1221,7 +1221,7 @@ else version (DragonFlyBSD)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1229,7 +1229,7 @@ else version (DragonFlyBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1237,7 +1237,7 @@ else version (DragonFlyBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1246,58 +1246,58 @@ else version (DragonFlyBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED()( const scope in6_addr* a) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST()( const scope in6_addr* a) pure
     {
         return a.s6_addr[0] == 0xff;
     }
 
-    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( const scope in6_addr* a ) pure
+    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE()( const scope in6_addr* a) pure
     {
         return a.s6_addr[1] & 0x0f;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_NODELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_LINKLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_SITELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_ORGLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL()( const scope in6_addr* a) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
@@ -1350,67 +1350,67 @@ else version (Solaris)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED()( const scope in6_addr* a) pure
     {
         return (a.s6_addr32[0] == 0) && (a.s6_addr32[1] == 0) &&
                (a.s6_addr32[2] == 0) && (a.s6_addr32[3] == 0);
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK()( const scope in6_addr* a) pure
     {
         return (a.s6_addr32[0] == 0) && (a.s6_addr32[1] == 0) &&
                (a.s6_addr32[2] == 0) && (a.s6_addr32[3] == ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT()( const scope in6_addr* a) pure
     {
         return (a.s6_addr32[0] == 0) && (a.s6_addr32[1] == 0) &&
                (a.s6_addr32[2] == 0) && (a.s6_addr32[3] != 0) &&
                (a.s6_addr32[3] != ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED()( const scope in6_addr* a) pure
     {
         return (a.s6_addr32[0] == 0) && (a.s6_addr32[1] == 0) &&
                (a.s6_addr32[2] == ntohl(0x0000ffff));
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr8[0] == 0xfe && (a.s6_addr8[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr8[0] == 0xfe && (a.s6_addr8[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST()( const scope in6_addr* a) pure
     {
         return a.s6_addr8[0] == 0xff;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr8[0] == 0xff && (a.s6_addr8[1] & 0x0f) == 0x01;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr8[0] == 0xff && (a.s6_addr8[1] & 0x0f) == 0x02;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr8[0] == 0xff && (a.s6_addr8[1] & 0x0f) == 0x05;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr8[0] == 0xff && (a.s6_addr8[1] & 0x0f) == 0x08;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL()( const scope in6_addr* a) pure
     {
         return a.s6_addr8[0] == 0xff && (a.s6_addr8[1] & 0x0f) == 0x0e;
     }
@@ -1640,7 +1640,7 @@ else version (CRuntime_UClibc)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED()( in6_addr* addr) pure
     {
         return (cast(uint32_t*) addr)[0] == 0 &&
                (cast(uint32_t*) addr)[1] == 0 &&
@@ -1648,7 +1648,7 @@ else version (CRuntime_UClibc)
                (cast(uint32_t*) addr)[3] == 0;
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK()( in6_addr* addr) pure
     {
         return (cast(uint32_t*) addr)[0] == 0  &&
                (cast(uint32_t*) addr)[1] == 0  &&
@@ -1656,29 +1656,29 @@ else version (CRuntime_UClibc)
                (cast(uint32_t*) addr)[3] == htonl( 1 );
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST()( in6_addr* addr) pure
     {
         return (cast(uint8_t*) addr)[0] == 0xff;
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL()( in6_addr* addr) pure
     {
         return ((cast(uint32_t*) addr)[0] & htonl( 0xffc00000 )) == htonl( 0xfe800000 );
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL()( in6_addr* addr) pure
     {
         return ((cast(uint32_t*) addr)[0] & htonl( 0xffc00000 )) == htonl( 0xfec00000 );
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED()( in6_addr* addr) pure
     {
         return (cast(uint32_t*) addr)[0] == 0 &&
                (cast(uint32_t*) addr)[1] == 0 &&
                (cast(uint32_t*) addr)[2] == htonl( 0xffff );
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT()( in6_addr* addr) pure
     {
         return (cast(uint32_t*) addr)[0] == 0 &&
                (cast(uint32_t*) addr)[1] == 0 &&
@@ -1686,7 +1686,7 @@ else version (CRuntime_UClibc)
                ntohl( (cast(uint32_t*) addr)[3] ) > 1;
     }
 
-    extern (D) int IN6_ARE_ADDR_EQUAL( in6_addr* a, in6_addr* b ) pure
+    extern (D) int IN6_ARE_ADDR_EQUAL()( in6_addr* a, in6_addr* b) pure
     {
         return (cast(uint32_t*) a)[0] == (cast(uint32_t*) b)[0] &&
                (cast(uint32_t*) a)[1] == (cast(uint32_t*) b)[1] &&
@@ -1694,31 +1694,31 @@ else version (CRuntime_UClibc)
                (cast(uint32_t*) a)[3] == (cast(uint32_t*) b)[3];
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL()( in6_addr* addr) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr ) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x1;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL()( in6_addr* addr) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr ) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x2;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL()( in6_addr* addr) pure
     {
         return IN6_IS_ADDR_MULTICAST(addr) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x5;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL()( in6_addr* addr) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0x8;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( in6_addr* addr ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL()( in6_addr* addr) pure
     {
         return IN6_IS_ADDR_MULTICAST( addr ) &&
                ((cast(uint8_t*) addr)[1] & 0xf) == 0xe;

--- a/druntime/src/core/sys/posix/signal.d
+++ b/druntime/src/core/sys/posix/signal.d
@@ -179,7 +179,7 @@ else version (linux)
         int __libc_current_sigrtmax();
     }
 
-    @property int SIGRTMIN() nothrow @nogc {
+    @property int SIGRTMIN()() nothrow @nogc {
         __gshared int sig = -1;
         if (sig == -1) {
             sig = __libc_current_sigrtmin();
@@ -187,7 +187,7 @@ else version (linux)
         return sig;
     }
 
-    @property int SIGRTMAX() nothrow @nogc {
+    @property int SIGRTMAX()() nothrow @nogc {
         __gshared int sig = -1;
         if (sig == -1) {
             sig = __libc_current_sigrtmax();
@@ -1012,12 +1012,12 @@ version (linux)
         } _sifields_t _sifields;
 
     nothrow @nogc:
-        @property ref pid_t si_pid() return { return _sifields._kill.si_pid; }
-        @property ref uid_t si_uid() return { return _sifields._kill.si_uid; }
-        @property ref void* si_addr() return { return _sifields._sigfault.si_addr; }
-        @property ref int si_status() return { return _sifields._sigchld.si_status; }
-        @property ref c_long si_band() return { return _sifields._sigpoll.si_band; }
-        @property ref sigval si_value() return { return _sifields._rt.si_sigval; }
+        @property ref pid_t si_pid()() { return _sifields._kill.si_pid; }
+        @property ref uid_t si_uid()() { return _sifields._kill.si_uid; }
+        @property ref void* si_addr()() { return _sifields._sigfault.si_addr; }
+        @property ref int si_status()() { return _sifields._sigchld.si_status; }
+        @property ref c_long si_band()() { return _sifields._sigpoll.si_band; }
+        @property ref sigval si_value()() { return _sifields._rt.si_sigval; }
     }
 
     enum

--- a/druntime/src/core/sys/posix/sys/ioctl.d
+++ b/druntime/src/core/sys/posix/sys/ioctl.d
@@ -61,7 +61,7 @@ version (linux)
                (is(T == typeof(null)) ? 0 : T.sizeof << _IOC_SIZESHIFT);
     }
 
-    extern (D) int _IO(int type, int nr)
+    extern (D) int _IO()(int type, int nr)
     {
         return _IOC(_IOC_NONE, type, nr);
     }
@@ -81,22 +81,22 @@ version (linux)
         return _IOC!T(_IOC_READ | _IOC_WRITE, type, nr);
     }
 
-    extern (D) int _IOC_DIR(int nr)
+    extern (D) int _IOC_DIR()(int nr)
     {
         return (nr >> _IOC_DIRSHIFT) & _IOC_DIRMASK;
     }
 
-    extern (D) int _IOC_TYPE(int nr)
+    extern (D) int _IOC_TYPE()(int nr)
     {
         return (nr >> _IOC_TYPESHIFT) & _IOC_TYPEMASK;
     }
 
-    extern (D) int _IOC_NR(int nr)
+    extern (D) int _IOC_NR()(int nr)
     {
         return (nr >> _IOC_NRSHIFT) & _IOC_NRMASK;
     }
 
-    extern (D) int _IOC_SIZE(int nr)
+    extern (D) int _IOC_SIZE()(int nr)
     {
         return (nr >> _IOC_SIZESHIFT) & _IOC_SIZEMASK;
     }

--- a/druntime/src/core/sys/posix/sys/select.d
+++ b/druntime/src/core/sys/posix/sys/select.d
@@ -57,12 +57,12 @@ version (CRuntime_Glibc)
         alias c_long __fd_mask;
         enum uint __NFDBITS = 8 * __fd_mask.sizeof;
 
-        extern (D) auto __FDELT( int d ) pure
+        extern (D) auto __FDELT()( int d ) pure
         {
             return d / __NFDBITS;
         }
 
-        extern (D) auto __FDMASK( int d ) pure
+        extern (D) auto __FDMASK()( int d ) pure
         {
             return cast(__fd_mask) 1 << ( d % __NFDBITS );
         }
@@ -75,22 +75,22 @@ version (CRuntime_Glibc)
         __fd_mask[FD_SETSIZE / __NFDBITS] fds_bits;
     }
 
-    extern (D) void FD_CLR( int fd, fd_set* fdset ) pure
+    extern (D) void FD_CLR()( int fd, fd_set* fdset ) pure
     {
         fdset.fds_bits[__FDELT( fd )] &= ~__FDMASK( fd );
     }
 
-    extern (D) bool FD_ISSET( int fd, const(fd_set)* fdset ) pure
+    extern (D) bool FD_ISSET()( int fd, const(fd_set)* fdset ) pure
     {
         return (fdset.fds_bits[__FDELT( fd )] & __FDMASK( fd )) != 0;
     }
 
-    extern (D) void FD_SET( int fd, fd_set* fdset ) pure
+    extern (D) void FD_SET()( int fd, fd_set* fdset ) pure
     {
         fdset.fds_bits[__FDELT( fd )] |= __FDMASK( fd );
     }
 
-    extern (D) void FD_ZERO( fd_set* fdset ) pure
+    extern (D) void FD_ZERO()( fd_set* fdset ) pure
     {
         fdset.fds_bits[0 .. $] = 0;
     }
@@ -148,22 +148,22 @@ else version (Darwin)
         int[(FD_SETSIZE + (__DARWIN_NFDBITS - 1)) / __DARWIN_NFDBITS] fds_bits;
     }
 
-    extern (D) void FD_CLR( int fd, fd_set* fdset ) pure
+    extern (D) void FD_CLR()( int fd, fd_set* fdset ) pure
     {
         fdset.fds_bits[fd / __DARWIN_NFDBITS] &= ~(1 << (fd % __DARWIN_NFDBITS));
     }
 
-    extern (D) bool FD_ISSET( int fd, const(fd_set)* fdset ) pure
+    extern (D) bool FD_ISSET()( int fd, const(fd_set)* fdset ) pure
     {
         return (fdset.fds_bits[fd / __DARWIN_NFDBITS] & (1 << (fd % __DARWIN_NFDBITS))) != 0;
     }
 
-    extern (D) void FD_SET( int fd, fd_set* fdset ) pure
+    extern (D) void FD_SET()( int fd, fd_set* fdset ) pure
     {
         fdset.fds_bits[fd / __DARWIN_NFDBITS] |= 1 << (fd % __DARWIN_NFDBITS);
     }
 
-    extern (D) void FD_ZERO( fd_set* fdset ) pure
+    extern (D) void FD_ZERO()( fd_set* fdset ) pure
     {
         fdset.fds_bits[0 .. $] = 0;
     }
@@ -187,27 +187,27 @@ else version (FreeBSD)
         deprecated("druntime incorrectly named fds_bits __fds_bits") alias __fds_bits = fds_bits;
     }
 
-    extern (D) __fd_mask __fdset_mask(uint n) pure
+    extern (D) __fd_mask __fdset_mask()(uint n) pure
     {
         return cast(__fd_mask) 1 << (n % _NFDBITS);
     }
 
-    extern (D) void FD_CLR( int n, fd_set* p ) pure
+    extern (D) void FD_CLR()( int n, fd_set* p ) pure
     {
         p.fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
     }
 
-    extern (D) bool FD_ISSET( int n, const(fd_set)* p ) pure
+    extern (D) bool FD_ISSET()( int n, const(fd_set)* p ) pure
     {
         return (p.fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
     }
 
-    extern (D) void FD_SET( int n, fd_set* p ) pure
+    extern (D) void FD_SET()( int n, fd_set* p ) pure
     {
         p.fds_bits[n / _NFDBITS] |= __fdset_mask(n);
     }
 
-    extern (D) void FD_ZERO( fd_set* p ) pure
+    extern (D) void FD_ZERO()( fd_set* p ) pure
     {
         fd_set *_p;
         size_t _n;
@@ -237,27 +237,27 @@ else version (NetBSD)
         deprecated("druntime incorrectly named fds_bits __fds_bits") alias __fds_bits = fds_bits;
     }
 
-    extern (D) __fd_mask __fdset_mask(uint n) pure
+    extern (D) __fd_mask __fdset_mask()(uint n) pure
     {
         return cast(__fd_mask) 1 << (n % _NFDBITS);
     }
 
-    extern (D) void FD_CLR( int n, fd_set* p ) pure
+    extern (D) void FD_CLR()( int n, fd_set* p ) pure
     {
         p.fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
     }
 
-    extern (D) bool FD_ISSET( int n, const(fd_set)* p ) pure
+    extern (D) bool FD_ISSET()( int n, const(fd_set)* p ) pure
     {
         return (p.fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
     }
 
-    extern (D) void FD_SET( int n, fd_set* p ) pure
+    extern (D) void FD_SET()( int n, fd_set* p ) pure
     {
         p.fds_bits[n / _NFDBITS] |= __fdset_mask(n);
     }
 
-    extern (D) void FD_ZERO( fd_set* p ) pure
+    extern (D) void FD_ZERO()( fd_set* p ) pure
     {
         fd_set *_p;
         size_t _n;
@@ -287,27 +287,27 @@ else version (OpenBSD)
         deprecated("druntime incorrectly named fds_bits __fds_bits") alias __fds_bits = fds_bits;
     }
 
-    extern (D) __fd_mask __fdset_mask(uint n) pure
+    extern (D) __fd_mask __fdset_mask()(uint n) pure
     {
         return cast(__fd_mask) 1 << (n % _NFDBITS);
     }
 
-    extern (D) void FD_CLR(int n, fd_set* p) pure
+    extern (D) void FD_CLR()(int n, fd_set* p) pure
     {
         p.fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
     }
 
-    extern (D) bool FD_ISSET(int n, const(fd_set)* p) pure
+    extern (D) bool FD_ISSET()(int n, const(fd_set)* p) pure
     {
         return (p.fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
     }
 
-    extern (D) void FD_SET(int n, fd_set* p) pure
+    extern (D) void FD_SET()(int n, fd_set* p) pure
     {
         p.fds_bits[n / _NFDBITS] |= __fdset_mask(n);
     }
 
-    extern (D) void FD_ZERO(fd_set* p) pure
+    extern (D) void FD_ZERO()(fd_set* p) pure
     {
         fd_set *_p = p;
         size_t _n = (FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS;
@@ -335,27 +335,27 @@ else version (DragonFlyBSD)
         deprecated("druntime incorrectly named fds_bits __fds_bits") alias __fds_bits = fds_bits;
     }
 
-    extern (D) __fd_mask __fdset_mask(uint n) pure
+    extern (D) __fd_mask __fdset_mask()(uint n) pure
     {
         return cast(__fd_mask) 1 << (n % _NFDBITS);
     }
 
-    extern (D) void FD_CLR( int n, fd_set* p ) pure
+    extern (D) void FD_CLR()( int n, fd_set* p ) pure
     {
         p.fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
     }
 
-    extern (D) bool FD_ISSET( int n, const(fd_set)* p ) pure
+    extern (D) bool FD_ISSET()( int n, const(fd_set)* p ) pure
     {
         return (p.fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
     }
 
-    extern (D) void FD_SET( int n, fd_set* p ) pure
+    extern (D) void FD_SET()( int n, fd_set* p ) pure
     {
         p.fds_bits[n / _NFDBITS] |= __fdset_mask(n);
     }
 
-    extern (D) void FD_ZERO( fd_set* p ) pure
+    extern (D) void FD_ZERO()( fd_set* p ) pure
     {
         fd_set *_p;
         size_t _n;
@@ -389,22 +389,22 @@ else version (Solaris)
         c_long[(FD_SETSIZE + (FD_NFDBITS - 1)) / FD_NFDBITS] fds_bits;
     }
 
-    extern (D) void FD_SET(int __n, fd_set* __p) pure
+    extern (D) void FD_SET()(int __n, fd_set* __p) pure
     {
         __p.fds_bits[__n / FD_NFDBITS] |= 1UL << (__n % FD_NFDBITS);
     }
 
-    extern (D) void FD_CLR(int __n, fd_set* __p) pure
+    extern (D) void FD_CLR()(int __n, fd_set* __p) pure
     {
         __p.fds_bits[__n / FD_NFDBITS] &= ~(1UL << (__n % FD_NFDBITS));
     }
 
-    extern (D) bool FD_ISSET(int __n, const(fd_set)* __p) pure
+    extern (D) bool FD_ISSET()(int __n, const(fd_set)* __p) pure
     {
         return (__p.fds_bits[__n / FD_NFDBITS] & (1UL << (__n % FD_NFDBITS))) != 0;
     }
 
-    extern (D) void FD_ZERO(fd_set* __p) pure
+    extern (D) void FD_ZERO()(fd_set* __p) pure
     {
         __p.fds_bits[0 .. $] = 0;
     }
@@ -419,12 +419,12 @@ else version (CRuntime_Bionic)
         alias c_ulong __fd_mask;
         enum uint __NFDBITS = 8 * __fd_mask.sizeof;
 
-        extern (D) auto __FDELT( int d ) pure
+        extern (D) auto __FDELT()( int d ) pure
         {
             return d / __NFDBITS;
         }
 
-        extern (D) auto __FDMASK( int d ) pure
+        extern (D) auto __FDMASK()( int d ) pure
         {
             return cast(__fd_mask) 1 << ( d % __NFDBITS );
         }
@@ -438,22 +438,22 @@ else version (CRuntime_Bionic)
     }
 
     // These functions are generated in assembly in bionic.
-    extern (D) void FD_CLR( int fd, fd_set* fdset ) pure
+    extern (D) void FD_CLR()( int fd, fd_set* fdset ) pure
     {
         fdset.fds_bits[__FDELT( fd )] &= ~__FDMASK( fd );
     }
 
-    extern (D) bool FD_ISSET( int fd, const(fd_set)* fdset ) pure
+    extern (D) bool FD_ISSET()( int fd, const(fd_set)* fdset ) pure
     {
         return (fdset.fds_bits[__FDELT( fd )] & __FDMASK( fd )) != 0;
     }
 
-    extern (D) void FD_SET( int fd, fd_set* fdset ) pure
+    extern (D) void FD_SET()( int fd, fd_set* fdset ) pure
     {
         fdset.fds_bits[__FDELT( fd )] |= __FDMASK( fd );
     }
 
-    extern (D) void FD_ZERO( fd_set* fdset ) pure
+    extern (D) void FD_ZERO()( fd_set* fdset ) pure
     {
         fdset.fds_bits[0 .. $] = 0;
     }
@@ -471,12 +471,12 @@ else version (CRuntime_Musl)
     {
         enum uint __NFDBITS = 8 * fd_mask.sizeof;
 
-        extern (D) auto __FDELT( int d ) pure
+        extern (D) auto __FDELT()( int d ) pure
         {
             return d / __NFDBITS;
         }
 
-        extern (D) auto __FDMASK( int d ) pure
+        extern (D) auto __FDMASK()( int d ) pure
         {
             return cast(fd_mask) 1 << ( d % __NFDBITS );
         }
@@ -486,22 +486,22 @@ else version (CRuntime_Musl)
         ulong[FD_SETSIZE / 8 / long.sizeof] fds_bits;
     }
 
-    extern (D) void FD_CLR( int fd, fd_set* fdset ) pure
+    extern (D) void FD_CLR()( int fd, fd_set* fdset ) pure
     {
         fdset.fds_bits[__FDELT( fd )] &= ~__FDMASK( fd );
     }
 
-    extern (D) bool FD_ISSET( int fd, const(fd_set)* fdset ) pure
+    extern (D) bool FD_ISSET()( int fd, const(fd_set)* fdset ) pure
     {
         return (fdset.fds_bits[__FDELT( fd )] & __FDMASK( fd )) != 0;
     }
 
-    extern (D) void FD_SET( int fd, fd_set* fdset ) pure
+    extern (D) void FD_SET()( int fd, fd_set* fdset ) pure
     {
         fdset.fds_bits[__FDELT( fd )] |= __FDMASK( fd );
     }
 
-    extern (D) void FD_ZERO( fd_set* fdset ) pure
+    extern (D) void FD_ZERO()( fd_set* fdset ) pure
     {
         fdset.fds_bits[0 .. $] = 0;
     }
@@ -517,12 +517,12 @@ else version (CRuntime_UClibc)
         alias c_long __fd_mask;
         enum uint __NFDBITS = 8 * __fd_mask.sizeof;
 
-        extern (D) auto __FDELT( int d ) pure
+        extern (D) auto __FDELT()( int d ) pure
         {
             return d / __NFDBITS;
         }
 
-        extern (D) auto __FDMASK( int d ) pure
+        extern (D) auto __FDMASK()( int d ) pure
         {
             return cast(__fd_mask) 1 << ( d % __NFDBITS );
         }
@@ -535,22 +535,22 @@ else version (CRuntime_UClibc)
         __fd_mask[FD_SETSIZE / __NFDBITS] fds_bits;
     }
 
-    extern (D) void FD_CLR( int fd, fd_set* fdset ) pure
+    extern (D) void FD_CLR()( int fd, fd_set* fdset ) pure
     {
         fdset.fds_bits[__FDELT( fd )] &= ~__FDMASK( fd );
     }
 
-    extern (D) bool FD_ISSET( int fd, const(fd_set)* fdset ) pure
+    extern (D) bool FD_ISSET()( int fd, const(fd_set)* fdset ) pure
     {
         return (fdset.fds_bits[__FDELT( fd )] & __FDMASK( fd )) != 0;
     }
 
-    extern (D) void FD_SET( int fd, fd_set* fdset ) pure
+    extern (D) void FD_SET()( int fd, fd_set* fdset ) pure
     {
         fdset.fds_bits[__FDELT( fd )] |= __FDMASK( fd );
     }
 
-    extern (D) void FD_ZERO( fd_set* fdset ) pure
+    extern (D) void FD_ZERO()( fd_set* fdset ) pure
     {
         fdset.fds_bits[0 .. $] = 0;
     }

--- a/druntime/src/core/sys/posix/sys/socket.d
+++ b/druntime/src/core/sys/posix/sys/socket.d
@@ -233,12 +233,12 @@ version (linux)
 
     extern (D)
     {
-        size_t CMSG_ALIGN( size_t len ) pure nothrow @nogc
+        size_t CMSG_ALIGN()( size_t len ) pure nothrow @nogc
         {
             return (len + size_t.sizeof - 1) & cast(size_t) (~(size_t.sizeof - 1));
         }
 
-        size_t CMSG_LEN( size_t len ) pure nothrow @nogc
+        size_t CMSG_LEN()( size_t len ) pure nothrow @nogc
         {
             return CMSG_ALIGN(cmsghdr.sizeof) + len;
         }
@@ -668,13 +668,13 @@ else version (Darwin)
 
     extern (D)
     {
-        socklen_t CMSG_ALIGN(socklen_t len) pure nothrow @nogc { return (len + socklen_t.sizeof - 1) & cast(socklen_t) (~(socklen_t.sizeof - 1)); }
-        socklen_t CMSG_SPACE(socklen_t len) pure nothrow @nogc { return CMSG_ALIGN(len) + CMSG_ALIGN(cmsghdr.sizeof); }
-        socklen_t CMSG_LEN(socklen_t len) pure nothrow @nogc { return CMSG_ALIGN(cmsghdr.sizeof) + len; }
+        socklen_t CMSG_ALIGN()(socklen_t len) pure nothrow @nogc { return (len + socklen_t.sizeof - 1) & cast(socklen_t) (~(socklen_t.sizeof - 1)); }
+        socklen_t CMSG_SPACE()(socklen_t len) pure nothrow @nogc { return CMSG_ALIGN(len) + CMSG_ALIGN(cmsghdr.sizeof); }
+        socklen_t CMSG_LEN()(socklen_t len) pure nothrow @nogc { return CMSG_ALIGN(cmsghdr.sizeof) + len; }
 
-        inout(ubyte)*   CMSG_DATA( return scope inout(cmsghdr)* cmsg ) pure nothrow @nogc { return cast(ubyte*)( cmsg + 1 ); }
+        inout(ubyte)*   CMSG_DATA()( return scope inout(cmsghdr)* cmsg ) pure nothrow @nogc { return cast(ubyte*)( cmsg + 1 ); }
 
-        inout(cmsghdr)* CMSG_FIRSTHDR( inout(msghdr)* mhdr ) pure nothrow @nogc
+        inout(cmsghdr)* CMSG_FIRSTHDR()( inout(msghdr)* mhdr ) pure nothrow @nogc
         {
             return ( cast(socklen_t)mhdr.msg_controllen >= cmsghdr.sizeof ? cast(inout(cmsghdr)*) mhdr.msg_control : cast(inout(cmsghdr)*) null );
         }

--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -1464,19 +1464,19 @@ version (CRuntime_Glibc)
 
     private
     {
-        extern (D) bool S_ISTYPE( mode_t mode, uint mask )
+        extern (D) bool S_ISTYPE()( mode_t mode, uint mask )
         {
             return ( mode & S_IFMT ) == mask;
         }
     }
 
-    extern (D) bool S_ISBLK( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
-    extern (D) bool S_ISCHR( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
-    extern (D) bool S_ISDIR( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
-    extern (D) bool S_ISFIFO( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
-    extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
-    extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
-    extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+    extern (D) bool S_ISBLK()( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
+    extern (D) bool S_ISCHR()( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
+    extern (D) bool S_ISDIR()( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
+    extern (D) bool S_ISFIFO()( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
+    extern (D) bool S_ISREG()( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
+    extern (D) bool S_ISLNK()( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
+    extern (D) bool S_ISSOCK()( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 
     int utimensat(int dirfd, const char *pathname,
         ref const(timespec)[2] times, int flags);
@@ -1501,19 +1501,19 @@ else version (Darwin)
 
     private
     {
-        extern (D) bool S_ISTYPE( mode_t mode, uint mask )
+        extern (D) bool S_ISTYPE()( mode_t mode, uint mask )
         {
             return ( mode & S_IFMT ) == mask;
         }
     }
 
-    extern (D) bool S_ISBLK( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
-    extern (D) bool S_ISCHR( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
-    extern (D) bool S_ISDIR( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
-    extern (D) bool S_ISFIFO( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
-    extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
-    extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
-    extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+    extern (D) bool S_ISBLK()( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
+    extern (D) bool S_ISCHR()( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
+    extern (D) bool S_ISDIR()( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
+    extern (D) bool S_ISFIFO()( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
+    extern (D) bool S_ISREG()( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
+    extern (D) bool S_ISLNK()( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
+    extern (D) bool S_ISSOCK()( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 }
 else version (FreeBSD)
 {
@@ -1534,19 +1534,19 @@ else version (FreeBSD)
 
     private
     {
-        extern (D) bool S_ISTYPE( mode_t mode, uint mask )
+        extern (D) bool S_ISTYPE()( mode_t mode, uint mask )
         {
             return ( mode & S_IFMT ) == mask;
         }
     }
 
-    extern (D) bool S_ISBLK( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
-    extern (D) bool S_ISCHR( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
-    extern (D) bool S_ISDIR( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
-    extern (D) bool S_ISFIFO( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
-    extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
-    extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
-    extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+    extern (D) bool S_ISBLK()( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
+    extern (D) bool S_ISCHR()( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
+    extern (D) bool S_ISDIR()( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
+    extern (D) bool S_ISFIFO()( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
+    extern (D) bool S_ISREG()( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
+    extern (D) bool S_ISLNK()( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
+    extern (D) bool S_ISSOCK()( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 
     // Since FreeBSD 11:
     version (none)
@@ -1575,19 +1575,19 @@ else version (NetBSD)
 
     private
     {
-        extern (D) bool S_ISTYPE( mode_t mode, uint mask )
+        extern (D) bool S_ISTYPE()( mode_t mode, uint mask )
         {
             return ( mode & S_IFMT ) == mask;
         }
     }
 
-    extern (D) bool S_ISBLK( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
-    extern (D) bool S_ISCHR( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
-    extern (D) bool S_ISDIR( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
-    extern (D) bool S_ISFIFO( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
-    extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
-    extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
-    extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+    extern (D) bool S_ISBLK()( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
+    extern (D) bool S_ISCHR()( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
+    extern (D) bool S_ISDIR()( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
+    extern (D) bool S_ISFIFO()( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
+    extern (D) bool S_ISREG()( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
+    extern (D) bool S_ISLNK()( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
+    extern (D) bool S_ISSOCK()( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 }
 else version (OpenBSD)
 {
@@ -1606,13 +1606,13 @@ else version (OpenBSD)
     enum S_IXOTH    = 0x1; // 0000001
     enum S_IRWXO    = 0x7; // 0000007
 
-    extern (D) bool S_ISBLK(mode_t mode)  { return (mode & S_IFMT) == S_IFBLK;  }
-    extern (D) bool S_ISCHR(mode_t mode)  { return (mode & S_IFMT) == S_IFCHR;  }
-    extern (D) bool S_ISDIR(mode_t mode)  { return (mode & S_IFMT) == S_IFDIR;  }
-    extern (D) bool S_ISFIFO(mode_t mode) { return (mode & S_IFMT) == S_IFIFO;  }
-    extern (D) bool S_ISREG(mode_t mode)  { return (mode & S_IFMT) == S_IFREG;  }
-    extern (D) bool S_ISLNK(mode_t mode)  { return (mode & S_IFMT) == S_IFLNK;  }
-    extern (D) bool S_ISSOCK(mode_t mode) { return (mode & S_IFMT) == S_IFSOCK; }
+    extern (D) bool S_ISBLK()(mode_t mode)  { return (mode & S_IFMT) == S_IFBLK;  }
+    extern (D) bool S_ISCHR()(mode_t mode)  { return (mode & S_IFMT) == S_IFCHR;  }
+    extern (D) bool S_ISDIR()(mode_t mode)  { return (mode & S_IFMT) == S_IFDIR;  }
+    extern (D) bool S_ISFIFO()(mode_t mode) { return (mode & S_IFMT) == S_IFIFO;  }
+    extern (D) bool S_ISREG()(mode_t mode)  { return (mode & S_IFMT) == S_IFREG;  }
+    extern (D) bool S_ISLNK()(mode_t mode)  { return (mode & S_IFMT) == S_IFLNK;  }
+    extern (D) bool S_ISSOCK()(mode_t mode) { return (mode & S_IFMT) == S_IFSOCK; }
 }
 else version (DragonFlyBSD)
 {
@@ -1633,19 +1633,19 @@ else version (DragonFlyBSD)
 
     private
     {
-        extern (D) bool S_ISTYPE( mode_t mode, uint mask )
+        extern (D) bool S_ISTYPE()( mode_t mode, uint mask )
         {
             return ( mode & S_IFMT ) == mask;
         }
     }
 
-    extern (D) bool S_ISBLK( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
-    extern (D) bool S_ISCHR( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
-    extern (D) bool S_ISDIR( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
-    extern (D) bool S_ISFIFO( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
-    extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
-    extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
-    extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+    extern (D) bool S_ISBLK()( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
+    extern (D) bool S_ISCHR()( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
+    extern (D) bool S_ISDIR()( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
+    extern (D) bool S_ISFIFO()( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
+    extern (D) bool S_ISREG()( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
+    extern (D) bool S_ISLNK()( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
+    extern (D) bool S_ISSOCK()( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 }
 else version (Solaris)
 {
@@ -1666,21 +1666,21 @@ else version (Solaris)
 
     private
     {
-        extern (D) bool S_ISTYPE(mode_t mode, uint mask)
+        extern (D) bool S_ISTYPE()(mode_t mode, uint mask)
         {
             return (mode & S_IFMT) == mask;
         }
     }
 
-    extern (D) bool S_ISBLK(mode_t mode) { return S_ISTYPE(mode, S_IFBLK); }
-    extern (D) bool S_ISCHR(mode_t mode) { return S_ISTYPE(mode, S_IFCHR); }
-    extern (D) bool S_ISDIR(mode_t mode) { return S_ISTYPE(mode, S_IFDIR); }
-    extern (D) bool S_ISFIFO(mode_t mode) { return S_ISTYPE(mode, S_IFIFO); }
-    extern (D) bool S_ISREG(mode_t mode) { return S_ISTYPE(mode, S_IFREG); }
-    extern (D) bool S_ISLNK(mode_t mode) { return S_ISTYPE(mode, S_IFLNK); }
-    extern (D) bool S_ISSOCK(mode_t mode) { return S_ISTYPE(mode, S_IFSOCK); }
-    extern (D) bool S_ISDOOR(mode_t mode) { return S_ISTYPE(mode, S_IFDOOR); }
-    extern (D) bool S_ISPORT(mode_t mode) { return S_ISTYPE(mode, S_IFPORT); }
+    extern (D) bool S_ISBLK()(mode_t mode) { return S_ISTYPE(mode, S_IFBLK); }
+    extern (D) bool S_ISCHR()(mode_t mode) { return S_ISTYPE(mode, S_IFCHR); }
+    extern (D) bool S_ISDIR()(mode_t mode) { return S_ISTYPE(mode, S_IFDIR); }
+    extern (D) bool S_ISFIFO()(mode_t mode) { return S_ISTYPE(mode, S_IFIFO); }
+    extern (D) bool S_ISREG()(mode_t mode) { return S_ISTYPE(mode, S_IFREG); }
+    extern (D) bool S_ISLNK()(mode_t mode) { return S_ISTYPE(mode, S_IFLNK); }
+    extern (D) bool S_ISSOCK()(mode_t mode) { return S_ISTYPE(mode, S_IFSOCK); }
+    extern (D) bool S_ISDOOR()(mode_t mode) { return S_ISTYPE(mode, S_IFDOOR); }
+    extern (D) bool S_ISPORT()(mode_t mode) { return S_ISTYPE(mode, S_IFPORT); }
 }
 else version (CRuntime_Bionic)
 {
@@ -1701,19 +1701,19 @@ else version (CRuntime_Bionic)
 
     private
     {
-        extern (D) bool S_ISTYPE( uint mode, uint mask )
+        extern (D) bool S_ISTYPE()( uint mode, uint mask )
         {
             return ( mode & S_IFMT ) == mask;
         }
     }
 
-    extern (D) bool S_ISBLK( uint mode )  { return S_ISTYPE( mode, S_IFBLK );  }
-    extern (D) bool S_ISCHR( uint mode )  { return S_ISTYPE( mode, S_IFCHR );  }
-    extern (D) bool S_ISDIR( uint mode )  { return S_ISTYPE( mode, S_IFDIR );  }
-    extern (D) bool S_ISFIFO( uint mode ) { return S_ISTYPE( mode, S_IFIFO );  }
-    extern (D) bool S_ISREG( uint mode )  { return S_ISTYPE( mode, S_IFREG );  }
-    extern (D) bool S_ISLNK( uint mode )  { return S_ISTYPE( mode, S_IFLNK );  }
-    extern (D) bool S_ISSOCK( uint mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+    extern (D) bool S_ISBLK()( uint mode )  { return S_ISTYPE( mode, S_IFBLK );  }
+    extern (D) bool S_ISCHR()( uint mode )  { return S_ISTYPE( mode, S_IFCHR );  }
+    extern (D) bool S_ISDIR()( uint mode )  { return S_ISTYPE( mode, S_IFDIR );  }
+    extern (D) bool S_ISFIFO()( uint mode ) { return S_ISTYPE( mode, S_IFIFO );  }
+    extern (D) bool S_ISREG()( uint mode )  { return S_ISTYPE( mode, S_IFREG );  }
+    extern (D) bool S_ISLNK()( uint mode )  { return S_ISTYPE( mode, S_IFLNK );  }
+    extern (D) bool S_ISSOCK()( uint mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 
     // Added since Lollipop
     int utimensat(int dirfd, const char *pathname,
@@ -1740,19 +1740,19 @@ else version (CRuntime_Musl)
 
     private
     {
-        extern (D) bool S_ISTYPE( mode_t mode, uint mask )
+        extern (D) bool S_ISTYPE()( mode_t mode, uint mask )
         {
             return ( mode & S_IFMT ) == mask;
         }
     }
 
-    extern (D) bool S_ISBLK( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
-    extern (D) bool S_ISCHR( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
-    extern (D) bool S_ISDIR( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
-    extern (D) bool S_ISFIFO( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
-    extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
-    extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
-    extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+    extern (D) bool S_ISBLK()( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
+    extern (D) bool S_ISCHR()( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
+    extern (D) bool S_ISDIR()( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
+    extern (D) bool S_ISFIFO()( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
+    extern (D) bool S_ISREG()( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
+    extern (D) bool S_ISLNK()( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
+    extern (D) bool S_ISSOCK()( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 
     int utimensat(int dirfd, const char *pathname,
         ref const(timespec)[2] times, int flags);
@@ -1776,19 +1776,19 @@ else version (CRuntime_UClibc)
 
     private
     {
-        extern (D) bool S_ISTYPE( mode_t mode, uint mask )
+        extern (D) bool S_ISTYPE()( mode_t mode, uint mask )
         {
             return ( mode & S_IFMT ) == mask;
         }
     }
 
-    extern (D) bool S_ISBLK( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
-    extern (D) bool S_ISCHR( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
-    extern (D) bool S_ISDIR( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
-    extern (D) bool S_ISFIFO( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
-    extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
-    extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
-    extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+    extern (D) bool S_ISBLK()( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
+    extern (D) bool S_ISCHR()( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
+    extern (D) bool S_ISDIR()( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
+    extern (D) bool S_ISFIFO()( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
+    extern (D) bool S_ISREG()( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
+    extern (D) bool S_ISLNK()( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
+    extern (D) bool S_ISSOCK()( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 
     int utimensat(int dirfd, const char *pathname,
     ref const(timespec)[2] times, int flags);

--- a/druntime/src/core/sys/posix/sys/wait.d
+++ b/druntime/src/core/sys/posix/sys/wait.d
@@ -127,7 +127,7 @@ version (CRuntime_Glibc)
 
     private
     {
-        extern (D) int __WTERMSIG( int status ) { return status & 0x7F; }
+        extern (D) int __WTERMSIG()(int status) { return status & 0x7F; }
     }
 
     //
@@ -135,128 +135,128 @@ version (CRuntime_Glibc)
     //       C headers as the parameter definition there is different and
     //       much more complicated.
     //
-    extern (D) int  WEXITSTATUS( int status )  { return ( status & 0xFF00 ) >> 8;   }
-    extern (D) int  WIFCONTINUED( int status ) { return status == __W_CONTINUED;    }
-    extern (D) bool WIFEXITED( int status )    { return __WTERMSIG( status ) == 0;  }
-    extern (D) bool WIFSIGNALED( int status )
+    extern (D) int  WEXITSTATUS()( int status )  { return ( status & 0xFF00 ) >> 8;   }
+    extern (D) int  WIFCONTINUED()( int status ) { return status == __W_CONTINUED;    }
+    extern (D) bool WIFEXITED()( int status )    { return __WTERMSIG( status ) == 0;  }
+    extern (D) bool WIFSIGNALED()( int status )
     {
         return ( cast(byte) ( ( status & 0x7F ) + 1 ) >> 1 ) > 0;
     }
-    extern (D) bool WIFSTOPPED( int status )   { return ( status & 0xFF ) == 0x7F;  }
-    extern (D) int  WSTOPSIG( int status )     { return WEXITSTATUS( status );      }
-    extern (D) int  WTERMSIG( int status )     { return status & 0x7F;              }
+    extern (D) bool WIFSTOPPED()( int status )   { return ( status & 0xFF ) == 0x7F;  }
+    extern (D) int  WSTOPSIG()( int status )     { return WEXITSTATUS( status );      }
+    extern (D) int  WTERMSIG()( int status )     { return status & 0x7F;              }
 }
 else version (Darwin)
 {
     @safe pure:
 
-    extern (D) int _WSTATUS(int status)         { return (status & 0x7F);           }
-    extern (D) int  WEXITSTATUS( int status )   { return (status >> 8);             }
-    extern (D) int  WIFCONTINUED( int status )  { return status == 0x13;            }
-    extern (D) bool WIFEXITED( int status )     { return _WSTATUS(status) == 0;     }
-    extern (D) bool WIFSIGNALED( int status )
+    extern (D) int _WSTATUS()(int status)         { return (status & 0x7F);           }
+    extern (D) int  WEXITSTATUS()( int status )   { return (status >> 8);             }
+    extern (D) int  WIFCONTINUED()( int status )  { return status == 0x13;            }
+    extern (D) bool WIFEXITED()( int status )     { return _WSTATUS(status) == 0;     }
+    extern (D) bool WIFSIGNALED()( int status )
     {
         return _WSTATUS( status ) != _WSTOPPED && _WSTATUS( status ) != 0;
     }
-    extern (D) bool WIFSTOPPED( int status )   { return _WSTATUS( status ) == _WSTOPPED; }
-    extern (D) int  WSTOPSIG( int status )     { return status >> 8;                     }
-    extern (D) int  WTERMSIG( int status )     { return _WSTATUS( status );              }
+    extern (D) bool WIFSTOPPED()( int status )   { return _WSTATUS( status ) == _WSTOPPED; }
+    extern (D) int  WSTOPSIG()( int status )     { return status >> 8;                     }
+    extern (D) int  WTERMSIG()( int status )     { return _WSTATUS( status );              }
 }
 else version (FreeBSD)
 {
     @safe pure:
 
-    extern (D) int _WSTATUS(int status)         { return (status & 0x7F);           }
-    extern (D) int  WEXITSTATUS( int status )   { return (status >> 8);             }
-    extern (D) int  WIFCONTINUED( int status )  { return status == 0x13;            }
-    extern (D) bool WIFEXITED( int status )     { return _WSTATUS(status) == 0;     }
-    extern (D) bool WIFSIGNALED( int status )
+    extern (D) int _WSTATUS()(int status)         { return (status & 0x7F);           }
+    extern (D) int  WEXITSTATUS()( int status )   { return (status >> 8);             }
+    extern (D) int  WIFCONTINUED()( int status )  { return status == 0x13;            }
+    extern (D) bool WIFEXITED()( int status )     { return _WSTATUS(status) == 0;     }
+    extern (D) bool WIFSIGNALED()( int status )
     {
         return _WSTATUS( status ) != _WSTOPPED && _WSTATUS( status ) != 0;
     }
-    extern (D) bool WIFSTOPPED( int status )   { return _WSTATUS( status ) == _WSTOPPED; }
-    extern (D) int  WSTOPSIG( int status )     { return status >> 8;                     }
-    extern (D) int  WTERMSIG( int status )     { return _WSTATUS( status );              }
+    extern (D) bool WIFSTOPPED()( int status )   { return _WSTATUS( status ) == _WSTOPPED; }
+    extern (D) int  WSTOPSIG()( int status )     { return status >> 8;                     }
+    extern (D) int  WTERMSIG()( int status )     { return _WSTATUS( status );              }
 }
 else version (NetBSD)
 {
     @safe pure:
 
-    extern (D) int _WSTATUS(int status)         { return (status & 0x7F);           }
-    extern (D) int  WEXITSTATUS( int status )   { return (status >> 8);             }
-    extern (D) int  WIFCONTINUED( int status )  { return status == 0x13;            }
-    extern (D) bool WIFEXITED( int status )     { return _WSTATUS(status) == 0;     }
-    extern (D) bool WIFSIGNALED( int status )
+    extern (D) int _WSTATUS()(int status)         { return (status & 0x7F);           }
+    extern (D) int  WEXITSTATUS()( int status )   { return (status >> 8);             }
+    extern (D) int  WIFCONTINUED()( int status )  { return status == 0x13;            }
+    extern (D) bool WIFEXITED()( int status )     { return _WSTATUS(status) == 0;     }
+    extern (D) bool WIFSIGNALED()( int status )
     {
         return _WSTATUS( status ) != _WSTOPPED && _WSTATUS( status ) != 0;
     }
-    extern (D) bool WIFSTOPPED( int status )   { return _WSTATUS( status ) == _WSTOPPED; }
-    extern (D) int  WSTOPSIG( int status )     { return status >> 8;                     }
-    extern (D) int  WTERMSIG( int status )     { return _WSTATUS( status );              }
+    extern (D) bool WIFSTOPPED()( int status )   { return _WSTATUS( status ) == _WSTOPPED; }
+    extern (D) int  WSTOPSIG()( int status )     { return status >> 8;                     }
+    extern (D) int  WTERMSIG()( int status )     { return _WSTATUS( status );              }
 }
 else version (OpenBSD)
 {
     @safe pure:
 
-    extern (D) int _WSTATUS(int status)         { return (status & 0x7F);                     }
-    extern (D) int  WEXITSTATUS(int status)   { return (status >> 8) & 0xFF;                  }
-    extern (D) int  WIFCONTINUED(int status)  { return (status & _WCONTINUED) == _WCONTINUED; }
-    extern (D) bool WIFEXITED(int status)     { return _WSTATUS(status) == 0;                 }
-    extern (D) bool WIFSIGNALED(int status)
+    extern (D) int _WSTATUS()(int status)         { return (status & 0x7F);                     }
+    extern (D) int  WEXITSTATUS()(int status)   { return (status >> 8) & 0xFF;                  }
+    extern (D) int  WIFCONTINUED()(int status)  { return (status & _WCONTINUED) == _WCONTINUED; }
+    extern (D) bool WIFEXITED()(int status)     { return _WSTATUS(status) == 0;                 }
+    extern (D) bool WIFSIGNALED()(int status)
     {
         return _WSTATUS(status) != _WSTOPPED && _WSTATUS(status) != 0;
     }
-    extern (D) bool WIFSTOPPED(int status)   { return (status & 0xFF) == _WSTOPPED; }
-    extern (D) int  WSTOPSIG(int status)     { return (status >> 8) & 0xFF;         }
-    extern (D) int  WTERMSIG(int status)     { return _WSTATUS(status);             }
+    extern (D) bool WIFSTOPPED()(int status)   { return (status & 0xFF) == _WSTOPPED; }
+    extern (D) int  WSTOPSIG()(int status)     { return (status >> 8) & 0xFF;         }
+    extern (D) int  WTERMSIG()(int status)     { return _WSTATUS(status);             }
 }
 else version (DragonFlyBSD)
 {
     @safe pure:
 
-    extern (D) int _WSTATUS(int status)         { return (status & 0x7F);           }
-    extern (D) int  WEXITSTATUS( int status )   { return (status >> 8);             }
-    extern (D) int  WIFCONTINUED( int status )  { return status == 0x13;            }
-    extern (D) bool WIFEXITED( int status )     { return _WSTATUS(status) == 0;     }
-    extern (D) bool WIFSIGNALED( int status )
+    extern (D) int _WSTATUS()(int status)         { return (status & 0x7F);           }
+    extern (D) int  WEXITSTATUS()( int status )   { return (status >> 8);             }
+    extern (D) int  WIFCONTINUED()( int status )  { return status == 0x13;            }
+    extern (D) bool WIFEXITED()( int status )     { return _WSTATUS(status) == 0;     }
+    extern (D) bool WIFSIGNALED()( int status )
     {
         return _WSTATUS( status ) != _WSTOPPED && _WSTATUS( status ) != 0;
     }
-    extern (D) bool WIFSTOPPED( int status )   { return _WSTATUS( status ) == _WSTOPPED; }
-    extern (D) int  WSTOPSIG( int status )     { return status >> 8;                     }
-    extern (D) int  WTERMSIG( int status )     { return _WSTATUS( status );              }
+    extern (D) bool WIFSTOPPED()( int status )   { return _WSTATUS( status ) == _WSTOPPED; }
+    extern (D) int  WSTOPSIG()( int status )     { return status >> 8;                     }
+    extern (D) int  WTERMSIG()( int status )     { return _WSTATUS( status );              }
 }
 else version (Solaris)
 {
     @safe pure:
 
-    extern (D) int WEXITSTATUS(int status) { return (status >> 8) & 0xff; }
-    extern (D) int WIFCONTINUED(int status) { return (status & 0xffff) == 0xffff; }
-    extern (D) bool WIFEXITED(int status) { return (status & 0xff) == 0;     }
-    extern (D) bool WIFSIGNALED(int status) { return (status & 0xff) > 0 && (status & 0xff00) == 0; }
-    extern (D) bool WIFSTOPPED(int status) { return (status & 0xff) == 0x7f && (status & 0xff00) != 0; }
-    extern (D) int WSTOPSIG(int status) { return (status >> 8) & 0x7f; }
-    extern (D) int WTERMSIG(int status) { return (status & 0x7f); }
+    extern (D) int WEXITSTATUS()(int status) { return (status >> 8) & 0xff; }
+    extern (D) int WIFCONTINUED()(int status) { return (status & 0xffff) == 0xffff; }
+    extern (D) bool WIFEXITED()(int status) { return (status & 0xff) == 0;     }
+    extern (D) bool WIFSIGNALED()(int status) { return (status & 0xff) > 0 && (status & 0xff00) == 0; }
+    extern (D) bool WIFSTOPPED()(int status) { return (status & 0xff) == 0x7f && (status & 0xff00) != 0; }
+    extern (D) int WSTOPSIG()(int status) { return (status >> 8) & 0x7f; }
+    extern (D) int WTERMSIG()(int status) { return (status & 0x7f); }
 }
 else version (CRuntime_Bionic)
 {
     @safe pure:
-    extern (D) int  WEXITSTATUS( int status ) { return ( status & 0xFF00 ) >> 8; }
-    extern (D) bool WIFEXITED( int status ) { return WTERMSIG(status) == 0; }
-    extern (D) bool WIFSIGNALED( int status ) { return WTERMSIG(status + 1) >= 2; }
-    extern (D) bool WIFSTOPPED( int status ) { return WTERMSIG(status) == 0x7F; }
-    extern (D) int  WSTOPSIG( int status ) { return WEXITSTATUS(status); }
-    extern (D) int  WTERMSIG( int status ) { return status & 0x7F; }
+    extern (D) int  WEXITSTATUS()( int status ) { return ( status & 0xFF00 ) >> 8; }
+    extern (D) bool WIFEXITED()( int status ) { return WTERMSIG(status) == 0; }
+    extern (D) bool WIFSIGNALED()( int status ) { return WTERMSIG(status + 1) >= 2; }
+    extern (D) bool WIFSTOPPED()( int status ) { return WTERMSIG(status) == 0x7F; }
+    extern (D) int  WSTOPSIG()( int status ) { return WEXITSTATUS(status); }
+    extern (D) int  WTERMSIG()( int status ) { return status & 0x7F; }
 }
 else version (CRuntime_Musl)
 {
     @safe pure:
-    extern (D) int  WEXITSTATUS( int status ) { return ( status & 0xFF00 ) >> 8; }
-    extern (D) int  WIFCONTINUED( int status ) { return status == 0xffff; }
-    extern (D) bool WIFEXITED( int status ) { return WTERMSIG( status ) == 0; }
-    extern (D) bool WIFSIGNALED( int status ) { return (status&0xffff)-1U < 0xffU; }
-    extern (D) bool WIFSTOPPED( int status ) { return cast(short)(((status&0xffff)*0x10001)>>8) > 0x7f00; }
-    extern (D) int  WTERMSIG( int status ) { return status & 0x7F; }
+    extern (D) int  WEXITSTATUS()( int status ) { return ( status & 0xFF00 ) >> 8; }
+    extern (D) int  WIFCONTINUED()( int status ) { return status == 0xffff; }
+    extern (D) bool WIFEXITED()( int status ) { return WTERMSIG( status ) == 0; }
+    extern (D) bool WIFSIGNALED()( int status ) { return (status&0xffff)-1U < 0xffU; }
+    extern (D) bool WIFSTOPPED()( int status ) { return cast(short)(((status&0xffff)*0x10001)>>8) > 0x7f00; }
+    extern (D) int  WTERMSIG()( int status ) { return status & 0x7F; }
     alias WEXITSTATUS WSTOPSIG;
 }
 else version (CRuntime_UClibc)
@@ -265,7 +265,7 @@ else version (CRuntime_UClibc)
 
     private
     {
-        extern (D) int __WTERMSIG( int status ) { return status & 0x7F; }
+        extern (D) int __WTERMSIG()( int status ) { return status & 0x7F; }
     }
 
     //
@@ -273,23 +273,23 @@ else version (CRuntime_UClibc)
     //       C headers as the parameter definition there is different and
     //       much more complicated.
     //
-    extern (D) int  WEXITSTATUS( int status )  { return ( status & 0xFF00 ) >> 8;   }
-    extern (D) int  WIFCONTINUED( int status ) { return status == __W_CONTINUED;    }
-    extern (D) bool WIFEXITED( int status )    { return __WTERMSIG( status ) == 0;  }
-    extern (D) bool WIFSIGNALED( int status )
+    extern (D) int  WEXITSTATUS()( int status )  { return ( status & 0xFF00 ) >> 8;   }
+    extern (D) int  WIFCONTINUED()( int status ) { return status == __W_CONTINUED;    }
+    extern (D) bool WIFEXITED()( int status )    { return __WTERMSIG( status ) == 0;  }
+    extern (D) bool WIFSIGNALED()( int status )
     {
         return ( cast(ulong) ( ( status & 0xffff ) - 1U ) >> 1 ) < 0xffU;
     }
     version (MIPS32)
     {
-        extern (D) bool WIFSTOPPED( int status )   { return ( status & 0xFF ) == 0x7F;  }
+        extern (D) bool WIFSTOPPED()( int status )   { return ( status & 0xFF ) == 0x7F;  }
     }
     else
     {
-        extern (D) bool WIFSTOPPED( int status )   { return ( status & 0xFF ) == 0x7F && ( status & 0xFF00 );  }
+        extern (D) bool WIFSTOPPED()( int status )   { return ( status & 0xFF ) == 0x7F && ( status & 0xFF00 );  }
     }
-    extern (D) int  WSTOPSIG( int status )     { return WEXITSTATUS( status );      }
-    extern (D) int  WTERMSIG( int status )     { return status & 0x7F;              }
+    extern (D) int  WSTOPSIG()( int status )     { return WEXITSTATUS( status );      }
+    extern (D) int  WTERMSIG()( int status )     { return status & 0x7F;              }
 }
 else
 {

--- a/druntime/src/core/sys/windows/basetsd.d
+++ b/druntime/src/core/sys/windows/basetsd.d
@@ -44,20 +44,20 @@ enum ulong ADDRESS_TAG_BIT = 0x40000000000;
     alias uint UHALF_PTR;
     alias uint* PUHALF_PTR;
 
-    uint HandleToULong(void* h) { return(cast(uint) cast(ULONG_PTR) h); }
-    int HandleToLong(void* h)   { return(cast(int) cast(LONG_PTR) h); }
-    void* ULongToHandle(uint h) { return(cast(void*) cast(UINT_PTR) h); }
-    void* LongToHandle(int h)   { return(cast(void*) cast(INT_PTR) h); }
-    uint PtrToUlong(void* p)    { return(cast(uint) cast(ULONG_PTR) p); }
-    uint PtrToUint(void* p)     { return(cast(uint) cast(UINT_PTR) p); }
-    ushort PtrToUshort(void* p) { return(cast(ushort) cast(uint) cast(ULONG_PTR) p); }
-    int PtrToLong(void* p)      { return(cast(int) cast(LONG_PTR) p); }
-    int PtrToInt(void* p)       { return(cast(int) cast(INT_PTR) p); }
-    short PtrToShort(void* p)   { return(cast(short) cast(int) cast(LONG_PTR) p); }
-    void* IntToPtr(int i)       { return(cast(void*) cast(INT_PTR) i); }
-    void* UIntToPtr(uint ui)    { return(cast(void*) cast(UINT_PTR) ui); }
-    void* LongToPtr(int l)      { return(cast(void*) cast(LONG_PTR) l); }
-    void* ULongToPtr(uint ul)   { return(cast(void*) cast(ULONG_PTR) ul); }
+    uint HandleToULong()(void* h) { return(cast(uint) cast(ULONG_PTR) h); }
+    int HandleToLong()(void* h)   { return(cast(int) cast(LONG_PTR) h); }
+    void* ULongToHandle()(uint h) { return(cast(void*) cast(UINT_PTR) h); }
+    void* LongToHandle()(int h)   { return(cast(void*) cast(INT_PTR) h); }
+    uint PtrToUlong()(void* p)    { return(cast(uint) cast(ULONG_PTR) p); }
+    uint PtrToUint()(void* p)     { return(cast(uint) cast(UINT_PTR) p); }
+    ushort PtrToUshort()(void* p) { return(cast(ushort) cast(uint) cast(ULONG_PTR) p); }
+    int PtrToLong()(void* p)      { return(cast(int) cast(LONG_PTR) p); }
+    int PtrToInt()(void* p)       { return(cast(int) cast(INT_PTR) p); }
+    short PtrToShort()(void* p)   { return(cast(short) cast(int) cast(LONG_PTR) p); }
+    void* IntToPtr()(int i)       { return(cast(void*) cast(INT_PTR) i); }
+    void* UIntToPtr()(uint ui)    { return(cast(void*) cast(UINT_PTR) ui); }
+    void* LongToPtr()(int l)      { return(cast(void*) cast(LONG_PTR) l); }
+    void* ULongToPtr()(uint ul)   { return(cast(void*) cast(ULONG_PTR) ul); }
 
 } else {
     alias int __int3264;
@@ -72,16 +72,16 @@ enum uint ADDRESS_TAG_BIT = 0x80000000;
     alias ushort UHALF_PTR;
     alias ushort* PUHALF_PTR;
 
-    uint HandleToUlong(HANDLE h)      { return cast(uint) h; }
-    int HandleToLong(HANDLE h)        { return cast(int) h; }
-    HANDLE LongToHandle(LONG_PTR h)   { return cast(HANDLE)h; }
+    uint HandleToUlong()(HANDLE h)      { return cast(uint) h; }
+    int HandleToLong()(HANDLE h)        { return cast(int) h; }
+    HANDLE LongToHandle()(LONG_PTR h)   { return cast(HANDLE)h; }
     uint PtrToUlong(const(void)* p)    { return cast(uint) p; }
     uint PtrToUint(const(void)* p)     { return cast(uint) p; }
     int PtrToInt(const(void)* p)       { return cast(int) p; }
     ushort PtrToUshort(const(void)* p) { return cast(ushort) p; }
     short PtrToShort(const(void)* p)   { return cast(short) p; }
-    void* IntToPtr(int i)             { return cast(void*) i; }
-    void* UIntToPtr(uint ui)          { return cast(void*) ui; }
+    void* IntToPtr()(int i)             { return cast(void*) i; }
+    void* UIntToPtr()(uint ui)          { return cast(void*) ui; }
     alias IntToPtr LongToPtr;
     alias UIntToPtr ULongToPtr;
 }

--- a/druntime/src/core/sys/windows/commctrl.d
+++ b/druntime/src/core/sys/windows/commctrl.d
@@ -4937,8 +4937,8 @@ static if (_WIN32_WINNT >= 0x501) {
     alias NMLINK* PNMLINK;
 }
 
-uint INDEXTOOVERLAYMASK(uint i) { return i << 8; }
-uint INDEXTOSTATEIMAGEMASK(uint i) { return i << 12; }
+uint INDEXTOOVERLAYMASK()(uint i) { return i << 8; }
+uint INDEXTOSTATEIMAGEMASK()(uint i) { return i << 12; }
 
 template HANDLE_WM_NOTIFY(R) {
     private alias _prm_HANDLE_WM_NOTIFY = extern (Windows)

--- a/druntime/src/core/sys/windows/dde.d
+++ b/druntime/src/core/sys/windows/dde.d
@@ -31,7 +31,7 @@ struct DDEACK {
     ubyte bAppReturnCode;
     ubyte _bf;
 
-    @property ubyte reserved() { return cast(ubyte) (_bf & 0x3F); }
+    @property ubyte reserved()() { return cast(ubyte) (_bf & 0x3F); }
     @property bool  fBusy()    { return cast(bool)  (_bf & 0x40); }
     @property bool  fAck()     { return cast(bool)  (_bf & 0x80); }
 
@@ -49,7 +49,7 @@ struct DDEADVISE {
     short  cfFormat;
 
     @property ushort reserved()  { return cast(ushort) (_bf & 0x3FFF); }
-    @property bool   fDeferUpd() { return cast(bool)   (_bf & 0x4000); }
+    @property bool   fDeferUpd()() { return cast(bool)   (_bf & 0x4000); }
     @property bool   fAckReq()   { return cast(bool)   (_bf & 0x8000); }
 
     @property ushort reserved(ushort r) {
@@ -67,12 +67,12 @@ struct DDEDATA {
     byte   _Value;
 
     @property ushort unused()    { return cast(ushort) (_bf & 0x0FFF); }
-    @property bool   fResponse() { return cast(bool)   (_bf & 0x1000); }
+    @property bool   fResponse()() { return cast(bool)   (_bf & 0x1000); }
     @property bool   fRelease()  { return cast(bool)   (_bf & 0x2000); }
     @property bool   reserved()  { return cast(bool)   (_bf & 0x4000); }
     @property bool   fAckReq()   { return cast(bool)   (_bf & 0x8000); }
 
-    @property byte*  Value() return { return &_Value; }
+    @property byte*  Value() { return &_Value; }
 
     @property ushort unused(ushort r) {
         _bf = cast(ushort) ((_bf & ~0x0FFF) | (r & 0x0FFF));
@@ -90,38 +90,38 @@ struct DDEPOKE {
     short  cfFormat;
     byte   _Value;
 
-    @property ushort unused()    { return cast(ushort) (_bf & 0x1FFF); }
-    @property bool   fRelease()  { return cast(bool)   (_bf & 0x2000); }
-    @property ubyte  fReserved() { return cast(ubyte)  ((_bf & 0xC000) >>> 14); }
+    @property ushort unused()()    { return cast(ushort) (_bf & 0x1FFF); }
+    @property bool   fRelease()()  { return cast(bool)   (_bf & 0x2000); }
+    @property ubyte  fReserved()() { return cast(ubyte)  ((_bf & 0xC000) >>> 14); }
 
-    @property byte*  Value() return { return &_Value; }
+    @property byte*  Value() { return &_Value; }
 
-    @property ushort unused(ushort u) {
+    @property ushort unused()(ushort u) {
         _bf = cast(ushort) ((_bf & ~0x1FFF) | (u & 0x1FFF));
         return cast(ushort)(u & 0x1FFF);
     }
 
-    @property bool   fRelease(bool f)   { _bf = cast(ushort) ((_bf & ~0x2000) | (f << 13)); return f; }
-    @property ubyte  fReserved(ubyte r) { _bf = cast(ushort) ((_bf & ~0xC000) | (r << 14)); return r; }
+    @property bool   fRelease()(bool f)   { _bf = cast(ushort) ((_bf & ~0x2000) | (f << 13)); return f; }
+    @property ubyte  fReserved()(ubyte r) { _bf = cast(ushort) ((_bf & ~0xC000) | (r << 14)); return r; }
 }
 
 deprecated struct DDELN {
     ushort _bf;
     short  cfFormat;
 
-    @property ushort unused()    { return cast(ushort) (_bf & 0x1FFF); }
-    @property bool   fRelease()  { return cast(bool)   (_bf & 0x2000); }
-    @property bool   fDeferUpd() { return cast(bool)   (_bf & 0x4000); }
-    @property bool   fAckReq()   { return cast(bool)   (_bf & 0x8000); }
+    @property ushort unused()()    { return cast(ushort) (_bf & 0x1FFF); }
+    @property bool   fRelease()()  { return cast(bool)   (_bf & 0x2000); }
+    @property bool   fDeferUpd()() { return cast(bool)   (_bf & 0x4000); }
+    @property bool   fAckReq()()   { return cast(bool)   (_bf & 0x8000); }
 
-    @property ushort unused(ushort u) {
+    @property ushort unused()(ushort u) {
         _bf = cast(ushort)((_bf & ~0x1FFF) | (u & 0x1FFF));
         return cast(ushort)(u & 0x1FFF);
     }
 
-    @property bool   fRelease(bool f)  { _bf = cast(ushort) ((_bf & ~0x2000) | (f << 13)); return f; }
-    @property bool   fDeferUpd(bool f) { _bf = cast(ushort) ((_bf & ~0x4000) | (f << 14)); return f; }
-    @property bool   fAckReq(bool f)   { _bf = cast(ushort) ((_bf & ~0x8000) | (f << 15)); return f; }
+    @property bool   fRelease()(bool f)  { _bf = cast(ushort) ((_bf & ~0x2000) | (f << 13)); return f; }
+    @property bool   fDeferUpd()(bool f) { _bf = cast(ushort) ((_bf & ~0x4000) | (f << 14)); return f; }
+    @property bool   fAckReq()(bool f)   { _bf = cast(ushort) ((_bf & ~0x8000) | (f << 15)); return f; }
 }
 
 deprecated struct DDEUP {
@@ -129,23 +129,23 @@ deprecated struct DDEUP {
     short  cfFormat;
     byte   _rgb;
 
-    @property ushort unused()    { return cast(ushort) (_bf & 0x0FFF); }
-    @property bool   fAck()      { return cast(bool)   (_bf & 0x1000); }
-    @property bool   fRelease()  { return cast(bool)   (_bf & 0x2000); }
-    @property bool   fReserved() { return cast(bool)   (_bf & 0x4000); }
-    @property bool   fAckReq()   { return cast(bool)   (_bf & 0x8000); }
+    @property ushort unused()()    { return cast(ushort) (_bf & 0x0FFF); }
+    @property bool   fAck()()      { return cast(bool)   (_bf & 0x1000); }
+    @property bool   fRelease()()  { return cast(bool)   (_bf & 0x2000); }
+    @property bool   fReserved()() { return cast(bool)   (_bf & 0x4000); }
+    @property bool   fAckReq()()   { return cast(bool)   (_bf & 0x8000); }
 
-    @property byte*  rgb() return { return &_rgb; }
+    @property byte*  rgb()()       { return &_rgb; }
 
-    @property ushort unused(ushort r) {
+    @property ushort unused()(ushort r) {
         _bf = cast(ushort) ((_bf & ~0x0FFF) | (r & 0x0FFF));
         return cast(ushort)(r & 0x0FFF);
     }
 
-    @property bool   fAck(bool f)      { _bf = cast(ushort) ((_bf & ~0x1000) | (f << 12)); return f; }
-    @property bool   fRelease(bool f)  { _bf = cast(ushort) ((_bf & ~0x2000) | (f << 13)); return f; }
-    @property bool   fReserved(bool f) { _bf = cast(ushort) ((_bf & ~0x4000) | (f << 14)); return f; }
-    @property bool   fAckReq(bool f)   { _bf = cast(ushort) ((_bf & ~0x8000) | (f << 15)); return f; }
+    @property bool   fAck()(bool f)      { _bf = cast(ushort) ((_bf & ~0x1000) | (f << 12)); return f; }
+    @property bool   fRelease()(bool f)  { _bf = cast(ushort) ((_bf & ~0x2000) | (f << 13)); return f; }
+    @property bool   fReserved()(bool f) { _bf = cast(ushort) ((_bf & ~0x4000) | (f << 14)); return f; }
+    @property bool   fAckReq()(bool f)   { _bf = cast(ushort) ((_bf & ~0x8000) | (f << 15)); return f; }
 }
 
 extern (Windows) nothrow @nogc {

--- a/druntime/src/core/sys/windows/mmsystem.d
+++ b/druntime/src/core/sys/windows/mmsystem.d
@@ -283,8 +283,8 @@ enum MEVT_F_SHORT=0;
 enum MEVT_F_LONG=0x80000000;
 enum MEVT_F_CALLBACK=0x40000000;
 
-BYTE MEVT_EVENTTYPE(DWORD x) { return cast(BYTE)((x>>24) &0xFF); }
-DWORD MEVT_EVENTPARM(DWORD x) { return x & 0xFFFFFF; }
+BYTE MEVT_EVENTTYPE()(DWORD x) { return cast(BYTE)((x>>24) &0xFF); }
+DWORD MEVT_EVENTPARM()(DWORD x) { return x & 0xFFFFFF; }
 
 enum MEVT_SHORTMSG=0;
 enum MEVT_TEMPO=1;
@@ -766,22 +766,22 @@ enum MCI_FORMAT_TMSF=10;
 
 
 // Macros
-BYTE MCI_HMS_HOUR(DWORD t) { return cast(BYTE)(t); }
-BYTE MCI_HMS_MINUTE(DWORD t) { return cast(BYTE)(t>>>8); }
-BYTE MCI_HMS_SECOND(DWORD t) { return cast(BYTE)( t>>>16); }
-DWORD MCI_MAKE_HMS(BYTE h, BYTE m, BYTE s) { return h |(m<<8)|(cast(DWORD)(s)<<16); }
-DWORD MCI_MAKE_MSF(BYTE m, BYTE s, BYTE f) { return m |(s<<8)|(cast(DWORD)(f)<<16); }
+BYTE MCI_HMS_HOUR()(DWORD t) { return cast(BYTE)(t); }
+BYTE MCI_HMS_MINUTE()(DWORD t) { return cast(BYTE)(t>>>8); }
+BYTE MCI_HMS_SECOND()(DWORD t) { return cast(BYTE)( t>>>16); }
+DWORD MCI_MAKE_HMS()(BYTE h, BYTE m, BYTE s) { return h |(m<<8)|(cast(DWORD)(s)<<16); }
+DWORD MCI_MAKE_MSF()(BYTE m, BYTE s, BYTE f) { return m |(s<<8)|(cast(DWORD)(f)<<16); }
 DWORD MCI_MAKE_TMSF(BYTE t, BYTE m, BYTE s, BYTE f) {
  return t |(m<<8)|(s<<16)|(cast(DWORD)(f)<< 24); }
 
-BYTE MCI_MSF_MINUTE(DWORD t) { return cast(BYTE)(t); }
-BYTE MCI_MSF_SECOND(DWORD t) { return cast(BYTE)(t >>> 8); }
+BYTE MCI_MSF_MINUTE()(DWORD t) { return cast(BYTE)(t); }
+BYTE MCI_MSF_SECOND()(DWORD t) { return cast(BYTE)(t >>> 8); }
 BYTE MCI_MSF_FRAME(DWORD t)  {  return cast(BYTE)(t >>> 16); }
 
-BYTE MCI_TMSF_TRACK(DWORD t)  { return cast(BYTE)(t); }
-BYTE MCI_TMSF_MINUTE(DWORD t) { return cast(BYTE)(t>>8); }
-BYTE MCI_TMSF_SECOND(DWORD t) { return cast(BYTE)(t>>16); }
-BYTE MCI_TMSF_FRAME(DWORD t)  { return cast(BYTE)(t>>24); }
+BYTE MCI_TMSF_TRACK()(DWORD t)  { return cast(BYTE)(t); }
+BYTE MCI_TMSF_MINUTE()(DWORD t) { return cast(BYTE)(t>>8); }
+BYTE MCI_TMSF_SECOND()(DWORD t) { return cast(BYTE)(t>>16); }
+BYTE MCI_TMSF_FRAME()(DWORD t)  { return cast(BYTE)(t>>24); }
 
 
 enum MCI_NOTIFY_SUCCESSFUL=1;

--- a/druntime/src/core/sys/windows/ntdef.d
+++ b/druntime/src/core/sys/windows/ntdef.d
@@ -34,10 +34,10 @@ void InitializeObjectAttributes(OBJECT_ATTRIBUTES* p, UNICODE_STRING* n,
 }
 
 pragma(inline, true) @safe pure nothrow @nogc {
-    bool NT_SUCCESS(NTSTATUS Status)     { return Status >= 0; }
-    bool NT_INFORMATION(NTSTATUS Status) { return ((cast(ULONG) Status) >> 30) == 1; }
-    bool NT_WARNING(NTSTATUS Status)     { return ((cast(ULONG) Status) >> 30) == 2; }
-    bool NT_ERROR(NTSTATUS Status)       { return ((cast(ULONG) Status) >> 30) == 3; }
+    bool NT_SUCCESS()(NTSTATUS Status)     { return Status >= 0; }
+    bool NT_INFORMATION()(NTSTATUS Status) { return ((cast(ULONG) Status) >> 30) == 1; }
+    bool NT_WARNING()(NTSTATUS Status)     { return ((cast(ULONG) Status) >> 30) == 2; }
+    bool NT_ERROR()(NTSTATUS Status)       { return ((cast(ULONG) Status) >> 30) == 3; }
 }
 
 /*  In MinGW, NTSTATUS, UNICODE_STRING, STRING and their associated pointer

--- a/druntime/src/core/sys/windows/ntsecapi.d
+++ b/druntime/src/core/sys/windows/ntsecapi.d
@@ -40,7 +40,7 @@ enum {
     LSA_MODE_LOG_FULL
 }
 
-bool LSA_SUCCESS(int x) { return x >= 0; }
+bool LSA_SUCCESS()(int x) { return x >= 0; }
 
 /*  TOTHINKABOUT: These constants don't have ANSI/Unicode versioned
  *  aliases.  Should we merge them anyway?

--- a/druntime/src/core/sys/windows/oleauto.d
+++ b/druntime/src/core/sys/windows/oleauto.d
@@ -41,7 +41,7 @@ enum DISPATCH_PROPERTYGET = 2;
 enum DISPATCH_PROPERTYPUT = 4;
 enum DISPATCH_PROPERTYPUTREF = 8;
 
-//ULONG LHashValOfName(LCID l, OLECHAR* n) { return LHashValOfNameSys(SYSKIND.SYS_WIN32, l, n); }
+//ULONG LHashValOfName()(LCID l, OLECHAR* n) { return LHashValOfNameSys(SYSKIND.SYS_WIN32, l, n); }
 
 // DAC: These aren't in the 2003 SDK.
 //MACRO #define WHashValOfLHashVal(h) ((unsigned short)(0x0000ffff&(h)))

--- a/druntime/src/core/sys/windows/shlobj.d
+++ b/druntime/src/core/sys/windows/shlobj.d
@@ -1034,35 +1034,35 @@ struct SHELLFLAGSTATE {
     BOOL fHideIcons : 1;
     UINT fRestFlags : 3;
 */
-    @property bool fShowAllObjects()       { return cast(bool) (_bf & 0x0001); }
-    @property bool fShowExtensions()       { return cast(bool) (_bf & 0x0002); }
-    @property bool fNoConfirmRecycle()     { return cast(bool) (_bf & 0x0004); }
-    @property bool fShowSysFiles()         { return cast(bool) (_bf & 0x0008); }
-    @property bool fShowCompColor()        { return cast(bool) (_bf & 0x0010); }
-    @property bool fDoubleClickInWebView() { return cast(bool) (_bf & 0x0020); }
-    @property bool fDesktopHTML()          { return cast(bool) (_bf & 0x0040); }
-    @property bool fWin95Classic()         { return cast(bool) (_bf & 0x0080); }
-    @property bool fDontPrettyPath()       { return cast(bool) (_bf & 0x0100); }
-    @property bool fShowAttribCol()        { return cast(bool) (_bf & 0x0200); }
-    @property bool fMapNetDrvBtn()         { return cast(bool) (_bf & 0x0400); }
-    @property bool fShowInfoTip()          { return cast(bool) (_bf & 0x0800); }
-    @property bool fHideIcons()            { return cast(bool) (_bf & 0x1000); }
-    @property ubyte fRestFlags()           { return cast(ubyte) (_bf >> 13); }
+    @property bool fShowAllObjects()()       { return cast(bool) (_bf & 0x0001); }
+    @property bool fShowExtensions()()       { return cast(bool) (_bf & 0x0002); }
+    @property bool fNoConfirmRecycle()()     { return cast(bool) (_bf & 0x0004); }
+    @property bool fShowSysFiles()()         { return cast(bool) (_bf & 0x0008); }
+    @property bool fShowCompColor()()        { return cast(bool) (_bf & 0x0010); }
+    @property bool fDoubleClickInWebView()() { return cast(bool) (_bf & 0x0020); }
+    @property bool fDesktopHTML()()          { return cast(bool) (_bf & 0x0040); }
+    @property bool fWin95Classic()()         { return cast(bool) (_bf & 0x0080); }
+    @property bool fDontPrettyPath()()       { return cast(bool) (_bf & 0x0100); }
+    @property bool fShowAttribCol()()        { return cast(bool) (_bf & 0x0200); }
+    @property bool fMapNetDrvBtn()()         { return cast(bool) (_bf & 0x0400); }
+    @property bool fShowInfoTip()()          { return cast(bool) (_bf & 0x0800); }
+    @property bool fHideIcons()()            { return cast(bool) (_bf & 0x1000); }
+    @property ubyte fRestFlags()()           { return cast(ubyte) (_bf >> 13); }
 
-    @property bool fShowAllObjects(bool f)       { _bf = cast(ushort) ((_bf & ~0xFFFE) | f);        return f; }
-    @property bool fShowExtensions(bool f)       { _bf = cast(ushort) ((_bf & ~0xFFFD) | (f <<  1)); return f; }
-    @property bool fNoConfirmRecycle(bool f)     { _bf = cast(ushort) ((_bf & ~0xFFFB) | (f <<  2)); return f; }
-    @property bool fShowSysFiles(bool f)         { _bf = cast(ushort) ((_bf & ~0xFFF8) | (f <<  3)); return f; }
-    @property bool fShowCompColor(bool f)        { _bf = cast(ushort) ((_bf & ~0xFFEF) | (f <<  4)); return f; }
-    @property bool fDoubleClickInWebView(bool f) { _bf = cast(ushort) ((_bf & ~0xFFDF) | (f <<  5)); return f; }
-    @property bool fDesktopHTML(bool f)          { _bf = cast(ushort) ((_bf & ~0xFFBF) | (f <<  6)); return f; }
-    @property bool fWin95Classic(bool f)         { _bf = cast(ushort) ((_bf & ~0xFF8F) | (f <<  7)); return f; }
-    @property bool fDontPrettyPath(bool f)       { _bf = cast(ushort) ((_bf & ~0xFEFF) | (f <<  8)); return f; }
-    @property bool fShowAttribCol(bool f)        { _bf = cast(ushort) ((_bf & ~0xFDFF) | (f <<  9)); return f; }
-    @property bool fMapNetDrvBtn(bool f)         { _bf = cast(ushort) ((_bf & ~0xFBFF) | (f << 10)); return f; }
-    @property bool fShowInfoTip(bool f)          { _bf = cast(ushort) ((_bf & ~0xF8FF) | (f << 11)); return f; }
-    @property bool fHideIcons(bool f)            { _bf = cast(ushort) ((_bf & ~0xEFFF) | (f << 12)); return f; }
-    @property ubyte fRestFlags(ubyte f)          { _bf = cast(ushort) ((_bf & ~0x1FFF) | (f << 13)); return cast(ubyte) (f & 7); }
+    @property bool fShowAllObjects()(bool f)       { _bf = cast(ushort) ((_bf & ~0xFFFE) | f);        return f; }
+    @property bool fShowExtensions()(bool f)       { _bf = cast(ushort) ((_bf & ~0xFFFD) | (f <<  1)); return f; }
+    @property bool fNoConfirmRecycle()(bool f)     { _bf = cast(ushort) ((_bf & ~0xFFFB) | (f <<  2)); return f; }
+    @property bool fShowSysFiles()(bool f)         { _bf = cast(ushort) ((_bf & ~0xFFF8) | (f <<  3)); return f; }
+    @property bool fShowCompColor()(bool f)        { _bf = cast(ushort) ((_bf & ~0xFFEF) | (f <<  4)); return f; }
+    @property bool fDoubleClickInWebView()(bool f) { _bf = cast(ushort) ((_bf & ~0xFFDF) | (f <<  5)); return f; }
+    @property bool fDesktopHTML()(bool f)          { _bf = cast(ushort) ((_bf & ~0xFFBF) | (f <<  6)); return f; }
+    @property bool fWin95Classic()(bool f)         { _bf = cast(ushort) ((_bf & ~0xFF8F) | (f <<  7)); return f; }
+    @property bool fDontPrettyPath()(bool f)       { _bf = cast(ushort) ((_bf & ~0xFEFF) | (f <<  8)); return f; }
+    @property bool fShowAttribCol()(bool f)        { _bf = cast(ushort) ((_bf & ~0xFDFF) | (f <<  9)); return f; }
+    @property bool fMapNetDrvBtn()(bool f)         { _bf = cast(ushort) ((_bf & ~0xFBFF) | (f << 10)); return f; }
+    @property bool fShowInfoTip()(bool f)          { _bf = cast(ushort) ((_bf & ~0xF8FF) | (f << 11)); return f; }
+    @property bool fHideIcons()(bool f)            { _bf = cast(ushort) ((_bf & ~0xEFFF) | (f << 12)); return f; }
+    @property ubyte fRestFlags()(ubyte f)          { _bf = cast(ushort) ((_bf & ~0x1FFF) | (f << 13)); return cast(ubyte) (f & 7); }
 }
 alias SHELLFLAGSTATE* LPSHELLFLAGSTATE;
 
@@ -1118,56 +1118,56 @@ static if (_WIN32_WINNT >= 0x500) {
         BOOL fShowSuperHidden : 1;
         BOOL fNoNetCrawling : 1;
     */
-        @property bool fShowAllObjects()       { return cast(bool) (_bf1 & 0x00000001); }
-        @property bool fShowExtensions()       { return cast(bool) (_bf1 & 0x00000002); }
-        @property bool fNoConfirmRecycle()     { return cast(bool) (_bf1 & 0x00000004); }
-        @property bool fShowSysFiles()         { return cast(bool) (_bf1 & 0x00000008); }
-        @property bool fShowCompColor()        { return cast(bool) (_bf1 & 0x00000010); }
-        @property bool fDoubleClickInWebView() { return cast(bool) (_bf1 & 0x00000020); }
-        @property bool fDesktopHTML()          { return cast(bool) (_bf1 & 0x00000040); }
-        @property bool fWin95Classic()         { return cast(bool) (_bf1 & 0x00000080); }
-        @property bool fDontPrettyPath()       { return cast(bool) (_bf1 & 0x00000100); }
-        @property bool fShowAttribCol()        { return cast(bool) (_bf1 & 0x00000200); }
-        @property bool fMapNetDrvBtn()         { return cast(bool) (_bf1 & 0x00000400); }
-        @property bool fShowInfoTip()          { return cast(bool) (_bf1 & 0x00000800); }
-        @property bool fHideIcons()            { return cast(bool) (_bf1 & 0x00001000); }
-        @property bool fWebView()              { return cast(bool) (_bf1 & 0x00002000); }
-        @property bool fFilter()               { return cast(bool) (_bf1 & 0x00004000); }
-        @property bool fShowSuperHidden()      { return cast(bool) (_bf1 & 0x00008000); }
-        @property bool fNoNetCrawling()        { return cast(bool) (_bf1 & 0x00010000); }
+        @property bool fShowAllObjects()()       { return cast(bool) (_bf1 & 0x00000001); }
+        @property bool fShowExtensions()()       { return cast(bool) (_bf1 & 0x00000002); }
+        @property bool fNoConfirmRecycle()()     { return cast(bool) (_bf1 & 0x00000004); }
+        @property bool fShowSysFiles()()         { return cast(bool) (_bf1 & 0x00000008); }
+        @property bool fShowCompColor()()        { return cast(bool) (_bf1 & 0x00000010); }
+        @property bool fDoubleClickInWebView()() { return cast(bool) (_bf1 & 0x00000020); }
+        @property bool fDesktopHTML()()          { return cast(bool) (_bf1 & 0x00000040); }
+        @property bool fWin95Classic()()         { return cast(bool) (_bf1 & 0x00000080); }
+        @property bool fDontPrettyPath()()       { return cast(bool) (_bf1 & 0x00000100); }
+        @property bool fShowAttribCol()()        { return cast(bool) (_bf1 & 0x00000200); }
+        @property bool fMapNetDrvBtn()()         { return cast(bool) (_bf1 & 0x00000400); }
+        @property bool fShowInfoTip()()          { return cast(bool) (_bf1 & 0x00000800); }
+        @property bool fHideIcons()()            { return cast(bool) (_bf1 & 0x00001000); }
+        @property bool fWebView()()              { return cast(bool) (_bf1 & 0x00002000); }
+        @property bool fFilter()()               { return cast(bool) (_bf1 & 0x00004000); }
+        @property bool fShowSuperHidden()()      { return cast(bool) (_bf1 & 0x00008000); }
+        @property bool fNoNetCrawling()()        { return cast(bool) (_bf1 & 0x00010000); }
 
-        @property bool fShowAllObjects(bool f)       { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFFE) | f);         return f; }
-        @property bool fShowExtensions(bool f)       { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFFD) | (f <<  1)); return f; }
-        @property bool fNoConfirmRecycle(bool f)     { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFFB) | (f <<  2)); return f; }
-        @property bool fShowSysFiles(bool f)         { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFF8) | (f <<  3)); return f; }
-        @property bool fShowCompColor(bool f)        { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFEF) | (f <<  4)); return f; }
-        @property bool fDoubleClickInWebView(bool f) { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFDF) | (f <<  5)); return f; }
-        @property bool fDesktopHTML(bool f)          { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFBF) | (f <<  6)); return f; }
-        @property bool fWin95Classic(bool f)         { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFF8F) | (f <<  7)); return f; }
-        @property bool fDontPrettyPath(bool f)       { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFEFF) | (f <<  8)); return f; }
-        @property bool fShowAttribCol(bool f)        { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFDFF) | (f <<  9)); return f; }
-        @property bool fMapNetDrvBtn(bool f)         { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFBFF) | (f << 10)); return f; }
-        @property bool fShowInfoTip(bool f)          { _bf1 = cast(uint) ((_bf1 & ~0xFFFFF8FF) | (f << 11)); return f; }
-        @property bool fHideIcons(bool f)            { _bf1 = cast(uint) ((_bf1 & ~0xFFFFEFFF) | (f << 12)); return f; }
-        @property bool fWebView(bool f)              { _bf1 = cast(uint) ((_bf1 & ~0xFFFFDFFF) | (f << 13)); return f; }
-        @property bool fFilter(bool f)               { _bf1 = cast(uint) ((_bf1 & ~0xFFFFBFFF) | (f << 14)); return f; }
-        @property bool fShowSuperHidden(bool f)      { _bf1 = cast(uint) ((_bf1 & ~0xFFFF8FFF) | (f << 15)); return f; }
-        @property bool fNoNetCrawling(bool f)        { _bf1 = cast(uint) ((_bf1 & ~0xFFFEFFFF) | (f << 16)); return f; }
+        @property bool fShowAllObjects()(bool f)       { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFFE) | f);         return f; }
+        @property bool fShowExtensions()(bool f)       { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFFD) | (f <<  1)); return f; }
+        @property bool fNoConfirmRecycle()(bool f)     { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFFB) | (f <<  2)); return f; }
+        @property bool fShowSysFiles()(bool f)         { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFF8) | (f <<  3)); return f; }
+        @property bool fShowCompColor()(bool f)        { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFEF) | (f <<  4)); return f; }
+        @property bool fDoubleClickInWebView()(bool f) { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFDF) | (f <<  5)); return f; }
+        @property bool fDesktopHTML()(bool f)          { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFFBF) | (f <<  6)); return f; }
+        @property bool fWin95Classic()(bool f)         { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFF8F) | (f <<  7)); return f; }
+        @property bool fDontPrettyPath()(bool f)       { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFEFF) | (f <<  8)); return f; }
+        @property bool fShowAttribCol()(bool f)        { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFDFF) | (f <<  9)); return f; }
+        @property bool fMapNetDrvBtn()(bool f)         { _bf1 = cast(uint) ((_bf1 & ~0xFFFFFBFF) | (f << 10)); return f; }
+        @property bool fShowInfoTip()(bool f)          { _bf1 = cast(uint) ((_bf1 & ~0xFFFFF8FF) | (f << 11)); return f; }
+        @property bool fHideIcons()(bool f)            { _bf1 = cast(uint) ((_bf1 & ~0xFFFFEFFF) | (f << 12)); return f; }
+        @property bool fWebView()(bool f)              { _bf1 = cast(uint) ((_bf1 & ~0xFFFFDFFF) | (f << 13)); return f; }
+        @property bool fFilter()(bool f)               { _bf1 = cast(uint) ((_bf1 & ~0xFFFFBFFF) | (f << 14)); return f; }
+        @property bool fShowSuperHidden()(bool f)      { _bf1 = cast(uint) ((_bf1 & ~0xFFFF8FFF) | (f << 15)); return f; }
+        @property bool fNoNetCrawling()(bool f)        { _bf1 = cast(uint) ((_bf1 & ~0xFFFEFFFF) | (f << 16)); return f; }
     /*
         BOOL fSepProcess : 1;
         BOOL fStartPanelOn : 1;
         BOOL fShowStartPage : 1;
         UINT fSpareFlags : 13;
     */
-        @property bool fSepProcess()           { return cast(bool) (_bf2 & 0x00000001); }
-        @property bool fStartPanelOn()         { return cast(bool) (_bf2 & 0x00000002); }
-        @property bool fShowStartPage()        { return cast(bool) (_bf2 & 0x00000004); }
-        @property ushort fSpareFlags()         { return cast(ushort) ((_bf2 & 0x0000FFF8) >> 3); }
+        @property bool fSepProcess()()           { return cast(bool) (_bf2 & 0x00000001); }
+        @property bool fStartPanelOn()()         { return cast(bool) (_bf2 & 0x00000002); }
+        @property bool fShowStartPage()()        { return cast(bool) (_bf2 & 0x00000004); }
+        @property ushort fSpareFlags()()         { return cast(ushort) ((_bf2 & 0x0000FFF8) >> 3); }
 
-        @property bool fSepProcess(bool f)     { _bf2 = cast(uint) ((_bf2 & ~0xFFFFFFFE) | f);        return f; }
-        @property bool fStartPanelOn(bool f)   { _bf2 = cast(uint) ((_bf2 & ~0xFFFFFFFD) | (f << 1)); return f; }
-        @property bool fShowStartPage(bool f)  { _bf2 = cast(uint) ((_bf2 & ~0xFFFFFFFB) | (f << 2)); return f; }
-        @property ushort fSpareFlags(ushort f) {
+        @property bool fSepProcess()(bool f)     { _bf2 = cast(uint) ((_bf2 & ~0xFFFFFFFE) | f);        return f; }
+        @property bool fStartPanelOn()(bool f)   { _bf2 = cast(uint) ((_bf2 & ~0xFFFFFFFD) | (f << 1)); return f; }
+        @property bool fShowStartPage()(bool f)  { _bf2 = cast(uint) ((_bf2 & ~0xFFFFFFFB) | (f << 2)); return f; }
+        @property ushort fSpareFlags()(ushort f) {
             _bf2 = cast(ushort) ((_bf2 & ~0xFFFF0007) | ((f & 0x1FFF) << 3));
             return cast(ushort) (f & 0x1FFF);
         }

--- a/druntime/src/core/sys/windows/stat.d
+++ b/druntime/src/core/sys/windows/stat.d
@@ -24,11 +24,11 @@ enum S_IFNAM  = 0x5000;
 
 @safe pure
 {
-int S_ISREG(int m)  { return (m & S_IFMT) == S_IFREG; }
-int S_ISBLK(int m)  { return (m & S_IFMT) == S_IFBLK; }
-int S_ISNAM(int m)  { return (m & S_IFMT) == S_IFNAM; }
-int S_ISDIR(int m)  { return (m & S_IFMT) == S_IFDIR; }
-int S_ISCHR(int m)  { return (m & S_IFMT) == S_IFCHR; }
+int S_ISREG()(int m)  { return (m & S_IFMT) == S_IFREG; }
+int S_ISBLK()(int m)  { return (m & S_IFMT) == S_IFBLK; }
+int S_ISNAM()(int m)  { return (m & S_IFMT) == S_IFNAM; }
+int S_ISDIR()(int m)  { return (m & S_IFMT) == S_IFDIR; }
+int S_ISCHR()(int m)  { return (m & S_IFMT) == S_IFCHR; }
 }
 
 version (CRuntime_Microsoft)

--- a/druntime/src/core/sys/windows/threadaux.d
+++ b/druntime/src/core/sys/windows/threadaux.d
@@ -311,8 +311,8 @@ struct thread_aux
             enum TEB_offset_TlsSlots = 0xE10;
             enum TEB_offset_TlsExpansionSlots = 0xF94;
         }
-        void* tlsSlotsAdr(void** teb) { return cast(void*) teb + TEB_offset_TlsSlots; }
-        ref void* tlsExpansionSlots(void** teb) { return *cast(void**)(cast(void*) teb + TEB_offset_TlsExpansionSlots); }
+        void* tlsSlotsAdr()(void** teb) { return cast(void*) teb + TEB_offset_TlsSlots; }
+        ref void* tlsExpansionSlots()(void** teb) { return *cast(void**)(cast(void*) teb + TEB_offset_TlsExpansionSlots); }
 
         import core.stdc.string;
         void*[64] slots = void;

--- a/druntime/src/core/sys/windows/vfw.d
+++ b/druntime/src/core/sys/windows/vfw.d
@@ -2115,75 +2115,75 @@ enum {
  * message wrapper
  */
 
-BOOL capSetCallbackOnError(HWND hWnd, LPVOID fpProc)                { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_ERROR, 0, cast(LPARAM)fpProc); }
-BOOL capSetCallbackOnStatus(HWND hWnd, LPVOID fpProc)               { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_STATUS, 0, cast(LPARAM)fpProc); }
-BOOL capSetCallbackOnYield(HWND hWnd, LPVOID fpProc)                { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_YIELD, 0, cast(LPARAM)fpProc); }
-BOOL capSetCallbackOnFrame(HWND hWnd, LPVOID fpProc)                { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_FRAME, 0, cast(LPARAM)fpProc); }
-BOOL capSetCallbackOnVideoStream(HWND hWnd, LPVOID fpProc)          { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_VIDEOSTREAM, 0, cast(LPARAM)fpProc); }
-BOOL capSetCallbackOnWaveStream(HWND hWnd, LPVOID fpProc)           { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_WAVESTREAM, 0, cast(LPARAM)fpProc); }
-BOOL capSetCallbackOnCapControl(HWND hWnd, LPVOID fpProc)           { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_CAPCONTROL, 0, cast(LPARAM)fpProc); }
+BOOL capSetCallbackOnError()(HWND hWnd, LPVOID fpProc)                { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_ERROR, 0, cast(LPARAM)fpProc); }
+BOOL capSetCallbackOnStatus()(HWND hWnd, LPVOID fpProc)               { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_STATUS, 0, cast(LPARAM)fpProc); }
+BOOL capSetCallbackOnYield()(HWND hWnd, LPVOID fpProc)                { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_YIELD, 0, cast(LPARAM)fpProc); }
+BOOL capSetCallbackOnFrame()(HWND hWnd, LPVOID fpProc)                { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_FRAME, 0, cast(LPARAM)fpProc); }
+BOOL capSetCallbackOnVideoStream()(HWND hWnd, LPVOID fpProc)          { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_VIDEOSTREAM, 0, cast(LPARAM)fpProc); }
+BOOL capSetCallbackOnWaveStream()(HWND hWnd, LPVOID fpProc)           { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_WAVESTREAM, 0, cast(LPARAM)fpProc); }
+BOOL capSetCallbackOnCapControl()(HWND hWnd, LPVOID fpProc)           { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_CALLBACK_CAPCONTROL, 0, cast(LPARAM)fpProc); }
 
-BOOL capSetUserData(HWND hWnd, LPARAM lUser)                        { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_USER_DATA, 0, lUser); }
-BOOL capGetUserData(HWND hWnd)                                      { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GET_USER_DATA, 0, 0); }
+BOOL capSetUserData()(HWND hWnd, LPARAM lUser)                        { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_USER_DATA, 0, lUser); }
+BOOL capGetUserData()(HWND hWnd)                                      { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GET_USER_DATA, 0, 0); }
 
-BOOL capDriverConnect(HWND hWnd, WPARAM i)                          { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DRIVER_CONNECT, i, 0); }
-BOOL capDriverDisconnect(HWND hWnd)                                 { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DRIVER_DISCONNECT, 0, 0); }
-BOOL capDriverGetName(HWND hWnd, LPTSTR szName, WPARAM wSize)       { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DRIVER_GET_NAME, wSize, cast(LPARAM)szName); }
-BOOL capDriverGetVersion(HWND hWnd, LPTSTR szVer, WPARAM wSize)     { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DRIVER_GET_VERSION, wSize, cast(LPARAM)szVer); }
-BOOL capDriverGetCaps(HWND hWnd, LPCAPDRIVERCAPS s, WPARAM wSize)   { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DRIVER_GET_CAPS, wSize, cast(LPARAM)s); }
+BOOL capDriverConnect()(HWND hWnd, WPARAM i)                          { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DRIVER_CONNECT, i, 0); }
+BOOL capDriverDisconnect()(HWND hWnd)                                 { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DRIVER_DISCONNECT, 0, 0); }
+BOOL capDriverGetName()(HWND hWnd, LPTSTR szName, WPARAM wSize)       { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DRIVER_GET_NAME, wSize, cast(LPARAM)szName); }
+BOOL capDriverGetVersion()(HWND hWnd, LPTSTR szVer, WPARAM wSize)     { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DRIVER_GET_VERSION, wSize, cast(LPARAM)szVer); }
+BOOL capDriverGetCaps()(HWND hWnd, LPCAPDRIVERCAPS s, WPARAM wSize)   { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DRIVER_GET_CAPS, wSize, cast(LPARAM)s); }
 
-BOOL capFileSetCaptureFile(HWND hWnd, LPTSTR szName)                { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_SET_CAPTURE_FILE, 0, cast(LPARAM)szName); }
-BOOL capFileGetCaptureFile(HWND hWnd, LPTSTR szName, WPARAM wSize)  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_GET_CAPTURE_FILE, wSize, cast(LPARAM)szName); }
-BOOL capFileAlloc(HWND hWnd, WPARAM wSize)                          { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_ALLOCATE, wSize, 0); }
-BOOL capFileSaveAs(HWND hWnd, LPTSTR szName)                        { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_SAVEAS, 0, cast(LPARAM)szName); }
-BOOL capFileSetInfoChunk(HWND hWnd, LPCAPINFOCHUNK lpInfoChunk)     { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_SET_INFOCHUNK, 0, cast(LPARAM)lpInfoChunk); }
-BOOL capFileSaveDIB(HWND hWnd, LPTSTR szName)                       { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_SAVEDIB, 0, cast(LPARAM)szName); }
+BOOL capFileSetCaptureFile()(HWND hWnd, LPTSTR szName)                { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_SET_CAPTURE_FILE, 0, cast(LPARAM)szName); }
+BOOL capFileGetCaptureFile()(HWND hWnd, LPTSTR szName, WPARAM wSize)  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_GET_CAPTURE_FILE, wSize, cast(LPARAM)szName); }
+BOOL capFileAlloc()(HWND hWnd, WPARAM wSize)                          { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_ALLOCATE, wSize, 0); }
+BOOL capFileSaveAs()(HWND hWnd, LPTSTR szName)                        { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_SAVEAS, 0, cast(LPARAM)szName); }
+BOOL capFileSetInfoChunk()(HWND hWnd, LPCAPINFOCHUNK lpInfoChunk)     { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_SET_INFOCHUNK, 0, cast(LPARAM)lpInfoChunk); }
+BOOL capFileSaveDIB()(HWND hWnd, LPTSTR szName)                       { return cast(BOOL)AVICapSM(hWnd, WM_CAP_FILE_SAVEDIB, 0, cast(LPARAM)szName); }
 
-BOOL capEditCopy(HWND hWnd)                                         { return cast(BOOL)AVICapSM(hWnd, WM_CAP_EDIT_COPY, 0, 0); }
+BOOL capEditCopy()(HWND hWnd)                                         { return cast(BOOL)AVICapSM(hWnd, WM_CAP_EDIT_COPY, 0, 0); }
 
-BOOL capSetAudioFormat(HWND hWnd, LPWAVEFORMATEX s, WPARAM wSize)   { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_AUDIOFORMAT, wSize, cast(LPARAM)s); }
-DWORD capGetAudioFormat(HWND hWnd, LPWAVEFORMATEX s, WPARAM wSize)  { return cast(DWORD)AVICapSM(hWnd, WM_CAP_GET_AUDIOFORMAT, wSize, cast(LPARAM)s); }
-DWORD capGetAudioFormatSize(HWND hWnd)                              { return cast(DWORD)AVICapSM(hWnd, WM_CAP_GET_AUDIOFORMAT, 0, 0); }
+BOOL capSetAudioFormat()(HWND hWnd, LPWAVEFORMATEX s, WPARAM wSize)   { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_AUDIOFORMAT, wSize, cast(LPARAM)s); }
+DWORD capGetAudioFormat()(HWND hWnd, LPWAVEFORMATEX s, WPARAM wSize)  { return cast(DWORD)AVICapSM(hWnd, WM_CAP_GET_AUDIOFORMAT, wSize, cast(LPARAM)s); }
+DWORD capGetAudioFormatSize()(HWND hWnd)                              { return cast(DWORD)AVICapSM(hWnd, WM_CAP_GET_AUDIOFORMAT, 0, 0); }
 
-BOOL capDlgVideoFormat(HWND hWnd)                                   { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DLG_VIDEOFORMAT, 0, 0); }
-BOOL capDlgVideoSource(HWND hWnd)                                   { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DLG_VIDEOSOURCE, 0, 0); }
-BOOL capDlgVideoDisplay(HWND hWnd)                                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DLG_VIDEODISPLAY, 0, 0); }
-BOOL capDlgVideoCompression(HWND hWnd)                              { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DLG_VIDEOCOMPRESSION, 0, 0); }
+BOOL capDlgVideoFormat()(HWND hWnd)                                   { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DLG_VIDEOFORMAT, 0, 0); }
+BOOL capDlgVideoSource()(HWND hWnd)                                   { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DLG_VIDEOSOURCE, 0, 0); }
+BOOL capDlgVideoDisplay()(HWND hWnd)                                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DLG_VIDEODISPLAY, 0, 0); }
+BOOL capDlgVideoCompression()(HWND hWnd)                              { return cast(BOOL)AVICapSM(hWnd, WM_CAP_DLG_VIDEOCOMPRESSION, 0, 0); }
 
-DWORD capGetVideoFormat(HWND hWnd, void* s, WPARAM wSize)           { return cast(DWORD)AVICapSM(hWnd, WM_CAP_GET_VIDEOFORMAT, wSize, cast(LPARAM)s); }
-DWORD capGetVideoFormatSize(HWND hWnd)                              { return cast(DWORD)AVICapSM(hWnd, WM_CAP_GET_VIDEOFORMAT, 0, 0); }
-BOOL capSetVideoFormat(HWND hWnd, void* s, WPARAM wSize)            { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_VIDEOFORMAT, wSize, cast(LPARAM)s); }
+DWORD capGetVideoFormat()(HWND hWnd, void* s, WPARAM wSize)           { return cast(DWORD)AVICapSM(hWnd, WM_CAP_GET_VIDEOFORMAT, wSize, cast(LPARAM)s); }
+DWORD capGetVideoFormatSize()(HWND hWnd)                              { return cast(DWORD)AVICapSM(hWnd, WM_CAP_GET_VIDEOFORMAT, 0, 0); }
+BOOL capSetVideoFormat()(HWND hWnd, void* s, WPARAM wSize)            { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_VIDEOFORMAT, wSize, cast(LPARAM)s); }
 
-BOOL capPreview(HWND hWnd, BOOL f)                                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_PREVIEW, cast(WPARAM)f, 0); }
-BOOL capPreviewRate(HWND hWnd, WPARAM wMS)                          { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_PREVIEWRATE, wMS, 0); }
-BOOL capOverlay(HWND hWnd, BOOL f)                                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_OVERLAY, cast(WPARAM)f, 0); }
-BOOL capPreviewScale(HWND hWnd, BOOL f)                             { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_SCALE, cast(WPARAM)f, 0); }
-BOOL capGetStatus(HWND hWnd, LPCAPSTATUS s, WPARAM wSize)           { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GET_STATUS, wSize, cast(LPARAM)s); }
-BOOL capSetScrollPos(HWND hWnd, LPPOINT lpP)                        { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_SCROLL, 0, cast(LPARAM)lpP); }
+BOOL capPreview()(HWND hWnd, BOOL f)                                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_PREVIEW, cast(WPARAM)f, 0); }
+BOOL capPreviewRate()(HWND hWnd, WPARAM wMS)                          { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_PREVIEWRATE, wMS, 0); }
+BOOL capOverlay()(HWND hWnd, BOOL f)                                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_OVERLAY, cast(WPARAM)f, 0); }
+BOOL capPreviewScale()(HWND hWnd, BOOL f)                             { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_SCALE, cast(WPARAM)f, 0); }
+BOOL capGetStatus()(HWND hWnd, LPCAPSTATUS s, WPARAM wSize)           { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GET_STATUS, wSize, cast(LPARAM)s); }
+BOOL capSetScrollPos()(HWND hWnd, LPPOINT lpP)                        { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_SCROLL, 0, cast(LPARAM)lpP); }
 
-BOOL capGrabFrame(HWND hWnd)                                        { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GRAB_FRAME, 0, 0); }
-BOOL capGrabFrameNoStop(HWND hWnd)                                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GRAB_FRAME_NOSTOP, 0, 0); }
+BOOL capGrabFrame()(HWND hWnd)                                        { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GRAB_FRAME, 0, 0); }
+BOOL capGrabFrameNoStop()(HWND hWnd)                                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GRAB_FRAME_NOSTOP, 0, 0); }
 
-BOOL capCaptureSequence(HWND hWnd)                                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SEQUENCE, 0, 0); }
-BOOL capCaptureSequenceNoFile(HWND hWnd)                            { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SEQUENCE_NOFILE, 0, 0); }
-BOOL capCaptureStop(HWND hWnd)                                      { return cast(BOOL)AVICapSM(hWnd, WM_CAP_STOP, 0, 0); }
-BOOL capCaptureAbort(HWND hWnd)                                     { return cast(BOOL)AVICapSM(hWnd, WM_CAP_ABORT, 0, 0); }
+BOOL capCaptureSequence()(HWND hWnd)                                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SEQUENCE, 0, 0); }
+BOOL capCaptureSequenceNoFile()(HWND hWnd)                            { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SEQUENCE_NOFILE, 0, 0); }
+BOOL capCaptureStop()(HWND hWnd)                                      { return cast(BOOL)AVICapSM(hWnd, WM_CAP_STOP, 0, 0); }
+BOOL capCaptureAbort()(HWND hWnd)                                     { return cast(BOOL)AVICapSM(hWnd, WM_CAP_ABORT, 0, 0); }
 
-BOOL capCaptureSingleFrameOpen(HWND hWnd)                           { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SINGLE_FRAME_OPEN, 0, 0); }
-BOOL capCaptureSingleFrameClose(HWND hWnd)                          { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SINGLE_FRAME_CLOSE, 0, 0); }
-BOOL capCaptureSingleFrame(HWND hWnd)                               { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SINGLE_FRAME, 0, 0); }
+BOOL capCaptureSingleFrameOpen()(HWND hWnd)                           { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SINGLE_FRAME_OPEN, 0, 0); }
+BOOL capCaptureSingleFrameClose()(HWND hWnd)                          { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SINGLE_FRAME_CLOSE, 0, 0); }
+BOOL capCaptureSingleFrame()(HWND hWnd)                               { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SINGLE_FRAME, 0, 0); }
 
-BOOL capCaptureGetSetup(HWND hWnd, LPCAPTUREPARMS s, WPARAM wSize)  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GET_SEQUENCE_SETUP, wSize, cast(LPARAM)s); }
-BOOL capCaptureSetSetup(HWND hWnd, LPCAPTUREPARMS s, WPARAM wSize)  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_SEQUENCE_SETUP, wSize, cast(LPARAM)s); }
+BOOL capCaptureGetSetup()(HWND hWnd, LPCAPTUREPARMS s, WPARAM wSize)  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GET_SEQUENCE_SETUP, wSize, cast(LPARAM)s); }
+BOOL capCaptureSetSetup()(HWND hWnd, LPCAPTUREPARMS s, WPARAM wSize)  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_SEQUENCE_SETUP, wSize, cast(LPARAM)s); }
 
-BOOL capSetMCIDeviceName(HWND hWnd, LPTSTR szName)                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_MCI_DEVICE, 0, cast(LPARAM)szName); }
-BOOL capGetMCIDeviceName(HWND hWnd, LPTSTR szName, WPARAM wSize)    { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GET_MCI_DEVICE, wSize, cast(LPARAM)szName); }
+BOOL capSetMCIDeviceName()(HWND hWnd, LPTSTR szName)                  { return cast(BOOL)AVICapSM(hWnd, WM_CAP_SET_MCI_DEVICE, 0, cast(LPARAM)szName); }
+BOOL capGetMCIDeviceName()(HWND hWnd, LPTSTR szName, WPARAM wSize)    { return cast(BOOL)AVICapSM(hWnd, WM_CAP_GET_MCI_DEVICE, wSize, cast(LPARAM)szName); }
 
-BOOL capPaletteOpen(HWND hWnd, LPTSTR szName)                       { return cast(BOOL)AVICapSM(hWnd, WM_CAP_PAL_OPEN, 0, cast(LPARAM)szName); }
-BOOL capPaletteSave(HWND hWnd, LPTSTR szName)                       { return cast(BOOL)AVICapSM(hWnd, WM_CAP_PAL_SAVE, 0, cast(LPARAM)szName); }
-BOOL capPalettePaste(HWND hWnd)                                     { return cast(BOOL)AVICapSM(hWnd, WM_CAP_PAL_PASTE, 0, 0); }
-BOOL capPaletteAuto(HWND hWnd, WPARAM iFrames, LPARAM iColors)      { return cast(BOOL)AVICapSM(hWnd, WM_CAP_PAL_AUTOCREATE, iFrames, iColors); }
-BOOL capPaletteManual(HWND hWnd, WPARAM fGrab, LPARAM iColors)      { return cast(BOOL)AVICapSM(hWnd, WM_CAP_PAL_MANUALCREATE, fGrab, iColors); }
+BOOL capPaletteOpen()(HWND hWnd, LPTSTR szName)                       { return cast(BOOL)AVICapSM(hWnd, WM_CAP_PAL_OPEN, 0, cast(LPARAM)szName); }
+BOOL capPaletteSave()(HWND hWnd, LPTSTR szName)                       { return cast(BOOL)AVICapSM(hWnd, WM_CAP_PAL_SAVE, 0, cast(LPARAM)szName); }
+BOOL capPalettePaste()(HWND hWnd)                                     { return cast(BOOL)AVICapSM(hWnd, WM_CAP_PAL_PASTE, 0, 0); }
+BOOL capPaletteAuto()(HWND hWnd, WPARAM iFrames, LPARAM iColors)      { return cast(BOOL)AVICapSM(hWnd, WM_CAP_PAL_AUTOCREATE, iFrames, iColors); }
+BOOL capPaletteManual()(HWND hWnd, WPARAM fGrab, LPARAM iColors)      { return cast(BOOL)AVICapSM(hWnd, WM_CAP_PAL_MANUALCREATE, fGrab, iColors); }
 
 /**
  * structs

--- a/druntime/src/core/sys/windows/winbase.d
+++ b/druntime/src/core/sys/windows/winbase.d
@@ -963,7 +963,7 @@ struct DCB {
     bool fOutxDsrFlow()      { return cast(bool) (_bf & 8); }
     byte fDtrControl()       { return cast(byte) ((_bf & (32+16))>>4); }
     bool fDsrSensitivity()   { return cast(bool) (_bf & 64); }
-    bool fTXContinueOnXoff() { return cast(bool) (_bf & 128); }
+    bool fTXContinueOnXoff()() { return cast(bool) (_bf & 128); }
     bool fOutX()             { return cast(bool) (_bf & 256); }
     bool fInX()              { return cast(bool) (_bf & 512); }
     bool fErrorChar()        { return cast(bool) (_bf & 1024); }
@@ -1031,9 +1031,9 @@ struct COMSTAT {
 
     bool fCtsHold()  { return cast(bool) (_bf & 1); }
     bool fDsrHold()  { return cast(bool) (_bf & 2); }
-    bool fRlsdHold() { return cast(bool) (_bf & 4); }
-    bool fXoffHold() { return cast(bool) (_bf & 8); }
-    bool fXoffSent() { return cast(bool) (_bf & 16); }
+    bool fRlsdHold()() { return cast(bool) (_bf & 4); }
+    bool fXoffHold()() { return cast(bool) (_bf & 8); }
+    bool fXoffSent()() { return cast(bool) (_bf & 16); }
     bool fEof()      { return cast(bool) (_bf & 32); }
     bool fTxim()     { return cast(bool) (_bf & 64); }
 
@@ -1494,8 +1494,8 @@ struct LDT_ENTRY {
 
         byte LimitHi()     { return cast(byte) (Flags2 & 0x0F); }
         bool Sys()         { return cast(bool) (Flags2 & 0x10); }
-        bool Default_Big() { return cast(bool) (Flags2 & 0x40); }
-        bool Granularity() { return cast(bool) (Flags2 & 0x80); }
+        bool Default_Big()() { return cast(bool) (Flags2 & 0x40); }
+        bool Granularity()() { return cast(bool) (Flags2 & 0x80); }
     }
 /+
     union  HighWord {
@@ -2567,8 +2567,8 @@ WINBASEAPI BOOL WINAPI SetEvent(HANDLE);
 // For compatibility with old core.sys.windows.windows:
 version (LittleEndian) nothrow @nogc
 {
-    BOOL QueryPerformanceCounter(long* lpPerformanceCount) { return QueryPerformanceCounter(cast(PLARGE_INTEGER)lpPerformanceCount); }
-    BOOL QueryPerformanceFrequency(long* lpFrequency) { return QueryPerformanceFrequency(cast(PLARGE_INTEGER)lpFrequency); }
+    BOOL QueryPerformanceCounter()(long* lpPerformanceCount) { return QueryPerformanceCounter(cast(PLARGE_INTEGER)lpPerformanceCount); }
+    BOOL QueryPerformanceFrequency()(long* lpFrequency) { return QueryPerformanceFrequency(cast(PLARGE_INTEGER)lpFrequency); }
 }
 
 mixin DECLARE_AW!("STARTUPINFO");

--- a/druntime/src/core/sys/windows/wincrypt.d
+++ b/druntime/src/core/sys/windows/wincrypt.d
@@ -44,9 +44,9 @@ const TCHAR[] MS_ENH_RSA_AES_PROV
       = "Microsoft Enhanced RSA and AES Cryptographic Provider (Prototype)";
 }
 
-ALG_ID GET_ALG_CLASS(ALG_ID x) { return x & 0xE000; }
-ALG_ID GET_ALG_TYPE (ALG_ID x) { return x & 0x1E00; }
-ALG_ID GET_ALG_SID  (ALG_ID x) { return x & 0x01FF; }
+ALG_ID GET_ALG_CLASS()(ALG_ID x) { return x & 0xE000; }
+ALG_ID GET_ALG_TYPE ()(ALG_ID x) { return x & 0x1E00; }
+ALG_ID GET_ALG_SID  ()(ALG_ID x) { return x & 0x01FF; }
 
 enum : ALG_ID {
     ALG_CLASS_ANY           = 0,
@@ -214,8 +214,8 @@ enum {
     CRYPT_SUCCEED = TRUE,
 }
 
-bool RCRYPT_SUCCEEDED(BOOL r) { return r==CRYPT_SUCCEED; }
-bool RCRYPT_FAILED(BOOL r) { return r==CRYPT_FAILED; }
+bool RCRYPT_SUCCEEDED()(BOOL r) { return r==CRYPT_SUCCEED; }
+bool RCRYPT_FAILED()(BOOL r) { return r==CRYPT_FAILED; }
 
 enum {
     PP_ENUMALGS = 1,

--- a/druntime/src/core/sys/windows/winnt.d
+++ b/druntime/src/core/sys/windows/winnt.d
@@ -858,16 +858,16 @@ enum : WORD {
 }
 
 pure nothrow @nogc {
-    WORD MAKELANGID(/*USHORT*/uint p, /*USHORT*/ uint s) { return cast(WORD)((s << 10) | p); }
-    WORD PRIMARYLANGID(/*WORD*/uint lgid) { return cast(WORD)(lgid & 0x3FF); }
-    WORD SUBLANGID(/*WORD*/uint lgid) { return cast(WORD)(lgid >>> 10); }
+    WORD MAKELANGID()(/*USHORT*/uint p, /*USHORT*/ uint s) { return cast(WORD)((s << 10) | p); }
+    WORD PRIMARYLANGID()(/*WORD*/uint lgid) { return cast(WORD)(lgid & 0x3FF); }
+    WORD SUBLANGID()(/*WORD*/uint lgid) { return cast(WORD)(lgid >>> 10); }
 
-    DWORD MAKELCID(/*WORD*/uint lgid, /*WORD*/uint srtid) { return (cast(DWORD) srtid << 16) | cast(DWORD) lgid; }
+    DWORD MAKELCID()(/*WORD*/uint lgid, /*WORD*/uint srtid) { return (cast(DWORD) srtid << 16) | cast(DWORD) lgid; }
     // ???
-    //DWORD MAKESORTLCID(WORD lgid, WORD srtid, WORD ver) { return (MAKELCID(lgid, srtid)) | ((cast(DWORD)ver) << 20); }
-    WORD LANGIDFROMLCID(LCID lcid) { return cast(WORD) lcid; }
-    WORD SORTIDFROMLCID(LCID lcid) { return cast(WORD) ((lcid >>> 16) & 0x0F); }
-    WORD SORTVERSIONFROMLCID(LCID lcid) { return cast(WORD) ((lcid >>> 20) & 0x0F); }
+    //DWORD MAKESORTLCID()(WORD lgid, WORD srtid, WORD ver) { return (MAKELCID(lgid, srtid)) | ((cast(DWORD)ver) << 20); }
+    WORD LANGIDFROMLCID()(LCID lcid) { return cast(WORD) lcid; }
+    WORD SORTIDFROMLCID()(LCID lcid) { return cast(WORD) ((lcid >>> 16) & 0x0F); }
+    WORD SORTVERSIONFROMLCID()(LCID lcid) { return cast(WORD) ((lcid >>> 20) & 0x0F); }
 }
 
 enum WORD LANG_SYSTEM_DEFAULT = (SUBLANG_SYS_DEFAULT << 10) | LANG_NEUTRAL;
@@ -1555,8 +1555,8 @@ const TCHAR[]
 
 enum IMAGE_ORDINAL_FLAG32 = 0x80000000;
 
-ulong IMAGE_ORDINAL64(ulong Ordinal) { return Ordinal & 0xFFFF; }
-uint IMAGE_ORDINAL32(uint Ordinal)   { return Ordinal & 0xFFFF; }
+ulong IMAGE_ORDINAL64()(ulong Ordinal) { return Ordinal & 0xFFFF; }
+uint IMAGE_ORDINAL32()(uint Ordinal)   { return Ordinal & 0xFFFF; }
 
 bool IMAGE_SNAP_BY_ORDINAL32(uint Ordinal) {
     return (Ordinal & IMAGE_ORDINAL_FLAG32) != 0;
@@ -1919,10 +1919,10 @@ static if (_WIN32_WINNT >= 0x501) {
 }
 
 // Macros
-BYTE BTYPE(BYTE x) { return cast(BYTE) (x & N_BTMASK); }
-bool ISPTR(uint x) { return (x & N_TMASK) == (IMAGE_SYM_DTYPE_POINTER << N_BTSHFT); }
-bool ISFCN(uint x) { return (x & N_TMASK) == (IMAGE_SYM_DTYPE_FUNCTION << N_BTSHFT); }
-bool ISARY(uint x) { return (x & N_TMASK) == (IMAGE_SYM_DTYPE_ARRAY << N_BTSHFT); }
+BYTE BTYPE()(BYTE x) { return cast(BYTE) (x & N_BTMASK); }
+bool ISPTR()(uint x) { return (x & N_TMASK) == (IMAGE_SYM_DTYPE_POINTER << N_BTSHFT); }
+bool ISFCN()(uint x) { return (x & N_TMASK) == (IMAGE_SYM_DTYPE_FUNCTION << N_BTSHFT); }
+bool ISARY()(uint x) { return (x & N_TMASK) == (IMAGE_SYM_DTYPE_ARRAY << N_BTSHFT); }
 bool ISTAG(uint x) {
     return x == IMAGE_SYM_CLASS_STRUCT_TAG
         || x == IMAGE_SYM_CLASS_UNION_TAG
@@ -1932,7 +1932,7 @@ uint INCREF(uint x) {
     return ((x & ~N_BTMASK) << N_TSHIFT) | (IMAGE_SYM_DTYPE_POINTER << N_BTSHFT)
       | (x & N_BTMASK);
 }
-uint DECREF(uint x) { return ((x >>> N_TSHIFT) & ~N_BTMASK) | (x & N_BTMASK); }
+uint DECREF()(uint x) { return ((x >>> N_TSHIFT) & ~N_BTMASK) | (x & N_BTMASK); }
 
 enum DWORD TLS_MINIMUM_AVAILABLE = 64;
 
@@ -1948,9 +1948,9 @@ enum ULONG
 /*  Although these are semantically boolean, they are documented and
  *  implemented to return ULONG; this behaviour is preserved for compatibility
  */
-ULONG IsReparseTagMicrosoft(ULONG x)     { return x & 0x80000000; }
-ULONG IsReparseTagHighLatency(ULONG x)   { return x & 0x40000000; }
-ULONG IsReparseTagNameSurrogate(ULONG x) { return x & 0x20000000; }
+ULONG IsReparseTagMicrosoft()(ULONG x)     { return x & 0x80000000; }
+ULONG IsReparseTagHighLatency()(ULONG x)   { return x & 0x40000000; }
+ULONG IsReparseTagNameSurrogate()(ULONG x) { return x & 0x20000000; }
 
 bool IsReparseTagValid(ULONG x) {
     return !(x & ~IO_REPARSE_TAG_VALID_VALUES) && (x > IO_REPARSE_TAG_RESERVED_RANGE);
@@ -3380,7 +3380,7 @@ struct IMAGE_RESOURCE_DIRECTORY_ENTRY {
 
     uint NameOffset()        { return Name & 0x7FFFFFFF; }
     bool NameIsString()      { return cast(bool)(Name & 0x80000000); }
-    uint OffsetToDirectory() { return OffsetToData & 0x7FFFFFFF; }
+    uint OffsetToDirectory()() { return OffsetToData & 0x7FFFFFFF; }
     bool DataIsDirectory()   { return cast(bool)(OffsetToData & 0x80000000); }
 
     uint NameOffset(uint n) {
@@ -3498,7 +3498,7 @@ struct IMAGE_CE_RUNTIME_FUNCTION_ENTRY {
 +/
     uint FuncLen()       { return (_bf >> 8) & 0x3FFFFF; }
     bool ThirtyTwoBit()  { return cast(bool)(_bf & 0x40000000); }
-    bool ExceptionFlag() { return cast(bool)(_bf & 0x80000000); }
+    bool ExceptionFlag()() { return cast(bool)(_bf & 0x80000000); }
 
     uint FuncLen(uint f) {
         _bf = (_bf & ~0x3FFFFF00) | ((f & 0x3FFFFF) << 8); return f & 0x3FFFFF;
@@ -3543,8 +3543,8 @@ struct FPO_DATA {
     ubyte cbRegs()  { return cast(ubyte)(_bf & 0x07); }
     bool fHasSEH()  { return cast(bool)(_bf & 0x08); }
     bool fUseBP()   { return cast(bool)(_bf & 0x10); }
-    bool reserved() { return cast(bool)(_bf & 0x20); }
-    ubyte cbFrame() { return cast(ubyte)(_bf >> 6); }
+    bool reserved()() { return cast(bool)(_bf & 0x20); }
+    ubyte cbFrame()() { return cast(ubyte)(_bf >> 6); }
 
     ubyte cbRegs(ubyte c) {
         _bf = cast(ubyte) ((_bf & ~0x07) | (c & 0x07));
@@ -4108,7 +4108,7 @@ struct PROCESSOR_POWER_POLICY_INFO {
     uint     _bf;
 
     bool AllowDemotion()  { return cast(bool)(_bf & 1); }
-    bool AllowPromotion() { return cast(bool)(_bf & 2); }
+    bool AllowPromotion()() { return cast(bool)(_bf & 2); }
 
     bool AllowDemotion(bool a)  { _bf = (_bf & ~1) | a; return a; }
     bool AllowPromotion(bool a) { _bf = (_bf & ~2) | (a << 1); return a; }

--- a/druntime/src/core/sys/windows/winuser.d
+++ b/druntime/src/core/sys/windows/winuser.d
@@ -3275,10 +3275,10 @@ struct MENUBARINFO {
     byte bf_; // Simulated bitfield
 //  BOOL  fBarFocused:1;
 //  BOOL  fFocused:1;
-    bool fBarFocused()       { return (bf_ & 1) == 1; }
-    bool fFocused()          { return (bf_ & 2) == 2; }
-    bool fBarFocused(bool b) { bf_ = cast(byte) ((bf_ & 0xFE) | b);           return b; }
-    bool fFocused(bool b)    { bf_ = cast(byte) (b ? (bf_ | 2) : bf_ & 0xFD); return b; }
+    bool fBarFocused()()       { return (bf_ & 1) == 1; }
+    bool fFocused()()          { return (bf_ & 2) == 2; }
+    bool fBarFocused()(bool b) { bf_ = cast(byte) ((bf_ & 0xFE) | b);           return b; }
+    bool fFocused()(bool b)    { bf_ = cast(byte) (b ? (bf_ | 2) : bf_ & 0xFD); return b; }
 }
 alias MENUBARINFO* PMENUBARINFO;
 
@@ -4424,9 +4424,9 @@ int BroadcastSystemMessageW(DWORD, LPDWORD, UINT, WPARAM, LPARAM);
 UINT SendInput(UINT, LPINPUT, int);
 BOOL EnumDisplayMonitors(HDC, LPCRECT, MONITORENUMPROC, LPARAM);
 BOOL GetMonitorInfoA(HMONITOR, LPMONITORINFO);
-extern(D) BOOL GetMonitorInfoA(HMONITOR m, LPMONITORINFOEXA mi) { return GetMonitorInfoA(m, cast(LPMONITORINFO)mi); }
+extern(D) BOOL GetMonitorInfoA()(HMONITOR m, LPMONITORINFOEXA mi) { return GetMonitorInfoA(m, cast(LPMONITORINFO)mi); }
 BOOL GetMonitorInfoW(HMONITOR, LPMONITORINFO);
-extern(D) BOOL GetMonitorInfoW(HMONITOR m, LPMONITORINFOEXW mi) { return GetMonitorInfoW(m, cast(LPMONITORINFO)mi); }
+extern(D) BOOL GetMonitorInfoW()(HMONITOR m, LPMONITORINFOEXW mi) { return GetMonitorInfoW(m, cast(LPMONITORINFO)mi); }
 HMONITOR MonitorFromPoint(POINT, DWORD);
 HMONITOR MonitorFromRect(LPCRECT, DWORD);
 HMONITOR MonitorFromWindow(HWND, DWORD);


### PR DESCRIPTION
An issue that tsoding ran into recently (https://youtu.be/_kRsbu82zqs&t=5881), but I've also run into this in the past. 

There's still chances of linker errors with init symbols of structs, and long term there are better solutions (like replacing -betterC with pay-as-you-go druntime or using ImportC for these bindings), but in the mean time, I think this is a net positive.