### PR TITLE
ImportC: can't access members in static array

### DIFF
--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -126,6 +126,12 @@ Expression fieldLookup(Expression e, Scope* sc, Identifier id, bool arrow)
     e = e.expressionSemantic(sc);
     if (e.isErrorExp())
         return e;
+    if (arrow)
+    {
+        e = arrayFuncConv(e, sc);
+        if (e.isErrorExp())
+            return e;
+    }
 
     auto t = e.type;
     if (t.isTypePointer())

--- a/compiler/test/compilable/test20472.c
+++ b/compiler/test/compilable/test20472.c
@@ -1,0 +1,12 @@
+// https://github.com/dlang/dmd/issues/20472
+typedef struct {
+    char c;
+} stuff;
+
+char test20472(void)
+{
+    stuff s[1];
+    s->c = 1;
+    return s->c;
+}
+_Static_assert(test20472() == 1, "1");

--- a/compiler/test/compilable/testcstuff1.c
+++ b/compiler/test/compilable/testcstuff1.c
@@ -398,8 +398,9 @@ void* tests3()
 
 int tests4()
 {
-    struct S { int b; } a, *p;
-    a.b = 3;
+    struct S { int b; } a, *p, b[1];
+    b->b = 3;
+    a.b = b->b;
     p = &a;
     return p->b;
 }


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/20472

Arrays in C implicitly convert to a pointer to their first member, so do the implicit conversion when using them in an arrow member lookup.