### PR TITLE
Fixed missing `constexpr` from `enum string` and similar

### DIFF
--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -1001,7 +1001,7 @@ public:
                     break;
 
                 case EnumKind.String, EnumKind.Enum:
-                    buf.writestring("static ");
+                    buf.writestring("constexpr static ");
                     auto target = determineEnumType(type);
                     target.accept(this);
                     buf.writestring(" const ");
@@ -1684,7 +1684,7 @@ public:
             }
             else
             {
-                buf.writestring("static ");
+                buf.writestring("constexpr static ");
                 auto target = determineEnumType(memberType);
                 target.accept(this);
                 buf.writestring(" const ");


### PR DESCRIPTION
It fixes #21487 for C++ code which was not generated properly.