### PR TITLE
fix #21665: Incorrect CodeView debug info for bitfields

### DIFF
--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -915,7 +915,7 @@ idx_t cv4_struct(Classsym* s,int flags)
                 }
                 else
                 {   db = debtyp_alloc(8);
-                    TOWORD(db.data.ptr,LF_BITFIELD);
+                    TOWORD(db.data.ptr,LF_BITFIELD_V2);
                     db.data.ptr[6] = sf.Swidth;
                     db.data.ptr[7] = sf.Sbit;
                     TOLONG(db.data.ptr + 2,cv4_symtypidx(sf));

--- a/compiler/src/dmd/tocvdebug.d
+++ b/compiler/src/dmd/tocvdebug.d
@@ -1146,6 +1146,26 @@ private extern (C++) class CVMember : Visitor
         else
         {
             idx_t typidx = cv_typidx(Type_toCtype(vd.type));
+            if (auto bfd = vd.isBitFieldDeclaration())
+            {
+                debtyp_t* db;
+                if (config.fulltypes == CV4)
+                {
+                    db = debtyp_alloc(6);
+                    TOWORD(db.data.ptr, LF_BITFIELD);
+                    db.data.ptr[2] = cast(ubyte) bfd.fieldWidth;
+                    db.data.ptr[3] = cast(ubyte) bfd.bitOffset;
+                    TOWORD(db.data.ptr + 4, typidx);
+                }
+                else
+                {   db = debtyp_alloc(8);
+                    TOWORD(db.data.ptr, LF_BITFIELD_V2);
+                    db.data.ptr[6] = cast(ubyte) bfd.fieldWidth;
+                    db.data.ptr[7] = cast(ubyte) bfd.bitOffset;
+                    TOLONG(db.data.ptr + 2, typidx);
+                }
+                typidx = cv_debtyp(db);
+            }
             uint attribute = visibilityToCVAttr(vd.visible().kind);
             assert((attribute & ~3) == 0);
             switch (config.fulltypes)

--- a/compiler/test/runnable/testpdb.d
+++ b/compiler/test/runnable/testpdb.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -gf -mixin=${RESULTS_DIR}/runnable/testpdb.mixin
+// REQUIRED_ARGS: -gf -mixin=${RESULTS_DIR}/runnable/testpdb.mixin -preview=bitfields
 // PERMUTE_ARGS:
 
 import core.time;
@@ -57,6 +57,8 @@ void main(string[] args)
         test18147(session, globals);
 
         test21382(session, globals);
+
+        test21665(session, globals);
 
         source.Release();
         session.Release();
@@ -637,6 +639,43 @@ void test18950(IDiaSession session, IDiaSymbol globals)
     // ref returned as pointer to hidden return value
     retType.get_symTag(&tag) == S_OK && tag == SymTagEnum.SymTagPointerType
         || assert(false, "testpdb.foo18950: bad return type");
+}
+
+// https://github.com/dlang/dmd/issues/21665
+struct S21665
+{
+    int itg;
+    int a:3;
+    uint b:6;
+}
+void test21665(IDiaSession session, IDiaSymbol globals)
+{
+    IDiaSymbol dSym = searchSymbol(globals, "testpdb.S21665");
+    dSym || assert(false, "testpdb.S21665 not found");
+
+    void checkBitField(string name, uint pos, uint len)()
+    {
+        IDiaSymbol aMember = searchSymbol(dSym, name);
+        string fqn = "testpdb.S21665." ~ name;
+        aMember || assert(false, fqn ~ " not found");
+
+        DWORD loc;
+        LONG off;
+        DWORD bitPos;
+        ULONGLONG bitLen;
+
+        aMember.get_locationType(&loc) == S_OK || assert(false, fqn ~ ": no location type");
+        loc == LocationType.LocIsBitField || assert(false, fqn ~ ": not a bitfield");
+
+        aMember.get_offset(&off) == S_OK || assert(false, fqn ~ ": no offset");
+        off == 4 || assert(false, fqn ~ ": not at offset 4");
+        aMember.get_bitPosition(&bitPos) == S_OK || assert(false, fqn ~ ": no bit position");
+        bitPos == pos || assert(false, fqn ~ ": not at bit position " ~ pos.stringof);
+        aMember.get_length(&bitLen) == S_OK || assert(false, fqn ~ ": no bit length");
+        bitLen == len || assert(false, fqn ~ ": not bit length " ~ len.stringof);
+    }
+    checkBitField!("a", 0, 3);
+    checkBitField!("b", 3, 6);
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
add LF_BITFIELD entries

Verified in WinDbg, The VS extension mago needs additional support.