### PR TITLE
prefer __gshared to static, as dmd is not multithreaded

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1059,8 +1059,8 @@ public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, c
                 auto smbuf = SmallBuffer!wchar(scratch.length, scratch[]);
 
                 // INCLUDE
-                static VSOptions vsopt; // cache, as this can be expensive
-                static Strings includePaths;
+                __gshared VSOptions vsopt; // cache, as this can be expensive
+                __gshared Strings includePaths;
                 if (includePaths.length == 0)
                 {
                     if (!vsopt.VSInstallDir)

--- a/compiler/src/dmd/timetrace.d
+++ b/compiler/src/dmd/timetrace.d
@@ -23,7 +23,7 @@ import dmd.common.outbuffer;
 import dmd.root.string : toDString;
 
 // Thread local profiler instance (multithread currently not supported because compiler is single-threaded)
-TimeTraceProfiler* timeTraceProfiler = null;
+__gshared TimeTraceProfiler* timeTraceProfiler = null;
 
 /**
  * Initialize time tracing functionality.


### PR DESCRIPTION
Caused these errors when building on x86:
```
src\dmd\link.d(1062): `vsopt` is thread local
src\dmd\link.d(1063): `includePaths` is thread local
src\dmd\timetrace.d(26): `timeTraceProfiler` is thread local
```