### PR TITLE
Fix: Incorrect claim that a foreach-ref variable is "stack-allocated"

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -16140,9 +16140,12 @@ private bool checkAddressVar(Scope* sc, Expression exp, VarDeclaration v)
     }
     if (sc.func && !sc.intypeof && !v.isDataseg())
     {
+        auto msg = (v.storage_class & STC.ref_) ?
+            "taking the address of local variable `%s`" :
+            "taking the address of stack-allocated local variable `%s`";
         if (sc.useDIP1000 != FeatureState.enabled &&
             !(v.storage_class & STC.temp) &&
-            sc.setUnsafe(false, exp.loc, "taking the address of stack-allocated local variable `%s`", v))
+            sc.setUnsafe(false, exp.loc, msg.ptr, v))
         {
             return false;
         }

--- a/compiler/test/fail_compilation/fail6497.d
+++ b/compiler/test/fail_compilation/fail6497.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6497.d(12): Error: taking the address of stack-allocated local variable `n` is not allowed in a `@safe` function
-fail_compilation/fail6497.d(12): Error: taking the address of stack-allocated local variable `n` is not allowed in a `@safe` function
+fail_compilation/fail6497.d(13): Error: taking the address of stack-allocated local variable `n` is not allowed in a `@safe` function
+fail_compilation/fail6497.d(13): Error: taking the address of stack-allocated local variable `n` is not allowed in a `@safe` function
+fail_compilation/fail6497.d(19): Error: taking the address of local variable `i` is not allowed in a `@safe` function
 ---
 */
 
@@ -10,4 +11,10 @@ void main() @safe
 {
     int n;
     auto b = &(0 ? n : n);
+}
+
+void f() @safe
+{
+    ref i = *new int;
+    auto b = &i;
 }


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/21341.