### PR TITLE
`getrandom()` backwards compatibility shim

### DIFF
--- a/changelog/dmd.emulate_getrandom.dd
+++ b/changelog/dmd.emulate_getrandom.dd
@@ -1,0 +1,19 @@
+`getrandom()` backwards compatibility shim
+
+To restore compatibility with older Linux platforms where `getrandom()` is
+unavailable either due to an outdated kernel or a legacy C library, Phobos now
+ships with a shim that emulates a limited subset of `getrandom()` by reading
+random bytes from `/dev/urandom`.
+
+To enable the shim, build DMD and Phobos with the environment variable
+`LINUX_LEGACY_EMULATE_GETRANDOM` set to `1`.
+
+```
+cd phobos
+LINUX_LEGACY_EMULATE_GETRANDOM=1 make
+```
+
+While this is actually Phobos feature, proper enablement requires compiler
+support. This has been implemented by appending the version flag to the default
+compiler configuration found in `dmd.conf. Hence the DMD build script has been
+made aware of this new option as well.

--- a/changelog/dmd.emulate_getrandom.dd
+++ b/changelog/dmd.emulate_getrandom.dd
@@ -15,5 +15,5 @@ LINUX_LEGACY_EMULATE_GETRANDOM=1 make
 
 While this is actually Phobos feature, proper enablement requires compiler
 support. This has been implemented by appending the version flag to the default
-compiler configuration found in `dmd.conf. Hence the DMD build script has been
+compiler configuration found in `dmd.conf`. Hence the DMD build script has been
 made aware of this new option as well.

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -305,12 +305,16 @@ DFLAGS=%DFLAGS% -L/OPT:NOICF
     {
         enum confFile = "dmd.conf";
         enum conf = `[Environment32]
-DFLAGS=-I%@P%/../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/{OS}/{BUILD}/32{exportDynamic} -fPIC
+DFLAGS=-I%@P%/../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/{OS}/{BUILD}/32{exportDynamic}{extraVersions} -fPIC
 
 [Environment64]
-DFLAGS=-I%@P%/../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/{OS}/{BUILD}/64{exportDynamic} -fPIC
+DFLAGS=-I%@P%/../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/{OS}/{BUILD}/64{exportDynamic}{extraVersions} -fPIC
 `;
     }
+
+    const extraVersions = (env.getNumberedBool("LINUX_LEGACY_EMULATE_GETRANDOM"))
+        ? " -version=linux_legacy_emulate_getrandom"
+        : "";
 
     builder
         .name("dmdconf")
@@ -318,6 +322,7 @@ DFLAGS=-I%@P%/../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/
         .msg("(TX) DMD_CONF")
         .commandFunction(() {
             const expConf = conf
+                .replace("{extraVersions}", extraVersions)
                 .replace("{exportDynamic}", exportDynamic)
                 .replace("{BUILD}", env["BUILD"])
                 .replace("{OS}", env["OS"]);


### PR DESCRIPTION
People have been unhappy about the new `getrandom()` dependency.
Check out the sibling PR <https://github.com/dlang/phobos/pull/10741> for further details.