### PR TITLE
Fix #21215: Wrong location for "not a member" error when constructing a struct literal

### DIFF
--- a/compiler/src/dmd/arraytypes.d
+++ b/compiler/src/dmd/arraytypes.d
@@ -29,6 +29,7 @@ alias Strings = Array!(const(char)*);
 alias Identifiers = Array!(Identifier);
 alias TemplateParameters = Array!(TemplateParameter);
 alias Expressions = Array!(Expression);
+alias ArgumentLabels = Array!(ArgumentLabel);
 alias Statements = Array!(Statement);
 alias BaseClasses = Array!(BaseClass*);
 alias ClassDeclarations = Array!(ClassDeclaration);

--- a/compiler/src/dmd/arraytypes.h
+++ b/compiler/src/dmd/arraytypes.h
@@ -17,6 +17,8 @@ typedef Array<class TemplateParameter *> TemplateParameters;
 
 typedef Array<class Expression *> Expressions;
 
+typedef Array<struct ArgumentLabel> ArgumentLabels;
+
 typedef Array<class Statement *> Statements;
 
 typedef Array<struct BaseClass *> BaseClasses;

--- a/compiler/src/dmd/arraytypes.h
+++ b/compiler/src/dmd/arraytypes.h
@@ -17,8 +17,6 @@ typedef Array<class TemplateParameter *> TemplateParameters;
 
 typedef Array<class Expression *> Expressions;
 
-typedef Array<struct ArgumentLabel> ArgumentLabels;
-
 typedef Array<class Statement *> Statements;
 
 typedef Array<struct BaseClass *> BaseClasses;

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -13,6 +13,7 @@ module dmd.astbase;
 import dmd.astenums;
 import dmd.visitor.parsetime;
 import dmd.tokens : EXP;
+import dmd.expression;
 
 /** The ASTBase  family defines a family of AST nodes appropriate for parsing with
   * no semantic information. It defines all the AST nodes that the parser needs
@@ -46,6 +47,7 @@ struct ASTBase
     alias Dsymbols              = Array!(Dsymbol);
     alias Objects               = Array!(RootObject);
     alias Expressions           = Array!(Expression);
+    alias ArgumentLabels        = Array!(ArgumentLabel);
     alias Types                 = Array!(Type);
     alias TemplateParameters    = Array!(TemplateParameter);
     alias BaseClasses           = Array!(BaseClass*);

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -5582,12 +5582,14 @@ struct ASTBase
     {
         Expressions* arguments;
         Identifiers* names;
+        ArgumentLabels* argLabels;
 
-        extern (D) this(Loc loc, Expression e, Expressions* exps, Identifiers* names = null)
+        extern (D) this(Loc loc, Expression e, Expressions* exps, Identifiers* names = null, ArgumentLabels* argLabels = null)
         {
             super(loc, EXP.call, __traits(classInstanceSize, CallExp), e);
             this.arguments = exps;
             this.names = names;
+            this.argLabels = argLabels;
         }
 
         extern (D) this(Loc loc, Expression e)

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3300,7 +3300,7 @@ extern (C++) final class CallExp : UnaExp
 {
     Expressions* arguments; // function arguments
     Identifiers* names;     // named argument identifiers
-    ArgumentLabel[] argLabels; // named argument labels
+    ArgumentLabels* argLabels; // named argument labels
     FuncDeclaration f;      // symbol to call
     bool directcall;        // true if a virtual call is devirtualized
     bool inDebugStatement;  /// true if this was in a debug statement
@@ -3312,7 +3312,7 @@ extern (C++) final class CallExp : UnaExp
     /// The fields are still separate for backwards compatibility
     extern (D) ArgumentList argumentList() { return ArgumentList(arguments, names); }
 
-    extern (D) this(Loc loc, Expression e, Expressions* exps, Identifiers* names = null, ArgumentLabel[] argLabels = null) @safe
+    extern (D) this(Loc loc, Expression e, Expressions* exps, Identifiers* names = null, ArgumentLabels *argLabels = null) @safe
     {
         super(loc, EXP.call, e);
         this.arguments = exps;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3288,7 +3288,7 @@ struct ArgumentList
     }
 }
 
-struct ArgumentLabel
+extern (C++) struct ArgumentLabel
 {
     Identifier name;    // name of the argument
     Loc loc;            // location of the argument
@@ -3312,17 +3312,11 @@ extern (C++) final class CallExp : UnaExp
     /// The fields are still separate for backwards compatibility
     extern (D) ArgumentList argumentList() { return ArgumentList(arguments, names); }
 
-    extern (D) this(Loc loc, Expression e, Expressions* exps, Identifiers* names = null) @safe
+    extern (D) this(Loc loc, Expression e, Expressions* exps, Identifiers* names = null, ArgumentLabel[] argLabels = null) @safe
     {
         super(loc, EXP.call, e);
         this.arguments = exps;
         this.names = names;
-    }
-
-    extern (D) this(Loc loc, Expression e, Expressions* exps, ArgumentLabel[] argLabels) @safe
-    {
-        super(loc, EXP.call, e);
-        this.arguments = exps;
         this.argLabels = argLabels;
     }
 

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3288,12 +3288,19 @@ struct ArgumentList
     }
 }
 
+struct ArgumentLabel
+{
+    Identifier name;    // name of the argument
+    Loc loc;            // location of the argument
+ }
+
 /***********************************************************
  */
 extern (C++) final class CallExp : UnaExp
 {
     Expressions* arguments; // function arguments
     Identifiers* names;     // named argument identifiers
+    ArgumentLabel[] argLabels; // named argument labels
     FuncDeclaration f;      // symbol to call
     bool directcall;        // true if a virtual call is devirtualized
     bool inDebugStatement;  /// true if this was in a debug statement
@@ -3310,6 +3317,13 @@ extern (C++) final class CallExp : UnaExp
         super(loc, EXP.call, e);
         this.arguments = exps;
         this.names = names;
+    }
+
+    extern (D) this(Loc loc, Expression e, Expressions* exps, ArgumentLabel[] argLabels) @safe
+    {
+        super(loc, EXP.call, e);
+        this.arguments = exps;
+        this.argLabels = argLabels;
     }
 
     extern (D) this(Loc loc, Expression e) @safe

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3288,7 +3288,7 @@ struct ArgumentList
     }
 }
 
-extern (C++) struct ArgumentLabel
+struct ArgumentLabel
 {
     Identifier name;    // name of the argument
     Loc loc;            // location of the argument
@@ -3300,7 +3300,7 @@ extern (C++) final class CallExp : UnaExp
 {
     Expressions* arguments; // function arguments
     Identifiers* names;     // named argument identifiers
-    ArgumentLabels* argLabels; // named argument labels
+    ArgumentLabels *argLabels; // named argument labels
     FuncDeclaration f;      // symbol to call
     bool directcall;        // true if a virtual call is devirtualized
     bool inDebugStatement;  /// true if this was in a debug statement

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -828,7 +828,7 @@ class CallExp final : public UnaExp
 public:
     Expressions *arguments;     // function arguments
     Identifiers *names;         // function argument names
-    _d_dynamicArray< ArgumentLabel > argLabels;    // function argument names + location
+    ArgumentLabels* argLabels;    // function argument names + location
     FuncDeclaration *f;         // symbol to call
     d_bool directcall;            // true if a virtual call is devirtualized
     d_bool inDebugStatement;      // true if this was in a debug statement

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -15,7 +15,6 @@
 #include "arraytypes.h"
 #include "visitor.h"
 #include "tokens.h"
-#include "frontend.h"
 
 #include "root/complex_t.h"
 #include "root/dcompat.h"

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -15,6 +15,7 @@
 #include "arraytypes.h"
 #include "visitor.h"
 #include "tokens.h"
+#include "frontend.h"
 
 #include "root/complex_t.h"
 #include "root/dcompat.h"
@@ -807,11 +808,27 @@ struct ArgumentList final
         {}
 };
 
+struct ArgumentLabel final
+{
+    Identifier* name;
+    Loc loc;
+    ArgumentLabel() :
+        name(),
+        loc()
+    {
+    }
+    ArgumentLabel(Identifier* name, Loc loc = Loc()) :
+        name(name),
+        loc(loc)
+        {}
+};
+
 class CallExp final : public UnaExp
 {
 public:
     Expressions *arguments;     // function arguments
-    Identifiers *names;
+    Identifiers *names;         // function argument names
+    _d_dynamicArray< ArgumentLabel > argLabels;    // function argument names + location
     FuncDeclaration *f;         // symbol to call
     d_bool directcall;            // true if a virtual call is devirtualized
     d_bool inDebugStatement;      // true if this was in a debug statement

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6273,7 +6273,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         (*exp.names)[],
                         (size_t i, Type t) => (*exp.arguments)[i],
                         i => (*exp.arguments)[i].loc,
-                        i => (exp.argLabels.length > i) ? exp.argLabels[i].loc : (*exp.arguments)[i].loc
+                        i => ((*exp.argLabels).length > i) ? (*exp.argLabels)[i].loc : (*exp.arguments)[i].loc
                     );
                     if (!resolvedArgs)
                     {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6267,12 +6267,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                  */
             Lx:
                 Expressions* resolvedArgs = exp.arguments;
-                if (exp.names)
+                Identifiers* expNames = new Identifiers();
+                foreach (label; exp.argLabels)
+                    expNames.push(label.name);
+
+                if (exp.argLabels)
                 {
                     resolvedArgs = resolveStructLiteralNamedArgs(sd, exp.e1.type, sc, exp.loc,
-                        (*exp.names)[],
+                        (*expNames)[],
                         (size_t i, Type t) => (*exp.arguments)[i],
-                        i => (*exp.arguments)[i].loc
+                        i => exp.argLabels[i].loc
                     );
                     if (!resolvedArgs)
                     {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6267,16 +6267,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                  */
             Lx:
                 Expressions* resolvedArgs = exp.arguments;
-                Identifiers* expNames = new Identifiers();
-                foreach (label; exp.argLabels)
-                    expNames.push(label.name);
-
-                if (exp.argLabels)
+                if (exp.names)
                 {
                     resolvedArgs = resolveStructLiteralNamedArgs(sd, exp.e1.type, sc, exp.loc,
-                        (*expNames)[],
+                        (*exp.names)[],
                         (size_t i, Type t) => (*exp.arguments)[i],
-                        i => exp.argLabels[i].loc
+                        i => (*exp.arguments)[i].loc,
+                        i => (exp.argLabels.length > i) ? exp.argLabels[i].loc : (*exp.arguments)[i].loc
                     );
                     if (!resolvedArgs)
                     {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6273,7 +6273,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         (*exp.names)[],
                         (size_t i, Type t) => (*exp.arguments)[i],
                         i => (*exp.arguments)[i].loc,
-                        i => ((*exp.argLabels).length > i) ? (*exp.argLabels)[i].loc : (*exp.arguments)[i].loc
+                        i => (exp.argLabels && (*exp.argLabels).length > i) ? (*exp.argLabels)[i].loc : (*exp.arguments)[i].loc
                     );
                     if (!resolvedArgs)
                     {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2582,6 +2582,21 @@ public:
     void accept(Visitor* v) override;
 };
 
+struct ArgumentLabel final
+{
+    Identifier* name;
+    Loc loc;
+    ArgumentLabel() :
+        name(),
+        loc()
+    {
+    }
+    ArgumentLabel(Identifier* name, Loc loc = Loc()) :
+        name(name),
+        loc(loc)
+        {}
+};
+
 struct ArgumentList final
 {
     Array<Expression* >* arguments;
@@ -2684,18 +2699,12 @@ class CTFEExp final : public Expression
 {
 };
 
-struct ArgumentLabel
-{
-    Identifier *name;
-    Loc loc;
-};
-
 class CallExp final : public UnaExp
 {
 public:
     Array<Expression* >* arguments;
     Array<Identifier* >* names;
-    DArray<ArgumentLabel> argLabels;
+    _d_dynamicArray< ArgumentLabel > argLabels;
     FuncDeclaration* f;
     bool directcall;
     bool inDebugStatement;
@@ -5723,6 +5732,7 @@ struct ASTCodegen final
     using AddrExp = ::AddrExp;
     using AndAssignExp = ::AndAssignExp;
     using AndExp = ::AndExp;
+    using ArgumentLabel = ::ArgumentLabel;
     using ArgumentList = ::ArgumentList;
     using ArrayExp = ::ArrayExp;
     using ArrayLengthExp = ::ArrayLengthExp;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2684,11 +2684,18 @@ class CTFEExp final : public Expression
 {
 };
 
+struct ArgumentLabel
+{
+    Identifier *name;
+    Loc loc;
+};
+
 class CallExp final : public UnaExp
 {
 public:
     Array<Expression* >* arguments;
     Array<Identifier* >* names;
+    DArray<ArgumentLabel> argLabels;
     FuncDeclaration* f;
     bool directcall;
     bool inDebugStatement;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1485,6 +1485,23 @@ struct MangleOverride final
 
 typedef Array<AliasDeclaration* > AliasDeclarations;
 
+struct ArgumentLabel final
+{
+    Identifier* name;
+    Loc loc;
+    ArgumentLabel() :
+        name(),
+        loc()
+    {
+    }
+    ArgumentLabel(Identifier* name, Loc loc = Loc()) :
+        name(name),
+        loc(loc)
+        {}
+};
+
+typedef Array<ArgumentLabel > ArgumentLabels;
+
 typedef Array<BaseClass* > BaseClasses;
 
 typedef Array<CaseStatement* > CaseStatements;
@@ -2582,21 +2599,6 @@ public:
     void accept(Visitor* v) override;
 };
 
-struct ArgumentLabel final
-{
-    Identifier* name;
-    Loc loc;
-    ArgumentLabel() :
-        name(),
-        loc()
-    {
-    }
-    ArgumentLabel(Identifier* name, Loc loc = Loc()) :
-        name(name),
-        loc(loc)
-        {}
-};
-
 struct ArgumentList final
 {
     Array<Expression* >* arguments;
@@ -2704,7 +2706,7 @@ class CallExp final : public UnaExp
 public:
     Array<Expression* >* arguments;
     Array<Identifier* >* names;
-    _d_dynamicArray< ArgumentLabel > argLabels;
+    Array<ArgumentLabel >* argLabels;
     FuncDeclaration* f;
     bool directcall;
     bool inDebugStatement;
@@ -5602,6 +5604,7 @@ struct ASTCodegen final
     using MangleOverride = ::MangleOverride;
     using AliasThis = ::AliasThis;
     using AliasDeclarations = ::AliasDeclarations;
+    using ArgumentLabels = ::ArgumentLabels;
     using BaseClasses = ::BaseClasses;
     using CaseStatements = ::CaseStatements;
     using Catches = ::Catches;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -9008,7 +9008,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             case TOK.leftParenthesis:
                 AST.Expressions* args = new AST.Expressions();
                 ArgumentLabel[] argLabels;
-                parseNamedArguments(args, null, argLabels);
+                parseNamedArguments(args, null, &argLabels);
                 e = new AST.CallExp(loc, e, args, argLabels);
                 continue;
 
@@ -9453,7 +9453,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Collect argument list.
      * Assume current token is ',', '$(LPAREN)' or '['.
      */
-    private void parseNamedArguments(AST.Expressions* arguments, AST.Identifiers* names, ArgumentLabel[] argLabels)
+    private void parseNamedArguments(AST.Expressions* arguments, AST.Identifiers* names, ArgumentLabel[]* argLabels)
     {
         assert(arguments);
 
@@ -9473,7 +9473,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 if (names)
                     names.push(ident);
                 else if (argLabels)
-                    argLabels ~= ArgumentLabel(ident, loc);
+                    (*argLabels) ~= ArgumentLabel(ident, loc);
                 else
                     error(loc, "named arguments not allowed here");
             }
@@ -9482,7 +9482,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 if (names)
                     names.push(null);
                 else if (argLabels)
-                    argLabels ~= ArgumentLabel(null, Loc.init);
+                    (*argLabels) ~= ArgumentLabel(null, Loc.init);
             }
 
             auto arg = parseAssignExp();

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -9007,9 +9007,10 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
             case TOK.leftParenthesis:
                 AST.Expressions* args = new AST.Expressions();
+                AST.Identifiers* names = new AST.Identifiers();
                 ArgumentLabel[] argLabels;
-                parseNamedArguments(args, null, &argLabels);
-                e = new AST.CallExp(loc, e, args, argLabels);
+                parseNamedArguments(args, names, &argLabels);
+                e = new AST.CallExp(loc, e, args, names, argLabels);
                 continue;
 
             case TOK.leftBracket:
@@ -9470,19 +9471,23 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 auto ident = token.ident;
                 check(TOK.identifier);
                 check(TOK.colon);
-                if (names)
+                if (names && argLabels){
                     names.push(ident);
-                else if (argLabels)
                     (*argLabels) ~= ArgumentLabel(ident, loc);
+                }
+                else if (names)
+                    names.push(ident);
                 else
                     error(loc, "named arguments not allowed here");
             }
             else
             {
-                if (names)
+                if (names && argLabels){
                     names.push(null);
-                else if (argLabels)
                     (*argLabels) ~= ArgumentLabel(null, Loc.init);
+                }
+                else if (names)
+                    names.push(null);
             }
 
             auto arg = parseAssignExp();

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -9008,8 +9008,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             case TOK.leftParenthesis:
                 AST.Expressions* args = new AST.Expressions();
                 AST.Identifiers* names = new AST.Identifiers();
-                ArgumentLabel[] argLabels;
-                parseNamedArguments(args, names, &argLabels);
+                AST.ArgumentLabels* argLabels = new AST.ArgumentLabels();
+                parseNamedArguments(args, names, argLabels);
                 e = new AST.CallExp(loc, e, args, names, argLabels);
                 continue;
 
@@ -9454,7 +9454,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Collect argument list.
      * Assume current token is ',', '$(LPAREN)' or '['.
      */
-    private void parseNamedArguments(AST.Expressions* arguments, AST.Identifiers* names, ArgumentLabel[]* argLabels)
+    private void parseNamedArguments(AST.Expressions* arguments, AST.Identifiers* names, AST.ArgumentLabels* argLabels)
     {
         assert(arguments);
 
@@ -9473,7 +9473,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 check(TOK.colon);
                 if (names && argLabels){
                     names.push(ident);
-                    (*argLabels) ~= ArgumentLabel(ident, loc);
+                    argLabels.push(ArgumentLabel(ident, loc));
                 }
                 else if (names)
                     names.push(ident);
@@ -9484,7 +9484,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             {
                 if (names && argLabels){
                     names.push(null);
-                    (*argLabels) ~= ArgumentLabel(null, Loc.init);
+                    argLabels.push(ArgumentLabel(null, Loc.init));
+
                 }
                 else if (names)
                     names.push(null);

--- a/compiler/test/fail_compilation/test21215.d
+++ b/compiler/test/fail_compilation/test21215.d
@@ -1,0 +1,32 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test21215.d(14): Error: named arguments not allowed here
+fail_compilation/test21215.d(19): Error: named arguments not allowed here
+fail_compilation/test21215.d(23): Error: named arguments not allowed here
+fail_compilation/test21215.d(24): Error: named arguments not allowed here
+fail_compilation/test21215.d(28): Error: named arguments not allowed here
+---
+*/
+struct S { int x; }
+
+void test() {
+	auto s = S(
+		y:
+    1
+	);
+
+  auto s2 = S(
+    x: 1
+  );
+
+  auto s3 = S(
+    x: 1,
+    y: 2
+  );
+
+  auto s4 = S(
+    yashu:
+    
+    2
+  );
+}

--- a/compiler/test/fail_compilation/test21215.d
+++ b/compiler/test/fail_compilation/test21215.d
@@ -1,43 +1,34 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test21215.d(14): Error: `y` is not a member of `S`
-fail_compilation/test21215.d(19): Error: `xhs` is not a member of `S`, did you mean variable `xsh`?
-fail_compilation/test21215.d(31): Error: too many initializers for `S` with 1 field
-fail_compilation/test21215.d(37): Error: `y` is not a member of `S`
-fail_compilation/test21215.d(41): Error: `yashu` is not a member of `S`
+fail_compilation/test21215.d(13): Error: `y` is not a member of `S`
+fail_compilation/test21215.d(18): Error: `xhs` is not a member of `S`, did you mean variable `xsh`?
+fail_compilation/test21215.d(28): Error: `y` is not a member of `S`
+fail_compilation/test21215.d(32): Error: `yashu` is not a member of `S`
 ---
 */
 struct S { int xsh; }
 
 void test() {
-	auto s = S(
+	auto s1 = S(
 		y:
     1
 	);
 
-  auto s3 = S(
+  auto s2 = S(
     xhs:
     1
   );
 
-  auto s4 = S(
+  auto s3 = S(
     xsh: 1
   );
 
-  auto s5 = S(
-    xsh:
-    1,
-
-    xsh:
-    1
-  );
-
-  auto s6 = S(
+  auto s4 = S(
     xsh: 1,
     y: 2
   );
 
-  auto s7 = S(
+  auto s5 = S(
     yashu:
     
     2

--- a/compiler/test/fail_compilation/test21215.d
+++ b/compiler/test/fail_compilation/test21215.d
@@ -30,7 +30,6 @@ void test() {
 
   auto s5 = S(
     yashu:
-    
     2
   );
 }

--- a/compiler/test/fail_compilation/test21215.d
+++ b/compiler/test/fail_compilation/test21215.d
@@ -1,13 +1,13 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test21215.d(14): Error: named arguments not allowed here
-fail_compilation/test21215.d(19): Error: named arguments not allowed here
-fail_compilation/test21215.d(23): Error: named arguments not allowed here
-fail_compilation/test21215.d(24): Error: named arguments not allowed here
-fail_compilation/test21215.d(28): Error: named arguments not allowed here
+fail_compilation/test21215.d(14): Error: `y` is not a member of `S`
+fail_compilation/test21215.d(19): Error: `xhs` is not a member of `S`, did you mean variable `xsh`?
+fail_compilation/test21215.d(31): Error: too many initializers for `S` with 1 field
+fail_compilation/test21215.d(37): Error: `y` is not a member of `S`
+fail_compilation/test21215.d(41): Error: `yashu` is not a member of `S`
 ---
 */
-struct S { int x; }
+struct S { int xsh; }
 
 void test() {
 	auto s = S(
@@ -15,16 +15,29 @@ void test() {
     1
 	);
 
-  auto s2 = S(
-    x: 1
-  );
-
   auto s3 = S(
-    x: 1,
-    y: 2
+    xhs:
+    1
   );
 
   auto s4 = S(
+    xsh: 1
+  );
+
+  auto s5 = S(
+    xsh:
+    1,
+
+    xsh:
+    1
+  );
+
+  auto s6 = S(
+    xsh: 1,
+    y: 2
+  );
+
+  auto s7 = S(
     yashu:
     
     2


### PR DESCRIPTION
Fixes #21215 
Fixed Error msg from:
``` test.d(6): Error: `y` is not a member of `S` ```
To:
``` test.d(5): Error: `y` is not a member of `S` ```
Now it points to the correct location.
