### PR TITLE
[func.d] move `isUnique` to `funcsem.d`

### DIFF
--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -730,7 +730,6 @@ public:
     virtual bool addPreInvariant();
     virtual bool addPostInvariant();
     const char *kind() const override;
-    bool isUnique();
     bool needsClosure();
     bool hasNestedFrameRefs();
     ParameterList getParameterList();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4100,7 +4100,6 @@ public:
     virtual bool addPreInvariant();
     virtual bool addPostInvariant();
     const char* kind() const override;
-    bool isUnique() const;
     bool needsClosure();
     bool hasNestedFrameRefs();
     ParameterList getParameterList();

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -35,7 +35,7 @@ import dmd.dsymbol;
 import dmd.dtemplate;
 import dmd.escape;
 import dmd.expression;
-import dmd.funcsem : overloadApply;
+import dmd.funcsem : isUnique;
 import dmd.globals;
 import dmd.hdrgen;
 import dmd.id;
@@ -831,33 +831,6 @@ extern (C++) class FuncDeclaration : Declaration
     override const(char)* kind() const
     {
         return this.isGenerated ? "generated function" : "function";
-    }
-
-    /********************************************
-     * Returns:
-     *  true if there are no overloads of this function
-     */
-    final bool isUnique() const
-    {
-        bool result = false;
-        overloadApply(cast() this, (Dsymbol s)
-        {
-            auto f = s.isFuncDeclaration();
-            auto td = s.isTemplateDeclaration();
-            if (!f && !td)
-                return 0;
-            if (result)
-            {
-                result = false;
-                return 1; // ambiguous, done
-            }
-            else
-            {
-                result = true;
-                return 0;
-            }
-        });
-        return result;
     }
 
     /*******************************

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -174,6 +174,33 @@ extern (C++) bool onlyOneMain(FuncDeclaration fd)
     return true;
 }
 
+/********************************************
+ * Returns:
+ *  true if there are no overloads of this function
+ */
+bool isUnique(const FuncDeclaration fd)
+{
+    bool result = false;
+    overloadApply(cast() fd, (Dsymbol s)
+    {
+        auto f = s.isFuncDeclaration();
+        auto td = s.isTemplateDeclaration();
+        if (!f && !td)
+            return 0;
+        if (result)
+        {
+            result = false;
+            return 1; // ambiguous, done
+        }
+        else
+        {
+            result = true;
+            return 0;
+        }
+    });
+    return result;
+}
+
 /**********************************
  * Main semantic routine for functions.
  */


### PR DESCRIPTION
`isUnique` is still used by `equals`