### PR TITLE
use OPpair instead of OPadd to form complex type

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -1671,6 +1671,7 @@ elem* toElem(Expression e, ref IRState irs)
 
         elem* el = toElem(be.e1, irs);
         elem* er = toElem(be.e2, irs);
+
         elem* e = el_bin(op,tym,el,er);
 
         elem_setLoc(e,be.loc);
@@ -1752,7 +1753,11 @@ elem* toElem(Expression e, ref IRState irs)
 
     elem* visitAdd(AddExp e)
     {
-        return toElemBin(e, OPadd);
+        int op = OPadd;
+        if (e.type.ty == Tcomplex64 && e.e1.type.ty == Tfloat64 && e.e2.type.ty == Timaginary64)
+            op = OPpair;
+
+        return toElemBin(e, op);
     }
 
     /***************************************


### PR DESCRIPTION
I know we deprecated complex number support a very long time ago. But it persists, and it also persists in ImportC. They introduce a fair amount of complexity to the backend, which is troubling me with the AArch64 conversion.

What I'd like to do is simplify the backend by getting rid of the imaginary types - just use the real types. This PR is a toe in the water to see how it might go.