### PR TITLE
allow running compilable/test19266.sh under git bash

### DIFF
--- a/compiler/test/compilable/test19266.sh
+++ b/compiler/test/compilable/test19266.sh
@@ -3,5 +3,6 @@
 if [ "${OS}" == "windows" ]; then
    # break out of bash to get Windows paths
    # use cmd.exe instead of cmd to work from WSL
-   cmd.exe /c $(echo $DMD | tr / \\) -c \\\\.\\%CD%\\compilable\\extra-files\\test19266.d -deps=nul:
+   # use MSYS_NO_PATHCONV=1 to disable /c -> c:\ translation in git bash
+   MSYS_NO_PATHCONV=1 cmd.exe /c $(echo $DMD | tr / \\) -c \\\\.\\%CD%\\compilable\\extra-files\\test19266.d -deps=nul:
 fi


### PR DESCRIPTION
On my system the dmd-tests always stall because this test never terminates. This happens because bash is used from the git installation, which might be a bit more lightweight and is more likely to exist on a user system than wsl. Unfortunately, it translates /c to c:\ in the call to cmd.exe by default. The MSYS_NO_PATHCONV=1 setting avoids that.