### PR TITLE
Fix 21225: ImportC: macro interpreted as an enum conflicts with function

### DIFF
--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -548,7 +548,7 @@ Dsymbol handleSymbolRedeclarations(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsy
     auto vd2 = s2.isVarDeclaration(); // existing declaration
 
     if (vd && vd.isCmacro())
-        return vd2;
+        return s2;
 
     assert(!(vd2 && vd2.isCmacro()));
 

--- a/compiler/test/compilable/test21225.c
+++ b/compiler/test/compilable/test21225.c
@@ -1,0 +1,7 @@
+// https://github.com/dlang/dmd/issues/21225
+void x(void){
+}
+#define x 3
+
+typedef struct Foo {int y; } foo;
+#define foo 3


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/21225

Don't let C macro variable declarations shadow any symbol.