### PR TITLE
Fix #21408 : Array comparison with recursive inferred opEquals gives confusing error message

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6890,8 +6890,21 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (!exp.type)
         {
             exp.e1 = e1org; // https://issues.dlang.org/show_bug.cgi?id=10922
-                        // avoid recursive expression printing
-            error(exp.loc, "forward reference to inferred return type of function call `%s`", exp.toErrMsg());
+                            // avoid recursive expression printing
+            FuncDeclaration fd = null;
+            if (auto dve = exp.e1.isDotVarExp())
+                fd = cast(FuncDeclaration)dve.var;
+            else if (auto ve = exp.e1.isVarExp())
+                fd = cast(FuncDeclaration)ve.var;
+
+            if (fd && fd.inferRetType && sc && sc.func == fd)
+            {
+                error(exp.loc, "can't infer return type in function `%s`", fd.toChars());
+            }
+            else
+            {
+                error(exp.loc, "forward reference to inferred return type of function call `%s`", exp.toErrMsg());
+            }
             return setError();
         }
 
@@ -13416,8 +13429,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             __equals = __equals.trySemantic(sc); // for better error message
             if (!__equals)
             {
-                error(exp.loc, "incompatible types for array comparison: `%s` and `%s`",
-                          exp.e1.type.toChars(), exp.e2.type.toChars());
+                if (sc.func)
+                    error(exp.loc, "can't infer return type in function `%s`", sc.func.toChars());
+                else
+                    error(exp.loc, "incompatible types for array comparison: `%s` and `%s`",
+                  exp.e1.type.toChars(), exp.e2.type.toChars());
                 __equals = ErrorExp.get();
             }
 

--- a/compiler/test/fail_compilation/ice10938.d
+++ b/compiler/test/fail_compilation/ice10938.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice10938.d(14): Error: no property `opts` for `this` of type `ice10938.C`
-fail_compilation/ice10938.d(19): Error: forward reference to inferred return type of function call `this.opDispatch()`
+fail_compilation/ice10938.d(19): Error: can't infer return type in function `opDispatch`
 fail_compilation/ice10938.d(14): Error: template instance `ice10938.C.opDispatch!"opts"` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/test21408.d
+++ b/compiler/test/fail_compilation/test21408.d
@@ -1,0 +1,23 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21408.d(12): Error: can't infer return type in function `opEquals`
+fail_compilation/test21408.d(19): Error: can't infer return type in function `opEquals`
+---
+*/
+
+struct A {
+    A[] as;
+    auto opEquals(A x) {
+        return as == x.as;
+    }
+}
+
+struct B {
+    B[] as;
+    auto opEquals(B x) {
+        return x == this;
+    }
+}
+
+void main() {}


### PR DESCRIPTION
- fixed #21408 