### PR TITLE
Fix #20499 - [ImportC] typedef struct with name as a pointer cannot be used with struct name

### DIFF
--- a/compiler/test/compilable/imports/imp20499.c
+++ b/compiler/test/compilable/imports/imp20499.c
@@ -1,0 +1,8 @@
+// https://github.com/dlang/dmd/issues/20499
+typedef struct Foo {
+    int x;
+} *pFoo;
+
+struct Bar {
+    struct Foo foo;
+};

--- a/compiler/test/compilable/nested_struct_20499.c
+++ b/compiler/test/compilable/nested_struct_20499.c
@@ -1,0 +1,61 @@
+// https://github.com/dlang/dmd/issues/20499
+
+
+struct Outer {
+    struct __attribute__((aligned(8))) {
+        int x;
+    } n;
+    enum {A};
+    enum {B} b;
+};
+
+struct Outer2 {
+    struct __attribute__((aligned(8))) Nested {
+        int x;
+    } n;
+};
+
+const int x = A;
+const int y = B;
+
+struct Outer o = {3};
+_Static_assert(_Alignof(typeof(o.n)) == 8, "");
+_Static_assert(_Alignof(struct Outer) == 8, "");
+_Static_assert(_Alignof(struct Outer2) == 8, "");
+_Static_assert(_Alignof(struct Nested) == 8, "");
+
+void test(void){
+    struct Outer {
+        struct __attribute__((aligned(16))) {
+            int x;
+        } n;
+        enum {A=2};
+        enum {B=3} b;
+    };
+
+    struct Outer2 {
+        struct __attribute__((aligned(16))) Nested {
+            int x;
+        } n;
+    };
+
+    const int x = A;
+    const int y = B;
+
+    struct Outer o = {3};
+    _Static_assert(_Alignof(typeof(o.n)) == 16, "");
+    _Static_assert(_Alignof(struct Outer) == 16, "");
+    _Static_assert(_Alignof(struct Outer2) == 16, "");
+    _Static_assert(_Alignof(struct Nested) == 16, "");
+}
+
+void test2(void){
+    const int x = A;
+    const int y = B;
+
+    struct Outer o = {3};
+    _Static_assert(_Alignof(typeof(o.n)) == 8, "");
+    _Static_assert(_Alignof(struct Outer) == 8, "");
+    _Static_assert(_Alignof(struct Outer2) == 8, "");
+    _Static_assert(_Alignof(struct Nested) == 8, "");
+}

--- a/compiler/test/compilable/struct_decls_20499.c
+++ b/compiler/test/compilable/struct_decls_20499.c
@@ -1,0 +1,287 @@
+// https://github.com/dlang/dmd/issues/20499
+
+//
+// attribute((aligned())) is so we can tell if attributes are being applied.
+//
+typedef struct __attribute__((aligned(8))) S {
+    int x, y;
+} S;
+_Static_assert(sizeof(struct S) == 8, "sizeof(S)");
+_Static_assert(_Alignof(struct S) == 8, "_Alignof(S)");
+
+typedef struct __attribute__((aligned(8))) Foo {
+    int x, y;
+} *pFoo, Foo, FooB;
+
+_Static_assert(sizeof(struct Foo) == sizeof(struct S), "sizeof(Foo)");
+_Static_assert(_Alignof(struct Foo) == _Alignof(struct S), "_Alignof(Foo)");
+_Static_assert(sizeof(Foo) == sizeof(struct S), "sizeof(Foo)");
+_Static_assert(_Alignof(Foo) == _Alignof(struct S), "_Alignof(Foo)");
+_Static_assert(sizeof(FooB) == sizeof(struct S), "sizeof(FooB)");
+_Static_assert(_Alignof(FooB) == _Alignof(struct S), "_Alignof(FooB)");
+
+pFoo pf;
+_Static_assert(sizeof(*pf) == sizeof(struct S), "sizeof(*pf)");
+_Static_assert(_Alignof(typeof(*pf)) == _Alignof(struct S), "_Alignof(*pf)");
+
+typedef struct __attribute__((aligned(8))) {
+    int x, y;
+} Baz, *pBaz, BazB;
+_Static_assert(sizeof(Baz) == sizeof(struct S), "sizeof(Baz)");
+_Static_assert(sizeof(BazB) == sizeof(struct S), "sizeof(BazB)");
+_Static_assert(_Alignof(Baz) == _Alignof(struct S), "_Alignof(Baz)");
+_Static_assert(_Alignof(BazB) == _Alignof(struct S), "_Alignof(BazB)");
+
+pBaz pb;
+_Static_assert(sizeof(*pb) == sizeof(struct S), "sizeof(*pb)");
+_Static_assert(_Alignof(typeof(*pb)) == _Alignof(struct S), "_Alignof(*pb)");
+
+typedef struct __attribute__((aligned(8))) {
+    int x, y;
+} *pTux;
+pTux pt;
+_Static_assert(sizeof(*pt) == sizeof(struct S), "sizeof(*pt)");
+_Static_assert(_Alignof(typeof(*pt)) == _Alignof(struct S), "_Alignof(*pt)");
+
+typedef struct __attribute__((aligned(8))) {
+    int x, y;
+} Qux;
+_Static_assert(sizeof(Qux) == sizeof(struct S), "sizeof(FooB)");
+_Static_assert(_Alignof(Qux) == _Alignof(struct S), "_Alignof(FooB)");
+
+struct Bar {
+    struct S foo;
+};
+_Static_assert(sizeof(struct Bar) == sizeof(struct S), "sizeof(Bar)");
+_Static_assert(_Alignof(struct Bar) == _Alignof(struct S), "_Alignof(Bar)");
+
+typedef struct __attribute__((aligned(8))) {
+    int x, y;
+} *pLux;
+pLux pl;
+_Static_assert(sizeof(*pl) == sizeof(struct S), "sizeof(*pl)");
+_Static_assert(_Alignof(typeof(*pl)) == _Alignof(struct S), "_Alignof(*pl)");
+
+
+typedef struct __attribute__((aligned(8))) {
+    int x, y;
+} ****pWux;
+pWux pw;
+_Static_assert(sizeof(****pw) == sizeof(struct S), "sizeof(****pw)");
+_Static_assert(_Alignof(typeof(****pw)) == _Alignof(struct S), "_Alignof(****pw)");
+
+struct __attribute__((aligned(8))) {
+    int x, y;
+} f;
+_Static_assert(sizeof(f) == sizeof(struct S), "sizeof(f)");
+_Static_assert(_Alignof(typeof(f)) == _Alignof(struct S), "_Alignof(f)");
+
+struct __attribute__((aligned(8))) {
+    int x, y;
+} fa[3];
+_Static_assert(sizeof(fa[0]) == sizeof(struct S), "sizeof(fa[0])");
+_Static_assert(_Alignof(typeof(fa[0])) == _Alignof(struct S), "_Alignof(fa[0])");
+
+void locals(void){
+    // function local version
+    // Use different values so we know we aren't just using globals
+    typedef struct __attribute__((aligned(16))) S {
+        int x, y[7];
+    } S;
+    _Static_assert(sizeof(struct S) == 32, "sizeof(S)");
+    _Static_assert(_Alignof(struct S) == 16, "_Alignof(S)");
+
+    typedef struct __attribute__((aligned(16))) Foo {
+        int x, y[7];
+    } *pFoo, Foo, FooB;
+
+    _Static_assert(sizeof(struct Foo) == sizeof(struct S), "sizeof(Foo)");
+    _Static_assert(_Alignof(struct Foo) == _Alignof(struct S), "_Alignof(Foo)");
+    _Static_assert(sizeof(Foo) == sizeof(struct S), "sizeof(Foo)");
+    _Static_assert(_Alignof(Foo) == _Alignof(struct S), "_Alignof(Foo)");
+    _Static_assert(sizeof(FooB) == sizeof(struct S), "sizeof(FooB)");
+    _Static_assert(_Alignof(FooB) == _Alignof(struct S), "_Alignof(FooB)");
+
+    pFoo pf;
+    _Static_assert(sizeof(*pf) == sizeof(struct S), "sizeof(*pf)");
+    _Static_assert(_Alignof(typeof(*pf)) == _Alignof(struct S), "_Alignof(*pf)");
+
+    typedef struct __attribute__((aligned(16))) {
+        int x, y[7];
+    } Baz, *pBaz, BazB;
+    _Static_assert(sizeof(Baz) == sizeof(struct S), "sizeof(Baz)");
+    _Static_assert(sizeof(BazB) == sizeof(struct S), "sizeof(BazB)");
+    _Static_assert(_Alignof(Baz) == _Alignof(struct S), "_Alignof(Baz)");
+    _Static_assert(_Alignof(BazB) == _Alignof(struct S), "_Alignof(BazB)");
+
+
+    pBaz pb;
+    _Static_assert(sizeof(*pb) == sizeof(struct S), "sizeof(*pb)");
+    _Static_assert(_Alignof(typeof(*pb)) == _Alignof(struct S), "_Alignof(*pb)");
+
+
+    typedef struct __attribute__((aligned(16))) {
+        int x, y[7];
+    } *pTux;
+    pTux pt;
+    _Static_assert(sizeof(*pt) == sizeof(struct S), "sizeof(*pt)");
+    _Static_assert(_Alignof(typeof(*pt)) == _Alignof(struct S), "_Alignof(*pt)");
+
+
+    typedef struct __attribute__((aligned(16))) {
+        int x, y[7];
+    } Qux;
+    _Static_assert(sizeof(Qux) == sizeof(struct S), "sizeof(FooB)");
+    _Static_assert(_Alignof(Qux) == _Alignof(struct S), "_Alignof(FooB)");
+
+    struct Bar {
+        struct S foo;
+    };
+    _Static_assert(sizeof(struct Bar) == sizeof(struct S), "sizeof(Bar)");
+    _Static_assert(_Alignof(struct Bar) == _Alignof(struct S), "_Alignof(Bar)");
+
+    typedef struct __attribute__((aligned(16))) {
+        int x, y[7];
+    } *pLux;
+    pLux pl;
+    _Static_assert(sizeof(*pl) == sizeof(struct S), "sizeof(*pl)");
+    _Static_assert(_Alignof(typeof(*pl)) == _Alignof(struct S), "_Alignof(*pl)");
+
+
+    typedef struct __attribute__((aligned(16))) {
+        int x, y[7];
+    } ****pWux;
+    pWux pw;
+    _Static_assert(sizeof(****pw) == sizeof(struct S), "sizeof(****pw)");
+    _Static_assert(_Alignof(typeof(****pw)) == _Alignof(struct S), "_Alignof(****pw)");
+
+    struct __attribute__((aligned(16))) {
+        int x, y[7];
+    } f;
+    _Static_assert(sizeof(f) == sizeof(struct S), "sizeof(f)");
+    _Static_assert(_Alignof(typeof(f)) == _Alignof(struct S), "_Alignof(f)");
+    // Verify shadowing works
+    {
+        typedef struct __attribute__((aligned(32))) S {
+            int x, y[15];
+        } S;
+        _Static_assert(sizeof(struct S) == 64, "sizeof(S)");
+        _Static_assert(_Alignof(struct S) == 32, "_Alignof(S)");
+
+        typedef struct __attribute__((aligned(32))) Foo {
+            int x, y[15];
+        } *pFoo, Foo, FooB;
+
+        _Static_assert(sizeof(struct Foo) == sizeof(struct S), "sizeof(Foo)");
+        _Static_assert(_Alignof(struct Foo) == _Alignof(struct S), "_Alignof(Foo)");
+        _Static_assert(sizeof(Foo) == sizeof(struct S), "sizeof(Foo)");
+        _Static_assert(_Alignof(Foo) == _Alignof(struct S), "_Alignof(Foo)");
+        _Static_assert(sizeof(FooB) == sizeof(struct S), "sizeof(FooB)");
+        _Static_assert(_Alignof(FooB) == _Alignof(struct S), "_Alignof(FooB)");
+
+        pFoo pf;
+        _Static_assert(sizeof(*pf) == sizeof(struct S), "sizeof(*pf)");
+        _Static_assert(_Alignof(typeof(*pf)) == _Alignof(struct S), "_Alignof(*pf)");
+
+        typedef struct __attribute__((aligned(32))) {
+            int x, y[15];
+        } Baz, *pBaz, BazB;
+        _Static_assert(sizeof(Baz) == sizeof(struct S), "sizeof(Baz)");
+        _Static_assert(sizeof(BazB) == sizeof(struct S), "sizeof(BazB)");
+        _Static_assert(_Alignof(Baz) == _Alignof(struct S), "_Alignof(Baz)");
+        _Static_assert(_Alignof(BazB) == _Alignof(struct S), "_Alignof(BazB)");
+
+
+        pBaz pb;
+        _Static_assert(sizeof(*pb) == sizeof(struct S), "sizeof(*pb)");
+        _Static_assert(_Alignof(typeof(*pb)) == _Alignof(struct S), "_Alignof(*pb)");
+
+
+        typedef struct __attribute__((aligned(32))) {
+            int x, y[15];
+        } *pTux;
+        pTux pt;
+        _Static_assert(sizeof(*pt) == sizeof(struct S), "sizeof(*pt)");
+        _Static_assert(_Alignof(typeof(*pt)) == _Alignof(struct S), "_Alignof(*pt)");
+
+
+        typedef struct __attribute__((aligned(32))) {
+            int x, y[15];
+        } Qux;
+        _Static_assert(sizeof(Qux) == sizeof(struct S), "sizeof(FooB)");
+        _Static_assert(_Alignof(Qux) == _Alignof(struct S), "_Alignof(FooB)");
+
+        struct Bar {
+            struct S foo;
+        };
+        _Static_assert(sizeof(struct Bar) == sizeof(struct S), "sizeof(Bar)");
+        _Static_assert(_Alignof(struct Bar) == _Alignof(struct S), "_Alignof(Bar)");
+
+        typedef struct __attribute__((aligned(32))) {
+            int x, y[15];
+        } *pLux;
+        pLux pl;
+        _Static_assert(sizeof(*pl) == sizeof(struct S), "sizeof(*pl)");
+        _Static_assert(_Alignof(typeof(*pl)) == _Alignof(struct S), "_Alignof(*pl)");
+
+
+        typedef struct __attribute__((aligned(32))) {
+            int x, y[15];
+        } ****pWux;
+        pWux pw;
+        _Static_assert(sizeof(****pw) == sizeof(struct S), "sizeof(****pw)");
+        _Static_assert(_Alignof(typeof(****pw)) == _Alignof(struct S), "_Alignof(****pw)");
+
+        struct __attribute__((aligned(32))) {
+            int x, y[15];
+        } f;
+        _Static_assert(sizeof(f) == sizeof(struct S), "sizeof(f)");
+        _Static_assert(_Alignof(typeof(f)) == _Alignof(struct S), "_Alignof(f)");
+    }
+}
+
+void globals(void){
+    _Static_assert(sizeof(struct S) == 8, "sizeof(S)");
+    _Static_assert(_Alignof(struct S) == 8, "_Alignof(S)");
+
+    _Static_assert(sizeof(struct Foo) == sizeof(struct S), "sizeof(Foo)");
+    _Static_assert(_Alignof(struct Foo) == _Alignof(struct S), "_Alignof(Foo)");
+    _Static_assert(sizeof(Foo) == sizeof(struct S), "sizeof(Foo)");
+    _Static_assert(_Alignof(Foo) == _Alignof(struct S), "_Alignof(Foo)");
+    _Static_assert(sizeof(FooB) == sizeof(struct S), "sizeof(FooB)");
+    _Static_assert(_Alignof(FooB) == _Alignof(struct S), "_Alignof(FooB)");
+
+    pFoo pf;
+    _Static_assert(sizeof(*pf) == sizeof(struct S), "sizeof(*pf)");
+    _Static_assert(_Alignof(typeof(*pf)) == _Alignof(struct S), "_Alignof(*pf)");
+
+    _Static_assert(sizeof(Baz) == sizeof(struct S), "sizeof(Baz)");
+    _Static_assert(sizeof(BazB) == sizeof(struct S), "sizeof(BazB)");
+    _Static_assert(_Alignof(Baz) == _Alignof(struct S), "_Alignof(Baz)");
+    _Static_assert(_Alignof(BazB) == _Alignof(struct S), "_Alignof(BazB)");
+
+    pBaz pb;
+    _Static_assert(sizeof(*pb) == sizeof(struct S), "sizeof(*pb)");
+    _Static_assert(_Alignof(typeof(*pb)) == _Alignof(struct S), "_Alignof(*pb)");
+
+    pTux pt;
+    _Static_assert(sizeof(*pt) == sizeof(struct S), "sizeof(*pt)");
+    _Static_assert(_Alignof(typeof(*pt)) == _Alignof(struct S), "_Alignof(*pt)");
+
+    _Static_assert(sizeof(Qux) == sizeof(struct S), "sizeof(FooB)");
+    _Static_assert(_Alignof(Qux) == _Alignof(struct S), "_Alignof(FooB)");
+
+    _Static_assert(sizeof(struct Bar) == sizeof(struct S), "sizeof(Bar)");
+    _Static_assert(_Alignof(struct Bar) == _Alignof(struct S), "_Alignof(Bar)");
+
+    pLux pl;
+    _Static_assert(sizeof(*pl) == sizeof(struct S), "sizeof(*pl)");
+    _Static_assert(_Alignof(typeof(*pl)) == _Alignof(struct S), "_Alignof(*pl)");
+
+
+    pWux pw;
+    _Static_assert(sizeof(****pw) == sizeof(struct S), "sizeof(****pw)");
+    _Static_assert(_Alignof(typeof(****pw)) == _Alignof(struct S), "_Alignof(****pw)");
+    Foo foo = {1, 2, 3};
+    struct Foo foo2 = {1, 2, 3};
+}

--- a/compiler/test/compilable/test20499.d
+++ b/compiler/test/compilable/test20499.d
@@ -1,0 +1,2 @@
+// https://github.com/dlang/dmd/issues/20499
+import imports.imp20499;

--- a/compiler/test/compilable/test20963.c
+++ b/compiler/test/compilable/test20963.c
@@ -1,0 +1,12 @@
+// https://github.com/dlang/dmd/issues/20963
+
+void cdind() {
+    struct ABC {
+        int y;
+    } *p;
+
+    {
+        struct ABC { int x; } abc;
+        abc.x = 1;
+    }
+}

--- a/compiler/test/fail_compilation/failcstuff3.c
+++ b/compiler/test/fail_compilation/failcstuff3.c
@@ -1,7 +1,7 @@
 // check importAll analysis of C files
 /* TEST_OUTPUT:
 ---
-fail_compilation/failcstuff3.c(54): Error: union `failcstuff3.S22061` conflicts with struct `failcstuff3.S22061` at fail_compilation/failcstuff3.c(50)
+fail_compilation/failcstuff3.c(54): Error: redeclaration of `S22061`
 ---
 */
 

--- a/compiler/test/runnable/exe1.c
+++ b/compiler/test/runnable/exe1.c
@@ -1242,7 +1242,6 @@ void cdind()
                 assert(cbptr->nextread == 4);
         }
 
-#if 0 // TODO ImportC
         {       struct ABC { char a,b,*l_text; } abc;
                 static struct { int w_doto; struct ABC *w_dotp; } curw,*curwp;
 
@@ -1253,7 +1252,6 @@ void cdind()
                 c = curwp->w_dotp->l_text[curwp->w_doto]&0xFF;
                 assert(c == '2');
         }
-#endif
 }
 
 void logexp()


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/20499
Fixes https://github.com/dlang/dmd/issues/20963

ImportC deferred declaring "tagged" types (structs/unions/enums) until after it saw a possible typedef so that the identifier for a typedef declaration like:

    typedef struct { int x; } Foo;

would give the struct the name Foo. In several circumstances, this led to tagged types not being declared. Resolve this by chasing down those circumstances.

Also, there were other circumstances where types weren't being correctly declared which caused other issues. Lock those down.

---

I think there’s still some bugs lurking around this subject, but I tried to add as many tests as I could.