### PR TITLE
fix #21153 - [REG 2.111.0] Infinite loop in isAliasThisTuple

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -655,7 +655,11 @@ TupleDeclaration isAliasThisTuple(Expression e)
                 return td;
         }
         if (Type att = t.aliasthisOf())
+        {
             t = att;
+            continue;
+        }
+        return null;
     }
 }
 

--- a/compiler/test/compilable/test21153.d
+++ b/compiler/test/compilable/test21153.d
@@ -1,0 +1,8 @@
+// https://github.com/dlang/dmd/issues/21153
+alias AliasSeq(TList...) = TList;
+class DataClass;
+void reduce(DataClass[] r)
+{
+    alias Args = AliasSeq!(DataClass);
+    Args result = r[0];
+}


### PR DESCRIPTION
Looking at https://github.com/dlang/dmd/pull/16868/files#diff-a556a8e6917dd4042f541bdb19673f96940149ec3d416b0156af4d0e4cc5e4bdL633-L655 - I think I can see where the "refactoring" went wrong.

@thewilsonator I'd rather revert the change to this function.