### PR TITLE
backend: Remove void initialization from `code` vars

### DIFF
--- a/compiler/src/dmd/backend/arm/cod2.d
+++ b/compiler/src/dmd/backend/arm/cod2.d
@@ -1375,7 +1375,7 @@ void getoffset(ref CGstate cg, ref CodeBuilder cdb,elem* e,reg_t reg)
 {
     enum log = false;
     if (log) printf("getoffset(e = %p, reg = %s)\n", e, regm_str(mask(reg)));
-    code cs = void;
+    code cs;
     cs.Iflags = 0;
     ubyte rex = 0;
     cs.Irex = rex;
@@ -1417,7 +1417,7 @@ static if (0)
                      *   LEA DI,s@TLSGD[RIP]
                      */
                     //assert(reg == DI);
-                    code css = void;
+                    code css;
                     css.Irex = REX | REX_W;
                     css.Iop = LEA;
                     css.Irm = modregrm(0,reg,5);
@@ -1436,7 +1436,7 @@ static if (0)
                      */
                     assert(reg == AX);
                     load_localgot(cdb);
-                    code css = void;
+                    code css;
                     css.Iflags = 0;
                     css.Iop = LEA;             // LEA
                     css.Irex = 0;
@@ -1466,7 +1466,7 @@ static if (0)
                 stack = 1;
             }
 
-            code css = void;
+            code css;
             css.Irex = rex;
             css.Iop = 0x8B;
             css.Irm = modregrm(0, 0, BPRM);

--- a/compiler/src/dmd/backend/x86/cg87.d
+++ b/compiler/src/dmd/backend/x86/cg87.d
@@ -3806,7 +3806,7 @@ void cload87(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
     }
 
     tym_t ty = tybasic(e.Ety);
-    code cs = void;
+    code cs;
     uint mf;
     uint sz;
     ubyte ldop;

--- a/compiler/src/dmd/backend/x86/cgxmm.d
+++ b/compiler/src/dmd/backend/x86/cgxmm.d
@@ -1920,7 +1920,7 @@ void cloadxmm(ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
     if (pretregs == (mXMM0 | mXMM1) &&
         e.Eoper != OPconst)
     {
-        code cs = void;
+        code cs;
         tym_t tym = tybasic(e.Ety);
         tym_t ty = tym == TYcdouble ? TYdouble : TYfloat;
         opcode_t opmv = xmmload(tym, xmmIsAligned(e));

--- a/compiler/src/dmd/backend/x86/cod2.d
+++ b/compiler/src/dmd/backend/x86/cod2.d
@@ -285,7 +285,7 @@ void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
         // Handle the case of (var & const)
         if (e2.Eoper == OPconst && el_signx32(e2))
         {
-            code cs = void;
+            code cs;
             cs.Iflags = 0;
             cs.Irex = 0;
             getlvalue(cdb,cs,e1,0);
@@ -324,7 +324,7 @@ void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
         regm_t retregs;
         if (isregvar(e2,retregs,reg))
         {
-            code cs = void;
+            code cs;
             cs.Iflags = 0;
             cs.Irex = 0;
             getlvalue(cdb,cs,e1,0);
@@ -340,7 +340,7 @@ void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
         }
     }
 
-    code cs = void;
+    code cs;
     cs.Iflags = 0;
     cs.Irex = 0;
 
@@ -370,7 +370,7 @@ void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
         {
             const inc = e.Ecount != 0;
             nest += inc;
-            code csx = void;
+            code csx;
             getlvalue(cdb,csx,e,0);
             nest -= inc;
             const regx = allocreg(cdb,pretregs,ty);
@@ -943,7 +943,7 @@ void cdmul(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
     const uint grex = rex << 16;
     const OPER opunslng = I16 ? OPu16_32 : OPu32_64;
 
-    code cs = void;
+    code cs;
     cs.Iflags = 0;
     cs.Irex = 0;
 
@@ -1331,7 +1331,7 @@ void cddiv(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
     const ubyte rex = (I64 && sz == 8) ? REX_W : 0;
     const uint grex = rex << 16;
 
-    code cs = void;
+    code cs;
     cs.Iflags = 0;
     cs.IFL2 = FL.unde;
     cs.Irex = 0;
@@ -4756,7 +4756,7 @@ void getoffset(ref CGstate cg, ref CodeBuilder cdb,elem* e,reg_t reg)
         return dmd.backend.arm.cod2.getoffset(cg, cdb, e, reg);
 
     //printf("getoffset(e = %p, reg = %s)\n", e, regm_str(mask(reg)));
-    code cs = void;
+    code cs;
     cs.Iflags = 0;
     ubyte rex = 0;
     cs.Irex = rex;
@@ -4783,7 +4783,7 @@ void getoffset(ref CGstate cg, ref CodeBuilder cdb,elem* e,reg_t reg)
                      *   LEA DI,s@TLSGD[RIP]
                      */
                     //assert(reg == DI);
-                    code css = void;
+                    code css;
                     css.Irex = REX | REX_W;
                     css.Iop = LEA;
                     css.Irm = modregrm(0,reg,5);
@@ -4802,7 +4802,7 @@ void getoffset(ref CGstate cg, ref CodeBuilder cdb,elem* e,reg_t reg)
                      */
                     assert(reg == AX);
                     load_localgot(cdb);
-                    code css = void;
+                    code css;
                     css.Iflags = 0;
                     css.Iop = LEA;             // LEA
                     css.Irex = 0;
@@ -4832,7 +4832,7 @@ void getoffset(ref CGstate cg, ref CodeBuilder cdb,elem* e,reg_t reg)
                 stack = 1;
             }
 
-            code css = void;
+            code css;
             css.Irex = rex;
             css.Iop = 0x8B;
             css.Irm = modregrm(0, 0, BPRM);
@@ -5216,7 +5216,7 @@ void cdpost(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
     }
 
     //printf("cdpost(pretregs = %s)\n", regm_str(pretregs));
-    code cs = void;
+    code cs;
     const op = e.Eoper;                      // OPxxxx
     if (pretregs == 0)                        // if nothing to return
     {
@@ -5384,7 +5384,7 @@ if (config.exe & EX_windos)
     }
     else if (sz <= REGSIZE || tyfv(tyml))
     {
-        code cs2 = void;
+        code cs2;
 
         cs.Iop = 0x8B ^ isbyte;
         regm_t retregs = possregs & ~idxregs & pretregs;

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -6546,7 +6546,7 @@ private void pinholeopt_unittest()
     for (int i = 0; i < tests.length; i++)
     {   CS* pin  = &tests[i][0];
         CS* pout = &tests[i][1];
-        code cs = void;
+        code cs;
         memset(&cs, 0, cs.sizeof);
         if (pin.model)
         {

--- a/compiler/src/dmd/backend/x86/cod4.d
+++ b/compiler/src/dmd/backend/x86/cod4.d
@@ -1726,7 +1726,7 @@ void cddivass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
         return;
     }
 
-    code cs = void;
+    code cs;
 
     //printf("cddivass(e=%p, pretregs = %s)\n",e,regm_str(pretregs));
     char uns = tyuns(tyml) || tyuns(e2.Ety);
@@ -1864,7 +1864,7 @@ void cddivass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
             ulong m;
             int shpre;
             int shpost;
-            code cs = void;
+            code cs;
 
             if (udiv_coefficients(sz * 8, e2factor, &shpre, &m, &shpost))
             {
@@ -3752,7 +3752,7 @@ void cdshtlng(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
         else if (e1.Eoper == OPvar ||
             (e1.Eoper == OPind && !e1.Ecount))
         {
-            code cs = void;
+            code cs;
 
             if (I32 && op == OPu16_32 && config.flags4 & CFG4speed)
                 goto L2;
@@ -4545,7 +4545,7 @@ void cdbscan(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
     const tyml = tybasic(e.E1.Ety);
     const sz = _tysize[tyml];
     assert(sz == 2 || sz == 4 || sz == 8);
-    code cs = void;
+    code cs;
 
     if ((e.E1.Eoper == OPind && !e.E1.Ecount) || e.E1.Eoper == OPvar)
     {
@@ -4606,7 +4606,7 @@ void cdpopcnt(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
     const sz = _tysize[tyml];
     assert(sz == 2 || sz == 4 || (sz == 8 && I64));     // no byte op
 
-    code cs = void;
+    code cs;
     if ((e.E1.Eoper == OPind && !e.E1.Ecount) || e.E1.Eoper == OPvar)
     {
         getlvalue(cdb, cs, e.E1, 0, RM.load);     // get addressing mode
@@ -4748,7 +4748,7 @@ void cdcmpxchg(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs
         regm_t retregs = mCX|mBX;
         scodelem(cgstate,cdb,e2.E2,retregs,mDX|mAX,false);  // [CX,BX] = e2.E2
 
-        code cs = void;
+        code cs;
         getlvalue(cdb,cs,e1,mCX|mBX|mAX|mDX);        // get EA
 
         getregs(cdb,mDX|mAX);                 // CMPXCHG destroys these regs
@@ -4775,7 +4775,7 @@ void cdcmpxchg(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs
         regm_t retregs = (ALLREGS | mBP) & ~mAX;
         scodelem(cgstate,cdb,e2.E2,retregs,mAX,false);   // load rvalue in reg
 
-        code cs = void;
+        code cs;
         getlvalue(cdb,cs,e1,mAX | retregs); // get EA
 
         getregs(cdb,mAX);                  // CMPXCHG destroys AX
@@ -4842,7 +4842,7 @@ void cdprefetch(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretreg
 
     freenode(e.E2);
 
-    code cs = void;
+    code cs;
     getlvalue(cdb,cs,e1,0);
     cs.Iop = op;
     cs.Irm |= modregrm(0,reg,0);


### PR DESCRIPTION
It's not `@safe` since it contains pointers, and it's not like `code` is such a large struct that leaving a few fields uninitialized is a big win.