### PR TITLE
Fix #21150 - ImportC: alignment value expected, not _Alignof

### DIFF
--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -1235,6 +1235,7 @@ extern (C++) class Dsymbol : ASTNode
             return null;
         }
     }
+    inout(AlignDeclaration)            isAlignDeclaration()            inout { return dsym == DSYM.alignDeclaration ? cast(inout(AlignDeclaration)) cast(void*) this : null; }
     inout(AnonDeclaration)             isAnonDeclaration()             inout { return dsym == DSYM.anonDeclaration ? cast(inout(AnonDeclaration)) cast(void*) this : null; }
     inout(CPPNamespaceDeclaration)     isCPPNamespaceDeclaration()     inout { return dsym == DSYM.cppNamespaceDeclaration ? cast(inout(CPPNamespaceDeclaration)) cast(void*) this : null; }
     inout(VisibilityDeclaration)       isVisibilityDeclaration()       inout { return dsym == DSYM.visibilityDeclaration ? cast(inout(VisibilityDeclaration)) cast(void*) this : null; }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -96,6 +96,7 @@ class Import;
 class EnumDeclaration;
 class SymbolDeclaration;
 class AttribDeclaration;
+class AlignDeclaration;
 class AnonDeclaration;
 class VisibilityDeclaration;
 class OverloadSet;
@@ -675,6 +676,7 @@ public:
     EnumDeclaration* isEnumDeclaration();
     SymbolDeclaration* isSymbolDeclaration();
     AttribDeclaration* isAttribDeclaration();
+    AlignDeclaration* isAlignDeclaration();
     AnonDeclaration* isAnonDeclaration();
     CPPNamespaceDeclaration* isCPPNamespaceDeclaration();
     VisibilityDeclaration* isVisibilityDeclaration();

--- a/compiler/test/compilable/test21150.c
+++ b/compiler/test/compilable/test21150.c
@@ -1,0 +1,43 @@
+// https://github.com/dlang/dmd/issues/21150
+
+struct S
+{
+        char            z[16][256];
+} __attribute__((aligned(_Alignof(unsigned int))));
+_Static_assert(_Alignof(struct S) == _Alignof(unsigned int), "S");
+
+struct T {
+    _Static_assert(1, "");
+    char x;
+} __attribute__((aligned(_Alignof(struct S))));
+
+_Static_assert(_Alignof(struct T) == _Alignof(unsigned int), "T");
+
+
+struct __attribute__ ((aligned(8))) Q {
+    short f[3];
+};
+_Static_assert(sizeof(struct Q) == 8, "Q1");
+_Static_assert(_Alignof(struct Q) == 8, "Q2");
+
+
+struct __attribute__ ((aligned(8))) R {
+    short f[3];
+    char c;
+};
+_Static_assert(sizeof(struct R) == 8, "R1");
+_Static_assert(_Alignof(struct R) == 8, "R2");
+
+struct C {
+    unsigned _Alignas(2) _Alignas(4) char c;
+}
+__attribute__((aligned(8)));
+
+_Static_assert(_Alignof(struct C)==8, "C");
+
+struct __attribute__((aligned(4))) D {
+    unsigned char c;
+}
+__attribute__((aligned(8)));
+
+_Static_assert(_Alignof(struct D)==8, "D");

--- a/compiler/test/fail_compilation/alignedext.i
+++ b/compiler/test/fail_compilation/alignedext.i
@@ -2,13 +2,10 @@
 ---
 fail_compilation/alignedext.i(10): Error: __decspec(align(123)) must be an integer positive power of 2 and be <= 8,192
 fail_compilation/alignedext.i(11): Error: __decspec(align(16384)) must be an integer positive power of 2 and be <= 8,192
-fail_compilation/alignedext.i(13): Error: __attribute__((aligned(123))) must be an integer positive power of 2 and be <= 32,768
-fail_compilation/alignedext.i(14): Error: __attribute__((aligned(65536))) must be an integer positive power of 2 and be <= 32,768
+
+
 ---
 */
 
 typedef struct __declspec(align(123)) S { int a; } S;
 struct __declspec(align(16384)) T { int a; };
-
-typedef struct __attribute__((aligned(123))) U { int a; } S;
-struct __attribute__((aligned(65536))) V { int a; };

--- a/compiler/test/fail_compilation/alignedext2.i
+++ b/compiler/test/fail_compilation/alignedext2.i
@@ -1,0 +1,9 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/alignedext2.i(8): Error: alignment must be an integer positive power of 2, not 0x7b
+fail_compilation/alignedext2.i(9): Error: alignment must be an integer positive power of 2, not 0x10000
+---
+*/
+
+typedef struct __attribute__((aligned(123))) U { int a; } S;
+struct __attribute__((aligned(65536))) V { int a; };


### PR DESCRIPTION
Fixes #21150.

The gnu attribute `aligned()` allows specifying the alignment of an entire struct, mostly as a syntatic convenience. This attribute allows compile-time integer expressions, but the parser was trying to evaluate them ahead of time by checking for an integer literal. Instead we need to preserve the expression and defer it to a later semantic stage. Accomplish this by emulating the behavior by specifying the alignment of the first member of the struct.

I didn't change how `__declspec(align(#))` parses as from the documentation it seems to only allow integer literals. Some light testing with cl.exe gives syntax errors when trying to use `_Alignof()` in that position.