### PR TITLE
editions syntax and command line

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -1381,7 +1381,7 @@ struct ASTBase
 
         const FileName srcfile;
         const(char)[] arg;
-        Edition edition = Edition.legacy;
+        Edition edition = Edition.min;
 
         extern (D) this(Loc loc, const(char)[] filename, Identifier ident, int doDocComment, int doHdrGen)
         {

--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -19,12 +19,12 @@ enum Sizeok : ubyte
 }
 
 /// D Language version
-enum Edition : ubyte
+enum Edition : ushort
 {
-    none,
-    legacy,          /// Before the introduction of editions
-    v2024,           /// Experimental first new edition
-    latest = v2024   /// Newest edition that this compiler knows of
+    v2023 = 2023,    /// Edition.min for default edition
+    v2024,           /// first Edition
+    v2025,           /// next Edition
+                     /// use Edition.max for latest edition
 }
 
 enum Baseok : ubyte

--- a/compiler/src/dmd/backend/arm/disasmarm.d
+++ b/compiler/src/dmd/backend/arm/disasmarm.d
@@ -3116,6 +3116,7 @@ unittest
     ubyte[BUFMAX] buf2;
     bool errors;
 
+    @trusted
     void testcase(int line, string s, uint size)
     {
         //printf("testcase(line %d s: '%.*s'\n", cast(int)line, cast(int)s.length, s.ptr);

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -345,6 +345,10 @@ dmd -cov -unittest myprog.d
                 $(LI $(I all): All)
             )`,
         ),
+        Option("edition[=<NNNN>G[<filename>]]",
+            "set language edition to edition year, apply to <filename>",
+            "set edition to default, to a particular year NNNN, apply only to a particular $(I filename)"
+        ),
         Option("extern-std=<standard>",
             "set C++ name mangling compatibility with <standard>",
             "Standards supported are:

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -474,7 +474,7 @@ extern (C++) final class Module : Package
         if (doHdrGen)
             hdrfile = setOutfilename(global.params.dihdr.name, global.params.dihdr.dir, arg, hdr_ext);
 
-        this.edition = Edition.legacy;
+        this.edition = Edition.min;
     }
 
     extern (D) this(const(char)[] filename, Identifier ident, int doDocComment, int doHdrGen)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1015,12 +1015,11 @@ enum class FileType : uint8_t
     c = 3u,
 };
 
-enum class Edition : uint8_t
+enum class Edition : uint16_t
 {
-    none = 0u,
-    legacy = 1u,
-    v2024 = 2u,
-    latest = 2u,
+    v2023 = 2023u,
+    v2024 = 2024u,
+    v2025 = 2025u,
 };
 
 struct OutBuffer final
@@ -8444,6 +8443,8 @@ struct Param final
     CppStdRevision cplusplus;
     Help help;
     Verbose v;
+    Edition edition;
+    void* editionFiles;
     FeatureState useDIP25;
     FeatureState useDIP1000;
     bool ehnogc;
@@ -8585,7 +8586,7 @@ struct Param final
         timeTraceFile()
     {
     }
-    Param(bool obj, bool readStdin = false, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting useWarnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState safer = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<ImportPathInfo > imppath = Array<ImportPathInfo >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), bool debugEnabled = false, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool fullyQualifiedObjectFiles = false, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
+    Param(bool obj, bool readStdin = false, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting useWarnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), Edition edition = (Edition)2023u, void* editionFiles = nullptr, FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState safer = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<ImportPathInfo > imppath = Array<ImportPathInfo >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), bool debugEnabled = false, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool fullyQualifiedObjectFiles = false, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
         obj(obj),
         readStdin(readStdin),
         multiobj(multiobj),
@@ -8613,6 +8614,8 @@ struct Param final
         cplusplus(cplusplus),
         help(help),
         v(v),
+        edition(edition),
+        editionFiles(editionFiles),
         useDIP25(useDIP25),
         useDIP1000(useDIP1000),
         ehnogc(ehnogc),

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -189,6 +189,11 @@ extern (C++) struct Param
     Help help;
     Verbose v;
 
+    // Editions
+    Edition edition;             // edition year
+    Edition[const(char)*] editionFiles; // Edition corresponding to a filespec
+
+
     // Options for `-preview=/-revert=`
     FeatureState useDIP25 = FeatureState.enabled; // implement https://wiki.dlang.org/DIP25
     FeatureState useDIP1000;     // implement https://dlang.org/spec/memory-safe-d.html#scope-return-params

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -1,4 +1,3 @@
-
 /* Compiler implementation of the D programming language
  * Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
  * written by Walter Bright
@@ -195,6 +194,9 @@ struct Param
 
     Help help;
     Verbose v;
+
+    unsigned short edition;      // edition year
+    void* editionFiles;          // Edition corresponding to a filespec
 
     // Options for `-preview=/-revert=`
     FeatureState useDIP25;       // implement https://wiki.dlang.org/DIP25

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -843,6 +843,24 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                     error("unknown dllimport '%.*s', must be 'none', 'defaultLibsOnly' or 'all'", cast(int) imp.length, imp.ptr);
             }
         }
+        else if (arg == "-edition")
+            params.edition = Edition.min;       // i.e. no edition
+        else if (startsWith(p + 1, "edition="))
+        {
+            if (arg.length >= 9 + 4 &&
+                !parseDigits!(Edition)(params.edition, arg[9 .. 9 + 4], Edition.max) ||
+                params.edition < Edition.min)
+            {
+                error("edition %d is not in the range %d ... %d", params.edition, Edition.min, Edition.max);
+            }
+
+            if (arg.length > 1+7+1+4) // -edition=YYYYfilename
+            {
+                auto filename = p + 1+7+1+4;
+                files.push(filename);
+                params.editionFiles[filename] = params.edition;
+            }
+        }
         else if (arg == "-fIBT")
         {
             driverParams.ibt = true;

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "dsymbol.h"
 
 struct ModuleDeclaration;
@@ -28,12 +30,11 @@ enum PKG
     PKGpackage  // already determined that's an actual package
 };
 
-enum class Edition : unsigned char
+enum class Edition : uint16_t
 {
-    none = 0u,
-    legacy = 1u,
-    v2024 = 2u,
-    latest = 2u,
+    v2023 = 2023,
+    v2024,
+    v2025,
 };
 
 class Package : public ScopeDsymbol

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -141,6 +141,18 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
         md = new AST.ModuleDeclaration(loc, a, id, msg, isdeprecated);
 
+        if (token.value == TOK.int32Literal)
+        {
+            auto edition = token.intvalue;
+            if (edition < Edition.min || Edition.max < edition)
+            {
+                error("module edition %lld must be in the range %d ... %d", edition, Edition.min, Edition.max);
+                edition = edition.min;
+            }
+            mod.edition = cast(Edition)edition;
+            nextToken();
+        }
+
         if (token.value != TOK.semicolon)
             error("`;` expected following module declaration instead of `%s`", token.toChars());
         nextToken();
@@ -237,7 +249,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                                 if (auto id = (*exps)[0].isIdentifierExp())
                                     if (id.ident == Id.__edition_latest_do_not_use)
                                     {
-                                        mod.edition = Edition.latest;
+                                        mod.edition = Edition.max;      // latest edition
                                         continue;
                                     }
 


### PR DESCRIPTION
Updated earlier PR https://github.com/dlang/dmd/commit/400dd0134d43b8c5aeb59879150465e76b152c08 for dip https://github.com/atilaneves/DIPs/blob/editions/editions.md and added command line parsing for editions switch.