### PR TITLE
dcast.d: Improve pointer conversion error messages

### DIFF
--- a/compiler/test/fail_compilation/diag_ptr_conversion.d
+++ b/compiler/test/fail_compilation/diag_ptr_conversion.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-dmd/compiler/test/fail_compilation/diag_ptr_conversion.d(5): Error: cannot implicitly convert `const(int)*` to `int*`
-dmd/compiler/test/fail_compilation/diag_ptr_conversion.d(5):        Note: Converting const to mutable requires an explicit cast (`cast(int*)`).
-dmd/compiler/test/fail_compilation/diag_ptr_conversion.d(6): Error: cannot implicitly convert `int*` to `float*`
-dmd/compiler/test/fail_compilation/diag_ptr_conversion.d(6):        Note: Pointer types point to different base types (`int` vs `float`)
+fail_compilation/diag_ptr_conversion.d(15): Error: cannot implicitly convert `const(int)*` to `int*`
+fail_compilation/diag_ptr_conversion.d(15):        Note: Converting const to mutable requires an explicit cast (`cast(int*)`).
+fail_compilation/diag_ptr_conversion.d(16): Error: cannot implicitly convert `int*` to `float*`
+fail_compilation/diag_ptr_conversion.d(16):        Note: Pointer types point to different base types (`int` vs `float`)
 ---
 */
 

--- a/compiler/test/fail_compilation/diag_ptr_conversion.d
+++ b/compiler/test/fail_compilation/diag_ptr_conversion.d
@@ -1,0 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+dmd/compiler/test/fail_compilation/diag_ptr_conversion.d(5): Error: cannot implicitly convert `const(int)*` to `int*`
+dmd/compiler/test/fail_compilation/diag_ptr_conversion.d(5):        Note: Converting const to mutable requires an explicit cast (`cast(int*)`).
+dmd/compiler/test/fail_compilation/diag_ptr_conversion.d(6): Error: cannot implicitly convert `int*` to `float*`
+dmd/compiler/test/fail_compilation/diag_ptr_conversion.d(6):        Note: Pointer types point to different base types (`int` vs `float`)
+---
+*/
+
+void testPointerConversions()
+{
+    int* p;
+    const(int)* cp = p;  // Warn: mutable -> const
+    p = cp;              // Error: const -> mutable
+    float* f = p;        // Error: incompatible types
+}

--- a/compiler/test/fail_compilation/diag_ptr_conversion.d
+++ b/compiler/test/fail_compilation/diag_ptr_conversion.d
@@ -11,7 +11,7 @@ dmd/compiler/test/fail_compilation/diag_ptr_conversion.d(6):        Note: Pointe
 void testPointerConversions()
 {
     int* p;
-    const(int)* cp = p;  // Warn: mutable -> const
-    p = cp;              // Error: const -> mutable
-    float* f = p;        // Error: incompatible types
+    const(int)* cp = p;
+    p = cp;
+    float* f = p;
 }

--- a/compiler/test/fail_compilation/fail163.d
+++ b/compiler/test/fail_compilation/fail163.d
@@ -14,8 +14,8 @@ void test1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(24): Error: cannot implicitly convert `const(int***)` to `const(int)***`
-fail_compilation/fail163.d(24):        Note: Converting const to mutable requires an explicit cast (`cast(int*)`).
+fail_compilation/fail163.d(25): Error: cannot implicitly convert `const(int***)` to `const(int)***`
+fail_compilation/fail163.d(25):        Note: Converting const to mutable requires an explicit cast (`cast(int*)`).
 ---
 */
 void test2()
@@ -28,7 +28,7 @@ void test2()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(37): Error: cannot modify `const` expression `p`
+fail_compilation/fail163.d(38): Error: cannot modify `const` expression `p`
 ---
 */
 void test3()
@@ -41,7 +41,7 @@ void test3()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(50): Error: cannot implicitly convert expression `cp` of type `const(int)***[]` to `const(uint***)[]`
+fail_compilation/fail163.d(51): Error: cannot implicitly convert expression `cp` of type `const(int)***[]` to `const(uint***)[]`
 ---
 */
 void test4()
@@ -54,7 +54,7 @@ void test4()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(63): Error: cannot modify `const` expression `*p`
+fail_compilation/fail163.d(64): Error: cannot modify `const` expression `*p`
 ---
 */
 void test5()
@@ -67,8 +67,8 @@ void test5()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(76): Error: cannot implicitly convert expression `& x` of type `int*` to `immutable(int)*`
-fail_compilation/fail163.d(77): Error: cannot modify `immutable` expression `*p`
+fail_compilation/fail163.d(77): Error: cannot implicitly convert expression `& x` of type `int*` to `immutable(int)*`
+fail_compilation/fail163.d(78): Error: cannot modify `immutable` expression `*p`
 ---
 */
 void test6()
@@ -81,8 +81,8 @@ void test6()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(89): Error: cannot implicitly convert `const(int)*` to `int*`
-fail_compilation/fail163.d(89):        Note: Converting const to mutable requires an explicit cast (`cast(int*)`).
+fail_compilation/fail163.d(91): Error: cannot implicitly convert `const(int)*` to `int*`
+fail_compilation/fail163.d(91):        Note: Converting const to mutable requires an explicit cast (`cast(int*)`).
 ---
 */
 void test7()

--- a/compiler/test/fail_compilation/fail163.d
+++ b/compiler/test/fail_compilation/fail163.d
@@ -14,7 +14,8 @@ void test1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(24): Error: cannot implicitly convert expression `p` of type `const(int***)` to `const(int)***`
+fail_compilation/fail163.d(24): Error: cannot implicitly convert `const(int***)` to `const(int)***`
+fail_compilation/fail163.d(24):        Note: Converting const to mutable requires an explicit cast (`cast(int*)`).
 ---
 */
 void test2()
@@ -80,7 +81,8 @@ void test6()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(89): Error: cannot implicitly convert expression `& x` of type `const(int)*` to `int*`
+fail_compilation/fail163.d(89): Error: cannot implicitly convert `const(int)*` to `int*`
+fail_compilation/fail163.d(89):        Note: Converting const to mutable requires an explicit cast (`cast(int*)`).
 ---
 */
 void test7()


### PR DESCRIPTION
## Improved Pointer Conversion Errors

### Changes
- Show simplified type names (e.g., `const(int)*` instead of `expression of type const(int)*`).
- Added actionable notes:
  - For const → mutable conversions: suggests explicit cast
  - For type mismatches: shows conflicting base types

### Testing
Added test case in `test/fail_compilation/diag_pointer_conversion.d` verifying:
1. const → mutable pointer error
2. int* → float* type mismatch error