### PR TITLE
dcast.d: Improve pointer conversion error messages

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -174,7 +174,7 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
                         errorSupplemental(e.loc, "Note: Converting const to mutable requires an explicit cast (`cast(int*)`).");
                         return ErrorExp.get();
                     }
-                    // Incompatible pointee types (e.g., int* -> float*)
+                    // Incompatible pointee types (e.g., int* -> float* )
                     else if (fromPointee.toBasetype().ty != toPointee.toBasetype().ty)
                     {
                         error(e.loc, "cannot implicitly convert `%s` to `%s`", e.type.toChars(), t.toChars());

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -170,26 +170,19 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
                     // Const -> mutable conversion (disallowed)
                     if (fromPointee.isConst() && !toPointee.isConst())
                     {
-                        error(e.loc, "cannot implicitly convert `%s` to `%s`", 
-                            e.type.toChars(), t.toChars());
-                        errorSupplemental(e.loc, 
-                            "Note: Converting const to mutable requires an explicit cast (`cast(int*)`).");
+                        error(e.loc, "cannot implicitly convert `%s` to `%s`", e.type.toChars(), t.toChars());
+                        errorSupplemental(e.loc, "Note: Converting const to mutable requires an explicit cast (`cast(int*)`).");
                         return ErrorExp.get();
                     }
-                    
                     // Incompatible pointee types (e.g., int* -> float*)
                     else if (fromPointee.toBasetype().ty != toPointee.toBasetype().ty)
                     {
-                        error(e.loc, "cannot implicitly convert `%s` to `%s`", 
-                            e.type.toChars(), t.toChars());
-                        errorSupplemental(e.loc, 
-                            "Note: Pointer types point to different base types (`%s` vs `%s`)",
-                            fromPointee.toChars(), toPointee.toChars());
+                        error(e.loc, "cannot implicitly convert `%s` to `%s`", e.type.toChars(), t.toChars());
+                        errorSupplemental(e.loc, "Note: Pointer types point to different base types (`%s` vs `%s`)", fromPointee.toChars(), toPointee.toChars());
                         return ErrorExp.get();
                     }
                 }
-                error(e.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`",
-                    e.toErrMsg(), ts[0], ts[1]);
+                error(e.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`", e.toErrMsg(), ts[0], ts[1]);
             }
         }
         return ErrorExp.get();

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -161,6 +161,33 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
                     return ErrorExp.get();
                 }
 
+                // Special case for pointer conversions
+                if (e.type.toBasetype().ty == Tpointer && t.toBasetype().ty == Tpointer)
+                {
+                    Type fromPointee = e.type.nextOf();
+                    Type toPointee = t.nextOf();
+
+                    // Const -> mutable conversion (disallowed)
+                    if (fromPointee.isConst() && !toPointee.isConst())
+                    {
+                        error(e.loc, "cannot implicitly convert `%s` to `%s`", 
+                            e.type.toChars(), t.toChars());
+                        errorSupplemental(e.loc, 
+                            "Note: Converting const to mutable requires an explicit cast (`cast(int*)`).");
+                        return ErrorExp.get();
+                    }
+                    
+                    // Incompatible pointee types (e.g., int* -> float*)
+                    else if (fromPointee.toBasetype().ty != toPointee.toBasetype().ty)
+                    {
+                        error(e.loc, "cannot implicitly convert `%s` to `%s`", 
+                            e.type.toChars(), t.toChars());
+                        errorSupplemental(e.loc, 
+                            "Note: Pointer types point to different base types (`%s` vs `%s`)",
+                            fromPointee.toChars(), toPointee.toChars());
+                        return ErrorExp.get();
+                    }
+                }
                 error(e.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`",
                     e.toErrMsg(), ts[0], ts[1]);
             }

--- a/compiler/test/fail_compilation/diag_pointer_conversion.d
+++ b/compiler/test/fail_compilation/diag_pointer_conversion.d
@@ -1,0 +1,17 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/diag_in_array.d(15): Error: cannot implicitly convert `const(int)*` to `int*`
+fail_compilation/diag_in_array.d(15):        Note: Converting const to mutable requires an explicit cast (`cast(int*)`).
+fail_compilation/diag_in_array.d(16): Error: cannot implicitly convert `int*` to `float*`
+fail_compilation/diag_in_array.d(16):        Note: Pointer types point to different base types (`int` vs `float`)
+---
+*/
+
+void testPointerConversions()
+{
+    int* p;
+    const(int)* cp = p;
+    p = cp;
+    float* f = p;
+}


### PR DESCRIPTION
## Improved Pointer Conversion Errors

### Changes
- Added actionable notes:
  - For const → mutable conversions: suggests explicit cast
  - For type mismatches: shows conflicting base types

### Testing
Added test case in `test/fail_compilation/diag_pointer_conversion.d` verifying:
1. const → mutable pointer error
2. int* → float* type mismatch error