### PR TITLE
fix(preview=in|rvaluerefparam): Allow int to uint implicit conversion

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1174,7 +1174,7 @@ private extern(D) MATCH argumentMatchParameter (FuncDeclaration fd, TypeFunction
      *  ref T      <- an lvalue of const(T) argument
      *  ref T[dim] <- an lvalue of const(T[dim]) argument
      */
-    if (!ta.constConv(tp))
+    if (arg.isLvalue() && !ta.constConv(tp))
     {
         if (pMessage) *pMessage = tf.getParamError(arg, p);
         return MATCH.nomatch;

--- a/compiler/test/compilable/rvalueref.d
+++ b/compiler/test/compilable/rvalueref.d
@@ -17,3 +17,6 @@ int toString(Writer)(ref Writer sink) => 3;
 int toString(void delegate(scope const(char)[]) sink) => 4;
 void put() {}
 static assert(toString(dst => put()) == 4);
+
+void constConv(ref uint value) {}
+void testConstConv() { constConv(42); }


### PR DESCRIPTION
One would expect that a CT-known value such as 42 can implicitly convert to 'ref uint' when rvalue-ref preview switches are on.