### PR TITLE
fix #21523 A template function in an imported module does not inline functions annotated with pragma(inline, true)

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3032,7 +3032,9 @@ private bool functionParameters(Loc loc, Scope* sc,
      */
     if (fd && fd.inlining == PINLINE.always)
     {
-        if (sc._module)
+        if (sc.minst)
+            sc.minst.hasAlwaysInlines = true;
+        else if (sc._module)
             sc._module.hasAlwaysInlines = true;
         if (sc.func)
             sc.func.hasAlwaysInlines = true;


### PR DESCRIPTION
inlining of a template instance must be checked on the module that generates the instance, not the source module.

Not sure how to easily setup a test for inlining. Parsing the output of '-v' is probably not compatible across different backends.