### PR TITLE
Fix ICE on foreach type sequence parameter with type

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4575,7 +4575,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
                 var = new AliasDeclaration(loc, ident, t);
                 if (paramtype)
                 {
-                    error(fs.loc, "cannot specify element type for symbol `%s`", fs.toChars());
+                    error(fs.loc, "cannot specify element type for symbol `%s`", ident.toChars());
                     return false;
                 }
             }


### PR DESCRIPTION
Fixes part of #21648.
```d
foreach (int e; AliasSeq!int) {}
```
See #21649 for test file (which is not in stable).