### PR TITLE
compilable/stdcheaders.c: Skip math.h on linux aarch64

### DIFF
--- a/compiler/test/compilable/stdcheaders.c
+++ b/compiler/test/compilable/stdcheaders.c
@@ -19,9 +19,11 @@
 #include <limits.h>
 #include <locale.h>
 
+#if !(defined(__linux__) && defined(__aarch64__)) // /usr/include/bits/math-vector.h(162): Error: undefined identifier `__Float32x4_t`
 #include <math.h>
 #ifndef _MSC_VER // C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\ucrt\corecrt_math.h(93): Error: reinterpretation through overlapped field `f` is not allowed in CTFE
 float x = NAN;
+#endif
 #endif
 
 #ifndef _MSC_VER // setjmp.h(51): Error: missing tag `identifier` after `struct


### PR DESCRIPTION
It happens with both clang and gcc. Tested with ldc2

Part of the full error:
```
Error: undefined identifier `__Float32x4_t`
Error: undefined identifier `__Float64x2_t`
Error: undefined identifier `__SVFloat32_t`
Error: undefined identifier `__SVFloat64_t`
Error: undefined identifier `__SVBool_t`
/usr/include/bits/math-vector.h(162): Error: undefined identifier `__Float32x4_t`
__attribute__ ((__aarch64_vector_pcs__)) __f32x4_t _ZGVnN4vv_atan2f (__f32x4_t, __f32x4_t);
                                                                                          ^
/usr/include/bits/math-vector.h(162): Error: undefined identifier `__Float32x4_t`
__attribute__ ((__aarch64_vector_pcs__)) __f32x4_t _ZGVnN4vv_atan2f (__f32x4_t, __f32x4_t);
                                                                                          ^
/usr/include/bits/math-vector.h(162): Error: undefined identifier `__Float32x4_t`
__attribute__ ((__aarch64_vector_pcs__)) __f32x4_t _ZGVnN4vv_atan2f (__f32x4_t, __f32x4_t);
                                                                                          ^
/usr/include/bits/math-vector.h(163): Error: undefined identifier `__Float32x4_t`
__attribute__ ((__aarch64_vector_pcs__)) __f32x4_t _ZGVnN4v_acosf (__f32x4_t);
                                                                             ^
/usr/include/bits/math-vector.h(163): Error: undefined identifier `__Float32x4_t`
__attribute__ ((__aarch64_vector_pcs__)) __f32x4_t _ZGVnN4v_acosf (__f32x4_t);
                                                                             ^
```