### PR TITLE
Fix #21271 - ImportC: incorrect compatibility macro for __pragma

### DIFF
--- a/compiler/test/compilable/test21271.c
+++ b/compiler/test/compilable/test21271.c
@@ -1,0 +1,16 @@
+// https://github.com/dlang/dmd/issues/21271
+#define PUSH __pragma(pack(push))
+#define PACK  __pragma(pack(1))
+#define POP __pragma(pack(pop))
+
+PUSH
+PACK
+struct S21271_1 {
+    int x;
+};
+_Static_assert(_Alignof(struct S21271_1)==1, "1");
+POP
+struct S21271_2 {
+    int x;
+};
+_Static_assert(_Alignof(struct S21271_2)==_Alignof(int), "2");

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -59,7 +59,7 @@
 #define __forceinline
 #undef _Check_return_
 //#define _Check_return_
-#define __pragma(x)
+#define __pragma(x) _Pragma(#x)
 
 #undef _GLIBCXX_USE_FLOAT128
 


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/21271

Redefine the compatibility macro in terms of C99's `_Pragma()` instead of ignoring it. Clang and GCC will replace `_Pragma()` with `#pragma` directives in the preprocessed output, while cl.exe will actually convert it back to `__pragma()`.

This is still a better situation than before as ImportC partially supports `__pragma()`.