### PR TITLE
fix #21630: `enum` and `alias` ignored on runtime foreach loop variables

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3953,8 +3953,8 @@ private extern(C++) final class IsMemcmpableVisitor : Visitor
         /* We recursively check all variable declaration within the struct.
          * The recursiveness is needed to handle cases like this:
          * struct Test {
-	     *     nothrow:
-	     *     int[] contents;
+         *     nothrow:
+         *     int[] contents;
          * }
          * Here a `StorageClassDeclaration` symbol will be created, which wraps the variable declaration.
          */
@@ -17932,10 +17932,11 @@ void lowerNonArrayAggregate(StaticForeach sfe, Scope* sc)
     Parameters*[3] pparams = [new Parameters(), new Parameters(), new Parameters()];
     foreach (i; 0 .. nvars)
     {
-        foreach (params; pparams)
+        foreach (j, params; pparams)
         {
             auto p = sfe.aggrfe ? (*sfe.aggrfe.parameters)[i] : sfe.rangefe.param;
-            params.push(new Parameter(aloc, p.storageClass, p.type, p.ident, null, null));
+            auto storageClass = j == 2 ? p.storageClass : p.storageClass & ~(STC.manifest | STC.alias_);
+            params.push(new Parameter(aloc, storageClass, p.type, p.ident, null, null));
         }
     }
     Expression[2] res;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1458,6 +1458,16 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
          */
 
         //printf("ForeachRangeStatement::semantic() %p\n", fs);
+
+        if (fs.param.storageClass & STC.manifest)
+        {
+            error(fs.loc, "cannot declare `enum` loop variables for non-unrolled foreach");
+        }
+        if (fs.param.storageClass & STC.alias_)
+        {
+            error(fs.loc, "cannot declare `alias` loop variables for non-unrolled foreach");
+        }
+
         auto loc = fs.loc;
         fs.lwr = fs.lwr.expressionSemantic(sc);
         fs.lwr = resolveProperties(sc, fs.lwr);

--- a/compiler/test/fail_compilation/issue21630.d
+++ b/compiler/test/fail_compilation/issue21630.d
@@ -1,0 +1,18 @@
+/+
+TEST_OUTPUT:
+---
+fail_compilation/issue21630.d(14): Error: cannot declare `enum` loop variables for non-unrolled foreach
+fail_compilation/issue21630.d(15): Error: cannot declare `alias` loop variables for non-unrolled foreach
+fail_compilation/issue21630.d(16): Error: cannot declare `enum` loop variables for non-unrolled foreach
+fail_compilation/issue21630.d(17): Error: cannot declare `alias` loop variables for non-unrolled foreach
+---
++/
+
+void main()
+{
+    enum a = [1, 2, 3];
+    foreach(enum i; a) { } // error
+    foreach(alias i; a) { } // error
+    foreach(enum i; 0 .. 3) {  } // error
+    foreach(alias i; 0 .. 3) {  } // error
+}


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/21630 . (Additionally adds tests for the existing checks in the analysis of `ForeachStatement`.)