### PR TITLE
druntime: Move syscall bindings in perf_event to own module

### DIFF
--- a/druntime/mak/COPY
+++ b/druntime/mak/COPY
@@ -243,6 +243,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\sched.d \
 	$(IMPDIR)\core\sys\linux\stdio.d \
 	$(IMPDIR)\core\sys\linux\string.d \
+	$(IMPDIR)\core\sys\linux\syscall.d \
 	$(IMPDIR)\core\sys\linux\termios.d \
 	$(IMPDIR)\core\sys\linux\time.d \
 	$(IMPDIR)\core\sys\linux\timerfd.d \
@@ -263,6 +264,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\sys\mount.d \
 	$(IMPDIR)\core\sys\linux\sys\signalfd.d \
 	$(IMPDIR)\core\sys\linux\sys\socket.d \
+	$(IMPDIR)\core\sys\linux\sys\syscall.d \
 	$(IMPDIR)\core\sys\linux\sys\sysinfo.d \
 	$(IMPDIR)\core\sys\linux\sys\xattr.d \
 	$(IMPDIR)\core\sys\linux\sys\time.d \

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -238,6 +238,7 @@ SRCS=\
 	src\core\sys\linux\sched.d \
 	src\core\sys\linux\stdio.d \
 	src\core\sys\linux\string.d \
+	src\core\sys\linux\syscall.d \
 	src\core\sys\linux\termios.d \
 	src\core\sys\linux\time.d \
 	src\core\sys\linux\timerfd.d \
@@ -258,6 +259,7 @@ SRCS=\
 	src\core\sys\linux\sys\mount.d \
 	src\core\sys\linux\sys\signalfd.d \
 	src\core\sys\linux\sys\socket.d \
+	src\core\sys\linux\sys\syscall.d \
 	src\core\sys\linux\sys\sysinfo.d \
 	src\core\sys\linux\sys\xattr.d \
 	src\core\sys\linux\sys\time.d \

--- a/druntime/src/core/sys/linux/perf_event.d
+++ b/druntime/src/core/sys/linux/perf_event.d
@@ -13,82 +13,13 @@ nothrow:
 import core.sys.posix.sys.ioctl;
 import core.sys.posix.unistd;
 
-version (HPPA)    version = HPPA_Any;
-version (HPPA64)  version = HPPA_Any;
-version (PPC)     version = PPC_Any;
-version (PPC64)   version = PPC_Any;
-version (RISCV32) version = RISCV_Any;
-version (RISCV64) version = RISCV_Any;
-version (S390)    version = IBMZ_Any;
-version (SPARC)   version = SPARC_Any;
-version (SPARC64) version = SPARC_Any;
-version (SystemZ) version = IBMZ_Any;
-
-version (X86_64)
-{
-    version (D_X32)
-        enum __NR_perf_event_open = 0x40000000 + 298;
-    else
-        enum __NR_perf_event_open = 298;
-}
-else version (X86)
-{
-        enum __NR_perf_event_open = 336;
-}
-else version (ARM)
-{
-        enum __NR_perf_event_open = 364;
-}
-else version (AArch64)
-{
-        enum __NR_perf_event_open = 241;
-}
-else version (HPPA_Any)
-{
-        enum __NR_perf_event_open = 318;
-}
-else version (IBMZ_Any)
-{
-        enum __NR_perf_event_open = 331;
-}
-else version (MIPS32)
-{
-        enum __NR_perf_event_open = 4333;
-}
-else version (MIPS64)
-{
-    version (MIPS_N32)
-        enum __NR_perf_event_open = 6296;
-    else version (MIPS_N64)
-        enum __NR_perf_event_open = 5292;
-    else
-        static assert(0, "Architecture not supported");
-}
-else version (PPC_Any)
-{
-        enum __NR_perf_event_open = 319;
-}
-else version (RISCV_Any)
-{
-        enum __NR_perf_event_open = 241;
-}
-else version (SPARC_Any)
-{
-        enum __NR_perf_event_open = 327;
-}
-else version (LoongArch64)
-{
-        enum __NR_perf_event_open = 241;
-}
-else
-{
-        static assert(0, "Architecture not supported");
-}
-extern (C) extern long syscall(long __sysno, ...);
 static long perf_event_open(perf_event_attr* hw_event, pid_t pid, int cpu, int group_fd, ulong flags)
 {
-        return syscall(__NR_perf_event_open, hw_event, pid, cpu, group_fd, flags);
+    import core.sys.linux.unistd : syscall;
+    import core.sys.linux.syscall : __NR_perf_event_open;
+    return syscall(__NR_perf_event_open, hw_event, pid, cpu, group_fd, flags);
 }
+
 /*
  * User-space ABI bits:
  */

--- a/druntime/src/core/sys/linux/sys/syscall.d
+++ b/druntime/src/core/sys/linux/sys/syscall.d
@@ -1,0 +1,90 @@
+/**
+ * D header file for GNU/Linux
+ *
+ * $(LINK2 https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sys/syscall.h, glibc sys/syscall.h)
+ */
+
+module core.sys.linux.sys.syscall;
+
+version (linux):
+extern (C):
+@nogc:
+nothrow:
+
+version (HPPA)    version = HPPA_Any;
+version (HPPA64)  version = HPPA_Any;
+version (PPC)     version = PPC_Any;
+version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
+version (S390)    version = IBMZ_Any;
+version (SPARC)   version = SPARC_Any;
+version (SPARC64) version = SPARC_Any;
+version (SystemZ) version = IBMZ_Any;
+
+// <asm/unistd.h>
+// List the numbers of the system calls the system knows.
+version (X86_64)
+{
+    version (D_X32)
+        enum __NR_perf_event_open = 0x40000000 + 298;
+    else
+        enum __NR_perf_event_open = 298;
+}
+else version (X86)
+{
+    enum __NR_perf_event_open = 336;
+}
+else version (ARM)
+{
+    enum __NR_perf_event_open = 364;
+}
+else version (AArch64)
+{
+    enum __NR_perf_event_open = 241;
+}
+else version (HPPA_Any)
+{
+    enum __NR_perf_event_open = 318;
+}
+else version (IBMZ_Any)
+{
+    enum __NR_perf_event_open = 331;
+}
+else version (MIPS32)
+{
+    enum __NR_perf_event_open = 4333;
+}
+else version (MIPS64)
+{
+    version (MIPS_N32)
+        enum __NR_perf_event_open = 6296;
+    else version (MIPS_N64)
+        enum __NR_perf_event_open = 5292;
+    else
+        static assert(0, "Architecture not supported");
+}
+else version (PPC_Any)
+{
+    enum __NR_perf_event_open = 319;
+}
+else version (RISCV_Any)
+{
+    enum __NR_perf_event_open = 241;
+}
+else version (SPARC_Any)
+{
+    enum __NR_perf_event_open = 327;
+}
+else version (LoongArch64)
+{
+    enum __NR_perf_event_open = 241;
+}
+else
+{
+    static assert(0, "Architecture not supported");
+}
+
+// <bits/syscall.h>
+// Defines SYS_* names for the __NR_* numbers of known names.
+enum SYS_perf_event_open = __NR_perf_event_open;

--- a/druntime/src/core/sys/linux/syscall.d
+++ b/druntime/src/core/sys/linux/syscall.d
@@ -1,0 +1,14 @@
+/**
+ * D header file for GNU/Linux
+ *
+ * $(LINK2 https://sourceware.org/git/?p=glibc.git;a=blob;f=misc/syscall.h, glibc syscall.h)
+ */
+
+module core.sys.linux.syscall;
+
+version (linux):
+extern (C):
+@nogc:
+nothrow:
+
+public import core.sys.linux.sys.syscall;

--- a/druntime/src/core/sys/linux/unistd.d
+++ b/druntime/src/core/sys/linux/unistd.d
@@ -7,6 +7,8 @@ extern(C):
 nothrow:
 @nogc:
 
+import core.stdc.config : c_long;
+
 // Additional seek constants for sparse file handling
 // from Linux's unistd.h, stdio.h, and linux/fs.h
 // (see http://man7.org/linux/man-pages/man2/lseek.2.html)
@@ -25,3 +27,6 @@ void exit_group(int status);
 
 /// Close all open file descriptors greater or equal to `lowfd`
 void closefrom(int lowfd);
+
+/// Invoke system call number `sysno`, passing it the remaining arguments.
+c_long syscall(c_long sysno, ...);


### PR DESCRIPTION
- `syscall()` is part of `unistd.h`  ->  `core.sys.linux.unistd`.
- `__NR_*` are included by `sys/syscall.h` -> `core.sys.linux.sys.syscall`
- Add traditional form `SYS_*` constants.
- Add convenience header `syscall.h` -> `core.sys.linux.syscall`. 

Not going to attempt to add the thousands of constants defined in the Linux kernel here.  Rather these can be added as-needed, or by anyone who wants to do the full translation work.

FYI @0xEAB 