### PR TITLE
va_list, etc., improperly declared for AArch64

### DIFF
--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -940,7 +940,7 @@ bool parseCommandlineAndConfig(size_t argc, const(char)** argv, out Param params
     if (parseConfFile(environment, global.inifilename, inifilepath, cast(ubyte[])inifileBuffer[], &sections))
         return true;
 
-    const(char)[] arch = target.isX86_64 ? "64" : "32"; // use default
+    const(char)[] arch = (target.isX86_64 || target.isAArch64) ? "64" : "32"; // use default
     arch = parse_arch_arg(&arguments, arch);
 
     // parse architecture from DFLAGS read from [Environment] section

--- a/druntime/src/core/internal/vararg/aarch64.d
+++ b/druntime/src/core/internal/vararg/aarch64.d
@@ -35,8 +35,16 @@ extern (C++, std) struct __va_list
     int __vr_offs;
 }
 
-///
-alias va_list = __va_list;
+version (DigitalMars)
+{
+    ///
+    alias __va_list_tag = __va_list;
+    ///
+    alias va_list = __va_list*;
+}
+else
+    ///
+    alias va_list = __va_list; // kludge - va_list always passed by ref (!)
 
 ///
 T va_arg(T)(ref va_list ap)

--- a/druntime/src/core/stdc/config.d
+++ b/druntime/src/core/stdc/config.d
@@ -260,6 +260,23 @@ else version (DigitalMars)
         else version (Darwin)
             alias real c_long_double;
     }
+    else version (AArch64)
+    {
+        version (linux)
+            alias real c_long_double;
+        else version (FreeBSD)
+            alias real c_long_double;
+        else version (OpenBSD)
+            alias real c_long_double;
+        else version (NetBSD)
+            alias real c_long_double;
+        else version (DragonFlyBSD)
+            alias real c_long_double;
+        else version (Solaris)
+            alias real c_long_double;
+        else version (Darwin)
+            alias real c_long_double;
+    }
 }
 
 static assert(is(c_long_double), "c_long_double needs to be declared for this platform/architecture.");

--- a/druntime/src/core/stdc/stdarg.d
+++ b/druntime/src/core/stdc/stdarg.d
@@ -130,6 +130,8 @@ else version (AAPCS32)
 else version (AAPCS64)
 {
     alias va_list = core.internal.vararg.aarch64.va_list;
+    version (DigitalMars)
+        public import core.internal.vararg.aarch64 : __va_list, __va_list_tag;
 }
 else version (RISCV_Any)
 {


### PR DESCRIPTION
There's quite an ugly snarl of versions and imports in the druntime headers. I had to add a bunch of `pragma(msg, ...)` statements to try and figure out what path it was going down.

See also:

https://github.com/dlang/dmd/pull/21374

which was reverted.

ping @kinke