### PR TITLE
Fixes compilation of ucontext_t-based fibers

### DIFF
--- a/druntime/src/core/thread/fiber/base.d
+++ b/druntime/src/core/thread/fiber/base.d
@@ -558,7 +558,7 @@ protected:
         //       of the executing thread.
         static ucontext_t       sm_utxt = void;
         ucontext_t              m_utxt  = void;
-        ucontext_t*             m_ucur  = null;
+        package ucontext_t*     m_ucur  = null;
     }
 
 


### PR DESCRIPTION
Fixes issue brought in https://github.com/dlang/dmd/pull/16695 (described in https://github.com/dlang/dmd/pull/16695#issuecomment-2358432942)

This is part of PR https://github.com/dlang/dmd/pull/20923. Just to speed up problem fix I cherry-picked part what does not raised any objections