### PR TITLE
don't pretend dmd can inline checkint.mulu, just let each compiler decide

### DIFF
--- a/compiler/test/compilable/warn3882.d
+++ b/compiler/test/compilable/warn3882.d
@@ -76,3 +76,41 @@ void test13899()
     {
     }
 }
+
+import core.checkedint;
+
+// check inlining of checkedint with -wi
+T testCheckedSigned(T)(T x, T y)
+{
+    bool overflow;
+    T z = adds(x, y, overflow);
+    z = subs(z, x, overflow);
+    z = muls(z, x, overflow);
+    z = negs(z, overflow);
+    return z;
+}
+
+T testCheckedUnsigned(T)(T x, T y)
+{
+    bool overflow;
+    T z = addu(x, y, overflow);
+    z = subu(z, x, overflow);
+    z = mulu(z, x, overflow);
+    return z;
+}
+
+void testCkeckedInt()
+{
+    assert(testCheckedSigned!int(3,4) == -12);
+    assert(testCheckedSigned!long(3,4) == -12);
+    static if (is(cent))
+        assert(testCheckedSigned!cent(3,4) == -12);
+
+    bool overflow;
+    assert(mulu(cast(long)3, cast(uint)4, overflow) == 12);
+
+    assert(testCheckedUnsigned!uint(3,4) == 12);
+    assert(testCheckedUnsigned!ulong(3,4) == 12);
+    static if (is(ucent))
+        assert(testCheckedUnsigned!ucent(3,4) == 12);
+}

--- a/druntime/src/core/checkedint.d
+++ b/druntime/src/core/checkedint.d
@@ -757,7 +757,7 @@ unittest
  * Returns:
  *      the product
  */
-pragma(inline, true)
+// pragma(inline, true)
 uint mulu()(uint x, uint y, ref bool overflow)
 {
     version (D_InlineAsm_X86)         enum useAsm = true;
@@ -768,24 +768,17 @@ uint mulu()(uint x, uint y, ref bool overflow)
     {
         if (!__ctfe)
         {
-            version (DigitalMars) // this asm used by dmd only, but it cannot inline it
+            uint r;
+            bool o;
+            asm pure nothrow @nogc @trusted
             {
-                uint mulu_asm(uint x, uint y, ref bool overflow)
-                {
-                    uint r;
-                    bool o;
-                    asm pure nothrow @nogc @trusted
-                    {
-                        mov EAX, x;
-                        mul y;        // EDX:EAX = EAX * y
-                        mov r, EAX;
-                        setc o;
-                    }
-                    overflow |= o;
-                    return r;
-                }
-                return mulu_asm(x, y, overflow);
+                mov EAX, x;
+                mul y;        // EDX:EAX = EAX * y
+                mov r, EAX;
+                setc o;
             }
+            overflow |= o;
+            return r;
         }
     }
 
@@ -834,31 +827,24 @@ ulong mulu()(ulong x, uint y, ref bool overflow)
 }
 
 /// ditto
-pragma(inline, true)
+// pragma(inline, true)
 ulong mulu()(ulong x, ulong y, ref bool overflow)
 {
     version (D_InlineAsm_X86_64)
     {
         if (!__ctfe)
         {
-            version (DigitalMars) // this asm used by dmd only, but it cannot inline it
+            ulong r;
+            bool o;
+            asm pure nothrow @nogc @trusted
             {
-                ulong mulu_asm(ulong x, ulong y, ref bool overflow)
-                {
-                    ulong r;
-                    bool o;
-                    asm pure nothrow @nogc @trusted
-                    {
-                        mov RAX, x;
-                        mul y;        // RDX:RAX = RAX * y
-                        mov r, RAX;
-                        setc o;
-                    }
-                    overflow |= o;
-                    return r;
-                }
-                return mulu_asm(x, y, overflow);
+                mov RAX, x;
+                mul y;        // RDX:RAX = RAX * y
+                mov r, RAX;
+                setc o;
             }
+            overflow |= o;
+            return r;
         }
     }
 


### PR DESCRIPTION
The dmd inliner is just too limited:
- it doesn't like `if (__ctfe)`
- it doesn't like local function
- it doesn't like asm

The previous attempts were not good enough, not sure why they didn't trigger any warnings. This restores the original version of https://github.com/dlang/dmd/pull/21434, but without `pragma(inline, true)`.

