### PR TITLE
Replace TimeDateStamp with deterministic hash for reproducible builds

### DIFF
--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -35,6 +35,7 @@ import dmd.backend.type;
 import dmd.backend.mscoff;
 
 import dmd.common.outbuffer;
+import dmd.common.blake3;
 
 nothrow:
 @safe:
@@ -673,8 +674,23 @@ void MsCoffObj_term(const(char)[] objfilename)
     BIGOBJ_HEADER header = void;
     IMAGE_FILE_HEADER header_old = void;
 
-    time_t f_timedat = 0;
-    time(&f_timedat);
+    // Use a hash of segment content instead of current timestamp for reproducible builds
+    ubyte[] hashInput;
+    for (segidx_t seg = 1; seg < SegData.length; seg++)
+    {
+        seg_data* pseg = SegData[seg];
+        if (pseg.SDbuf && pseg.SDbuf.length())
+        {
+            // Sample a few bytes from each segment
+            size_t bytesToAdd = pseg.SDbuf.length() >= 16 ? 16 : pseg.SDbuf.length();
+            hashInput.length += bytesToAdd;
+            memcpy(&hashInput[hashInput.length - bytesToAdd], pseg.SDbuf.buf, bytesToAdd);
+        }
+    }
+
+    // Blake3 hash the input and use first 4 bytes for timestamp field
+    ubyte[32] hashValue = blake3(hashInput);
+    uint deterministicTimestamp = *cast(uint*)&hashValue[0];
     uint symtable_offset;
 
     if (bigobj)
@@ -684,7 +700,7 @@ void MsCoffObj_term(const(char)[] objfilename)
         header.Version = 2;
         header.Machine = I64 ? IMAGE_FILE_MACHINE_AMD64 : IMAGE_FILE_MACHINE_I386;
         header.NumberOfSections = scnhdr_cnt;
-        header.TimeDateStamp = cast(uint)f_timedat;
+        header.TimeDateStamp = deterministicTimestamp;
         static immutable ubyte[16] uuid =
                                   [ '\xc7', '\xa1', '\xba', '\xd1', '\xee', '\xba', '\xa9', '\x4b',
                                     '\xaf', '\x20', '\xfa', '\xf6', '\x6a', '\xa4', '\xdc', '\xb8' ];
@@ -701,7 +717,7 @@ void MsCoffObj_term(const(char)[] objfilename)
     {
         header_old.Machine = I64 ? IMAGE_FILE_MACHINE_AMD64 : IMAGE_FILE_MACHINE_I386;
         header_old.NumberOfSections = cast(ushort)scnhdr_cnt;
-        header_old.TimeDateStamp = cast(uint)f_timedat;
+        header_old.TimeDateStamp = deterministicTimestamp;
         header_old.SizeOfOptionalHeader = 0;
         header_old.Characteristics = 0;
         foffset = (header_old).sizeof;   // start after header

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -35,7 +35,7 @@ import dmd.backend.type;
 import dmd.backend.mscoff;
 
 import dmd.common.outbuffer;
-import dmd.common.blake3;
+import dmd.root.hash;
 
 nothrow:
 @safe:
@@ -674,23 +674,28 @@ void MsCoffObj_term(const(char)[] objfilename)
     BIGOBJ_HEADER header = void;
     IMAGE_FILE_HEADER header_old = void;
 
-    // Use a hash of segment content instead of current timestamp for reproducible builds
-    ubyte[] hashInput;
-    for (segidx_t seg = 1; seg < SegData.length; seg++)
+    // Use a hash of the object content instead of current timestamp for reproducible builds
+    uint calcDeterministicTimestamp()
     {
-        seg_data* pseg = SegData[seg];
-        if (pseg.SDbuf && pseg.SDbuf.length())
+        uint hash = 0;
+
+        // Hash each segment
+        for (segidx_t seg = 1; seg < SegData.length; seg++)
         {
-            // Sample a few bytes from each segment
-            size_t bytesToAdd = pseg.SDbuf.length() >= 16 ? 16 : pseg.SDbuf.length();
-            hashInput.length += bytesToAdd;
-            memcpy(&hashInput[hashInput.length - bytesToAdd], pseg.SDbuf.buf, bytesToAdd);
+            seg_data* pseg = SegData[seg];
+            if (pseg.SDbuf && pseg.SDbuf.length())
+            {
+                uint segHash = calcHash(cast(const(ubyte)[])pseg.SDbuf.buf[0..pseg.SDbuf.length()]);
+
+                // Mix this segment's hash into the overall hash
+                hash = cast(uint)mixHash(hash, segHash);
+            }
         }
+
+        return hash;
     }
 
-    // Blake3 hash the input and use first 4 bytes for timestamp field
-    ubyte[32] hashValue = blake3(hashInput);
-    uint deterministicTimestamp = *cast(uint*)&hashValue[0];
+    uint deterministicTimestamp = calcDeterministicTimestamp();
     uint symtable_offset;
 
     if (bigobj)


### PR DESCRIPTION
fixes: https://github.com/dlang/dmd/issues/21095
I replaced the time-based TimeDateStamp in `mscoffobj.d` files with a deterministic hash derived from the object file's content.
Implemented a deterministic hash generation system using Blake3.
Used the first 4 bytes of the resulting hash as the TimeDateStamp value.

For Testing - 
I compiled the same code at different times, and the object file was the same hash.
```
abulk@MSI MINGW64 ~/OneDrive/Desktop/hash
$ certutil -hashfile prog1.obj SHA256
SHA256 hash of prog1.obj:
9319df865f216e72e0f63407cae7e00ed08ae00e7b8a486ab34780a60020ec9a
CertUtil: -hashfile command completed successfully.

abulk@MSI MINGW64 ~/OneDrive/Desktop/hash
$ certutil -hashfile prog2.obj SHA256
SHA256 hash of prog2.obj:
9319df865f216e72e0f63407cae7e00ed08ae00e7b8a486ab34780a60020ec9a
CertUtil: -hashfile command completed successfully.
```