### PR TITLE
druntime: add support for musl RISCV64

### DIFF
--- a/druntime/src/core/stdc/fenv.d
+++ b/druntime/src/core/stdc/fenv.d
@@ -440,6 +440,11 @@ else version (CRuntime_Musl)
         }
         alias uint fexcept_t;
     }
+    else version (RICV64)
+    {
+        alias uint fenv_t;
+        alias uint fexcept_t;
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/druntime/src/core/sys/posix/signal.d
+++ b/druntime/src/core/sys/posix/signal.d
@@ -2763,6 +2763,11 @@ else version (CRuntime_Musl)
         enum MINSIGSTKSZ = 4096;
         enum SIGSTKSZ    = 16384;
     }
+    else version (RISCV64)
+    {
+        enum MINSIGSTKSZ = 2048;
+        enum SIGSTKSZ    = 8192;
+    }
     else
         static assert(0, "unimplemented");
 


### PR DESCRIPTION
Based on https://git.musl-libc.org/cgit/musl/tree/arch/riscv64/bits?h=v1.2.5

(we've been using this patch downstream in Alpine Linux since Sep 2024)