### PR TITLE
fix #21406: generating header with debug condition crashes compiler

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -3258,9 +3258,13 @@ public:
 
     override void visit(DebugCondition c)
     {
-        buf.writestring("debug (");
-        buf.writestring(c.ident.toString());
-        buf.writeByte(')');
+        buf.writestring("debug");
+        if (c.ident)
+        {
+            buf.writestring(" (");
+            buf.writestring(c.ident.toString());
+            buf.writeByte(')');
+        }
     }
 
     override void visit(VersionCondition c)

--- a/compiler/test/compilable/extra-files/header1.d
+++ b/compiler/test/compilable/extra-files/header1.d
@@ -627,3 +627,5 @@ interface I12344
 {
     int i12344(int x) in(x > 0) out(result) {assert(result > 0);};
 }
+
+debug enum issue21406 = 1;

--- a/compiler/test/compilable/extra-files/header1.di
+++ b/compiler/test/compilable/extra-files/header1.di
@@ -565,3 +565,7 @@ interface I12344
 	}
 	;
 }
+debug
+{
+	enum issue21406 = 1;
+}

--- a/compiler/test/compilable/extra-files/header1i.di
+++ b/compiler/test/compilable/extra-files/header1i.di
@@ -728,3 +728,7 @@ interface I12344
 	}
 	;
 }
+debug
+{
+	enum issue21406 = 1;
+}


### PR DESCRIPTION
check for missing ident