### PR TITLE
dshell_prebuilt should be rebuilt when the tested compiler changes

### DIFF
--- a/compiler/test/run.d
+++ b/compiler/test/run.d
@@ -283,10 +283,15 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
             if (sourceFile is null)
                 sourceFile = toolsDir.buildPath(tool ~ ".d");
         }
-        if (targetBin.timeLastModified.ifThrown(SysTime.init) >= sourceFile.timeLastModified)
+        auto lastModifiedBin = targetBin.timeLastModified.ifThrown(SysTime.init);
+        if (lastModifiedBin >= sourceFile.timeLastModified)
         {
-            log("%s is already up-to-date", tool);
-            continue;
+            auto lastModifiedDmd = env["DMD"].timeLastModified.ifThrown(SysTime.init);
+            if (!tool.linksWithTests || lastModifiedBin >= lastModifiedDmd)
+            {
+                log("%s is already up-to-date", tool);
+                continue;
+            }
         }
 
         string[] buildCommand;


### PR DESCRIPTION
Locally, the dshell tests often fail to build after switching branches, because dshell_prebuilt.obj is not rebuilt. Even if it links, it might behave erratically.