### PR TITLE
druntime: Add core.sys.linux.sched.sched_getcpu() for musl libc

### DIFF
--- a/druntime/src/core/sys/linux/sched.d
+++ b/druntime/src/core/sys/linux/sched.d
@@ -151,6 +151,10 @@ version (CRuntime_Glibc)
     /* Determine CPU on which the calling thread is running */
     int sched_getcpu();
 }
+else version (CRuntime_Musl)
+{
+    int sched_getcpu();
+}
 
 /* Reassociate the calling thread with namespace referred to by fd */
 int setns(int fd, int nstype);


### PR DESCRIPTION
It was added in 2016: https://git.musl-libc.org/cgit/musl/commit/src/sched/sched_getcpu.c?id=98d335735d64ee34a34cb9c08ea2cb51a076d2a1