### PR TITLE
Fix #21267: ImportC: `__forceinline` ignored

### DIFF
--- a/compiler/test/compilable/test21267.c
+++ b/compiler/test/compilable/test21267.c
@@ -1,0 +1,4 @@
+// https://github.com/dlang/dmd/issues/21267
+static inline __forceinline int square(int x) { return x * x; }
+
+int doSquare(int x) { return square(x); }

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -56,7 +56,7 @@
  */
 #define __fastcall
 
-#define __forceinline
+#define __forceinline __attribute__((always_inline))
 #undef _Check_return_
 //#define _Check_return_
 #define __pragma(x)


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/21267

`__forceinline` is the same as `__attribute__((always_inline))`, so `#define` it to be the same.