### PR TITLE
Clarify that contributions are meant to be positive, and add a short intro to point out that the expectations placed upon contributors sections exist.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,9 @@ git checkout -b fix-bug
 
 - Confine a PR to addressing one issue, unless multiple issues are different aspects of the same bug.
 
+- Using tools to help you contribute is a good thing, but if a tool produced slop, and you contributed it then it's your slop.
+    If you need help please ask for it, don't let an unthinking tool rule the PR queue, that's for humans to mess up!
+    Please note that LLM's are considered tools by the D community.
 
 - If the pull request affects the language specifications in any way (i.e. changing the grammar, deprecating a feature, or adding a new one),
   a pull request to [the specification in the dlang.org repository](https://github.com/dlang/dlang.org) should be submitted in parallel.


### PR DESCRIPTION
This was talked about at the monthly meeting yesterday, It was agreed that a sentence saying that we want human contributions, not automated tools ruling the PR queue. Basically, a friendly way of saying an LLM is a tool, anything it produces must be intended to go in by a human, rather than the tool making the decisions for a human without understanding it.

To kick this off, I'll give @mdparker and @LightBender a ping, to see how far off this is.