### PR TITLE
Enforce preprocessor to run with gnu11

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1155,6 +1155,8 @@ public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, c
                 argv.push(p);
         }
 
+        argv.push("-std=gnu11"); 
+
         // Set memory model
         argv.push(target.isX86_64 ? "-m64" : "-m32");
 


### PR DESCRIPTION
After updating my machine, I started getting  ton of errors like:

```
/usr/lib/gcc/x86_64-pc-linux-gnu/15.1.1/include/stddef.h(465): Error: undefined identifier `nullptr`, did you mean alias `nullptr_t`?
```

when using `-std=c11` i get:

```
/usr/include/bits/mathcalls-helper-functions.h(21): Error: undefined identifier `_Float128`
```

when using `-std=gnu11` it all works properly


Perhaps: #21311