### PR TITLE
druntime, posix: Add bindings for POSIX endian.h

### DIFF
--- a/druntime/mak/COPY
+++ b/druntime/mak/COPY
@@ -312,6 +312,7 @@ COPY=\
 	$(IMPDIR)\core\sys\posix\config.d \
 	$(IMPDIR)\core\sys\posix\dirent.d \
 	$(IMPDIR)\core\sys\posix\dlfcn.d \
+	$(IMPDIR)\core\sys\posix\endian.d \
 	$(IMPDIR)\core\sys\posix\fcntl.d \
 	$(IMPDIR)\core\sys\posix\grp.d \
 	$(IMPDIR)\core\sys\posix\iconv.d \

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -307,6 +307,7 @@ SRCS=\
 	src\core\sys\posix\config.d \
 	src\core\sys\posix\dirent.d \
 	src\core\sys\posix\dlfcn.d \
+	src\core\sys\posix\endian.d \
 	src\core\sys\posix\fcntl.d \
 	src\core\sys\posix\grp.d \
 	src\core\sys\posix\iconv.d \

--- a/druntime/src/core/sys/posix/endian.d
+++ b/druntime/src/core/sys/posix/endian.d
@@ -1,0 +1,60 @@
+/**
+ * D header file for POSIX.
+ *
+ * $(LINK2 https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/endian.h.html posix endian.h)
+ *
+ * Standards: The Open Group Base Specifications Issue 8, IEEE Std 1003.1, 2024 Edition
+ */
+module core.sys.posix.endian;
+
+version (Posix):
+nothrow:
+@safe:
+@nogc:
+
+import core.bitop;
+
+enum LITTLE_ENDIAN = 1234;
+enum BIG_ENDIAN = 4321;
+enum PDP_ENDIAN = 3412;
+
+version (LittleEndian)
+{
+    enum BYTE_ORDER = LITTLE_ENDIAN;
+
+    pragma(inline, true):
+    ushort htobe16(ushort x) => core.bitop.byteswap(x);
+    ushort htole16(ushort x) => x;
+    ushort be16toh(ushort x) => core.bitop.byteswap(x);
+    ushort le16toh(ushort x) => x;
+
+    uint htobe32(uint x) => core.bitop.bswap(x);
+    uint htole32(uint x) => x;
+    uint be32toh(uint x) => core.bitop.bswap(x);
+    uint le32toh(uint x) => x;
+
+    ulong htobe64(ulong x) => core.bitop.bswap(x);
+    ulong htole64(ulong x) => x;
+    ulong be64toh(ulong x) => core.bitop.bswap(x);
+    ulong le64toh(ulong x) => x;
+}
+else
+{
+    enum BYTE_ORDER = BIG_ENDIAN;
+
+    pragma(inline, true):
+    ushort htobe16(ushort x) => x;
+    ushort htole16(ushort x) => core.bitop.byteswap(x);
+    ushort be16toh(ushort x) => x;
+    ushort le16toh(ushort x) => core.bitop.byteswap(x);
+
+    uint htobe32(uint x) => x;
+    uint htole32(uint x) => core.bitop.bswap(x);
+    uint be32toh(uint x) => x;
+    uint le32toh(uint x) => core.bitop.bswap(x);
+
+    ulong htobe64(ulong x) => x;
+    ulong htole64(ulong x) => core.bitop.bswap(x);
+    ulong be64toh(ulong x) => x;
+    ulong le64toh(ulong x) => core.bitop.bswap(x);
+}


### PR DESCRIPTION
This is part of the IEEE Std 1003.1 Issue 8

https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/endian.h.html

On a spot check of OS's, amongst Linux, OSX and *BSDs, many already had these in `endian.h` prior to it becoming standard.

Of those which have omissions to the spec:
- OSX 12 doesn't define the `hto*`, `be*`, and `le*` macros
- Solaris 11.4 doesn't have the header at all.

But that doesn't matter as this is meant to be a macro-only header, and the implementation is obvious for all platforms.