### PR TITLE
ImportC: don't translate reserved macros.

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -28,6 +28,7 @@ import dmd.common.outbuffer;
 import dmd.root.rmem;
 import dmd.tokens;
 import dmd.typesem : size;
+import dmd.root.string: startsWith;
 
 /***********************************************************
  */
@@ -6104,6 +6105,11 @@ final class CParser(AST) : Parser!AST
                     // https://github.com/dlang/dmd/issues/20423
                     // skip macros that could shadow special builtins
                     if (id == Id.va_arg)
+                    {
+                        nextLine();
+                        continue;
+                    }
+                    if (id.toString().startsWith("__"))
                     {
                         nextLine();
                         continue;

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -53,11 +53,6 @@ extern (C)
 		Callback cb = void;
 	}
 	extern __gshared int[cast(ULONG)3] arr;
-	/+enum int __DATE__ = 1+/;
-	/+enum int __TIME__ = 1+/;
-	/+enum int __TIMESTAMP__ = 1+/;
-	/+enum int __EOF__ = 1+/;
-	/+enum int __VENDOR__ = 1+/;
 	enum int DEF = 123;
 	enum int SQL_DRIVER_STMT_ATTR_BASE = 16384;
 	enum int ABC = 64;


### PR DESCRIPTION
Closes https://github.com/dlang/dmd/issues/21255

Identifiers in C starting with two underscores (`__`) are reserved for the implementation and so it is undefined behavior to use them in non-implementation code. Because of that, no API that anyone cares about will have a macro starting with two underscores. For cleaner "headergen" and to just have fewer symbols to churn through, don't translate macros that start with two underscores.