### PR TITLE
windows druntime/shared test: avoid spurious failures by building to folder 64, not to 64.obj

### DIFF
--- a/druntime/test/shared/Makefile
+++ b/druntime/test/shared/Makefile
@@ -92,7 +92,7 @@ ifeq (windows,$(OS))
     CC := cl
     OUTPUT_FLAG := /Fe
     # we additionally specify the .obj output path (/Fo) to prevent collisions
-    extra_cflags += /Fo$(OBJDIR)
+    extra_cflags += /Fo$(OBJDIR)/
 endif
 
 # $(LINKDL) == -L-ldl => $(ldl) == -ldl


### PR DESCRIPTION
this avoids concurrently creating the same file multiple times