### PR TITLE
Cherry pick fix for #21523 to master to fix build errors before merging stable to master

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3027,7 +3027,9 @@ private bool functionParameters(Loc loc, Scope* sc,
      */
     if (fd && fd.inlining == PINLINE.always)
     {
-        if (sc._module)
+        if (sc.minst)
+            sc.minst.hasAlwaysInlines = true;
+        else if (sc._module)
             sc._module.hasAlwaysInlines = true;
         if (sc.func)
             sc.func.hasAlwaysInlines = true;

--- a/compiler/test/compilable/test3004.d
+++ b/compiler/test/compilable/test3004.d
@@ -1,7 +1,7 @@
 // https://issues.dlang.org/show_bug.cgi?id=3004
 /*
 REQUIRED_ARGS: -ignore -v
-TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|import|\(imported|semantic|entry|library|function  object|function  core|\s*$)")
+TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|inline|.*_d_newarrayU|import|\(imported|semantic|entry|library|function  object|function  core|\s*$)")
 TEST_OUTPUT:
 ---
 pragma    GNU_attribute (__error)

--- a/druntime/src/core/checkedint.d
+++ b/druntime/src/core/checkedint.d
@@ -760,7 +760,8 @@ unittest
 pragma(inline, true)
 uint mulu()(uint x, uint y, ref bool overflow)
 {
-    version (D_InlineAsm_X86)         enum useAsm = true;
+    version (DigitalMars)             enum useAsm = false; // cannot inline asm
+    else version (D_InlineAsm_X86)    enum useAsm = true;
     else version (D_InlineAsm_X86_64) enum useAsm = true;
     else                              enum useAsm = false;
 
@@ -813,6 +814,7 @@ unittest
 pragma(inline, true)
 ulong mulu()(ulong x, uint y, ref bool overflow)
 {
+    version (DigitalMars) {} else // cannot inline asm
     version (D_InlineAsm_X86_64)
     {
         if (!__ctfe)
@@ -830,6 +832,7 @@ ulong mulu()(ulong x, uint y, ref bool overflow)
 pragma(inline, true)
 ulong mulu()(ulong x, ulong y, ref bool overflow)
 {
+    version (DigitalMars) {} else // cannot inline asm
     version (D_InlineAsm_X86_64)
     {
         if (!__ctfe)

--- a/druntime/src/core/internal/convert.d
+++ b/druntime/src/core/internal/convert.d
@@ -647,6 +647,7 @@ package template floatSize(T) if (is(T:real) || is(T:ireal))
 @trusted pure nothrow @nogc
 const(ubyte)[] toUbyte(T)(return scope const T[] arr) if (T.sizeof == 1)
 {
+    pragma(inline, true);
     return cast(const(ubyte)[])arr;
 }
 
@@ -687,6 +688,7 @@ const(ubyte)[] toUbyte(T)(const ref scope T val) if (__traits(isIntegral, T) && 
 {
     static if (T.sizeof == 1)
     {
+        pragma(inline, true);
         if (__ctfe)
         {
             ubyte[] result = ctfe_alloc(1);
@@ -722,6 +724,7 @@ const(ubyte)[] toUbyte(T)(const ref scope T val) if (__traits(isIntegral, T) && 
 @trusted pure nothrow @nogc
 const(ubyte)[] toUbyte(T)(const ref scope T val) if (is(T == __vector))
 {
+    pragma(inline, true);
     if (!__ctfe)
         return (cast(const ubyte*) &val)[0 .. T.sizeof];
     else static if (is(typeof(val[0]) : void))
@@ -744,6 +747,7 @@ const(ubyte)[] toUbyte(T)(const ref scope T val) if (is(T == __vector))
 @trusted pure nothrow @nogc
 const(ubyte)[] toUbyte(T)(const ref return scope T val) if (is(T == enum))
 {
+    pragma(inline, true);
     if (__ctfe)
     {
         static if (is(T V == enum)){}
@@ -767,6 +771,7 @@ nothrow pure @safe unittest
 @trusted pure nothrow @nogc
 const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == delegate) || is(T : V*, V) && __traits(getAliasThis, T).length == 0)
 {
+    pragma(inline, true);
     if (__ctfe)
     {
         if (val !is null) assert(0, "Unable to compute byte representation of non-null pointer at compile time");
@@ -781,6 +786,7 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == delegate) || is(T : V*, V
 @trusted pure nothrow @nogc
 const(ubyte)[] toUbyte(T)(const return ref scope T val) if (is(T == struct) || is(T == union))
 {
+    pragma(inline, true);
     if (__ctfe)
     {
         ubyte[] bytes = ctfe_alloc(T.sizeof);

--- a/druntime/src/core/internal/hash.d
+++ b/druntime/src/core/internal/hash.d
@@ -132,6 +132,7 @@ private template canBitwiseHash(T)
 size_t hashOf(T)(auto ref T val, size_t seed = 0)
 if (is(T == enum) && !__traits(isScalar, T))
 {
+    pragma(inline, true);
     static if (is(T EType == enum)) {} //for EType
     return hashOf(cast(EType) val, seed);
 }
@@ -140,6 +141,7 @@ if (is(T == enum) && !__traits(isScalar, T))
 size_t hashOf(T)(scope const auto ref T val, size_t seed = 0)
 if (!is(T == enum) && __traits(isStaticArray, T) && canBitwiseHash!T)
 {
+    pragma(inline, true);
     import core.internal.convert : toUbyte;
     // FIXME:
     // We would like to to do this:
@@ -173,6 +175,7 @@ if (!is(T == enum) && __traits(isStaticArray, T) && canBitwiseHash!T)
 size_t hashOf(T)(auto ref T val, size_t seed = 0)
 if (!is(T == enum) && __traits(isStaticArray, T) && !canBitwiseHash!T)
 {
+    pragma(inline, true);
     // FIXME:
     // We would like to to do this:
     //
@@ -207,10 +210,12 @@ if (is(T == S[], S) && (__traits(isScalar, S) || canBitwiseHash!S)) // excludes 
     else static if (is(typeof(toUbyte(val)) == const(ubyte)[]))
     //ubyteble array (arithmetic types and structs without toHash) CTFE ready for arithmetic types and structs without reference fields
     {
+        pragma(inline, true);
         return bytesHashAlignedBy!ElementType(toUbyte(val), seed);
     }
     else //Other types. CTFE unsupported
     {
+        pragma(inline, true);
         assert(!__ctfe, "unable to compute hash of "~T.stringof~" at compile time");
         return bytesHashAlignedBy!ElementType((cast(const(ubyte)*) val.ptr)[0 .. ElementType.sizeof*val.length], seed);
     }
@@ -258,6 +263,7 @@ size_t hashOf(T)(scope const T val) if (__traits(isScalar, T) && !is(T == __vect
     else static if (is(T EType == enum) && is(typeof(val[0])))
     {
         // Enum type whose base type is vector.
+        pragma(inline, true);
         return hashOf(cast(EType) val);
     }
     else static if (__traits(isIntegral, T))
@@ -293,6 +299,7 @@ size_t hashOf(T)(scope const T val, size_t seed) if (__traits(isScalar, T) && !i
 {
     static if (is(T V : V*))
     {
+        pragma(inline, true);
         if (__ctfe)
         {
             if (val is null) return hashOf(size_t(0), seed);
@@ -303,6 +310,7 @@ size_t hashOf(T)(scope const T val, size_t seed) if (__traits(isScalar, T) && !i
     else static if (is(T EType == enum) && is(typeof(val[0])))
     {
         // Enum type whose base type is vector.
+        pragma(inline, true);
         return hashOf(cast(EType) val, seed);
     }
     else static if (__traits(isIntegral, val) && T.sizeof <= size_t.sizeof)
@@ -379,6 +387,7 @@ if (is(T == __vector)) // excludes enum types
     }
     else
     {
+        pragma(inline, true);
         import core.internal.convert : toUbyte;
         return bytesHashAlignedBy!T(toUbyte(val), seed);
     }
@@ -388,6 +397,7 @@ if (is(T == __vector)) // excludes enum types
 @trusted @nogc nothrow pure
 size_t hashOf(T)(scope const T val) if (!is(T == enum) && is(T : typeof(null)))
 {
+    pragma(inline, true);
     return 0;
 }
 
@@ -395,6 +405,7 @@ size_t hashOf(T)(scope const T val) if (!is(T == enum) && is(T : typeof(null)))
 @trusted @nogc nothrow pure
 size_t hashOf(T)(scope const T val, size_t seed) if (!is(T == enum) && is(T : typeof(null)))
 {
+    pragma(inline, true);
     return hashOf(size_t(0), seed);
 }
 
@@ -572,6 +583,7 @@ if (!is(T == enum) && (is(T == struct) || is(T == union))
 @trusted @nogc nothrow pure
 size_t hashOf(T)(scope const T val, size_t seed = 0) if (!is(T == enum) && is(T == delegate))
 {
+    pragma(inline, true);
     if (__ctfe)
     {
         if (val is null) return hashOf(size_t(0), hashOf(size_t(0), seed));
@@ -586,6 +598,7 @@ size_t hashOf(T)(scope const T val)
 if (!is(T == enum) && (is(T == interface) || is(T == class))
     && canBitwiseHash!T)
 {
+    pragma(inline, true);
     if (__ctfe) if (val is null) return 0;
     return hashOf(cast(const void*) val);
 }
@@ -596,6 +609,7 @@ size_t hashOf(T)(scope const T val, size_t seed)
 if (!is(T == enum) && (is(T == interface) || is(T == class))
     && canBitwiseHash!T)
 {
+    pragma(inline, true);
     if (__ctfe) if (val is null) return hashOf(size_t(0), seed);
     return hashOf(cast(const void*) val, seed);
 }
@@ -664,6 +678,7 @@ size_t hashOf(T)(T aa, size_t seed) if (!is(T == enum) && __traits(isAssociative
 @system pure nothrow @nogc
 size_t bytesHash()(scope const(void)* buf, size_t len, size_t seed)
 {
+    pragma(inline, true);
     return bytesHashAlignedBy!ubyte((cast(const(ubyte)*) buf)[0 .. len], seed);
 }
 
@@ -702,6 +717,7 @@ private alias smallBytesHash = fnv;
 // handle aligned reads, do the conversion here
 private uint get32bits()(scope const(ubyte)* x) @nogc nothrow pure @system
 {
+    pragma(inline, true);
     version (BigEndian)
     {
         return ((cast(uint) x[0]) << 24) | ((cast(uint) x[1]) << 16) | ((cast(uint) x[2]) << 8) | (cast(uint) x[3]);


### PR DESCRIPTION
When merging the fix for #21523 to master honoring `pragma(inline, true)` for templated functions, builds will break because of the inline asm in `core.checkedint.mulu()` introduced in master. The asm prohibits inlining with dmd, but the setup code for the asm is worse than using the generic code anyway.

In anticipation of problems with the merge, disable the asm for dmd.

This PR also adds some pragma(inline,true) to simple wrapper functions during hash calculation to reduce the difference between debug and optimized builds in #21066 .

