### PR TITLE
Bump Cirrus CI to FreeBSD 13.5

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,10 +53,10 @@ coverage_environment_template: &COVERAGE_ENVIRONMENT_TEMPLATE
 
 # FreeBSD
 freebsd13_task:
-  name: FreeBSD 13.0 x64, DMD ($TASK_NAME_TYPE)
+  name: FreeBSD 13.5 x64, DMD ($TASK_NAME_TYPE)
   allow_failures: true # might be out of credits
   freebsd_instance:
-    image_family: freebsd-13-0
+    image_family: freebsd-13-5
     cpu: 4
     memory: 8G
   timeout_in: 60m


### PR DESCRIPTION
The test failures in #21327 made me curious.
Feel free to just close this, if it fails as well.