### PR TITLE
iasmgcc: Remove colonColon special case from the parser

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3512,21 +3512,6 @@ final class CParser(AST) : Parser!AST
                     error("matching `)` expected, not end of file");
                     break;
 
-                case TOK.colonColon:  // treat as two separate : tokens for iasmgcc
-                    *ptoklist = allocateToken();
-                    **ptoklist = this.token;
-                    (*ptoklist).value = TOK.colon;
-                    ptoklist = &(*ptoklist).next;
-
-                    *ptoklist = allocateToken();
-                    **ptoklist = this.token;
-                    (*ptoklist).value = TOK.colon;
-                    ptoklist = &(*ptoklist).next;
-
-                    *ptoklist = null;
-                    nextToken();
-                    continue;
-
                 default:
                     *ptoklist = allocateToken();
                     **ptoklist = this.token;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -7103,21 +7103,6 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 error("matching `}` expected, not end of file");
                 break;
 
-            case TOK.colonColon:  // treat as two separate : tokens for iasmgcc
-                *ptoklist = allocateToken();
-                **ptoklist = this.token;
-                (*ptoklist).value = TOK.colon;
-                ptoklist = &(*ptoklist).next;
-
-                *ptoklist = allocateToken();
-                **ptoklist = this.token;
-                (*ptoklist).value = TOK.colon;
-                ptoklist = &(*ptoklist).next;
-
-                *ptoklist = null;
-                nextToken();
-                continue;
-
             default:
                 *ptoklist = allocateToken();
                 **ptoklist = this.token;


### PR DESCRIPTION
Handle the mix of colon and colonColon tokens in the GCC IASM parser instead of the D and ImportC parsers.