### PR TITLE
fix issue #21384: function arguments are shown in the wrong order in a debugger

### DIFF
--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -672,7 +672,8 @@ enum
     SFLnodebug      = 0x20000,     // don't generate debug info
     SFLwasstatic    = 0x800000,    // was an uninitialized static
     SFLweak         = 0x1000000,   // resolve to NULL if not found
-    SFLhidden       = 0x2000000,   // not visible outside of DSOs (-fvisibility=hidden)
+    SFLhidden       = 0x2000000,   // SC.static_/SC.global: not visible outside of DSOs (-fvisibility=hidden)
+                                   // SC.parameter: hidden return value parameter
     SFLartifical    = 0x4000000,   // compiler generated symbol
     SFLnounderscore = 0x8000_0000, // don't prepend an _ to identifiers in object file
 

--- a/compiler/src/dmd/backend/cv8.d
+++ b/compiler/src/dmd/backend/cv8.d
@@ -487,7 +487,7 @@ void cv8_func_term(Symbol* sfunc)
             buf.write16(S_END);
         }
     }
-    varStats_writeSymbolTable(globsym, &cv8_outsym, &cv8.endArgs, &cv8.beginBlock, &cv8.endBlock);
+    varStats_writeSymbolTable(sfunc, globsym, &cv8_outsym, &cv8.endArgs, &cv8.beginBlock, &cv8.endBlock);
 
     /* Put out function return record S_RETURN
      * (VC doesn't, so we won't bother, either.)

--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -1883,7 +1883,7 @@ private void cv4_func(Funcsym* s, ref symtab_t symtab)
         }
     }
 
-    varStats_writeSymbolTable(symtab, &cv4_outsym, &cv4.endArgs, &cv4.beginBlock, &cv4.endBlock);
+    varStats_writeSymbolTable(sfunc, symtab, &cv4_outsym, &cv4.endArgs, &cv4.beginBlock, &cv4.endBlock);
 
     // Put out function return record
     if (1)

--- a/compiler/src/dmd/backend/dvarstats.d
+++ b/compiler/src/dmd/backend/dvarstats.d
@@ -20,6 +20,7 @@ import dmd.backend.cdef;
 import dmd.backend.global;
 import dmd.backend.code;
 import dmd.backend.symtab;
+import dmd.backend.ty;
 import dmd.backend.barray;
 
 
@@ -32,11 +33,11 @@ version (all) // free function version
 {
     import dmd.backend.dvarstats;
 
-    void varStats_writeSymbolTable(ref symtab_t symtab,
+    void varStats_writeSymbolTable(Symbol* sfn, ref symtab_t symtab,
             void function(Symbol*) nothrow fnWriteVar, void function() nothrow fnEndArgs,
             void function(int off,int len) nothrow fnBeginBlock, void function() nothrow fnEndBlock)
     {
-        varStats.writeSymbolTable(symtab, fnWriteVar, fnEndArgs, fnBeginBlock, fnEndBlock);
+        varStats.writeSymbolTable(sfn, symtab, fnWriteVar, fnEndArgs, fnBeginBlock, fnEndBlock);
     }
 
     void varStats_startFunction()
@@ -180,9 +181,14 @@ private bool hasUniqueIdentifier(ref symtab_t symtab, SYMIDX si)
     return true;
 }
 
+private bool isParameter(Symbol* s)
+{
+    return s.Sclass == SC.parameter || s.Sclass == SC.regpar || s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg;
+}
+
 // gather statistics about creation and destructions of variables that are
 //  used by the current function
-private symtab_t* calcLexicalScope(return ref symtab_t symtab) return
+private symtab_t* calcLexicalScope(Symbol* sfn, return ref symtab_t symtab) return
 {
     // make a copy of the symbol table
     // - arguments should be kept at the very beginning
@@ -191,20 +197,46 @@ private symtab_t* calcLexicalScope(return ref symtab_t symtab) return
     nextSym.setLength(symtab.length);
     sortedSymtab.setLength(symtab.length);
 
-    if (!hashSymbolIdentifiers(symtab))
+    // reconstruct original order of arguments, see FuncDeclaration_toObjFile:
+    // sort hidden params to the end of the params, keep 'this' at the front
+    // TH PPP H VVV -> TPPP HH VVV, with PPP optionally reversed
+    bool reverse = tyrevfunc(sfn.Stype.Tty) != 0;
+    SYMIDX hiddencnt, paramcnt, thiscnt;
+    for (paramcnt = 0; paramcnt < symtab.length; paramcnt++)
+    {
+        Symbol* sa = symtab[paramcnt];
+        if (!isParameter(sa))
+            break;
+        if (sa.Sflags & SFLhidden)
+            hiddencnt++;
+        if (strcmp(sa.Sident.ptr, "this") == 0)
+            thiscnt++;
+    }
+    paramcnt -= hiddencnt + thiscnt;
+    bool hashCollisions = hashSymbolIdentifiers(symtab);
+    if (!reverse && hiddencnt == 0 && !hashCollisions)
     {
         // without any collisions, there are no duplicate symbol names, so bail out early
         uniquecnt = cast(int)symtab.length;
         return &symtab;
     }
 
-    SYMIDX argcnt;
+    SYMIDX argcnt, hiddenidx, thisidx, paramidx;
     for (argcnt = 0; argcnt < symtab.length; argcnt++)
     {
         Symbol* sa = symtab[argcnt];
-        if (sa.Sclass != SC.parameter && sa.Sclass != SC.regpar && sa.Sclass != SC.fastpar && sa.Sclass != SC.shadowreg)
+        if (!isParameter(sa))
             break;
-        sortedSymtab[argcnt] = sa;
+        SYMIDX idx;
+        if (sa.Sflags & SFLhidden)
+            idx = thiscnt + paramcnt + hiddenidx++;
+        else if (strcmp(sa.Sident.ptr, "this") == 0)
+            idx = thisidx++;
+        else if (reverse)
+            idx = thiscnt + paramcnt - ++paramidx;
+        else
+            idx = thiscnt + paramidx++;
+        sortedSymtab[idx] = sa;
     }
 
     // find symbols with identical names, only these need lexical scope
@@ -220,7 +252,7 @@ private symtab_t* calcLexicalScope(return ref symtab_t symtab) return
     }
     sortedSymtab.length = symtab.length;
     if(dupcnt == 0)
-        return &symtab;
+        return paramcnt > 0 ? &sortedSymtab : &symtab;
 
     sortLineOffsets();
 
@@ -265,11 +297,11 @@ private symtab_t* calcLexicalScope(return ref symtab_t symtab) return
     return &sortedSymtab;
 }
 
-public void writeSymbolTable(ref symtab_t symtab,
+public void writeSymbolTable(Symbol* sfn, ref symtab_t symtab,
             void function(Symbol*) nothrow fnWriteVar, void function() nothrow fnEndArgs,
             void function(int off,int len) nothrow fnBeginBlock, void function() nothrow fnEndBlock)
 {
-    auto symtab2 = calcLexicalScope(symtab);
+    auto symtab2 = calcLexicalScope(sfn, symtab);
 
     int openBlocks = 0;
     int lastOffset = 0;
@@ -279,12 +311,9 @@ public void writeSymbolTable(ref symtab_t symtab,
     for (SYMIDX si = 0; si < symtab2.length; si++)
     {
         Symbol* sa = (*symtab2)[si];
-        if (endarg == false &&
-            sa.Sclass != SC.parameter &&
-            sa.Sclass != SC.fastpar &&
-            sa.Sclass != SC.regpar &&
-            sa.Sclass != SC.shadowreg)
+        if (endarg == false && (!isParameter(sa) || (sa.Sflags & SFLhidden) != 0))
         {
+            // the hidden parameter is a named return value, i.e. a local variable
             if(fnEndArgs)
                 (*fnEndArgs)();
             endarg = true;

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -644,7 +644,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             name = hiddenparam.ptr;
         }
         shidden = symbol_name(name[0 .. strlen(name)], SC.parameter, thidden);
-        shidden.Sflags |= SFLtrue | SFLfree;
+        shidden.Sflags |= SFLtrue | SFLfree | SFLhidden;
         if (fd.isNRVO() && fd.nrvo_var && fd.nrvo_var.nestedrefs.length)
             type_setcv(&shidden.Stype, shidden.Stype.Tty | mTYvolatile);
         irs.shidden = shidden;

--- a/compiler/test/runnable/testpdb.d
+++ b/compiler/test/runnable/testpdb.d
@@ -51,6 +51,8 @@ void main(string[] args)
 
         test20253(session, globals);
 
+        test21384(session, globals);
+
         test18147(session, globals);
 
         source.Release();
@@ -398,6 +400,90 @@ void test20253(IDiaSession session, IDiaSymbol globals)
 
     (checkRange.ptr >= funcRange.ptr + funcRange.length) ||
         assert(false, "code range of check20253 overlaps with func20253");
+}
+
+///////////////////////////////////////////////
+// https://github.com/dlang/dmd/issues/21384
+int sum21384(int a, int b, int c)
+{
+	int s = a + b + c;
+	return s;
+}
+
+struct S21384
+{
+	long x, y;
+}
+
+S21384 makeS21384(int a, int b)
+{
+	S21384 s = S21384(a, b);
+	return s;
+}
+
+class T21384
+{
+	S21384 genS21384(int a, int b)
+	{
+		S21384 s = S21384(a, b);
+		return s;
+	}
+}
+
+void testVar(IDiaSymbol var, string name, DWORD kind, string msg)
+{
+    BSTR varname;
+    var.get_name(&varname) == S_OK || assert(false, "testpdb.sum21384: vars[0]: no name");
+    scope(exit) SysFreeString(varname);
+    auto vname = toUTF8(varname[0..wcslen(varname)]);
+    vname == name || assert(false, msg ~ " name " ~ vname ~ ", expected " ~ name);
+
+    DWORD vkind;
+    var.get_dataKind(&vkind) == S_OK || assert(false, msg ~ " cannot retrieve data kind");
+    vkind == kind || assert(false, msg ~ " unexpected data kind");
+}
+
+DWORD getFuncVars(IDiaSymbol globals, const(wchar)* func, IDiaSymbol[] vars)
+{
+    IDiaSymbol funcSym = searchSymbol(globals, func);
+    funcSym || assert(false, "testpdb.sum21384 not found");
+
+    auto sfunc = toUTF8(func[0..wcslen(func)]);
+    IDiaEnumSymbols pEnumSymbols;
+    HRESULT hr = funcSym.findChildrenEx(SymTagEnum.SymTagData, NULL, NameSearchOptions.nsNone, &pEnumSymbols);
+    hr == S_OK && pEnumSymbols || assert(false, sfunc ~ ": no children found");
+
+    DWORD fetched;
+    hr = pEnumSymbols.Next(cast(uint)vars.length, vars.ptr, &fetched);
+    hr == S_OK || assert(false, sfunc ~ ": failed to fetch any vars");
+    return fetched;
+}
+
+void test21384(IDiaSession session, IDiaSymbol globals)
+{
+    IDiaSymbol[5] vars;
+    DWORD cnt = getFuncVars(globals, "testpdb.sum21384", vars[]);
+    cnt == 4 || assert(false, "testpdb.sum21384: failed to fetch 4 vars");
+
+    testVar(vars[0], "a", DataKind.DataIsParam, "testpdb.sum21384: arg1:");
+    testVar(vars[1], "b", DataKind.DataIsParam, "testpdb.sum21384: arg2:");
+    testVar(vars[2], "c", DataKind.DataIsParam, "testpdb.sum21384: arg3:");
+    testVar(vars[3], "s", DataKind.DataIsLocal, "testpdb.sum21384: local:");
+
+    cnt = getFuncVars(globals, "testpdb.makeS21384", vars[]);
+    cnt == 3 || assert(false, "testpdb.makeS21384: failed to fetch 3 vars");
+
+    testVar(vars[0], "a", DataKind.DataIsParam, "testpdb.makeS21384: arg1:");
+    testVar(vars[1], "b", DataKind.DataIsParam, "testpdb.makeS21384: arg2:");
+    testVar(vars[2], "s", DataKind.DataIsLocal, "testpdb.makeS21384: hidden:");
+
+    cnt = getFuncVars(globals, "testpdb.T21384.genS21384", vars[]);
+    cnt == 4 || assert(false, "testpdb.T21384.genS21384: failed to fetch 4 vars");
+
+    testVar(vars[0], "this", DataKind.DataIsObjectPtr, "testpdb.T21384.genS21384: this:");
+    testVar(vars[1], "a", DataKind.DataIsParam, "testpdb.T21384.genS21384: arg1:");
+    testVar(vars[2], "b", DataKind.DataIsParam, "testpdb.T21384.genS21384: arg2:");
+    testVar(vars[3], "s", DataKind.DataIsLocal, "testpdb.T21384.genS21384: hidden:");
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
reconstructs order in calcLexicalScope. This also takes care of moving the named return value back into the local variables.