### PR TITLE
Fix #21273 - ImportC: typedef function pointer changes if C file compiled

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -1992,6 +1992,9 @@ MATCH cimplicitConvTo(Expression e, Type t)
         return MATCH.convert;
     if (tb.ty == Tpointer && typeb.ty == Tpointer) // C11 6.3.2.3-7
         return MATCH.convert;
+    if (typeb.ty == Tstruct && t.ty == Tstruct &&
+                    typeb.isTypeStruct().sym == t.isTypeStruct().sym)
+        return MATCH.convert;
 
     return implicitConvTo(e, t);
 }

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -298,6 +298,7 @@ void funcDeclarationSemantic(Scope* sc, FuncDeclaration funcdecl)
                 auto tjf2 = new TypeFunction(tjf.parameterList, tjf.next, tjf.linkage);
                 funcdecl.type = tjf2;
                 funcdecl.originalType = tjf2;
+                tf = tjf2;
             }
         }
     }

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -42,8 +42,8 @@ extern (C)
 	}
 	alias weird = int[(cast(foo*)cast(void*)0).x.sizeof];
 	alias ULONG = ulong;
-	alias ULONG_Deluxe = ulong;
-	alias ULONG_PTR = ulong*;
+	alias ULONG_Deluxe = ULONG;
+	alias ULONG_PTR = ULONG_Deluxe*;
 	alias Callback = void* function();
 	struct Test
 	{

--- a/compiler/test/compilable/imports/imp21273.i
+++ b/compiler/test/compilable/imports/imp21273.i
@@ -1,0 +1,8 @@
+// https://github.com/dlang/dmd/issues/21273
+typedef void (__stdcall *proc)(void);
+proc p1;
+void (__stdcall *p2)(void);
+struct S21273 {
+    proc p1;
+    void (__stdcall *p2)(void);
+};

--- a/compiler/test/compilable/test21273.d
+++ b/compiler/test/compilable/test21273.d
@@ -1,0 +1,11 @@
+// https://github.com/dlang/dmd/issues/21273
+import imports.imp21273;
+extern(Windows) void w();
+proc p = &w;
+void main(){
+    p1 = &w;
+    p2 = &w;
+    S21273 s;
+    s.p1 = &w;
+    s.p2 = &w;
+}

--- a/compiler/test/compilable/test22885.c
+++ b/compiler/test/compilable/test22885.c
@@ -6,4 +6,11 @@ void test()
     typedef T* T;  // should declare a new T that is an int*
     int i;
     T p = &i;
+    {
+        typedef void (T)(T); // function type, returning void, taking int*
+        void func(int*);
+        T func2;
+        T* f = func;
+        f = func2;
+    }
 }

--- a/compiler/test/fail_compilation/generic.c
+++ b/compiler/test/fail_compilation/generic.c
@@ -1,9 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/generic.c(103): Error: generic association type `float` can only appear once
-fail_compilation/generic.c(108): Error: no compatible generic association type for controlling expression type `long`
-fail_compilation/generic.c(110): Error: undefined identifier `T`
-fail_compilation/generic.c(112): Error: undefined identifier `E`
+fail_compilation/generic.c(110): Error: unknown type `T`
 ---
 */
 

--- a/compiler/test/fail_compilation/generic3.c
+++ b/compiler/test/fail_compilation/generic3.c
@@ -1,0 +1,22 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/generic3.c(103): Error: generic association type `float` can only appear once
+fail_compilation/generic3.c(108): Error: no compatible generic association type for controlling expression type `long`
+fail_compilation/generic3.c(112): Error: undefined identifier `E`
+---
+*/
+#line 100
+
+void test()
+{
+    int e1 = _Generic(1,
+        int: 4,
+        float: 5,
+        float: 6);
+
+    int e2 = _Generic(1LL, int:5);
+
+
+
+    int e5 = _Generic(1, int:E);
+}


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/21273

The C parser was very aggressively resolving typedefs, resolving them to their actual underlying Type instead of using a level of indirection through their name. This would lead to the same Type being shared in multiple declarations. However, the semantic routines can mutate the types based on various attribute declarations they are contained in.  As a result of the aliasing, the type could be reached by traversing different attribute declarations which would lead to different attributes being applied to the type, such as `extern(Windows)` vs. `extern(C)`.

Fix this by not immediately resolving the types and making use of TypeIdentifier for its intended purpose.

---

I also found `extern(Windows)` wasn't being applied to VarDeclarations, so I fixed that while I was in here.