### PR TITLE
Moved OverDeclaration.isUnique to funcsem

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -27,7 +27,7 @@ import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
 import dmd.func;
-import dmd.funcsem : overloadApply, getLevelAndCheck;
+import dmd.funcsem : getLevelAndCheck;
 import dmd.globals;
 import dmd.gluelayer;
 import dmd.hdrgen;
@@ -781,25 +781,6 @@ extern (C++) final class OverDeclaration : Declaration
     override bool isOverloadable() const
     {
         return true;
-    }
-
-    Dsymbol isUnique()
-    {
-        Dsymbol result = null;
-        overloadApply(aliassym, (Dsymbol s)
-        {
-            if (result)
-            {
-                result = null;
-                return 1; // ambiguous, done
-            }
-            else
-            {
-                result = s;
-                return 0;
-            }
-        });
-        return result;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6822,7 +6822,6 @@ public:
     bool equals(const RootObject* const o) const override;
     bool overloadInsert(Dsymbol* s) override;
     bool isOverloadable() const override;
-    Dsymbol* isUnique();
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -3664,3 +3664,22 @@ extern (D) int overloadApply(Dsymbol fstart, scope int delegate(Dsymbol) dg, Sco
     }
     return overloadApplyRecurse(fstart, dg, sc);
 }
+
+Dsymbol isUnique(OverDeclaration od)
+{
+    Dsymbol result = null;
+    overloadApply(od.aliassym, (Dsymbol s)
+    {
+        if (result)
+        {
+            result = null;
+            return 1; // ambiguous, done
+        }
+        else
+        {
+            result = s;
+            return 0;
+        }
+    });
+    return result;
+}


### PR DESCRIPTION
Part of the project to separate semantic routines from AST nodes: https://github.com/dlang/project-ideas/blob/master/separate-semantic-routines-from-ast-nodes/description.md

@RazvanN7