### PR TITLE
eliminate need for getting msw of cent

### DIFF
--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -5445,7 +5445,8 @@ elem* elmsw(elem* e, Goal goal)
             e = evalu8(e, goal);
         }
     }
-    else if (OPTIMIZER && I64 &&
+    else if ((OPTIMIZER || config.target_cpu == TARGET_AArch64) &&
+        I64 &&
         tysize(e1.Ety) == CENTSIZE &&
         tysize(ty) == LLONGSIZE)
     {


### PR DESCRIPTION
AArch64 cannot deal well with register pairs, so optimize the need away.