### PR TITLE
importc: Better isolate clang-cpp fixes

### DIFF
--- a/compiler/test/compilable/fix24187.c
+++ b/compiler/test/compilable/fix24187.c
@@ -3,7 +3,7 @@
 // https://issues.dlang.org/show_bug.cgi?id=24187
 
 #ifdef linux
-#ifndef __aarch64__
+#ifndef __clang__
 extern _Complex _Float32 cacosf32 (_Complex _Float32 __z) __attribute__ ((__nothrow__ , __leaf__));
 
 extern _Complex _Float32x __cacosf32x (_Complex _Float32x __z) __attribute__ ((__nothrow__ , __leaf__));

--- a/compiler/test/compilable/stdcheaders.c
+++ b/compiler/test/compilable/stdcheaders.c
@@ -58,11 +58,12 @@ float x = NAN;
 #include <string.h>
 
 #ifndef _MSC_VER // C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\tgmath.h(33): Error: no type for declarator before `)`
-#ifndef __APPLE__ // /Applications/Xcode-14.2.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/tgmath.h(39): Error: named parameter required before `...`
-#ifndef __OpenBSD__ // /usr/lib/clang/13.0.0/include/tgmath.h(34): Error: named parameter required before `...`
-#if !(defined(__linux__) && defined(__aarch64__)) // /tmp/clang/lib/clang/15.0.3/include/tgmath.h(34): Error: named parameter required before `...`
+#ifndef __clang__
+// Apple: /Applications/Xcode-14.2.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/tgmath.h(39): Error: named parameter required before `...`
+// OpenBSD: /usr/lib/clang/13.0.0/include/tgmath.h(34): Error: named parameter required before `...`
+// Linux: /tmp/clang/lib/clang/15.0.3/include/tgmath.h(34): Error: named parameter required before `...`
+#if !(defined(__linux__) && defined(__aarch64__)) // /usr/include/bits/math-vector.h(162): Error: undefined identifier `__Float32x4_t`
 #include <tgmath.h>
-#endif
 #endif
 #endif
 #endif

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -173,7 +173,10 @@ typedef unsigned long long __uint64_t;
 // Ubuntu's assert.h uses this
 #define __PRETTY_FUNCTION__ __func__
 
-#ifndef __aarch64__
+#ifndef __clang__
+// Glibc with clang gets upset when some _Float* is defined:
+// /usr/include/bits/floatn-common.h(214): Error: illegal combination of type specifiers
+// typedef float float;
 #define _Float32 float
 #define _Float32x double
 #define _Float64 double


### PR DESCRIPTION
It should fix running clang-cpp on linux x86_64.

This involves moving some linux+aarch64 fixes to linux+clang since clang was the actual issue.

See-also: https://github.com/dlang/dmd/pull/15320