### PR TITLE
added 'version (D_BetterC)' to bypass try-catch

### DIFF
--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -67,23 +67,31 @@ Tarr _d_arrayctor(Tarr : T[], T)(return scope Tarr to, scope Tarr from, char* ma
 
     static if (hasElaborateCopyConstructor!T)
     {
-        size_t i;
-        try
+        version (D_BetterC)
         {
-            for (i = 0; i < to.length; i++)
+            for (size_t i = 0; i < to.length; i++)
                 copyEmplace(from[i], to[i]);
         }
-        catch (Exception o)
+        else
         {
-            /* Destroy, in reverse order, what we've constructed so far
-            */
-            while (i--)
+            size_t i;
+            try
             {
-                auto elem = cast(Unqual!T*) &to[i];
-                destroy(*elem);
+                for (i = 0; i < to.length; i++)
+                    copyEmplace(from[i], to[i]);
             }
+            catch (Exception o)
+            {
+                /* Destroy, in reverse order, what we've constructed so far
+                */
+                while (i--)
+                {
+                    auto elem = cast(Unqual!T*) &to[i];
+                    destroy(*elem);
+                }
 
-            throw o;
+                throw o;
+            }
         }
     }
     else
@@ -207,22 +215,30 @@ void _d_arraysetctor(Tarr : T[], T)(scope Tarr p, scope ref T value) @trusted
     version (DigitalMars) pragma(inline, false);
     import core.lifetime : copyEmplace;
 
-    size_t i;
-    try
+    version (D_BetterC)
     {
-        for (i = 0; i < p.length; i++)
+        for (size_t i = 0; i < p.length; i++)
             copyEmplace(value, p[i]);
     }
-    catch (Exception o)
+    else
     {
-        // Destroy, in reverse order, what we've constructed so far
-        while (i--)
+        size_t i;
+        try
         {
-            auto elem = cast(Unqual!T*)&p[i];
-            destroy(*elem);
+            for (i = 0; i < p.length; i++)
+                copyEmplace(value, p[i]);
         }
+        catch (Exception o)
+        {
+            // Destroy, in reverse order, what we've constructed so far
+            while (i--)
+            {
+                auto elem = cast(Unqual!T*)&p[i];
+                destroy(*elem);
+            }
 
-        throw o;
+            throw o;
+        }
     }
 }
 

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -1289,18 +1289,26 @@ void copyEmplace(S, T)(ref S source, ref T target) @system
     {
         static if (hasElaborateCopyConstructor!E)
         {
-            size_t i;
-            try
+            version (D_BetterC)
             {
-                for (i = 0; i < n; i++)
+                for (size_t i = 0; i < n; i++)
                     copyEmplace(source[i], target[i]);
             }
-            catch (Exception e)
+            else
             {
-                // destroy, in reverse order, what we've constructed so far
-                while (i--)
-                    destroy(*cast(Unconst!(E)*) &target[i]);
-                throw e;
+                size_t i;
+                try
+                {
+                    for (i = 0; i < n; i++)
+                        copyEmplace(source[i], target[i]);
+                }
+                catch (Exception e)
+                {
+                    // destroy, in reverse order, what we've constructed so far
+                    while (i--)
+                        destroy(*cast(Unconst!(E)*) &target[i]);
+                    throw e;
+                }
             }
         }
         else // trivial copy


### PR DESCRIPTION
I've added a `version (D_BetterC)` check to bypass the try-catch blocks in `core.lifetime.d` and `core.internal.array.construction.d`

The rationale is that these modules are called as part of the creation and usage of arrays from `std.container.array` and prevent the usage of the containers with `betterC` because of the try-catch blocks.

There should be no need for try-catch when compiling with `betterC` because if the compiler encounters anything that might throw it's going to refuse to compile anyway.