### PR TITLE
makedep: add missing libs from pragma(lib)

### DIFF
--- a/compiler/src/dmd/pragmasem.d
+++ b/compiler/src/dmd/pragmasem.d
@@ -227,6 +227,8 @@ void pragmaDeclSemantic(PragmaDeclaration pd, Scope* sc)
             .error(pd.loc, "%s `%s` string expected for library name", pd.kind, pd.toPrettyChars);
         else
         {
+            import dmd.root.string: toCString, hasExtension;
+
             auto se = semanticString(sc, (*pd.args)[0], "library name");
             if (!se)
                 return noDeclarations();
@@ -248,9 +250,8 @@ void pragmaDeclSemantic(PragmaDeclaration pd, Scope* sc)
                 ob.writenl();
             }
 
-            if (global.params.makeDeps.doOutput)
+            if (global.params.makeDeps.doOutput && name.hasExtension)
             {
-                import dmd.root.string: toCString;
                 global.params.makeDeps.files.push(name.toCString.ptr);
             }
 

--- a/compiler/src/dmd/pragmasem.d
+++ b/compiler/src/dmd/pragmasem.d
@@ -227,7 +227,7 @@ void pragmaDeclSemantic(PragmaDeclaration pd, Scope* sc)
             .error(pd.loc, "%s `%s` string expected for library name", pd.kind, pd.toPrettyChars);
         else
         {
-            import dmd.root.string: toCString, hasExtension;
+            import dmd.root.string: toCString;
 
             auto se = semanticString(sc, (*pd.args)[0], "library name");
             if (!se)

--- a/compiler/src/dmd/pragmasem.d
+++ b/compiler/src/dmd/pragmasem.d
@@ -250,7 +250,7 @@ void pragmaDeclSemantic(PragmaDeclaration pd, Scope* sc)
                 ob.writenl();
             }
 
-            if (global.params.makeDeps.doOutput && name.hasExtension)
+            if (global.params.makeDeps.doOutput)
             {
                 global.params.makeDeps.files.push(name.toCString.ptr);
             }

--- a/compiler/src/dmd/pragmasem.d
+++ b/compiler/src/dmd/pragmasem.d
@@ -247,6 +247,13 @@ void pragmaDeclSemantic(PragmaDeclaration pd, Scope* sc)
                 ob.writestring(name);
                 ob.writenl();
             }
+
+            if (global.params.makeDeps.doOutput)
+            {
+                import dmd.root.string: toCString;
+                global.params.makeDeps.files.push(name.toCString.ptr);
+            }
+
             mem.xfree(name.ptr);
         }
         return noDeclarations();

--- a/compiler/src/dmd/root/string.d
+++ b/compiler/src/dmd/root/string.d
@@ -238,30 +238,6 @@ int dstrcmp()( scope const char[] s1, scope const char[] s2 ) @trusted
     return s1.length < s2.length ? -1 : (s1.length > s2.length);
 }
 
-
-/**
- * Checks if a given path points to file with an extension.
- */
-bool hasExtension(char[] path)
-{
-    int len = cast(int)path.length;
-    int lastSep = -1;
-    for (int i = len - 1; i >= 0; --i)
-    {
-        if (path[i] == '/' || path[i] == '\\')
-        {
-            lastSep = i;
-            break;
-        }
-    }
-    for (int i = lastSep + 1; i < len; ++i)
-    {
-        if (path[i] == '.')
-            return true;
-    }
-    return false;
-}
-
 //
 unittest
 {

--- a/compiler/src/dmd/root/string.d
+++ b/compiler/src/dmd/root/string.d
@@ -238,6 +238,30 @@ int dstrcmp()( scope const char[] s1, scope const char[] s2 ) @trusted
     return s1.length < s2.length ? -1 : (s1.length > s2.length);
 }
 
+
+/**
+ * Checks if a given path points to file with an extension.
+ */
+bool hasExtension(char[] path)
+{
+    int len = cast(int)path.length;
+    int lastSep = -1;
+    for (int i = len - 1; i >= 0; --i)
+    {
+        if (path[i] == '/' || path[i] == '\\')
+        {
+            lastSep = i;
+            break;
+        }
+    }
+    for (int i = lastSep + 1; i < len; ++i)
+    {
+        if (path[i] == '.')
+            return true;
+    }
+    return false;
+}
+
 //
 unittest
 {


### PR DESCRIPTION
Build tools like xmake depend on that file to be able to implement incremental compilation, it was missing static libraries from `pragma(lib)` so it resulting in `undefined reference` errors