### PR TITLE
fix #21426: Windows GC only wakes up one thread when doing parallel scanning

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -2457,6 +2457,19 @@ struct Gcx
             _length += RANGE.sizeof;
         }
 
+        void pushReverse(RANGE)(RANGE[] ranges)
+        {
+            while (_length + ranges.length * RANGE.sizeof > _cap)
+                grow();
+
+            // reverse order for depth-first-order traversal
+            foreach_reverse (ref range; ranges)
+            {
+                *cast(RANGE*)(_p + _length) = range;
+                _length += RANGE.sizeof;
+            }
+        }
+
         void pop(RANGE)(ref RANGE rng)
         in { assert(_length >= RANGE.sizeof); }
         do
@@ -2711,9 +2724,7 @@ struct Gcx
                     }
                     else
                     {
-                        // reverse order for depth-first-order traversal
-                        foreach_reverse (ref range; stack)
-                            scanStack.push(range);
+                        scanStack.pushReverse(stack);
                     }
                     stackPos = 0;
                 }
@@ -3765,9 +3776,7 @@ Lmark:
         scope(exit) stackLock.unlock();
         bool wasEmpty = scanStack.empty;
 
-        // reverse order for depth-first-order traversal
-        foreach_reverse (ref range; ranges)
-            scanStack.push(range);
+        scanStack.pushReverse(ranges);
 
         if (wasEmpty)
             evStackFilled.setIfInitialized();

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -3523,7 +3523,7 @@ Lmark:
                         Gcx.instance.numScanThreads = 0;
                         Gcx.instance.scanThreadData = null;
                         Gcx.instance.busyThreads = 0;
-                        Gcx.instance.stackLock.unlock();
+                        Gcx.instance.stackLock = shared(AlignedSpinLock)(SpinLock.Contention.brief);
 
                         memset(&Gcx.instance.evStackFilled, 0, Gcx.instance.evStackFilled.sizeof);
                         memset(&Gcx.instance.evDone, 0, Gcx.instance.evDone.sizeof);

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -2509,7 +2509,7 @@ struct Gcx
     }
     template scanStack(bool precise)
     {
-        static if(precise)
+        static if (precise)
             alias scanStack = scanStackPrecise;
         else
             alias scanStack = scanStackConservative;

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -3611,6 +3611,7 @@ Lmark:
         else
             mark!(false, true, true)(ScanRange!false(pbot, ptop));
 
+        evStart.reset();
         busyThreads.atomicOp!"-="(1);
 
         debug(PARALLEL_PRINTF) printf("waitForScanDone\n");
@@ -3662,7 +3663,7 @@ Lmark:
         if (!scanThreadData)
             onOutOfMemoryError();
 
-        evStart.initialize(false, false);
+        evStart.initialize(true, false);
         evDone.initialize(false, false);
 
         version (Posix)

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -3503,6 +3503,7 @@ Lmark:
                         Gcx.instance.numScanThreads = 0;
                         Gcx.instance.scanThreadData = null;
                         Gcx.instance.busyThreads = 0;
+                        Gcx.instance.stackLock.unlock();
 
                         memset(&Gcx.instance.evStackFilled, 0, Gcx.instance.evStackFilled.sizeof);
                         memset(&Gcx.instance.evDone, 0, Gcx.instance.evDone.sizeof);


### PR DESCRIPTION
use manual event reset to wake up all background scanning threads, because sys.core.event.setIfInitialized only wakes up one thread otherwise. These threads keep spinning until busyThreads becomes 0, which only happens after the event is manually reset from the main scanning thread.