### PR TITLE
fix #21456: foreach over associative array allows incompatible types for key and value

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4007,6 +4007,7 @@ private extern(D) Statement loopReturn(Expression e, Statements* cases, Loc loc)
  */
 private FuncExp foreachBodyToFunction(Scope* sc, ForeachStatement fs, TypeFunction tfld)
 {
+    auto taa = fs.aggr.type.toBasetype().isTypeAArray();
     auto params = new Parameters();
     foreach (i, p; *fs.parameters)
     {
@@ -4049,6 +4050,8 @@ private FuncExp foreachBodyToFunction(Scope* sc, ForeachStatement fs, TypeFuncti
             v.storage_class |= STC.temp | (stc & STC.scope_);
             Statement s = new ExpStatement(fs.loc, v);
             fs._body = new CompoundStatement(fs.loc, s, fs._body);
+            if (taa)
+                p.type = i == 1 || fs.parameters.length == 1 ? taa.nextOf() : taa.index;
         }
         params.push(new Parameter(fs.loc, stc, p.type, id, null, null));
     }

--- a/compiler/test/runnable/foreach5.d
+++ b/compiler/test/runnable/foreach5.d
@@ -1046,6 +1046,21 @@ void test13756()
     {
         static assert(is(typeof(k) == const int));
     }
+
+    // https://github.com/dlang/dmd/issues/21456
+    foreach (long k, long v; aa)
+    {
+        assert(k == 1 && v == 20);
+    }
+    static struct S
+    {
+        int x, y, z;
+        this(int a) { z = a; }
+    }
+    foreach (long k, S s; aa)
+    {
+        assert(k == 1 && s.z == 20);
+    }
 }
 
 /***************************************/


### PR DESCRIPTION
fix the lambda parameter type to correspond to key or value