### PR TITLE
Moved _foreach and indirect dep getLocalClasses from dmodule to dsymbolsem

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -112,11 +112,6 @@ void mangleToBuffer(TemplateInstance ti, ref OutBuffer buf)
 /***********************************************************
  * dmodule.d
  */
-void getLocalClasses(Module mod, ref ClassDeclarations aclasses)
-{
-    return dmd.dmodule.getLocalClasses(mod, aclasses);
-}
-
 FuncDeclaration findGetMembers(ScopeDsymbol dsym)
 {
     return dmd.dmodule.findGetMembers(dsym);
@@ -202,6 +197,12 @@ bool hasPointers(Dsymbol d)
 {
     import dmd.dsymbolsem;
     return dmd.dsymbolsem.hasPointers(d);
+}
+
+void getLocalClasses(Module mod, ref ClassDeclarations aclasses)
+{
+    import dmd.dsymbolsem;
+    return dmd.dsymbolsem.getLocalClasses(mod, aclasses);
 }
 
 /***********************************************************

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -8926,3 +8926,77 @@ private extern(C++) class HasPointersVisitor : Visitor
         result = ns.members.foreachDsymbol( (s) { return s.hasPointers(); } ) != 0;
     }
 }
+
+/***************************************
+ * Expands attribute declarations in members in depth first
+ * order. Calls dg(size_t symidx, Dsymbol *sym) for each
+ * member.
+ * If dg returns !=0, stops and returns that value else returns 0.
+ * Use this function to avoid the O(N + N^2/2) complexity of
+ * calculating dim and calling N times getNth.
+ * Returns:
+ *  last value returned by dg()
+ */
+int _foreach(Scope* sc, Dsymbols* members, scope ForeachDg dg, size_t* pn = null)
+{
+    assert(dg);
+    if (!members)
+        return 0;
+    size_t n = pn ? *pn : 0; // take over index
+    int result = 0;
+    foreach (size_t i; 0 .. members.length)
+    {
+        import dmd.attrib : AttribDeclaration;
+        import dmd.dtemplate : TemplateMixin;
+
+        Dsymbol s = (*members)[i];
+        if (AttribDeclaration a = s.isAttribDeclaration())
+            result = _foreach(sc, a.include(sc), dg, &n);
+        else if (TemplateMixin tm = s.isTemplateMixin())
+            result = _foreach(sc, tm.members, dg, &n);
+        else if (s.isTemplateInstance())
+        {
+        }
+        else if (s.isUnitTestDeclaration())
+        {
+        }
+        else
+            result = dg(n++, s);
+        if (result)
+            break;
+    }
+    if (pn)
+        *pn = n; // update index
+    return result;
+}
+
+/****************************************
+ * Create array of the local classes in the Module, suitable
+ * for inclusion in ModuleInfo
+ * Params:
+ *      mod = the Module
+ *      aclasses = array to fill in
+ * Returns: array of local classes
+ */
+void getLocalClasses(Module mod, ref ClassDeclarations aclasses)
+{
+    //printf("members.length = %d\n", mod.members.length);
+    int pushAddClassDg(size_t n, Dsymbol sm)
+    {
+        if (!sm)
+            return 0;
+
+        if (auto cd = sm.isClassDeclaration())
+        {
+            // compatibility with previous algorithm
+            if (cd.parent && cd.parent.isTemplateMixin())
+                return 0;
+
+            if (cd.classKind != ClassKind.objc)
+                aclasses.push(cd);
+        }
+        return 0;
+    }
+
+    _foreach(null, mod.members, &pushAddClassDg);
+}

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -35,7 +35,7 @@ import dmd.dmodule;
 import dmd.dscope;
 import dmd.dstruct;
 import dmd.dsymbol;
-import dmd.dsymbolsem : hasPointers, hasStaticCtorOrDtor, include, isFuncHidden, isAbstract;
+import dmd.dsymbolsem : getLocalClasses, hasPointers, hasStaticCtorOrDtor, include, isFuncHidden, isAbstract;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.errorsink;


### PR DESCRIPTION
Part of the project to separate semantic routines from AST nodes: https://github.com/dlang/project-ideas/blob/master/separate-semantic-routines-from-ast-nodes/description.md

@RazvanN7

getLocalClasses uses _foreach in dmd.dmodule, so they were moved together in this PR.