### PR TITLE
introduce root.Array.only and test it out in expressionsem

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -2,7 +2,7 @@
 
 set -uexo pipefail
 
-HOST_DMD_VER=2.095.0 # same as in dmd/src/bootstrap.sh
+HOST_DMD_VER=2.098.0 # same as in dmd/src/bootstrap.sh
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=4
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -2,7 +2,7 @@
 
 set -uexo pipefail
 
-HOST_DMD_VER=2.098.0 # same as in dmd/src/bootstrap.sh
+HOST_DMD_VER=2.095.0 # same as in dmd/src/bootstrap.sh
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=4
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -714,7 +714,7 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, out Expression pe0)
         {
             Expression edim = new IntegerExp(ae.loc, i, Type.tsize_t);
             edim = edim.expressionSemantic(sc);
-            auto tiargs = Objects.only([edim]);
+            auto tiargs = new Objects(edim);
 
             auto fargs = new Expressions(2);
             (*fargs)[0] = ie.lwr;
@@ -3842,7 +3842,7 @@ private void lowerCastExp(CastExp cex, Scope* sc)
     // Unqualify the type being casted to, avoiding multiple instantiations
     auto unqual_tob = tob.unqualify(MODFlags.wild | MODFlags.const_ |
         MODFlags.immutable_ | MODFlags.shared_);
-    auto tiargs = Objects.only([unqual_tob]);
+    auto tiargs = new Objects(unqual_tob);
     lowering = new DotTemplateInstanceExp(cex.loc, lowering, hook, tiargs);
 
     auto arguments = new Expressions();
@@ -4375,7 +4375,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression makeNonTemplateItem(Identifier which) {
             Expression id = new IdentifierExp(e.loc, Id.empty);
             id = new DotIdExp(e.loc, id, Id.object);
-            auto moduleNameArgs = Objects.only([new StringExp(e.loc, "core.interpolation")]);
+            auto moduleNameArgs = new Objects(new StringExp(e.loc, "core.interpolation"));
             id = new DotTemplateInstanceExp(e.loc, id, Id.imported, moduleNameArgs);
             id = new DotIdExp(e.loc, id, which);
             id = new CallExp(e.loc, id, new Expressions());
@@ -4385,13 +4385,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression makeTemplateItem(Identifier which, string arg) {
             Expression id = new IdentifierExp(e.loc, Id.empty);
             id = new DotIdExp(e.loc, id, Id.object);
-            auto moduleNameArgs = Objects.only([new StringExp(e.loc, "core.interpolation")]);
+            auto moduleNameArgs = new Objects(new StringExp(e.loc, "core.interpolation"));
             id = new DotTemplateInstanceExp(e.loc, id, Id.imported, moduleNameArgs);
 
             auto templateStringArg = new StringExp(e.loc, arg);
             // banning those instead of forwarding them
             // templateStringArg.postfix = e.postfix; // forward the postfix to these literals
-            auto tiargs = Objects.only([templateStringArg]);
+            auto tiargs = new Objects(templateStringArg);
             id = new DotTemplateInstanceExp(e.loc, id, which, tiargs);
             id = new CallExp(e.loc, id, new Expressions());
             return id;
@@ -4927,7 +4927,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          */
         auto t = ne.type.nextOf.unqualify(MODFlags.wild | MODFlags.const_ |
             MODFlags.immutable_ | MODFlags.shared_);
-        auto tiargs = Objects.only([t]);
+        auto tiargs = new Objects(t);
         id = new DotTemplateInstanceExp(ne.loc, id, hook, tiargs);
 
         auto arguments = new Expressions();
@@ -5280,7 +5280,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression id = new IdentifierExp(exp.loc, Id.empty);
                 id = new DotIdExp(exp.loc, id, Id.object);
 
-                auto tiargs = Objects.only([exp.newtype]);
+                auto tiargs = new Objects(exp.newtype);
 
                 id = new DotTemplateInstanceExp(exp.loc, id, Id._d_newThrowable, tiargs);
 
@@ -5306,7 +5306,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 id = new DotIdExp(exp.loc, id, Id.object);
 
                 auto t = exp.newtype.unqualify(MODFlags.wild);  // remove `inout`
-                auto tiargs = Objects.only([t]);
+                auto tiargs = new Objects(t);
                 id = new DotTemplateInstanceExp(exp.loc, id, hook, tiargs);
                 auto arguments = new Expressions();
                 id = new CallExp(exp.loc, id, arguments);
@@ -5499,7 +5499,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 const isShared = exp.type.nextOf.isShared();
                 auto t = exp.type.nextOf.unqualify(MODFlags.wild | MODFlags.const_ |
                     MODFlags.immutable_ | MODFlags.shared_);
-                auto tiargs = Objects.only([t]);
+                auto tiargs = new Objects(t);
                 lowering = new DotTemplateInstanceExp(exp.loc, lowering, hook, tiargs);
 
                 auto arguments = new Expressions();
@@ -5528,7 +5528,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 auto unqualTbn = tbn.unqualify(MODFlags.wild | MODFlags.const_ |
                     MODFlags.immutable_ | MODFlags.shared_);
 
-                auto tiargs = Objects.only([exp.type, unqualTbn]);
+                auto tiargs = new Objects(exp.type, unqualTbn);
                 lowering = new DotTemplateInstanceExp(exp.loc, lowering, hook, tiargs);
 
                 auto arguments = new Expressions();
@@ -8126,7 +8126,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression comp = new StringExp(loc, isEqualsCallExpression ? "==" : EXPtoString(exp.e1.op));
                 comp = comp.expressionSemantic(sc);
                 (*es)[0] = comp;
-                tiargs = Objects.only([(*es)[1].type]);
+                tiargs = new Objects((*es)[1].type);
             }
 
             // Format exp.e1 before any additional boolean conversion
@@ -8157,7 +8157,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     (*es)[1] = maybePromoteToTmp(exp.e1);
                 }
 
-                tiargs = Objects.only([(*es)[1].type]);
+                tiargs = new Objects((*es)[1].type);
 
                 // Passing __ctfe to auto ref infers ref and aborts compilation:
                 // "cannot modify compiler-generated variable __ctfe"
@@ -9382,7 +9382,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             Expression id = new IdentifierExp(exp.loc, Id.empty);
                             auto dotid = new DotIdExp(exp.loc, id, Id.object);
 
-                            auto tiargs = Objects.only([tFrom, tTo]);
+                            auto tiargs = new Objects(tFrom, tTo);
                             auto dt = new DotTemplateInstanceExp(exp.loc, dotid, Id.__ArrayCast, tiargs);
 
                             auto arguments = new Expressions();
@@ -12479,7 +12479,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression id = new IdentifierExp(exp.loc, Id.empty);
         id = new DotIdExp(exp.loc, id, Id.object);
 
-        auto tiargs = Objects.only([exp.type]);
+        auto tiargs = new Objects(exp.type);
         id = new DotTemplateInstanceExp(exp.loc, id, hook, tiargs);
         id = new CallExp(exp.loc, id, arguments);
         return id.expressionSemantic(sc);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -712,10 +712,9 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, out Expression pe0)
 
         if (auto ie = e.isIntervalExp())
         {
-            auto tiargs = new Objects();
             Expression edim = new IntegerExp(ae.loc, i, Type.tsize_t);
             edim = edim.expressionSemantic(sc);
-            tiargs.push(edim);
+            auto tiargs = Objects.only([edim]);
 
             auto fargs = new Expressions(2);
             (*fargs)[0] = ie.lwr;
@@ -3840,11 +3839,10 @@ private void lowerCastExp(CastExp cex, Scope* sc)
     Expression lowering = new IdentifierExp(cex.loc, Id.empty);
     lowering = new DotIdExp(cex.loc, lowering, Id.object);
 
-    auto tiargs = new Objects();
     // Unqualify the type being casted to, avoiding multiple instantiations
     auto unqual_tob = tob.unqualify(MODFlags.wild | MODFlags.const_ |
         MODFlags.immutable_ | MODFlags.shared_);
-    tiargs.push(unqual_tob);
+    auto tiargs = Objects.only([unqual_tob]);
     lowering = new DotTemplateInstanceExp(cex.loc, lowering, hook, tiargs);
 
     auto arguments = new Expressions();
@@ -4377,8 +4375,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression makeNonTemplateItem(Identifier which) {
             Expression id = new IdentifierExp(e.loc, Id.empty);
             id = new DotIdExp(e.loc, id, Id.object);
-            auto moduleNameArgs = new Objects();
-            moduleNameArgs.push(new StringExp(e.loc, "core.interpolation"));
+            auto moduleNameArgs = Objects.only([new StringExp(e.loc, "core.interpolation")]);
             id = new DotTemplateInstanceExp(e.loc, id, Id.imported, moduleNameArgs);
             id = new DotIdExp(e.loc, id, which);
             id = new CallExp(e.loc, id, new Expressions());
@@ -4388,14 +4385,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression makeTemplateItem(Identifier which, string arg) {
             Expression id = new IdentifierExp(e.loc, Id.empty);
             id = new DotIdExp(e.loc, id, Id.object);
-            auto moduleNameArgs = new Objects();
-            moduleNameArgs.push(new StringExp(e.loc, "core.interpolation"));
+            auto moduleNameArgs = Objects.only([new StringExp(e.loc, "core.interpolation")]);
             id = new DotTemplateInstanceExp(e.loc, id, Id.imported, moduleNameArgs);
-            auto tiargs = new Objects();
+
             auto templateStringArg = new StringExp(e.loc, arg);
             // banning those instead of forwarding them
             // templateStringArg.postfix = e.postfix; // forward the postfix to these literals
-            tiargs.push(templateStringArg);
+            auto tiargs = Objects.only([templateStringArg]);
             id = new DotTemplateInstanceExp(e.loc, id, which, tiargs);
             id = new CallExp(e.loc, id, new Expressions());
             return id;
@@ -4925,14 +4921,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          */
         Expression id = new IdentifierExp(ne.loc, Id.empty);
         id = new DotIdExp(ne.loc, id, Id.object);
-        auto tiargs = new Objects();
         /*
          * Remove `inout`, `const`, `immutable` and `shared` to reduce the
          * number of generated `_d_newitemT` instances.
          */
         auto t = ne.type.nextOf.unqualify(MODFlags.wild | MODFlags.const_ |
             MODFlags.immutable_ | MODFlags.shared_);
-        tiargs.push(t);
+        auto tiargs = Objects.only([t]);
         id = new DotTemplateInstanceExp(ne.loc, id, hook, tiargs);
 
         auto arguments = new Expressions();
@@ -5285,8 +5280,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression id = new IdentifierExp(exp.loc, Id.empty);
                 id = new DotIdExp(exp.loc, id, Id.object);
 
-                auto tiargs = new Objects();
-                tiargs.push(exp.newtype);
+                auto tiargs = Objects.only([exp.newtype]);
 
                 id = new DotTemplateInstanceExp(exp.loc, id, Id._d_newThrowable, tiargs);
 
@@ -5311,9 +5305,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression id = new IdentifierExp(exp.loc, Id.empty);
                 id = new DotIdExp(exp.loc, id, Id.object);
 
-                auto tiargs = new Objects();
                 auto t = exp.newtype.unqualify(MODFlags.wild);  // remove `inout`
-                tiargs.push(t);
+                auto tiargs = Objects.only([t]);
                 id = new DotTemplateInstanceExp(exp.loc, id, hook, tiargs);
                 auto arguments = new Expressions();
                 id = new CallExp(exp.loc, id, arguments);
@@ -5499,14 +5492,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                  */
                 Expression lowering = new IdentifierExp(exp.loc, Id.empty);
                 lowering = new DotIdExp(exp.loc, lowering, Id.object);
-                auto tiargs = new Objects();
+
                 /* Remove `inout`, `const`, `immutable` and `shared` to reduce
                  * the number of generated `_d_newarrayT` instances.
                  */
                 const isShared = exp.type.nextOf.isShared();
                 auto t = exp.type.nextOf.unqualify(MODFlags.wild | MODFlags.const_ |
                     MODFlags.immutable_ | MODFlags.shared_);
-                tiargs.push(t);
+                auto tiargs = Objects.only([t]);
                 lowering = new DotTemplateInstanceExp(exp.loc, lowering, hook, tiargs);
 
                 auto arguments = new Expressions();
@@ -5535,9 +5528,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 auto unqualTbn = tbn.unqualify(MODFlags.wild | MODFlags.const_ |
                     MODFlags.immutable_ | MODFlags.shared_);
 
-                auto tiargs = new Objects();
-                tiargs.push(exp.type);
-                tiargs.push(unqualTbn);
+                auto tiargs = Objects.only([exp.type, unqualTbn]);
                 lowering = new DotTemplateInstanceExp(exp.loc, lowering, hook, tiargs);
 
                 auto arguments = new Expressions();
@@ -8097,7 +8088,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 isEqualsCallExpression)
             {
                 es = new Expressions(3);
-                tiargs = new Objects(1);
 
                 if (isEqualsCallExpression)
                 {
@@ -8136,7 +8126,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression comp = new StringExp(loc, isEqualsCallExpression ? "==" : EXPtoString(exp.e1.op));
                 comp = comp.expressionSemantic(sc);
                 (*es)[0] = comp;
-                (*tiargs)[0] = (*es)[1].type;
+                tiargs = Objects.only([(*es)[1].type]);
             }
 
             // Format exp.e1 before any additional boolean conversion
@@ -8144,7 +8134,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             else if (op != EXP.andAnd && op != EXP.orOr)
             {
                 es = new Expressions(2);
-                tiargs = new Objects(1);
 
                 if (auto ne = exp.e1.isNotExp())
                 {
@@ -8168,7 +8157,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     (*es)[1] = maybePromoteToTmp(exp.e1);
                 }
 
-                (*tiargs)[0] = (*es)[1].type;
+                tiargs = Objects.only([(*es)[1].type]);
 
                 // Passing __ctfe to auto ref infers ref and aborts compilation:
                 // "cannot modify compiler-generated variable __ctfe"
@@ -9393,9 +9382,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             Expression id = new IdentifierExp(exp.loc, Id.empty);
                             auto dotid = new DotIdExp(exp.loc, id, Id.object);
 
-                            auto tiargs = new Objects();
-                            tiargs.push(tFrom);
-                            tiargs.push(tTo);
+                            auto tiargs = Objects.only([tFrom, tTo]);
                             auto dt = new DotTemplateInstanceExp(exp.loc, dotid, Id.__ArrayCast, tiargs);
 
                             auto arguments = new Expressions();
@@ -12492,8 +12479,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression id = new IdentifierExp(exp.loc, Id.empty);
         id = new DotIdExp(exp.loc, id, Id.object);
 
-        auto tiargs = new Objects();
-        tiargs.push(exp.type);
+        auto tiargs = Objects.only([exp.type]);
         id = new DotTemplateInstanceExp(exp.loc, id, hook, tiargs);
         id = new CallExp(exp.loc, id, arguments);
         return id.expressionSemantic(sc);

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -56,15 +56,15 @@ public:
             mem.xfree(data.ptr);
     }
 
-    static if (is(T == struct) || is(T == class))
+
+    // this is a "dummy" template because of c++ header generation
+    // challenges with wrapping this in static if instead
+    extern(D) this()(T[] elems ...) pure nothrow if (is(T == struct) || is(T == class))
     {
-        extern(D) this(T[] elems ...) pure nothrow
+        this(elems.length);
+        foreach(i; 0 .. elems.length)
         {
-            this(elems.length);
-            foreach(i; 0 .. elems.length)
-            {
-                this[i] = elems[i];
-            }
+            this[i] = elems[i];
         }
     }
 

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -56,9 +56,8 @@ public:
             mem.xfree(data.ptr);
     }
 
-
-    // this is a "dummy" template because of c++ header generation
-    // challenges with wrapping this in static if instead
+    // this is using a template constraint because of ambiguity with this(size_t) when T is
+    // int, and c++ header generation doesn't accept wrapping this in static if
     extern(D) this()(T[] elems ...) pure nothrow if (is(T == struct) || is(T == class))
     {
         this(elems.length);

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -56,13 +56,15 @@ public:
             mem.xfree(data.ptr);
     }
 
-
-    extern(D) this(T[] elems ...) pure nothrow
+    static if (is(T == struct) || is(T == class))
     {
-        this(elems.length);
-        foreach(i; 0 .. elems.length)
+        extern(D) this(T[] elems ...) pure nothrow
         {
-            this[i] = elems[i];
+            this(elems.length);
+            foreach(i; 0 .. elems.length)
+            {
+                this[i] = elems[i];
+            }
         }
     }
 
@@ -1194,12 +1196,9 @@ pure nothrow @nogc @safe unittest
 }
 
 
-/// Test Array.only
+/// Test Array array constructor
 pure nothrow unittest
 {
-    auto ints = new Array!int(1,2,3);
-    assert(equal((*ints)[], [1,2,3]));
-
     //check to make sure that this works with the aliases in arraytypes.d
     import dmd.rootobject;
     alias Objects = Array!RootObject;

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -55,6 +55,18 @@ public:
         if (data.ptr && data.ptr != &smallarray[0])
             mem.xfree(data.ptr);
     }
+
+
+    extern(D) static Array!(T)* only(scope T[] elems) pure nothrow
+    {
+        auto ret = new Array!T(elems.length);
+        foreach(i; 0 .. elems.length)
+        {
+            (*ret)[i] = elems[i];
+        }
+        return ret;
+    }
+
     ///returns elements comma separated in []
     extern(D) const(char)[] toString() const
     {
@@ -1180,4 +1192,23 @@ pure nothrow @nogc @safe unittest
 
     b.popFront();
     assert(b == expected[]);
+}
+
+
+/// Test Array.only
+pure nothrow unittest
+{
+    auto ints = Array!int.only([1,2,3]);
+    assert(equal((*ints)[], [1,2,3]));
+
+    //check to make sure that this works with the aliases in arraytypes.d
+    import dmd.rootobject;
+    alias Objects = Array!RootObject;
+
+    auto ro1 = new RootObject();
+    auto ro2 = new RootObject();
+
+    auto aoo = Objects.only([ro1, ro2]);
+    assert((*aoo)[0] is ro1);
+    assert((*aoo)[1] is ro2);
 }

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -57,14 +57,13 @@ public:
     }
 
 
-    extern(D) static Array!(T)* only(scope T[] elems) pure nothrow
+    extern(D) this(T[] elems ...) pure nothrow
     {
-        auto ret = new Array!T(elems.length);
+        this(elems.length);
         foreach(i; 0 .. elems.length)
         {
-            (*ret)[i] = elems[i];
+            this[i] = elems[i];
         }
-        return ret;
     }
 
     ///returns elements comma separated in []
@@ -1198,7 +1197,7 @@ pure nothrow @nogc @safe unittest
 /// Test Array.only
 pure nothrow unittest
 {
-    auto ints = Array!int.only([1,2,3]);
+    auto ints = new Array!int(1,2,3);
     assert(equal((*ints)[], [1,2,3]));
 
     //check to make sure that this works with the aliases in arraytypes.d
@@ -1208,7 +1207,7 @@ pure nothrow unittest
     auto ro1 = new RootObject();
     auto ro2 = new RootObject();
 
-    auto aoo = Objects.only([ro1, ro2]);
+    auto aoo = new Objects(ro1, ro2);
     assert((*aoo)[0] is ro1);
     assert((*aoo)[1] is ro2);
 }


### PR DESCRIPTION
There's a lot of places where we create an empty array (often new Objects();) and then push 1 or 2 items into it.  

This PR adds a method like phobos's `only` to create these arrays more succinctly

I considered using typesafe variadics, but IIRC we're trying to move away from those so I used a scope slice instead (should it be `return scope`?)

If folks like this I'll grep for `new \w+s\(\)` to find other array creation spots and do similar replacements as I did in expressionsem