### PR TITLE
Windows: Preprocess C files in C11 mode, as on Posix

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3425,6 +3425,11 @@ final class CParser(AST) : Parser!AST
                         cparseParens();
                 }
             }
+            else if (token.value == TOK._Noreturn)
+            {
+                specifier.noreturn = true;
+                nextToken();
+            }
             else if (token.value == TOK.restrict) // ImportC assigns no semantics to `restrict`, so just ignore the keyword.
                 nextToken();
             else

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -993,7 +993,7 @@ public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, c
                  */
                 OutBuffer buf;
                 buf.writestring(cpp);
-                buf.printf(" /P /Zc:preprocessor /PD /nologo /utf-8 \"%.*s\" \"/FI%s\" \"/Fi%.*s\"",
+                buf.printf(" /std:c11 /P /Zc:preprocessor /PD /nologo /utf-8 \"%.*s\" \"/FI%s\" \"/Fi%.*s\"",
                     cast(int)filename.length, filename.ptr, importc_h, cast(int)output.length, output.ptr);
 
                 /* Append preprocessor switches to command line

--- a/compiler/test/compilable/testcstuff1.c
+++ b/compiler/test/compilable/testcstuff1.c
@@ -293,6 +293,8 @@ void test2()
 
     inline int f();
     _Noreturn void g();
+    __declspec(noreturn) void g2();
+    __declspec(_Noreturn) void g3();
 
     _Static_assert(1, "ok");
 }

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -166,7 +166,9 @@ typedef unsigned long long __uint64_t;
 /***************************
  * C11 6.10.8.3 Conditional feature macros
  */
+#if !(defined(_MSC_VER) && defined(__STDC_NO_VLA__)) // pre-defined to 1 by MS when using /std:cXX and causing warning C4117
 #define __STDC_NO_VLA__ 1
+#endif
 
 #define _Float16 float
 #ifdef __linux__  // Microsoft won't allow the following macro

--- a/druntime/test/importc_compare/Makefile
+++ b/druntime/test/importc_compare/Makefile
@@ -11,7 +11,3 @@ endif
 include ../common.mak
 
 extra_dflags += -d
-
-ifeq ($(OS),windows)
-    extra_dflags += -P=/std:c11
-endif


### PR DESCRIPTION
Incl. supporting `__declspec(_Noreturn)` in ImportC, as apparently used in Microsoft headers when running with `/std:c11`, e.g.:
```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\intrin.h(204): Error: extended-decl-modifier expected after `__declspec(`, saw `_Noreturn` instead
__declspec(_Noreturn) void __fastfail(unsigned int);
```