### PR TITLE
Replace `Identifiers* names` with `ArgumentLabels* names` across the frontend

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -5023,10 +5023,10 @@ struct ASTBase
         Expression thisexp;         // if !=null, 'this' for class being allocated
         Type newtype;
         Expressions* arguments;     // Array of Expression's
-        Identifiers* names;         // Array of names corresponding to expressions
+        ArgumentLabels* names;      // Array of names & loc corresponding to expressions
         Expression placement;       // if != null, then PlacementExpression
 
-        extern (D) this(Loc loc, Expression placement, Expression thisexp, Type newtype, Expressions* arguments, Identifiers* names = null)
+        extern (D) this(Loc loc, Expression placement, Expression thisexp, Type newtype, Expressions* arguments, ArgumentLabels* names = null)
         {
             super(loc, EXP.new_, __traits(classInstanceSize, NewExp));
             this.placement = placement;
@@ -5581,15 +5581,13 @@ struct ASTBase
     extern (C++) final class CallExp : UnaExp
     {
         Expressions* arguments;
-        Identifiers* names;
-        ArgumentLabels* argLabels;
+        ArgumentLabels* names;
 
-        extern (D) this(Loc loc, Expression e, Expressions* exps, Identifiers* names = null, ArgumentLabels* argLabels = null)
+        extern (D) this(Loc loc, Expression e, Expressions* exps, ArgumentLabels* names = null)
         {
             super(loc, EXP.call, __traits(classInstanceSize, CallExp), e);
             this.arguments = exps;
             this.names = names;
-            this.argLabels = argLabels;
         }
 
         extern (D) this(Loc loc, Expression e)

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -256,7 +256,7 @@ Expression getDefaultValue(EnumDeclaration ed, Loc loc)
 /***********************************************************
  * expression.d
  */
-void expandTuples(Expressions* exps, Identifiers* names = null)
+void expandTuples(Expressions* exps, ArgumentLabels* names = null)
 {
     return dmd.expression.expandTuples(exps, names);
 }
@@ -305,7 +305,7 @@ bool functionSemantic3(FuncDeclaration fd)
     return dmd.funcsem.functionSemantic3(fd);
 }
 
-MATCH leastAsSpecialized(FuncDeclaration fd, FuncDeclaration g, Identifiers* names)
+MATCH leastAsSpecialized(FuncDeclaration fd, FuncDeclaration g, ArgumentLabels* names)
 {
     import dmd.funcsem;
     return dmd.funcsem.leastAsSpecialized(fd, g, names);

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -3661,11 +3661,11 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     ScopeDsymbol argsym;        // argument symbol table
     size_t hash;                // cached result of toHash()
 
-    /// For function template, these are the function names and arguments
+    /// For function template, these are the function fnames(name and loc of it) and arguments
     /// Relevant because different resolutions of `auto ref` parameters
     /// create different template instances even with the same template arguments
     Expressions* fargs;
-    Identifiers* fnames;
+    ArgumentLabels* fnames;
 
     TemplateInstances* deferred;
 

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -86,7 +86,7 @@ inout(Expression) lastComma(inout Expression e)
  *     exps  = array of Expressions
  *     names = optional array of names corresponding to Expressions
  */
-void expandTuples(Expressions* exps, Identifiers* names = null)
+void expandTuples(Expressions* exps, ArgumentLabels* names = null)
 {
     //printf("expandTuples()\n");
     if (exps is null)
@@ -116,7 +116,7 @@ void expandTuples(Expressions* exps, Identifiers* names = null)
             }
             foreach (i; 1 .. length)
             {
-                names.insert(index + i, cast(Identifier) null);
+                names.insert(index + i, ArgumentLabel(cast(Identifier) null, Loc.init));
             }
         }
     }
@@ -2445,7 +2445,7 @@ extern (C++) final class NewExp : Expression
     Expression thisexp;         // if !=null, 'this' for class being allocated
     Type newtype;
     Expressions* arguments;     // Array of Expression's
-    Identifiers* names;         // Array of names corresponding to expressions
+    ArgumentLabels* names;         // Array of names(name and location of name) corresponding to expressions
     Expression placement;       // if !=null, then PlacementExpression
 
     Expression argprefix;       // expression to be evaluated just before arguments[]
@@ -2457,9 +2457,10 @@ extern (C++) final class NewExp : Expression
 
     /// Puts the `arguments` and `names` into an `ArgumentList` for easily passing them around.
     /// The fields are still separate for backwards compatibility
+
     extern (D) ArgumentList argumentList() { return ArgumentList(arguments, names); }
 
-    extern (D) this(Loc loc, Expression placement, Expression thisexp, Type newtype, Expressions* arguments, Identifiers* names = null) @safe
+    extern (D) this(Loc loc, Expression placement, Expression thisexp, Type newtype, Expressions* arguments, ArgumentLabels* names = null) @safe
     {
         super(loc, EXP.new_);
         this.placement = placement;
@@ -3271,27 +3272,28 @@ extern (C++) final class DotTypeExp : UnaExp
 struct ArgumentList
 {
     Expressions* arguments; // function arguments
-    Identifiers* names;     // named argument identifiers
+    ArgumentLabels* names;  // named argument labels
 
     size_t length() const @nogc nothrow pure @safe { return arguments ? arguments.length : 0; }
 
     /// Returns: whether this argument list contains any named arguments
-    bool hasNames() const @nogc nothrow pure @safe
+    bool hasArgNames() const @nogc nothrow pure @safe
     {
         if (names is null)
             return false;
-        foreach (name; *names)
-            if (name !is null)
+        foreach (argLabel; *names)
+            if (argLabel.name !is null)
                 return true;
 
         return false;
     }
 }
 
+// Contains both `name` and `location of the name` for an expression.
 struct ArgumentLabel
 {
     Identifier name;    // name of the argument
-    Loc loc;            // location of the argument
+    Loc loc;            // location of the name
  }
 
 /***********************************************************
@@ -3299,8 +3301,7 @@ struct ArgumentLabel
 extern (C++) final class CallExp : UnaExp
 {
     Expressions* arguments; // function arguments
-    Identifiers* names;     // named argument identifiers
-    ArgumentLabels *argLabels; // named argument labels
+    ArgumentLabels *names;  // named argument labels
     FuncDeclaration f;      // symbol to call
     bool directcall;        // true if a virtual call is devirtualized
     bool inDebugStatement;  /// true if this was in a debug statement
@@ -3312,12 +3313,11 @@ extern (C++) final class CallExp : UnaExp
     /// The fields are still separate for backwards compatibility
     extern (D) ArgumentList argumentList() { return ArgumentList(arguments, names); }
 
-    extern (D) this(Loc loc, Expression e, Expressions* exps, Identifiers* names = null, ArgumentLabels *argLabels = null) @safe
+    extern (D) this(Loc loc, Expression e, Expressions* exps, ArgumentLabels *names = null) @safe
     {
         super(loc, EXP.call, e);
         this.arguments = exps;
         this.names = names;
-        this.argLabels = argLabels;
     }
 
     extern (D) this(Loc loc, Expression e) @safe

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -58,7 +58,7 @@ namespace dmd
     // Entry point for CTFE.
     // A compile-time result is required. Give an error if not possible
     Expression *ctfeInterpret(Expression *e);
-    void expandTuples(Expressions *exps, Identifiers *names = nullptr);
+    void expandTuples(Expressions *exps, ArgumentLabels *names = nullptr);
     Expression *optimize(Expression *exp, int result, bool keepLvalue = false);
 }
 
@@ -518,7 +518,7 @@ public:
     Expression *thisexp;        // if !NULL, 'this' for class being allocated
     Type *newtype;
     Expressions *arguments;     // Array of Expression's
-    Identifiers *names;         // Array of names corresponding to expressions
+    ArgumentLabels *names;      // Array of argument Labels (name and location of name) corresponding to expressions
     Expression *placement;      // if !NULL, placement expression
 
     Expression *argprefix;      // expression to be evaluated just before arguments[]
@@ -795,13 +795,13 @@ public:
 struct ArgumentList final
 {
     Expressions* arguments;
-    Identifiers* names;
+    ArgumentLabels* names;
     ArgumentList() :
         arguments(),
         names()
     {
     }
-    ArgumentList(Expressions* arguments, Identifiers* names = nullptr) :
+    ArgumentList(Expressions* arguments, ArgumentLabels* names = nullptr) :
         arguments(arguments),
         names(names)
         {}
@@ -826,8 +826,7 @@ class CallExp final : public UnaExp
 {
 public:
     Expressions *arguments;     // function arguments
-    Identifiers *names;         // function argument names
-    ArgumentLabels* argLabels;    // function argument names + location
+    ArgumentLabels* names;      // function argument Labels (name + location of name)
     FuncDeclaration *f;         // symbol to call
     d_bool directcall;            // true if a virtual call is devirtualized
     d_bool inDebugStatement;      // true if this was in a debug statement

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1334,8 +1334,8 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
         ce.arguments = new Expressions();
     ce.arguments.shift(eleft);
     if (!ce.names)
-        ce.names = new Identifiers();
-    ce.names.shift(null);
+        ce.names = new ArgumentLabels();
+    ce.names.shift(ArgumentLabel(cast(Identifier) null, Loc.init));
     ce.isUfcsRewrite = true;
     return null;
 }
@@ -5300,10 +5300,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 if (exp.names)
                 {
-                    exp.arguments = resolveStructLiteralNamedArgs(sd, exp.type, sc, exp.loc,
-                        exp.names ? (*exp.names)[] : null,
+                    exp.arguments = resolveStructLiteralNamedArgs(sd, exp.type, sc, exp.loc, exp.names.length,
+                        i => (*exp.names)[i].name,
                         (size_t i, Type t) => (*exp.arguments)[i],
-                        i => (*exp.arguments)[i].loc
+                        i => (*exp.arguments)[i].loc,
+                        i => (*exp.names)[i].loc
                     );
                     if (!exp.arguments)
                         return setError();
@@ -5367,9 +5368,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
 
                 Expression arg = (*exp.arguments)[i];
-                if (exp.names && (*exp.names)[i])
+                if (exp.names && (*exp.names)[i].name)
                 {
-                    error(exp.loc, "no named argument `%s` allowed for array dimension", (*exp.names)[i].toChars());
+                    error(exp.loc, "no named argument `%s` allowed for array dimension", (*exp.names)[i].name.toChars());
                     return setError();
                 }
 
@@ -5483,9 +5484,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (nargs == 1)
             {
-                if (exp.names && (*exp.names)[0])
+                if (exp.names && (*exp.names)[0].name)
                 {
-                    error(exp.loc, "no named argument `%s` allowed for scalar", (*exp.names)[0].toChars());
+                    error(exp.loc, "no named argument `%s` allowed for scalar", (*exp.names)[0].name.toChars());
                     return setError();
                 }
                 Expression e = (*exp.arguments)[0];
@@ -6275,11 +6276,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expressions* resolvedArgs = exp.arguments;
                 if (exp.names)
                 {
-                    resolvedArgs = resolveStructLiteralNamedArgs(sd, exp.e1.type, sc, exp.loc,
-                        (*exp.names)[],
+                    resolvedArgs = resolveStructLiteralNamedArgs(sd, exp.e1.type, sc, exp.loc, exp.names.length,
+                        i => (*exp.names)[i].name,
                         (size_t i, Type t) => (*exp.arguments)[i],
                         i => (*exp.arguments)[i].loc,
-                        i => (exp.argLabels && (*exp.argLabels).length > i) ? (*exp.argLabels)[i].loc : (*exp.arguments)[i].loc
+                        i => (*exp.names)[i].loc
                     );
                     if (!resolvedArgs)
                     {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1795,7 +1795,7 @@ public:
     ScopeDsymbol* argsym;
     size_t hash;
     Array<Expression* >* fargs;
-    Array<Identifier* >* fnames;
+    Array<ArgumentLabel >* fnames;
     Array<TemplateInstance* >* deferred;
     Module* memberOf;
     TemplateInstance* tinst;
@@ -2602,13 +2602,13 @@ public:
 struct ArgumentList final
 {
     Array<Expression* >* arguments;
-    Array<Identifier* >* names;
+    Array<ArgumentLabel >* names;
     ArgumentList() :
         arguments(),
         names()
     {
     }
-    ArgumentList(Array<Expression* >* arguments, Array<Identifier* >* names = nullptr) :
+    ArgumentList(Array<Expression* >* arguments, Array<ArgumentLabel >* names = nullptr) :
         arguments(arguments),
         names(names)
         {}
@@ -2705,8 +2705,7 @@ class CallExp final : public UnaExp
 {
 public:
     Array<Expression* >* arguments;
-    Array<Identifier* >* names;
-    Array<ArgumentLabel >* argLabels;
+    Array<ArgumentLabel >* names;
     FuncDeclaration* f;
     bool directcall;
     bool inDebugStatement;
@@ -3419,7 +3418,7 @@ public:
     Expression* thisexp;
     Type* newtype;
     Array<Expression* >* arguments;
-    Array<Identifier* >* names;
+    Array<ArgumentLabel >* names;
     Expression* placement;
     Expression* argprefix;
     CtorDeclaration* member;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2050,16 +2050,17 @@ int overrides(FuncDeclaration fd1, FuncDeclaration fd2)
  * Params:
  *  f = first function
  *  g = second function
- *  names = names of parameters
+ *  names = argument Labels of parameters(name and location of the name)
  * Returns:
  *      match   'this' is at least as specialized as g
  *      0       g is more specialized than 'this'
  */
-MATCH leastAsSpecialized(FuncDeclaration f, FuncDeclaration g, Identifiers* names)
+MATCH leastAsSpecialized(FuncDeclaration f, FuncDeclaration g, ArgumentLabels* names)
 {
     enum LOG_LEASTAS = 0;
     static if (LOG_LEASTAS)
     {
+        Identifiers *names = extractNames(names);
         import core.stdc.stdio : printf;
         printf("leastAsSpecialized(%s, %s, %s)\n", f.toChars(), g.toChars(), names ? names.toChars() : "null");
         printf("%s, %s\n", f.type.toChars(), g.type.toChars());

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -3695,9 +3695,9 @@ private void parameterToBuffer(Parameter p, ref OutBuffer buf, ref HdrGenState h
  *     buf = buffer to write to
  *     hgs = context
  *     basis = replace `null`s in argument list with this expression (for sparse array literals)
- *     names = if non-null, use these as the names for the arguments
+ *     names = if non-null, use these as the argument Labels for the arguments
  */
-private void argsToBuffer(Expressions* expressions, ref OutBuffer buf, ref HdrGenState hgs, Expression basis = null, Identifiers* names = null)
+private void argsToBuffer(Expressions* expressions, ref OutBuffer buf, ref HdrGenState hgs, Expression basis = null, ArgumentLabels* names = null)
 {
     if (!expressions || !expressions.length)
         return;
@@ -3708,9 +3708,9 @@ private void argsToBuffer(Expressions* expressions, ref OutBuffer buf, ref HdrGe
             if (i)
                 buf.writestring(", ");
 
-            if (names && i < names.length && (*names)[i])
+            if (names && i < names.length && (*names)[i].name)
             {
-                buf.writestring((*names)[i].toString());
+                buf.writestring((*names)[i].name.toString());
                 buf.writestring(": ");
             }
             if (!el)

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -171,7 +171,8 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                 return ex;
             }
 
-            auto elements = resolveStructLiteralNamedArgs(sd, t, sc, i.loc, i.field[], &getExp, (size_t j) => i.value[j].loc);
+            auto elements = resolveStructLiteralNamedArgs(sd, t, sc, i.loc, i.field.length, (size_t j) => i.field[j], &getExp, (size_t j) => i.value[j].loc, (size_t j) => i.value[j].loc);
+            //Keeping both the getArgLoc and getNameLoc same as i.field doesn't have a .loc value here.
             if (!elements)
                 return err();
 
@@ -1505,16 +1506,18 @@ Params:
     t = type of struct (potentially including qualifiers such as `const` or `immutable`)
     sc = scope of the expression initializing the struct
     iloc = location of expression initializing the struct
-    names = identifiers passed in argument list, `null` entries for positional arguments
-    getExp = function that, given an index into `names` and destination type, returns the initializing expression
-    getArgLoc = function that, given an index into `names`, returns a location of argument for error messages
-    getNameLoc = function that, given an index into `names`, returns a location of that `name` for error messages
+    argCount = count of argumnet present
+    getExp = function that, given an index into `argNames` and destination type, returns the initializing expression
+    getArgName = function that, given an index into `argNames`, returns the name of argument for error messages
+    getArgLoc = function that, given an index into `argNames`, returns a location of argument for error messages
+    getNameLoc = function that, given an index into `argNames`, returns a location of that `name` for error messages
 
 Returns: list of expressions ordered to the struct's fields, or `null` on error
 */
 Expressions* resolveStructLiteralNamedArgs(StructDeclaration sd, Type t, Scope* sc,
-    Loc iloc, Identifier[] names, scope Expression delegate(size_t i, Type fieldType) getExp,
-    scope Loc delegate(size_t i) getArgLoc, scope Loc delegate(size_t i) getNameLoc = null
+    Loc iloc, size_t argCount, scope Identifier delegate(size_t i) getArgName, scope Expression delegate(size_t i, Type fieldType) getExp,
+    scope Loc delegate(size_t i) getArgLoc,
+    scope Loc delegate(size_t i) getNameLoc
 )
 {
     //expandTuples for non-identity arguments?
@@ -1528,12 +1531,11 @@ Expressions* resolveStructLiteralNamedArgs(StructDeclaration sd, Type t, Scope* 
     // TODO: this part is slightly different from StructLiteralExp::semantic.
     bool errors = false;
     size_t fieldi = 0;
-    foreach (j, id; names)
+    foreach (j; 0 .. argCount)
     {
         const argLoc = getArgLoc(j);
-        Loc nameLoc = argLoc;
-        if(getNameLoc !is null)
-            nameLoc = getNameLoc(j);
+        const nameLoc = getNameLoc(j);
+        Identifier id = getArgName(j);
         if (id)
         {
             // Determine `fieldi` that `id` matches

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2631,7 +2631,7 @@ extern (C++) final class TypeFunction : TypeNext
     extern(D) Expressions* resolveNamedArgs(ArgumentList argumentList, OutBuffer* buf)
     {
         Expression[] args = argumentList.arguments ? (*argumentList.arguments)[] : null;
-        Identifier[] names = argumentList.names ? (*argumentList.names)[] : null;
+        ArgumentLabel[] names = argumentList.names ? (*argumentList.names)[] : null;
         const nParams = parameterList.length(); // cached because O(n)
         auto newArgs = new Expressions(nParams);
         newArgs.zero();
@@ -2645,7 +2645,7 @@ extern (C++) final class TypeFunction : TypeNext
                 ci++;
                 continue;
             }
-            auto name = i < names.length ? names[i] : null;
+            auto name = i < names.length ? names[i].name : null;
             if (name)
             {
                 hasNamedArgs = true;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1325,8 +1325,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             {
                 const loc = token.loc;
                 AST.Expressions* args = new AST.Expressions();
-                AST.Identifiers* names = new AST.Identifiers();
-                parseNamedArguments(args, names, null);
+                AST.ArgumentLabels* names = new AST.ArgumentLabels();
+                parseNamedArguments(args, names);
                 exp = new AST.CallExp(loc, exp, args, names);
             }
 
@@ -9007,10 +9007,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
             case TOK.leftParenthesis:
                 AST.Expressions* args = new AST.Expressions();
-                AST.Identifiers* names = new AST.Identifiers();
-                AST.ArgumentLabels* argLabels = new AST.ArgumentLabels();
-                parseNamedArguments(args, names, argLabels);
-                e = new AST.CallExp(loc, e, args, names, argLabels);
+                AST.ArgumentLabels* names = new AST.ArgumentLabels();
+                parseNamedArguments(args, names);
+                e = new AST.CallExp(loc, e, args, names);
                 continue;
 
             case TOK.leftBracket:
@@ -9446,7 +9445,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         // function call
         AST.Expressions* arguments = new AST.Expressions();
-        parseNamedArguments(arguments, null, null);
+        parseNamedArguments(arguments, null);
         return arguments;
     }
 
@@ -9454,7 +9453,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Collect argument list.
      * Assume current token is ',', '$(LPAREN)' or '['.
      */
-    private void parseNamedArguments(AST.Expressions* arguments, AST.Identifiers* names, AST.ArgumentLabels* argLabels)
+    private void parseNamedArguments(AST.Expressions* arguments, AST.ArgumentLabels* names)
     {
         assert(arguments);
 
@@ -9471,24 +9470,15 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 auto ident = token.ident;
                 check(TOK.identifier);
                 check(TOK.colon);
-                if (names && argLabels){
-                    names.push(ident);
-                    argLabels.push(ArgumentLabel(ident, loc));
-                }
-                else if (names)
-                    names.push(ident);
+                if (names)
+                    names.push(ArgumentLabel(ident, loc));
                 else
                     error(loc, "named arguments not allowed here");
             }
             else
             {
-                if (names && argLabels){
-                    names.push(null);
-                    argLabels.push(ArgumentLabel(null, Loc.init));
-
-                }
-                else if (names)
-                    names.push(null);
+                if (names)
+                    names.push(ArgumentLabel(null, Loc.init));
             }
 
             auto arg = parseAssignExp();
@@ -9529,7 +9519,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         }
 
         AST.Expressions* arguments = null;
-        AST.Identifiers* names = null;
+        AST.ArgumentLabels* names = null;
 
         // An anonymous nested class starts with "class"
         if (token.value == TOK.class_)
@@ -9538,8 +9528,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (token.value == TOK.leftParenthesis)
             {
                 arguments = new AST.Expressions();
-                names = new AST.Identifiers();
-                parseNamedArguments(arguments, names, null);
+                names = new AST.ArgumentLabels();
+                parseNamedArguments(arguments, names);
             }
 
             AST.BaseClasses* baseclasses = null;
@@ -9583,8 +9573,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         else if (token.value == TOK.leftParenthesis && t.ty != Tsarray)
         {
             arguments = new AST.Expressions();
-            names = new AST.Identifiers();
-            parseNamedArguments(arguments, names, null);
+            names = new AST.ArgumentLabels();
+            parseNamedArguments(arguments, names);
         }
 
         auto e = new AST.NewExp(loc, placement, thisexp, t, arguments, names);

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -948,7 +948,7 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
         size_t nfargs2 = argumentList.length; // total number of arguments including applied defaultArgs
         uint inoutMatch = 0; // for debugging only
         Expression[] fargs = argumentList.arguments ? (*argumentList.arguments)[] : null;
-        Identifier[] fnames = argumentList.names ? (*argumentList.names)[] : null;
+        ArgumentLabel[] fnames = argumentList.names ? (*argumentList.names)[] : null;
 
         for (size_t parami = 0; parami < nfparams; parami++)
         {
@@ -958,16 +958,17 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
             Type prmtype = fparam.type.addStorageClass(fparam.storageClass);
 
             Expression farg;
-            Identifier fname = argi < fnames.length ? fnames[argi] : null;
+            Identifier fname = argi < fnames.length ? fnames[argi].name : null;
             bool foundName = false;
             if (fparam.ident)
             {
                 foreach (i; 0 .. fnames.length)
                 {
-                    if (fparam.ident == fnames[i])
+                    if (fparam.ident == fnames[i].name)
                     {
                         argi = i;
                         foundName = true;
+                        break;  //Exits the loop after a match
                     }
                 }
             }
@@ -1002,9 +1003,9 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
                         {
                             break;
                         }
-                        foreach(name; fnames)
+                        foreach(argLabel; fnames)
                         {
-                            if (p.ident == name)
+                            if (p.ident == argLabel.name)
                                 break;
                         }
                         if (!reliesOnTemplateParameters(p.type, (*td.parameters)[inferStart .. td.parameters.length]))


### PR DESCRIPTION
This PR is a continuation of PR #21262. Check it out for more details.

### #Summary
This PR replaces all uses of the `Identifiers* names` field in expression-related functions (`callExp`, `newExp`, etc.) with a more expressive and structured alternative: `ArgumentLabels* argLabels`.

- Replaced all `names` fields (of type `Identifiers*`) with `argLabels` (of type `ArgumentLabels* = Array!(ArgumentLabel)`).
- Code using `argLabels` is backwards-compatible where necessary by providing `Identifiers*` via helper conversion.