### PR TITLE
Revert "fix druntime for return-ref-scope discipline"

### DIFF
--- a/druntime/src/core/stdcpp/string.d
+++ b/druntime/src/core/stdcpp/string.d
@@ -343,7 +343,7 @@ extern(D):
         ///
         inout(T)* data() inout @safe                                        { return _Get_data()._Myptr; }
         ///
-        inout(T)[] as_array() return scope inout nothrow @trusted           { return _Get_data()._Myptr[0 .. _Get_data()._Mysize]; }
+        inout(T)[] as_array() scope return inout nothrow @trusted           { return _Get_data()._Myptr[0 .. _Get_data()._Mysize]; }
         ///
         ref inout(T) at(size_type i) inout nothrow @trusted                 { return _Get_data()._Myptr[0 .. _Get_data()._Mysize][i]; }
 
@@ -1920,7 +1920,7 @@ extern(D):
         ///
         inout(T)* data() inout @trusted                                     { return __get_pointer(); }
         ///
-        inout(T)[] as_array() return scope inout nothrow @trusted           { return __get_pointer()[0 .. size()]; }
+        inout(T)[] as_array() scope return inout nothrow @trusted           { return __get_pointer()[0 .. size()]; }
         ///
         ref inout(T) at(size_type i) inout nothrow @trusted                 { return __get_pointer()[0 .. size()][i]; }
 


### PR DESCRIPTION
Reverts dlang/dmd#21379

This doesn't refactor syntax, it swaps return ref out for return scope, which is wrong