### PR TITLE
add dmd/hostcompiler.d

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1575,7 +1575,7 @@ auto sourceFiles()
             mtype.d mustuse.d nogc.d nspace.d ob.d objc.d opover.d optimize.d
             parse.d pragmasem.d printast.d rootobject.d safe.d
             semantic2.d semantic3.d sideeffect.d statement.d
-            statementsem.d staticassert.d staticcond.d stmtstate.d target.d templatesem.d templateparamsem.d traits.d
+            statementsem.d staticassert.d staticcond.d stmtstate.d target.d targetcompiler.d templatesem.d templateparamsem.d traits.d
             typesem.d typinf.d utils.d
             iasm/package.d iasm/gcc.d
             mangle/package.d mangle/basic.d mangle/cpp.d mangle/cppwin.d

--- a/compiler/src/dmd/README.md
+++ b/compiler/src/dmd/README.md
@@ -46,6 +46,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | [compiler.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/compiler.d)   | Describe a back-end compiler and implements compiler-specific actions |
 | [deps.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/deps.d)           | Implement the `-deps` and `-makedeps` switches                        |
 | [timetrace.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/timetrace.d) | Build time profiling utility                                          |
+| [targetcompiler.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/targetcompiler.d) | Differences in building gdc, ldc and dmd                    |
 
 ### Lexing / parsing
 

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -25,6 +25,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem : dsymbolSemantic, aliasSemantic;
 import dmd.dtemplate;
 import dmd.errors;
+import dmd.errorsink;
 import dmd.expression;
 import dmd.func;
 import dmd.globals;
@@ -41,32 +42,22 @@ import dmd.common.outbuffer;
 import dmd.rootobject;
 import dmd.root.filename;
 import dmd.target;
+import dmd.targetcompiler;
 import dmd.tokens;
 import dmd.typesem : toDsymbol, typeSemantic, size, hasPointers;
 import dmd.visitor;
 
-version (IN_GCC) {}
-else version (IN_LLVM) {}
-else version = MARS;
 
 /******************************************
  */
 void ObjectNotFound(Loc loc, Identifier id)
 {
     global.gag = 0; // never gag the fatal error
-    error(loc, "`%s` not found. object.d may be incorrectly installed or corrupt.", id.toChars());
-    version (IN_LLVM)
-    {
-        errorSupplemental(loc, "ldc2 might not be correctly installed.");
-        errorSupplemental(loc, "Please check your ldc2.conf configuration file.");
-        errorSupplemental(loc, "Installation instructions can be found at http://wiki.dlang.org/LDC.");
-    }
-    else version (MARS)
-    {
-        errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
-        const dmdConfFile = global.inifilename.length ? FileName.canonicalName(global.inifilename) : "not found";
-        errorSupplemental(loc, "config file: %.*s", cast(int)dmdConfFile.length, dmdConfFile.ptr);
-    }
+    const dmdConfFile = global.inifilename.length ? FileName.canonicalName(global.inifilename) : "not found";
+
+    mixin HostObjectNotFound;
+    hostObjectNotFound(loc, id.toChars(), dmdConfFile, global.errorSink); // print host-specific diagnostic
+
     fatal();
 }
 
@@ -833,11 +824,7 @@ extern (C++) class VarDeclaration : Declaration
         bool isCmacro;          /// it is a C macro turned into a C declaration
         bool dllImport;         /// __declspec(dllimport)
         bool dllExport;         /// __declspec(dllexport)
-        version (MARS)
-        {
-            bool inClosure;         /// is inserted into a GC allocated closure
-            bool inAlignSection;    /// is inserted into an aligned section on stack
-        }
+        mixin VarDeclarationExtra;
         bool systemInferred;    /// @system was inferred from initializer
     }
 

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -68,10 +68,6 @@ else version (Posix)
 else
     static assert(0);
 
-version (IN_GCC) {}
-else version (IN_LLVM) {}
-else version = MARS;
-
 // function used to call semantic3 on a module's dependencies
 void semantic3OnDependencies(Module m)
 {

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -78,14 +78,11 @@ import dmd.tokens;
 import dmd.utils;
 import dmd.statement;
 import dmd.target;
+import dmd.targetcompiler;
 import dmd.templateparamsem;
 import dmd.templatesem;
 import dmd.typesem;
 import dmd.visitor;
-
-version (IN_GCC) {}
-else version (IN_LLVM) {}
-else version = MARS;
 
 enum LOG = false;
 
@@ -1033,21 +1030,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        /* If the alignment of a stack local is greater than the stack alignment,
-         * note it in the enclosing function's alignSectionVars
-         */
-        version (MARS)
-        {
-            if (!dsym.alignment.isDefault() && sc.func &&
-                dsym.alignment.get() > target.stackAlign() &&
-                sc.func && !dsym.isDataseg() && !dsym.isParameter() && !dsym.isField())
-            {
-                auto fd = sc.func;
-                if (!fd.alignSectionVars)
-                    fd.alignSectionVars = new VarDeclarations();
-                fd.alignSectionVars.push(dsym);
-            }
-        }
+        mixin alignSectionVarsExtra; doAlign(); // align section variables
 
         if ((dsym.storage_class & (STC.ref_ | STC.field)) == (STC.ref_ | STC.field) && dsym.ident != Id.This)
         {
@@ -1584,10 +1567,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (!(sc.previews.bitfields || sc.inCfile))
         {
-            version (IN_GCC)
-                .error(dsym.loc, "%s `%s` use `-fpreview=bitfields` for bitfield support", dsym.kind, dsym.toPrettyChars);
-            else
-                .error(dsym.loc, "%s `%s` use -preview=bitfields for bitfield support", dsym.kind, dsym.toPrettyChars);
+            .error(dsym.loc, "%s `%s` use `-%spreview=bitfields` for bitfield support", dsym.kind, dsym.toPrettyChars, SwitchPrefix.ptr);
         }
 
         if (!dsym.parent.isStructDeclaration() && !dsym.parent.isClassDeclaration())

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -82,6 +82,7 @@ import dmd.semantic3;
 import dmd.sideeffect;
 import dmd.safe;
 import dmd.target;
+import dmd.targetcompiler;
 import dmd.templatesem : matchWithInstance;
 import dmd.tokens;
 import dmd.traits;
@@ -5397,10 +5398,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             if (!global.params.useGC && sc.needsCodegen())
             {
-                version(IN_GCC)
-                    error(exp.loc, "expression `%s` allocates with the GC and cannot be used with switch `-fno-rtti`", exp.toErrMsg());
-                else
-                    error(exp.loc, "expression `%s` allocates with the GC and cannot be used with switch `-betterC`", exp.toErrMsg());
+                error(exp.loc, "expression `%s` allocates with the GC and cannot be used with switch `-%s`", exp.toErrMsg(), SwitchVariadic.ptr);
                 return setError();
             }
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6309,6 +6309,7 @@ struct CompileEnv final
     bool transitionIn;
     bool ddocOutput;
     bool masm;
+    _d_dynamicArray< const char > switchPrefix;
     IdentifierCharLookup cCharLookupTable;
     IdentifierCharLookup dCharLookupTable;
     CompileEnv() :
@@ -6321,11 +6322,12 @@ struct CompileEnv final
         transitionIn(),
         ddocOutput(),
         masm(),
+        switchPrefix(),
         cCharLookupTable(),
         dCharLookupTable()
     {
     }
-    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool transitionIn = false, bool ddocOutput = false, bool masm = false, IdentifierCharLookup cCharLookupTable = IdentifierCharLookup(), IdentifierCharLookup dCharLookupTable = IdentifierCharLookup()) :
+    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool transitionIn = false, bool ddocOutput = false, bool masm = false, _d_dynamicArray< const char > switchPrefix = {}, IdentifierCharLookup cCharLookupTable = IdentifierCharLookup(), IdentifierCharLookup dCharLookupTable = IdentifierCharLookup()) :
         versionNumber(versionNumber),
         date(date),
         time(time),
@@ -6335,6 +6337,7 @@ struct CompileEnv final
         transitionIn(transitionIn),
         ddocOutput(ddocOutput),
         masm(masm),
+        switchPrefix(switchPrefix),
         cCharLookupTable(cCharLookupTable),
         dCharLookupTable(dCharLookupTable)
         {}

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -50,12 +50,9 @@ import dmd.rootobject;
 import dmd.root.string;
 import dmd.root.stringtable;
 import dmd.statement;
+import dmd.targetcompiler;
 import dmd.tokens;
 import dmd.visitor;
-
-version (IN_GCC) {}
-else version (IN_LLVM) {}
-else version = MARS;
 
 /// Inline Status
 enum ILS : ubyte
@@ -246,11 +243,7 @@ extern (C++) class FuncDeclaration : Declaration
 
     GotoStatements* gotos;              /// Gotos with forward references
 
-    version (MARS)
-    {
-        VarDeclarations* alignSectionVars;  /// local variables with alignment needs larger than stackAlign
-        Symbol* salignSection;              /// pointer to aligned section, if any
-    }
+    mixin FuncDeclarationExtra;
 
     /// set if this is a known, builtin function we can evaluate at compile time
     BUILTIN builtin = BUILTIN.unknown;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -60,15 +60,13 @@ import dmd.semantic3;
 import dmd.statement;
 import dmd.statementsem;
 import dmd.target;
+import dmd.targetcompiler;
 import dmd.templatesem;
 import dmd.tokens;
 import dmd.typesem;
 import dmd.visitor;
 import dmd.visitor.statement_rewrite_walker;
 
-version (IN_GCC) {}
-else version (IN_LLVM) {}
-else version = MARS;
 
 /* Tweak all return statements and dtor call for nrvo_var, for correct NRVO.
  */
@@ -3185,12 +3183,12 @@ extern (D) bool checkNRVO(FuncDeclaration fd)
                     return false;
                 if (v.nestedrefs.length && fd.needsClosure())
                     return false;
+
                 // don't know if the return storage is aligned
-                version (MARS)
-                {
-                    if (fd.alignSectionVars && (*fd.alignSectionVars).contains(v))
-                        return false;
-                }
+                mixin alignSectionVarsContains;
+                if (isAlignSectionVar(v))
+                    return false;
+
                 // The variable type needs to be equivalent to the return type.
                 if (!v.type.equivalent(tf.next))
                     return false;

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -26,11 +26,8 @@ import dmd.file_manager;
 import dmd.identifier;
 import dmd.location;
 import dmd.lexer : CompileEnv;
+import dmd.targetcompiler;
 import dmd.utils;
-
-version (IN_GCC) {}
-else version (IN_LLVM) {}
-else version = MARS;
 
 /// Defines a setting for how compiler warnings and deprecations are handled
 enum DiagnosticReporting : ubyte
@@ -392,21 +389,11 @@ extern (C++) struct Global
         errorSinkNull = new ErrorSinkNull;
 
         this.fileManager = new FileManager();
+        compileEnv.vendor = TargetCompiler;
+        compileEnv.switchPrefix = SwitchPrefix;
 
-        version (MARS)
-        {
-            compileEnv.vendor = "Digital Mars D";
-        }
-        else version (IN_GCC)
-        {
-            compileEnv.vendor = "GNU D";
-        }
-        else version (IN_LLVM)
-        {
-            compileEnv.vendor = "LDC";
-        }
-        else
-            static assert(0, "unknown vendor");
+        mixin UseAnsiColors;
+        params.v.color = useAnsiColors();
 
         compileEnv.versionNumber = parseVersionNumber(versionString());
 

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -51,6 +51,7 @@ struct CompileEnv
     bool transitionIn;       /// `-transition=in` is active, `in` parameters are listed
     bool ddocOutput;         /// collect embedded documentation comments
     bool masm;               /// use MASM inline asm syntax
+    const(char)[] switchPrefix;
 
     // these need a default otherwise tests won't work.
     IdentifierCharLookup cCharLookupTable; /// C identifier table (set to the lexer by the C parser)

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1265,10 +1265,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             }
             else
             {
-                version (IN_GCC)
-                    error("attribute `scope` cannot be applied with `in`, use `-fpreview=in` instead");
-                else
-                    error("attribute `scope` cannot be applied with `in`, use `-preview=in` instead");
+                error("attribute `scope` cannot be applied with `in`, use `-%spreview=in` instead", compileEnv.switchPrefix.ptr);
             }
             return orig;
         }
@@ -1290,10 +1287,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             }
             else
             {
-                version (IN_GCC)
-                    error("attribute `in` cannot be added after `scope`: remove `scope` and use `-fpreview=in`");
-                else
-                    error("attribute `in` cannot be added after `scope`: remove `scope` and use `-preview=in`");
+                error("attribute `in` cannot be added after `scope`: remove `scope` and use `-%spreview=in`", compileEnv.switchPrefix.ptr);
             }
             return orig;
         }

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -36,6 +36,7 @@ import dmd.mtype;
 import dmd.rootobject;
 import dmd.root.string : fTuple;
 import dmd.target;
+import dmd.targetcompiler;
 import dmd.tokens;
 import dmd.typesem : hasPointers, arrayOf, size;
 
@@ -355,7 +356,7 @@ bool isTrusted(FuncDeclaration fd)
  * Call when `fd` was just inferred to be @system OR
  * `fd` was @safe and an tried something unsafe.
  * Params:
- *   fd    = function we're gonna rat on
+ *   fd    = function we are gonna rat on
  *   gag   = suppress error message (used in escape.d)
  *   loc   = location of error
  *   format = printf-style format string
@@ -388,10 +389,7 @@ extern (D) void reportSafeError(FuncDeclaration fd, bool gag, Loc loc,
                 buf.writestring(" is not allowed in a `@safe` function");
             else
             {
-                version (IN_GCC)
-                    buf.writestring(" is not allowed in a function with default safety with `-fpreview=safer`");
-                else
-                    buf.writestring(" is not allowed in a function with default safety with `-preview=safer`");
+                buf.printf(" is not allowed in a function with default safety with `-%spreview=safer`", SwitchPrefix.ptr);
             }
             .error(loc, "%s", buf.extractChars());
         }

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -69,12 +69,12 @@ import dmd.tokens;
 import dmd.semantic2;
 import dmd.statement;
 import dmd.target;
+import dmd.targetcompiler;
 import dmd.templateparamsem;
 import dmd.typesem;
 import dmd.visitor;
 
 enum LOG = false;
-
 
 /*************************************
  * Does semantic analysis on function bodies.
@@ -421,12 +421,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if (!global.params.useTypeInfo || !Type.dtypeinfo || !Type.typeinfotypelist)
                     {
                         if (!global.params.useTypeInfo)
-                        {
-                            version (IN_GCC)
-                                .error(funcdecl.loc, "%s `%s` D-style variadic functions cannot be used with `-fno-rtti`", funcdecl.kind, funcdecl.toPrettyChars);
-                            else
-                                .error(funcdecl.loc, "%s `%s` D-style variadic functions cannot be used with -betterC", funcdecl.kind, funcdecl.toPrettyChars);
-                        }
+                            .error(funcdecl.loc, "%s `%s` D-style variadic functions cannot be used with `-%s`", funcdecl.kind, funcdecl.toPrettyChars, SwitchVariadic.ptr);
                         else if (!Type.typeinfotypelist)
                             .error(funcdecl.loc, "%s `%s` `object.TypeInfo_Tuple` could not be found, but is implicitly used in D-style variadic functions", funcdecl.kind, funcdecl.toPrettyChars);
                         else

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -62,6 +62,7 @@ import dmd.semantic2;
 import dmd.sideeffect;
 import dmd.statement;
 import dmd.target;
+import dmd.targetcompiler;
 import dmd.tokens;
 import dmd.typesem;
 import dmd.visitor;
@@ -3296,7 +3297,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         if (!global.params.useExceptions)
         {
-            error(tcs.loc, "cannot use try-catch statements with %s", global.params.betterC ? "-betterC".ptr : "-nothrow".ptr);
+            error(tcs.loc, "cannot use try-catch statements with `%s`", global.params.betterC ? "-betterC".ptr : "-nothrow".ptr);
             return setError();
         }
 
@@ -3444,10 +3445,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             // https://issues.dlang.org/show_bug.cgi?id=23159
             if (!global.params.useExceptions)
             {
-                version (IN_GCC)
-                    error(oss.loc, "`%s` cannot be used with `-fno-exceptions`", Token.toChars(oss.tok));
-                else
-                    error(oss.loc, "`%s` cannot be used with -betterC", Token.toChars(oss.tok));
+                error(oss.loc, "`%s` cannot be used with `-%s`", Token.toChars(oss.tok), SwitchScopeGuard);
                 return setError();
             }
 
@@ -3720,10 +3718,10 @@ public bool throwSemantic(Loc loc, ref Expression exp, Scope* sc)
 {
     if (!global.params.useExceptions)
     {
-        version (IN_GCC)
-            loc.error("cannot use `throw` statements with `-fno-exceptions`");
-        else
-            loc.error("cannot use `throw` statements with %s", global.params.betterC ? "-betterC".ptr : "-nothrow".ptr);
+        const(char)* s = SwitchExceptions      ? SwitchExceptions :
+                         global.params.betterC ? "betterC".ptr :
+                                                 "nothrow".ptr;
+        loc.error("cannot use `throw` statements with `-%s`", s);
         return false;
     }
 

--- a/compiler/src/dmd/targetcompiler.d
+++ b/compiler/src/dmd/targetcompiler.d
@@ -1,0 +1,210 @@
+/**
+ * Encapsulates the vagaries of which of the three D compilers (gdc, ldc or dmd) is being built
+ *
+ * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/mars.d, _targetcompiler.d)
+ * Documentation:  https://dlang.org/phobos/dmd_targetcompiler.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/compiler/src/dmd/targetcompiler.d
+ */
+
+module dmd.targetcompiler;
+
+version (IN_GCC) {}        // compiler is being built with gdc
+else version (IN_LLVM) {}  // compiler is being built with ldc
+else version = MARS;       // default means compiler is built with Digital Mars compiler (DMD)
+
+/***************************
+ */
+
+version (IN_GCC)
+{
+    enum TargetCompiler = "GNU D";    // compiler being built
+    enum SwitchPrefix = "f";          // prefix to switch
+    enum SwitchVariadic = "fno-rtti"; // disables D-style variadic functions
+    enum const(char)* SwitchExceptions = "fno-exceptions"; // switch that disables exceptions
+    enum const(char)* SwitchScopeGuard = "fno-exceptions"; // switch that disables exceptions
+}
+else version (IN_LLVM)
+{
+    enum TargetCompiler = "LDC";
+    enum SwitchPrefix = "";
+    enum SwitchVariadic = "betterC";
+    enum const(char)* SwitchExceptions = null;
+    enum const(char)* SwitchScopeGuard = "betterC";
+}
+else version (MARS)
+{
+    enum TargetCompiler = "Digital Mars D";
+    enum SwitchPrefix = "";
+    enum SwitchVariadic = "betterC";
+    enum const(char)* SwitchExceptions = null;
+    enum const(char)* SwitchScopeGuard = "betterC";
+}
+else
+    static assert(0, "unknown compiler being built");
+
+
+/**********************************
+ * Extra Fields for VarDeclaration
+ */
+version (IN_GCC)
+{
+    mixin template VarDeclarationExtra() { }
+}
+else version (IN_LLVM)
+{
+    mixin template VarDeclarationExtra() { }
+}
+else version (MARS)
+{
+    mixin template VarDeclarationExtra()
+    {
+        bool inClosure;         /// is inserted into a GC allocated closure
+        bool inAlignSection;    /// is inserted into an aligned section on stack
+    }
+}
+else
+    static assert(0, "unknown compiler being built");
+
+/**********************************
+ * Extra Fields for FuncDeclaration
+ */
+version (IN_GCC)
+{
+    mixin template FuncDeclarationExtra() { }
+}
+else version (IN_LLVM)
+{
+    mixin template FuncDeclarationExtra() { }
+}
+else version (MARS)
+{
+    mixin template FuncDeclarationExtra()
+    {
+        VarDeclarations* alignSectionVars;  /// local variables with alignment needs larger than stackAlign
+        Symbol* salignSection;              /// pointer to aligned section, if any
+    }
+}
+else
+    static assert(0, "unknown compiler being built");
+
+/**********************************
+ * Extra Fields for FuncDeclaration
+ */
+version (IN_GCC)
+{
+    mixin template alignSectionVarsExtra() { void doAlign() { } }
+}
+else version (IN_LLVM)
+{
+    mixin template alignSectionVarsExtra() { void doAlign() { } }
+}
+else version (MARS)
+{
+    /* If the alignment of a stack local is greater than the stack alignment,
+     * note it in the enclosing function's alignSectionVars
+     */
+    mixin template alignSectionVarsExtra()
+    {
+        void doAlign()
+        {
+            if (!dsym.alignment.isDefault() && sc.func &&
+                dsym.alignment.get() > target.stackAlign() &&
+                sc.func && !dsym.isDataseg() && !dsym.isParameter() && !dsym.isField())
+            {
+                auto fd = sc.func;
+                if (!fd.alignSectionVars)
+                    fd.alignSectionVars = new VarDeclarations();
+                fd.alignSectionVars.push(dsym);
+            }
+        }
+    }
+}
+else
+    static assert(0, "unknown compiler being built");
+
+
+/* Returns: true if v is in an align section
+ */
+mixin template alignSectionVarsContains()
+{
+    version (IN_GCC)
+    {
+        bool isAlignSectionVar(VarDeclaration v) { return false; }
+    }
+    else version (IN_LLVM)
+    {
+        bool isAlignSectionVar(VarDeclaration v) { return false; }
+    }
+    else version (MARS)
+    {
+        bool isAlignSectionVar(VarDeclaration v)
+        {
+            return fd.alignSectionVars && (*fd.alignSectionVars).contains(v);
+        }
+    }
+    else
+        static assert(0, "unknown compiler being built");
+}
+
+/* Returns: true if ansi color is to be used
+ */
+
+mixin template UseAnsiColors()
+{
+    bool useAnsiColors()
+    {
+        version (IN_GCC)
+        {
+            return false;
+        }
+        else version (IN_LLVM)
+        {
+            import dmd.console : detectTerminal;
+            return detectTerminal();
+        }
+        else version (MARS)
+        {
+            // -color=auto is the default value
+            import dmd.console : detectTerminal, detectColorPreference;
+            return detectTerminal() && detectColorPreference();
+        }
+        else
+            static assert(0, "unknown compiler being built");
+    }
+}
+
+/******************************************
+ * Let user know object.d cannot be found.
+ * Parameters:
+ *      loc = location of error
+ *      id = name of symbol that cannot be found
+ *      configFile = configuration file name
+ *      eSink = where to send the error messages
+ */
+
+mixin template HostObjectNotFound()
+{
+    void hostObjectNotFound(Loc loc, const(char)* id, const(char)[] configFile, ErrorSink eSink)
+    {
+        eSink.error(loc, "`%s` not found. object.d may be incorrectly installed or corrupt.", id);
+        version (IN_GCC)
+        {
+        }
+        else version (IN_LLVM)
+        {
+            eSink.errorSupplemental(loc, "ldc2 might not be correctly installed.");
+            eSink.errorSupplemental(loc, "Please check your ldc2.conf configuration file.");
+            eSink.errorSupplemental(loc, "Installation instructions can be found at http://wiki.dlang.org/LDC.");
+        }
+        else version (MARS)
+        {
+            eSink.errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
+            eSink.errorSupplemental(loc, "config file: %.*s", configFile.length, configFile.ptr);
+        }
+        else
+            static assert(0, "unknown compiler being built");
+    }
+}

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -51,7 +51,7 @@ bool genTypeInfo(Expression e, Loc loc, Type torig, Scope* sc)
             if (e)
                 .error(loc, "expression `%s` uses the GC and cannot be used with switch `-betterC`", e.toChars());
             else
-                .error(loc, "`TypeInfo` cannot be used with -betterC");
+                .error(loc, "`TypeInfo` cannot be used with `-betterC`");
 
             if (sc && sc.tinst)
                 sc.tinst.printInstantiationTrace(Classification.error, uint.max);

--- a/compiler/test/fail_compilation/betterc.d
+++ b/compiler/test/fail_compilation/betterc.d
@@ -1,9 +1,9 @@
 /* REQUIRED_ARGS: -betterC
  * TEST_OUTPUT:
 ---
-fail_compilation/betterc.d(12): Error: cannot use `throw` statements with -betterC
-fail_compilation/betterc.d(17): Error: cannot use try-catch statements with -betterC
-fail_compilation/betterc.d(29): Error: `TypeInfo` cannot be used with -betterC
+fail_compilation/betterc.d(12): Error: cannot use `throw` statements with `-betterC`
+fail_compilation/betterc.d(17): Error: cannot use try-catch statements with `-betterC`
+fail_compilation/betterc.d(29): Error: `TypeInfo` cannot be used with `-betterC`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail19911a.d
+++ b/compiler/test/fail_compilation/fail19911a.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -betterC
 TEST_OUTPUT:
 ---
-fail_compilation/fail19911a.d(9): Error: function `fail19911a.fun` D-style variadic functions cannot be used with -betterC
+fail_compilation/fail19911a.d(9): Error: function `fail19911a.fun` D-style variadic functions cannot be used with `-betterC`
 ---
 */
 

--- a/compiler/test/fail_compilation/test23159.d
+++ b/compiler/test/fail_compilation/test23159.d
@@ -4,8 +4,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test23159.d(14): Error: `scope(failure)` cannot be used with -betterC
-fail_compilation/test23159.d(18): Error: `scope(success)` cannot be used with -betterC
+fail_compilation/test23159.d(14): Error: `scope(failure)` cannot be used with `-betterC`
+fail_compilation/test23159.d(18): Error: `scope(success)` cannot be used with `-betterC`
 ---
 */
 

--- a/compiler/test/fail_compilation/test24084.d
+++ b/compiler/test/fail_compilation/test24084.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -nothrow
  * TEST_OUTPUT:
 ---
-fail_compilation/test24084.d(110): Error: cannot use `throw` statements with -nothrow
-fail_compilation/test24084.d(112): Error: cannot use try-catch statements with -nothrow
+fail_compilation/test24084.d(110): Error: cannot use `throw` statements with `-nothrow`
+fail_compilation/test24084.d(112): Error: cannot use try-catch statements with `-nothrow`
 ---
  */
 


### PR DESCRIPTION
This is to encapsulate host compiler differences. The logic is spread across several files, and should be encapsulated into one file.

This is not about the host operating system, the target operating system, or the target machine. It's only about the host compiler.

Putting abstracting this into one file makes the rest of the compiler more generic, and makes things easier to maintain.

This PR is just a first step towards implementing this.

Every effort should be made to minimize the number of imports this file does.