### PR TITLE
CI: Rework runnable_cxx GHA workflow

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -58,24 +58,34 @@ jobs:
       matrix:
         include:
           # Linux, clang:
-          - { os: ubuntu-24.04, compiler: clang-18 }
-          - { os: ubuntu-24.04, compiler: clang-17 }
-          - { os: ubuntu-24.04, compiler: clang-16 }
-          - { os: ubuntu-24.04, compiler: clang-15 }
-          - { os: ubuntu-24.04, compiler: clang-14 }
+          - { os: ubuntu-24.04, compiler: clang-18, model: 64 }
+          - { os: ubuntu-24.04, compiler: clang-18, model: 32 }
+          - { os: ubuntu-24.04, compiler: clang-17, model: 64 }
+          - { os: ubuntu-24.04, compiler: clang-17, model: 32 }
+          - { os: ubuntu-24.04, compiler: clang-16, model: 64 }
+          - { os: ubuntu-24.04, compiler: clang-16, model: 32 }
+          - { os: ubuntu-24.04, compiler: clang-15, model: 64 }
+          - { os: ubuntu-24.04, compiler: clang-15, model: 32 }
+          - { os: ubuntu-24.04, compiler: clang-14, model: 64 }
+          - { os: ubuntu-24.04, compiler: clang-14, model: 32 }
           # Linux, g++:
-          - { os: ubuntu-24.04, compiler: g++-13 }
-          - { os: ubuntu-24.04, compiler: g++-12 }
-          - { os: ubuntu-24.04, compiler: g++-11 }
-          - { os: ubuntu-24.04, compiler: g++-10 }
-          - { os: ubuntu-24.04, compiler: g++-9 }
+          - { os: ubuntu-24.04, compiler: g++-13, model: 64 }
+          - { os: ubuntu-24.04, compiler: g++-13, model: 32 }
+          - { os: ubuntu-24.04, compiler: g++-12, model: 64 }
+          - { os: ubuntu-24.04, compiler: g++-12, model: 32 }
+          - { os: ubuntu-24.04, compiler: g++-11, model: 64 }
+          - { os: ubuntu-24.04, compiler: g++-11, model: 32 }
+          - { os: ubuntu-24.04, compiler: g++-10, model: 64 }
+          - { os: ubuntu-24.04, compiler: g++-10, model: 32 }
+          - { os: ubuntu-24.04, compiler: g++-9, model: 64 }
+          - { os: ubuntu-24.04, compiler: g++-9, model: 32 }
           # macOS, Apple clang from Xcode:
-          - { os: macos-13, xcode: '14.3.1' }
-          - { os: macos-13, xcode: '15.2' }
-          - { os: macos-14, xcode: '16.2' }
+          - { os: macos-13, xcode: '14.3.1', model: 64 }
+          - { os: macos-13, xcode: '15.2', model: 64 }
+          - { os: macos-14, xcode: '16.2', model: 64 }
           # Windows, cl.exe from Visual Studio:
-          - { os: windows-2022 }
-          - { os: windows-2019 }
+          - { os: windows-2022, model: 64 }
+          - { os: windows-2019, model: 64 }
 
     runs-on: ${{ matrix.os }}
     defaults:
@@ -85,6 +95,8 @@ jobs:
 
     - name: Set environment variable N (parallelism)
       run: echo "N=$(${{ runner.os == 'macOS' && 'sysctl -n hw.logicalcpu' || 'nproc' }})" >> $GITHUB_ENV
+    - name: Set environment variable MODEL
+      run: echo "MODEL=${{ matrix.model }}" >> $GITHUB_ENV
 
     - name: 'macOS: Upgrade GNU make'
       if: runner.os == 'macOS'
@@ -145,11 +157,12 @@ jobs:
         set -eux
         sudo apt-get update
         apt_packages='${{ matrix.compiler }}'
-        # add 32-bit package for 32-bit tests
-        if [[ '${{ matrix.compiler }}' =~ ^g\+\+ ]]; then
-          apt_packages+=" ${{ matrix.compiler }}-multilib"
-        else
-          apt_packages+=" g++-multilib"
+        if [[ "$MODEL" == 32 ]]; then
+          if [[ '${{ matrix.compiler }}' =~ ^g\+\+ ]]; then
+            apt_packages+=" ${{ matrix.compiler }}-multilib"
+          else
+            apt_packages+=" g++-multilib"
+          fi
         fi
         sudo apt-get install -y $apt_packages
 
@@ -188,38 +201,21 @@ jobs:
     - name: Build compiler & standard library
       run: |
         set -eux
-        # All hosts are 64 bits but let's be explicit
         if [[ '${{ matrix.os }}' == macos-14 ]]; then
           # don't try compiling a native arm64 DMD on macOS (doesn't work)
-          make -C dmd  -j$N dmd MODEL=64 DFLAGS="-mtriple=x86_64-apple-macos14"
+          make -C dmd  -j$N dmd DFLAGS="-mtriple=x86_64-apple-macos14"
         fi
-        make -C dmd    -j$N MODEL=64
-        make -C phobos -j$N MODEL=64
-
-    - name: Build compiler & standard library (32-bit)
-      if: runner.os == 'Linux'
-      run: |
-        set -eux
-        make -C dmd    -j$N MODEL=32
-        make -C phobos -j$N MODEL=32
+        make -C dmd    -j$N
+        make -C phobos -j$N
 
     ########################################
     #        Running the test suite        #
     ########################################
     - name: Run compiler C++ test suite
-      run: ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=64 ${{ matrix.os == 'macos-14' && 'HOST_DMD="$PWD/dmd/generated/osx/release/64/dmd"' || '' }}
-    - name: Run compiler C++ test suite (32-bit)
-      if: runner.os == 'Linux'
-      run: |
-        set -eux
-        ./dmd/compiler/test/run.d clean
-        ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=32
+      run: ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d ${{ matrix.os == 'macos-14' && 'HOST_DMD="$PWD/dmd/generated/osx/release/64/dmd"' || '' }}
 
     - name: Run druntime C++ tests
-      run: make -C dmd/druntime -j$N test/stdcpp/.run MODEL=64
-    - name: Run druntime C++ tests (32-bit)
-      if: runner.os == 'Linux'
-      run: make -C dmd/druntime -j$N test/stdcpp/.run MODEL=32
+      run: make -C dmd/druntime -j$N test/stdcpp/.run
 
     - name: 'Posix: Run frontend C++ unittests'
       if: runner.os != 'Windows' # not supported by build.d yet
@@ -231,7 +227,4 @@ jobs:
           export CXXFLAGS="-arch x86_64"
           rm ./dmd/generated/osx/release/64/*.o
         fi
-        ./dmd/generated/build cxx-unittest MODEL=64
-    - name: Run frontend C++ unittests (32-bit)
-      if: runner.os == 'Linux'
-      run: ./dmd/generated/build cxx-unittest MODEL=32
+        ./dmd/generated/build cxx-unittest

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -11,18 +11,13 @@
 # which is usually whatever the vendor (Canonical, Apple, Microsoft) supports.
 #
 # Notes:
-# - Some patterns used here have been developed through a lot of trial and error
-#   In particular, the build matrix approach, with two rows, and a large list of
-#   excludes, ended up being the most useful approach.
-# - Additionally, the check for the compiler version will save you a lot of trouble.
-#   Having the wrong path added to the $PATH and ending up with the wrong compiler
-#   being used can make debugging very painful.
+# - When debugging/troubleshooting, make sure to check the printed compiler versions.
 # - Try to use the native Github action syntax (${{ expression }}) when possible,
 #   as they are substituted with their value in the logs, unlike env variable.
 #   For example use `${{ github.workspace }}` over `${GITHUB_WORKSPACE}`
 #
 # TODO:
-# - Implement Windows + clang support
+# - Test clang on Windows? (note: probably not all tests respect a CC/CXX env variable on Windows)
 name: C++ interop tests
 
 # Only triggers on pushes to master & stable, as well as PR to master and stable
@@ -73,13 +68,14 @@ jobs:
           - { os: ubuntu-24.04, compiler: g++-11, model: 32 }
           - { os: ubuntu-24.04, compiler: g++-10, model: 64 }
           - { os: ubuntu-24.04, compiler: g++-10, model: 32 }
-          - { os: ubuntu-24.04, compiler: g++-9, model: 64 }
-          - { os: ubuntu-24.04, compiler: g++-9, model: 32 }
+          - { os: ubuntu-24.04, compiler: g++-9,  model: 64 }
+          - { os: ubuntu-24.04, compiler: g++-9,  model: 32 }
           # macOS, Apple clang from Xcode:
+          - { os: macos-14, xcode: '16.2',   model: 64 }
+          - { os: macos-13, xcode: '15.2',   model: 64 }
           - { os: macos-13, xcode: '14.3.1', model: 64 }
-          - { os: macos-13, xcode: '15.2', model: 64 }
-          - { os: macos-14, xcode: '16.2', model: 64 }
           # Windows, cl.exe from Visual Studio:
+          # NOTE: as of April 2025, image windows-2025 only has VS 2022, so no point in testing that image too
           - { os: windows-2022, model: 64 }
           - { os: windows-2022, model: 32 }
           - { os: windows-2019, model: 64 }
@@ -107,7 +103,7 @@ jobs:
     ########################################
     #    Setting up the host D compiler    #
     ########################################
-    - name: Prepare compiler
+    - name: Install D host compiler
       uses: dlang-community/setup-dlang@v2
     - name: 'Posix: Clear LD_LIBRARY_PATH environment variable' # don't use host druntime/Phobos .so/.dylib etc.
       if: runner.os != 'Windows'
@@ -170,9 +166,10 @@ jobs:
       with:
         arch: ${{ matrix.model == '64' && 'x64' || 'x86' }}
 
-    - name: 'Posix: Setup CC and CXX environment variables'
+    - name: 'Posix: Set up CC and CXX environment variables'
       if: runner.os != 'Windows'
       run: |
+        set -eux
         if [[ '${{ runner.os }}' == Linux ]]; then
           compiler='${{ matrix.compiler }}'
           echo "CC=${compiler/g++/gcc}" >> $GITHUB_ENV
@@ -183,7 +180,7 @@ jobs:
           echo "CXX=c++" >> $GITHUB_ENV
         fi
 
-    - name: Verify used C/C++ compiler versions
+    - name: Print used C/C++ compiler versions
       run: |
         set -eux
         if [[ '${{ runner.os }}' == Windows ]]; then
@@ -215,7 +212,7 @@ jobs:
     - name: Run druntime C++ tests
       run: make -C dmd/druntime -j$N test/stdcpp/.run
 
-    - name: 'Posix: Run frontend C++ unittests'
+    - name: 'Posix: Run C++ frontend unittests'
       if: runner.os != 'Windows' # not supported by build.d yet
       run: |
         set -eux

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -22,7 +22,6 @@
 #   For example use `${{ github.workspace }}` over `${GITHUB_WORKSPACE}`
 #
 # TODO:
-# - Implement Windows + MSVC support
 # - Implement Windows + clang support
 name: C++ interop tests
 
@@ -85,7 +84,9 @@ jobs:
           - { os: macos-14, xcode: '16.2', model: 64 }
           # Windows, cl.exe from Visual Studio:
           - { os: windows-2022, model: 64 }
+          - { os: windows-2022, model: 32 }
           - { os: windows-2019, model: 64 }
+          - { os: windows-2019, model: 32 }
 
     runs-on: ${{ matrix.os }}
     defaults:
@@ -170,7 +171,7 @@ jobs:
       if: runner.os == 'Windows'
       uses: seanmiddleditch/gha-setup-vsdevenv@v4
       with:
-        arch: x64
+        arch: ${{ matrix.model == '64' && 'x64' || 'x86' }}
 
     - name: 'Posix: Setup CC and CXX environment variables'
       if: runner.os != 'Windows'

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -57,92 +57,25 @@ jobs:
       # very few PRs actually benefit from this.
       fail-fast: false
       matrix:
-        os: [ macos-13, ubuntu-22.04, windows-2019 ]
-
-        target: [
-          # Versions of clang earlier than 11 are not available on 22.04, but are on macOS 13
-          clang-13.0.0, clang-12.0.0, clang-11.0.0, clang-10.0.0, clang-9.0.0, clang-8.0.0,
-        # For g++, we test the oldest compiler on Ubuntu 22.04, which is GCC-9
-          g++-11, g++-10, g++-9,
-          # Finally, we test MSVC 2013 - 2019
-          msvc-2019, msvc-2017, msvc-2015, msvc-2013
-        ]
-
-        # Exclude target compilers not supported by the host
-        # Note: Pattern matching is not supported so this list is quite long,
-        # and brittle, as changing an msvc entry would break on OSX, for example.
-        exclude:
-          # 22.04 only has g++-9 through to 11, and clang-11.0.0 through to 13.0.0
-          - { os: ubuntu-22.04, target: clang-10.0.0 }
-          - { os: ubuntu-22.04, target: clang-9.0.0 }
-          - { os: ubuntu-22.04, target: clang-8.0.0 }
-          - { os: ubuntu-22.04, target: msvc-2019 }
-          - { os: ubuntu-22.04, target: msvc-2017 }
-          - { os: ubuntu-22.04, target: msvc-2015 }
-          - { os: ubuntu-22.04, target: msvc-2013 }
-          # OSX only supports clang
-          - { os: macos-13, target: g++-11 }
-          - { os: macos-13, target: g++-10 }
-          - { os: macos-13, target: g++-9 }
-          - { os: macos-13, target: msvc-2019 }
-          - { os: macos-13, target: msvc-2017 }
-          - { os: macos-13, target: msvc-2015 }
-          - { os: macos-13, target: msvc-2013 }
-          # We don't test g++ on Windows as DMD only mangles for MSVC
-          - { os: windows-2019, target: g++-11 }
-          - { os: windows-2019, target: g++-10 }
-          - { os: windows-2019, target: g++-9 }
-
-          # TODO: Implement support for clang and MSVC2017 on Windows
-          # Currently those are still being run by the auto-tester
-          # We can hardly test below 2017 in the CI because there's
-          # no way to install it via command line
-          # (TODO: Test with 2015 as the blog post is slightly ambiguous)
-          # https://devblogs.microsoft.com/cppblog/introducing-the-visual-studio-build-tools/
-          - { os: windows-2019, target: msvc-2017 }
-          - { os: windows-2019, target: msvc-2015 }
-          - { os: windows-2019, target: msvc-2013 }
-          - { os: windows-2019, target: clang-13.0.0 }
-          - { os: windows-2019, target: clang-12.0.0 }
-          - { os: windows-2019, target: clang-11.0.0 }
-          - { os: windows-2019, target: clang-10.0.0 }
-          - { os: windows-2019, target: clang-9.0.0 }
-          - { os: windows-2019, target: clang-8.0.0 }
-
-        # This sets the configuration for each jobs
-        # There's a bit of duplication involved (e.g. breaking down g++-9.3 into 2 strings),
-        # but some items are unique (e.g. clang-9.0.0 and 4.0.1 have differences in their naming).
         include:
-          # Clang boilerplate
-          - { target: clang-13.0.0, compiler: clang, cxx-version: 13.0.0 }
-          - { target: clang-12.0.0, compiler: clang, cxx-version: 12.0.0 }
-          - { target: clang-11.0.0, compiler: clang, cxx-version: 11.0.0 }
-          - { target: clang-10.0.0, compiler: clang, cxx-version: 10.0.0 }
-          - { target: clang-9.0.0, compiler: clang, cxx-version: 9.0.0 }
-          - { target: clang-8.0.0, compiler: clang, cxx-version: 8.0.0 }
-          # g++ boilerplace
-          - { target: g++-11, compiler: g++, cxx-version: 11.2.0, major: 11 }
-          - { target: g++-10, compiler: g++, cxx-version: 10.3.0, major: 10 }
-          - { target: g++-9, compiler: g++, cxx-version: 9.4.0, major: 9 }
-          # Platform boilerplate
-          - { os: ubuntu-22.04, arch: x86_64-linux-gnu-ubuntu-20.04 }
-          - { os: macos-13,  arch: x86_64-apple-darwin }
-          # Clang 9.0.0 have a different arch for OSX
-          - { os: macos-13, target: clang-9.0.0, arch: x86_64-darwin-apple }
-          # Those targets will generate artifacts that can be used by other testers
-          - { storeArtifacts: false }
-          - { os: ubuntu-22.04, target: g++-9,    storeArtifacts: true }
-          - { os: macos-13,  target: clang-9.0.0, storeArtifacts: true }
-          #- { os: windows-2019, target: msvc-2019,   storeArtifacts: true }
+          # Linux, clang:
+          - { os: ubuntu-24.04, compiler: clang-18 }
+          - { os: ubuntu-24.04, compiler: clang-17 }
+          - { os: ubuntu-24.04, compiler: clang-16 }
+          - { os: ubuntu-24.04, compiler: clang-15 }
+          - { os: ubuntu-24.04, compiler: clang-14 }
+          # Linux, g++:
+          - { os: ubuntu-24.04, compiler: g++-13 }
+          - { os: ubuntu-24.04, compiler: g++-12 }
+          - { os: ubuntu-24.04, compiler: g++-11 }
+          - { os: ubuntu-24.04, compiler: g++-10 }
+          - { os: ubuntu-24.04, compiler: g++-9 }
+          # TODO: macOS & Windows
 
-    # We're using the latest available images at the time of this commit.
-    # Using a specific version for reproductibility.
-    # Feel free to update when a new release has matured.
     runs-on: ${{ matrix.os }}
     steps:
 
     - name: Set environment variable N (parallelism)
-      shell: bash
       run: echo "N=$(${{ runner.os == 'macOS' && 'sysctl -n hw.logicalcpu' || 'nproc' }})" >> $GITHUB_ENV
 
     ########################################
@@ -150,13 +83,15 @@ jobs:
     ########################################
     - name: Prepare compiler
       uses: dlang-community/setup-dlang@v1
+    - name: 'Posix: Clear LD_LIBRARY_PATH environment variable' # don't use host druntime/Phobos .so/.dylib etc.
+      if: runner.os != 'Windows'
+      run: echo "LD_LIBRARY_PATH=" >> $GITHUB_ENV
 
     ##############################################
     # Find out which branch we need to check out #
     ##############################################
     - name: Determine base branch
       id: base_branch
-      shell: bash
       run: |
         # For pull requests, base_ref will not be empty
         if [ ! -z ${{ github.base_ref }} ]; then
@@ -168,9 +103,9 @@ jobs:
             echo "branch=${{ github.ref }}" >> $GITHUB_OUTPUT
         fi
 
-    #########################################
-    # Checking out up DMD, druntime, Phobos #
-    #########################################
+    #####################################
+    #    Checking out DMD and Phobos    #
+    #####################################
     - name: Checkout DMD
       uses: actions/checkout@v4
       with:
@@ -188,190 +123,65 @@ jobs:
     ########################################
     #   Setting up the host C++ compiler   #
     ########################################
-    - name: '[Posix] Load cached clang'
-      id: cache-clang
-      if: matrix.compiler == 'clang' && runner.os != 'Windows'
-      uses: actions/cache@v4
-      with:
-        path: ${{ github.workspace }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}/
-        key: ${{ matrix.cxx-version }}-${{ matrix.arch }}-2022-09-25-2121
-
-    - name: '[Posix] Setting up clang ${{ matrix.cxx-version }}'
-      if: matrix.compiler == 'clang' && runner.os != 'Windows' && steps.cache-clang.outputs.cache-hit != 'true'
+    - name: Install C++ compiler
       run: |
-        if [ "${{ matrix.cxx-version }}" == "8.0.0" -o "${{ matrix.cxx-version }}" == "9.0.0" ]; then
-          wget --quiet --directory-prefix=${{ github.workspace }} https://releases.llvm.org/${{ matrix.cxx-version }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}.tar.xz
-        else
-          wget --quiet --directory-prefix=${{ github.workspace }} https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ matrix.cxx-version }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}.tar.xz
-        fi
-        tar -x -C ${{ github.workspace }} -f ${{ github.workspace }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}.tar.xz
-        TMP_CC='${{ github.workspace }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}/bin/clang'
-        # On OSX, the system header are installed via `xcode-select` and not distributed with clang
-        # Since some part of the testsuite rely on CC and CXX being only a binary (not a command),
-        # and config files where only introduced from 6.0.0, use a wrapper script.
-        if [ "${{ matrix.os }}" == "macos-13" ]; then
-          # Note: heredoc shouldn't be indented
-          cat << 'EOF' > ${TMP_CC}-wrapper
-        #!/bin/bash
-        # Note: We need to use this because github.workspace is not stable
-        SCRIPT_FULL_PATH=$(dirname "$0")
-        ${SCRIPT_FULL_PATH}/clang -isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ $@
-        EOF
-          # Invoking clang with `clang++` will link the C++ standard library
-          # Make sure we got two separate wrapper for this
-          cat << 'EOF' > ${TMP_CC}++-wrapper
-        #!/bin/bash
-        SCRIPT_FULL_PATH=$(dirname "$0")
-        ${SCRIPT_FULL_PATH}/clang++ -isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ $@
-        EOF
-          chmod +x ${TMP_CC}-wrapper ${TMP_CC}++-wrapper
-        fi
-
-    - name: 'macOS 13: Switch to Xcode v14.3.1' # to work around '-macosx_version_min has been renamed to -macos_version_min' with some clang versions
-      if: matrix.os == 'macos-13'
-      run: sudo xcode-select -switch /Applications/Xcode_14.3.1.app
-
-    - name: '[Posix] Setup environment variables'
-      if: matrix.compiler == 'clang' && runner.os != 'Windows'
-      run: |
-        TMP_CC='${{ github.workspace }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}/bin/clang'
-        if [ "${{ matrix.os }}" == "macos-13" ]; then
-          echo "CC=${TMP_CC}-wrapper" >> $GITHUB_ENV
-          echo "CXX=${TMP_CC}++-wrapper" >> $GITHUB_ENV
-          echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
-        else
-          echo "CC=${TMP_CC}" >> $GITHUB_ENV
-          echo "CXX=${TMP_CC}++" >> $GITHUB_ENV
-        fi
-
-    # On OSX and Linux, clang is installed by default and in the path,
-    # so make sure ${CC} works
-    - name: '[Posix] Verifying installed clang version'
-      if: matrix.compiler == 'clang' && runner.os != 'Windows'
-      run: |
-        set -e
-        if ${CXX} --version | grep -q 'version ${{ matrix.cxx-version }}'; then
-          ${CXX} --version
-        else
-            echo "Expected version ${{ matrix.cxx-version }}, from '${CXX}', got:"
-            ${CXX} --version
-            exit 1
-        fi
-
-    # G++ is only supported on Linux
-    - name: '[Linux] Setting up g++ ${{ matrix.cxx-version }}'
-      if: matrix.compiler == 'g++'
-      run: |
-        # Workaround bug in Github actions
-        wget https://cli-assets.heroku.com/apt/release.key
-        sudo apt-key add release.key
-        # Make sure we have the essentials
+        set -eux
         sudo apt-get update
-        sudo apt-get install ca-certificates
-        sudo apt-get install build-essential software-properties-common -y
-        # This ppa provides multiple versions of g++
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.target }} ${{ matrix.target }}-multilib
-        echo "CC=${{ matrix.target }}" >> $GITHUB_ENV
-        echo "CXX=${{ matrix.target }}" >> $GITHUB_ENV
-
-    # Make sure ${CC} works and we don't use the $PATH one
-    - name: '[Linux] Verifying installed g++ version'
-      if: matrix.compiler == 'g++'
-      run: |
-        set -e
-        if ${CXX} --version | grep -q '${{ matrix.target }} (Ubuntu '; then
-          ${CXX} --version
-        else
-            echo "Expected version ${{ matrix.target }}, from '${CXX}', got:"
-            ${CXX} --version
-            exit 1
+        apt_packages='${{ matrix.compiler }}'
+        if [[ '${{ matrix.compiler }}' =~ ^g\+\+ ]]; then
+          apt_packages+=" ${{ matrix.compiler }}-multilib" # for 32-bit tests
         fi
+        sudo apt-get install -y $apt_packages
 
-    - name: '[Windows] Add VC toolset to PATH'
-      if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
-
-    - name: '[Windows] Set environment variables'
-      if: runner.os == 'Windows'
-      shell: bash
+    - name: Setup CC and CXX environment variables
       run: |
-        echo "HOST_DMD=${{ env.DC }}" >> $GITHUB_ENV
+        compiler='${{ matrix.compiler }}'
+        echo "CC=${compiler/g++/gcc}" >> $GITHUB_ENV
+        echo "CXX=${compiler/clang/clang++}" >> $GITHUB_ENV
+
+    - name: Verify used C/C++ compiler versions
+      run: |
+        set -eux
+        $CC --version
+        $CXX --version
 
     ########################################
     #    Building DMD, druntime, Phobos    #
     ########################################
-    - name: '[Posix] Build compiler & standard library'
-      if: runner.os != 'Windows'
+    - name: Build compiler & standard library
       run: |
+        set -eux
         # All hosts are 64 bits but let's be explicit
-        ./dmd/compiler/src/build.d -j$N MODEL=64
-        make -C dmd/druntime -j$N MODEL=64
-        make -C phobos       -j$N MODEL=64
-        # Both version can live side by side (they end up in a different directory)
-        # However, since clang does not provide a multilib package, only test 32 bits with g++
-        if [ ${{ matrix.compiler }} == "g++" ]; then
-          ./dmd/compiler/src/build.d install -j$N MODEL=32
-          make -C dmd/druntime install -j$N MODEL=32
-          make -C phobos       install -j$N MODEL=32
-        fi
+        make -C dmd    -j$N MODEL=64
+        make -C phobos -j$N MODEL=64
 
-    - name: '[Windows] Build compiler & standard library'
-      if: runner.os == 'Windows'
-      shell: bash
+    - name: Build compiler & standard library (32-bit)
+      if: startsWith(matrix.compiler, 'g++')
       run: |
-        dmd -run dmd/compiler/src/build.d -j$N MODEL=64
-        if [ $? -ne 0 ]; then return 1; fi
-        # Note: Only CC for druntime and AR for Phobos are required ATM,
-        # but providing all three to avoid surprise for future contributors
-        # Those should really be in the path, though.
-        make -j$N -C dmd/druntime
-        if [ $? -ne 0 ]; then return 1; fi
-        make -j$N -C phobos
-        if [ $? -ne 0 ]; then return 1; fi
+        set -eux
+        make -C dmd    -j$N MODEL=32
+        make -C phobos -j$N MODEL=32
 
     ########################################
     #        Running the test suite        #
     ########################################
-    - name: '[Posix] Run C++ test suite'
-      if: runner.os != 'Windows'
-      env:
-        # Reset LD_LIBRARY_PATH when running the tests, so they use the newly built libphobos2.so.
-        LD_LIBRARY_PATH: ''
+    - name: Run compiler C++ test suite
+      run: ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=64
+    - name: Run compiler C++ test suite (32-bit)
+      if: startsWith(matrix.compiler, 'g++')
       run: |
-        ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=64
-        if [ ${{ matrix.compiler }} == "g++" ]; then
-          ./dmd/compiler/test/run.d clean
-          ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=32
-        fi
+        set -eux
+        ./dmd/compiler/test/run.d clean
+        ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=32
 
-    - name: '[Windows] Run C++ test suite'
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        make -j$N -C dmd/druntime test/stdcpp/.run
-        if [ $? -ne 0 ]; then return 1; fi
+    - name: Run druntime C++ tests
+      run: make -C dmd/druntime -j$N test/stdcpp/.run MODEL=64
+    - name: Run druntime C++ tests (32-bit)
+      if: startsWith(matrix.compiler, 'g++')
+      run: make -C dmd/druntime -j$N test/stdcpp/.run MODEL=32
 
-    ########################################
-    #      Run C++ frontend unittests      #
-    ########################################
-    - name: Run C++ frontend unittests
-      if: matrix.compiler == 'g++'
-      run: |
-        ./dmd/compiler/src/build.d cxx-unittest MODEL=64
-
-    - name: Run C++ frontend unittests (32-bit)
-      if: matrix.compiler == 'g++'
-      run: |
-        ./dmd/compiler/src/build.d cxx-unittest MODEL=32
-
-    ########################################
-    #      Store generated artifacts       #
-    ########################################
-    - name: Store artifacts
-      if: ${{ matrix.storeArtifacts }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: dmd-${{ matrix.os }}
-        path: install
+    - name: Run frontend C++ unittests
+      run: ./dmd/compiler/src/build.d cxx-unittest MODEL=64
+    - name: Run frontend C++ unittests (32-bit)
+      if: startsWith(matrix.compiler, 'g++')
+      run: ./dmd/compiler/src/build.d cxx-unittest MODEL=32

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -55,21 +55,16 @@ jobs:
           # NOTE: cannot test MODEL=32 with clang on Linux, due to a single failure as of April 2025:
           #       runnable_cxx/cppa.d:261: cppa.check13956: Assertion `arg6 == 6' failed.
           - { os: ubuntu-24.04, compiler: clang-18, model: 64 }
-          - { os: ubuntu-24.04, compiler: clang-17, model: 64 }
-          - { os: ubuntu-24.04, compiler: clang-16, model: 64 }
-          - { os: ubuntu-24.04, compiler: clang-15, model: 64 }
+          - { os: ubuntu-22.04, compiler: clang-15, model: 64 }
           - { os: ubuntu-24.04, compiler: clang-14, model: 64 }
+          - { os: ubuntu-22.04, compiler: clang-11, model: 64 }
           # Linux, g++:
           - { os: ubuntu-24.04, compiler: g++-13, model: 64 }
           - { os: ubuntu-24.04, compiler: g++-13, model: 32 }
-          - { os: ubuntu-24.04, compiler: g++-12, model: 64 }
-          - { os: ubuntu-24.04, compiler: g++-12, model: 32 }
-          - { os: ubuntu-24.04, compiler: g++-11, model: 64 }
-          - { os: ubuntu-24.04, compiler: g++-11, model: 32 }
-          - { os: ubuntu-24.04, compiler: g++-10, model: 64 }
-          - { os: ubuntu-24.04, compiler: g++-10, model: 32 }
-          - { os: ubuntu-24.04, compiler: g++-9,  model: 64 }
-          - { os: ubuntu-24.04, compiler: g++-9,  model: 32 }
+          - { os: ubuntu-22.04, compiler: g++-12, model: 64 }
+          - { os: ubuntu-22.04, compiler: g++-12, model: 32 }
+          - { os: ubuntu-22.04, compiler: g++-9,  model: 64 }
+          - { os: ubuntu-22.04, compiler: g++-9,  model: 32 }
           # macOS, Apple clang from Xcode:
           - { os: macos-14, xcode: '16.2',   model: 64 }
           - { os: macos-13, xcode: '15.2',   model: 64 }

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -213,7 +213,13 @@ jobs:
     #        Running the test suite        #
     ########################################
     - name: Run compiler C++ test suite
-      run: ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d ${{ matrix.os == 'macos-14' && 'HOST_DMD="$PWD/dmd/generated/osx/release/64/dmd"' || '' }}
+      run: |
+        set -eux
+        if [[ "$MODEL" == 32 && '${{ matrix.compiler }}' =~ ^clang ]]; then
+          # FIXME: fails with clang and -m32
+          rm ./dmd/compiler/test/runnable_cxx/cppa.d
+        fi
+        ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d ${{ matrix.os == 'macos-14' && 'HOST_DMD="$PWD/dmd/generated/osx/release/64/dmd"' || '' }}
 
     - name: Run druntime C++ tests
       run: make -C dmd/druntime -j$N test/stdcpp/.run

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -74,9 +74,14 @@ jobs:
           - { os: macos-13, xcode: '14.3.1' }
           - { os: macos-13, xcode: '15.2' }
           - { os: macos-14, xcode: '16.2' }
-          # TODO: Windows
+          # Windows, cl.exe from Visual Studio:
+          - { os: windows-2022 }
+          - { os: windows-2019 }
 
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
 
     - name: Set environment variable N (parallelism)
@@ -146,7 +151,14 @@ jobs:
         fi
         sudo apt-get install -y $apt_packages
 
-    - name: Setup CC and CXX environment variables
+    - name: 'Windows: Set up MSVC environment' # puts cl.exe in PATH etc.
+      if: runner.os == 'Windows'
+      uses: seanmiddleditch/gha-setup-vsdevenv@v4
+      with:
+        arch: x64
+
+    - name: 'Posix: Setup CC and CXX environment variables'
+      if: runner.os != 'Windows'
       run: |
         if [[ '${{ runner.os }}' == Linux ]]; then
           compiler='${{ matrix.compiler }}'
@@ -161,8 +173,12 @@ jobs:
     - name: Verify used C/C++ compiler versions
       run: |
         set -eux
-        $CC --version
-        $CXX --version
+        if [[ '${{ runner.os }}' == Windows ]]; then
+          which cl.exe
+        else
+          $CC --version
+          $CXX --version
+        fi
 
     ########################################
     #    Building DMD, druntime, Phobos    #
@@ -203,7 +219,8 @@ jobs:
       if: startsWith(matrix.compiler, 'g++')
       run: make -C dmd/druntime -j$N test/stdcpp/.run MODEL=32
 
-    - name: Run frontend C++ unittests
+    - name: 'Posix: Run frontend C++ unittests'
+      if: runner.os != 'Windows' # not supported by build.d yet
       run: |
         set -eux
         if [[ '${{ matrix.os }}' == macos-14 ]]; then

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -213,13 +213,7 @@ jobs:
     #        Running the test suite        #
     ########################################
     - name: Run compiler C++ test suite
-      run: |
-        set -eux
-        if [[ "$MODEL" == 32 && '${{ matrix.compiler }}' =~ ^clang ]]; then
-          # FIXME: fails with clang and -m32
-          rm ./dmd/compiler/test/runnable_cxx/cppa.d
-        fi
-        ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d ${{ matrix.os == 'macos-14' && 'HOST_DMD="$PWD/dmd/generated/osx/release/64/dmd"' || '' }}
+      run: ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d ${{ matrix.os == 'macos-14' && 'HOST_DMD="$PWD/dmd/generated/osx/release/64/dmd"' || '' }}
 
     - name: Run druntime C++ tests
       run: make -C dmd/druntime -j$N test/stdcpp/.run

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -38,6 +38,10 @@ on:
       # Use this branch name in your fork to test changes
       - github-actions
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Run

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -70,7 +70,11 @@ jobs:
           - { os: ubuntu-24.04, compiler: g++-11 }
           - { os: ubuntu-24.04, compiler: g++-10 }
           - { os: ubuntu-24.04, compiler: g++-9 }
-          # TODO: macOS & Windows
+          # macOS, Apple clang from Xcode:
+          - { os: macos-13, xcode: '14.3.1' }
+          - { os: macos-13, xcode: '15.2' }
+          - { os: macos-14, xcode: '16.2' }
+          # TODO: Windows
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -78,11 +82,22 @@ jobs:
     - name: Set environment variable N (parallelism)
       run: echo "N=$(${{ runner.os == 'macOS' && 'sysctl -n hw.logicalcpu' || 'nproc' }})" >> $GITHUB_ENV
 
+    - name: 'macOS: Upgrade GNU make'
+      if: runner.os == 'macOS'
+      run: |
+        set -eux
+        brew install make
+        sudo ln -s $(which gmake) /usr/local/bin/make
+        make --version
+
     ########################################
     #    Setting up the host D compiler    #
     ########################################
     - name: Prepare compiler
       uses: dlang-community/setup-dlang@v1
+      with:
+        # can't install DMD host compiler on macOS arm64, use LDC
+        compiler: ${{ matrix.os == 'macos-14' && 'ldc-latest' || 'dmd-latest' }}
     - name: 'Posix: Clear LD_LIBRARY_PATH environment variable' # don't use host druntime/Phobos .so/.dylib etc.
       if: runner.os != 'Windows'
       run: echo "LD_LIBRARY_PATH=" >> $GITHUB_ENV
@@ -123,7 +138,8 @@ jobs:
     ########################################
     #   Setting up the host C++ compiler   #
     ########################################
-    - name: Install C++ compiler
+    - name: 'Linux: Install C++ compiler'
+      if: runner.os == 'Linux'
       run: |
         set -eux
         sudo apt-get update
@@ -135,9 +151,15 @@ jobs:
 
     - name: Setup CC and CXX environment variables
       run: |
-        compiler='${{ matrix.compiler }}'
-        echo "CC=${compiler/g++/gcc}" >> $GITHUB_ENV
-        echo "CXX=${compiler/clang/clang++}" >> $GITHUB_ENV
+        if [[ '${{ runner.os }}' == Linux ]]; then
+          compiler='${{ matrix.compiler }}'
+          echo "CC=${compiler/g++/gcc}" >> $GITHUB_ENV
+          echo "CXX=${compiler/clang/clang++}" >> $GITHUB_ENV
+        elif [[ '${{ runner.os }}' == macOS ]]; then
+          sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+          echo "CC=cc" >> $GITHUB_ENV
+          echo "CXX=c++" >> $GITHUB_ENV
+        fi
 
     - name: Verify used C/C++ compiler versions
       run: |

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -57,16 +57,13 @@ jobs:
       matrix:
         include:
           # Linux, clang:
+          # NOTE: cannot test MODEL=32 with clang on Linux, due to a single failure as of April 2025:
+          #       runnable_cxx/cppa.d:261: cppa.check13956: Assertion `arg6 == 6' failed.
           - { os: ubuntu-24.04, compiler: clang-18, model: 64 }
-          - { os: ubuntu-24.04, compiler: clang-18, model: 32 }
           - { os: ubuntu-24.04, compiler: clang-17, model: 64 }
-          - { os: ubuntu-24.04, compiler: clang-17, model: 32 }
           - { os: ubuntu-24.04, compiler: clang-16, model: 64 }
-          - { os: ubuntu-24.04, compiler: clang-16, model: 32 }
           - { os: ubuntu-24.04, compiler: clang-15, model: 64 }
-          - { os: ubuntu-24.04, compiler: clang-15, model: 32 }
           - { os: ubuntu-24.04, compiler: clang-14, model: 64 }
-          - { os: ubuntu-24.04, compiler: clang-14, model: 32 }
           # Linux, g++:
           - { os: ubuntu-24.04, compiler: g++-13, model: 64 }
           - { os: ubuntu-24.04, compiler: g++-13, model: 32 }

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -24,7 +24,6 @@
 # TODO:
 # - Implement Windows + MSVC support
 # - Implement Windows + clang support
-# - Implement Linux + Clang 32 bits support (if possible)
 name: C++ interop tests
 
 # Only triggers on pushes to master & stable, as well as PR to master and stable
@@ -146,8 +145,11 @@ jobs:
         set -eux
         sudo apt-get update
         apt_packages='${{ matrix.compiler }}'
+        # add 32-bit package for 32-bit tests
         if [[ '${{ matrix.compiler }}' =~ ^g\+\+ ]]; then
-          apt_packages+=" ${{ matrix.compiler }}-multilib" # for 32-bit tests
+          apt_packages+=" ${{ matrix.compiler }}-multilib"
+        else
+          apt_packages+=" g++-multilib"
         fi
         sudo apt-get install -y $apt_packages
 
@@ -195,7 +197,7 @@ jobs:
         make -C phobos -j$N MODEL=64
 
     - name: Build compiler & standard library (32-bit)
-      if: startsWith(matrix.compiler, 'g++')
+      if: runner.os == 'Linux'
       run: |
         set -eux
         make -C dmd    -j$N MODEL=32
@@ -207,7 +209,7 @@ jobs:
     - name: Run compiler C++ test suite
       run: ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=64 ${{ matrix.os == 'macos-14' && 'HOST_DMD="$PWD/dmd/generated/osx/release/64/dmd"' || '' }}
     - name: Run compiler C++ test suite (32-bit)
-      if: startsWith(matrix.compiler, 'g++')
+      if: runner.os == 'Linux'
       run: |
         set -eux
         ./dmd/compiler/test/run.d clean
@@ -216,7 +218,7 @@ jobs:
     - name: Run druntime C++ tests
       run: make -C dmd/druntime -j$N test/stdcpp/.run MODEL=64
     - name: Run druntime C++ tests (32-bit)
-      if: startsWith(matrix.compiler, 'g++')
+      if: runner.os == 'Linux'
       run: make -C dmd/druntime -j$N test/stdcpp/.run MODEL=32
 
     - name: 'Posix: Run frontend C++ unittests'
@@ -231,5 +233,5 @@ jobs:
         fi
         ./dmd/generated/build cxx-unittest MODEL=64
     - name: Run frontend C++ unittests (32-bit)
-      if: startsWith(matrix.compiler, 'g++')
+      if: runner.os == 'Linux'
       run: ./dmd/generated/build cxx-unittest MODEL=32

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -94,10 +94,7 @@ jobs:
     #    Setting up the host D compiler    #
     ########################################
     - name: Prepare compiler
-      uses: dlang-community/setup-dlang@v1
-      with:
-        # can't install DMD host compiler on macOS arm64, use LDC
-        compiler: ${{ matrix.os == 'macos-14' && 'ldc-latest' || 'dmd-latest' }}
+      uses: dlang-community/setup-dlang@v2
     - name: 'Posix: Clear LD_LIBRARY_PATH environment variable' # don't use host druntime/Phobos .so/.dylib etc.
       if: runner.os != 'Windows'
       run: echo "LD_LIBRARY_PATH=" >> $GITHUB_ENV
@@ -174,6 +171,10 @@ jobs:
       run: |
         set -eux
         # All hosts are 64 bits but let's be explicit
+        if [[ '${{ matrix.os }}' == macos-14 ]]; then
+          # don't try compiling a native arm64 DMD on macOS (doesn't work)
+          make -C dmd  -j$N dmd MODEL=64 DFLAGS="-mtriple=x86_64-apple-macos14"
+        fi
         make -C dmd    -j$N MODEL=64
         make -C phobos -j$N MODEL=64
 
@@ -188,7 +189,7 @@ jobs:
     #        Running the test suite        #
     ########################################
     - name: Run compiler C++ test suite
-      run: ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=64
+      run: ./dmd/compiler/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=64 ${{ matrix.os == 'macos-14' && 'HOST_DMD="$PWD/dmd/generated/osx/release/64/dmd"' || '' }}
     - name: Run compiler C++ test suite (32-bit)
       if: startsWith(matrix.compiler, 'g++')
       run: |
@@ -203,7 +204,15 @@ jobs:
       run: make -C dmd/druntime -j$N test/stdcpp/.run MODEL=32
 
     - name: Run frontend C++ unittests
-      run: ./dmd/compiler/src/build.d cxx-unittest MODEL=64
+      run: |
+        set -eux
+        if [[ '${{ matrix.os }}' == macos-14 ]]; then
+          # switch from LDC to freshly built DMD as host compiler
+          export HOST_DMD="$PWD/dmd/generated/osx/release/64/dmd"
+          export CXXFLAGS="-arch x86_64"
+          rm ./dmd/generated/osx/release/64/*.o
+        fi
+        ./dmd/generated/build cxx-unittest MODEL=64
     - name: Run frontend C++ unittests (32-bit)
       if: startsWith(matrix.compiler, 'g++')
-      run: ./dmd/compiler/src/build.d cxx-unittest MODEL=32
+      run: ./dmd/generated/build cxx-unittest MODEL=32


### PR DESCRIPTION
Bring it up to speed, incl. simplifications and increased coverage.

* Windows:
  * Test VS 2022 too, not just VS 2019.
  * Test 32-bit too, for each VS version.
  * Don't just test druntime's `stdcpp` test, but compiler's `runnable_cxx` tests too. The C++ frontend tests (`cxx-unittest`) are the only part which doesn't run on Windows (not supported by `build.d`).
* macOS:
  * Test druntime's `stdcpp` (formerly Windows only) and `cxx-unittest` (formerly Linux g++ only) too.
  * Instead of testing multiple versions of official clang binaries (from LLVM GitHub), all on macos-13 and Xcode v14, test the *Apple* clang versions bundled with the currently 3 (major) Xcode versions supported by the GHA images - Xcode 14, 15 and 16. Xcode v16 is available for the `macos-14` and `macos-15` images only, which means on a native arm64 machine only. I've had to add a few special cases to get the tests working on macOS arm64.
 * Linux:
   * Test druntime's `stdcpp`, and `cxx-unittest` with clang too.
   * Use the g++/clang *distro* packages available on Ubuntu 22 and 24 (the current GHA-supported Linux x64_64 platforms), testing the latest and oldest versions each. So no more usage of official clang binaries (from LLVM GitHub), nor g++ from a PPA.
     * In intermediate attempts, I've tested *all* available g++ and clang versions on Ubuntu 24, and all succeeded. Then pruned the versions to reduce the number of jobs.
   * In intermediate attempts, I've also tested 32-bit with clang. A single `runnable_cxx` test failed (see comment). IIRC, clang and gcc aren't perfectly ABI-compatible on 32-bit x86, clang NOT passing empty struct values or something like that.
   * The 32-bit tests are now extracted to their own jobs, to reduce YAML duplication and make it trivial to add/remove a 32-bit test run by extending the CI jobs matrix.
 * Don't upload any CI artifact anymore.