### PR TITLE
dmd should not run a GC collection for cleanup

### DIFF
--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -95,7 +95,7 @@ extern (C) int main(int argc, char** argv)
     }
     if (!lowmem)
     {
-        __gshared string[] disable_options = [ "gcopt=disable:1" ];
+        __gshared string[] disable_options = [ "gcopt=disable:1 cleanup:none" ];
         rt_options = disable_options;
         mem.disableGC();
     }

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -95,7 +95,10 @@ extern (C) int main(int argc, char** argv)
     }
     if (!lowmem)
     {
-        __gshared string[] disable_options = [ "gcopt=disable:1 cleanup:none" ];
+        static if(__VERSION__ < 2085)
+            __gshared string[] disable_options = [ "gcopt=disable:1" ];
+        else
+            __gshared string[] disable_options = [ "gcopt=disable:1 cleanup:none" ];
         rt_options = disable_options;
         mem.disableGC();
     }


### PR DESCRIPTION
With recent changes to the druntime compiler hooks and more use of some D style dynamic and associative arrays, dmd allocates more memory from the GC heap. Compiling current dmd optimized with LDC 1.40.1 for Win64 and using it to compile unittest for the std.range package yields:
```
> dmd.exe -unittest -preview=dip1000 -version=StdUnittest ..\phobos\std\range\package.d -c "--DRT-gcopt=profile:1"
        Number of collections:  1
        Total GC prep time:  0 milliseconds
        Total mark time:  2 milliseconds
        Total sweep time:  61 milliseconds
        Max Pause Time:  3 milliseconds
        Grand total GC time:  64 milliseconds
GC summary:  210 MB,    1 GC   64 ms, Pauses    3 ms <    3 ms
```
dmd.exe uses 1679 MB of private process memory and runs for 0:03.130 min:sec on my system.

Even though disabled, it still runs a collection at shutdown by default. When disabling that with the respective GC option, I get
```
> dmd.exe -unittest -preview=dip1000 -version=StdUnittest ..\phobos\std\range\package.d -c "--DRT-gcopt=profile:1 cleanup:none"
        Number of collections:  0
        Total GC prep time:  0 milliseconds
        Total mark time:  0 milliseconds
        Total sweep time:  0 milliseconds
        Max Pause Time:  0 milliseconds
        Grand total GC time:  0 milliseconds
GC summary:  210 MB,    0 GC    0 ms, Pauses    0 ms <    0 ms
```
with dmd.exe using the same process memory, but running for 0:03.080 min:sec. With timing measurements reproducible by about +/- 10ms, that makes a small runtime improvement of about 2%. That's also consistent with results when buillding all phobos unittests in a single build, see https://github.com/dlang/dmd/pull/21428#issuecomment-2953018709

