### PR TITLE
 Tweak & add tests for foreach sequence parameter errors

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4340,7 +4340,8 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
     const bool skipCheck = isStatic && needExpansion;
     if (!skipCheck && (dim < 1 || dim > 2))
     {
-        error(fs.loc, "only one (value) or two (key,value) arguments allowed for sequence `foreach`");
+        error(fs.loc, "only one (element) or two (index, element) arguments allowed for sequence `foreach`, not %lu",
+            dim);
         return returnEarly();
     }
 
@@ -4399,10 +4400,11 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
         const bool skip = isStatic && needExpansion;
         if (!skip && dim == 2)
         {
-            // Declare key
+            // Declare index
             if (p.isReference() || p.isLazy())
             {
-                error(fs.loc, "no storage class for key `%s`", p.ident.toChars());
+                error(fs.loc, "invalid storage class `%s` for index `%s`",
+                    stcToString(p.storageClass).ptr, p.ident.toChars());
                 return returnEarly();
             }
 
@@ -4417,7 +4419,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
 
             if (!p.type.isIntegral())
             {
-                error(fs.loc, "foreach: key cannot be of non-integral type `%s`",
+                error(fs.loc, "foreach: index cannot be of non-integral type `%s`",
                          p.type.toChars());
                 return returnEarly();
             }
@@ -4462,7 +4464,8 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
             if (storageClass & (STC.out_ | STC.lazy_) ||
                 storageClass & STC.ref_ && !te)
             {
-                error(fs.loc, "no storage class for value `%s`", ident.toChars());
+                error(fs.loc, "invalid storage class `%s` for element `%s`",
+                    stcToString(p.storageClass).ptr, ident.toChars());
                 return false;
             }
             Declaration var;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4340,8 +4340,8 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
     const bool skipCheck = isStatic && needExpansion;
     if (!skipCheck && (dim < 1 || dim > 2))
     {
-        error(fs.loc, "only one (element) or two (index, element) arguments allowed for sequence `foreach`, not %lu",
-            dim);
+        error(fs.loc, "only one (element) or two (index, element) arguments allowed for sequence `foreach`, not %llu",
+            ulong(dim));
         return returnEarly();
     }
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1011,7 +1011,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     Type tindex = (*fs.parameters)[0].type;
                     if (!tindex.isIntegral())
                     {
-                        error(fs.loc, "foreach: key cannot be of non-integral type `%s`", tindex.toChars());
+                        error(fs.loc, "foreach: index cannot be of non-integral type `%s`", tindex.toChars());
                         return retError();
                     }
                     /* What cases to deprecate implicit conversions for:

--- a/compiler/test/fail_compilation/diag16976.d
+++ b/compiler/test/fail_compilation/diag16976.d
@@ -1,37 +1,37 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/diag16976.d(44): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(45): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(46): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(47): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(48): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(49): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(50): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(51): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(52): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(53): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(54): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(55): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(56): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(57): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(58): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(59): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(44): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(45): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(46): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(47): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(48): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(49): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(50): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(51): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(52): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(53): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(54): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(55): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(56): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(57): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(58): Error: foreach: index cannot be of non-integral type `float`
+fail_compilation/diag16976.d(59): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(65): Error: foreach: index cannot be of non-integral type `float`
-fail_compilation/diag16976.d(66): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(66): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(67): Error: foreach: index cannot be of non-integral type `float`
-fail_compilation/diag16976.d(68): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(68): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(69): Error: foreach: index cannot be of non-integral type `float`
-fail_compilation/diag16976.d(70): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(70): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(71): Error: foreach: index cannot be of non-integral type `float`
-fail_compilation/diag16976.d(72): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(72): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(73): Error: foreach: index cannot be of non-integral type `float`
-fail_compilation/diag16976.d(74): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(74): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(75): Error: foreach: index cannot be of non-integral type `float`
-fail_compilation/diag16976.d(76): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(76): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(77): Error: foreach: index cannot be of non-integral type `float`
-fail_compilation/diag16976.d(78): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(78): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(79): Error: foreach: index cannot be of non-integral type `float`
-fail_compilation/diag16976.d(80): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(80): Error: foreach: index cannot be of non-integral type `float`
 ---
 */
 

--- a/compiler/test/fail_compilation/diag16976.d
+++ b/compiler/test/fail_compilation/diag16976.d
@@ -16,21 +16,21 @@ fail_compilation/diag16976.d(56): Error: foreach: key cannot be of non-integral 
 fail_compilation/diag16976.d(57): Error: foreach: key cannot be of non-integral type `float`
 fail_compilation/diag16976.d(58): Error: foreach: key cannot be of non-integral type `float`
 fail_compilation/diag16976.d(59): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(65): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(65): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(66): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(67): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(67): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(68): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(69): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(69): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(70): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(71): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(71): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(72): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(73): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(73): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(74): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(75): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(75): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(76): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(77): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(77): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(78): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(79): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(79): Error: foreach: index cannot be of non-integral type `float`
 fail_compilation/diag16976.d(80): Error: foreach: key cannot be of non-integral type `float`
 ---
 */

--- a/compiler/test/fail_compilation/foreach_seq.d
+++ b/compiler/test/fail_compilation/foreach_seq.d
@@ -1,0 +1,36 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/foreach_seq.d(23): Error: only one (element) or two (index, element) arguments allowed for sequence `foreach`, not 3
+fail_compilation/foreach_seq.d(24): Error: invalid storage class `ref` for index `i`
+fail_compilation/foreach_seq.d(25): Error: foreach: index cannot be of non-integral type `void`
+fail_compilation/foreach_seq.d(26): Error: index type `bool` cannot cover index range 0..3
+fail_compilation/foreach_seq.d(27): Error: `foreach` loop variable cannot be both `enum` and `alias`
+fail_compilation/foreach_seq.d(28): Error: constant value `1` cannot be `ref`
+fail_compilation/foreach_seq.d(29): Error: invalid storage class `enum` for index `i`
+fail_compilation/foreach_seq.d(31): Error: invalid storage class `ref` for element `e`
+fail_compilation/foreach_seq.d(32): Error: symbol `object` cannot be `ref`
+fail_compilation/foreach_seq.d(34): Error: cannot specify element type for symbol `object`
+---
+*/
+
+// test semantic errors on foreach parameters
+void main()
+{
+    alias AliasSeq(A...) = A;
+    alias seq = AliasSeq!(1, 2, 3);
+
+    foreach (a, b, c; seq) {}
+    foreach (ref i, e; seq) {}
+    foreach (void i, e; seq) {}
+    foreach (bool i, e; seq) {}
+    foreach (enum alias e; seq) {}
+    foreach (ref enum e; seq) {}
+    foreach (ref enum i, e; seq) {}
+
+    foreach (ref e; AliasSeq!int) {}
+    foreach (ref e; AliasSeq!object) {}
+    //foreach (int e; AliasSeq!int) {} // FIXME calls invalid RootObject.toChars
+    foreach (int e; AliasSeq!object) {}
+    foreach (enum e; AliasSeq!int) {} // FIXME should error
+}

--- a/compiler/test/fail_compilation/ice13644.d
+++ b/compiler/test/fail_compilation/ice13644.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice13644.d(22): Error: foreach: key cannot be of non-integral type `string`
+fail_compilation/ice13644.d(22): Error: foreach: index cannot be of non-integral type `string`
 ---
 */
 


### PR DESCRIPTION
Use 'index' not 'key' in messages.
Fix wrong 'no storage class' messages (actually invalid storage). 
Fixes #21642.

Add tests.
Also use 'index' instead of 'key' for foreach array index error for consistency.