### PR TITLE
use out parameter on createModules()

### DIFF
--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -456,7 +456,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 
     // Create Modules
     Modules modules;
-    modules.reserve(files.length);
     if (createModules(files, libmodules, params, target, global.errorSink, modules))
         fatal();
 

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1935,14 +1935,15 @@ Params:
   params = command line params
   target = target system
   eSink = error message sink
-  modules = empty array of modules to be filled in
+  modules = uninitialized array of modules to be filled in
 
 Returns:
   true on error
 */
 bool createModules(ref Strings files, ref Strings libmodules, ref Param params, const ref Target target,
-    ErrorSink eSink, ref Modules modules)
+    ErrorSink eSink, out Modules modules)
 {
+    modules.reserve(files.length);
     bool firstmodule = true;
     foreach(file; files)
     {


### PR DESCRIPTION
Should use `out` parameters wherever practical. Initialization should be done in one place if possible, not spread out.