### PR TITLE
fix #18950 CodeView: debug info for return type of ref return function

### DIFF
--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -1793,7 +1793,7 @@ static if (1)
 
         int filenum = dwarf_line_addfile(filename);
 
-        uint ret_type = dwarf_typidx(sfunc.Stype.Tnext);
+        uint ret_type = dwarf_typidx(sfunc.Stype.Tnext, sfunc);
         if (tybasic(sfunc.Stype.Tnext.Tty) == TYvoid)
             ret_type = 0;
 
@@ -2214,7 +2214,7 @@ static if (1)
 
     /* ======================= Type Index ============================== */
 
-    uint dwarf_typidx(type* t)
+    uint dwarf_typidx(type* t, Symbol* sym = null)
     {
         uint idx = 0;
         uint nextidx;
@@ -2488,6 +2488,10 @@ static if (1)
             case TYnref:
             case TYref:
                 nextidx = dwarf_typidx(t.Tnext);
+                if (!nextidx)
+                {
+                    printf("t = %s, sym = %s\n", t.Tident, sym ? sym.Sident.ptr : "(no sym)");
+                }
                 assert(nextidx);
                 code = DWARFAbbrev.write!(abbrevTypeRef);
                 idx = cast(uint)cast(uint)debug_info.buf.length();

--- a/compiler/src/dmd/toctype.d
+++ b/compiler/src/dmd/toctype.d
@@ -140,7 +140,7 @@ type* Type_toCtype(Type t)
             types[i] = tp;
         }
         type* tret = Type_toCtype(t.next);
-        if (t.isRef)
+        if (t.isRef && tret && tret.Tty != TYvoid) // don't apply ref for `ref void`
             tret = type_allocn(TYnref, tret);
         return type_function(totym(t), types, t.parameterList.varargs == VarArg.variadic, tret);
     }

--- a/compiler/src/dmd/toctype.d
+++ b/compiler/src/dmd/toctype.d
@@ -139,7 +139,10 @@ type* Type_toCtype(Type t)
             }
             types[i] = tp;
         }
-        return type_function(totym(t), types, t.parameterList.varargs == VarArg.variadic, Type_toCtype(t.next));
+        type* tret = Type_toCtype(t.next);
+        if (t.isRef)
+            tret = type_allocn(TYnref, tret);
+        return type_function(totym(t), types, t.parameterList.varargs == VarArg.variadic, tret);
     }
 
     static type* visitDelegate(TypeDelegate t)

--- a/compiler/src/dmd/toctype.d
+++ b/compiler/src/dmd/toctype.d
@@ -140,7 +140,7 @@ type* Type_toCtype(Type t)
             types[i] = tp;
         }
         type* tret = Type_toCtype(t.next);
-        if (t.isRef && tret && tret.Tty != TYvoid) // don't apply ref for `ref void`
+        if (t.isRef && tret && tret.Tty != TYvoid && tret.Tty != TYnoreturn) // skip ref for `ref void` or `ref noreturn`
             tret = type_allocn(TYnref, tret);
         return type_function(totym(t), types, t.parameterList.varargs == VarArg.variadic, tret);
     }

--- a/compiler/test/runnable/testpdb.d
+++ b/compiler/test/runnable/testpdb.d
@@ -620,6 +620,25 @@ void test21382(IDiaSession session, IDiaSymbol globals)
     virtualSym.get_virtual(&virt) == S_OK && virt || assert(false, "testpdb.Dsym21382.virtualFun is virtual");
 }
 
+// https://github.com/dlang/dmd/issues/18950
+int x18950;
+ref int foo18950() { return x18950; }
+
+void test18950(IDiaSession session, IDiaSymbol globals)
+{
+    IDiaSymbol dSym = searchSymbol(globals, "testpdb.foo18950");
+    dSym || assert(false, "testpdb.foo18950 not found");
+
+    IDiaSymbol funcType;
+    dSym.get_type(&funcType) == S_OK || assert(false, "testpdb.foo18950: no type");
+    IDiaSymbol retType;
+    funcType.get_type(&retType) == S_OK || assert(false, "testpdb.foo18950: no return type");
+    DWORD tag;
+    // ref returned as pointer to hidden return value
+    retType.get_symTag(&tag) == S_OK && tag == SymTagEnum.SymTagPointerType
+        || assert(false, "testpdb.foo18950: bad return type");
+}
+
 ///////////////////////////////////////////////
 import core.stdc.stdio;
 import core.stdc.wchar_;


### PR DESCRIPTION
pass "ref" to glue code type

AFAICT it does not affect code generation.