### PR TITLE
[stable] Windows: Fix object-file collisions for druntime 'shared' tests

### DIFF
--- a/druntime/test/shared/Makefile
+++ b/druntime/test/shared/Makefile
@@ -92,7 +92,7 @@ ifeq (windows,$(OS))
     CC := cl
     OUTPUT_FLAG := /Fe
     # we additionally specify the .obj output path (/Fo) to prevent collisions
-    extra_cflags += /Fo$(OBJDIR)
+    extra_cflags += /Fo$(OBJDIR)/
 endif
 
 # $(LINKDL) == -L-ldl => $(ldl) == -ldl


### PR DESCRIPTION
As I've just hit that problem in https://dev.azure.com/dlanguage/dmd/_build/results?buildId=47558&view=logs&jobId=6775e4b2-0d76-5db7-9bcd-015c7821c824&j=6775e4b2-0d76-5db7-9bcd-015c7821c824&t=1bf40372-f529-586c-b834-12b53d9adf74.