### PR TITLE
Fixed the Pre-Generate command used to build dmd with dub

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -54,7 +54,7 @@ subPackage {
 
   # generate files `generated/dub/{VERSION,SYSCONFDIR.imp}` for string-imports
   # by building & running the config.d tool
-  preGenerateCommands `"$DUB_EXE" "--compiler=$DC" --single "${DMD_PACKAGE_DIR}/config.d" -- "${DMD_PACKAGE_DIR}/generated/dub" "${DMD_PACKAGE_DIR}/VERSION" /etc`
+  preGenerateCommands `"$DUB_EXE" "--compiler=$DC" --single "${PACKAGE_DIR}/config.d" -- "${PACKAGE_DIR}/generated/dub" "${PACKAGE_DIR}/VERSION" /etc`
 
   stringImportPaths \
     "compiler/src/dmd/res" \

--- a/dub.sdl
+++ b/dub.sdl
@@ -54,7 +54,7 @@ subPackage {
 
   # generate files `generated/dub/{VERSION,SYSCONFDIR.imp}` for string-imports
   # by building & running the config.d tool
-  preGenerateCommands `"$DUB_EXE" "--compiler=$DC" --single "${DUB_PACKAGE_DIR}config.d" -- "${DUB_PACKAGE_DIR}generated/dub" "${DUB_PACKAGE_DIR}VERSION" /etc`
+  preGenerateCommands `"$DUB_EXE" "--compiler=$DC" --single "${DMD_PACKAGE_DIR}/config.d" -- "${DMD_PACKAGE_DIR}/generated/dub" "${DMD_PACKAGE_DIR}/VERSION" /etc`
 
   stringImportPaths \
     "compiler/src/dmd/res" \


### PR DESCRIPTION
Previously, the Pre-Generate command would search for `config.d` inside the dub folder, instead of the DMD folder where the file is actually located; this made it impossible to actually use the compiler via dub (see issue #21519). My changes use Dub's pre-defined environment variables, and the changes make it so that the package builds on my system (and there's no reason why it shouldn't work on others).