### PR TITLE
[stable] build.d: Fix VERSION fallback if `git describe` fails

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -411,7 +411,7 @@ alias versionFile = makeRule!((builder, rule) {
                 return gitResult.output.strip;
         }
         // version fallback
-        return dmdRepo.buildPath("VERSION").readText;
+        return dmdRepo.buildPath("VERSION").readText.strip;
     });
     builder
     .target(env["G"].buildPath("VERSION"))

--- a/config.d
+++ b/config.d
@@ -55,7 +55,7 @@ string generateVersion(const string versionFile)
     enum workDir = __FILE_FULL_PATH__.dirName;
     const result = execute(["git", "-C", workDir, "describe", "--dirty"]);
 
-    return result.status == 0 ? result.output.strip : versionFile.readText;
+    return result.status == 0 ? result.output.strip : versionFile.readText.strip;
 }
 
 /**


### PR DESCRIPTION
`git describe --dirty` currently fails for GitHub Actions (at least for the `stable` branch), due to a *shallow* clone: https://github.com/dlang/dmd/blob/0b29c8a5bd76dd3bd23ec36dfdeb776705564523/.github/workflows/main.yml#L103-L105

```
fatal: No names found, cannot describe anything.
```

That then shows that the (non-generated) `VERSION` fallback was buggy, including the trailing newline, leading to 3 sarif-related compiler test failures.