### PR TITLE
Call C preprocessor with -std=c11 on posix

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1149,6 +1149,8 @@ public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, c
         Strings argv;
         argv.push(cpp.xarraydup.ptr);       // null terminated copy
 
+        argv.push("-std=c11");
+
         foreach (p; cppswitches)
         {
             if (p && p[0])

--- a/compiler/test/compilable/fix24187.c
+++ b/compiler/test/compilable/fix24187.c
@@ -2,7 +2,7 @@
 
 // https://issues.dlang.org/show_bug.cgi?id=24187
 
-#ifdef linux
+#ifdef __linux__
 #ifndef __clang__
 extern _Complex _Float32 cacosf32 (_Complex _Float32 __z) __attribute__ ((__nothrow__ , __leaf__));
 

--- a/compiler/test/runnable/test23889.c
+++ b/compiler/test/runnable/test23889.c
@@ -1,8 +1,8 @@
 // DISABLED: win freebsd openbsd
 
-// https://issues.dlang.org/show_bug.cgi?id=23886
+// https://issues.dlang.org/show_bug.cgi?id=23889
 
-#include <stdlib.h>
+#include <alloca.h>
 
 int main()
 {

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -169,7 +169,7 @@ typedef unsigned long long __uint64_t;
 #define __STDC_NO_VLA__ 1
 
 #define _Float16 float
-#if linux  // Microsoft won't allow the following macro
+#ifdef __linux__  // Microsoft won't allow the following macro
 // Ubuntu's assert.h uses this
 #define __PRETTY_FUNCTION__ __func__
 


### PR DESCRIPTION
Like https://github.com/dlang/dmd/pull/21349 but uses `-std=c11` instead of `-std=gnu11`