### PR TITLE
CI: remove windows-2019 tests

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -77,8 +77,6 @@ jobs:
           # NOTE: as of April 2025, image windows-2025 only has VS 2022, so no point in testing that image too
           - { os: windows-2022, model: 64 }
           - { os: windows-2022, model: 32 }
-          - { os: windows-2019, model: 64 }
-          - { os: windows-2019, model: 32 }
 
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
Github has removed the windows-2019 runners and all actions using them automatically fail with the message:

Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045