### PR TITLE
ImportC: Fix interaction of aligned and packed structs.

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -3775,13 +3775,14 @@ struct ASTBase
         TOK tok;
         Identifier id;
         structalign_t packalign;
+        Expressions* alignExps;
         Dsymbols* members;
         Type base;
 
         Type resolved;
         MOD mod;
 
-        extern (D) this(Loc loc, TOK tok, Identifier id, structalign_t packalign, Type base, Dsymbols* members)
+        extern (D) this(Loc loc, TOK tok, Identifier id, structalign_t packalign, Expressions* alignExps, Type base, Dsymbols* members)
         {
             //printf("TypeTag %p\n", this);
             super(Ttag);
@@ -3789,6 +3790,7 @@ struct ASTBase
             this.tok = tok;
             this.id = id;
             this.packalign = packalign;
+            this.alignExps = alignExps;
             this.base = base;
             this.members = members;
             this.mod = 0;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4850,6 +4850,7 @@ public:
     Loc loc;
     TOK tok;
     structalign_t packalign;
+    Array<Expression* >* alignExps;
     Identifier* id;
     Type* base;
     Array<Dsymbol* >* members;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -3761,6 +3761,7 @@ extern (C++) final class TypeTag : Type
     Loc loc;                /// location of declaration
     TOK tok;                /// TOK.struct_, TOK.union_, TOK.enum_
     structalign_t packalign; /// alignment of struct/union fields
+    Expressions* alignExps; /// alignment of struct itself
     Identifier id;          /// tag name identifier
     Type base;              /// base type for enums otherwise null
     Dsymbols* members;      /// members of struct, null if none
@@ -3770,7 +3771,7 @@ extern (C++) final class TypeTag : Type
                             ///   struct S { int a; } s1, *s2;
     MOD mod;                /// modifiers to apply after type is resolved (only MODFlags.const_ at the moment)
 
-    extern (D) this(Loc loc, TOK tok, Identifier id, structalign_t packalign, Type base, Dsymbols* members) @safe
+    extern (D) this(Loc loc, TOK tok, Identifier id, structalign_t packalign, Expressions* alignExps, Type base, Dsymbols* members) @safe
     {
         //printf("TypeTag ctor %s %p\n", id ? id.toChars() : "null".ptr, this);
         super(Ttag);
@@ -3778,6 +3779,7 @@ extern (C++) final class TypeTag : Type
         this.tok = tok;
         this.id = id;
         this.packalign = packalign;
+        this.alignExps = alignExps;
         this.base = base;
         this.members = members;
         this.mod = 0;

--- a/compiler/test/compilable/test21150.c
+++ b/compiler/test/compilable/test21150.c
@@ -41,3 +41,37 @@ struct __attribute__((aligned(4))) D {
 __attribute__((aligned(8)));
 
 _Static_assert(_Alignof(struct D)==8, "D");
+//
+// Interaction of aligned() and packed
+//
+#include <stddef.h>
+ struct Spacked {
+     unsigned a;
+     unsigned long long b;
+ } __attribute__((aligned(4), packed));
+_Static_assert(_Alignof(struct Spacked) == 4, "Spacked");
+_Static_assert(_Alignof(struct Spacked) == 4, "Spacked");
+_Static_assert(offsetof(struct Spacked, a) == 0, "Spacked.a");
+_Static_assert(offsetof(struct Spacked, b) == sizeof(unsigned), "Spacked.b");
+_Static_assert(sizeof(struct Spacked) == sizeof(unsigned) + sizeof(unsigned long long), "sizeof(Spacked)");
+
+struct __attribute__((aligned(4))) Spacked2 {
+    unsigned a;
+    unsigned long long b;
+} __attribute__((packed));
+_Static_assert(_Alignof(struct Spacked2) == 4, "Spacked2");
+_Static_assert(offsetof(struct Spacked2, a) == 0, "Spacked2.a");
+_Static_assert(offsetof(struct Spacked2, b) == sizeof(unsigned), "Spacked2.b");
+_Static_assert(sizeof(struct Spacked2) == sizeof(unsigned) + sizeof(unsigned long long), "sizeof(Spacked2)");
+
+#pragma pack(push)
+#pragma pack(1)
+struct __attribute__((aligned(4))) Spacked3 {
+    unsigned a;
+    unsigned long long b;
+};
+#pragma pack(pop)
+_Static_assert(_Alignof(struct Spacked3) == 4, "Spacked3");
+_Static_assert(offsetof(struct Spacked3, a) == 0, "Spacked3.a");
+_Static_assert(offsetof(struct Spacked3, b) == sizeof(unsigned), "Spacked3.b");
+_Static_assert(sizeof(struct Spacked3) == sizeof(unsigned) + sizeof(unsigned long long), "sizeof(Spacked3)");


### PR DESCRIPTION
Previous iteration of this did not properly account for the interaction of aligned and packed and would even segfault on a null access in such a case. This version properly handles that interaction by aligning the struct itself instead of the first member and not forcing the struct alignment to 1 if it is packed.

--- 

I accidentally introduced this in https://github.com/dlang/dmd/pull/21180
