### PR TITLE
fix #21033: Add template `_d_newarrayUTrace`

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8958,6 +8958,8 @@ struct Id final
     static Identifier* _d_newitemTTrace;
     static Identifier* _d_newarrayT;
     static Identifier* _d_newarrayTTrace;
+    static Identifier* _d_newarrayU;
+    static Identifier* _d_newarrayUTrace;
     static Identifier* _d_newarraymTX;
     static Identifier* _d_newarraymTXTrace;
     static Identifier* _d_assert_fail;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -278,6 +278,8 @@ immutable Msgtable[] msgtable =
     { "_d_newitemTTrace" },
     { "_d_newarrayT" },
     { "_d_newarrayTTrace" },
+    { "_d_newarrayU" },
+    { "_d_newarrayUTrace" },
     { "_d_newarraymTX" },
     { "_d_newarraymTXTrace" },
     { "_d_assert_fail" },

--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -468,7 +468,7 @@ unittest
 version (D_ProfileGC)
 {
     /**
-    * TraceGC wrapper around $(REF _d_newitemT, core,lifetime).
+    * TraceGC wrapper around $(REF _d_newarrayT, core,internal.array.construction).
     */
     T[] _d_newarrayTTrace(T)(size_t length, bool isShared, string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
     {
@@ -478,6 +478,22 @@ version (D_ProfileGC)
             mixin(TraceHook!("T", "_d_newarrayT"));
 
             return _d_newarrayT!T(length, isShared);
+        }
+        else
+            assert(0, "Cannot create new array if compiling without support for runtime type information!");
+    }
+
+    /**
+    * TraceGC wrapper around $(REF _d_newarrayU, core,internal.array.construction).
+    */
+    T[] _d_newarrayUTrace(T)(size_t length, bool isShared, string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
+    {
+        version (D_TypeInfo)
+        {
+            import core.internal.array.utils : TraceHook, gcStatsPure, accumulatePure;
+            mixin(TraceHook!("T", "_d_newarrayU"));
+
+            return _d_newarrayUPureNothrow!T(length, isShared);
         }
         else
             assert(0, "Cannot create new array if compiling without support for runtime type information!");

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -4729,6 +4729,7 @@ version (D_ProfileGC)
     public import core.internal.array.concatenation : _d_arraycatnTXTrace;
     public import core.lifetime : _d_newitemTTrace;
     public import core.internal.array.construction : _d_newarrayTTrace;
+    public import core.internal.array.construction : _d_newarrayUTrace;
     public import core.internal.array.construction : _d_newarraymTXTrace;
     public import core.internal.array.capacity: _d_arraysetlengthTTrace;
 }
@@ -4740,6 +4741,7 @@ public import core.internal.array.concatenation : _d_arraycatnTX;
 public import core.internal.array.construction : _d_arrayctor;
 public import core.internal.array.construction : _d_arraysetctor;
 public import core.internal.array.construction : _d_newarrayT;
+public import core.internal.array.construction : _d_newarrayU;
 public import core.internal.array.construction : _d_newarraymTX;
 public import core.internal.array.arrayassign : _d_arrayassign_l;
 public import core.internal.array.arrayassign : _d_arrayassign_r;


### PR DESCRIPTION
PR #15299 added the template `_d_newarrayU`, but not its corresponding trace-GC hook. This commit adds the latter as a wrapper on top of `_d_newarrayUPureNothrow` so `_d_newarrayUTrace` can be called from such contexts