### PR TITLE
fix #21663 - Bit-fields missing from DWARF debug info

### DIFF
--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -2845,6 +2845,7 @@ static if (1)
                     switch (sf.Sclass)
                     {
                         case SC.member:
+                        case SC.field:
                             fieldidx.write32(dwarf_typidx(sf.Stype));
                             nfields++;
                             break;
@@ -2896,6 +2897,16 @@ static if (1)
                         DW_AT_data_member_location, DW_FORM_block1
                     ]);
 
+                    uint bitfieldcode;
+                    if (st.Sflags & STRbitfields)
+                        bitfieldcode = DWARFAbbrev.write!([
+                            DW_TAG_member,         DW_CHILDREN_no,
+                            DW_AT_name,            DW_FORM_string,
+                            DW_AT_type,            DW_FORM_ref4,
+                            DW_AT_bit_size,        DW_FORM_data1,
+                            DW_AT_data_bit_offset, DW_FORM_data8
+                        ]);
+
                     uint baseclasscode;
                     if (st.Sbase)
                         baseclasscode = DWARFAbbrev.write!([
@@ -2941,13 +2952,23 @@ static if (1)
                                 debug_info.buf.writeStringz(getSymName(sf));      // DW_AT_name
                                 //debug_info.buf.write32(dwarf_typidx(sf.Stype));
                                 uint fi = (cast(uint*)fieldidx.buf)[n];
-                                debug_info.buf.write32(fi);
+                                debug_info.buf.write32(fi);                       // DW_AT_type
                                 n++;
                                 soffset = debug_info.buf.length();
-                                debug_info.buf.writeByte(2);
+                                debug_info.buf.writeByte(2);                      // DW_AT_data_member_location
                                 debug_info.buf.writeByte(DW_OP_plus_uconst);
                                 debug_info.buf.writeuLEB128(cast(uint)sf.Smemoff);
                                 debug_info.buf.buf[soffset] = cast(ubyte)(debug_info.buf.length() - soffset - 1);
+                                break;
+
+                            case SC.field:
+                                debug_info.buf.writeuLEB128(bitfieldcode);
+                                debug_info.buf.writeStringz(getSymName(sf));      // DW_AT_name
+                                uint fi = (cast(uint*)fieldidx.buf)[n];
+                                debug_info.buf.write32(fi);                       // DW_AT_type
+                                n++;
+                                debug_info.buf.writeByte(sf.Swidth);              // DW_AT_bit_size
+                                debug_info.buf.write64(sf.Smemoff * 8 + sf.Sbit); // DW_AT_data_bit_offset
                                 break;
 
                             default:

--- a/compiler/src/dmd/toctype.d
+++ b/compiler/src/dmd/toctype.d
@@ -272,13 +272,27 @@ type* Type_toCtype(Type t)
             {
                 foreach (v; t.sym.fields)
                 {
-                    symbol_struct_addField(*cast(Symbol*)tc.Ttag, v.ident.toChars(), Type_toCtype(v.type), v.offset);
+                    if (auto bf = v.isBitFieldDeclaration())
+                        symbol_struct_addBitField(*cast(Symbol*)tc.Ttag, v.ident.toChars(), Type_toCtype(v.type), v.offset, bf.fieldWidth, bf.bitOffset);
+                    else
+                        symbol_struct_addField(*cast(Symbol*)tc.Ttag, v.ident.toChars(), Type_toCtype(v.type), v.offset);
                 }
                 if (auto bc = t.sym.baseClass)
                 {
                     auto ptr_to_basetype = Type_toCtype(bc.type);
                     assert(ptr_to_basetype .Tty == TYnptr);
                     symbol_struct_addBaseClass(*cast(Symbol*)tc.Ttag, ptr_to_basetype.Tnext, 0);
+                }
+            }
+            else
+            {
+                foreach (v; t.sym.fields)
+                {
+                    if (auto bf = v.isBitFieldDeclaration())
+                    {
+                        symbol_struct_hasBitFields(*cast(Symbol*)tc.Ttag);
+                        break;
+                    }
                 }
             }
 

--- a/compiler/test/dshell/extra-files/dwarf/excepted_results/fix21663.txt
+++ b/compiler/test/dshell/extra-files/dwarf/excepted_results/fix21663.txt
@@ -1,0 +1,20 @@
+DW_AT_name        : a1
+DW_AT_bit_size    : 6
+DW_AT_data_bit_offset: 0x20
+DW_AT_name        : b1
+DW_AT_bit_size    : 7
+DW_AT_data_bit_offset: 0x26
+DW_AT_name        : c1
+DW_AT_bit_size    : 14
+DW_AT_data_bit_offset: 0x2d
+DW_AT_name        : d1
+DW_AT_bit_size    : 5
+DW_AT_data_bit_offset: 0x3b
+DW_AT_name        : a2
+DW_AT_bit_size    : 31
+DW_AT_name        : b2
+DW_AT_bit_size    : 1
+DW_AT_name        : c2
+DW_AT_bit_size    : 19
+DW_AT_name        : d2
+DW_AT_bit_size    : 13

--- a/compiler/test/dshell/extra-files/dwarf/fix21663.d
+++ b/compiler/test/dshell/extra-files/dwarf/fix21663.d
@@ -1,0 +1,24 @@
+/*
+EXTRA_ARGS: -preview=bitfields -main
+*/
+struct S
+{
+    uint first;
+    uint a1 : 6;
+    uint b1 : 7;
+    uint c1 : 14;
+    uint d1 : 5;
+    uint last;
+}
+S s;
+
+class C
+{
+    uint first;
+    uint a2 : 31;
+    uint b2 : 1;
+    uint c2 : 19;
+    uint d2 : 13;
+    uint last;
+}
+C c;


### PR DESCRIPTION
Bit-fields require the use of the DW_AT_data_bit_offset and DW_AT_bit_size attributes to tell the debugger which exact position in the class, struct, or union to find the bit value.