### PR TITLE
core/internal/array/utils.d: TraceHook support types with quotes in name

### DIFF
--- a/compiler/test/compilable/profilegc_typename.d
+++ b/compiler/test/compilable/profilegc_typename.d
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -profile=gc
+struct T(string s) {}
+alias TypeWithQuotes = T!q"EOS
+`"'}])>
+EOS";
+
+void foo() {
+    TypeWithQuotes[] arr;
+    arr ~= TypeWithQuotes();
+}

--- a/druntime/src/core/internal/array/appending.d
+++ b/druntime/src/core/internal/array/appending.d
@@ -57,7 +57,7 @@ version (D_ProfileGC)
         version (D_TypeInfo)
         {
             import core.internal.array.utils: TraceHook, gcStatsPure, accumulatePure;
-            mixin(TraceHook!(Tarr.stringof, "_d_arrayappendcTX"));
+            mixin(TraceHook!("Tarr", "_d_arrayappendcTX"));
 
             return _d_arrayappendcTX(px, n);
         }
@@ -120,7 +120,7 @@ version (D_ProfileGC)
         version (D_TypeInfo)
         {
             import core.internal.array.utils: TraceHook, gcStatsPure, accumulatePure;
-            mixin(TraceHook!(Tarr.stringof, "_d_arrayappendT"));
+            mixin(TraceHook!("Tarr", "_d_arrayappendT"));
 
             return _d_arrayappendT(x, y);
         }

--- a/druntime/src/core/internal/array/concatenation.d
+++ b/druntime/src/core/internal/array/concatenation.d
@@ -174,7 +174,7 @@ version (D_ProfileGC)
         version (D_TypeInfo)
         {
             import core.internal.array.utils: TraceHook, gcStatsPure, accumulatePure;
-            mixin(TraceHook!(Tarr.stringof, "_d_arraycatnTX"));
+            mixin(TraceHook!("Tarr", "_d_arraycatnTX"));
 
             import core.lifetime: forward;
             return _d_arraycatnTX!Tret(forward!froms);

--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -475,7 +475,7 @@ version (D_ProfileGC)
         version (D_TypeInfo)
         {
             import core.internal.array.utils : TraceHook, gcStatsPure, accumulatePure;
-            mixin(TraceHook!(T.stringof, "_d_newarrayT"));
+            mixin(TraceHook!("T", "_d_newarrayT"));
 
             return _d_newarrayT!T(length, isShared);
         }
@@ -607,7 +607,7 @@ version (D_ProfileGC)
         version (D_TypeInfo)
         {
             import core.internal.array.utils : TraceHook, gcStatsPure, accumulatePure;
-            mixin(TraceHook!(T.stringof, "_d_newarraymTX"));
+            mixin(TraceHook!("T", "_d_newarraymTX"));
 
             return _d_newarraymTX!(Tarr, T)(dims, isShared);
         }

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -41,16 +41,16 @@ version (D_ProfileGC)
     /**
      * TraceGC wrapper generator around the runtime hook `Hook`.
      * Params:
-     *   Type = The type of hook to report to accumulate
+     *   TypeIdent = The symbol of the type of hook to report to accumulate
      *   Hook = The name hook to wrap
      */
-    template TraceHook(string Type, string Hook)
+    template TraceHook(string TypeIdent, string Hook)
     {
         const char[] TraceHook = q{
             import core.internal.array.utils : gcStatsPure, accumulatePure;
 
             pragma(inline, false);
-            string name = } ~ "`" ~ Type ~ "`;" ~ q{
+            string name = } ~ TypeIdent ~ q{.stringof;
 
             // FIXME: use rt.tracegc.accumulator when it is accessable in the future.
             ulong currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
@@ -91,7 +91,7 @@ version (D_ProfileGC)
     {
         version (D_TypeInfo)
         {
-            mixin(TraceHook!(T.stringof, __traits(identifier, Hook)));
+            mixin(TraceHook!("T", __traits(identifier, Hook)));
             return Hook(parameters);
         }
         else

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -2793,7 +2793,7 @@ T _d_newclassTTrace(T)(string file = __FILE__, int line = __LINE__, string funcn
     version (D_TypeInfo)
     {
         import core.internal.array.utils : TraceHook, gcStatsPure, accumulatePure;
-        mixin(TraceHook!(T.stringof, "_d_newclassT"));
+        mixin(TraceHook!("T", "_d_newclassT"));
 
         return _d_newclassT!T();
     }
@@ -2999,7 +2999,7 @@ version (D_ProfileGC)
             }
 
             import core.internal.array.utils : TraceHook, gcStatsPure, accumulatePure;
-            mixin(TraceHook!(T.stringof, "_d_newitemT"));
+            mixin(TraceHook!("T", "_d_newitemT"));
 
             return _d_newitemT!T();
         }


### PR DESCRIPTION
Avoid directly mixin'ing the result of T.stringof for arbitrary types since that proves problematic with string parameters to templates with their quote and other special characters.

-----
I've hit this in the CI of [dcd](https://github.com/dlang-community/dcd) where [`dub build --profile=gc`](https://github.com/dlang-community/DCD/blob/e48216e4a8da81c100b84d8dcba02fc714fa2585/ci/summary_comment.sh#L49) fails with:
```
2025-07-02T18:28:13.0112323Z     Building dcd:dsymbol 0.16.0-beta.3: building configuration [library]
2025-07-02T18:28:13.8846640Z /opt/hostedtoolcache/dmd/2.111.0/x64/dmd2/linux/bin64/../../src/druntime/import/core/internal/array/utils.d-mixin-94(98,830): Error: semicolon needed to end declaration of `name` instead of `trivia`
2025-07-02T18:28:13.8849145Z /opt/hostedtoolcache/dmd/2.111.0/x64/dmd2/linux/bin64/../../src/druntime/import/core/lifetime.d-mixin-3002(3006,847): Error: semicolon needed to end declaration of `name` instead of `trivia`
2025-07-02T18:28:13.8861060Z /opt/hostedtoolcache/dmd/2.111.0/x64/dmd2/linux/bin64/../../src/phobos/std/array.d(3588,16): Error: template instance `core.lifetime._d_newitemTTrace!(InPlaceAppender!(TokenStructure!(ubyte, "\n    import dparse.lexer : Token;\n\n    this(Token token) pure nothrow @safe @nogc {\n        this(token.type, token.text, token.line, token.column, token.index);\n    }\n\n    int opCmp(size_t i) const pure nothrow @safe @nogc {\n        if (index < i) return -1;\n        if (index > i) return 1;\n        return 0;\n    }\n\n    int opCmp(ref const typeof(this) other) const pure nothrow @safe @nogc {\n        return opCmp(other.index);\n    }\n\n    string toString() const @safe pure\n    {\n        import std.array : appender;\n\n        auto sink = appender!string;\n        toString(sink);\n        return sink.data;\n    }\n\n    void toString(R)(auto ref R sink) const\n    {\n        import std.conv : to;\n        import dparse.lexer : str;\n\n        sink.put(`trivia!\"`);\n        sink.put(str(type));\n        sink.put(`\"(`);\n        sink.put(\"text: \");\n        sink.put([text].to!string[1 .. $ - 1]); // escape hack\n        sink.put(\", index: \");\n        sink.put(index.to!string);\n        sink.put(\", line: \");\n        sink.put(line.to!string);\n        sink.put(\", column: \");\n        sink.put(column.to!string);\n        sink.put(\")\");\n    }\n")[]))` error instantiating
2025-07-02T18:28:13.8867415Z         impl = new InPlaceAppender!A(arr);
2025-07-02T18:28:13.8867851Z                ^
2025-07-02T18:28:13.8873549Z /opt/hostedtoolcache/dmd/2.111.0/x64/dmd2/linux/bin64/../../src/phobos/std/array.d(4494,1):        instantiated from here: `Appender!(TokenStructure!(ubyte, "\n    import dparse.lexer : Token;\n\n    this(Token token) pure nothrow @safe @nogc {\n        this(token.type, token.text, token.line, token.column, token.index);\n    }\n\n    int opCmp(size_t i) const pure nothrow @safe @nogc {\n        if (index < i) return -1;\n        if (index > i) return 1;\n        return 0;\n    }\n\n    int opCmp(ref const typeof(this) other) const pure nothrow @safe @nogc {\n        return opCmp(other.index);\n    }\n\n    string toString() const @safe pure\n    {\n        import std.array : appender;\n\n        auto sink = appender!string;\n        toString(sink);\n        return sink.data;\n    }\n\n    void toString(R)(auto ref R sink) const\n    {\n        import std.conv : to;\n        import dparse.lexer : str;\n\n        sink.put(`trivia!\"`);\n        sink.put(str(type));\n        sink.put(`\"(`);\n        sink.put(\"text: \");\n        sink.put([text].to!string[1 .. $ - 1]); // escape hack\n        sink.put(\", index: \");\n        sink.put(index.to!string);\n        sink.put(\", line: \");\n        sink.put(line.to!string);\n        sink.put(\", column: \");\n        sink.put(column.to!string);\n        sink.put(\")\");\n    }\n")[])`
2025-07-02T18:28:13.8879528Z Appender!A appender(A)()
2025-07-02T18:28:13.8879870Z ^
2025-07-02T18:28:13.8884998Z ../../../.dub/packages/libdparse/0.25.0/libdparse/src/dparse/lexer.d(568,58):        instantiated from here: `appender!(TokenStructure!(ubyte, "\n    import dparse.lexer : Token;\n\n    this(Token token) pure nothrow @safe @nogc {\n        this(token.type, token.text, token.line, token.column, token.index);\n    }\n\n    int opCmp(size_t i) const pure nothrow @safe @nogc {\n        if (index < i) return -1;\n        if (index > i) return 1;\n        return 0;\n    }\n\n    int opCmp(ref const typeof(this) other) const pure nothrow @safe @nogc {\n        return opCmp(other.index);\n    }\n\n    string toString() const @safe pure\n    {\n        import std.array : appender;\n\n        auto sink = appender!string;\n        toString(sink);\n        return sink.data;\n    }\n\n    void toString(R)(auto ref R sink) const\n    {\n        import std.conv : to;\n        import dparse.lexer : str;\n\n        sink.put(`trivia!\"`);\n        sink.put(str(type));\n        sink.put(`\"(`);\n        sink.put(\"text: \");\n        sink.put([text].to!string[1 .. $ - 1]); // escape hack\n        sink.put(\", index: \");\n        sink.put(index.to!string);\n        sink.put(\", line: \");\n        sink.put(line.to!string);\n        sink.put(\", column: \");\n        sink.put(column.to!string);\n        sink.put(\")\");\n    }\n")[])`
2025-07-02T18:28:13.8890838Z     auto leadingTriviaAppender = appender!(TriviaToken[])();
2025-07-02T18:28:13.8891374Z                                                          ^
2025-07-02T18:28:13.8892128Z dsymbol/src/dsymbol/modulecache.d(181,31):        instantiated from here: `getTokensForParser!(ubyte[])`
2025-07-02T18:28:13.8892923Z             tokens = getTokensForParser(
2025-07-02T18:28:13.8893344Z                                        ^
2025-07-02T18:28:14.0152750Z Error dmd failed with exit code 1.
```