### PR TITLE
Templatize `_d_arrayshrinkfit`

### DIFF
--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -17,7 +17,65 @@ extern(C) {
     bool gc_expandArrayUsed(void[] slice, size_t newUsed, bool atomic) nothrow pure;
     size_t gc_reserveArrayCapacity(void[] slice, size_t request, bool atomic) nothrow pure;
     bool gc_shrinkArrayUsed(void[] slice, size_t existingUsed, bool atomic) nothrow pure;
+    void[] gc_getArrayUsed(void *ptr, bool atomic) nothrow pure;
 }
+
+/**
+Shrink the "allocated" length of an array to be the exact size of the array.
+
+It doesn't matter what the current allocated length of the array is, the
+user is telling the runtime that he knows what he is doing.
+
+Params:
+    T = the type of the elements in the array (this should be unqualified)
+    arr = array to shrink. Its `.length` is element length, not byte length, despite `void` type
+    isshared = true if the underlying data is shared
+*/
+void _d_arrayshrinkfit(Tarr: T[], T)(Tarr arr, bool isshared) @trusted
+{
+    import core.exception : onFinalizeError;
+    import core.internal.traits: hasElaborateDestructor;
+
+    debug(PRINTF) printf("_d_arrayshrinkfit, elemsize = %zd, arr.ptr = %p arr.length = %zd\n", T.sizeof, arr.ptr, arr.length);
+    auto reqlen = arr.length;
+
+    auto curArr = cast(Tarr)gc_getArrayUsed(arr.ptr, isshared);
+    if (curArr.ptr is null)
+        // not a valid GC pointer
+        return;
+
+    // align the array.
+    auto offset = arr.ptr - curArr.ptr;
+    auto curlen = curArr.length - offset;
+    if (curlen <= reqlen)
+        // invalid situation, or no change.
+        return;
+
+    // if the type has a destructor, destroy elements we are about to remove.
+    static if(is(T == struct) && hasElaborateDestructor!T)
+    {
+        try
+        {
+            // Finalize the elements that are being removed
+
+            // Due to the fact that the delete operator calls destructors
+            // for arrays from the last element to the first, we maintain
+            // compatibility here by doing the same.
+            for (auto curP = arr.ptr + curlen - 1; curP >= arr.ptr + reqlen; curP--)
+            {
+                // call destructor
+                curP.__xdtor();
+            }
+        }
+        catch (Exception e)
+        {
+            onFinalizeError(typeid(T), e);
+        }
+    }
+
+    gc_shrinkArrayUsed(arr[0 .. reqlen], curlen * T.sizeof, isshared);
+}
+
 /**
 Set the array capacity.
 

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -4031,7 +4031,13 @@ Returns:
 */
 auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr) nothrow @system
 {
-    _d_arrayshrinkfit(typeid(T[]), *(cast(void[]*)&arr));
+    import core.internal.array.capacity : _d_arrayshrinkfit;
+    import core.internal.traits : Unqual;
+
+    alias Unqual_Tarr = Unqual!T[];
+    enum isshared = is(T == shared);
+    _d_arrayshrinkfit(cast(Unqual_Tarr)arr, isshared);
+
     return arr;
 }
 

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -4010,10 +4010,6 @@ size_t reserve(T)(ref T[] arr, size_t newcapacity) pure nothrow @trusted
     a.reserve(10);
 }
 
-// HACK:  This is a lie.  `_d_arrayshrinkfit` is not `nothrow`, but this lie is necessary
-// for now to prevent breaking code.
-private extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow;
-
 /**
 Assume that it is safe to append to this array. Appends made to this array
 after calling this function may append in place, even if the array was a


### PR DESCRIPTION
In this PR, I've converted the `_d_arrayshrinkfit` runtime hook to a template function, eliminating the **TypeInfo** parameter. This new version is now located in `core.internal.array.capacity`.