### PR TITLE
Add hooks to the GC to manage thread lifetimes

### DIFF
--- a/druntime/src/core/gc/config.d
+++ b/druntime/src/core/gc/config.d
@@ -12,6 +12,8 @@ import core.stdc.stdio : printf;
 
 __gshared Config config;
 
+private __gshared bool _initialized;
+
 struct Config
 {
     bool disable;            // start disabled
@@ -31,7 +33,9 @@ struct Config
 
     bool initialize()
     {
-        return initConfigOptions(this, "gcopt");
+        if (!_initialized)
+            _initialized = initConfigOptions(this, "gcopt");
+        return _initialized;
     }
 
     void help() @nogc nothrow

--- a/druntime/src/core/gc/registry.d
+++ b/druntime/src/core/gc/registry.d
@@ -8,6 +8,7 @@
 module core.gc.registry;
 
 import core.gc.gcinterface : GC;
+import core.thread.threadbase : ThreadBase;
 
 /*@nogc nothrow:*/
 
@@ -22,27 +23,50 @@ import core.gc.gcinterface : GC;
 alias GCFactory = GC function();
 
 /**
+ * A function that will initialize a thread before the GC has been initialized.
+ * Once the GC is initialized, the interface method GC.initThread for each new
+ * thread.
+ */
+alias GCThreadInitFunction = void function(ThreadBase base) nothrow @nogc;
+
+private void defaultThreadInit(ThreadBase base) nothrow @nogc { }
+
+/**
  * Register a GC factory under the given `name`.  This function must be called
  * from a C constructor before druntime is initialized.
  *
  * To use the registered GC, it's name must be specified gcopt runtime option,
  * e.g. by passing $(TT, --DRT-gcopt=gc:my_gc_name) as application argument.
  *
+ * The thread init function will be called *only before* the GC has been
+ * initialized to the registered GC. It is called as the first step in starting
+ * the new thread before the thread is registered with the runtime as a running
+ * thread. This allows any specific thread data that is needed for running the
+ * GC to be registered with the thread object.
+ *
+ * After the GC is initialized, the GC interface function `initThread` is
+ * called instead. This function should expect the possibility that the
+ * reciprocal `cleanupThread` method may not be called if the GC is never
+ * initialized.
+ *
  * Params:
  *   name = name of the GC implementation; should be unique
  *   factory = function to instantiate the implementation
+ *   threadInit = function to call from a new thread *before* registration in
+ *       the list of running threads, to set up any GC-specific data.
  * Note: The registry does not perform synchronization, as registration is
  *   assumed to be executed serially, as is the case for C constructors.
  * See_Also:
  *   $(LINK2 https://dlang.org/spec/garbage.html#gc_config, Configuring the Garbage Collector)
  */
-void registerGCFactory(string name, GCFactory factory) nothrow @nogc
+void registerGCFactory(string name, GCFactory factory,
+        GCThreadInitFunction threadInit = &defaultThreadInit) nothrow @nogc
 {
     import core.stdc.stdlib : realloc;
 
     auto ptr = cast(Entry*)realloc(entries.ptr, (entries.length + 1) * Entry.sizeof);
     entries = ptr[0 .. entries.length + 1];
-    entries[$ - 1] = Entry(name, factory);
+    entries[$ - 1] = Entry(name, factory, threadInit);
 }
 
 /**
@@ -70,6 +94,25 @@ GC createGCInstance(string name)
     return null;
 }
 
+/**
+ * Get the thread init function used for the selected GC.
+ *
+ * Note, this must be called before `createGCInstance`. It is typically called by
+ * `rt_init`.
+ */
+GCThreadInitFunction threadInit(string name) nothrow @nogc
+{
+    foreach (entry; entries)
+    {
+        if (entry.name == name)
+            return entry.threadInit;
+    }
+    // No init function selected, this probably means the GC name isn't
+    // correct. But nobody has used any GC related functions yet, so give back
+    // the default function.
+    return &defaultThreadInit;
+}
+
 // list of all registerd GCs
 const(Entry[]) registeredGCFactories(scope int dummy=0) nothrow @nogc
 {
@@ -82,6 +125,7 @@ struct Entry
 {
     string name;
     GCFactory factory;
+    GCThreadInitFunction threadInit;
 }
 
 __gshared Entry[] entries;

--- a/druntime/src/core/gc/registry.d
+++ b/druntime/src/core/gc/registry.d
@@ -29,8 +29,6 @@ alias GCFactory = GC function();
  */
 alias GCThreadInitFunction = void function(ThreadBase base) nothrow @nogc;
 
-private void defaultThreadInit(ThreadBase base) nothrow @nogc { }
-
 /**
  * Register a GC factory under the given `name`.  This function must be called
  * from a C constructor before druntime is initialized.
@@ -60,7 +58,7 @@ private void defaultThreadInit(ThreadBase base) nothrow @nogc { }
  *   $(LINK2 https://dlang.org/spec/garbage.html#gc_config, Configuring the Garbage Collector)
  */
 void registerGCFactory(string name, GCFactory factory,
-        GCThreadInitFunction threadInit = &defaultThreadInit) nothrow @nogc
+        GCThreadInitFunction threadInit = null) nothrow @nogc
 {
     import core.stdc.stdlib : realloc;
 
@@ -107,10 +105,7 @@ GCThreadInitFunction threadInit(string name) nothrow @nogc
         if (entry.name == name)
             return entry.threadInit;
     }
-    // No init function selected, this probably means the GC name isn't
-    // correct. But nobody has used any GC related functions yet, so give back
-    // the default function.
-    return &defaultThreadInit;
+    return null;
 }
 
 // list of all registerd GCs

--- a/druntime/src/core/internal/gc/blkcache.d
+++ b/druntime/src/core/internal/gc/blkcache.d
@@ -63,17 +63,16 @@ else
 }
 
 // free the allocation on thread exit.
-@standalone static ~this()
+void cleanupBlkCache(void* storage) nothrow @nogc
 {
-    if (__blkcache_storage)
+    if (storage)
     {
+        // check if this is the same thread as the current running thread, and
+        // if so, make sure we don't leave a dangling pointer.
+        if (__blkcache_storage is storage)
+            __blkcache_storage = null;
         import core.stdc.stdlib : free;
-        import core.thread.threadbase;
-        auto tBase = ThreadBase.getThis();
-        if (tBase !is null)
-            tBase.tlsGCData = null;
-        free(__blkcache_storage);
-        __blkcache_storage = null;
+        free(storage);
     }
 }
 

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -1637,6 +1637,14 @@ class ConservativeGC : GC
 
         return existingCapacity - offset;
     }
+
+    void initThread(ThreadBase t) nothrow @nogc { }
+
+    void cleanupThread(ThreadBase t) nothrow @nogc
+    {
+        cleanupBlkCache(t.tlsGCData);
+        t.tlsGCData = null;
+    }
 }
 
 

--- a/druntime/src/core/internal/gc/impl/manual/gc.d
+++ b/druntime/src/core/internal/gc/impl/manual/gc.d
@@ -23,6 +23,8 @@ import core.gc.gcinterface;
 
 import core.internal.container.array;
 
+import core.thread.threadbase : ThreadBase;
+
 import cstdlib = core.stdc.stdlib : calloc, free, malloc, realloc;
 static import core.memory;
 
@@ -286,5 +288,13 @@ class ManualGC : GC
     bool shrinkArrayUsed(void[] slice, size_t existingUsed, bool atomic = false) nothrow
     {
         return false;
+    }
+
+    void initThread(ThreadBase t) nothrow @nogc
+    {
+    }
+
+    void cleanupThread(ThreadBase t) nothrow @nogc
+    {
     }
 }

--- a/druntime/src/core/internal/gc/impl/proto/gc.d
+++ b/druntime/src/core/internal/gc/impl/proto/gc.d
@@ -32,6 +32,7 @@ private
     extern (C) void gc_addRoot(const void* p ) nothrow @nogc;
 }
 
+
 class ProtoGC : GC
 {
     Array!Root roots;
@@ -273,10 +274,12 @@ class ProtoGC : GC
     {
         if (_initThreadFn is null)
         {
+            static void defaultThreadInit(ThreadBase base) nothrow @nogc { }
             import core.gc.config;
             config.initialize();
             _initThreadFn = .threadInit(config.gc);
-            assert(_initThreadFn !is null, "Invalid thread initialization function!");
+            if (_initThreadFn is null)
+                _initThreadFn = &defaultThreadInit;
         }
 
         _initThreadFn(thread);

--- a/druntime/src/core/internal/gc/proxy.d
+++ b/druntime/src/core/internal/gc/proxy.d
@@ -266,7 +266,7 @@ extern (C)
         return instance.shrinkArrayUsed( slice, existingUsed, atomic );
     }
 
-    GC gc_getProxy() nothrow
+    GC gc_getProxy() nothrow @nogc
     {
         return instance;
     }

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -133,6 +133,10 @@ class ThreadBase
     package void tlsRTdataInit() nothrow @nogc
     {
         m_tlsrtdata = rt_tlsgc_init();
+
+        // Let the selected GC initialize anything it needs.
+        import core.internal.gc.proxy : gc_getProxy;
+        gc_getProxy().initThread(this);
     }
 
     package void initDataStorage() nothrow
@@ -146,6 +150,10 @@ class ThreadBase
 
     package void destroyDataStorage() nothrow @nogc
     {
+        // allow the GC to clean up any resources it allocated for this thread.
+        import core.internal.gc.proxy : gc_getProxy;
+        gc_getProxy().cleanupThread(this);
+
         rt_tlsgc_destroy(m_tlsrtdata);
         m_tlsrtdata = null;
     }

--- a/druntime/test/init_fini/src/custom_gc.d
+++ b/druntime/test/init_fini/src/custom_gc.d
@@ -4,6 +4,8 @@ import core.stdc.stdlib : calloc, malloc, realloc;
 
 static import core.memory;
 
+import core.thread.threadbase : ThreadBase;
+
 extern (C) __gshared string[] rt_options = ["gcopt=gc:malloc"];
 
 extern (C) pragma(crt_constructor) void register_mygc()
@@ -207,6 +209,14 @@ nothrow @nogc:
     bool shrinkArrayUsed(void[] slice, size_t existingUsed, bool atomic = false) nothrow
     {
         return false;
+    }
+
+    void initThread(ThreadBase thread) nothrow @nogc
+    {
+    }
+
+    void cleanupThread(ThreadBase thread) nothrow @nogc
+    {
     }
 
 private:


### PR DESCRIPTION
Any custom GC may depend on initialization of the `tlsGCData` property before the thread starts. For instance, in the new GC, I need access to a specific TLS variable (threadCache), to allow properly suspending threads on Windows.

On cleanup, the GC may need to unregister something in TLS, or free resources such as malloc'd data.

This is the case for the blkcache in the conservative GC. The original code would free this block as part of static destructors, but the order of this is not determined. It is better to free the cache when we know the static destructors are done running, and we know no other usage of TLS will occur.

This PR touches a lot of files, but mostly just for adding API calls to all the GCs.

The `initThread` documentation is a bit convoluted. I can explain. The GC may not be initialized when we are creating threads (it is possible to emplace a thread object on the stack, or in global memory, and the main thread does not init the GC). Therefore, when we first want to init the thread, the GC may not have been initialized.

This presents a problem, because we need to run the `initThread` from the target thread's context *before* the thread really starts. So to work around this situation, we have 2 hooks, one from the GC interface, and one from the registration. The Proto GC will first check which registration was selected, and use the registered init function. This allows proper initialization of the thread TLSGC data from the main thread, or any threads created before the GC is initialized. Then once the GC is initialized, we can have access to that data.

However, once the real GC is initialized, we don't have access to the ProtoGC instance. So at that point, we then will call the new GC's initThread function.

In this way, there can be a subtle difference between initThread before GC initialization, and initThread afterwards.

In the new GC, the calls will be the same.