### PR TITLE
Fix issue #21397 - Refcounting with Throwable is unsound

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6703,7 +6703,7 @@ ThrownExceptionExp chainExceptions(ThrownExceptionExp oldest, ThrownExceptionExp
     }
     // Little sanity check to make sure it's really a Throwable
     ClassReferenceExp boss = oldest.thrown;
-    const next = 5;                         // index of Throwable.next
+    const next = 5;                         // index of Throwable._nextInChainPtr
     assert((*boss.value.elements)[next].type.ty == Tpointer); // Throwable._nextInChainPtr
     ClassReferenceExp collateral = newest.thrown;
     if (collateral.originalClass().isErrorException() && !boss.originalClass().isErrorException())

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6703,8 +6703,9 @@ ThrownExceptionExp chainExceptions(ThrownExceptionExp oldest, ThrownExceptionExp
     }
     // Little sanity check to make sure it's really a Throwable
     ClassReferenceExp boss = oldest.thrown;
-    const next = 5;                         // index of Throwable._nextInChainPtr
-    assert((*boss.value.elements)[next].type.ty == Tpointer); // Throwable._nextInChainPtr
+    const next = 5;                          // index of Throwable._nextInChainPtr
+    with ((*boss.value.elements)[next].type) // Throwable._nextInChainPtr
+        assert(ty == Tpointer || ty == Tclass);
     ClassReferenceExp collateral = newest.thrown;
     if (collateral.originalClass().isErrorException() && !boss.originalClass().isErrorException())
     {

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6704,7 +6704,7 @@ ThrownExceptionExp chainExceptions(ThrownExceptionExp oldest, ThrownExceptionExp
     // Little sanity check to make sure it's really a Throwable
     ClassReferenceExp boss = oldest.thrown;
     const next = 5;                         // index of Throwable.next
-    assert((*boss.value.elements)[next].type.ty == Tclass); // Throwable.next
+    assert((*boss.value.elements)[next].type.ty == Tpointer); // Throwable._nextInChainPtr
     ClassReferenceExp collateral = newest.thrown;
     if (collateral.originalClass().isErrorException() && !boss.originalClass().isErrorException())
     {

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2562,7 +2562,6 @@ class Throwable : Object
                                 // 1 : allocated by _d_newThrowable()
                                 // 2.. : reference count + 1
 
-
     /**
      * Returns:
      * A reference to the _next error in the list. This is used when a new

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2550,7 +2550,6 @@ class Throwable : Object
      */
     private void*   _nextInChainPtr;
 
-    // 0 = not ref counted, 1 = ref counted
     private @property bool _nextIsRefcounted() @trusted scope pure nothrow @nogc const
     {
         if (__ctfe)

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2535,12 +2535,33 @@ class Throwable : Object
      * $(D Throwable) is thrown from inside a $(D catch) block. The originally
      * caught $(D Exception) will be chained to the new $(D Throwable) via this
      * field.
+     *
+     * If the 0 bit is set in this, it means the next exception is refcounted,
+     * meaning this object owns that object and should destroy it on
+     * destruction.
+     *
+     * WARNING: This means we are storing an interior pointer to the next in
+     * chain, to signify that the next in the chain is actually reference
+     * counted. We rely on the fact that a pointer to a Throwable is not 1-byte
+     * aligned. It is important to use a local field to indicate reference
+     * counting since we are not allowed to look at GC-allocated references
+     * inside the destructor. It is very important to store this as a void*,
+     * since optimizers can consider an unaligned pointer to not exist.
      */
-    private Throwable   nextInChain;
+    private void*   _nextInChainPtr;
+
+    // 0 = not ref counted, 1 = ref counted
+    private @property size_t _nextIsRefcounted() @trusted scope pure nothrow @nogc const
+    {
+        if (__ctfe)
+            return 0;
+        return (cast(size_t)_nextInChainPtr) & 1;
+    }
 
     private uint _refcount;     // 0 : allocated by GC
                                 // 1 : allocated by _d_newThrowable()
                                 // 2.. : reference count + 1
+
 
     /**
      * Returns:
@@ -2549,24 +2570,36 @@ class Throwable : Object
      * caught $(D Exception) will be chained to the new $(D Throwable) via this
      * field.
      */
-    @property inout(Throwable) next() @safe inout return scope pure nothrow @nogc { return nextInChain; }
+    @property inout(Throwable) next() @trusted inout return scope pure nothrow @nogc
+    {
+        if (__ctfe)
+            return cast(inout(Throwable)) _nextInChainPtr;
+
+        return cast(inout(Throwable)) (_nextInChainPtr - _nextIsRefcounted);
+    }
+
 
     /**
      * Replace next in chain with `tail`.
      * Use `chainTogether` instead if at all possible.
      */
-    @property void next(Throwable tail) @safe scope pure nothrow @nogc
+    @property void next(Throwable tail) @trusted scope pure nothrow @nogc
     {
+        void* newTail = cast(void*)tail;
         if (tail && tail._refcount)
+        {
             ++tail._refcount;           // increment the replacement *first*
+            ++newTail;                  // indicate ref counting is used
+        }
 
-        auto n = nextInChain;
-        nextInChain = null;             // sever the tail before deleting it
+        auto n = next;
+        auto nrc = _nextIsRefcounted;
+        _nextInChainPtr = null;          // sever the tail before deleting it
 
-        if (n && n._refcount)
+        if (nrc)
             _d_delThrowable(n);         // now delete the old tail
 
-        nextInChain = tail;             // and set the new tail
+        _nextInChainPtr = newTail;       // and set the new tail
     }
 
     /**
@@ -2585,7 +2618,7 @@ class Throwable : Object
     int opApply(scope int delegate(Throwable) dg)
     {
         int result = 0;
-        for (Throwable t = this; t; t = t.nextInChain)
+        for (Throwable t = this; t; t = t.next)
         {
             result = dg(t);
             if (result)
@@ -2608,14 +2641,12 @@ class Throwable : Object
             return e2;
         if (!e2)
             return e1;
-        if (e2.refcount())
-            ++e2.refcount();
 
-        for (auto e = e1; 1; e = e.nextInChain)
+        for (auto e = e1; 1; e = e.next)
         {
-            if (!e.nextInChain)
+            if (!e.next)
             {
-                e.nextInChain = e2;
+                e.next = e2;
                 break;
             }
         }
@@ -2625,9 +2656,7 @@ class Throwable : Object
     @nogc @safe pure nothrow this(string msg, Throwable nextInChain = null)
     {
         this.msg = msg;
-        this.nextInChain = nextInChain;
-        if (nextInChain && nextInChain._refcount)
-            ++nextInChain._refcount;
+        this.next = nextInChain;
         //this.info = _d_traceContext();
     }
 
@@ -2641,8 +2670,9 @@ class Throwable : Object
 
     @trusted nothrow ~this()
     {
-        if (nextInChain && nextInChain._refcount)
-            _d_delThrowable(nextInChain);
+        if (_nextIsRefcounted)
+            _d_delThrowable(next);
+
         // handle owned traceinfo
         if (infoDeallocator !is null)
         {
@@ -2771,7 +2801,7 @@ class Exception : Throwable
         auto e = new Exception("msg");
         assert(e.file == __FILE__);
         assert(e.line == __LINE__ - 2);
-        assert(e.nextInChain is null);
+        assert(e._nextInChainPtr is null);
         assert(e.msg == "msg");
     }
 
@@ -2779,7 +2809,7 @@ class Exception : Throwable
         auto e = new Exception("msg", new Exception("It's an Exception!"), "hello", 42);
         assert(e.file == "hello");
         assert(e.line == 42);
-        assert(e.nextInChain !is null);
+        assert(e._nextInChainPtr !is null);
         assert(e.msg == "msg");
     }
 
@@ -2787,7 +2817,7 @@ class Exception : Throwable
         auto e = new Exception("msg", "hello", 42, new Exception("It's an Exception!"));
         assert(e.file == "hello");
         assert(e.line == 42);
-        assert(e.nextInChain !is null);
+        assert(e._nextInChainPtr !is null);
         assert(e.msg == "msg");
     }
 
@@ -2854,7 +2884,7 @@ class Error : Throwable
         auto e = new Error("msg");
         assert(e.file is null);
         assert(e.line == 0);
-        assert(e.nextInChain is null);
+        assert(e._nextInChainPtr is null);
         assert(e.msg == "msg");
         assert(e.bypassedException is null);
     }
@@ -2863,7 +2893,7 @@ class Error : Throwable
         auto e = new Error("msg", new Exception("It's an Exception!"));
         assert(e.file is null);
         assert(e.line == 0);
-        assert(e.nextInChain !is null);
+        assert(e._nextInChainPtr !is null);
         assert(e.msg == "msg");
         assert(e.bypassedException is null);
     }
@@ -2872,7 +2902,7 @@ class Error : Throwable
         auto e = new Error("msg", "hello", 42, new Exception("It's an Exception!"));
         assert(e.file == "hello");
         assert(e.line == 42);
-        assert(e.nextInChain !is null);
+        assert(e._nextInChainPtr !is null);
         assert(e.msg == "msg");
         assert(e.bypassedException is null);
     }

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2551,10 +2551,10 @@ class Throwable : Object
     private void*   _nextInChainPtr;
 
     // 0 = not ref counted, 1 = ref counted
-    private @property size_t _nextIsRefcounted() @trusted scope pure nothrow @nogc const
+    private @property bool _nextIsRefcounted() @trusted scope pure nothrow @nogc const
     {
         if (__ctfe)
-            return 0;
+            return false;
         return (cast(size_t)_nextInChainPtr) & 1;
     }
 


### PR DESCRIPTION
A throwable looks at a potentially GC-allocated memory location to determine if it is refcounted. Using the reference is not valid in the destructor, so we must store a flag in a local field to determine whether to look at it.

We use the `nextInChain` pointer to store the bit which indicates whether the `nextInChain` is a refcounted object. At first I intended to use `_refcount` since that has plenty of bits to spare, but it is exposed via reference with the `refcount` accessor (unsure why that exists).

Open to alternatives for storage of the bit.

This fixes a segfault I am seeing on Windows with the new GC, which is more aggressive in reclaiming memory for the OS (and sets the memory as uncommitted).