### PR TITLE
so getFunctionAttributes() behaves like hdrgen.d

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4294,12 +4294,32 @@ void attributesApply(const TypeFunction tf, void delegate(string) dg, TRUSTforma
         dg("@nogc");
     if (tf.isProperty)
         dg("@property");
+
+    /* The following is more or less like dmd.hdrgen.stcToBuffer(), in the future
+     * it should be merged. The idea is consistent ordering
+     */
+    STC stc;
     if (tf.isRef)
-        dg("ref");
+        stc |= STC.ref_;
     if (tf.isReturn && !tf.isReturnInferred)
-        dg("return");
+        stc |= STC.return_;
     if (tf.isScopeQual && !tf.isScopeInferred)
-        dg("scope");
+        stc |= STC.scope_;
+    if (tf.isReturnScope)
+        stc |= STC.returnScope;
+    final switch (buildScopeRef(stc))
+    {
+        case ScopeRef.None:                                                      break;
+        case ScopeRef.Scope:            dg("scope");                             break;
+        case ScopeRef.Return:           dg("return");                            break;
+        case ScopeRef.ReturnScope:      dg("return"); dg("scope");               break;
+        case ScopeRef.ReturnRef:        dg("return"); dg("ref");                 break;
+        case ScopeRef.Ref:              dg("ref");                               break;
+        case ScopeRef.RefScope:         dg("ref");    dg("scope");               break;
+        case ScopeRef.ReturnRef_Scope:  dg("return"); dg("ref");    dg("scope"); break;
+        case ScopeRef.Ref_ReturnScope:  dg("ref");    dg("return"); dg("scope"); break;
+    }
+
     if (tf.isLive)
         dg("@live");
 

--- a/compiler/test/compilable/traits_getFunctionAttributes.d
+++ b/compiler/test/compilable/traits_getFunctionAttributes.d
@@ -44,8 +44,8 @@ void test_getFunctionAttributes()
     static assert(__traits(getFunctionAttributes, S.sharedF) == tuple!("shared", "@system"));
     static assert(__traits(getFunctionAttributes, typeof(S.sharedF)) == tuple!("shared", "@system"));
 
-    static assert(__traits(getFunctionAttributes, S.refF) == tuple!("ref", "return", "@system"));
-    static assert(__traits(getFunctionAttributes, typeof(S.refF)) == tuple!("ref", "return", "@system"));
+    static assert(__traits(getFunctionAttributes, S.refF) == tuple!("return", "ref", "@system"));
+    static assert(__traits(getFunctionAttributes, typeof(S.refF)) == tuple!("return", "ref", "@system"));
 
     static assert(__traits(getFunctionAttributes, S.propertyF) == tuple!("@property", "@system"));
     static assert(__traits(getFunctionAttributes, typeof(&S.propertyF)) == tuple!("@property", "@system"));

--- a/compiler/test/fail_compilation/test21546.d
+++ b/compiler/test/fail_compilation/test21546.d
@@ -3,10 +3,10 @@
 fail_compilation/test21546.d(113): Error: cannot implicitly convert expression `pc` of type `const(int)* delegate() return` to `int* delegate() return`
 fail_compilation/test21546.d(114): Error: cannot implicitly convert expression `pc` of type `const(int)* delegate() return` to `immutable(int)* delegate() return`
 fail_compilation/test21546.d(115): Error: cannot implicitly convert expression `pi` of type `immutable(int)* delegate() return` to `int* delegate() return`
-fail_compilation/test21546.d(213): Error: cannot implicitly convert expression `dc` of type `const(int) delegate() ref return` to `int delegate() ref return`
-fail_compilation/test21546.d(214): Error: cannot implicitly convert expression `dc` of type `const(int) delegate() ref return` to `immutable(int) delegate() ref return`
-fail_compilation/test21546.d(215): Error: cannot implicitly convert expression `di` of type `immutable(int) delegate() ref return` to `int delegate() ref return`
-fail_compilation/test21546.d(305): Error: cannot implicitly convert expression `[dgi]` of type `immutable(int) delegate() ref return[]` to `int delegate() ref return[]`
+fail_compilation/test21546.d(213): Error: cannot implicitly convert expression `dc` of type `const(int) delegate() return ref` to `int delegate() return ref`
+fail_compilation/test21546.d(214): Error: cannot implicitly convert expression `dc` of type `const(int) delegate() return ref` to `immutable(int) delegate() return ref`
+fail_compilation/test21546.d(215): Error: cannot implicitly convert expression `di` of type `immutable(int) delegate() return ref` to `int delegate() return ref`
+fail_compilation/test21546.d(305): Error: cannot implicitly convert expression `[dgi]` of type `immutable(int) delegate() return ref[]` to `int delegate() return ref[]`
 ---
  */
 // https://issues.dlang.org/show_bug.cgi?id=21546

--- a/compiler/test/runnable/testscope2.d
+++ b/compiler/test/runnable/testscope2.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-foo1 ulong function(return ref int* delegate() return p) ref return
+foo1 ulong function(return ref int* delegate() return p) return ref
 foo2 int function(return ref int delegate() p) ref
 foo3 int function(ref inout(int*) p) ref
 foo4 int function(return ref inout(int*) p) ref


### PR DESCRIPTION
So if you getFunctionAttributes() you will get them in the same sequence as hdrgen for the ref-return-scope cases.