### PR TITLE
pow: Ensure side effects are evaluated in e1^^0 rewrite

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12818,11 +12818,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 result = ex;
                 return;
             }
-            // Replace e1 ^^ 0 with 1
+            // Replace e1 ^^ 0 with (e1, 1)
             else if (expo == 0)
             {
-                Expression ex = one;
-                ex.loc = exp.loc;
+                Expression ex = new CommaExp(exp.loc, pe.e1, one, exp);
                 ex = ex.expressionSemantic(sc);
                 result = ex;
                 return;

--- a/compiler/test/runnable/powinline.d
+++ b/compiler/test/runnable/powinline.d
@@ -35,10 +35,30 @@ void test3()
     static assert(4.0 ^^ -1 == 0.25);
 }
 
+void test4()
+{
+    // Test that LHS side effects are evaluated.
+    int count = 0;
+    double x()
+    {
+        count++;
+        return 8.0;
+    }
+    assert(x ^^ -1 == 1.0 / 8.0);
+    assert(count == 1);
+    assert(x ^^ 0 == 1.0);
+    assert(count == 2);
+    assert(x ^^ 1 == 8.0);
+    assert(count == 3);
+    assert(x ^^ 2 == 64.0);
+    assert(count == 4);
+}
+
 extern(C) void main()
 {
     test1();
     test2();
     test3();
+    test4();
     printf("Success\n");
 }


### PR DESCRIPTION
Thanks @faresbakhit for implementing this, only a minor detail was forgotten.

This is to prevent regressions in the `e1 ^^ 0` case.