### PR TITLE
Use AA for `cpp_type_info_ptr_sym` cache

### DIFF
--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -273,7 +273,6 @@ public:
     ThreeState isabstract;              // if abstract class
     Baseok baseok;                      // set the progress of base classes resolving
     ObjcClassDeclaration objc;          // Data for a class declaration that is needed for the Objective-C integration
-    Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
     static ClassDeclaration *create(Loc loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);
     const char *toPrettyChars(bool QualifyTypes = false) override;

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -19,7 +19,6 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astenums;
-import dmd.gluelayer;
 import dmd.declaration;
 import dmd.dscope;
 import dmd.dsymbol;
@@ -193,8 +192,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
      * integration.
      */
     ObjcClassDeclaration objc;
-
-    Symbol* cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
     final extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses, Dsymbols* members, bool inObject)
     {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6728,7 +6728,6 @@ public:
     ThreeState isabstract;
     Baseok baseok;
     ObjcClassDeclaration objc;
-    Symbol* cpp_type_info_ptr_sym;
     static ClassDeclaration* create(Loc loc, Identifier* id, Array<BaseClass* >* baseclasses, Array<Dsymbol* >* members, bool inObject);
     const char* toPrettyChars(bool qualifyTypes = false) override;
     ClassDeclaration* syntaxCopy(Dsymbol* s) override;

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -821,23 +821,27 @@ Symbol* toSymbolCpp(ClassDeclaration cd)
 {
     assert(cd.isCPPclass());
 
+    __gshared Symbol*[ClassDeclaration] cache;
+
     /* For the symbol std::exception, the type info is _ZTISt9exception
      */
-    if (!cd.cpp_type_info_ptr_sym)
+    if (auto cpp_type_info_ptr_sym = cd in cache)
     {
-        __gshared Symbol* scpp;
-        if (!scpp)
-            scpp = fake_classsym(Id.cpp_type_info_ptr);
-        Symbol* s = toSymbolX(cd, "_cpp_type_info_ptr", SC.comdat, scpp.Stype, "");
-        s.Sfl = FL.data;
-        s.Sflags |= SFLnodebug;
-        auto dtb = DtBuilder(0);
-        cpp_type_info_ptr_toDt(cd, dtb);
-        s.Sdt = dtb.finish();
-        outdata(s);
-        cd.cpp_type_info_ptr_sym = s;
+        return *cpp_type_info_ptr_sym;
     }
-    return cd.cpp_type_info_ptr_sym;
+
+    __gshared Symbol* scpp;
+    if (!scpp)
+        scpp = fake_classsym(Id.cpp_type_info_ptr);
+    Symbol* s = toSymbolX(cd, "_cpp_type_info_ptr", SC.comdat, scpp.Stype, "");
+    s.Sfl = FL.data;
+    s.Sflags |= SFLnodebug;
+    auto dtb = DtBuilder(0);
+    cpp_type_info_ptr_toDt(cd, dtb);
+    s.Sdt = dtb.finish();
+    outdata(s);
+
+    return cache[cd] = s;
 }
 
 /**********************************


### PR DESCRIPTION
This is used by GDC here https://github.com/D-Programming-GDC/gcc/blob/94fd88f6520d70d28fd7f392fdea644f10d0f703/gcc/d/typeinfo.cc#L1533
So ping @ibuclaw 

This is unused by LDC.

This is part of a wider effort to remove dependance of the frontend on the glue layer so that it can be packageised.
