### PR TITLE
Report correct location for undefined identifiers in function return types

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -181,7 +181,7 @@ private void resolveHelper(TypeQualified mt, Loc loc, Scope* sc, Dsymbol s, Dsym
                      (id == Id._super && sc.getClassScope()))
                 error(loc, "undefined identifier `%s`, did you mean `typeof(%s)`?", p, p);
             else
-                error(loc, "undefined identifier `%s`", p);
+                error(mt.loc, "undefined identifier `%s`", p);
         }
         else {
             if (const n = cIncludeHint(id.toString()))

--- a/compiler/test/fail_compilation/b23686.d
+++ b/compiler/test/fail_compilation/b23686.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/b23686.d(107): Error: undefined identifier `eFN1`, did you mean template `eFN0()()`?
 fail_compilation/b23686.d(107): Error: `mixin(_error_)` does not give a valid type
 fail_compilation/b23686.d(115):        while looking for match for `eload!(int, 1)`
-fail_compilation/b23686.d(121): Error: undefined identifier `FNwtf`
+fail_compilation/b23686.d-mixin-121(121): Error: undefined identifier `FNwtf`
 fail_compilation/b23686.d(121): Error: `mixin(_error_)` does not give a valid type
 fail_compilation/b23686.d(126):        while looking for match for `load!"wtf"`
 ---

--- a/compiler/test/fail_compilation/fix21165.d
+++ b/compiler/test/fail_compilation/fix21165.d
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fix21165.d(9): Error: undefined identifier `foo`
+---
+*/
+
+// Test case from Issue #21165
+foo
+f() {}

--- a/compiler/test/fail_compilation/noreturn2.d
+++ b/compiler/test/fail_compilation/noreturn2.d
@@ -117,7 +117,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/noreturn2.d(130): Error: cannot create instance of interface `I`
 fail_compilation/noreturn2.d(133): Error: can only throw class objects derived from `Throwable`, not type `int[]`
-fail_compilation/noreturn2.d(138): Error: undefined identifier `UnkownException`
+fail_compilation/noreturn2.d(139): Error: undefined identifier `UnkownException`
 ---
 +/
 


### PR DESCRIPTION
Fix: https://github.com/dlang/dmd/issues/21165
I use the location stored in the type node (`mt.loc`) rather than the function declaration location when reporting undefined identifier errors. This ensures that error messages point directly to where the invalid type is declared.
Added test `fix21165.d`, which verifies the corrected error location. Also Fix an Existing test `fail_compilation/noreturn2.d `