### PR TITLE
ImportC: Fix potential ICE after parsing function type

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1867,7 +1867,7 @@ final class CParser(AST) : Parser!AST
         {
             Identifier id;
             AST.StringExp asmName;
-            auto dt = cparseDeclarator(DTR.xdirect, tspec, id, specifier);
+            auto dt = cparseDeclarator(DTR.xdirect_fd, tspec, id, specifier);
             if (!dt)
             {
                 panic();
@@ -2839,6 +2839,18 @@ final class CParser(AST) : Parser!AST
         //printf("cparseDeclarator(%d, %s)\n", declarator, tbase.toChars());
         AST.Types constTypes; // all the Types that will need `const` applied to them
 
+        // this.symbols can get changed to the symbol table for the
+        // parameter-type-list if we parse a function type.
+        // Callers are only ready to handle this if they pass DTR.xdirect_fd,
+        // so remember to restore this.symbols.
+        bool restore_symbols = true;
+        if (declarator == DTR.xdirect_fd)
+        {
+            declarator = DTR.xdirect;
+            restore_symbols = false;
+        }
+
+
         /* Insert tx -> t into
          *   ts -> ... -> t
          * so that
@@ -3030,7 +3042,7 @@ final class CParser(AST) : Parser!AST
                         //tf = tf.addSTC(storageClass);  // TODO
                         insertTx(ts, tf, t);  // ts -> ... -> tf -> t
 
-                        if (ts != tf)
+                        if (ts != tf || restore_symbols)
                             this.symbols = symbolsSave;
                         break;
                     }
@@ -5104,6 +5116,7 @@ final class CParser(AST) : Parser!AST
     /// Types of declarator to parse
     enum DTR
     {
+        xdirect_fd = 0, /// C11 6.7.6 direct-declarator, allow to start function definition
         xdirect    = 1, /// C11 6.7.6 direct-declarator
         xabstract  = 2, /// C11 6.7.7 abstract-declarator
         xparameter = 3, /// parameter declarator may be either direct or abstract

--- a/compiler/test/compilable/test21244.c
+++ b/compiler/test/compilable/test21244.c
@@ -1,0 +1,2 @@
+// https://github.com/dlang/dmd/issues/21244
+int z = _Generic(1, int()(int): 3, int: 3);

--- a/compiler/test/compilable/test21246.c
+++ b/compiler/test/compilable/test21246.c
@@ -1,0 +1,4 @@
+// https://github.com/dlang/dmd/issues/21246
+#define M1(x) _Generic(x, (
+#define M2(a,b) _Generic(val, int(int) a
+#define M3(str,val) _Generic(val, M(F) struct{int foo;}: 0)(__FILE__, __func__, __LINE__, str, val)

--- a/compiler/test/fail_compilation/test21244.c
+++ b/compiler/test/fail_compilation/test21244.c
@@ -1,0 +1,9 @@
+// https://github.com/dlang/dmd/issues/21244
+// This used to segfault the compiler. The below error message can change.
+/*
+* TEST_OUTPUT:
+---
+fail_compilation/test21244.c(9): Error: no size for type `extern (C) int(int)`
+---
+ */
+int x = sizeof(int()(int));


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/21244
Fixes https://github.com/dlang/dmd/issues/21246

When parsing a function type, the cparser pushes a new symbols array onto the implicit scope stack, as symbols declared in a parameter-list are visible in the body of a function. Instead of an actual new symbols array it use a null pointer so that the array can be allocated lazily for the common case where it isn't needed.

However, the same code is called by places that expect a type only, not a function-definition. Because of this, the implicit stack could get lost, leading to a null symbols array or just the wrong symbols array.

Fix this by indicating what the caller expects in regards to this symbols stack so that it can get properly restored.