### PR TITLE
change writeByte() parameter to ubyte

### DIFF
--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -376,10 +376,10 @@ static if (1)
         assert(location >= CFA_state_current.location);
         uint inc = cast(uint)(location - CFA_state_current.location);
         if (inc <= 63)
-            cfa_buf.writeByte(DW_CFA_advance_loc + inc);
+            cfa_buf.writeByte(cast(ubyte)(DW_CFA_advance_loc + inc));
         else if (inc <= 255)
         {   cfa_buf.writeByte(DW_CFA_advance_loc1);
-            cfa_buf.writeByte(inc);
+            cfa_buf.writeByte(cast(ubyte)inc);
         }
         else if (inc <= 0xFFFF)
         {   cfa_buf.writeByte(DW_CFA_advance_loc2);
@@ -448,7 +448,7 @@ static if (1)
         {
             if (offset <= 0)
             {
-                cfa_buf.writeByte(DW_CFA_offset + dw_reg);
+                cfa_buf.writeByte(cast(ubyte)(DW_CFA_offset + dw_reg));
                 cfa_buf.writeuLEB128(offset / -OFFSET_FAC);
             }
             else
@@ -1273,7 +1273,7 @@ static if (1)
                 filename[$ - 2] == '.' &&
                 (filename[$ - 1] == 'c' || filename[$ - 1] == 'i'))
                 language = DW_LANG_C89;
-            debug_info.buf.writeByte(language);
+            debug_info.buf.writeByte(cast(ubyte)language);
 
             debug_info.buf.writeStringz(filename);             // DW_AT_name
 
@@ -1554,7 +1554,7 @@ static if (1)
                                 if (config.dwarf >= 5)
                                     --index; // Minus 1 because it must be an index, not a element number
                                 // directory table index.
-                                debug_line.buf.writeByte(index);
+                                debug_line.buf.writeByte(cast(ubyte)index);
                                 if (config.dwarf < 5)
                                 {
                                     debug_line.buf.writeByte(0);      // mtime
@@ -1590,7 +1590,7 @@ static if (1)
 
                 // Set address to start of segment with DW_LNE_set_address
                 debug_line.buf.writeByte(0);
-                debug_line.buf.writeByte(_tysize[TYnptr] + 1);
+                debug_line.buf.writeByte(cast(ubyte)(_tysize[TYnptr] + 1));
                 debug_line.buf.writeByte(DW_LNE_set_address);
 
                 dwarf_appreladdr(debug_line.seg,debug_line.buf,seg,0);
@@ -1628,7 +1628,7 @@ static if (1)
                         // special opcode
                         if (opcode <= 255)
                         {
-                            debug_line.buf.writeByte(opcode);
+                            debug_line.buf.writeByte(cast(ubyte)opcode);
                             continue;
                         }
                     }
@@ -1930,8 +1930,8 @@ static if (1)
         if (config.dwarf < 4 && sfunc.Sfunc.Fflags3 & Fpure)
             debug_info.buf.writeByte(true);                           // DW_AT_pure
 
-        debug_info.buf.writeStringz(name);                             // DW_AT_name
-        debug_info.buf.writeByte(filenum);                            // DW_AT_decl_file
+        debug_info.buf.writeStringz(name);                            // DW_AT_name
+        debug_info.buf.writeByte(cast(ubyte)filenum);                 // DW_AT_decl_file
         debug_info.buf.writeuLEB128(sfunc.Sfunc.Fstartline.Slinnum);  // DW_AT_decl_line
         debug_info.buf.writeuLEB128(sfunc.Sfunc.Fstartline.Scharnum); // DW_AT_decl_column
 
@@ -1976,15 +1976,15 @@ static if (1)
                         debug_info.buf.writeStringz(getSymName(sa));   // DW_AT_name
                         debug_info.buf.write32(tidx);                 // DW_AT_type
                         debug_info.buf.writeByte(sa.Sflags & SFLartifical ? 1 : 0); // DW_FORM_tag
-                        debug_info.buf.writeByte(filenum);            // DW_AT_decl_file
-                        debug_info.buf.writeuLEB128(sa.lposscopestart.Slinnum);   // DW_AT_decl_line
-                        debug_info.buf.writeuLEB128(sa.lposscopestart.Scharnum);   // DW_AT_decl_column
+                        debug_info.buf.writeByte(cast(ubyte)filenum);               // DW_AT_decl_file
+                        debug_info.buf.writeuLEB128(sa.lposscopestart.Slinnum);     // DW_AT_decl_line
+                        debug_info.buf.writeuLEB128(sa.lposscopestart.Scharnum);    // DW_AT_decl_column
                         soffset = cast(uint)debug_info.buf.length();
                         debug_info.buf.writeByte(2);                  // DW_FORM_block1
                         if (sa.Sfl == FL.reg || sa.Sclass == SC.pseudo)
                         {
                             // BUG: register pairs not supported in Dwarf?
-                            debug_info.buf.writeByte(DW_OP_reg0 + sa.Sreglsw);
+                            debug_info.buf.writeByte(cast(ubyte)(DW_OP_reg0 + sa.Sreglsw));
                         }
                         else if (sa.Sscope && vcode == variablecode)
                         {
@@ -2777,7 +2777,7 @@ static if (1)
                 ]);
                 debug_info.buf.writeuLEB128(code2);       // DW_TAG_subrange_type
                 ubyte dim = cast(ubyte)(tysize(t.Tty) / tysize(tbase.Tty));
-                debug_info.buf.writeByte(dim - 1);        // DW_AT_upper_bound
+                debug_info.buf.writeByte(cast(ubyte)(dim - 1)); // DW_AT_upper_bound
 
                 debug_info.buf.writeByte(0);              // no more children
                 break;
@@ -2904,7 +2904,7 @@ static if (1)
                     debug_info.buf.writeuLEB128(code);
                     debug_info.buf.writeStringz(getSymName(s));      // DW_AT_name
                     if (sz <= 0xFF)
-                        debug_info.buf.writeByte(cast(uint)sz);     // DW_AT_byte_size
+                        debug_info.buf.writeByte(cast(ubyte)sz);     // DW_AT_byte_size
                     else if (sz <= 0xFFFF)
                         debug_info.buf.write16(cast(uint)sz);     // DW_AT_byte_size
                     else
@@ -3006,8 +3006,8 @@ static if (1)
 
                 idx = cast(uint)debug_info.buf.length();
                 debug_info.buf.writeuLEB128(code);
-                debug_info.buf.writeStringz(getSymName(s));// DW_AT_name
-                debug_info.buf.writeByte(sz);             // DW_AT_byte_size
+                debug_info.buf.writeStringz(getSymName(s)); // DW_AT_name
+                debug_info.buf.writeByte(cast(ubyte)sz);    // DW_AT_byte_size
 
                 foreach (sl2; ListRange(s.Senum.SEenumlist))
                 {

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -2473,7 +2473,7 @@ void ElfObj_byte(int seg,targ_size_t offset,uint byte_)
     int save = cast(int)buf.length();
     //dbg_printf("ElfObj_byte(seg=%d, offset=x%lx, byte_=x%x)\n",seg,offset,byte_);
     buf.setsize(cast(uint)offset);
-    buf.writeByte(byte_);
+    buf.writeByte(cast(ubyte)byte_);
     if (save > offset+1)
         buf.setsize(save);
     else
@@ -3665,7 +3665,7 @@ private void obj_rtinit()
                 {
                     // lea RAX, sym[RIP]
                     buf.writeByte(REX | REX_W);
-                    buf.writeByte(op);
+                    buf.writeByte(cast(ubyte)op);
                     buf.writeByte(modregrm(0,AX,5));
                     off += 3;
                     off += ElfObj_writerel(codseg, off, reltype, sym, -4);
@@ -3673,7 +3673,7 @@ private void obj_rtinit()
                 else
                 {
                     // lea EAX, sym[EBX]
-                    buf.writeByte(op);
+                    buf.writeByte(cast(ubyte)op);
                     buf.writeByte(modregrm(2,AX,BX));
                     off += 2;
                     off += ElfObj_writerel(codseg, off, reltype, sym, 0);
@@ -3799,7 +3799,7 @@ else
         {   // mov EBX,[EBP-4-align_]
             buf.writeByte(0x8B);
             buf.writeByte(modregrm(1,BX,BP));
-            buf.writeByte(cast(int)(-4-align_));
+            buf.writeByte(cast(ubyte)(-4-align_));
             off += 3;
         }
         // leave

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -2283,7 +2283,7 @@ void MachObj_byte(int seg,targ_size_t offset,uint byte_)
     int save = cast(int)buf.length();
     //dbg_printf("MachObj_byte(seg=%d, offset=x%lx, byte_=x%x)\n",seg,offset,byte_);
     buf.setsize(cast(uint)offset);
-    buf.writeByte(byte_);
+    buf.writeByte(cast(ubyte)byte_);
     if (save > offset+1)
         buf.setsize(save);
     else

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -1707,7 +1707,7 @@ void obj_mangle2(ref Symbol s, ref OutBuffer buf)
         case Mangle.fortran:
             foreach (c; name)
             {
-                buf.writeByte(('a' <= c && c <= 'z') ? c - 'a' + 'A' : c); // to upper case
+                buf.writeByte(cast(char)(('a' <= c && c <= 'z') ? c - 'a' + 'A' : c)); // to upper case
             }
             break;
 
@@ -2024,7 +2024,7 @@ void MsCoffObj_byte(segidx_t seg,targ_size_t offset,uint byte_)
     int save = cast(int)buf.length();
     //dbg_printf("MsCoffObj_byte(seg=%d, offset=x%lx, byte=x%x)\n",seg,offset,byte_);
     buf.setsize(cast(uint)offset);
-    buf.writeByte(byte_);
+    buf.writeByte(cast(char)byte_);
     if (save > offset+1)
         buf.setsize(save);
     else

--- a/compiler/src/dmd/common/outbuffer.d
+++ b/compiler/src/dmd/common/outbuffer.d
@@ -384,12 +384,12 @@ struct OutBuffer
      * Writes an 8 bit byte, no reserve check.
      */
     extern (C++) nothrow @safe
-    void writeByten(int b)
+    void writeByten(ubyte b)
     {
         this.data[offset++] = cast(ubyte) b;
     }
 
-    extern (C++) void writeByte(uint b) pure nothrow @safe
+    extern (C++) void writeByte(ubyte b) pure nothrow @safe
     {
         if (doindent && !notlinehead && b != '\n')
             indent();

--- a/compiler/src/dmd/common/outbuffer.h
+++ b/compiler/src/dmd/common/outbuffer.h
@@ -53,7 +53,7 @@ public:
     void writestring(const char *string);
     void prependstring(const char *string);
     void writenl();                     // write newline
-    void writeByte(unsigned b);
+    void writeByte(uint8_t b);
     void writeUTF8(unsigned b);
     void prependbyte(unsigned b);
     void writewchar(unsigned w);

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1386,7 +1386,7 @@ private const(char)[] processSource (const(ubyte)[] src, Module mod)
                 dbuf.writeUTF8(u);
             }
             else
-                dbuf.writeByte(u);
+                dbuf.writeByte(cast(ubyte)u);
         }
         dbuf.writeByte(0); //add null terminator
         return dbuf.extractSlice();
@@ -1455,7 +1455,7 @@ private const(char)[] processSource (const(ubyte)[] src, Module mod)
                 dbuf.writeUTF8(u);
             }
             else
-                dbuf.writeByte(u);
+                dbuf.writeByte(cast(ubyte)u);
         }
         dbuf.writeByte(0); //add a terminating null byte
         return dbuf.extractSlice();

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -254,9 +254,9 @@ Symbol* toStringSymbol(const(char)* str, size_t len, size_t sz)
         foreach (u; hash[0 .. 16])
         {
             ubyte u1 = u >> 4;
-            buf.writeByte((u1 < 10) ? u1 + '0' : u1 + 'A' - 10);
+            buf.writeByte(cast(char)((u1 < 10) ? u1 + '0' : u1 + 'A' - 10));
             u1 = u & 0xF;
-            buf.writeByte((u1 < 10) ? u1 + '0' : u1 + 'A' - 10);
+            buf.writeByte(cast(char)((u1 < 10) ? u1 + '0' : u1 + 'A' - 10));
         }
     }
 

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -2009,7 +2009,7 @@ extern (C++) final class ArrayLiteralExp : Expression
                     if (ch.op != EXP.int64)
                         return null;
                     if (sz == 1)
-                        buf.writeByte(cast(uint)ch.toInteger());
+                        buf.writeByte(cast(ubyte)ch.toInteger());
                     else if (sz == 2)
                         buf.writeword(cast(uint)ch.toInteger());
                     else

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1045,8 +1045,8 @@ public:
     void writestring(const char* s);
     void prependstring(const char* string);
     void writenl();
-    void writeByten(int32_t b);
-    void writeByte(uint32_t b);
+    void writeByten(uint8_t b);
+    void writeByte(uint8_t b);
     void writeUTF8(uint32_t b);
     void prependbyte(uint32_t b);
     void writewchar(uint32_t w);

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -1706,7 +1706,7 @@ class Lexer
                 }
                 break;
             }
-            stringbuffer.writeByte(c);
+            stringbuffer.writeByte(cast(char)c);
         }
     }
 
@@ -1750,7 +1750,7 @@ class Lexer
                 if (n & 1)
                 {
                     error("odd number (%d) of hex characters in hex string", n);
-                    stringbuffer.writeByte(v);
+                    stringbuffer.writeByte(cast(char)v);
                 }
                 t.setString(stringbuffer);
                 stringPostfix(t);
@@ -1777,7 +1777,7 @@ class Lexer
                 if (n & 1)
                 {
                     v = (v << 4) | c;
-                    stringbuffer.writeByte(v);
+                    stringbuffer.writeByte(cast(char)v);
                 }
                 else
                     v = c;
@@ -2195,7 +2195,7 @@ class Lexer
                 }
                 break;
             }
-            stringbuffer.writeByte(c);
+            stringbuffer.writeByte(cast(char)c);
         }
     }
 

--- a/compiler/src/dmd/mangle/cppwin.d
+++ b/compiler/src/dmd/mangle/cppwin.d
@@ -798,7 +798,7 @@ extern(D):
             }
             if (id == name) // ok, we've found same name. use index instead of name
             {
-                buf.writeByte(cast(uint)i + '0');
+                buf.writeByte(cast(char)(i + '0'));
                 return true;
             }
         }
@@ -892,7 +892,7 @@ extern(D):
             }
             if (ty.equals(type)) // ok, we've found same type. use index instead of type
             {
-                buf.writeByte(cast(uint)i + '0');
+                buf.writeByte(cast(char)(i + '0'));
                 isNotTopType = false;
                 ignoreConst = false;
                 return true;

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -409,7 +409,7 @@ void mangleFuncType(TypeFunction t, TypeFunction ta, ubyte modMask, Type tret, r
     foreach (idx, param; t.parameterList)
         mangleParameter(param, buf, backref);
     //if (buf.data[buf.length - 1] == '@') assert(0);
-    buf.writeByte('Z' - t.parameterList.varargs); // mark end of arg list
+    buf.writeByte(cast(ubyte)('Z' - t.parameterList.varargs)); // mark end of arg list
     if (tret !is null)
         mangleType(tret, 0, buf, backref);
     t.inuse--;
@@ -1213,11 +1213,11 @@ void writeBackRef(ref OutBuffer buf, size_t pos) @safe
     while (mul >= base)
     {
         auto dig = cast(ubyte)(pos / mul);
-        buf.writeByte('A' + dig);
+        buf.writeByte(cast(char)('A' + dig));
         pos -= dig * mul;
         mul /= base;
     }
-    buf.writeByte('a' + cast(ubyte)pos);
+    buf.writeByte(cast(char)('a' + pos));
 }
 
 

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -1180,7 +1180,7 @@ void writeCharLiteral(ref OutBuffer buf, dchar c)
             if (c <= 0xFF)
             {
                 if (isprint(c))
-                    buf.writeByte(c);
+                    buf.writeByte(cast(char)c);
                 else
                     buf.printf("\\x%02x", c);
             }


### PR DESCRIPTION
The problem is that writeByte() casts its parameter to a ubyte. The arguments should be a ubyte, so that the caller is checked for passing it with the correct type.

I.e. no longer rely on hidden integral conversions that wouldn't pass value range propagation checks, by requiring the conversions to be explicit.