### PR TITLE
Fix #18263: ImportC fails when DMD is installed in path with spaces

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -993,7 +993,7 @@ public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, c
                  */
                 OutBuffer buf;
                 buf.writestring(cpp);
-                buf.printf(" /P /Zc:preprocessor /PD /nologo /utf-8 %.*s /FI%s /Fi%.*s",
+                buf.printf(" /P /Zc:preprocessor /PD /nologo /utf-8 \"%.*s\" \"/FI%s\" \"/Fi%.*s\"",
                     cast(int)filename.length, filename.ptr, importc_h, cast(int)output.length, output.ptr);
 
                 /* Append preprocessor switches to command line


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/18263

Command to invoke the preprocessor wasn't quoting paths.

This isn't bulletproof and really the interface should be taking an array of strings or use a command-builder type pattern, but this resolves the common issue of paths with spaces in them.