### PR TITLE
add -preview=return switch for return ref scope disambiguation

### DIFF
--- a/changelog/dmd.returnRefScope.dd
+++ b/changelog/dmd.returnRefScope.dd
@@ -1,0 +1,6 @@
+Enforce ordering of `return ref` and `return scope` with `-preview=return`
+
+The `return` attribute is associated with the `ref` attribute or the `scope`
+attribute. In order to reduce the confusing permutations of the keywords `return`,
+`scope`, and `ref`, only the lexical combinations `return ref` and `return scope` are allowed
+when the -preview=return switch is applied.

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -775,6 +775,9 @@ dmd -cov -unittest myprog.d
             done for system and trusted functions, and assertion failures
             are undefined behaviour.`
         ),
+        Option("return",
+            "enforce 'return ref' and 'return scope' syntax"
+        ),
         Option("revert=<name>",
             "revert language change identified by 'name'",
             `Revert language change identified by $(I id)`,

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6305,6 +6305,7 @@ struct CompileEnv final
     _d_dynamicArray< const char > vendor;
     _d_dynamicArray< const char > timestamp;
     bool previewIn;
+    bool returnRefScope;
     bool transitionIn;
     bool ddocOutput;
     bool masm;
@@ -6317,6 +6318,7 @@ struct CompileEnv final
         vendor(),
         timestamp(),
         previewIn(),
+        returnRefScope(),
         transitionIn(),
         ddocOutput(),
         masm(),
@@ -6324,13 +6326,14 @@ struct CompileEnv final
         dCharLookupTable()
     {
     }
-    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool transitionIn = false, bool ddocOutput = false, bool masm = false, IdentifierCharLookup cCharLookupTable = IdentifierCharLookup(), IdentifierCharLookup dCharLookupTable = IdentifierCharLookup()) :
+    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool returnRefScope = false, bool transitionIn = false, bool ddocOutput = false, bool masm = false, IdentifierCharLookup cCharLookupTable = IdentifierCharLookup(), IdentifierCharLookup dCharLookupTable = IdentifierCharLookup()) :
         versionNumber(versionNumber),
         date(date),
         time(time),
         vendor(vendor),
         timestamp(timestamp),
         previewIn(previewIn),
+        returnRefScope(returnRefScope),
         transitionIn(transitionIn),
         ddocOutput(ddocOutput),
         masm(masm),
@@ -8454,6 +8457,7 @@ struct Param final
     FeatureState safer;
     FeatureState noSharedAccess;
     bool previewIn;
+    bool returnRefScope;
     bool inclusiveInContracts;
     bool shortenedMethods;
     bool fixImmutableConv;
@@ -8537,6 +8541,7 @@ struct Param final
         useDIP1021(),
         fixAliasThis(),
         previewIn(),
+        returnRefScope(),
         inclusiveInContracts(),
         shortenedMethods(true),
         fixImmutableConv(),
@@ -8585,7 +8590,7 @@ struct Param final
         timeTraceFile()
     {
     }
-    Param(bool obj, bool readStdin = false, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting useWarnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState safer = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<ImportPathInfo > imppath = Array<ImportPathInfo >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), bool debugEnabled = false, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool fullyQualifiedObjectFiles = false, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
+    Param(bool obj, bool readStdin = false, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting useWarnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState safer = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool returnRefScope = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<ImportPathInfo > imppath = Array<ImportPathInfo >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), bool debugEnabled = false, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool fullyQualifiedObjectFiles = false, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
         obj(obj),
         readStdin(readStdin),
         multiobj(multiobj),
@@ -8623,6 +8628,7 @@ struct Param final
         safer(safer),
         noSharedAccess(noSharedAccess),
         previewIn(previewIn),
+        returnRefScope(returnRefScope),
         inclusiveInContracts(inclusiveInContracts),
         shortenedMethods(shortenedMethods),
         fixImmutableConv(fixImmutableConv),

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -205,6 +205,7 @@ extern (C++) struct Param
                                  // https://github.com/WalterBright/documents/blob/38f0a846726b571f8108f6e63e5e217b91421c86/safer.md
     FeatureState noSharedAccess; // read/write access to shared memory objects
     bool previewIn;              // `in` means `[ref] scope const`, accepts rvalues
+    bool returnRefScope;         // -preview=return switch, must use `return ref` or `return scope`
     bool inclusiveInContracts;   // 'in' contracts of overridden methods must be a superset of parent contract
     bool shortenedMethods = true;       // allow => in normal function declarations
     bool fixImmutableConv;       // error on unsound immutable conversion - https://github.com/dlang/dmd/pull/14070

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -213,6 +213,7 @@ struct Param
 
     FeatureState noSharedAccess; // read/write access to shared memory objects
     d_bool previewIn;              // `in` means `[ref] scope const`, accepts rvalues
+    d_bool returnRefScope;         // -preview=return switch, must use `return ref` or `return scope`
     d_bool inclusiveInContracts;   // 'in' contracts of overridden methods must be a superset of parent contract
     d_bool shortenedMethods;       // allow => in normal function declarations
     d_bool fixImmutableConv;       // error on unsound immutable conversion - https://github.com/dlang/dmd/pull/14070

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -48,6 +48,7 @@ struct CompileEnv
     const(char)[] timestamp; /// __TIMESTAMP__
 
     bool previewIn;          /// `in` means `[ref] scope const`, accepts rvalues
+    bool returnRefScope;     /// -preview=return is on
     bool transitionIn;       /// `-transition=in` is active, `in` parameters are listed
     bool ddocOutput;         /// collect embedded documentation comments
     bool masm;               /// use MASM inline asm syntax

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -188,6 +188,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         return EXIT_FAILURE;
 
     global.compileEnv.previewIn        = global.params.previewIn;
+    global.compileEnv.returnRefScope   = global.params.returnRefScope;
     global.compileEnv.transitionIn     = global.params.v.vin;
     global.compileEnv.ddocOutput       = global.params.ddoc.doOutput;
 

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1535,6 +1535,8 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         }
         else if (arg == "-release")     // https://dlang.org/dmd.html#switch-release
             params.release = true;
+        else if (arg == "-return")     // https://dlang.org/dmd.html#switch-returnRefScope
+            params.returnRefScope = true;
         else if (arg == "-betterC")     // https://dlang.org/dmd.html#switch-betterC
         {
             params.betterC = true;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1286,7 +1286,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             return orig;
         }
 
-        if (0) // replace this with -preview=return in next PR
+        if (compileEnv.returnRefScope) // -preview=return
             switch (orig & (STC.out_ | STC.ref_ | STC.scope_ | STC.return_))
             {
                 case STC.return_ | STC.ref_:


### PR DESCRIPTION
The implementation is in https://github.com/dlang/dmd/pull/21369, this PR is for the switch mechanics.