### PR TITLE
druntime, musl: Remove unused __USE_FILE_OFFSET64 bindings

### DIFF
--- a/druntime/src/core/sys/posix/dirent.d
+++ b/druntime/src/core/sys/posix/dirent.d
@@ -394,16 +394,14 @@ else version (CRuntime_Musl)
 
     struct DIR
     {
+        // Managed by OS
     }
 
-    static if ( __USE_FILE_OFFSET64 )
+    dirent* readdir(DIR*);
+
+    static if (__USE_LARGEFILE64)
     {
-        dirent* readdir64(DIR*);
-        alias   readdir64 readdir;
-    }
-    else
-    {
-        dirent* readdir(DIR*);
+        alias readdir64 = readdir;
     }
 }
 else version (CRuntime_UClibc)

--- a/druntime/src/core/sys/posix/dlfcn.d
+++ b/druntime/src/core/sys/posix/dlfcn.d
@@ -189,8 +189,7 @@ version (CRuntime_Glibc)
         void* dli_saddr;
     }
 }
-else
-version (CRuntime_Musl)
+else version (CRuntime_Musl)
 {
     enum RTLD_LAZY   = 1;
     enum RTLD_NOW    = 2;
@@ -394,30 +393,6 @@ else version (CRuntime_Bionic)
     void*        dlopen(const scope char*, int);
     void*        dlsym(void*, const scope char*);
 
-    struct Dl_info
-    {
-        const(char)* dli_fname;
-        void*        dli_fbase;
-        const(char)* dli_sname;
-        void*        dli_saddr;
-    }
-}
-else version (CRuntime_Musl)
-{
-    enum {
-        RTLD_LAZY     = 1,
-        RTLD_NOW      = 2,
-        RTLD_NOLOAD   = 4,
-        RTLD_NODELETE = 4096,
-        RTLD_GLOBAL   = 256,
-        RTLD_LOCAL    = 0,
-    }
-    int          dlclose(void*);
-    const(char)* dlerror();
-    void*        dlopen(const scope char*, int);
-    void*        dlsym(void*, const scope char*);
-
-    int dladdr(scope const void *addr, Dl_info *info);
     struct Dl_info
     {
         const(char)* dli_fname;

--- a/druntime/src/core/sys/posix/stdio.d
+++ b/druntime/src/core/sys/posix/stdio.d
@@ -182,33 +182,20 @@ else version (CRuntime_UClibc)
 }
 else version (CRuntime_Musl)
 {
-    static if ( __USE_FILE_OFFSET64 )
+    int   fgetpos(FILE*, fpos_t *);
+    FILE* fopen(const scope char*, const scope char*);
+    FILE* freopen(const scope char*, const scope char*, FILE*);
+    int   fseek(FILE*, c_long, int);
+    int   fsetpos(FILE*, const scope fpos_t*);
+    FILE* tmpfile();
+
+    static if (__USE_LARGEFILE64)
     {
-        int   fgetpos64(FILE*, fpos_t *);
-        alias fgetpos64 fgetpos;
-
-        FILE* fopen64(const scope char*, const scope char*);
-        alias fopen64 fopen;
-
-        FILE* freopen64(const scope char*, const scope char*, FILE*);
-        alias freopen64 freopen;
-
-        int   fseek(FILE*, c_long, int);
-
-        int   fsetpos64(FILE*, const scope fpos_t*);
-        alias fsetpos64 fsetpos;
-
-        FILE* tmpfile64();
-        alias tmpfile64 tmpfile;
-    }
-    else
-    {
-        int   fgetpos(FILE*, fpos_t *);
-        FILE* fopen(const scope char*, const scope char*);
-        FILE* freopen(const scope char*, const scope char*, FILE*);
-        int   fseek(FILE*, c_long, int);
-        int   fsetpos(FILE*, const scope fpos_t*);
-        FILE* tmpfile();
+        alias fgetpos64 = fgetpos;
+        alias fopen64 = fopen;
+        alias freopen64 = freopen;
+        alias fsetpos64 = fsetpos;
+        alias tmpfile64 = tmpfile;
     }
 }
 else version (Solaris)
@@ -320,24 +307,13 @@ else version (CRuntime_Musl)
 {
     enum L_ctermid = 20;
 
-    static if ( __USE_FILE_OFFSET64 )
-    {
-        int   fseeko64(FILE*, off_t, int);
-        alias fseeko64 fseeko;
-    }
-    else
-    {
-        int   fseeko(FILE*, off_t, int);
-    }
+    int   fseeko(FILE*, off_t, int);
+    off_t ftello(FILE*);
 
-    static if ( __USE_FILE_OFFSET64 )
+    static if (__USE_LARGEFILE64)
     {
-        off_t ftello64(FILE*);
-        alias ftello64 ftello;
-    }
-    else
-    {
-        off_t ftello(FILE*);
+        alias fseeko64 = fseeko;
+        alias ftello64 = ftello;
     }
 
     ssize_t getdelim(char**, size_t*, int, FILE*);

--- a/druntime/src/core/sys/posix/stdlib.d
+++ b/druntime/src/core/sys/posix/stdlib.d
@@ -603,17 +603,12 @@ else version (CRuntime_Musl)
     void   srand48(c_long);
     void   srandom(uint);
     int    unlockpt(int);
-
-  static if ( __USE_LARGEFILE64 )
-  {
-    int    mkstemp64(char*);
-    alias  mkstemp64 mkstemp;
-  }
-  else
-  {
     int    mkstemp(char*);
-  }
 
+    static if (__USE_LARGEFILE64)
+    {
+        alias mkstemp64 = mkstemp;
+    }
 }
 else version (Solaris)
 {

--- a/druntime/src/core/sys/posix/sys/mman.d
+++ b/druntime/src/core/sys/posix/sys/mman.d
@@ -293,12 +293,13 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    static if (__USE_LARGEFILE64) void* mmap64(void*, size_t, int, int, int, off_t);
-    static if (__USE_FILE_OFFSET64)
-        alias mmap = mmap64;
-    else
-        void* mmap(void*, size_t, int, int, int, off_t);
+    void* mmap(void*, size_t, int, int, int, off_t);
     int munmap(void*, size_t);
+
+    static if (__USE_LARGEFILE64)
+    {
+        alias mmap64 = mmap;
+    }
 }
 else version (CRuntime_UClibc)
 {

--- a/druntime/src/core/sys/posix/sys/statvfs.d
+++ b/druntime/src/core/sys/posix/sys/statvfs.d
@@ -97,7 +97,7 @@ else version (CRuntime_Musl)
         fsfilcnt_t f_files;
         fsfilcnt_t f_ffree;
         fsfilcnt_t f_favail;
-        static if (true /+__BYTE_ORDER == __LITTLE_ENDIAN+/)
+        version (LittleEndian)
         {
             c_ulong f_fsid;
             byte[2*int.sizeof-c_long.sizeof] __padding;
@@ -133,8 +133,8 @@ else version (CRuntime_Musl)
     int statvfs (const char * file, statvfs_t* buf);
     int fstatvfs (int fildes, statvfs_t *buf);
 
-    alias statvfs statvfs64;
-    alias fstatvfs fstatvfs64;
+    alias statvfs64 = statvfs;
+    alias fstatvfs64 = fstatvfs;
 }
 else version (NetBSD)
 {


### PR DESCRIPTION
As pointed out in #21249, Musl doesn't implement *64 versions of these functions because off_t is always 64 bits. However there are aliases defined if `_USE_LARGEFILE64_SOURCE` is true.