### PR TITLE
fix #21549 Compiler crashing on placement new

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -1395,14 +1395,13 @@ elem* toElem(Expression e, ref IRState irs)
                 /* Structs return a ref, which gets automatically dereferenced.
                  * But we want a pointer to the instance.
                  */
-                if (!ne.placement)
-                    ez = el_una(OPaddr, TYnptr, ez);
+                ez = el_una(OPaddr, TYnptr, ez);
             }
             else
             {
                 StructLiteralExp sle = StructLiteralExp.create(ne.loc, sd, ne.arguments, t);
                 ez = toElemStructLit(sle, irs, EXP.construct, ev.Vsym, false);
-                if (tybasic(ez.Ety) == TYstruct && !ne.placement)
+                if (tybasic(ez.Ety) == TYstruct || ne.placement)
                     ez = el_una(OPaddr, TYnptr, ez);
             }
             static if (0)
@@ -1413,13 +1412,6 @@ elem* toElem(Expression e, ref IRState irs)
                 if (ezprefix) { printf("ezprefix:\n"); elem_print(ezprefix); }
                 if (ez) { printf("ez:\n"); elem_print(ez); }
                 printf("\n");
-            }
-
-            if (ne.placement)
-            {
-                ez = el_bin(OPstreq,TYstruct,el_copytree(ev),ez);
-                ez.ET = ev.ET;
-                ez = el_una(OPaddr, TYnptr, ez);
             }
 
             e = el_combine(ex, ey);

--- a/compiler/test/runnable/placenew.d
+++ b/compiler/test/runnable/placenew.d
@@ -133,6 +133,31 @@ void test8()
 }
 
 /*************************************************/
+// https://github.com/dlang/dmd/issues/21549
+
+struct Test9
+{
+    size_t a, b = 3;
+    this(int x)
+	{
+		a = x;
+	}
+}
+
+void new9(ref Test9 p)
+{
+    new(p) Test9(1);
+}
+
+void test9()
+{
+	Test9 t9 = void;
+	new9(t9);
+	assert(t9.a == 1);
+	// assert(t9.b == 3);  // Test9.init not copied yet
+}
+
+/*************************************************/
 
 int main()
 {
@@ -144,6 +169,7 @@ int main()
     test6();
     test7();
     test8();
+    test9();
 
     return 0;
 }


### PR DESCRIPTION
This doesn't address the code generator issue selecting bad registers, but removes the gratuitous copy generated after calling the ctor.

Just poking around here, I don't know why the copy was introduced in the first place. Maybe @WalterBright can explain.