### PR TITLE
add 128 bit support to add assignment operators

### DIFF
--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -68,6 +68,7 @@ nothrow:
 @trusted
 void REGSAVE_save(ref REGSAVE regsave, ref CodeBuilder cdb, reg_t reg, out uint idx)
 {
+    //printf("REGSAVE_save() %s\n", regm_str(mask(reg)));
     assert(reg < 32);    // TODO AArch64 floating point registers
     if (!regsave.alignment)
         regsave.alignment = REGSIZE;
@@ -96,6 +97,7 @@ void REGSAVE_save(ref REGSAVE regsave, ref CodeBuilder cdb, reg_t reg, out uint 
 @trusted
 void REGSAVE_restore(const ref REGSAVE regsave, ref CodeBuilder cdb, reg_t reg, uint idx)
 {
+    //printf("REGSAVE_restore() %s\n", regm_str(mask(reg)));
     assert(reg < 32);   // TODO AArch64 floating point registers
     // LDR reg,[BP, #idx]
     code cs;

--- a/compiler/src/dmd/backend/arm/disasmarm.d
+++ b/compiler/src/dmd/backend/arm/disasmarm.d
@@ -2232,6 +2232,9 @@ void disassemble(uint c) @trusted
             p2 = fregString(rbuf[0 .. 4],prefix,Rd);
             p3 = fregString(rbuf[4 .. 8],prefix,Rn);
             p4 = fregString(rbuf[8 ..12],prefix,Rm);
+
+            uint n = snprintf(buf.ptr, buf.length, "%s_float.html", p1.ptr);
+            url2 = buf[0 .. n];
         }
     }
 

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -4418,7 +4418,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
                         // STR preg,[sp,#offset]
 //printf("prolog_loadparams sz=%d preg:%d\n", sz, preg);
 //printf("offset(%d) = Fast.size(%d) + BPoff(%d) + EBPtoESP(%d)\n",cast(int)offset,cast(int)cgstate.Fast.size,cast(int)cgstate.BPoff,cast(int)cgstate.EBPtoESP);
-                        uint imm = cast(uint)(offset + localsize + 16);
+                        uint imm = cast(uint)offset;
                         if (mask(preg) & INSTR.FLOATREGS)
                         {
                             uint size, opc;


### PR DESCRIPTION
128 bit floats call library functions, as there are no arithmetic instructions for them.