### PR TITLE
remove leftover code

### DIFF
--- a/compiler/src/dmd/backend/arm/cod2.d
+++ b/compiler/src/dmd/backend/arm/cod2.d
@@ -1675,9 +1675,6 @@ void cdneg(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
     const sz = _tysize[tyml];
     if (tyfloating(tyml))
     {
-        regm_t retregs1 = INSTR.FLOATREGS;
-        codelem(cgstate,cdb,e.E1,retregs1,false);
-
         regm_t retregs = pretregs & INSTR.FLOATREGS;
         if (retregs == 0)                   /* if no return regs speced     */
                                             /* (like if wanted flags only)  */


### PR DESCRIPTION
I compared the arm version, which didn't work, with the x86 version, which worked. Found an extra 2 lines of code left over from an earlier refactoring.