### PR TITLE
Improve override suggestions to exclude final methods

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -986,6 +986,11 @@ void funcDeclarationSemantic(Scope* sc, FuncDeclaration funcdecl)
                         errorSupplemental(fd.loc, "Function `%s` contains errors in its declaration, therefore it cannot be correctly overridden",
                             fd.toPrettyChars());
                     }
+                    else if (fd.isFinalFunc())
+                    {
+                        // Don't suggest overriding a final method as it's not possible
+                        .error(funcdecl.loc, "%s `%s` does not override any function", funcdecl.kind, funcdecl.toPrettyChars);
+                    }
                     else
                     {
                         functionToBufferFull(cast(TypeFunction)(fd.type), buf1,

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -988,8 +988,43 @@ void funcDeclarationSemantic(Scope* sc, FuncDeclaration funcdecl)
                     }
                     else if (fd.isFinalFunc())
                     {
-                        // Don't suggest overriding a final method as it's not possible
+                        // When trying to override a final method, don't suggest it as a candidate(Issue #19613)
                         .error(funcdecl.loc, "%s `%s` does not override any function", funcdecl.kind, funcdecl.toPrettyChars);
+
+                        // Look for a non-final method with the same name to suggest as an alternative
+                        auto cdparent = fd.parent ? fd.parent.isClassDeclaration() : null;
+                        if (cdparent)
+                        {
+                            Dsymbol nonFinalAlt = null;
+
+                            auto overloadableSyms = cdparent.symtab.lookup(fd.ident);
+                            if (overloadableSyms)
+                            {
+                                // Check each overload to find one that's not final
+                                overloadApply(overloadableSyms, (Dsymbol s)
+                                {
+                                    if (auto funcAlt = s.isFuncDeclaration())
+                                    {
+                                        if (funcAlt != fd && !funcAlt.isFinalFunc())
+                                        {
+                                            nonFinalAlt = funcAlt;
+                                            return 1;
+                                        }
+                                    }
+                                    return 0;
+                                });
+
+                                // Provide a helpful suggestion if we found a viable alternative
+                                if (nonFinalAlt)
+                                {
+                                    auto funcAlt = nonFinalAlt.isFuncDeclaration();
+                                    OutBuffer buf2;
+                                    functionToBufferFull(cast(TypeFunction)(funcAlt.type), buf2,
+                                        new Identifier(funcAlt.toPrettyChars()), hgs, null);
+                                    errorSupplemental(funcdecl.loc, "Did you mean to override `%s`?", buf2.peekChars());
+                                }
+                            }
+                        }
                     }
                     else
                     {

--- a/compiler/test/fail_compilation/fix19613.d
+++ b/compiler/test/fail_compilation/fix19613.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation\fix19613.d(14): Error: function `fix19613.B.a` cannot override `final` function `fix19613.A.a`
+fail_compilation\fix19613.d(14): Error: function `fix19613.B.a` does not override any function
+---
+*/
+
+class A {
+        final void a(int) {}
+        void a(string) {}
+}
+class B : A {
+        override void a(int) {}
+}

--- a/compiler/test/fail_compilation/fix19613.d
+++ b/compiler/test/fail_compilation/fix19613.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation\fix19613.d(15): Error: function `fix19613.B.a` cannot override `final` function `fix19613.A.a`
-fail_compilation\fix19613.d(15): Error: function `fix19613.B.a` does not override any function
-fail_compilation\fix19613.d(15):        Did you mean to override `void fix19613.A.a(string)`?
+fail_compilation/fix19613.d(15): Error: function `fix19613.B.a` cannot override `final` function `fix19613.A.a`
+fail_compilation/fix19613.d(15): Error: function `fix19613.B.a` does not override any function
+fail_compilation/fix19613.d(15):        Did you mean to override `void fix19613.A.a(string)`?
 ---
 */
 

--- a/compiler/test/fail_compilation/fix19613.d
+++ b/compiler/test/fail_compilation/fix19613.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation\fix19613.d(14): Error: function `fix19613.B.a` cannot override `final` function `fix19613.A.a`
-fail_compilation\fix19613.d(14): Error: function `fix19613.B.a` does not override any function
+fail_compilation\fix19613.d(15): Error: function `fix19613.B.a` cannot override `final` function `fix19613.A.a`
+fail_compilation\fix19613.d(15): Error: function `fix19613.B.a` does not override any function
+fail_compilation\fix19613.d(15):        Did you mean to override `void fix19613.A.a(string)`?
 ---
 */
 


### PR DESCRIPTION
Fixes: https://github.com/dlang/dmd/issues/19613
This change prevents suggesting final methods as override candidates, making error messages more accurate and helpful for users. Instead of suggesting  an impossible override, the compiler now simply reports that no function was overridden without suggesting the final method. 
