### PR TITLE
Revert "add some DMC AArch64 versions to druntime"

### DIFF
--- a/druntime/src/core/internal/vararg/sysv_x64.d
+++ b/druntime/src/core/internal/vararg/sysv_x64.d
@@ -17,11 +17,6 @@ version (X86_64)
     version (Windows) { /* different ABI */ }
     else version = SysV_x64;
 }
-version (AArch64)
-{
-    version (Windows) { /* different ABI */ }
-    else version = SysV_x64;
-}
 
 version (SysV_x64):
 

--- a/druntime/src/core/stdc/config.d
+++ b/druntime/src/core/stdc/config.d
@@ -260,23 +260,6 @@ else version (DigitalMars)
         else version (Darwin)
             alias real c_long_double;
     }
-    else version (AArch64)
-    {
-        version (linux)
-            alias real c_long_double;
-        else version (FreeBSD)
-            alias real c_long_double;
-        else version (OpenBSD)
-            alias real c_long_double;
-        else version (NetBSD)
-            alias real c_long_double;
-        else version (DragonFlyBSD)
-            alias real c_long_double;
-        else version (Solaris)
-            alias real c_long_double;
-        else version (Darwin)
-            alias real c_long_double;
-    }
 }
 
 static assert(is(c_long_double), "c_long_double needs to be declared for this platform/architecture.");

--- a/druntime/src/core/stdc/stdarg.d
+++ b/druntime/src/core/stdc/stdarg.d
@@ -20,11 +20,6 @@ version (X86_64)
     version (Windows) { /* different ABI */ }
     else version = SysV_x64;
 }
-version (AArch64)
-{
-    version (Windows) { /* different ABI */ }
-    else version = SysV_x64;
-}
 
 version (GNU)
 {
@@ -36,28 +31,12 @@ else version (SysV_x64)
 
     version (DigitalMars)
     {
-        version (X86_64)
-            align(16) struct __va_argsave_t
-            {
-                size_t[6] regs;   // RDI,RSI,RDX,RCX,R8,R9
-                real[8] fpregs;   // XMM0..XMM7
-                __va_list va;
-            }
-        else version (AArch64)
-            align(16) struct __va_argsave_t
-            {
-                ulong[8] regs;
-                real[8] fpregs;
-                struct __va_list_tag
-                {
-                    void* stack;
-                    void* gr_top;
-                    void* vr_top;
-                    int gr_offs;
-                    int vr_offs;
-                }
-                void* stack_args_save;
-            }
+        align(16) struct __va_argsave_t
+        {
+            size_t[6] regs;   // RDI,RSI,RDX,RCX,R8,R9
+            real[8] fpregs;   // XMM0..XMM7
+            __va_list va;
+        }
     }
 }
 


### PR DESCRIPTION
Reverts dlang/dmd#21374, as it breaks AArch64 for non-DMD (and cannot work correctly with DMD either). Bluntly reverting the whole change, since Walter merged it without considering my comments, so I won't put any more effort into this either.