### PR TITLE
Fix segmentation fault on macOS 15.4

### DIFF
--- a/changelog/druntime.macos-15-4-segfault.dd
+++ b/changelog/druntime.macos-15-4-segfault.dd
@@ -1,0 +1,7 @@
+Fixed generated binaries crashing on macOS 15.4
+
+macOS 15.4 has introduced an undocumented ABI change to the format of
+thread local variable section, which causes almost all executable built with
+previous D compiler versions to crash during initialization, if they use
+DRuntime. This release introduces a mitigation for this issue that is
+backwards compatible with previous versions of macOS.

--- a/druntime/src/rt/sections_darwin_64.d
+++ b/druntime/src/rt/sections_darwin_64.d
@@ -145,7 +145,13 @@ pthread_key_t firstTLVKey(const mach_header_64* header) pure nothrow @nogc
                 if ((section.flags & SECTION_TYPE) != S_THREAD_LOCAL_VARIABLES)
                     continue;
 
-                return section.firstTLVDescriptor(slide).key;
+                // NOTE: macOS 15.4 has started to fill the upper 32 bits of
+                // the `key` field with an additional number. Using the whole
+                // 64-bit field as a key results in a segmentation fault. Even
+                // though none of this appears to be documented anywhere, we
+                // assume that only the lower 32 bits are used for the actual
+                // key and this results in binaries that execute normally.
+                return section.firstTLVDescriptor(slide).key & 0xFFFF_FFFF;
             }
         }
 


### PR DESCRIPTION
This strips off additional bits that are not part of the actual TLV key to avoid applications using DRuntime crashing during initialization.

The discussion of this being a correct fix is still ongoing, but this represents the best solution so far.

Issue: #21126