### PR TITLE
Refactor module coverage

### DIFF
--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -156,8 +156,13 @@ enum
 
 alias ClassDeclaration_ = void*;
 alias Declaration_ = void*;
-alias Module_ = void*;
 
+struct ModuleCoverage {
+    const(char)[] chars;
+    size_t numlines;
+    Symbol* cov;
+    uint[] covb;
+}
 /*************************************
  * While constructing a block list, BlockState maintains
  * the global state needed to construct that list.
@@ -174,7 +179,7 @@ struct BlockState
     block* tryblock;            // current enclosing try block
     ClassDeclaration_ classdec;
     Declaration_ member;        // member we're compiling for
-    Module_ _module;            // module we're in
+    ModuleCoverage coverage;    // coverage for module we're in
 }
 
 enum BFL : ushort

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1173,8 +1173,6 @@ extern (C++) final class Module : Package
     }
 
     // Back end
-    Symbol* cov; // private uint[] __coverage;
-    uint[] covb; // bit array of valid code line numbers
     Symbol* sictor; // module order independent constructor
     Symbol* sctor; // module constructor
     Symbol* sdtor; // module destructor

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7232,8 +7232,6 @@ public:
     int32_t imports(Module* m);
     bool isRoot();
     bool isCoreModule(Identifier* ident);
-    Symbol* cov;
-    _d_dynamicArray< uint32_t > covb;
     Symbol* sictor;
     Symbol* sctor;
     Symbol* sdtor;

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -143,8 +143,6 @@ public:
     bool isCoreModule(Identifier *ident);
 
     // Back end
-    Symbol *cov;                // private uint[] __coverage;
-    DArray<unsigned> covb;      // bit array of valid code line numbers
 
     Symbol *sictor;             // module order independent constructor
     Symbol *sctor;              // module constructor

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -166,10 +166,10 @@ extern (D) elem* incUsageElem(ref IRState irs, Loc loc)
 {
     uint linnum = loc.linnum;
 
-    Module m = cast(Module)irs.blx._module;
+    ModuleCoverage m = irs.blx.coverage;
     //printf("m.cov %p linnum %d filename %s srcfile %s numlines %d\n", m.cov, linnum, loc.filename, m.srcfile.toChars(), m.numlines);
     if (!m.cov || !linnum ||
-        strcmp(loc.filename, m.srcfile.toChars()))
+        strcmp(loc.filename, m.chars.ptr))
         return null;
 
     //printf("cov = %p, covb = %p, linnum = %u\n", m.cov, m.covb.ptr, p, linnum);

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -294,7 +294,7 @@ void TypeInfo_toObjFile(Expression e, Loc loc, Type t)
 
 /* ================================================================== */
 
-void toObjFile(Dsymbol ds, bool multiobj)
+void toObjFile(Dsymbol ds, bool multiobj, uint[] covb = null, Symbol* cov = null)
 {
     //printf("toObjFile(%s %s)\n", ds.kind(), ds.toChars());
 
@@ -328,7 +328,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
         override void visit(FuncDeclaration fd)
         {
             // in glue.c
-            FuncDeclaration_toObjFile(fd, multiobj);
+            FuncDeclaration_toObjFile(fd, multiobj, covb, cov);
         }
 
         override void visit(ClassDeclaration cd)


### PR DESCRIPTION
remove a use of `Symbol*` from `dmodule.d`

`cov` and `covb` are unused in [GDC](https://github.com/search?q=repo%3AD-Programming-GDC%2Fgcc+cov+language%3AC%2B%2B+path%3Agcc%2Fd%2F&type=code) and in LDC