### PR TITLE
Forbid incompatible foreach parameter types for AAs

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3901,7 +3901,9 @@ private extern(D) Expression applyAssocArray(ForeachStatement fs, Expression fld
     if (dim == 2)
     {
         Type ti = (isRef ? taa.index.addMod(MODFlags.const_) : taa.index);
-        if (isRef ? !ti.constConv(ta) : !ti.implicitConvTo(ta))
+        // TODO don't require sizes to match
+        // See https://github.com/dlang/dmd/issues/21456#issuecomment-2981509259
+        if (isRef ? !ti.constConv(ta) : !ti.implicitConvTo(ta) || ti.size != ta.size)
         {
             error(fs.loc, "`foreach`: index must be type `%s`, not `%s`",
                      ti.toChars(), ta.toChars());
@@ -3912,7 +3914,8 @@ private extern(D) Expression applyAssocArray(ForeachStatement fs, Expression fld
         ta = p.type;
     }
     Type taav = taa.nextOf();
-    if (isRef ? !taav.constConv(ta) : !taav.implicitConvTo(ta))
+    // TODO don't require sizes to match
+    if (isRef ? !taav.constConv(ta) : !taav.implicitConvTo(ta) || taav.size != ta.size)
     {
         error(fs.loc, "`foreach`: value must be type `%s`, not `%s`",
                  taav.toChars(), ta.toChars());

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3905,8 +3905,8 @@ private extern(D) Expression applyAssocArray(ForeachStatement fs, Expression fld
         // See https://github.com/dlang/dmd/issues/21456#issuecomment-2981509259
         if (isRef ? !ti.constConv(ta) : !ti.implicitConvTo(ta) || ti.size != ta.size)
         {
-            error(fs.loc, "`foreach`: index must be type `%s`, not `%s`",
-                     ti.toChars(), ta.toChars());
+            error(fs.loc, "`foreach`: index parameter `%s%s` must be type `%s`, not `%s`",
+                 isRef ? "ref ".ptr : "".ptr, p.toChars(), ti.toChars(), ta.toChars());
             return null;
         }
         p = (*fs.parameters)[1];
@@ -3917,8 +3917,8 @@ private extern(D) Expression applyAssocArray(ForeachStatement fs, Expression fld
     // TODO don't require sizes to match
     if (isRef ? !taav.constConv(ta) : !taav.implicitConvTo(ta) || taav.size != ta.size)
     {
-        error(fs.loc, "`foreach`: value must be type `%s`, not `%s`",
-                 taav.toChars(), ta.toChars());
+        error(fs.loc, "`foreach`: value parameter `%s%s` must be type `%s`, not `%s`",
+            isRef ? "ref ".ptr : "".ptr, p.toChars(), taav.toChars(), ta.toChars());
         return null;
     }
 

--- a/compiler/test/fail_compilation/fail13756.d
+++ b/compiler/test/fail_compilation/fail13756.d
@@ -1,7 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13756.d(11): Error: `foreach`: index must be type `const(int)`, not `int`
+fail_compilation/fail13756.d(16): Error: `foreach`: index parameter `ref k` must be type `const(int)`, not `int`
+fail_compilation/fail13756.d(19): Error: `foreach`: index parameter `key` must be type `int`, not `string`
+fail_compilation/fail13756.d(21): Error: `foreach`: value parameter `val` must be type `int`, not `char`
+fail_compilation/fail13756.d(22): Error: `foreach`: value parameter `ref val` must be type `int`, not `dchar`
+fail_compilation/fail13756.d(25): Error: `foreach`: index parameter `key` must be type `int`, not `ulong`
+fail_compilation/fail13756.d(26): Error: `foreach`: value parameter `val` must be type `int`, not `ulong`
 ---
 */
 
@@ -11,4 +16,12 @@ void maiin()
     foreach (ref int k, v; aa)
     {
     }
+    foreach (string key, val; aa) {}
+
+    foreach (key, char val; aa) {}
+    foreach (key, ref dchar val; aa) {}
+
+    // following not supported yet
+    foreach (size_t key, val; aa) {}
+    foreach (key, size_t val; aa) {}
 }

--- a/compiler/test/fail_compilation/fail13756.d
+++ b/compiler/test/fail_compilation/fail13756.d
@@ -22,6 +22,6 @@ void maiin()
     foreach (key, ref dchar val; aa) {}
 
     // following not supported yet
-    foreach (size_t key, val; aa) {}
-    foreach (key, size_t val; aa) {}
+    foreach (ulong key, val; aa) {}
+    foreach (key, ulong val; aa) {}
 }

--- a/compiler/test/runnable/xtest46.d
+++ b/compiler/test/runnable/xtest46.d
@@ -1495,7 +1495,7 @@ void test9212()
 {
     int[int] aa;
     foreach (const key, const val; aa) {}
-    foreach (size_t key, size_t val; aa) {}
+    //TODO foreach (size_t key, size_t val; aa) {}
 }
 
 /***************************************************/


### PR DESCRIPTION
Fixes #21456.

This errors unless both:
- the AA component types implicitly convert to the respective foreach parameter types
- each of those type checks have types the same size

Although it would be better to support larger foreach parameter types, this prevents corruption for now.

Also improve error messages (see commits).