### PR TITLE
fix #21478: Ref parameter overload not called when struct implements copy constructor

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1070,11 +1070,10 @@ private extern(D) MATCH argumentMatchParameter (FuncDeclaration fd, TypeFunction
         }
 
         // check if the copy constructor may be called to copy the argument
-        if (arg.isLvalue() && !isRef && argStruct && argStruct == prmStruct && argStruct.hasCopyCtor)
+        if (arg.isLvalue() && !isRef && argStruct && argStruct == prmStruct && argStruct.hasCopyCtor &&
+            !isCopyConstructorCallable(argStruct, arg, tprm, sc, pMessage))
         {
-            if (!isCopyConstructorCallable(argStruct, arg, tprm, sc, pMessage))
-                return MATCH.nomatch;
-            m = MATCH.exact;
+            return MATCH.nomatch;
         }
         else
         {

--- a/compiler/test/runnable/test21478a.d
+++ b/compiler/test/runnable/test21478a.d
@@ -1,0 +1,23 @@
+// https://github.com/dlang/dmd/issues/21478
+
+// Test struct that implements "rule of five"
+
+struct S21478
+{
+    // 1. destructor
+    ~this() { }
+    // 2. copy constructor
+    this(ref return scope S21478) { assert(0); }
+    // 3. copy assign
+    void opAssign(const ref S21478) { }
+    // 4. move constructor
+    this(return scope S21478) { assert(0); }
+    // 5. move assign
+    void opAssign(const S21478) { assert(0); }
+}
+
+void main()
+{
+    S21478 sa, sb;
+    sb = sa;    // Should call 3, not 2 + 5.
+}

--- a/compiler/test/runnable/test21478b.d
+++ b/compiler/test/runnable/test21478b.d
@@ -1,0 +1,36 @@
+// https://github.com/dlang/dmd/issues/21478
+
+// Test struct that implements copy constructor follows rvalue expression spec:
+//      If both ref and non-ref parameter overloads are present,
+//      an rvalue is preferably matched to the non-ref parameters,
+//      and an lvalue is preferably matched to the ref parameter.
+//      An RvalueExpression will preferably match with the non-ref parameter.
+
+struct S21478
+{
+    this(ref return scope S21478) { assert(0); }
+}
+
+struct P21478
+{
+    int plain_old_data;
+}
+
+int overload(const S21478) { return 1; }
+int overload(const ref S21478) { return 2; }
+
+int overload(const P21478) { return 1; }
+int overload(const ref P21478) { return 2; }
+
+void main()
+{
+    S21478 s;
+    assert(overload(s) == 2);
+    assert(overload(S21478()) == 1);
+    assert(overload(__rvalue(s)) == 1);
+
+    P21478 p;
+    assert(overload(p) == 2);
+    assert(overload(P21478()) == 1);
+    assert(overload(__rvalue(p)) == 1);
+}


### PR DESCRIPTION
If a struct implemented a copy constructor, then an rvalue opAssign would be given a better match score than the lvalue opAssign regardless of the ref-ness of the argument.
```
struct S
{
    this(ref return scope S);
    ref S opAssign(const ref S);
    ref S opAssign(const S);
}

s1 = s2;  // lowered as:  S.opAssign(&s1, *S.this(s2));
```

This change optimizes the assignment as:
```
s1 = s2;  // lowered as: S.opAssign(&s1, &s2);
```

Essentially, this is same as C++ semantics on object that implements rule of five.