### PR TITLE
fix #21660 - Error overlapping initialization for D bit-fields

### DIFF
--- a/compiler/test/fail_compilation/fail21660.d
+++ b/compiler/test/fail_compilation/fail21660.d
@@ -1,0 +1,57 @@
+// REQUIRED_ARGS: -preview=bitfields
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21660.d(29): Error: overlapping initialization for field `b` and `c`
+fail_compilation/fail21660.d(29):        `struct` initializers that contain anonymous unions must initialize only the first member of a `union`. All subsequent non-overlapping fields are default initialized
+fail_compilation/fail21660.d(30): Error: overlapping initialization for field `b` and `c`
+fail_compilation/fail21660.d(30):        `struct` initializers that contain anonymous unions must initialize only the first member of a `union`. All subsequent non-overlapping fields are default initialized
+fail_compilation/fail21660.d(52): Error: overlapping initialization for field `a` and `b`
+fail_compilation/fail21660.d(52): Error: overlapping initialization for field `a` and `d`
+fail_compilation/fail21660.d(52): Error: overlapping initialization for field `c` and `d`
+fail_compilation/fail21660.d(54): Error: overlapping initialization for field `a` and `d`
+---
+*/
+
+struct S
+{
+    uint a : 1;
+    union {
+        uint b : 2;
+        struct {
+            uint c : 3;
+        }
+    }
+}
+
+void testS()
+{
+    S s = S(1, 2, 3);       // b + c overlap
+    S t = S(a:1, b:2, c:3); // b + c overlap
+    S u = S(a:1, c:3);      // ok
+}
+
+union U
+{
+    union {
+        uint a : 5;
+        uint b : 4;
+    }
+    struct {
+        uint : 5;
+        uint c : 11;
+    }
+    struct {
+        uint : 4;
+        uint d : 12;
+    }
+}
+
+void testU()
+{
+    U s = U(1, 2, 3, 4); // a + b, a + d, c + d overlap
+    U t = U(a:1, c:3);   // ok
+    U u = U(a:1, d:2);   // a + d overlap
+    U v = U(b:1, c:3);   // ok
+    U w = U(b:1, d:2);   // ok
+}

--- a/compiler/test/runnable/test21660.d
+++ b/compiler/test/runnable/test21660.d
@@ -1,0 +1,31 @@
+// REQUIRED_ARGS: -preview=bitfields
+struct S
+{
+    int a : 3;
+    int b : 3;
+}
+
+struct T
+{
+    uint a : 1;
+    union {
+        uint b : 2;
+        struct {
+            uint : 2;
+            uint c : 3;
+        }
+    }
+}
+
+void main()
+{
+    S s = S(1, 2);
+    assert(s.a == 1 && s.b == 2);
+    S t = S(b:1, a:2);
+    assert(t.a == 2 && t.b == 1);
+
+    T u = T(1, 2, 3);
+    assert(u.a == 1 && u.b == 2 && u.c == 3);
+    T v = T(a:1, b:2, c:3);
+    assert(v.a == 1 && v.b == 2 && v.c == 3);
+}


### PR DESCRIPTION
The check for overlapping field initializers in dmd.expressionsem.fit was still comparing byte offsets of fields.