### PR TITLE
Templated _d_arrayshrinkfit implementation

### DIFF
--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -4002,7 +4002,7 @@ size_t reserve(T)(ref T[] arr, size_t newcapacity) pure nothrow @trusted
 
 // HACK:  This is a lie.  `_d_arrayshrinkfit` is not `nothrow`, but this lie is necessary
 // for now to prevent breaking code.
-private extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow;
+import core.internal.array.capacity: _d_arrayshrinkfit;
 
 /**
 Assume that it is safe to append to this array. Appends made to this array
@@ -4021,7 +4021,7 @@ Returns:
 */
 auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr) nothrow @system
 {
-    _d_arrayshrinkfit(typeid(T[]), *(cast(void[]*)&arr));
+    _d_arrayshrinkfit!T(*(cast(void[]*)&arr));
     return arr;
 }
 


### PR DESCRIPTION
Draft PR: Possible duplicate of #21152  This PR completely templatizes the _d_arrayshrinkfit hook and adds more unittests that cover good edge cases. This PR may be deleted if there is a conflict, and is therefore a draft.

This PR introduces a template version of the _d_arrayshrinkfit DRuntime Hook, often used as a call with `assumesafeappend`. 

Changes Made
1. Templated Hook: Implement a new template version of the hook in DRuntime
2. Change the lowering in the compiler (capacity.d) to use the templated version
3. Created unit-tests to check for any issues (tests all the edge cases I can think of)
4. Removed the old hook from DRuntime
