### PR TITLE
fix #21153 - [REG 2.111.0] Infinite loop in isAliasThisTuple

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -641,23 +641,23 @@ TupleDeclaration isAliasThisTuple(Expression e)
     Type t = e.type.toBasetype();
     while (true)
     {
-        Dsymbol s = t.toDsymbol(null);
-        if (!s)
-            return null;
-        auto ad = s.isAggregateDeclaration();
-        if (!ad)
-            return null;
-        s = ad.aliasthis ? ad.aliasthis.sym : null;
-        if (s && s.isVarDeclaration())
+        if (Dsymbol s = t.toDsymbol(null))
         {
-            TupleDeclaration td = s.isVarDeclaration().toAlias().isTupleDeclaration();
-            if (td && td.isexp)
-                return td;
-        }
-        if (Type att = t.aliasthisOf())
-        {
-            t = att;
-            continue;
+            if (auto ad = s.isAggregateDeclaration())
+            {
+                s = ad.aliasthis ? ad.aliasthis.sym : null;
+                if (s && s.isVarDeclaration())
+                {
+                    TupleDeclaration td = s.isVarDeclaration().toAlias().isTupleDeclaration();
+                    if (td && td.isexp)
+                        return td;
+                }
+                if (Type att = t.aliasthisOf())
+                {
+                    t = att;
+                    continue;
+                }
+            }
         }
         return null;
     }


### PR DESCRIPTION
Fixes the issue by way of reverting the "refactoring" in #16868.

Partially reverts the regressing change in 08901365d4. The "fixed"
refactoring should be applied to master/development branch.

Because fixing the refactoring might just introduce more bugs.

