### PR TITLE
Improve `foreach` AA error messages & add tests

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3903,8 +3903,8 @@ private extern(D) Expression applyAssocArray(ForeachStatement fs, Expression fld
         Type ti = (isRef ? taa.index.addMod(MODFlags.const_) : taa.index);
         if (isRef ? !ti.constConv(ta) : !ti.implicitConvTo(ta))
         {
-            error(fs.loc, "`foreach`: index must be type `%s`, not `%s`",
-                     ti.toChars(), ta.toChars());
+            error(fs.loc, "`foreach`: index parameter `%s%s` must be type `%s`, not `%s`",
+                 isRef ? "ref ".ptr : "".ptr, p.toChars(), ti.toChars(), ta.toChars());
             return null;
         }
         p = (*fs.parameters)[1];
@@ -3914,8 +3914,8 @@ private extern(D) Expression applyAssocArray(ForeachStatement fs, Expression fld
     Type taav = taa.nextOf();
     if (isRef ? !taav.constConv(ta) : !taav.implicitConvTo(ta))
     {
-        error(fs.loc, "`foreach`: value must be type `%s`, not `%s`",
-                 taav.toChars(), ta.toChars());
+        error(fs.loc, "`foreach`: value parameter `%s%s` must be type `%s`, not `%s`",
+            isRef ? "ref ".ptr : "".ptr, p.toChars(), taav.toChars(), ta.toChars());
         return null;
     }
 

--- a/compiler/test/fail_compilation/fail13756.d
+++ b/compiler/test/fail_compilation/fail13756.d
@@ -1,7 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13756.d(11): Error: `foreach`: index must be type `const(int)`, not `int`
+fail_compilation/fail13756.d(14): Error: `foreach`: index parameter `ref k` must be type `const(int)`, not `int`
+fail_compilation/fail13756.d(17): Error: `foreach`: index parameter `key` must be type `int`, not `string`
+fail_compilation/fail13756.d(19): Error: `foreach`: value parameter `val` must be type `int`, not `char`
+fail_compilation/fail13756.d(20): Error: `foreach`: value parameter `ref val` must be type `int`, not `dchar`
 ---
 */
 
@@ -11,4 +14,8 @@ void maiin()
     foreach (ref int k, v; aa)
     {
     }
+    foreach (string key, val; aa) {}
+
+    foreach (key, char val; aa) {}
+    foreach (key, ref dchar val; aa) {}
 }

--- a/compiler/test/fail_compilation/fail13756.d
+++ b/compiler/test/fail_compilation/fail13756.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail13756.d(14): Error: `foreach`: index parameter `ref k` must be type `const(int)`, not `int`
-fail_compilation/fail13756.d(17): Error: `foreach`: index parameter `key` must be type `int`, not `string`
-fail_compilation/fail13756.d(19): Error: `foreach`: value parameter `val` must be type `int`, not `char`
+fail_compilation/fail13756.d(17): Error: cannot implicitly convert expression `__applyArg0` of type `int` to `string`
+fail_compilation/fail13756.d(19): Error: cannot implicitly convert expression `__applyArg1` of type `int` to `char`
 fail_compilation/fail13756.d(20): Error: `foreach`: value parameter `ref val` must be type `int`, not `dchar`
 ---
 */


### PR DESCRIPTION
Split out of #21463.

Show parameter name and `ref`-ness.