### PR TITLE
Make va_end usable with -betterC

### DIFF
--- a/druntime/src/core/stdc/stdarg.d
+++ b/druntime/src/core/stdc/stdarg.d
@@ -316,7 +316,7 @@ else version (LDC)
 }
 else version (DigitalMars)
 {
-    void va_end(va_list ap) {}
+    void va_end()(va_list ap) {}
 }
 
 


### PR DESCRIPTION
When calling va_end() in -betterC with DMD i get:

```
./onlineapp.d:37: error: undefined reference to '_D4core4stdc6stdarg6va_endFNbNiPSQBf8internal6vararg8sysv_x6413__va_list_tagZv'
collect2: error: ld returned 1 exit status
Error: undefined reference to `nothrow @nogc void core.stdc.stdarg.va_end(core.internal.vararg.sysv_x64.__va_list_tag*)`
       perhaps `.d` files need to be added on the command line, or use `-i` to compile imports
Error: linker exited with status 1
       cc onlineapp.o -o /tmp/dmd_runSQYZNP -g -m64 -Xlinker --export-dynamic -L/dlang/dmd/linux/bin64/../lib64 -lpthread -lm -lrt -ldl 
```

This PR fixes it