### PR TITLE
Replace deprecated `event.set` with `event.setIfInitialized`

### DIFF
--- a/druntime/test/shared/src/dllgc.d
+++ b/druntime/test/shared/src/dllgc.d
@@ -29,7 +29,7 @@ version(DLL)
         void term() nothrow
         {
             stop = true;
-            event.set();
+            event.setIfInitialized();
             joinLowLevelThread(tid);
         }
     }


### PR DESCRIPTION
# PR Summary
The `event.set` method is deprecated and should be replaced with `event.setIfInitialized`. This small PR fixes it:
```d
src\dllgc.d(32): Deprecation: function `core.sync.event.Event.set` is deprecated - Use setIfInitialized() instead
```