### PR TITLE
add Apple predefined version to cover OSX, iOS, TVOS, WatchOS and Vis…

### DIFF
--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -366,6 +366,7 @@ extern (C++) final class VersionCondition : DVCondition
             case "Alpha_HardFloat":
             case "Alpha_SoftFloat":
             case "Android":
+            case "Apple":
             case "ARM":
             case "ARM_HardFloat":
             case "ARM_SoftFloat":

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -196,7 +196,8 @@ void addPredefinedGlobalIdentifiers(const ref Target tgt)
             }
             case OS.OSX:
             {
-                predef("OSX");
+                predef("OSX");          // macOS
+                predef("Apple");        // macOS is one of Apple's operating systems
                 // For legacy compatibility
                 predef("darwin");
                 break;

--- a/druntime/test/importc_compare/src/importc_compare.d
+++ b/druntime/test/importc_compare/src/importc_compare.d
@@ -1,14 +1,5 @@
 import core.stdc.stdio : printf;
 
-version (OSX)
-    version = Apple;
-version (iOS)
-    version = Apple;
-version (TVOS)
-    version = Apple;
-version (WatchOS)
-    version = Apple;
-
 /*
 This test tries to automatically find types with a wrong size in
 druntime C bindings. This is done by also getting type sizes from


### PR DESCRIPTION
…ionOS

The Apple operating systems OSX, iOS, TVOS, WatchOS and VisionOS are close enough that we see various sequences of the following code repeated in druntime:
```
version (OSX)
    version = Darwin;
else version (iOS)
    version = Darwin;
else version (TVOS)
    version = Darwin;
else version (WatchOS)
    version = Darwin;
```
Like `Windows` covers both `Win32` and `Win64`, `Apple` will cover those versions.