### PR TITLE
fix issue 21429 .  Allow mixed-in opDispatch overloads

### DIFF
--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -549,49 +549,20 @@ Expression opOverloadBinary(BinExp e, Scope* sc, Type[2] aliasThisStop)
     AggregateDeclaration ad1 = isAggregate(e.e1.type);
     AggregateDeclaration ad2 = isAggregate(e.e2.type);
 
-
     // Try opBinary and opBinaryRight
     Dsymbol s = search_function(ad1, Id.opBinary);
 
-    if (s)
+    if (s && !(s.isTemplateDeclaration() || s.isOverloadSet))
     {
-        if (OverloadSet os = s.isOverloadSet())
-        {
-            /*
-            //printf("opBinary is an overload set\n");
-            //multiple overloads in different scopes
-            auto dti = new DotTemplateInstanceExp(e.loc, e.e1, Id.opBinary, opToArg(sc, e.op));
-            //dtitype = new TypeIdentifier(Loc.initial, ttp.ident);
-            if (!findTempDecl(dti, sc))
-            {
-                .error(e.loc, "Couldn't find the template declaration for opBinary");
-                return ErrorExp.get();
-            }
-            s = dti.ti.tempdecl;
-            //printf("found temp decl in the overload set: %s\n", s.toChars);
-            */
-            s = os;
-        }
-        else if (!s.isTemplateDeclaration())
-        {
-            error(e.e1.loc, "`%s.opBinary` isn't a template", e.e1.toChars());
-            return ErrorExp.get();
-        }
+        error(e.e1.loc, "`%s.opBinary` isn't a template", e.e1.toChars());
+        return ErrorExp.get();
     }
 
     Dsymbol s_r = search_function(ad2, Id.opBinaryRight);
-    //TODO same check for opBinaryRight
-    if (s_r)
+    if (s_r && !(s_r.isTemplateDeclaration() || s_r.isOverloadSet()))
     {
-        if (OverloadSet os = s_r.isOverloadSet())
-        {
-            s_r = os;
-        }
-        else if (!s_r.isTemplateDeclaration())
-        {
-            error(e.e2.loc, "`%s.opBinaryRight` isn't a template", e.e2.toChars());
-            return ErrorExp.get();
-        }
+        error(e.e2.loc, "`%s.opBinaryRight` isn't a template", e.e2.toChars());
+        return ErrorExp.get();
     }
     if (s_r && s_r == s) // https://issues.dlang.org/show_bug.cgi?id=12778
         s_r = null;

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -557,6 +557,7 @@ Expression opOverloadBinary(BinExp e, Scope* sc, Type[2] aliasThisStop)
     {
         if (OverloadSet os = s.isOverloadSet())
         {
+            /*
             //printf("opBinary is an overload set\n");
             //multiple overloads in different scopes
             auto dti = new DotTemplateInstanceExp(e.loc, e.e1, Id.opBinary, opToArg(sc, e.op));
@@ -568,6 +569,8 @@ Expression opOverloadBinary(BinExp e, Scope* sc, Type[2] aliasThisStop)
             }
             s = dti.ti.tempdecl;
             //printf("found temp decl in the overload set: %s\n", s.toChars);
+            */
+            s = os;
         }
         else if (!s.isTemplateDeclaration())
         {

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -581,10 +581,17 @@ Expression opOverloadBinary(BinExp e, Scope* sc, Type[2] aliasThisStop)
 
     Dsymbol s_r = search_function(ad2, Id.opBinaryRight);
     //TODO same check for opBinaryRight
-    if (s_r && !s_r.isTemplateDeclaration())
+    if (s_r)
     {
-        error(e.e2.loc, "`%s.opBinaryRight` isn't a template", e.e2.toChars());
-        return ErrorExp.get();
+        if (OverloadSet os = s_r.isOverloadSet())
+        {
+            s_r = os;
+        }
+        else if (!s_r.isTemplateDeclaration())
+        {
+            error(e.e2.loc, "`%s.opBinaryRight` isn't a template", e.e2.toChars());
+            return ErrorExp.get();
+        }
     }
     if (s_r && s_r == s) // https://issues.dlang.org/show_bug.cgi?id=12778
         s_r = null;

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1029,7 +1029,7 @@ Expression opOverloadBinaryAssign(BinAssignExp e, Scope* sc, Type[2] aliasThisSt
 
     AggregateDeclaration ad1 = isAggregate(e.e1.type);
     Dsymbol s = search_function(ad1, Id.opOpAssign);
-    if (s && !s.isTemplateDeclaration())
+    if (s && !(s.isTemplateDeclaration() || s.isOverloadSet()))
     {
         error(e.loc, "`%s.opOpAssign` isn't a template", e.e1.toChars());
         return ErrorExp.get();

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1187,6 +1187,8 @@ Dsymbol search_function(ScopeDsymbol ad, Identifier funcid)
             return fd;
         if (TemplateDeclaration td = s2.isTemplateDeclaration())
             return td;
+        if (OverloadSet os = s2.isOverloadSet())
+            return os;
     }
     return null;
 }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -5020,8 +5020,12 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                     auto tiargs = new Objects();
                     tiargs.push(ident);
                     auto dti = new DotTemplateInstanceExp(e.loc, e, Id.opDispatch, tiargs);
-                    e = dti.dotTemplateSemanticProp(sc, false);
-                    return returnExp(e);
+                    if (!findTempDecl(dti, sc))
+                    {
+                        .error(fd.loc, "Couldn't find template declaration for opDispatch");
+                        return returnExp(ErrorExp.get());
+                    }
+                    return returnExp(dti);
 
                 }
 

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -5013,6 +5013,11 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                 /* Rewrite e.ident as:
                  *  e.opDispatch!("ident")
                  */
+
+                if(OverloadSet os = fd.isOverloadSet()){
+                    //??? resolve the correct one
+                }
+
                 TemplateDeclaration td = fd.isTemplateDeclaration();
                 if (!td)
                 {

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -5014,33 +5014,31 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                  *  e.opDispatch!("ident")
                  */
 
+                auto tiargs = new Objects();
+                auto se = new StringExp(e.loc, ident.toString());
+                tiargs.push(se);
+                auto dti = new DotTemplateInstanceExp(e.loc, e, Id.opDispatch, tiargs);
+
                 if (OverloadSet os = fd.isOverloadSet())
                 {
-                    //??? resolve the correct one
-                    auto tiargs = new Objects();
-                    auto se = new StringExp(e.loc, ident.toString());
-                    tiargs.push(se);
-                    auto dti = new DotTemplateInstanceExp(e.loc, e, Id.opDispatch, tiargs);
                     if (!findTempDecl(dti, sc))
                     {
                         .error(fd.loc, "Couldn't find template declaration for opDispatch");
                         return returnExp(ErrorExp.get());
                     }
-                    return returnExp(dti);
-
                 }
-
-                TemplateDeclaration td = fd.isTemplateDeclaration();
-                if (!td)
+                else
                 {
-                    .error(fd.loc, "%s `%s` must be a template `opDispatch(string s)`, not a %s", fd.kind, fd.toPrettyChars, fd.kind());
-                    return returnExp(ErrorExp.get());
+                    TemplateDeclaration td = fd.isTemplateDeclaration();
+                    if (!td)
+                    {
+                        .error(fd.loc, "%s `%s` must be a template `opDispatch(string s)`, not a %s",
+                               fd.kind, fd.toPrettyChars, fd.kind());
+                        return returnExp(ErrorExp.get());
+                    }
+                    dti.ti.tempdecl = td;
                 }
-                auto se = new StringExp(e.loc, ident.toString());
-                auto tiargs = new Objects();
-                tiargs.push(se);
-                auto dti = new DotTemplateInstanceExp(e.loc, e, Id.opDispatch, tiargs);
-                dti.ti.tempdecl = td;
+
                 /* opDispatch, which doesn't need IFTI,  may occur instantiate error.
                  * e.g.
                  *  template opDispatch(name) if (isValid!name) { ... }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -5014,8 +5014,15 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                  *  e.opDispatch!("ident")
                  */
 
-                if(OverloadSet os = fd.isOverloadSet()){
+                if (OverloadSet os = fd.isOverloadSet())
+                {
                     //??? resolve the correct one
+                    auto tiargs = new Objects();
+                    tiargs.push(ident);
+                    auto dti = new DotTemplateInstanceExp(e.loc, e, Id.opDispatch, tiargs);
+                    e = dti.dotTemplateSemanticProp(sc, false);
+                    return returnExp(e);
+
                 }
 
                 TemplateDeclaration td = fd.isTemplateDeclaration();

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -5018,7 +5018,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                 {
                     //??? resolve the correct one
                     auto tiargs = new Objects();
-                    tiargs.push(ident);
+                    auto se = new StringExp(e.loc, ident.toString());
+                    tiargs.push(se);
                     auto dti = new DotTemplateInstanceExp(e.loc, e, Id.opDispatch, tiargs);
                     if (!findTempDecl(dti, sc))
                     {

--- a/compiler/test/fail_compilation/test21429.d
+++ b/compiler/test/fail_compilation/test21429.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21429.d(20): Error: no property `z` for `s` of type `test21429.S`
+fail_compilation/test21429.d(13):        struct `S` defined here
+---
+*/
+//make sure this fails properly after fixing bug 21429.d
+template mixinOpDispatch(string id){
+    string opDispatch(string s)() if(s == id){ return id; }
+}
+
+struct S {
+    mixin mixinOpDispatch!"x";
+    mixin mixinOpDispatch!"y";
+}
+
+void main(){
+    S s;
+    auto fail = s.z;
+}

--- a/compiler/test/runnable/test21429.d
+++ b/compiler/test/runnable/test21429.d
@@ -41,7 +41,7 @@ template adder()
 
 template subtracter()
 {
-    int opBinary(string s : "-")(int x) { return x; }
+    int opBinary(string s : "-")(int x) { return -x; }
 }
 
 
@@ -50,6 +50,23 @@ struct Arithmetic
     mixin adder;
     mixin subtracter;
 
+}
+
+template adderRight()
+{
+    int opBinaryRight(string s : "+")(int x){ return x; }
+}
+
+
+template subtracterRight()
+{
+    int opBinaryRight(string s: "-")(int x){ return -x; }
+}
+
+struct ArithmeticRight
+{
+    mixin adderRight;
+    mixin subtracterRight;
 }
 
 void main(){
@@ -65,8 +82,13 @@ void main(){
 
     //TODO: fix these
     Arithmetic a;
-    a + 5; // error a.opBinary isn't a template (is an overload set, I assume)
-    a - 5; // error
+    assert((a + 5) == 5);
+    assert((a - 7) == -7);
+
+
+    ArithmeticRight ar;
+    assert((5 + ar) == 5);
+    assert((7 - ar) == -7);
 
 
     U u;

--- a/compiler/test/runnable/test21429.d
+++ b/compiler/test/runnable/test21429.d
@@ -69,6 +69,24 @@ struct ArithmeticRight
     mixin subtracterRight;
 }
 
+template mixinOpAssign(string op)
+{
+    void opOpAssign(string s)(int x) if(s == op)
+    {
+        val = x;
+        lastOp = s;
+    }
+}
+
+struct AssignOverloads
+{
+    int val;
+    string lastOp;
+    mixin mixinOpAssign!"+";
+    mixin mixinOpAssign!"-";
+}
+
+
 void main(){
 
     T t;
@@ -100,4 +118,13 @@ void main(){
     assert(ta.val == 5);
     ta.y = 10;
     assert(ta.val == 10);
+
+    AssignOverloads oa;
+    oa += 5;
+    assert(oa.val == 5);
+    assert(oa.lastOp == "+");
+    oa -= 10;
+    assert(oa.val == 10);
+    assert(oa.lastOp == "-");
+
 }

--- a/compiler/test/runnable/test21429.d
+++ b/compiler/test/runnable/test21429.d
@@ -87,7 +87,8 @@ struct AssignOverloads
 }
 
 
-void main(){
+void main()
+{
 
     T t;
     string s = t.x();

--- a/compiler/test/runnable/test21429.d
+++ b/compiler/test/runnable/test21429.d
@@ -1,0 +1,28 @@
+mixin template OD(string s){
+
+    string opDispatch(string name)() if(name == s){
+        return name;
+    }
+}
+
+struct T {
+    mixin OD!"x";
+    mixin OD!"y";
+}
+
+//struct U {
+//    mixin OD!"z";
+//}
+
+
+void main(){
+
+    T t;
+    string s = t.x(); //error!
+    //t.y(); //error!
+    //t.opDispatch!"x";
+    //t.opDispatch!"y";
+
+    //U u;
+    //u.z(); //OK
+}

--- a/compiler/test/runnable/test21429.d
+++ b/compiler/test/runnable/test21429.d
@@ -19,7 +19,11 @@ void main(){
 
     T t;
     string s = t.x(); //error!
-    //t.y(); //error!
+    assert(s == "x");
+    assert(t.y == "y");
+
+    //TODO opDispatch with assignment/parameters
+
     //t.opDispatch!"x";
     //t.opDispatch!"y";
 

--- a/compiler/test/runnable/test21429.d
+++ b/compiler/test/runnable/test21429.d
@@ -65,10 +65,9 @@ void main(){
 
     //TODO: fix these
     Arithmetic a;
-    //a + 5; // error a.opBinary isn't a template (is an overload set, I assume)
-    //a - 5; // error
+    a + 5; // error a.opBinary isn't a template (is an overload set, I assume)
+    a - 5; // error
 
-    //t.opDispatch!"y";
 
     U u;
     //should work for a single mixin

--- a/compiler/test/runnable/test21429.d
+++ b/compiler/test/runnable/test21429.d
@@ -1,32 +1,82 @@
-mixin template OD(string s){
+mixin template OD(string s)
+{
 
-    string opDispatch(string name)() if(name == s){
+    string opDispatch(string name)() if (name == s)
+    {
         return name;
     }
 }
 
-struct T {
+mixin template ODA(string s)
+{
+    void opDispatch(string name)(int x) if (name == s)
+    {
+        this.val = x;
+    }
+}
+
+struct T
+{
     mixin OD!"x";
     mixin OD!"y";
 }
 
-//struct U {
-//    mixin OD!"z";
-//}
+struct TAssign
+{
+    int val;
+    mixin ODA!"x";
+    mixin ODA!"y";
+}
 
+struct U
+{
+    mixin OD!"z";
+}
+
+
+template adder()
+{
+    int opBinary(string s : "+")(int x) { return x; }
+}
+
+template subtracter()
+{
+    int opBinary(string s : "-")(int x) { return x; }
+}
+
+
+struct Arithmetic
+{
+    mixin adder;
+    mixin subtracter;
+
+}
 
 void main(){
 
     T t;
-    string s = t.x(); //error!
+    string s = t.x();
     assert(s == "x");
     assert(t.y == "y");
 
-    //TODO opDispatch with assignment/parameters
+    //explicit call should work
+    assert(t.opDispatch!"x" == "x");
 
-    //t.opDispatch!"x";
+
+    //TODO: fix these
+    Arithmetic a;
+    //a + 5; // error a.opBinary isn't a template (is an overload set, I assume)
+    //a - 5; // error
+
     //t.opDispatch!"y";
 
-    //U u;
-    //u.z(); //OK
+    U u;
+    //should work for a single mixin
+    assert(u.z == "z");
+
+    TAssign ta;
+    ta.x = 5;
+    assert(ta.val == 5);
+    ta.y = 10;
+    assert(ta.val == 10);
 }


### PR DESCRIPTION
I think I've narrowed down the cause to the area I've edited.  There is an overload set containing multiple `opDispatch` implementations.  It think the next step is to resolve the correct on in the ??? block in typesem, but I'm not sure how best to do that.  Would appreciate any suggestions there.  The Issue also mentions issues with other op overloads, which I haven't looked at yet.  I'd like to get something actually working for `opDispatch` before hunting that down.