### PR TITLE
[stable] Don't merge function types with unknown return type

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -3315,6 +3315,11 @@ Type merge(Type type)
                 return type;
             goto default;
 
+        case Tfunction:
+            if (!type.nextOf()) // don't merge if return type is unknown
+                return type;
+            goto default;
+
         default:
             if (type.nextOf() && !type.nextOf().deco)
                 return type;


### PR DESCRIPTION
As that can cause a 'compatible' function type with resolved return type to wrongly get that deco. This is what happens with LDC for a particular test case as D v2.111 regression, causing an assertion in the frontend while generating a TypeInfo_Function for some TypeFunction, with `TypeFunction.next` being null (unknown return type).

The relevant `genTypeInfo()` calls before the patch, in the format `genTypeInfo: <type> (<deco>), <type after merge2()> (<deco after merge2()>)`:
```
// const funcptr: TypeInfo_Const
genTypeInfo: const(Algebraic!() function(Function) nothrow @system) (xPFNbC4util8FunctionZSQq__T9AlgebraicZQl), const(Algebraic!() function(Function) nothrow @system) (xPFNbC4util8FunctionZSQq__T9AlgebraicZQl)
// mutable funcptr: TypeInfo_Pointer
genTypeInfo: Algebraic!() function(Function) nothrow @system (PFNbC4util8FunctionZSQq__T9AlgebraicZQl), Algebraic!() function(Function) nothrow @system (PFNbC4util8FunctionZSQq__T9AlgebraicZQl)
// function: TypeInfo_Function
// NOTE the missing Algebraic return type in the decos, this is the bug
genTypeInfo: nothrow @system Algebraic!()(Function) (FNbC4util8FunctionZ), nothrow @system (Function) (FNbC4util8FunctionZ)
```

With this patch:
```
genTypeInfo: const(Algebraic!() function(Function) nothrow @system) (xPFNbC4util8FunctionZSQq__T9AlgebraicZQl), const(Algebraic!() function(Function) nothrow @system) (xPFNbC4util8FunctionZSQq__T9AlgebraicZQl)
genTypeInfo: Algebraic!() function(Function) nothrow @system (PFNbC4util8FunctionZSQq__T9AlgebraicZQl), Algebraic!() function(Function) nothrow @system (PFNbC4util8FunctionZSQq__T9AlgebraicZQl)
genTypeInfo: nothrow @system Algebraic!()(Function) (FNbC4util8FunctionZSQq__T9AlgebraicZQl), nothrow @system Algebraic!()(Function) (FNbC4util8FunctionZSQq__T9AlgebraicZQl)
```