### PR TITLE
druntime, Musl, MIPS_O32: Fix size of stat_t.st_dev

### DIFF
--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -263,8 +263,16 @@ version (linux)
     {
         struct stat_t
         {
-            c_ulong     st_dev;
-            c_long[3]   st_pad1;
+            version (CRuntime_Musl)
+            {
+                dev_t       st_dev;
+                c_long[2]   st_pad1;
+            }
+            else
+            {
+                c_ulong     st_dev;
+                c_long[3]   st_pad1;
+            }
             ino_t       st_ino;
             mode_t      st_mode;
             nlink_t     st_nlink;


### PR DESCRIPTION
The musl definition can be found at
https://git.musl-libc.org/cgit/musl/tree/arch/mips/bits/stat.h?id=8fd5d031876345e42ae3d11cc07b962f8625bc3b