### PR TITLE
Update source code and coverage links

### DIFF
--- a/compiler/src/dmd/access.d
+++ b/compiler/src/dmd/access.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/access.d, _access.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/access.d, _access.d)
  * Documentation:  https://dlang.org/phobos/dmd_access.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/access.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/access.d
  */
 
 module dmd.access;

--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -7,9 +7,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/aggregate.d, _aggregate.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/aggregate.d, _aggregate.d)
  * Documentation:  https://dlang.org/phobos/dmd_aggregate.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/aggregate.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/aggregate.d
  */
 
 module dmd.aggregate;

--- a/compiler/src/dmd/aliasthis.d
+++ b/compiler/src/dmd/aliasthis.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/aliasthis.d, _aliasthis.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/aliasthis.d, _aliasthis.d)
  * Documentation:  https://dlang.org/phobos/dmd_aliasthis.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/aliasthis.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/aliasthis.d
  */
 
 module dmd.aliasthis;

--- a/compiler/src/dmd/argtypes_aarch64.d
+++ b/compiler/src/dmd/argtypes_aarch64.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     Martin Kinkelin
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/argtypes_aarch64.d, _argtypes_aarch64.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/argtypes_aarch64.d, _argtypes_aarch64.d)
  * Documentation:  https://dlang.org/phobos/dmd_argtypes_aarch64.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/argtypes_aarch64.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/argtypes_aarch64.d
  */
 
 module dmd.argtypes_aarch64;

--- a/compiler/src/dmd/argtypes_sysv_x64.d
+++ b/compiler/src/dmd/argtypes_sysv_x64.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     Martin Kinkelin
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/argtypes_sysv_x64.d, _argtypes_sysv_x64.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/argtypes_sysv_x64.d, _argtypes_sysv_x64.d)
  * Documentation:  https://dlang.org/phobos/dmd_argtypes_sysv_x64.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/argtypes_sysv_x64.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/argtypes_sysv_x64.d
  */
 
 module dmd.argtypes_sysv_x64;

--- a/compiler/src/dmd/argtypes_x86.d
+++ b/compiler/src/dmd/argtypes_x86.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/argtypes_x86.d, _argtypes_x86.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/argtypes_x86.d, _argtypes_x86.d)
  * Documentation:  https://dlang.org/phobos/dmd_argtypes_x86.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/argtypes_x86.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/argtypes_x86.d
  */
 
 module dmd.argtypes_x86;

--- a/compiler/src/dmd/arrayop.d
+++ b/compiler/src/dmd/arrayop.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/arrayop.d, _arrayop.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/arrayop.d, _arrayop.d)
  * Documentation:  https://dlang.org/phobos/dmd_arrayop.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/arrayop.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/arrayop.d
  */
 
 module dmd.arrayop;

--- a/compiler/src/dmd/arraytypes.d
+++ b/compiler/src/dmd/arraytypes.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/arraytypes.d, _arraytypes.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/arraytypes.d, _arraytypes.d)
  * Documentation:  https://dlang.org/phobos/dmd_arraytypes.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/arraytypes.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/arraytypes.d
  */
 
 module dmd.arraytypes;

--- a/compiler/src/dmd/ast_node.d
+++ b/compiler/src/dmd/ast_node.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/ast_node.d, _ast_node.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/ast_node.d, _ast_node.d)
  * Documentation:  https://dlang.org/phobos/dmd_ast_node.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/ast_node.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/ast_node.d
  */
 module dmd.ast_node;
 

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -3,9 +3,9 @@
  *
  * Copyright:   Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/astbase.d, _astbase.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/astbase.d, _astbase.d)
  * Documentation:  https://dlang.org/phobos/dmd_astbase.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/astbase.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/astbase.d
  */
 
 module dmd.astbase;

--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -3,9 +3,9 @@
  *
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/astenums.d, _astenums.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/astenums.d, _astenums.d)
  * Documentation:  https://dlang.org/phobos/dmd_astenums.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/astenums.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/astenums.d
  */
 
 module dmd.astenums;

--- a/compiler/src/dmd/asttypename.d
+++ b/compiler/src/dmd/asttypename.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     Stefan Koch
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/asttypename.d, _asttypename.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/asttypename.d, _asttypename.d)
  * Documentation:  https://dlang.org/phobos/dmd_asttypename.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/asttypename.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/asttypename.d
  */
 
 module dmd.asttypename;

--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -17,9 +17,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/attrib.d, _attrib.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/attrib.d, _attrib.d)
  * Documentation:  https://dlang.org/phobos/dmd_attrib.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/attrib.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/attrib.d
  */
 
 module dmd.attrib;

--- a/compiler/src/dmd/attribsem.d
+++ b/compiler/src/dmd/attribsem.d
@@ -17,9 +17,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/attribsem.d, _attrib.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/attribsem.d, _attrib.d)
  * Documentation:  https://dlang.org/phobos/dmd_attribsem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/attribsem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/attribsem.d
  */
 
 module dmd.attribsem;

--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -10,9 +10,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/arm/cod1.d, backend/cod1.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/arm/cod1.d, backend/cod1.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_arm_cod1.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/arm/cod1.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/arm/cod1.d
  */
 
 module dmd.backend.arm.cod1;

--- a/compiler/src/dmd/backend/arm/cod2.d
+++ b/compiler/src/dmd/backend/arm/cod2.d
@@ -14,9 +14,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/arm/cod2.d, backend/cod2.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/arm/cod2.d, backend/cod2.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_arm_cod2.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/arm/cod2.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/arm/cod2.d
  */
 
 module dmd.backend.arm.cod2;

--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -13,9 +13,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/arm/cod3.d, backend/cod3.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/arm/cod3.d, backend/cod3.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_arm_cod3.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/arm/cod3.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/arm/cod3.d
  */
 
 module dmd.backend.arm.cod3;

--- a/compiler/src/dmd/backend/arm/cod4.d
+++ b/compiler/src/dmd/backend/arm/cod4.d
@@ -16,9 +16,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/arm/cod4.d, backend/cod4.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/arm/cod4.d, backend/cod4.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_arm_cod4.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/arm/cod4.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/arm/cod4.d
  */
 
 module dmd.backend.arm.cod4;

--- a/compiler/src/dmd/backend/arm/instr.d
+++ b/compiler/src/dmd/backend/arm/instr.d
@@ -7,9 +7,9 @@
  * Copyright:   Copyright (C) 2024 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/arm/instr.d, backend/cod3.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/arm/instr.d, backend/cod3.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_arm_insrt.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/arm/instr.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/arm/instr.d
  */
 
 module dmd.backend.arm.instr;

--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -7,7 +7,7 @@
  * Copyright:   Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/backconfig.d, backend/backconfig.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/backconfig.d, backend/backconfig.d)
  */
 
 module dmd.backend.backconfig;

--- a/compiler/src/dmd/backend/barray.d
+++ b/compiler/src/dmd/backend/barray.d
@@ -7,7 +7,7 @@
  * Copyright:   Copyright (C) 2018-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/barrayf.d, backend/barray.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/barray.d, backend/barray.d)
  * Documentation: https://dlang.org/phobos/dmd_backend_barray.html
  */
 

--- a/compiler/src/dmd/backend/blockopt.d
+++ b/compiler/src/dmd/backend/blockopt.d
@@ -5,9 +5,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/blockopt.d, backend/blockopt.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/blockopt.d, backend/blockopt.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_blockopt.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/blockopt.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/blockopt.d
  */
 
 module dmd.backend.blockopt;

--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cc.d, backend/_cc.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/cc.d, backend/_cc.d)
  */
 
 module dmd.backend.cc;

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cdef.d, backend/_cdef.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/cdef.d, backend/_cdef.d)
  */
 
 module dmd.backend.cdef;

--- a/compiler/src/dmd/backend/cg.d
+++ b/compiler/src/dmd/backend/cg.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cg.c, backend/cg.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/cg.d, backend/cg.d)
  */
 
 module dmd.backend.cg;

--- a/compiler/src/dmd/backend/cgcse.d
+++ b/compiler/src/dmd/backend/cgcse.d
@@ -8,8 +8,8 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cgcse.d, backend/cgcse.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/cgcse.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/cgcse.d, backend/cgcse.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/cgcse.d
  */
 
 module dmd.backend.cgcse;

--- a/compiler/src/dmd/backend/cgcv.d
+++ b/compiler/src/dmd/backend/cgcv.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cgcv.c, backend/cgcv.c)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/cgcv.d, backend/cgcv.c)
  */
 
 /* Header for cgcv.c    */

--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -11,9 +11,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cgelem.d, backend/cgelem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/cgelem.d, backend/cgelem.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_cgelem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/cgelem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/cgelem.d
  *              Add coverage tests to https://github.com/dlang/dmd/blob/master/test/runnable/testcgelem.d
  */
 

--- a/compiler/src/dmd/backend/cgen.d
+++ b/compiler/src/dmd/backend/cgen.d
@@ -5,9 +5,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cgen.d, backend/cgen.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/cgen.d, backend/cgen.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_cgen.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/cgen.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/cgen.d
  */
 
 module dmd.backend.cgen;

--- a/compiler/src/dmd/backend/cgsched.d
+++ b/compiler/src/dmd/backend/cgsched.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cgsched.c, backend/cgsched.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/cgsched.d, backend/cgsched.d)
  */
 
 module dmd.backend.cgsched;

--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/code.d, backend/_code.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/code.d, backend/_code.d)
  */
 
 module dmd.backend.code;

--- a/compiler/src/dmd/backend/codebuilder.d
+++ b/compiler/src/dmd/backend/codebuilder.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/codebuilder.d, backend/_codebuilder.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/codebuilder.d, backend/_codebuilder.d)
  * Documentation: https://dlang.org/phobos/dmd_backend_codebuilder.html
  */
 

--- a/compiler/src/dmd/backend/cv4.d
+++ b/compiler/src/dmd/backend/cv4.d
@@ -6,7 +6,7 @@
  * Compiler implementation of the
  * $(LINK2 https://www.dlang.org, D programming language).
  *
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cv4.d, backend/_cv4.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/cv4.d, backend/_cv4.d)
  */
 
 module dmd.backend.cv4;

--- a/compiler/src/dmd/backend/cv8.d
+++ b/compiler/src/dmd/backend/cv8.d
@@ -10,9 +10,9 @@
  * Copyright:    Copyright (C) 2012-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cv8.d, backend/cv8.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/cv8.d, backend/cv8.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_cv8.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/cv8.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/cv8.d
  */
 
 module dmd.backend.cv8;

--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -8,8 +8,8 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dcgcv.d, backend/dcgcv.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/dcgcv.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/dcgcv.d, backend/dcgcv.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/dcgcv.d
  */
 
 module dmd.backend.dcgcv;

--- a/compiler/src/dmd/backend/dcode.d
+++ b/compiler/src/dmd/backend/dcode.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dcode.d, backend/dcode.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/dcode.d, backend/dcode.d)
  */
 
 module dmd.backend.dcode;

--- a/compiler/src/dmd/backend/debugprint.d
+++ b/compiler/src/dmd/backend/debugprint.d
@@ -8,8 +8,8 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/debug.c, backend/debugprint.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/debug.c
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/debugprint.d, backend/debugprint.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/debugprint.d
  */
 
 module dmd.backend.debugprint;

--- a/compiler/src/dmd/backend/divcoeff.d
+++ b/compiler/src/dmd/backend/divcoeff.d
@@ -8,7 +8,7 @@
  * Copyright:   Copyright (C) 2013-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/divcoeff.d, backend/divcoeff.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/divcoeff.d, backend/divcoeff.d)
  */
 module dmd.backend.divcoeff;
 

--- a/compiler/src/dmd/backend/dlist.d
+++ b/compiler/src/dmd/backend/dlist.d
@@ -13,7 +13,7 @@
  *              Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dlist.d, backend/dlist.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/dlist.d, backend/dlist.d)
  */
 
 module dmd.backend.dlist;

--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -8,9 +8,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dout.d, backend/dout.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/dout.d, backend/dout.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_dout.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/dout.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/dout.d
  */
 
 module dmd.backend.dout;

--- a/compiler/src/dmd/backend/drtlsym.d
+++ b/compiler/src/dmd/backend/drtlsym.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/drtlsym.d, backend/drtlsym.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/drtlsym.d, backend/drtlsym.d)
  */
 
 module dmd.backend.drtlsym;

--- a/compiler/src/dmd/backend/dvarstats.d
+++ b/compiler/src/dmd/backend/dvarstats.d
@@ -7,7 +7,7 @@
  * Copyright:   Copyright (C) 2015-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     Rainer Schuetze
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dvarstats.d, backend/dvarstats.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/dvarstats.d, backend/dvarstats.d)
  */
 
 module dmd.backend.dvarstats;

--- a/compiler/src/dmd/backend/dvec.d
+++ b/compiler/src/dmd/backend/dvec.d
@@ -7,7 +7,7 @@
  * Copyright:   Copyright (C) 2013-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dvec.d, backend/dvec.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/dvec.d, backend/dvec.d)
  */
 
 module dmd.backend.dvec;

--- a/compiler/src/dmd/backend/dwarf2.d
+++ b/compiler/src/dmd/backend/dwarf2.d
@@ -3,7 +3,7 @@
  * Reflects declarations from the DWARF 3 to 5 specification, not the The D Language Foundation
  * dwarf implementation
  *
- * Source: $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dwarf2.d, backend/_dwarf2.d)
+ * Source: $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/dwarf2.d, backend/_dwarf2.d)
  */
 
 module dmd.backend.dwarf2;

--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -7,8 +7,8 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dwarfdbginf.d, backend/dwarfdbginf.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/dwarfdbginf.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/dwarfdbginf.d, backend/dwarfdbginf.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/dwarfdbginf.d
  */
 
 

--- a/compiler/src/dmd/backend/dwarfeh.d
+++ b/compiler/src/dmd/backend/dwarfeh.d
@@ -5,7 +5,7 @@
  * Copyright: Copyright (C) 2015-2025 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dwarfeh.d, backend/dwarfeh.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/dwarfeh.d, backend/dwarfeh.d)
  */
 
 module dmd.backend.dwarfeh;

--- a/compiler/src/dmd/backend/ee.d
+++ b/compiler/src/dmd/backend/ee.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/ee.d, backend/ee.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/ee.d, backend/ee.d)
  */
 module dmd.backend.ee;
 

--- a/compiler/src/dmd/backend/eh.d
+++ b/compiler/src/dmd/backend/eh.d
@@ -6,9 +6,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/eh.d, _eh.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/eh.d, _eh.d)
  * Documentation:  https://dlang.org/phobos/dmd_eh.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/eh.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/eh.d
  */
 
 module dmd.backend.eh;

--- a/compiler/src/dmd/backend/el.d
+++ b/compiler/src/dmd/backend/el.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/el.d, backend/el.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/el.d, backend/el.d)
  */
 
 module dmd.backend.el;

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/elem.d, backend/elem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/elem.d, backend/elem.d)
  */
 
 module dmd.backend.elem;

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -10,7 +10,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/elfobj.d, backend/elfobj.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/elfobj.d, backend/elfobj.d)
  */
 
 module dmd.backend.elfobj;
@@ -1564,7 +1564,7 @@ private void obj_tlssections()
  * Returns:
  *      "segment index" of COMDAT
  * References:
- *      Section Groups http://www.sco.com/developers/gabi/2003-12-17/ch4.sheader.html#section_groups
+ *      Section Groups https://www.sco.com/developers/gabi/2003-12-17/ch4.sheader.html#section_groups
  *      COMDAT section groups https://www.airs.com/blog/archives/52
  */
 

--- a/compiler/src/dmd/backend/elpicpie.d
+++ b/compiler/src/dmd/backend/elpicpie.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/elpicpie.d, backend/elpicpie.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/elpicpie.d, backend/elpicpie.d)
  */
 
 module dmd.backend.elpicpie;

--- a/compiler/src/dmd/backend/evalu8.d
+++ b/compiler/src/dmd/backend/evalu8.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/evalu8.d, backend/evalu8.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/evalu8.d, backend/evalu8.d)
  */
 
 module dmd.backend.evalu8;

--- a/compiler/src/dmd/backend/fp.d
+++ b/compiler/src/dmd/backend/fp.d
@@ -6,8 +6,8 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/fp.d backend/fp.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/fp.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/fp.d backend/fp.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/fp.d
  */
 
 module dmd.backend.fp;

--- a/compiler/src/dmd/backend/gdag.d
+++ b/compiler/src/dmd/backend/gdag.d
@@ -8,8 +8,8 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/gdag.d, backend/gdag.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/gdag.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/gdag.d, backend/gdag.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/gdag.d
  */
 
 module dmd.backend.gdag;

--- a/compiler/src/dmd/backend/gflow.d
+++ b/compiler/src/dmd/backend/gflow.d
@@ -5,9 +5,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/gflow.d, backend/gflow.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/gflow.d, backend/gflow.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_gflow.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/gflow.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/gflow.d
  */
 
 module dmd.backend.gflow;

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/global.d, backend/global.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/global.d, backend/global.d)
  */
 module dmd.backend.global;
 

--- a/compiler/src/dmd/backend/glocal.d
+++ b/compiler/src/dmd/backend/glocal.d
@@ -8,8 +8,8 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/glocal.d, backend/glocal.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/glocal.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/glocal.d, backend/glocal.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/glocal.d
  */
 
 module dmd.backend.glocal;

--- a/compiler/src/dmd/backend/gloop.d
+++ b/compiler/src/dmd/backend/gloop.d
@@ -8,8 +8,8 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/gloop.d, backend/gloop.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/gloop.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/gloop.d, backend/gloop.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/gloop.d
  */
 
 module dmd.backend.gloop;

--- a/compiler/src/dmd/backend/gsroa.d
+++ b/compiler/src/dmd/backend/gsroa.d
@@ -11,7 +11,7 @@
  * Copyright:   Copyright (C) 2016-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/gsroa.c, backend/gsroa.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/gsroa.d, backend/gsroa.d)
  */
 
 module dmd.backend.gsroa;

--- a/compiler/src/dmd/backend/iasm.d
+++ b/compiler/src/dmd/backend/iasm.d
@@ -5,9 +5,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     Mike Cote, John Micco, $(LINK2 https://www.digitalmars.com, Walter Bright),
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/iasm.d, backend/iasm.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/iasm.d, backend/iasm.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_iasm.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/iasm.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/iasm.d
  */
 
 module dmd.backend.iasm;

--- a/compiler/src/dmd/backend/inliner.d
+++ b/compiler/src/dmd/backend/inliner.d
@@ -19,7 +19,7 @@
  *              Some parts based on an inliner from the Digital Mars C compiler.
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/inliner.d, backend/inliner.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/inliner.d, backend/inliner.d)
  */
 
 // C++ specific routines

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -7,7 +7,7 @@
  * Copyright:   Copyright (C) 2009-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/machobj.d, backend/machobj.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/machobj.d, backend/machobj.d)
  */
 
 module dmd.backend.machobj;

--- a/compiler/src/dmd/backend/melf.d
+++ b/compiler/src/dmd/backend/melf.d
@@ -7,7 +7,7 @@
  *
  * Translation to D of Linux's melf.h
  *
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/melf.d, backend/melf.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/melf.d, backend/melf.d)
  * References:  $(LINK2 https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst, aaelf64)
  */
 

--- a/compiler/src/dmd/backend/mem.d
+++ b/compiler/src/dmd/backend/mem.d
@@ -6,8 +6,8 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/mem.d, backend/mem.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/mem.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/mem.d, backend/mem.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/mem.d
  */
 
 

--- a/compiler/src/dmd/backend/mscoff.d
+++ b/compiler/src/dmd/backend/mscoff.d
@@ -1,7 +1,7 @@
 /**
  * Microsoft COFF object file format
  *
- * Source: $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/mscoff.d, backend/_mscoff.d)
+ * Source: $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/mscoff.d, backend/_mscoff.d)
  */
 
 module dmd.backend.mscoff;

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -5,7 +5,7 @@
  * Copyright:   Copyright (C) 2009-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/mscoffobj.d, backend/mscoffobj.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/mscoffobj.d, backend/mscoffobj.d)
  */
 
 module dmd.backend.mscoffobj;

--- a/compiler/src/dmd/backend/obj.d
+++ b/compiler/src/dmd/backend/obj.d
@@ -6,7 +6,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/obj.d, backend/obj.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/obj.d, backend/obj.d)
  */
 
 module dmd.backend.obj;

--- a/compiler/src/dmd/backend/oper.d
+++ b/compiler/src/dmd/backend/oper.d
@@ -6,7 +6,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/oper.d, backend/oper.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/oper.d, backend/oper.d)
  */
 
 module dmd.backend.oper;

--- a/compiler/src/dmd/backend/pdata.d
+++ b/compiler/src/dmd/backend/pdata.d
@@ -7,7 +7,7 @@
  * Copyright:   Copyright (C) 2012-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/pdata.d, backend/pdata.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/pdata.d, backend/pdata.d)
  */
 
 module dmd.backend.pdata;

--- a/compiler/src/dmd/backend/ptrntab.d
+++ b/compiler/src/dmd/backend/ptrntab.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/ptrntab.d, backend/ptrntab.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/ptrntab.d, backend/ptrntab.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_ptrntab.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/ptrntab.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/ptrntab.d
  */
 
 module dmd.backend.ptrntab;

--- a/compiler/src/dmd/backend/symtab.d
+++ b/compiler/src/dmd/backend/symtab.d
@@ -5,9 +5,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/symtab.d, backend/_symtab.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/symtab.d, backend/_symtab.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_symtab.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/symtab.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/symtab.d
  */
 
 module dmd.backend.symtab;

--- a/compiler/src/dmd/backend/ty.d
+++ b/compiler/src/dmd/backend/ty.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/ty.d, backend/_ty.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/ty.d, backend/_ty.d)
  */
 
 module dmd.backend.ty;

--- a/compiler/src/dmd/backend/type.d
+++ b/compiler/src/dmd/backend/type.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/type.d, backend/_type.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/type.d, backend/_type.d)
  */
 
 module dmd.backend.type;

--- a/compiler/src/dmd/backend/util2.d
+++ b/compiler/src/dmd/backend/util2.d
@@ -10,7 +10,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/util2.d, backend/util2.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/util2.d, backend/util2.d)
  */
 
 module dmd.backend.util2;

--- a/compiler/src/dmd/backend/var.d
+++ b/compiler/src/dmd/backend/var.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/var.d, backend/var.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/var.d, backend/var.d)
  */
 
 module dmd.backend.var;

--- a/compiler/src/dmd/backend/x86/cg87.d
+++ b/compiler/src/dmd/backend/x86/cg87.d
@@ -8,9 +8,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/cg87.d, backend/cg87.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/cg87.d, backend/cg87.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_cg87.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/cg87.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/cg87.d
  */
 
 module dmd.backend.x86.cg87;

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -5,9 +5,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/cgcod.d, backend/cgcod.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/cgcod.d, backend/cgcod.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_cgcod.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/cgcod.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/cgcod.d
  */
 
 module dmd.backend.x86.cgcod;

--- a/compiler/src/dmd/backend/x86/cgreg.d
+++ b/compiler/src/dmd/backend/x86/cgreg.d
@@ -8,7 +8,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cgreg.c, backend/cgreg.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/cgreg.d, backend/cgreg.d)
  */
 
 module dmd.backend.x86.cgreg;

--- a/compiler/src/dmd/backend/x86/cgxmm.d
+++ b/compiler/src/dmd/backend/x86/cgxmm.d
@@ -7,9 +7,9 @@
  * Copyright:   Copyright (C) 2011-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/cgxmm.d, backend/cgxmm.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/cgxmm.d, backend/cgxmm.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_cgxmm.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/cgxmm.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/cgxmm.d
  */
 
 module dmd.backend.x86.cgxmm;

--- a/compiler/src/dmd/backend/x86/cod1.d
+++ b/compiler/src/dmd/backend/x86/cod1.d
@@ -10,9 +10,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/cod1.d, backend/cod1.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/cod1.d, backend/cod1.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_cod1.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/cod1.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/cod1.d
  */
 
 module dmd.backend.x86.cod1;

--- a/compiler/src/dmd/backend/x86/cod2.d
+++ b/compiler/src/dmd/backend/x86/cod2.d
@@ -14,9 +14,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/cod2.d, backend/cod2.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/cod2.d, backend/cod2.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_cod2.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/cod2.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/cod2.d
  */
 
 module dmd.backend.x86.cod2;

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -13,9 +13,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/cod3.d, backend/cod3.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/cod3.d, backend/cod3.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_cod3.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/cod3.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/cod3.d
  */
 
 module dmd.backend.x86.cod3;

--- a/compiler/src/dmd/backend/x86/cod4.d
+++ b/compiler/src/dmd/backend/x86/cod4.d
@@ -16,9 +16,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/cod4.d, backend/cod4.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/cod4.d, backend/cod4.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_cod4.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/cod4.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/cod4.d
  */
 
 module dmd.backend.x86.cod4;

--- a/compiler/src/dmd/backend/x86/cod5.d
+++ b/compiler/src/dmd/backend/x86/cod5.d
@@ -10,9 +10,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/cod5.d, backend/cod5.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/cod5.d, backend/cod5.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_cod5.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/cod5.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/cod5.d
  */
 module dmd.backend.x86.cod5;
 

--- a/compiler/src/dmd/backend/x86/code_x86.d
+++ b/compiler/src/dmd/backend/x86/code_x86.d
@@ -5,9 +5,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/code_x86.d, backend/code_x86.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/code_x86.d, backend/code_x86.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86/code_x86.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/code_x86.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/code_x86.d
  */
 
 module dmd.backend.x86.code_x86;

--- a/compiler/src/dmd/backend/x86/disasm86.d
+++ b/compiler/src/dmd/backend/x86/disasm86.d
@@ -6,9 +6,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/disasm86.d, backend/cod1.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/disasm86.d, backend/cod1.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_disasm86.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/disasm86.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/disasm86.d
  */
 
 module dmd.backend.x86.disasm86;

--- a/compiler/src/dmd/backend/x86/nteh.d
+++ b/compiler/src/dmd/backend/x86/nteh.d
@@ -8,8 +8,8 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/nteh.d, backend/nteh.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/nteh.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/nteh.d, backend/nteh.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/nteh.d
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_nteh.html
  */
 

--- a/compiler/src/dmd/backend/x86/xmm.d
+++ b/compiler/src/dmd/backend/x86/xmm.d
@@ -7,9 +7,9 @@
  * Copyright:   Copyright (C) ?-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/x86/xmm.d, backend/_xmm.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/x86/xmm.d, backend/_xmm.d)
  * Documentation:  https://dlang.org/phobos/dmd_backend_x86_xmm.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/x86/xmm.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/backend/x86/xmm.d
  */
 
 module dmd.backend.x86.xmm;

--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/blockexit.d, _blockexit.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/blockexit.d, _blockexit.d)
  * Documentation:  https://dlang.org/phobos/dmd_blockexit.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/blockexit.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/blockexit.d
  */
 
 module dmd.blockexit;

--- a/compiler/src/dmd/builtin.d
+++ b/compiler/src/dmd/builtin.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/builtin.d, _builtin.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/builtin.d, _builtin.d)
  * Documentation:  https://dlang.org/phobos/dmd_builtin.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/builtin.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/builtin.d
  */
 
 module dmd.builtin;

--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/canthrow.d, _canthrow.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/canthrow.d, _canthrow.d)
  * Documentation:  https://dlang.org/phobos/dmd_canthrow.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/canthrow.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/canthrow.d
  */
 
 module dmd.canthrow;

--- a/compiler/src/dmd/chkformat.d
+++ b/compiler/src/dmd/chkformat.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/chkformat.d, _chkformat.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/chkformat.d, _chkformat.d)
  * Documentation:  https://dlang.org/phobos/dmd_chkformat.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/chkformat.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/chkformat.d
  */
 module dmd.chkformat;
 

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -8,9 +8,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/cli.d, _cli.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/cli.d, _cli.d)
  * Documentation:  https://dlang.org/phobos/dmd_cli.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/cli.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/cli.d
  */
 module dmd.cli;
 

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -5,9 +5,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/clone.d, _clone.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/clone.d, _clone.d)
  * Documentation:  https://dlang.org/phobos/dmd_clone.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/clone.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/clone.d
  */
 
 module dmd.clone;

--- a/compiler/src/dmd/common/bitfields.d
+++ b/compiler/src/dmd/common/bitfields.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Dennis Korpel
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/bitfields.d, common/bitfields.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/bitfields.d, common/bitfields.d)
  * Documentation: https://dlang.org/phobos/dmd_common_bitfields.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/bitfields.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/common/bitfields.d
  */
 module dmd.common.bitfields;
 

--- a/compiler/src/dmd/common/charactertables.d
+++ b/compiler/src/dmd/common/charactertables.d
@@ -6,9 +6,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   $(LINK2 https://cattermole.co.nz, Richard (Rikki) Andrew Cattermole)
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/charactertables.d, common/charactertables.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/charactertables.d, common/charactertables.d)
  * Documentation: https://dlang.org/phobos/dmd_common_charactertables.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/charactertables.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/common/charactertables.d
  */
 module dmd.common.charactertables;
 

--- a/compiler/src/dmd/common/charactertables.h
+++ b/compiler/src/dmd/common/charactertables.h
@@ -6,7 +6,7 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   $(LINK2 https://cattermole.co.nz, Richard (Rikki) Andrew Cattermole)
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/charactertables.d, common/charactertables.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/charactertables.h, common/charactertables.d)
  */
 
 #pragma once

--- a/compiler/src/dmd/common/file.d
+++ b/compiler/src/dmd/common/file.d
@@ -7,9 +7,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/file.d, common/_file.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/file.d, common/_file.d)
  * Documentation: https://dlang.org/phobos/dmd_common_file.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/file.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/common/file.d
  */
 
 module dmd.common.file;

--- a/compiler/src/dmd/common/int128.d
+++ b/compiler/src/dmd/common/int128.d
@@ -5,9 +5,9 @@
  * Copyright: Copyright (C) 2022-2025 by The D Language Foundation, All Rights Reserved
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Authors:   Walter Bright
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/int128.d, root/_int128.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/int128.d, root/_int128.d)
  * Documentation: https://dlang.org/phobos/dmd_common_int128.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/int128.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/common/int128.d
  */
 
 module dmd.common.int128;

--- a/compiler/src/dmd/common/outbuffer.d
+++ b/compiler/src/dmd/common/outbuffer.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/outbuffer.d, root/_outbuffer.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/outbuffer.d, root/_outbuffer.d)
  * Documentation: https://dlang.org/phobos/dmd_root_outbuffer.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/outbuffer.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/common/outbuffer.d
  */
 
 module dmd.common.outbuffer;

--- a/compiler/src/dmd/common/smallbuffer.d
+++ b/compiler/src/dmd/common/smallbuffer.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/smallbuffer.d, common/_smallbuffer.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/smallbuffer.d, common/_smallbuffer.d)
  * Documentation: https://dlang.org/phobos/dmd_common_smallbuffer.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/smallbuffer
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/common/smallbuffer.d
  */
 module dmd.common.smallbuffer;
 

--- a/compiler/src/dmd/compiler.d
+++ b/compiler/src/dmd/compiler.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/compiler.d, _compiler.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/compiler.d, _compiler.d)
  * Documentation:  https://dlang.org/phobos/dmd_compiler.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/compiler.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/compiler.d
  */
 
 module dmd.compiler;

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/cond.d, _cond.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/cond.d, _cond.d)
  * Documentation:  https://dlang.org/phobos/dmd_cond.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/cond.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/cond.d
  */
 
 module dmd.cond;

--- a/compiler/src/dmd/console.d
+++ b/compiler/src/dmd/console.d
@@ -5,9 +5,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/console.d, _console.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/console.d, _console.d)
  * Documentation:  https://dlang.org/phobos/dmd_console.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/console.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/console.d
  */
 
 module dmd.console;

--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -8,9 +8,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/constfold.d, _constfold.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/constfold.d, _constfold.d)
  * Documentation:  https://dlang.org/phobos/dmd_constfold.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/constfold.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/constfold.d
  */
 
 module dmd.constfold;

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/cparse.d, _cparse.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/cparse.d, _cparse.d)
  * Documentation:  https://dlang.org/phobos/dmd_cparse.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/cparse.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/cparse.d
  */
 
 module dmd.cparse;

--- a/compiler/src/dmd/cpreprocess.d
+++ b/compiler/src/dmd/cpreprocess.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 2022-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/cpreprocess.d, _cpreprocess.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/cpreprocess.d, _cpreprocess.d)
  * Documentation:  https://dlang.org/phobos/dmd_cpreprocess.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/cpreprocess.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/cpreprocess.d
  */
 
 module dmd.cpreprocess;

--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/ctfeexpr.d, _ctfeexpr.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/ctfeexpr.d, _ctfeexpr.d)
  * Documentation:  https://dlang.org/phobos/dmd_ctfeexpr.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/ctfeexpr.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/ctfeexpr.d
  */
 
 module dmd.ctfeexpr;

--- a/compiler/src/dmd/ctorflow.d
+++ b/compiler/src/dmd/ctorflow.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/ctorflow.d, _ctorflow.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/ctorflow.d, _ctorflow.d)
  * Documentation:  https://dlang.org/phobos/dmd_ctorflow.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/ctorflow.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/ctorflow.d
  */
 
 module dmd.ctorflow;

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/cxxfrontend.d, _cxxfrontend.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/cxxfrontend.d, _cxxfrontend.d)
  * Documentation:  https://dlang.org/phobos/dmd_cxxfrontend.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/cxxfrontend.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/cxxfrontend.d
  */
 module dmd.cxxfrontend;
 

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dcast.d, _dcast.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dcast.d, _dcast.d)
  * Documentation:  https://dlang.org/phobos/dmd_dcast.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dcast.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dcast.d
  */
 
 module dmd.dcast;

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dclass.d, _dclass.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dclass.d, _dclass.d)
  * Documentation:  https://dlang.org/phobos/dmd_dclass.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dclass.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dclass.d
  */
 
 module dmd.dclass;

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -5,9 +5,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/declaration.d, _declaration.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/declaration.d, _declaration.d)
  * Documentation:  https://dlang.org/phobos/dmd_declaration.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/declaration.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/declaration.d
  */
 
 module dmd.declaration;

--- a/compiler/src/dmd/delegatize.d
+++ b/compiler/src/dmd/delegatize.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/delegatize.d, _delegatize.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/delegatize.d, _delegatize.d)
  * Documentation:  https://dlang.org/phobos/dmd_delegatize.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/delegatize.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/delegatize.d
  */
 
 module dmd.delegatize;

--- a/compiler/src/dmd/denum.d
+++ b/compiler/src/dmd/denum.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/denum.d, _denum.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/denum.d, _denum.d)
  * Documentation:  https://dlang.org/phobos/dmd_denum.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/denum.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/denum.d
  * References:  https://dlang.org/spec/enum.html
  */
 

--- a/compiler/src/dmd/deps.d
+++ b/compiler/src/dmd/deps.d
@@ -24,9 +24,9 @@
  *
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/deps.d, makedeps.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/deps.d, makedeps.d)
  * Documentation:  https://dlang.org/phobos/dmd_deps.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/deps.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/deps.d
  */
 module dmd.deps;
 

--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dimport.d, _dimport.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dimport.d, _dimport.d)
  * Documentation:  https://dlang.org/phobos/dmd_dimport.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dimport.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dimport.d
  */
 
 module dmd.dimport;

--- a/compiler/src/dmd/dinifile.d
+++ b/compiler/src/dmd/dinifile.d
@@ -5,9 +5,9 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dinifile.d, _dinifile.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dinifile.d, _dinifile.d)
  * Documentation:  https://dlang.org/phobos/dmd_dinifile.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dinifile.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dinifile.d
  */
 
 module dmd.dinifile;

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dinterpret.d, _dinterpret.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dinterpret.d, _dinterpret.d)
  * Documentation:  https://dlang.org/phobos/dmd_dinterpret.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dinterpret.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dinterpret.d
  */
 
 module dmd.dinterpret;

--- a/compiler/src/dmd/dmacro.d
+++ b/compiler/src/dmd/dmacro.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dmacro.d, _dmacro.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dmacro.d, _dmacro.d)
  * Documentation:  https://dlang.org/phobos/dmd_dmacro.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dmacro.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dmacro.d
  */
 
 module dmd.dmacro;

--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dmdparams.d, _dmdparams.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dmdparams.d, _dmdparams.d)
  * Documentation:  https://dlang.org/phobos/dmd_dmdparams.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dmdparams.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dmdparams.d
  */
 
 module dmd.dmdparams;

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dmodule.d, _dmodule.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dmodule.d, _dmodule.d)
  * Documentation:  https://dlang.org/phobos/dmd_dmodule.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dmodule.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dmodule.d
  */
 
 module dmd.dmodule;

--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dmsc.d, _dmsc.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dmsc.d, _dmsc.d)
  * Documentation:  https://dlang.org/phobos/dmd_dmsc.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dmsc.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dmsc.d
  */
 
 module dmd.dmsc;

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/doc.d, _doc.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/doc.d, _doc.d)
  * Documentation:  https://dlang.org/phobos/dmd_doc.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/doc.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/doc.d
  */
 
 module dmd.doc;

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dscope.d, _dscope.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dscope.d, _dscope.d)
  * Documentation:  https://dlang.org/phobos/dmd_dscope.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dscope.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dscope.d
  */
 
 module dmd.dscope;

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dstruct.d, _dstruct.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dstruct.d, _dstruct.d)
  * Documentation:  https://dlang.org/phobos/dmd_dstruct.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dstruct.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dstruct.d
  */
 
 module dmd.dstruct;

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dsymbol.d, _dsymbol.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dsymbol.d, _dsymbol.d)
  * Documentation:  https://dlang.org/phobos/dmd_dsymbol.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dsymbol.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dsymbol.d
  */
 
 module dmd.dsymbol;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -5,9 +5,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dsymbolsem.d, _dsymbolsem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dsymbolsem.d, _dsymbolsem.d)
  * Documentation:  https://dlang.org/phobos/dmd_dsymbolsem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dsymbolsem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dsymbolsem.d
  */
 
 module dmd.dsymbolsem;

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -31,9 +31,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dtemplate.d, _dtemplate.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dtemplate.d, _dtemplate.d)
  * Documentation:  https://dlang.org/phobos/dmd_dtemplate.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dtemplate.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dtemplate.d
  */
 
 module dmd.dtemplate;

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -5,9 +5,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dtohd, _dtoh.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dtoh.d, _dtoh.d)
  * Documentation:  https://dlang.org/phobos/dmd_dtoh.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dtoh.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dtoh.d
  */
 module dmd.dtoh;
 

--- a/compiler/src/dmd/dversion.d
+++ b/compiler/src/dmd/dversion.d
@@ -7,9 +7,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dversion.d, _dversion.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dversion.d, _dversion.d)
  * Documentation:  https://dlang.org/phobos/dmd_dversion.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dversion.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/dversion.d
  */
 
 module dmd.dversion;

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/e2ir.d, _e2ir.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/e2ir.d, _e2ir.d)
  * Documentation: https://dlang.org/phobos/dmd_e2ir.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/e2ir.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/e2ir.d
  */
 
 module dmd.e2ir;

--- a/compiler/src/dmd/entity.d
+++ b/compiler/src/dmd/entity.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/entity.d, _entity.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/entity.d, _entity.d)
  * Documentation:  https://dlang.org/phobos/dmd_entity.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/entity.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/entity.d
  */
 
 module dmd.entity;

--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/enumsem.d, _enumsem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/enumsem.d, _enumsem.d)
  * Documentation:  https://dlang.org/phobos/dmd_enumsem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/enumsem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/enumsem.d
  */
 
 module dmd.enumsem;

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/errors.d, _errors.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/errors.d, _errors.d)
  * Documentation:  https://dlang.org/phobos/dmd_errors.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/errors.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/errors.d
  */
 
 module dmd.errors;

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 2023-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/errorsink.d, _errorsink.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/errorsink.d, _errorsink.d)
  * Documentation:  https://dlang.org/phobos/dmd_errorsink.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/errorsink.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/errorsink.d
  */
 
 module dmd.errorsink;

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/escape.d, _escape.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/escape.d, _escape.d)
  * Documentation:  https://dlang.org/phobos/dmd_escape.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/escape.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/escape.d
  */
 
 module dmd.escape;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/expression.d, _expression.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/expression.d, _expression.d)
  * Documentation:  https://dlang.org/phobos/dmd_expression.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/expression.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/expression.d
  */
 
 module dmd.expression;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/expressionsem.d, _expressionsem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/expressionsem.d, _expressionsem.d)
  * Documentation:  https://dlang.org/phobos/dmd_expressionsem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/expressionsem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/expressionsem.d
  */
 
 module dmd.expressionsem;

--- a/compiler/src/dmd/file_manager.d
+++ b/compiler/src/dmd/file_manager.d
@@ -3,9 +3,9 @@
  *
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/file_manager.d, _file_manager.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/file_manager.d, _file_manager.d)
  * Documentation:  https://dlang.org/phobos/dmd_file_manager.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/file_manager.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/file_manager.d
  */
 
 module dmd.file_manager;

--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/id.d, _id.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/frontend.d, _id.d)
  * Documentation:  https://dlang.org/phobos/dmd_frontend.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/frontend.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/frontend.d
  */
 module dmd.frontend;
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -11,9 +11,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/func.d, _func.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/func.d, _func.d)
  * Documentation:  https://dlang.org/phobos/dmd_func.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/func.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/func.d
  */
 
 module dmd.func;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/funcsem.d, _funcsem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/funcsem.d, _funcsem.d)
  * Documentation:  https://dlang.org/phobos/dmd_funcsem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/funcsem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/funcsem.d
  */
 
 module dmd.funcsem;

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/globals.d, _globals.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/globals.d, _globals.d)
  * Documentation:  https://dlang.org/phobos/dmd_globals.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/globals.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/globals.d
  */
 
 module dmd.globals;

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/glue.d, _glue.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/glue.d, _glue.d)
  * Documentation: $(LINK https://dlang.org/phobos/dmd_glue.html)
- * Coverage:    $(LINK https://codecov.io/gh/dlang/dmd/src/master/src/dmd/glue.d)
+ * Coverage:    $(LINK https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/glue.d)
  */
 
 module dmd.glue;

--- a/compiler/src/dmd/gluelayer.d
+++ b/compiler/src/dmd/gluelayer.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/gluelayer.d, _gluelayer.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/gluelayer.d, _gluelayer.d)
  * Documentation:  https://dlang.org/phobos/dmd_gluelayer.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/gluelayer.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/gluelayer.d
  */
 
 module dmd.gluelayer;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/hdrgen.d, _hdrgen.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/hdrgen.d, _hdrgen.d)
  * Documentation:  https://dlang.org/phobos/dmd_hdrgen.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/hdrgen.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/hdrgen.d
  */
 
 module dmd.hdrgen;

--- a/compiler/src/dmd/iasm.d
+++ b/compiler/src/dmd/iasm.d
@@ -6,9 +6,9 @@
  *              Copyright (C) 2018-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/iasm.d, _iasm.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/iasm.d, _iasm.d)
  * Documentation:  https://dlang.org/phobos/dmd_iasm.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/iasm.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/iasm.d
  */
 
 module dmd.iasm;

--- a/compiler/src/dmd/iasmdmd.d
+++ b/compiler/src/dmd/iasmdmd.d
@@ -6,9 +6,9 @@
  *              Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     Mike Cote, John Micco and $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/iasmdmd.d, _iasmdmd.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/iasmdmd.d, _iasmdmd.d)
  * Documentation:  https://dlang.org/phobos/dmd_iasmdmd.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/iasmdmd.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/iasmdmd.d
  */
 
 module dmd.iasmdmd;

--- a/compiler/src/dmd/iasmgcc.d
+++ b/compiler/src/dmd/iasmgcc.d
@@ -4,9 +4,9 @@
  *              Copyright (C) 2018-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     Iain Buclaw
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/iasmgcc.d, _iasmgcc.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/iasmgcc.d, _iasmgcc.d)
  * Documentation:  https://dlang.org/phobos/dmd_iasmgcc.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/iasmgcc.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/iasmgcc.d
  */
 
 module dmd.iasmgcc;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/id.d, _id.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/id.d, _id.d)
  * Documentation:  https://dlang.org/phobos/dmd_id.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/id.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/id.d
  */
 
 module dmd.id;

--- a/compiler/src/dmd/identifier.d
+++ b/compiler/src/dmd/identifier.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/identifier.d, _identifier.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/identifier.d, _identifier.d)
  * Documentation:  https://dlang.org/phobos/dmd_identifier.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/identifier.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/identifier.d
  */
 
 module dmd.identifier;

--- a/compiler/src/dmd/impcnvtab.d
+++ b/compiler/src/dmd/impcnvtab.d
@@ -9,9 +9,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/impcnvtab.d, _impcnvtab.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/impcnvtab.d, _impcnvtab.d)
  * Documentation:  https://dlang.org/phobos/dmd_impcnvtab.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/impcnvtab.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/impcnvtab.d
  */
 
 module dmd.impcnvtab;

--- a/compiler/src/dmd/imphint.d
+++ b/compiler/src/dmd/imphint.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/imphint.d, _imphint.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/imphint.d, _imphint.d)
  * Documentation:  https://dlang.org/phobos/dmd_imphint.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/imphint.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/imphint.d
  */
 
 module dmd.imphint;

--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 2021-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/importc.d, _importc.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/importc.d, _importc.d)
  * Documentation:  https://dlang.org/phobos/dmd_importc.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/importc.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/importc.d
  */
 
 module dmd.importc;

--- a/compiler/src/dmd/init.d
+++ b/compiler/src/dmd/init.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/init.d, _init.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/init.d, _init.d)
  * Documentation:  https://dlang.org/phobos/dmd_init.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/init.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/init.d
  */
 
 module dmd.init;

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/initsem.d, _initsem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/initsem.d, _initsem.d)
  * Documentation:  https://dlang.org/phobos/dmd_initsem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/initsem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/initsem.d
  */
 
 module dmd.initsem;

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -7,9 +7,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/inline.d, _inline.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/inline.d, _inline.d)
  * Documentation:  https://dlang.org/phobos/dmd_inline.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/inline.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/inline.d
  */
 
 module dmd.inline;

--- a/compiler/src/dmd/inlinecost.d
+++ b/compiler/src/dmd/inlinecost.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/inlinecost.d, _inlinecost.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/inlinecost.d, _inlinecost.d)
  * Documentation:  https://dlang.org/phobos/dmd_inlinecost.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/inlinecost.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/inlinecost.d
  */
 
 module dmd.inlinecost;

--- a/compiler/src/dmd/intrange.d
+++ b/compiler/src/dmd/intrange.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/intrange.d, _intrange.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/intrange.d, _intrange.d)
  * Documentation:  https://dlang.org/phobos/dmd_intrange.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/intrange.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/intrange.d
  */
 
 module dmd.intrange;

--- a/compiler/src/dmd/json.d
+++ b/compiler/src/dmd/json.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/json.d, _json.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/json.d, _json.d)
  * Documentation:  https://dlang.org/phobos/dmd_json.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/json.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/json.d
  */
 
 module dmd.json;

--- a/compiler/src/dmd/lambdacomp.d
+++ b/compiler/src/dmd/lambdacomp.d
@@ -8,9 +8,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lamdbacomp.d, _lambdacomp.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/lambdacomp.d, _lambdacomp.d)
  * Documentation:  https://dlang.org/phobos/dmd_lambdacomp.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lambdacomp.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/lambdacomp.d
  */
 
 module dmd.lambdacomp;

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lexer.d, _lexer.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/lexer.d, _lexer.d)
  * Documentation:  https://dlang.org/phobos/dmd_lexer.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lexer.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/lexer.d
  */
 
 module dmd.lexer;

--- a/compiler/src/dmd/lib/elf.d
+++ b/compiler/src/dmd/lib/elf.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/libelf.d, _libelf.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/lib/elf.d, _libelf.d)
  * Documentation:  https://dlang.org/phobos/dmd_libelf.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/libelf.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/lib/elf.d
  */
 
 module dmd.lib.elf;

--- a/compiler/src/dmd/lib/mach.d
+++ b/compiler/src/dmd/lib/mach.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/libmach.d, _libmach.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/lib/mach.d, _libmach.d)
  * Documentation:  https://dlang.org/phobos/dmd_libmach.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/libmach.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/lib/mach.d
  */
 
 module dmd.lib.mach;

--- a/compiler/src/dmd/lib/mscoff.d
+++ b/compiler/src/dmd/lib/mscoff.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/libmscoff.d, _libmscoff.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/lib/mscoff.d, _libmscoff.d)
  * Documentation:  https://dlang.org/phobos/dmd_libmscoff.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/libmscoff.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/lib/mscoff.d
  */
 
 module dmd.lib.mscoff;

--- a/compiler/src/dmd/lib/package.d
+++ b/compiler/src/dmd/lib/package.d
@@ -5,9 +5,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib.d, _lib.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/lib/package.d, _lib.d)
  * Documentation:  https://dlang.org/phobos/dmd_lib.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/lib/package.d
  */
 
 module dmd.lib;

--- a/compiler/src/dmd/lib/scanelf.d
+++ b/compiler/src/dmd/lib/scanelf.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/scanelf.d, _scanelf.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/lib/scanelf.d, _scanelf.d)
  * Documentation:  https://dlang.org/phobos/dmd_scanelf.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/scanelf.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/lib/scanelf.d
  */
 
 module dmd.lib.scanelf;

--- a/compiler/src/dmd/lib/scanmach.d
+++ b/compiler/src/dmd/lib/scanmach.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/scanmach.d, _scanmach.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/lib/scanmach.d, _scanmach.d)
  * Documentation:  https://dlang.org/phobos/dmd_scanmach.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/scanmach.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/lib/scanmach.d
  */
 
 module dmd.lib.scanmach;

--- a/compiler/src/dmd/lib/scanmscoff.d
+++ b/compiler/src/dmd/lib/scanmscoff.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/scanmscoff.d, _scanmscoff.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/lib/scanmscoff.d, _scanmscoff.d)
  * Documentation:  https://dlang.org/phobos/dmd_scanmscoff.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/scanmscoff.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/lib/scanmscoff.d
  */
 
 module dmd.lib.scanmscoff;

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/link.d, _link.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/link.d, _link.d)
  * Documentation:  https://dlang.org/phobos/dmd_link.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/link.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/link.d
  */
 
 module dmd.link;

--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/location.d, _location.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/location.d, _location.d)
  * Documentation:  https://dlang.org/phobos/dmd_location.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/location.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/location.d
  */
 
 module dmd.location;

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -9,9 +9,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/main.d, _main.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/main.d, _main.d)
  * Documentation:  https://dlang.org/phobos/dmd_main.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/main.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/main.d
  */
 
 module dmd.main;

--- a/compiler/src/dmd/mangle/basic.d
+++ b/compiler/src/dmd/mangle/basic.d
@@ -3,9 +3,9 @@
  *
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/basicmangle.d, _basicmangle.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/mangle/basic.d, _basicmangle.d)
  * Documentation:  https://dlang.org/phobos/dmd_basicmangle.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/basicmangle.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/mangle/basic.d
  */
 module dmd.mangle.basic;
 

--- a/compiler/src/dmd/mangle/cpp.d
+++ b/compiler/src/dmd/mangle/cpp.d
@@ -7,9 +7,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/cppmangle.d, _cppmangle.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/mangle/cpp.d, _cppmangle.d)
  * Documentation:  https://dlang.org/phobos/dmd_cppmangle.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/cppmangle.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/mangle/cpp.d
  *
  * References:
  *  Follows Itanium C++ ABI 1.86 section 5.1

--- a/compiler/src/dmd/mangle/cppwin.d
+++ b/compiler/src/dmd/mangle/cppwin.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/cppmanglewin.d, _cppmanglewin.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/mangle/cppwin.d, _cppmanglewin.d)
  * Documentation:  https://dlang.org/phobos/dmd_cppmanglewin.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/cppmanglewin.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/mangle/cppwin.d
  */
 
 module dmd.mangle.cppwin;

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -6,9 +6,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/dmangle.d, _dmangle.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/mangle/package.d, _dmangle.d)
  * Documentation:  https://dlang.org/phobos/dmd_dmangle.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/dmangle.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/mangle/package.d
  * References:  https://dlang.org/blog/2017/12/20/ds-newfangled-name-mangling/
  */
 

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -7,9 +7,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/mars.d, _mars.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/mars.d, _mars.d)
  * Documentation:  https://dlang.org/phobos/dmd_mars.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/mars.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/mars.d
  */
 
 module dmd.mars;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/mtype.d, _mtype.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/mtype.d, _mtype.d)
  * Documentation:  https://dlang.org/phobos/dmd_mtype.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/mtype.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/mtype.d
  */
 
 module dmd.mtype;

--- a/compiler/src/dmd/mustuse.d
+++ b/compiler/src/dmd/mustuse.d
@@ -3,9 +3,9 @@
  *
  * Copyright: Copyright (C) 2022-2025 by The D Language Foundation, All Rights Reserved
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/mustuse.d, _mustuse.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/mustuse.d, _mustuse.d)
  * Documentation:  https://dlang.org/phobos/dmd_mustuse.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/mustuse.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/mustuse.d
  */
 
 module dmd.mustuse;

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/nogc.d, _nogc.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/nogc.d, _nogc.d)
  * Documentation:  https://dlang.org/phobos/dmd_nogc.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/nogc.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/nogc.d
  */
 
 module dmd.nogc;

--- a/compiler/src/dmd/nspace.d
+++ b/compiler/src/dmd/nspace.d
@@ -39,9 +39,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/nspace.d, _nspace.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/nspace.d, _nspace.d)
  * Documentation:  https://dlang.org/phobos/dmd_nspace.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/nspace.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/nspace.d
  */
 
 module dmd.nspace;

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/ob.d, _ob.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/ob.d, _ob.d)
  * Documentation:  https://dlang.org/phobos/dmd_escape.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/ob.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/ob.d
  * References:  https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1021.md Argument Ownership and Function Calls
  */
 

--- a/compiler/src/dmd/objc.d
+++ b/compiler/src/dmd/objc.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/objc.d, _objc.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/objc.d, _objc.d)
  * Documentation:  https://dlang.org/phobos/dmd_objc.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/objc.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/objc.d
  */
 
 module dmd.objc;

--- a/compiler/src/dmd/objc_glue.d
+++ b/compiler/src/dmd/objc_glue.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 2015-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/objc_glue.d, _objc_glue.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/objc_glue.d, _objc_glue.d)
  * Documentation:  https://dlang.org/phobos/dmd_objc_glue.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/objc_glue.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/objc_glue.d
  */
 
 module dmd.objc_glue;

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/opover.d, _opover.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/opover.d, _opover.d)
  * Documentation:  https://dlang.org/phobos/dmd_opover.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/opover.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/opover.d
  */
 
 module dmd.opover;

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/optimize.d, _optimize.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/optimize.d, _optimize.d)
  * Documentation:  https://dlang.org/phobos/dmd_optimize.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/optimize.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/optimize.d
  */
 
 module dmd.optimize;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/parse.d, _parse.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/parse.d, _parse.d)
  * Documentation:  https://dlang.org/phobos/dmd_parse.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/parse.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/parse.d
  */
 
 module dmd.parse;

--- a/compiler/src/dmd/pragmasem.d
+++ b/compiler/src/dmd/pragmasem.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2023 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/pragmasem.d, _pragmasem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/pragmasem.d, _pragmasem.d)
  * Documentation:  https://dlang.org/phobos/dmd_pragmasem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/pragmasem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/pragmasem.d
  */
 
 module dmd.pragmasem;

--- a/compiler/src/dmd/printast.d
+++ b/compiler/src/dmd/printast.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/printast.d, _printast.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/printast.d, _printast.d)
  * Documentation:  https://dlang.org/phobos/dmd_printast.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/printast.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/printast.d
  */
 
 module dmd.printast;

--- a/compiler/src/dmd/root/aav.d
+++ b/compiler/src/dmd/root/aav.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/aav.d, root/_aav.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/aav.d, root/_aav.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_aav.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/aav.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/aav.d
  */
 
 module dmd.root.aav;

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -5,9 +5,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/array.d, root/_array.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/array.d, root/_array.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_array.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/array.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/array.d
  */
 
 module dmd.root.array;

--- a/compiler/src/dmd/root/bitarray.d
+++ b/compiler/src/dmd/root/bitarray.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/bitarray.d, root/_bitarray.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/bitarray.d, root/_bitarray.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_array.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/bitarray.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/bitarray.d
  */
 
 module dmd.root.bitarray;

--- a/compiler/src/dmd/root/complex.d
+++ b/compiler/src/dmd/root/complex.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/complex.d, _complex.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/complex.d, _complex.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_complex.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/complex.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/complex.d
  */
 
 module dmd.root.complex;

--- a/compiler/src/dmd/root/ctfloat.d
+++ b/compiler/src/dmd/root/ctfloat.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/ctfloat.d, root/_ctfloat.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/ctfloat.d, root/_ctfloat.d)
  * Documentation: https://dlang.org/phobos/dmd_root_ctfloat.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/ctfloat.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/ctfloat.d
  */
 
 module dmd.root.ctfloat;

--- a/compiler/src/dmd/root/env.d
+++ b/compiler/src/dmd/root/env.d
@@ -3,9 +3,9 @@
  *
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/env.d, env.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/env.d, env.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_env.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/env.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/env.d
  */
 
 module dmd.root.env;

--- a/compiler/src/dmd/root/file.d
+++ b/compiler/src/dmd/root/file.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/file.d, root/_file.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/file.d, root/_file.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_file.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/file.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/file.d
  */
 
 module dmd.root.file;

--- a/compiler/src/dmd/root/filename.d
+++ b/compiler/src/dmd/root/filename.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/filename.d, root/_filename.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/filename.d, root/_filename.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_filename.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/filename.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/filename.d
  */
 
 module dmd.root.filename;

--- a/compiler/src/dmd/root/hash.d
+++ b/compiler/src/dmd/root/hash.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Martin Nowak, Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/hash.d, root/_hash.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/hash.d, root/_hash.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_hash.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/hash.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/hash.d
  */
 
 module dmd.root.hash;

--- a/compiler/src/dmd/root/man.d
+++ b/compiler/src/dmd/root/man.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/man.d, root/_man.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/man.d, root/_man.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_man.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/man.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/man.d
  */
 
 module dmd.root.man;

--- a/compiler/src/dmd/root/optional.d
+++ b/compiler/src/dmd/root/optional.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/optional.d, root/_optional.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/optional.d, root/_optional.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_optional.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/optional.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/optional.d
  */
 module dmd.root.optional;
 

--- a/compiler/src/dmd/root/optional.h
+++ b/compiler/src/dmd/root/optional.h
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/optional.h, root/_optional.h)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/optional.h, root/_optional.h)
  * Documentation:  https://dlang.org/phobos/dmd_root_optional.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/optional.h
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/optional.h
  */
 
 #include "dcompat.h"    // for d_bool

--- a/compiler/src/dmd/root/port.d
+++ b/compiler/src/dmd/root/port.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/port.d, root/_port.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/port.d, root/_port.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_port.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/port.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/port.d
  */
 
 module dmd.root.port;

--- a/compiler/src/dmd/root/region.d
+++ b/compiler/src/dmd/root/region.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 2019-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/region.d, root/_region.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/region.d, root/_region.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_region.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/region.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/region.d
  */
 
 module dmd.root.region;

--- a/compiler/src/dmd/root/response.d
+++ b/compiler/src/dmd/root/response.d
@@ -7,9 +7,9 @@
  *              Some portions copyright (c) 1994-1995 by Symantec
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/response.d, root/_response.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/response.d, root/_response.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_response.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/response.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/response.d
  */
 
 module dmd.root.response;

--- a/compiler/src/dmd/root/rmem.d
+++ b/compiler/src/dmd/root/rmem.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/rmem.d, root/_rmem.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/rmem.d, root/_rmem.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_rmem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/rmem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/rmem.d
  */
 
 module dmd.root.rmem;

--- a/compiler/src/dmd/root/speller.d
+++ b/compiler/src/dmd/root/speller.d
@@ -6,9 +6,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/speller.d, root/_speller.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/speller.d, root/_speller.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_speller.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/speller.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/speller.d
  */
 
 module dmd.root.speller;

--- a/compiler/src/dmd/root/string.d
+++ b/compiler/src/dmd/root/string.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/string.d, root/_string.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/string.d, root/_string.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_string.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/string.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/string.d
  */
 module dmd.root.string;
 

--- a/compiler/src/dmd/root/stringtable.d
+++ b/compiler/src/dmd/root/stringtable.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/stringtable.d, root/_stringtable.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/stringtable.d, root/_stringtable.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_stringtable.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/stringtable.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/stringtable.d
  */
 
 module dmd.root.stringtable;

--- a/compiler/src/dmd/root/strtold.d
+++ b/compiler/src/dmd/root/strtold.d
@@ -5,7 +5,7 @@
  *              Copyright (C) 2000-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/strtold.c, backend/strtold.c)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/strtold.d, backend/strtold.c)
  */
 
 module dmd.root.strtold;

--- a/compiler/src/dmd/root/utf.d
+++ b/compiler/src/dmd/root/utf.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/utf.d, _utf.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/root/utf.d, _utf.d)
  * Documentation:  https://dlang.org/phobos/dmd_root_utf.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/utf.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/root/utf.d
  */
 
 module dmd.root.utf;

--- a/compiler/src/dmd/rootobject.d
+++ b/compiler/src/dmd/rootobject.d
@@ -4,9 +4,9 @@
  * Copyright: Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/rootobject.d, _rootobject.d)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/rootobject.d, _rootobject.d)
  * Documentation:  https://dlang.org/phobos/dmd_rootobject.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/rootobject.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/rootobject.d
  */
 
 module dmd.rootobject;

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/tocsym.d, _s2ir.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/s2ir.d, _s2ir.d)
  * Documentation: $(LINK https://dlang.org/phobos/dmd_s2ir.html)
- * Coverage:    $(LINK https://codecov.io/gh/dlang/dmd/src/master/src/dmd/s2ir.d)
+ * Coverage:    $(LINK https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/s2ir.d)
  */
 
 module dmd.s2ir;

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/safe.d, _safe.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/safe.d, _safe.d)
  * Documentation:  https://dlang.org/phobos/dmd_safe.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/safe.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/safe.d
  */
 
 module dmd.safe;

--- a/compiler/src/dmd/sarif.d
+++ b/compiler/src/dmd/sarif.d
@@ -4,8 +4,8 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/sarif.d, sarif.d)
- * Coverage:    $(LINK2 https://codecov.io/gh/dlang/dmd/src/master/src/dmd/sarif.d, Code Coverage)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/sarif.d, sarif.d)
+ * Coverage:    $(LINK2 https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/sarif.d, Code Coverage)
  *
  * Description:
  * - This module generates SARIF reports for DMD errors, warnings, and messages.

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/semantic2.d, _semantic2.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/semantic2.d, _semantic2.d)
  * Documentation:  https://dlang.org/phobos/dmd_semantic2.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/semantic2.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/semantic2.d
  */
 
 module dmd.semantic2;

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/semantic3.d, _semantic3.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/semantic3.d, _semantic3.d)
  * Documentation:  https://dlang.org/phobos/dmd_semantic3.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/semantic3.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/semantic3.d
  */
 
 module dmd.semantic3;

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/sideeffect.d, _sideeffect.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/sideeffect.d, _sideeffect.d)
  * Documentation:  https://dlang.org/phobos/dmd_sideeffect.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/sideeffect.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/sideeffect.d
  */
 
 module dmd.sideeffect;

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/statement.d, _statement.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/statement.d, _statement.d)
  * Documentation:  https://dlang.org/phobos/dmd_statement.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/statement.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/statement.d
  */
 
 module dmd.statement;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/statementsem.d, _statementsem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/statementsem.d, _statementsem.d)
  * Documentation:  https://dlang.org/phobos/dmd_statementsem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/statementsem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/statementsem.d
  */
 
 module dmd.statementsem;

--- a/compiler/src/dmd/staticassert.d
+++ b/compiler/src/dmd/staticassert.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/staticassert.d, _staticassert.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/staticassert.d, _staticassert.d)
  * Documentation:  https://dlang.org/phobos/dmd_staticassert.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/staticassert.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/staticassert.d
  */
 
 module dmd.staticassert;

--- a/compiler/src/dmd/staticcond.d
+++ b/compiler/src/dmd/staticcond.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/staticcond.d, _staticcond.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/staticcond.d, _staticcond.d)
  * Documentation:  https://dlang.org/phobos/dmd_staticcond.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/staticcond.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/staticcond.d
  */
 
 module dmd.staticcond;

--- a/compiler/src/dmd/stmtstate.d
+++ b/compiler/src/dmd/stmtstate.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/stmtstate.d, _stmtstate.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/stmtstate.d, _stmtstate.d)
  * Documentation: https://dlang.org/phobos/dmd_stmtstate.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/stmtstate.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/stmtstate.d
  */
 
 module dmd.stmtstate;

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -18,9 +18,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/target.d, _target.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/target.d, _target.d)
  * Documentation:  https://dlang.org/phobos/dmd_target.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/target.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/target.d
  */
 
 module dmd.target;

--- a/compiler/src/dmd/templateparamsem.d
+++ b/compiler/src/dmd/templateparamsem.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/templateparamsem.d, _templateparamsem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/templateparamsem.d, _templateparamsem.d)
  * Documentation:  https://dlang.org/phobos/dmd_templateparamsem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/templateparamsem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/templateparamsem.d
  */
 
 module dmd.templateparamsem;

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/templatesem.d, _templatesem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/templatesem.d, _templatesem.d)
  * Documentation:  https://dlang.org/phobos/dmd_templatesem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/templatesem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/templatesem.d
  */
 
 module dmd.templatesem;

--- a/compiler/src/dmd/timetrace.d
+++ b/compiler/src/dmd/timetrace.d
@@ -9,9 +9,9 @@ This file is originally from LDC (the LLVM D compiler).
 Copyright: Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved
 Authors:   Johan Engelen, Max Haughton, Dennis Korpel
 License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
-Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/timetrace.d, common/_timetrace.d)
+Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/timetrace.d, common/_timetrace.d)
 Documentation: https://dlang.org/phobos/dmd_common_timetrace.html
-Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/timetrace.d
+Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/timetrace.d
 */
 module dmd.timetrace;
 

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/tocsym.d, _tocsym.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/tocsym.d, _tocsym.d)
  * Documentation:  https://dlang.org/phobos/dmd_tocsym.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/tocsym.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/tocsym.d
  */
 
 module dmd.tocsym;

--- a/compiler/src/dmd/toctype.d
+++ b/compiler/src/dmd/toctype.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/toctype.d, _toctype.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/toctype.d, _toctype.d)
  * Documentation:  https://dlang.org/phobos/dmd_toctype.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/toctype.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/toctype.d
  */
 
 module dmd.toctype;

--- a/compiler/src/dmd/tocvdebug.d
+++ b/compiler/src/dmd/tocvdebug.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/tocsym.d, _tocvdebug.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/tocvdebug.d, _tocvdebug.d)
  * Documentation:  https://dlang.org/phobos/dmd_tocvdebug.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/tocvdebug.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/tocvdebug.d
  */
 
 module dmd.tocvdebug;

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -5,9 +5,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/todt.d, _todt.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/todt.d, _todt.d)
  * Documentation:  https://dlang.org/phobos/dmd_todt.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/todt.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/todt.d
  */
 
 module dmd.todt;

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/_tocsym.d, _toir.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/toir.d, _toir.d)
  * Documentation:  https://dlang.org/phobos/dmd_toir.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/toir.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/toir.d
  */
 
 module dmd.toir;

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/tokens.d, _tokens.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/tokens.d, _tokens.d)
  * Documentation:  https://dlang.org/phobos/dmd_tokens.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/tokens.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/tokens.d
  */
 
 module dmd.tokens;

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/tocsym.d, _toobj.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/toobj.d, _toobj.d)
  * Documentation:  https://dlang.org/phobos/dmd_toobj.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/toobj.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/toobj.d
  */
 
 module dmd.toobj;

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -6,9 +6,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/traits.d, _traits.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/traits.d, _traits.d)
  * Documentation:  https://dlang.org/phobos/dmd_traits.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/traits.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/traits.d
  */
 
 module dmd.traits;

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/typesem.d, _typesem.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/typesem.d, _typesem.d)
  * Documentation:  https://dlang.org/phobos/dmd_typesem.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/typesem.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/typesem.d
  */
 
 module dmd.typesem;

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/typinf.d, _typinf.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/typinf.d, _typinf.d)
  * Documentation:  https://dlang.org/phobos/dmd_typinf.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/typinf.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/typinf.d
  */
 
 module dmd.typinf;

--- a/compiler/src/dmd/utils.d
+++ b/compiler/src/dmd/utils.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/utils.d, _utils.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/utils.d, _utils.d)
  * Documentation:  https://dlang.org/phobos/dmd_utils.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/utils.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/utils.d
  */
 
 module dmd.utils;

--- a/compiler/src/dmd/visitor/foreachvar.d
+++ b/compiler/src/dmd/visitor/foreachvar.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/foreachvar.d, _foreachvar.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/visitor/foreachvar.d, _foreachvar.d)
  * Documentation:  https://dlang.org/phobos/dmd_foreachvar.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/foreachvar.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/visitor/foreachvar.d
  */
 
 module dmd.visitor.foreachvar;

--- a/compiler/src/dmd/visitor/package.d
+++ b/compiler/src/dmd/visitor/package.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/visitor.d, _visitor.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/visitor/package.d, _visitor.d)
  * Documentation:  https://dlang.org/phobos/dmd_visitor.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/visitor.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/visitor/package.d
  */
 
 module dmd.visitor;

--- a/compiler/src/dmd/visitor/postorder.d
+++ b/compiler/src/dmd/visitor/postorder.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/apply.d, _apply.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/visitor/postorder.d, _apply.d)
  * Documentation:  https://dlang.org/phobos/dmd_apply.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/apply.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/visitor/postorder.d
  */
 
 module dmd.visitor.postorder;

--- a/compiler/src/dmd/visitor/statement_rewrite_walker.d
+++ b/compiler/src/dmd/visitor/statement_rewrite_walker.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/statement_rewrite_walker.d, _statement_rewrite_walker.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/visitor/statement_rewrite_walker.d, _statement_rewrite_walker.d)
  * Documentation:  https://dlang.org/phobos/dmd_statement_rewrite_walker.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/statement_rewrite_walker.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/visitor/statement_rewrite_walker.d
  */
 
 module dmd.visitor.statement_rewrite_walker;

--- a/compiler/src/dmd/vsoptions.d
+++ b/compiler/src/dmd/vsoptions.d
@@ -4,9 +4,9 @@
  * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/link.d, _vsoptions.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/vsoptions.d, _vsoptions.d)
  * Documentation:  https://dlang.org/phobos/dmd_vsoptions.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/vsoptions.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/vsoptions.d
  */
 
 module dmd.vsoptions;


### PR DESCRIPTION
I tried to be conservative in updating those links.

This PR should affect https://dlang.org/phobos/dmd_access.html and other dmd_*.html pages
