### PR TITLE
Use internal bit flag for deferred semantics deduplication

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -43,6 +43,7 @@ import dmd.id;
 import dmd.identifier;
 import dmd.location;
 import dmd.parse;
+import dmd.root.aav;
 import dmd.root.array;
 import dmd.root.file;
 import dmd.root.filename;
@@ -1008,22 +1009,31 @@ extern (C++) final class Module : Package
     extern (D) static void addDeferredSemantic(Dsymbol s)
     {
         //printf("Module::addDeferredSemantic('%s')\n", s.toChars());
-        if (!deferred.contains(s))
+        if (!s.deferred)
+        {
+            s.deferred = true;
             deferred.push(s);
+        }
     }
 
     extern (D) static void addDeferredSemantic2(Dsymbol s)
     {
         //printf("Module::addDeferredSemantic2('%s')\n", s.toChars());
-        if (!deferred2.contains(s))
+        if (!s.deferred2)
+        {
+            s.deferred2 = true;
             deferred2.push(s);
+        }
     }
 
     extern (D) static void addDeferredSemantic3(Dsymbol s)
     {
         //printf("Module::addDeferredSemantic3('%s')\n", s.toChars());
-        if (!deferred3.contains(s))
+        if (!s.deferred3)
+        {
+            s.deferred3 = true;
             deferred3.push(s);
+        }
     }
 
     /******************************************
@@ -1057,6 +1067,8 @@ extern (C++) final class Module : Package
                 todoalloc = todo;
             }
             memcpy(todo, deferred.tdata(), len * Dsymbol.sizeof);
+            foreach (Dsymbol s; Module.deferred[])
+                s.deferred = false;
             deferred.setDim(0);
 
             foreach (i; 0..len)
@@ -1082,6 +1094,7 @@ extern (C++) final class Module : Package
         for (size_t i = 0; i < a.length; i++)
         {
             Dsymbol s = (*a)[i];
+            s.deferred2 = false;
             //printf("[%d] %s semantic2a\n", i, s.toPrettyChars());
             s.semantic2(null);
 
@@ -1099,6 +1112,7 @@ extern (C++) final class Module : Package
         for (size_t i = 0; i < a.length; i++)
         {
             Dsymbol s = (*a)[i];
+            s.deferred3 = false;
             //printf("[%d] %s semantic3a\n", i, s.toPrettyChars());
             s.semantic3(null);
 

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1022,7 +1022,7 @@ extern (C++) final class Module : Package
     extern (D) static void addDeferredSemantic3(Dsymbol s)
     {
         //printf("Module::addDeferredSemantic3('%s')\n", s.toChars());
-        if (!deferred.contains(s))
+        if (!deferred3.contains(s))
             deferred3.push(s);
     }
 

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -343,6 +343,11 @@ extern (C++) class Dsymbol : ASTNode
     {
         bool errors;            // this symbol failed to pass semantic()
         PASS semanticRun = PASS.initial;
+
+        // Queued for deferred semantics:
+        bool deferred;  // In Module.deferred
+        bool deferred2; // In Module.deferred2
+        bool deferred3; // In Module.deferred3
     }
     import dmd.common.bitfields;
     mixin(generateBitFields!(BitFields, ubyte));

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -554,14 +554,23 @@ public:
     {
         bool errors;
         PASS semanticRun;
+        bool deferred;
+        bool deferred2;
+        bool deferred3;
         BitFields() :
             errors(),
-            semanticRun((PASS)0u)
+            semanticRun((PASS)0u),
+            deferred(),
+            deferred2(),
+            deferred3()
         {
         }
-        BitFields(bool errors, PASS semanticRun = (PASS)0u) :
+        BitFields(bool errors, PASS semanticRun = (PASS)0u, bool deferred = false, bool deferred2 = false, bool deferred3 = false) :
             errors(errors),
-            semanticRun(semanticRun)
+            semanticRun(semanticRun),
+            deferred(deferred),
+            deferred2(deferred2),
+            deferred3(deferred3)
             {}
     };
 
@@ -569,6 +578,12 @@ public:
     bool errors(bool v);
     PASS semanticRun() const;
     PASS semanticRun(PASS v);
+    bool deferred() const;
+    bool deferred(bool v);
+    bool deferred2() const;
+    bool deferred2(bool v);
+    bool deferred3() const;
+    bool deferred3(bool v);
 private:
     uint8_t bitFields;
 public:


### PR DESCRIPTION
Fix an O(n^2) inefficiency in the `Dsymbol` deduplication logic in the `addDeferredSemantic`, `addDeferredSemantic2` and `addDeferredSemantic3` functions.

The duplication check was added in dc9fa6c08c9de1610fbdb7b7c1e033fd1518bd89. Unfortunately, one effect of this is that each `Dsymbol` insertion required a full linear scan of the `Dsymbols` array. In modules which cause a lot of templates to be instantiated, where there can be many hundreds of thousands of `Dsymbol` instances queued for deferred semantic analysis, this can significantly impact compilation times.

Resolve this by checking a new bit flag in `Dsymbol` as the mechanism for deduplication.

Timings with an internal motivating use case:

Before:

```
27.05user 1.84system 0:29.00elapsed 99%CPU (0avgtext+0avgdata 7872684maxresident)k
0inputs+105216outputs (0major+1984500minor)pagefaults 0swaps
```

After:

```
15.02user 1.81system 0:16.90elapsed 99%CPU (0avgtext+0avgdata 7873108maxresident)k
0inputs+102720outputs (0major+1985074minor)pagefaults 0swaps
```
