### PR TITLE
fix #21207: enum AA as a function parameter default value causes dmd to crash

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4551,7 +4551,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             printf("AssocArrayLiteralExp::semantic('%s')\n", e.toChars());
         }
-
+        if (e.type)
+        {
+            // already done, but we might have missed generating type info
+            semanticTypeInfo(sc, e.type);
+            result = e;
+            return;
+        }
         // Run semantic() on each element
         bool err_keys = arrayExpressionSemantic(e.keys.peekSlice(), sc);
         bool err_vals = arrayExpressionSemantic(e.values.peekSlice(), sc);
@@ -13874,6 +13880,7 @@ private bool expressionSemanticDone(Expression e)
         || e.isTypeExp() // stores its type in the Expression.type field
         || e.isCompoundLiteralExp() // stores its `(type) {}` in type field, gets rewritten to struct literal
         || e.isVarExp() // type sometimes gets set already before semantic
+        || (e.isAssocArrayLiteralExp() && !e.type.vtinfo) // semanticTypeInfo not run during initialization
     );
 }
 

--- a/compiler/test/runnable/testaa2.d
+++ b/compiler/test/runnable/testaa2.d
@@ -317,6 +317,16 @@ void test21258()
         enum E { a = T.init, } // bug report uses bad syntax here, but this crashed, too
 }
 
+// https://github.com/dlang/dmd/issues/21207
+void test21207()
+{
+	struct S { int x; } // use a local type to not generate required TypeInfo elsewhere
+    enum aa = ["baz": S(7)];
+
+    void foo(S[string] x = aa) { }
+    foo();
+}
+
 /************************************************/
 
 int main()


### PR DESCRIPTION
semanticTypeInfo() has no effect for initializers run at CTFE, so redo it if copied elsewhere