### PR TITLE
Fix error message location for incompatible function arguments

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6723,7 +6723,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
 
-            void errorHelper(const(char)* failMessage) scope
+            void errorHelper(const(char)* failMessage, Loc argLoc = Loc.initial) scope
             {
                 OutBuffer buf;
                 buf.writeByte('(');
@@ -6736,7 +6736,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 .error(exp.loc, "%s `%s` is not callable using argument types `%s`",
                     p, exp.e1.toErrMsg(), buf.peekChars());
                 if (failMessage)
-                    errorSupplemental(exp.loc, "%s", failMessage);
+                {
+                    // Point to the specific argument that caused the error otherwise use the function call location
+                    errorSupplemental(argLoc != Loc.initial ? argLoc : exp.loc, "%s", failMessage);
+                }
             }
 
             if (callMatch(exp.f, tf, null, exp.argumentList, 0, &errorHelper, sc) == MATCH.nomatch)
@@ -6799,7 +6802,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.f = exp.f.toAliasFunc();
                 TypeFunction tf = cast(TypeFunction)exp.f.type;
 
-                void errorHelper2(const(char)* failMessage) scope
+                void errorHelper2(const(char)* failMessage, Loc argLoc = Loc.initial) scope
                 {
                     OutBuffer buf;
                     buf.writeByte('(');
@@ -6817,7 +6820,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     .error(exp.loc, "%s `%s` is not callable using argument types `%s`",
                         exp.f.kind(), exp.f.toErrMsg(), buf.peekChars());
                     if (failMessage)
-                        errorSupplemental(exp.loc, "%s", failMessage);
+                    {
+                        // Point to the specific argument that caused the error otherwise use the function call location
+                        errorSupplemental(argLoc != Loc.initial ? argLoc : exp.loc, "%s", failMessage);
+                    }
                     .errorSupplemental(exp.f.loc, "`%s%s` declared here", exp.f.toPrettyChars(), parametersTypeToChars(tf.parameterList));
                     exp.f = null;
                 }

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1837,12 +1837,13 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
         }
 
         bool calledHelper;
-        void errorHelper(const(char)* failMessage) scope
+        void errorHelper(const(char)* failMessage, Loc argLoc = Loc.initial) scope
         {
             .error(loc, "%s `%s%s%s` is not callable using argument types `%s`",
                    fd.kind(), fd.toPrettyChars(), parametersTypeToChars(tf.parameterList),
                    tf.modToChars(), fargsBuf.peekChars());
-            errorSupplemental(loc, failMessage);
+            // Point to the specific argument that caused the error if available
+            errorSupplemental(argLoc != Loc.initial ? argLoc : loc, failMessage);
             calledHelper = true;
         }
 
@@ -1910,9 +1911,9 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
         }
     }
 
-    void errorHelper2(const(char)* failMessage) scope
+    void errorHelper2(const(char)* failMessage, Loc argLoc = Loc.initial) scope
     {
-        errorSupplemental(loc, failMessage);
+        errorSupplemental(argLoc != Loc.initial ? argLoc : loc, failMessage);
     }
 
     functionResolve(m, orig_s, loc, sc, tiargs, tthis, argumentList, &errorHelper2);

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1886,7 +1886,7 @@ extern (D) RootObject declareParameter(TemplateDeclaration td, Scope* sc, Templa
  *      errorHelper = delegate to send error message to if not null
  */
 void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiargs,
-    Type tthis, ArgumentList argumentList, void delegate(const(char)*) scope errorHelper = null)
+    Type tthis, ArgumentList argumentList, void delegate(const(char)*, Loc = Loc.initial) scope errorHelper = null)
 {
     version (none)
     {

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -703,7 +703,7 @@ extern (D) bool checkComplexTransition(Type type, Loc loc, Scope* sc)
  *      MATCHxxxx
  */
 extern (D) MATCH callMatch(FuncDeclaration fd, TypeFunction tf, Type tthis, ArgumentList argumentList,
-        int flag = 0, void delegate(const(char)*) scope errorHelper = null, Scope* sc = null)
+        int flag = 0, void delegate(const(char)*, Loc = Loc.initial) scope errorHelper = null, Scope* sc = null)
 {
     //printf("callMatch() fd: %s, tf: %s\n", fd ? fd.ident.toChars() : "null", toChars(tf));
     MATCH match = MATCH.exact; // assume exact match
@@ -872,7 +872,12 @@ extern (D) MATCH callMatch(FuncDeclaration fd, TypeFunction tf, Type tthis, Argu
                         u + 1, parameterToChars(p, tf, false));
                 // If an error happened previously, `pMessage` was already filled
                 else if (buf.length == 0)
+                {
                     buf.writestring(tf.getParamError(args[u], p));
+                    // Point to the specific argument that caused the error
+                    errorHelper(buf.peekChars(), args[u].loc);
+                    return MATCH.nomatch;
+                }
 
                 errorHelper(buf.peekChars());
             }

--- a/compiler/test/fail_compilation/fix21167.d
+++ b/compiler/test/fail_compilation/fix21167.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fix21167.d(14): Error: function `f` is not callable using argument types `(int, string, int)`
+fail_compilation/fix21167.d(16):        cannot pass argument `"foo"` of type `string` to parameter `int __param_1`
+fail_compilation/fix21167.d(10):        `fix21167.f(int __param_0, int __param_1, int __param_2)` declared here
+---
+*/
+
+void f(int, int, int){}
+
+void main()
+{
+	f(
+		1,
+		"foo",
+		3
+	);
+
+}


### PR DESCRIPTION
Closes: https://github.com/dlang/dmd/issues/21167

So the error message should point to the line with the problematic argument rather than the line where the function call starts.
 So here's what I did - 
1. Updated the `callMatch` function in `typesem.d` to pass the argument's location to the error helper
2. Modified the error helper functions in `expressionsem.d` and `funcsem.d` to accept and use the argument's location also updated the `functionResolve` function in `templatesem.d` to accept the modified error helper delegate
4. Also added a test case in `fail_compilation/fix21167.d` to verify the fix