### PR TITLE
Fix #21304 : Redundant "cannot use array to initialize _error_" message when initializing invalid array

### DIFF
--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -240,11 +240,9 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                 goto default;
             break;
 
-        case Terror:
-            return err();
-
         default:
-            error(i.loc, "cannot use array to initialize `%s`", t.toChars());
+            if(t.toChars() != `_error_`)
+                error(i.loc, "cannot use array to initialize `%s`", t.toChars());
             return err();
         }
         i.type = t;

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -240,6 +240,10 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                 goto default;
             break;
 
+        case Terror:
+            return err();
+            break;
+
         default:
             error(i.loc, "cannot use array to initialize `%s`", t.toChars());
             return err();

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -242,7 +242,6 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
 
         case Terror:
             return err();
-            break;
 
         default:
             error(i.loc, "cannot use array to initialize `%s`", t.toChars());

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -240,9 +240,11 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                 goto default;
             break;
 
+        case Terror:
+            return err();
+
         default:
-            if(t.toChars() != `_error_`)
-                error(i.loc, "cannot use array to initialize `%s`", t.toChars());
+            error(i.loc, "cannot use array to initialize `%s`", t.toChars());
             return err();
         }
         i.type = t;

--- a/compiler/test/fail_compilation/test21304.d
+++ b/compiler/test/fail_compilation/test21304.d
@@ -1,0 +1,6 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test21304.d(6): Error: undefined identifier `unknown`
+---
+*/
+int[unknown] values = [1, 2, 3];


### PR DESCRIPTION
Fixes #21304 
### File Changes
Added a case `Terror`. To check if t is `_error_`

### Output
- #### Current Output:
<pre>test.d(1): Error: undefined identifier `unknown` 
test.d(1): Error: cannot use array to initialize `_error_` </pre>

- ### Updated Output:
<pre>test.d(1): Error: undefined identifier `unknown`</pre>

