### PR TITLE
Make `Dysmbol.size()` return a `ulong`

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -30,7 +30,6 @@ import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
 import dmd.func;
-import dmd.globals;
 import dmd.hdrgen;
 import dmd.id;
 import dmd.identifier;
@@ -186,7 +185,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         return fields.length - isNested() - (vthis2 !is null);
     }
 
-    override final uinteger_t size(Loc loc)
+    override final ulong size(Loc loc)
     {
         //printf("+AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
         bool ok = determineSize(this, loc);

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -121,7 +121,7 @@ extern (C++) abstract class Declaration : Dsymbol
         return "declaration";
     }
 
-    override final uinteger_t size(Loc loc)
+    override final ulong size(Loc loc)
     {
         assert(type);
         const sz = type.size();

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -104,22 +104,6 @@ void foreachDsymbol(Dsymbols* symbols, scope void delegate(Dsymbol) dg)
     }
 }
 
-
-struct Ungag
-{
-    uint oldgag;
-
-    extern (D) this(uint old) nothrow @safe
-    {
-        this.oldgag = old;
-    }
-
-    extern (C++) ~this() nothrow
-    {
-        global.gag = oldgag;
-    }
-}
-
 struct Visibility
 {
     ///
@@ -684,14 +668,6 @@ extern (C++) class Dsymbol : ASTNode
         if (!parent.toParent())
             return null;
         return parent.isSpeculative();
-    }
-
-    final Ungag ungagSpeculative() const
-    {
-        const oldgag = global.gag;
-        if (global.gag && !isSpeculative() && !toParent2().isFuncDeclaration())
-            global.gag = 0;
-        return Ungag(oldgag);
     }
 
     // kludge for template.isSymbol()

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -34,7 +34,6 @@ import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
 import dmd.func;
-import dmd.globals;
 import dmd.id;
 import dmd.identifier;
 import dmd.init;
@@ -784,7 +783,7 @@ extern (C++) class Dsymbol : ASTNode
      * Returns:
      *  SIZE_INVALID when the size cannot be determined
      */
-    uinteger_t size(Loc loc)
+    ulong size(Loc loc)
     {
         .error(loc, "%s `%s` symbol `%s` has no size", kind, toPrettyChars, toChars());
         return SIZE_INVALID;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -431,6 +431,28 @@ void deferDsymbolSemantic(Scope* sc, Dsymbol s, Scope* scx)
     Module.addDeferredSemantic(s);
 }
 
+struct Ungag
+{
+    uint oldgag;
+
+    extern (D) this(uint old) nothrow @safe
+    {
+        this.oldgag = old;
+    }
+
+    extern (C++) ~this() nothrow
+    {
+        global.gag = oldgag;
+    }
+}
+
+Ungag ungagSpeculative(const Dsymbol s)
+{
+    const oldgag = global.gag;
+    if (global.gag && !s.isSpeculative() && !s.toParent2().isFuncDeclaration())
+        global.gag = 0;
+    return Ungag(oldgag);
+}
 
 private extern(C++) final class DsymbolSemanticVisitor : Visitor
 {

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -53,7 +53,8 @@ import dmd.dinterpret;
 import dmd.dmodule;
 import dmd.dscope;
 import dmd.dsymbol;
-import dmd.dsymbolsem : dsymbolSemantic, checkDeprecated, aliasSemantic, search, search_correct, setScope, importAll, include, hasStaticCtorOrDtor, oneMembers;
+import dmd.dsymbolsem : dsymbolSemantic, checkDeprecated, aliasSemantic, search, search_correct,
+                        setScope, importAll, include, hasStaticCtorOrDtor, oneMembers, ungagSpeculative;
 import dmd.errors;
 import dmd.errorsink;
 import dmd.expression;
@@ -4342,7 +4343,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     if (td._scope)
                     {
                         // Try to fix forward reference. Ungag errors while doing so.
-                        Ungag ungag = td.ungagSpeculative();
+                        auto ungag = td.ungagSpeculative();
                         td.dsymbolSemantic(td._scope);
                     }
                     if (td.semanticRun == PASS.initial)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -503,18 +503,6 @@ enum class DSYM : uint8_t
     cAsmDeclaration = 65u,
 };
 
-struct Ungag final
-{
-    uint32_t oldgag;
-    ~Ungag();
-    Ungag() :
-        oldgag()
-    {
-    }
-};
-
-typedef uint64_t uinteger_t;
-
 struct Visibility final
 {
     enum class Kind : uint8_t
@@ -610,7 +598,6 @@ public:
     TemplateInstance* isInstantiated();
     bool followInstantiationContext(Dsymbol* p1, Dsymbol* p2 = nullptr);
     TemplateInstance* isSpeculative();
-    Ungag ungagSpeculative() const;
     DYNCAST dyncast() const final override;
     virtual Identifier* getIdent();
     virtual const char* toPrettyChars(bool QualifyTypes = false);
@@ -618,7 +605,7 @@ public:
     virtual Dsymbol* toAlias();
     virtual Dsymbol* toAlias2();
     virtual bool overloadInsert(Dsymbol* s);
-    virtual uinteger_t size(Loc loc);
+    virtual uint64_t size(Loc loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration* isThis();
     virtual bool isExport() const;
@@ -2366,6 +2353,8 @@ enum class EXP : uint8_t
 };
 
 typedef uint64_t dinteger_t;
+
+typedef uint64_t uinteger_t;
 
 struct complex_t final
 {
@@ -5735,7 +5724,6 @@ struct ASTCodegen final
     using ScopeDsymbol = ::ScopeDsymbol;
     using SearchOpt = ::SearchOpt;
     using SearchOptFlags = ::SearchOptFlags;
-    using Ungag = ::Ungag;
     using Visibility = ::Visibility;
     using WithScopeSymbol = ::WithScopeSymbol;
     using MATCHpair = ::MATCHpair;
@@ -6395,7 +6383,7 @@ public:
     bool disableNew;
     Sizeok sizeok;
     virtual Scope* newScope(Scope* sc);
-    uinteger_t size(Loc loc) final override;
+    uint64_t size(Loc loc) final override;
     Type* getType() final override;
     bool isDeprecated() const final override;
     bool isNested() const;
@@ -6789,7 +6777,7 @@ private:
     uint8_t bitFields;
 public:
     const char* kind() const override;
-    uinteger_t size(Loc loc) final override;
+    uint64_t size(Loc loc) final override;
     bool isStatic() const;
     LINK resolvedLinkage() const;
     virtual bool isDelete();


### PR DESCRIPTION
instead of a `uinteger_t`. Mangling is not a problem for return types, and this allows up to remove some `import dmd.globals;`