### PR TITLE
rename bit-field to bitfield in comments and strings

### DIFF
--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -868,7 +868,7 @@ FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
         // workaround https://issues.dlang.org/show_bug.cgi?id=17968
         "    static if(is(T* : const(.object.Object)*)) " ~
         "        h = h * 33 + typeid(const(.object.Object)).getHash(cast(const void*)&p.tupleof[i]);" ~
-        // and another workaround for bit-fields https://github.com/dlang/dmd/issues/20473
+        // and another workaround for bitfields https://github.com/dlang/dmd/issues/20473
         "    else static if (!__traits(compiles, &p.tupleof[i])) {" ~
         "        auto t = p.tupleof[i];" ~
         "        h = h * 33 + typeid(T).getHash(cast(const void*)&t);" ~

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1010,7 +1010,7 @@ extern (C++) class VarDeclaration : Declaration
         auto bitoffset  =   offset * 8;
         auto vbitoffset = v.offset * 8;
 
-        // Bitsize of types are overridden by any bit-field widths.
+        // Bitsize of types are overridden by any bitfield widths.
         ulong tbitsize;
         if (auto bf = isBitFieldDeclaration())
         {

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1640,7 +1640,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (!dsym.parent.isStructDeclaration() && !dsym.parent.isClassDeclaration())
         {
-            .error(dsym.loc, "%s `%s` - bit-field must be member of struct, union, or class", dsym.kind, dsym.toPrettyChars);
+            .error(dsym.loc, "%s `%s` - bitfield must be member of struct, union, or class", dsym.kind, dsym.toPrettyChars);
         }
 
         sc = sc.startCTFE();
@@ -1650,18 +1650,18 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!dsym.type.isIntegral())
         {
             // C11 6.7.2.1-5
-            error(width.loc, "bit-field type `%s` is not an integer type", dsym.type.toChars());
+            error(width.loc, "bitfield type `%s` is not an integer type", dsym.type.toChars());
             dsym.errors = true;
         }
         if (!width.isIntegerExp())
         {
-            error(width.loc, "bit-field width `%s` is not an integer constant", dsym.width.toChars());
+            error(width.loc, "bitfield width `%s` is not an integer constant", dsym.width.toChars());
             dsym.errors = true;
         }
         const uwidth = width.toInteger(); // uwidth is unsigned
         if (uwidth == 0 && !dsym.isAnonymous())
         {
-            error(width.loc, "bit-field `%s` has zero width", dsym.toChars());
+            error(width.loc, "bitfield `%s` has zero width", dsym.toChars());
             dsym.errors = true;
         }
         const sz = dsym.type.size();
@@ -1670,7 +1670,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         const max_width = sz * 8;
         if (uwidth > max_width)
         {
-            error(width.loc, "width `%lld` of bit-field `%s` does not fit in type `%s`", cast(long)uwidth, dsym.toChars(), dsym.type.toChars());
+            error(width.loc, "width `%lld` of bitfield `%s` does not fit in type `%s`", cast(long)uwidth, dsym.toChars(), dsym.type.toChars());
             dsym.errors = true;
         }
         dsym.fieldWidth = cast(uint)uwidth;
@@ -3376,7 +3376,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
 
             //
-            // For two structures or unions, corresponding bit-fields shall have the same widths.
+            // For two structures or unions, corresponding bitfields shall have the same widths.
             //
             BitFieldDeclaration bfa = a_field.isBitFieldDeclaration();
             BitFieldDeclaration bfb = b_field.isBitFieldDeclaration();
@@ -7852,7 +7852,7 @@ private extern(C++) class SetFieldOffsetVisitor : Visitor
 
         const style = target.c.bitFieldStyle;
         if (style != TargetC.BitFieldStyle.MS && style != TargetC.BitFieldStyle.Gcc_Clang)
-            assert(0, "unsupported bit-field style");
+            assert(0, "unsupported bitfield style");
 
         const isMicrosoftStyle = style == TargetC.BitFieldStyle.MS;
         const contributesToAggregateAlignment = target.c.contributesToAggregateAlignment(bfd);
@@ -7922,7 +7922,7 @@ private extern(C++) class SetFieldOffsetVisitor : Visitor
         }
         else if (!isMicrosoftStyle)
         {
-            // If the bit-field spans more units of alignment than its type
+            // If the bitfield spans more units of alignment than its type
             // and is at the alignment boundary, start a new field at the
             // next alignment boundary. This affects when offsetof reports
             // a higher number and bitoffsetof starts at zero again.

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -16610,11 +16610,11 @@ bool checkAddressable(Expression e, Scope* sc)
         {
             case EXP.dotVariable:
                 // https://issues.dlang.org/show_bug.cgi?id=22749
-                // Error about taking address of any bit-field, regardless of
+                // Error about taking address of any bitfield, regardless of
                 // whether SCOPE.Cfile is set.
                 if (auto bf = ex.isDotVarExp().var.isBitFieldDeclaration())
                 {
-                    error(e.loc, "cannot take address of bit-field `%s`", bf.toChars());
+                    error(e.loc, "cannot take address of bitfield `%s`", bf.toChars());
                     return false;
                 }
                 goto case EXP.cast_;
@@ -16849,7 +16849,7 @@ private bool fit(StructDeclaration sd, Loc loc, Scope* sc, Expressions* elements
         const vsize = v.type.size();
         if (vsize == SIZE_INVALID)
             return false;
-        // Bitsize of types are overridden by any bit-field widths.
+        // Bitsize of types are overridden by any bitfield widths.
         if (vbf)
             bitoffset = vbitoffset + vbf.fieldWidth;
         else

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4789,9 +4789,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 if (width)
                 {
                     if (_init)
-                        error("initializer not allowed for bit-field declaration");
+                        error("initializer not allowed for bitfield declaration");
                     if (storage_class)
-                        error("storage class not allowed for bit-field declaration");
+                        error("storage class not allowed for bitfield declaration");
                     s = new AST.BitFieldDeclaration(width.loc, t, ident, width);
                 }
                 else

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -1465,10 +1465,10 @@ struct TargetC
     }
 
     /**
-     * Indicates whether the specified bit-field contributes to the alignment
+     * Indicates whether the specified bitfield contributes to the alignment
      * of the containing aggregate.
      * E.g., (not all) ARM ABIs do NOT ignore anonymous (incl. 0-length)
-     * bit-fields.
+     * bitfields.
      */
     extern (C++) bool contributesToAggregateAlignment(BitFieldDeclaration bfd)
     {

--- a/compiler/test/fail_compilation/biterrors.d
+++ b/compiler/test/fail_compilation/biterrors.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -preview=bitfields
  * TEST_OUTPUT:
 ---
-fail_compilation/biterrors.d(103): Error: initializer not allowed for bit-field declaration
-fail_compilation/biterrors.d(104): Error: storage class not allowed for bit-field declaration
+fail_compilation/biterrors.d(103): Error: initializer not allowed for bitfield declaration
+fail_compilation/biterrors.d(104): Error: storage class not allowed for bitfield declaration
 ---
  */
 

--- a/compiler/test/fail_compilation/biterrors2.d
+++ b/compiler/test/fail_compilation/biterrors2.d
@@ -1,9 +1,9 @@
 /* REQUIRED_ARGS: -preview=bitfields
  * TEST_OUTPUT:
 ---
-fail_compilation/biterrors2.d(100): Error: variable `biterrors2.a` - bit-field must be member of struct, union, or class
-fail_compilation/biterrors2.d(104): Error: bit-field `b` has zero width
-fail_compilation/biterrors2.d(105): Error: bit-field type `float` is not an integer type
+fail_compilation/biterrors2.d(100): Error: variable `biterrors2.a` - bitfield must be member of struct, union, or class
+fail_compilation/biterrors2.d(104): Error: bitfield `b` has zero width
+fail_compilation/biterrors2.d(105): Error: bitfield type `float` is not an integer type
 ---
 */
 

--- a/compiler/test/fail_compilation/biterrors3.d
+++ b/compiler/test/fail_compilation/biterrors3.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=bitfields
  * TEST_OUTPUT:
 ---
-fail_compilation/biterrors3.d(103): Error: storage class not allowed for bit-field declaration
+fail_compilation/biterrors3.d(103): Error: storage class not allowed for bitfield declaration
 fail_compilation/biterrors3.d(106): Error: expected `,` or `=` after identifier, not `:`
 fail_compilation/biterrors3.d(106): Error: found `:` when expecting `,`
 fail_compilation/biterrors3.d(106): Error: found `3` when expecting `identifier`

--- a/compiler/test/fail_compilation/biterrors4.d
+++ b/compiler/test/fail_compilation/biterrors4.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=bitfields
  * TEST_OUTPUT:
 ---
-fail_compilation/biterrors4.d(109): Error: cannot take address of bit-field `a`
+fail_compilation/biterrors4.d(109): Error: cannot take address of bitfield `a`
 ---
 */
 

--- a/compiler/test/fail_compilation/biterrors5.d
+++ b/compiler/test/fail_compilation/biterrors5.d
@@ -3,8 +3,8 @@
 ---
 fail_compilation/biterrors5.d(25): Error: bitfield symbol expected not struct `biterrors5.S`
 fail_compilation/biterrors5.d(26): Error: bitfield symbol expected not variable `biterrors5.test0.i`
-fail_compilation/biterrors5.d(35): Error: cannot take address of bit-field `x`
-fail_compilation/biterrors5.d(35): Error: cannot take address of bit-field `y`
+fail_compilation/biterrors5.d(35): Error: cannot take address of bitfield `x`
+fail_compilation/biterrors5.d(35): Error: cannot take address of bitfield `y`
 ---
 */
 

--- a/compiler/test/fail_compilation/bitfields2.c
+++ b/compiler/test/fail_compilation/bitfields2.c
@@ -1,9 +1,9 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/bitfields2.c(103): Error: bit-field type `float` is not an integer type
-fail_compilation/bitfields2.c(104): Error: bit-field width `3.0` is not an integer constant
-fail_compilation/bitfields2.c(105): Error: bit-field `c` has zero width
-fail_compilation/bitfields2.c(106): Error: width `60` of bit-field `d` does not fit in type `int`
+fail_compilation/bitfields2.c(103): Error: bitfield type `float` is not an integer type
+fail_compilation/bitfields2.c(104): Error: bitfield width `3.0` is not an integer constant
+fail_compilation/bitfields2.c(105): Error: bitfield `c` has zero width
+fail_compilation/bitfields2.c(106): Error: width `60` of bitfield `d` does not fit in type `int`
 ---
  */
 

--- a/compiler/test/fail_compilation/fail22749.d
+++ b/compiler/test/fail_compilation/fail22749.d
@@ -1,7 +1,7 @@
 // EXTRA_FILES: imports/imp22749.c
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail22749.d(12): Error: cannot take address of bit-field `field`
+fail_compilation/fail22749.d(12): Error: cannot take address of bitfield `field`
 ---
 */
 import imports.imp22749;

--- a/compiler/test/fail_compilation/failcstuff2.c
+++ b/compiler/test/fail_compilation/failcstuff2.c
@@ -30,7 +30,7 @@ fail_compilation/failcstuff2.c(362): Error: cannot index through register variab
 fail_compilation/failcstuff2.c(373): Error: cannot take address of register variable `reg4`
 fail_compilation/failcstuff2.c(374): Error: cannot take address of register variable `reg4`
 fail_compilation/failcstuff2.c(375): Error: cannot take address of register variable `reg4`
-fail_compilation/failcstuff2.c(376): Error: cannot take address of bit-field `b`
+fail_compilation/failcstuff2.c(376): Error: cannot take address of bitfield `b`
 fail_compilation/failcstuff2.c(377): Error: cannot index through register variable `reg4`
 fail_compilation/failcstuff2.c(378): Error: cannot index through register variable `reg4`
 fail_compilation/failcstuff2.c(381): Error: cannot take address of register variable `reg5`

--- a/compiler/test/fail_compilation/failcstuff5.c
+++ b/compiler/test/fail_compilation/failcstuff5.c
@@ -3,7 +3,7 @@
 ---
 fail_compilation/failcstuff5.c(404): Error: undefined identifier `p1`
 fail_compilation/failcstuff5.c(404): Error: undefined identifier `p2`
-fail_compilation/failcstuff5.c(458): Error: cannot take address of bit-field `field`
+fail_compilation/failcstuff5.c(458): Error: cannot take address of bitfield `field`
 ---
 */
 


### PR DESCRIPTION
While the C Standard calls them "bit-fields", the D specification calls them "bitfields". The source code randomly uses "bit-field" or "bitfield".

"bitfield" has the advantage of it being usable as an identifier.

So, for consistency I changed the "bit-field"s to "bitfield".