### PR TITLE
do not use OPnegass for 128 bits

### DIFF
--- a/compiler/src/dmd/backend/arm/disasmarm.d
+++ b/compiler/src/dmd/backend/arm/disasmarm.d
@@ -488,13 +488,19 @@ void disassemble(uint c) @trusted
             p3 = regString(sf, Rn);
             ulong imm = decodeNImmrImms(N,immr,imms);
             p4 = wordtostring(imm);
+
+            uint n = snprintf(buf.ptr, buf.length, "%s_log_imm", p1.ptr);
+            url2 = buf[0 .. n];
+
             if (opc == 3 && Rd == 0x1F)
             {
+                url2 = "tst_ands_log_imm";
                 p1 = "tst";
                 shiftP();
             }
             else if (opc == 1 && Rn == 0x1F)
             {
+                url2 = "mov_orr_log_imm";
                 p1 = "mov";
                 p3 = p4;
                 p4 = "";
@@ -2478,7 +2484,7 @@ void disassemble(uint c) @trusted
         for (; plen < 29; ++plen)
             put(' ');
         puts(" // https://www.scs.stanford.edu/~zyedidia/arm64/");
-        if (url2)
+        if (url2.length)
         {
             puts(url2);
             puts(".html");

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -4416,9 +4416,18 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
                     if (AArch64)
                     {
                         // STR preg,[sp,#offset]
-//printf("prolog_loadparams sz=%d\n", sz);
+//printf("prolog_loadparams sz=%d preg:%d\n", sz, preg);
 //printf("offset(%d) = Fast.size(%d) + BPoff(%d) + EBPtoESP(%d)\n",cast(int)offset,cast(int)cgstate.Fast.size,cast(int)cgstate.BPoff,cast(int)cgstate.EBPtoESP);
-                        cdb.gen1(INSTR.str_imm_gen(sz > 4, preg, 31, offset + localsize + 16));
+                        uint imm = cast(uint)(offset + localsize + 16);
+                        if (mask(preg) & INSTR.FLOATREGS)
+                        {
+                            uint size, opc;
+                            INSTR.szToSizeOpc(sz, size, opc);
+                            imm /= sz;
+                            cdb.gen1(INSTR.str_imm_fpsimd(size,opc,imm,31,preg)); // https://www.scs.stanford.edu/~zyedidia/arm64/str_imm_fpsimd.html
+                        }
+                        else
+                            cdb.gen1(INSTR.str_imm_gen(sz > 4, preg, 31, imm));
                     }
                     else
                     {


### PR DESCRIPTION
OPnegass is an optimization that works if the lvalue fits in a register and can be operated on. But 128 bit floats cannot be directly operated on, so there is no point to this optimization. So it is disabled, and `x = -x` is left as-is.

Also added some small improvement to url generation in the disassembler.