### PR TITLE
Rename `ArgumentLabels* names` to `ArgumentLabels* argLabels`

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -5023,17 +5023,17 @@ struct ASTBase
         Expression thisexp;         // if !=null, 'this' for class being allocated
         Type newtype;
         Expressions* arguments;     // Array of Expression's
-        ArgumentLabels* names;      // Array of names & loc corresponding to expressions
+        ArgumentLabels* argLabels;      // Array of names & loc corresponding to expressions
         Expression placement;       // if != null, then PlacementExpression
 
-        extern (D) this(Loc loc, Expression placement, Expression thisexp, Type newtype, Expressions* arguments, ArgumentLabels* names = null)
+        extern (D) this(Loc loc, Expression placement, Expression thisexp, Type newtype, Expressions* arguments, ArgumentLabels* argLabels = null)
         {
             super(loc, EXP.new_, __traits(classInstanceSize, NewExp));
             this.placement = placement;
             this.thisexp = thisexp;
             this.newtype = newtype;
             this.arguments = arguments;
-            this.names = names;
+            this.argLabels = argLabels;
         }
 
         override void accept(Visitor v)
@@ -5581,13 +5581,13 @@ struct ASTBase
     extern (C++) final class CallExp : UnaExp
     {
         Expressions* arguments;
-        ArgumentLabels* names;
+        ArgumentLabels* argLabels;
 
-        extern (D) this(Loc loc, Expression e, Expressions* exps, ArgumentLabels* names = null)
+        extern (D) this(Loc loc, Expression e, Expressions* exps, ArgumentLabels* argLabels = null)
         {
             super(loc, EXP.call, __traits(classInstanceSize, CallExp), e);
             this.arguments = exps;
-            this.names = names;
+            this.argLabels = argLabels;
         }
 
         extern (D) this(Loc loc, Expression e)

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -256,9 +256,9 @@ Expression getDefaultValue(EnumDeclaration ed, Loc loc)
 /***********************************************************
  * expression.d
  */
-void expandTuples(Expressions* exps, ArgumentLabels* names = null)
+void expandTuples(Expressions* exps, ArgumentLabels* argLabels = null)
 {
-    return dmd.expression.expandTuples(exps, names);
+    return dmd.expression.expandTuples(exps, argLabels);
 }
 
 /***********************************************************
@@ -305,10 +305,10 @@ bool functionSemantic3(FuncDeclaration fd)
     return dmd.funcsem.functionSemantic3(fd);
 }
 
-MATCH leastAsSpecialized(FuncDeclaration fd, FuncDeclaration g, ArgumentLabels* names)
+MATCH leastAsSpecialized(FuncDeclaration fd, FuncDeclaration g, ArgumentLabels* argLabels)
 {
     import dmd.funcsem;
-    return dmd.funcsem.leastAsSpecialized(fd, g, names);
+    return dmd.funcsem.leastAsSpecialized(fd, g, argLabels);
 }
 
 PURE isPure(FuncDeclaration fd)

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -852,7 +852,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
     {
         //printf("findExistingInstance() %s\n", tithis.toChars());
         tithis.fargs = argumentList.arguments;
-        tithis.fnames = argumentList.names;
+        tithis.fargLabels = argumentList.argLabels;
         auto tibox = TemplateInstanceBox(tithis);
         auto p = tibox in this.instances;
         debug (FindExistingInstance) ++(p ? nFound : nNotFound);
@@ -3661,11 +3661,11 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     ScopeDsymbol argsym;        // argument symbol table
     size_t hash;                // cached result of toHash()
 
-    /// For function template, these are the function fnames(name and loc of it) and arguments
+    /// For function template, these are the function fargLabels(name and loc of it) and arguments
     /// Relevant because different resolutions of `auto ref` parameters
     /// create different template instances even with the same template arguments
     Expressions* fargs;
-    ArgumentLabels* fnames;
+    ArgumentLabels* fargLabels;
 
     TemplateInstances* deferred;
 
@@ -3965,7 +3965,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             return true;
 
         auto resolvedArgs = fd.type.isTypeFunction().resolveNamedArgs(
-            ArgumentList(this.fargs, this.fnames), null);
+            ArgumentList(this.fargs, this.fargLabels), null);
 
         // resolvedArgs can be null when there's an error: fail_compilation/fail14669.d
         // In that case, equalsx returns true to prevent endless template instantiations

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -58,7 +58,7 @@ namespace dmd
     // Entry point for CTFE.
     // A compile-time result is required. Give an error if not possible
     Expression *ctfeInterpret(Expression *e);
-    void expandTuples(Expressions *exps, ArgumentLabels *names = nullptr);
+    void expandTuples(Expressions *exps, ArgumentLabels *argLabels = nullptr);
     Expression *optimize(Expression *exp, int result, bool keepLvalue = false);
 }
 
@@ -518,7 +518,7 @@ public:
     Expression *thisexp;        // if !NULL, 'this' for class being allocated
     Type *newtype;
     Expressions *arguments;     // Array of Expression's
-    ArgumentLabels *names;      // Array of argument Labels (name and location of name) corresponding to expressions
+    ArgumentLabels *argLabels;  // Array of argument Labels (name and location of name) corresponding to expressions
     Expression *placement;      // if !NULL, placement expression
 
     Expression *argprefix;      // expression to be evaluated just before arguments[]
@@ -795,15 +795,15 @@ public:
 struct ArgumentList final
 {
     Expressions* arguments;
-    ArgumentLabels* names;
+    ArgumentLabels* argLabels;
     ArgumentList() :
         arguments(),
-        names()
+        argLabels()
     {
     }
-    ArgumentList(Expressions* arguments, ArgumentLabels* names = nullptr) :
+    ArgumentList(Expressions* arguments, ArgumentLabels* argLabels = nullptr) :
         arguments(arguments),
-        names(names)
+        argLabels(argLabels)
         {}
 };
 
@@ -826,7 +826,7 @@ class CallExp final : public UnaExp
 {
 public:
     Expressions *arguments;     // function arguments
-    ArgumentLabels* names;      // function argument Labels (name + location of name)
+    ArgumentLabels* argLabels;  // function argument Labels (name + location of name)
     FuncDeclaration *f;         // symbol to call
     d_bool directcall;            // true if a virtual call is devirtualized
     d_bool inDebugStatement;      // true if this was in a debug statement

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1333,9 +1333,9 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
     if (!ce.arguments)
         ce.arguments = new Expressions();
     ce.arguments.shift(eleft);
-    if (!ce.names)
-        ce.names = new ArgumentLabels();
-    ce.names.shift(ArgumentLabel(cast(Identifier) null, Loc.init));
+    if (!ce.argLabels)
+        ce.argLabels = new ArgumentLabels();
+    ce.argLabels.shift(ArgumentLabel(cast(Identifier) null, Loc.init));
     ce.isUfcsRewrite = true;
     return null;
 }
@@ -2890,7 +2890,7 @@ private bool preFunctionParameters(Scope* sc, ArgumentList argumentList, ErrorSi
     if (!exps)
         return false;
 
-    expandTuples(exps, argumentList.names);
+    expandTuples(exps, argumentList.argLabels);
 
     bool err = false;
     for (size_t i = 0; i < exps.length; i++)
@@ -2988,7 +2988,7 @@ private bool functionParameters(Loc loc, Scope* sc,
     Expression eprefix = null;
     *peprefix = null;
 
-    if (argumentList.names)
+    if (argumentList.argLabels)
     {
         OutBuffer buf;
         auto resolvedArgs = tf.resolveNamedArgs(argumentList, &buf);
@@ -5298,13 +5298,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else
             {
-                if (exp.names)
+                if (exp.argLabels)
                 {
-                    exp.arguments = resolveStructLiteralNamedArgs(sd, exp.type, sc, exp.loc, exp.names.length,
-                        i => (*exp.names)[i].name,
+                    exp.arguments = resolveStructLiteralNamedArgs(sd, exp.type, sc, exp.loc, exp.argLabels.length,
+                        i => (*exp.argLabels)[i].name,
                         (size_t i, Type t) => (*exp.arguments)[i],
                         i => (*exp.arguments)[i].loc,
-                        i => (*exp.names)[i].loc
+                        i => (*exp.argLabels)[i].loc
                     );
                     if (!exp.arguments)
                         return setError();
@@ -5368,9 +5368,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
 
                 Expression arg = (*exp.arguments)[i];
-                if (exp.names && (*exp.names)[i].name)
+                if (exp.argLabels && (*exp.argLabels)[i].name)
                 {
-                    error(exp.loc, "no named argument `%s` allowed for array dimension", (*exp.names)[i].name.toChars());
+                    error(exp.loc, "no named argument `%s` allowed for array dimension", (*exp.argLabels)[i].name.toChars());
                     return setError();
                 }
 
@@ -5484,9 +5484,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (nargs == 1)
             {
-                if (exp.names && (*exp.names)[0].name)
+                if (exp.argLabels && (*exp.argLabels)[0].name)
                 {
-                    error(exp.loc, "no named argument `%s` allowed for scalar", (*exp.names)[0].name.toChars());
+                    error(exp.loc, "no named argument `%s` allowed for scalar", (*exp.argLabels)[0].name.toChars());
                     return setError();
                 }
                 Expression e = (*exp.arguments)[0];
@@ -6250,7 +6250,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     }
                     else
                         assert(0);
-                    e = new CallExp(exp.loc, e, exp.arguments, exp.names);
+                    e = new CallExp(exp.loc, e, exp.arguments, exp.argLabels);
                     e = e.expressionSemantic(sc);
                     result = e;
                     return;
@@ -6274,13 +6274,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                  */
             Lx:
                 Expressions* resolvedArgs = exp.arguments;
-                if (exp.names)
+                if (exp.argLabels)
                 {
-                    resolvedArgs = resolveStructLiteralNamedArgs(sd, exp.e1.type, sc, exp.loc, exp.names.length,
-                        i => (*exp.names)[i].name,
+                    resolvedArgs = resolveStructLiteralNamedArgs(sd, exp.e1.type, sc, exp.loc, exp.argLabels.length,
+                        i => (*exp.argLabels)[i].name,
                         (size_t i, Type t) => (*exp.arguments)[i],
                         i => (*exp.arguments)[i].loc,
-                        i => (*exp.names)[i].loc
+                        i => (*exp.argLabels)[i].loc
                     );
                     if (!resolvedArgs)
                     {
@@ -6299,7 +6299,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             L1:
                 // Rewrite as e1.call(arguments)
                 Expression e = new DotIdExp(exp.loc, exp.e1, Id.opCall);
-                e = new CallExp(exp.loc, e, exp.arguments, exp.names);
+                e = new CallExp(exp.loc, e, exp.arguments, exp.argLabels);
                 e = e.expressionSemantic(sc);
                 result = e;
                 return;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1795,7 +1795,7 @@ public:
     ScopeDsymbol* argsym;
     size_t hash;
     Array<Expression* >* fargs;
-    Array<ArgumentLabel >* fnames;
+    Array<ArgumentLabel >* fargLabels;
     Array<TemplateInstance* >* deferred;
     Module* memberOf;
     TemplateInstance* tinst;
@@ -2602,15 +2602,15 @@ public:
 struct ArgumentList final
 {
     Array<Expression* >* arguments;
-    Array<ArgumentLabel >* names;
+    Array<ArgumentLabel >* argLabels;
     ArgumentList() :
         arguments(),
-        names()
+        argLabels()
     {
     }
-    ArgumentList(Array<Expression* >* arguments, Array<ArgumentLabel >* names = nullptr) :
+    ArgumentList(Array<Expression* >* arguments, Array<ArgumentLabel >* argLabels = nullptr) :
         arguments(arguments),
-        names(names)
+        argLabels(argLabels)
         {}
 };
 
@@ -2705,7 +2705,7 @@ class CallExp final : public UnaExp
 {
 public:
     Array<Expression* >* arguments;
-    Array<ArgumentLabel >* names;
+    Array<ArgumentLabel >* argLabels;
     FuncDeclaration* f;
     bool directcall;
     bool inDebugStatement;
@@ -3418,7 +3418,7 @@ public:
     Expression* thisexp;
     Type* newtype;
     Array<Expression* >* arguments;
-    Array<ArgumentLabel >* names;
+    Array<ArgumentLabel >* argLabels;
     Expression* placement;
     Expression* argprefix;
     CtorDeclaration* member;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2050,19 +2050,19 @@ int overrides(FuncDeclaration fd1, FuncDeclaration fd2)
  * Params:
  *  f = first function
  *  g = second function
- *  names = argument Labels of parameters(name and location of the name)
+ *  argLabels = argument Labels of parameters(name and location of the name)
  * Returns:
  *      match   'this' is at least as specialized as g
  *      0       g is more specialized than 'this'
  */
-MATCH leastAsSpecialized(FuncDeclaration f, FuncDeclaration g, ArgumentLabels* names)
+MATCH leastAsSpecialized(FuncDeclaration f, FuncDeclaration g, ArgumentLabels* argLabels)
 {
     enum LOG_LEASTAS = 0;
     static if (LOG_LEASTAS)
     {
         Identifiers *names = extractNames(names);
         import core.stdc.stdio : printf;
-        printf("leastAsSpecialized(%s, %s, %s)\n", f.toChars(), g.toChars(), names ? names.toChars() : "null");
+        printf("leastAsSpecialized(%s, %s, %s)\n", f.toChars(), g.toChars(), argLabels ? argLabels.toChars() : "null");
         printf("%s, %s\n", f.type.toChars(), g.type.toChars());
     }
 
@@ -2107,7 +2107,7 @@ MATCH leastAsSpecialized(FuncDeclaration f, FuncDeclaration g, ArgumentLabels* n
         args.push(e);
     }
 
-    MATCH m = callMatch(g, tg, null, ArgumentList(&args, names), 1);
+    MATCH m = callMatch(g, tg, null, ArgumentList(&args, argLabels), 1);
     if (m > MATCH.nomatch)
     {
         /* A variadic parameter list is less specialized than a

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2542,7 +2542,7 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
         if (e.arguments && e.arguments.length)
         {
             buf.writeByte('(');
-            argsToBuffer(e.arguments, buf, hgs, null, e.names);
+            argsToBuffer(e.arguments, buf, hgs, null, e.argLabels);
             buf.writeByte(')');
         }
     }
@@ -2861,7 +2861,7 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
         else
             expToBuffer(e.e1, precedence[e.op], buf, hgs);
         buf.writeByte('(');
-        argsToBuffer(e.arguments, buf, hgs, null, e.names);
+        argsToBuffer(e.arguments, buf, hgs, null, e.argLabels);
         buf.writeByte(')');
     }
 
@@ -3695,9 +3695,9 @@ private void parameterToBuffer(Parameter p, ref OutBuffer buf, ref HdrGenState h
  *     buf = buffer to write to
  *     hgs = context
  *     basis = replace `null`s in argument list with this expression (for sparse array literals)
- *     names = if non-null, use these as the argument Labels for the arguments
+ *     argLabels = if non-null, use these as the argument Labels for the arguments
  */
-private void argsToBuffer(Expressions* expressions, ref OutBuffer buf, ref HdrGenState hgs, Expression basis = null, ArgumentLabels* names = null)
+private void argsToBuffer(Expressions* expressions, ref OutBuffer buf, ref HdrGenState hgs, Expression basis = null, ArgumentLabels* argLabels = null)
 {
     if (!expressions || !expressions.length)
         return;
@@ -3708,9 +3708,9 @@ private void argsToBuffer(Expressions* expressions, ref OutBuffer buf, ref HdrGe
             if (i)
                 buf.writestring(", ");
 
-            if (names && i < names.length && (*names)[i].name)
+            if (argLabels && i < argLabels.length && (*argLabels)[i].name)
             {
-                buf.writestring((*names)[i].name.toString());
+                buf.writestring((*argLabels)[i].name.toString());
                 buf.writestring(": ");
             }
             if (!el)

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2631,7 +2631,7 @@ extern (C++) final class TypeFunction : TypeNext
     extern(D) Expressions* resolveNamedArgs(ArgumentList argumentList, OutBuffer* buf)
     {
         Expression[] args = argumentList.arguments ? (*argumentList.arguments)[] : null;
-        ArgumentLabel[] names = argumentList.names ? (*argumentList.names)[] : null;
+        ArgumentLabel[] argLabels = argumentList.argLabels ? (*argumentList.argLabels)[] : null;
         const nParams = parameterList.length(); // cached because O(n)
         auto newArgs = new Expressions(nParams);
         newArgs.zero();
@@ -2645,7 +2645,7 @@ extern (C++) final class TypeFunction : TypeNext
                 ci++;
                 continue;
             }
-            auto name = i < names.length ? names[i].name : null;
+            auto name = i < argLabels.length ? argLabels[i].name : null;
             if (name)
             {
                 hasNamedArgs = true;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1325,9 +1325,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             {
                 const loc = token.loc;
                 AST.Expressions* args = new AST.Expressions();
-                AST.ArgumentLabels* names = new AST.ArgumentLabels();
-                parseNamedArguments(args, names);
-                exp = new AST.CallExp(loc, exp, args, names);
+                AST.ArgumentLabels* argLabels = new AST.ArgumentLabels();
+                parseNamedArguments(args, argLabels);
+                exp = new AST.CallExp(loc, exp, args, argLabels);
             }
 
             if (udas is null)
@@ -9007,9 +9007,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
             case TOK.leftParenthesis:
                 AST.Expressions* args = new AST.Expressions();
-                AST.ArgumentLabels* names = new AST.ArgumentLabels();
-                parseNamedArguments(args, names);
-                e = new AST.CallExp(loc, e, args, names);
+                AST.ArgumentLabels* argLabels = new AST.ArgumentLabels();
+                parseNamedArguments(args, argLabels);
+                e = new AST.CallExp(loc, e, args, argLabels);
                 continue;
 
             case TOK.leftBracket:
@@ -9453,7 +9453,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Collect argument list.
      * Assume current token is ',', '$(LPAREN)' or '['.
      */
-    private void parseNamedArguments(AST.Expressions* arguments, AST.ArgumentLabels* names)
+    private void parseNamedArguments(AST.Expressions* arguments, AST.ArgumentLabels* argLabels)
     {
         assert(arguments);
 
@@ -9470,15 +9470,15 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 auto ident = token.ident;
                 check(TOK.identifier);
                 check(TOK.colon);
-                if (names)
-                    names.push(ArgumentLabel(ident, loc));
+                if (argLabels)
+                    argLabels.push(ArgumentLabel(ident, loc));
                 else
                     error(loc, "named arguments not allowed here");
             }
             else
             {
-                if (names)
-                    names.push(ArgumentLabel(null, Loc.init));
+                if (argLabels)
+                    argLabels.push(ArgumentLabel(null, Loc.init));
             }
 
             auto arg = parseAssignExp();
@@ -9519,7 +9519,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         }
 
         AST.Expressions* arguments = null;
-        AST.ArgumentLabels* names = null;
+        AST.ArgumentLabels* argLabels = null;
 
         // An anonymous nested class starts with "class"
         if (token.value == TOK.class_)
@@ -9528,8 +9528,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (token.value == TOK.leftParenthesis)
             {
                 arguments = new AST.Expressions();
-                names = new AST.ArgumentLabels();
-                parseNamedArguments(arguments, names);
+                argLabels = new AST.ArgumentLabels();
+                parseNamedArguments(arguments, argLabels);
             }
 
             AST.BaseClasses* baseclasses = null;
@@ -9573,11 +9573,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         else if (token.value == TOK.leftParenthesis && t.ty != Tsarray)
         {
             arguments = new AST.Expressions();
-            names = new AST.ArgumentLabels();
-            parseNamedArguments(arguments, names);
+            argLabels = new AST.ArgumentLabels();
+            parseNamedArguments(arguments, argLabels);
         }
 
-        auto e = new AST.NewExp(loc, placement, thisexp, t, arguments, names);
+        auto e = new AST.NewExp(loc, placement, thisexp, t, arguments, argLabels);
         return e;
     }
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -948,7 +948,7 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
         size_t nfargs2 = argumentList.length; // total number of arguments including applied defaultArgs
         uint inoutMatch = 0; // for debugging only
         Expression[] fargs = argumentList.arguments ? (*argumentList.arguments)[] : null;
-        ArgumentLabel[] fnames = argumentList.names ? (*argumentList.names)[] : null;
+        ArgumentLabel[] fargLabels = argumentList.argLabels ? (*argumentList.argLabels)[] : null;
 
         for (size_t parami = 0; parami < nfparams; parami++)
         {
@@ -958,13 +958,13 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
             Type prmtype = fparam.type.addStorageClass(fparam.storageClass);
 
             Expression farg;
-            Identifier fname = argi < fnames.length ? fnames[argi].name : null;
+            Identifier fname = argi < fargLabels.length ? fargLabels[argi].name : null;
             bool foundName = false;
             if (fparam.ident)
             {
-                foreach (i; 0 .. fnames.length)
+                foreach (i; 0 .. fargLabels.length)
                 {
-                    if (fparam.ident == fnames[i].name)
+                    if (fparam.ident == fargLabels[i].name)
                     {
                         argi = i;
                         foundName = true;
@@ -1003,7 +1003,7 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
                         {
                             break;
                         }
-                        foreach(argLabel; fnames)
+                        foreach(argLabel; fargLabels)
                         {
                             if (p.ident == argLabel.name)
                                 break;
@@ -2028,8 +2028,8 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
          * This is because f() is "more specialized."
          */
         {
-            MATCH c1 = funcLeastAsSpecialized(fd, m.lastf, argumentList.names);
-            MATCH c2 = funcLeastAsSpecialized(m.lastf, fd, argumentList.names);
+            MATCH c1 = funcLeastAsSpecialized(fd, m.lastf, argumentList.argLabels);
+            MATCH c2 = funcLeastAsSpecialized(m.lastf, fd, argumentList.argLabels);
             //printf("c1 = %d, c2 = %d\n", c1, c2);
             if (c1 > c2) return firstIsBetter();
             if (c1 < c2) return 0;
@@ -2308,8 +2308,8 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
             }
             {
                 // Disambiguate by picking the most specialized FunctionDeclaration
-                MATCH c1 = funcLeastAsSpecialized(fd, m.lastf, argumentList.names);
-                MATCH c2 = funcLeastAsSpecialized(m.lastf, fd, argumentList.names);
+                MATCH c1 = funcLeastAsSpecialized(fd, m.lastf, argumentList.argLabels);
+                MATCH c2 = funcLeastAsSpecialized(m.lastf, fd, argumentList.argLabels);
                 //printf("3: c1 = %d, c2 = %d\n", c1, c2);
                 if (c1 > c2) goto Ltd;
                 if (c1 < c2) goto Ltd_best;


### PR DESCRIPTION
- This is a follow-up PR for #21297. Refer to that for more details.

As `Identifiers* names` was changed to `ArgumentLabels* names`,  keeping the variable name to `names` is a bit misleading. As it now stores both `name` and `Loc` of an argument.
#### I am open to other suggestions for the variable name :)
