### PR TITLE
fix #21476: Presence of move constructor causes overload error

### DIFF
--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -307,7 +307,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             }
             if (auto ctorDecl = s.isCtorDeclaration())
             {
-                if (!ctorDecl.isCpCtor && (!ignoreDisabled || !(ctorDecl.storage_class & STC.disable)))
+                if (!ctorDecl.isCpCtor && !ctorDecl.isMoveCtor && (!ignoreDisabled || !(ctorDecl.storage_class & STC.disable)))
                 {
                     result = true;
                     return 1;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1373,7 +1373,8 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
 
     override const(char)* kind() const
     {
-        return isCpCtor ? "copy constructor" : "constructor";
+        return isCpCtor ? "copy constructor" :
+             isMoveCtor ? "move constructor" : "constructor";
     }
 
     override bool isVirtual() const

--- a/compiler/test/compilable/test21476.d
+++ b/compiler/test/compilable/test21476.d
@@ -1,0 +1,13 @@
+// https://github.com/dlang/dmd/issues/21476
+
+struct S21476
+{
+    string field;
+    this(ref return scope S21476);
+    this(return scope S21476);
+}
+
+void test21476()
+{
+    auto o = S21476("aoe");
+}


### PR DESCRIPTION
Move constructors were incorrectly being considered as regular constructors, which resulted in the test case failing with:
```
compilable/test21476.d(12): Error: none of the overloads of `this` are callable using argument types `(string)`
    auto o = S21476("aoe");
                   ^
compilable/test21476.d(6):        Candidates are: `test21476.S21476.this(ref return scope S21476)`
    this(ref return scope S21476);
    ^
compilable/test21476.d(7):                        `test21476.S21476.this(return scope S21476)`
    this(return scope S21476);
    ^
```
With this change, a struct literal is now used to construct the object.

Closes: #21476