### PR TITLE
ImportC: undefined identifier _Float16

### DIFF
--- a/compiler/test/compilable/stdcheaders.c
+++ b/compiler/test/compilable/stdcheaders.c
@@ -19,11 +19,9 @@
 #include <limits.h>
 #include <locale.h>
 
-#ifndef __APPLE__ // /Applications/Xcode-14.2.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/tgmath.h(39): Error: named parameter required before `...`
 #include <math.h>
 #ifndef _MSC_VER // C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\ucrt\corecrt_math.h(93): Error: reinterpretation through overlapped field `f` is not allowed in CTFE
 float x = NAN;
-#endif
 #endif
 
 #ifndef _MSC_VER // setjmp.h(51): Error: missing tag `identifier` after `struct

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -168,12 +168,12 @@ typedef unsigned long long __uint64_t;
  */
 #define __STDC_NO_VLA__ 1
 
+#define _Float16 float
 #if linux  // Microsoft won't allow the following macro
 // Ubuntu's assert.h uses this
 #define __PRETTY_FUNCTION__ __func__
 
 #ifndef __aarch64__
-#define _Float16 float
 #define _Float32 float
 #define _Float32x double
 #define _Float64 double


### PR DESCRIPTION
Fixes: https://github.com/dlang/dmd/issues/21183

The previous MR put the macro in a `#if linux` which meant it didn't actually solve the problem of being unable to `#include <math.h>` on macos. So put it in a better spot.

Also enable the test that includes that header for macos so that it stays solved.