### PR TITLE
Improve error message when cl.exe is missing on Windows

### DIFF
--- a/compiler/src/dmd/cpreprocess.d
+++ b/compiler/src/dmd/cpreprocess.d
@@ -123,7 +123,7 @@ private const(char)[] cppCommand()
             //if the path to cl.exe is found, check if cl.exe is in the path.
             if(FileName.exists(path) != 1)
             {
-                error(Loc.initial, "Error: cl.exe not found. Ensure that Visual Studio is installed and properly configured");
+                error(Loc.initial, "cl.exe not found. Please ensure that Visual Studio Build Tools are installed and properly configured.");
                 fatal();
             }
             return toDString(path);

--- a/compiler/src/dmd/cpreprocess.d
+++ b/compiler/src/dmd/cpreprocess.d
@@ -120,6 +120,12 @@ private const(char)[] cppCommand()
             VSOptions vsopt;
             vsopt.initialize();
             const path = vsopt.compilerPath(target.isX86_64);
+            //if the path to cl.exe is found, check if cl.exe is in the path.
+            if(FileName.exists(path) != 1)
+            {
+                error(Loc.initial, "Error: cl.exe not found. Ensure that Visual Studio is installed and properly configured");
+                fatal();
+            }
             return toDString(path);
         }
         // Perhaps we are cross-compiling.

--- a/compiler/src/dmd/cpreprocess.d
+++ b/compiler/src/dmd/cpreprocess.d
@@ -123,7 +123,7 @@ private const(char)[] cppCommand()
             //if the path to cl.exe is found, check if cl.exe is in the path.
             if(FileName.exists(path) != 1)
             {
-                error(Loc.initial, "Error: cl.exe not found. Ensure that Visual Studio is installed and properly configured");
+                error(Loc.initial, "Error: cl.exe not found. Please ensure that Visual Studio Build Tools are installed and properly configured.");
                 fatal();
             }
             return toDString(path);

--- a/compiler/src/dmd/vsoptions.d
+++ b/compiler/src/dmd/vsoptions.d
@@ -26,8 +26,6 @@ import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
 import dmd.root.string : toDString;
-import dmd.errors;
-import dmd.location;
 
 private immutable supportedPre2017Versions = ["14.0", "12.0", "11.0", "10.0", "9.0"];
 

--- a/compiler/src/dmd/vsoptions.d
+++ b/compiler/src/dmd/vsoptions.d
@@ -193,7 +193,7 @@ extern(C++) struct VSOptions
     * Params:
     *   x64 = target architecture (x86 if false)
     * Returns:
-    *   absolute path to cl.exe, an error message along with "cl.exe" if not found
+    *   absolute path to cl.exe, and just "cl.exe" if not found
     */
     const(char)* compilerPath(bool x64)
     {
@@ -205,11 +205,7 @@ extern(C++) struct VSOptions
             cmdbuf.writestring(r"\cl.exe");
             return cmdbuf.extractChars();
         }
-        //Display an error message if path to cl.exe not found
-        error(Loc.initial, "Error: cl.exe not found. Ensure that Visual Studio is installed and properly configured.");
-        fatal();
-        //This return statement is never reached, but satisfies the function signature.
-        return null;
+        return "cl.exe";
     }
 
 private:

--- a/compiler/src/dmd/vsoptions.d
+++ b/compiler/src/dmd/vsoptions.d
@@ -26,6 +26,9 @@ import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
 import dmd.root.string : toDString;
+import dmd.errors;
+import dmd.location;
+import core.stdc.stdlib : exit;
 
 private immutable supportedPre2017Versions = ["14.0", "12.0", "11.0", "10.0", "9.0"];
 
@@ -191,7 +194,7 @@ extern(C++) struct VSOptions
     * Params:
     *   x64 = target architecture (x86 if false)
     * Returns:
-    *   absolute path to cl.exe, just "cl.exe" if not found
+    *   absolute path to cl.exe, an error message along with "cl.exe" if not found
     */
     const(char)* compilerPath(bool x64)
     {
@@ -203,7 +206,11 @@ extern(C++) struct VSOptions
             cmdbuf.writestring(r"\cl.exe");
             return cmdbuf.extractChars();
         }
-        return "cl.exe";
+        //Display an error message if path to cl.exe not found
+        error(Loc.initial, "Error: cl.exe not found. Ensure that Visual Studio is installed and properly configured.");
+        exit(1);
+        //This return statement is never reached, but satisfies the function signature.
+        return null;
     }
 
 private:

--- a/compiler/src/dmd/vsoptions.d
+++ b/compiler/src/dmd/vsoptions.d
@@ -28,7 +28,6 @@ import dmd.root.rmem;
 import dmd.root.string : toDString;
 import dmd.errors;
 import dmd.location;
-import core.stdc.stdlib : exit;
 
 private immutable supportedPre2017Versions = ["14.0", "12.0", "11.0", "10.0", "9.0"];
 
@@ -208,7 +207,7 @@ extern(C++) struct VSOptions
         }
         //Display an error message if path to cl.exe not found
         error(Loc.initial, "Error: cl.exe not found. Ensure that Visual Studio is installed and properly configured.");
-        exit(1);
+        fatal();
         //This return statement is never reached, but satisfies the function signature.
         return null;
     }

--- a/compiler/src/dmd/vsoptions.d
+++ b/compiler/src/dmd/vsoptions.d
@@ -206,7 +206,7 @@ extern(C++) struct VSOptions
             return cmdbuf.extractChars();
         }
         //Display an error message if path to cl.exe not found
-        error(Loc.initial, "Error: cl.exe not found. Ensure that Visual Studio is installed and properly configured.");
+        error(Loc.initial, "Error: cl.exe not found. Please ensure that Visual Studio Build Tools are installed and properly configured.");
         fatal();
         //This return statement is never reached, but satisfies the function signature.
         return null;


### PR DESCRIPTION
Fix #21083 

- In vsoptions.d: Modified compilerPath() to report an error and exit when path to cl.exe is not found.
- In cpreprocess.d: Updated cppCommand() to check for the existence of cl.exe using exists() and report an error if it's not found at the path returned by compilerPath()"

If not found, an error is reported with:
'Error: cl.exe not found. Ensure that Visual Studio is installed and properly configured.'

I have tested by renaming my 'cl.exe' to something else and then building dmd. Below is a screenshot of how the error is reported when building on windows.
![Screenshot 2025-03-30 152102](https://github.com/user-attachments/assets/b70023cd-bf97-4141-b58c-0b5bf3a1d933)

i am not sure how to create a testfile for this to include in "compiler/test", or should i create a test for this at all.

