### PR TITLE
Deprecate `ref` for range foreach parameter

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1315,7 +1315,7 @@ private const(char)[] processSource (const(ubyte)[] src, Module mod)
         dbuf.reserve(eBuf.length);
 
         //i will be incremented in the loop for high codepoints
-        foreach (ref i; 0 .. eBuf.length)
+        for (size_t i = 0; i < eBuf.length; i++)
         {
             uint u = readNext(&eBuf[i]);
             if (u & ~0x7F)

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1542,6 +1542,19 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             return setError();
         }
 
+        // a struct is allowed to be `ref` to prevent destructor calls or
+        // non-copyable structs.
+        // See test/runnable/foreach5.d: test6659, test6652.
+        if (fs.param.storageClass & STC.ref_ && !fs.param.type.isTypeStruct())
+        {
+            // @@@DEPRECATED_2.121@@@
+            // turn deprecation into an error & uncomment return
+            deprecation(fs.loc, "`foreach` range variable `%s` cannot be `ref`",
+                fs.param.toChars());
+            deprecationSupplemental(fs.loc, "use a `for` loop instead");
+            //return setError();
+        }
+
         /* Convert to a for loop:
          *  foreach (key; lwr .. upr) =>
          *  for (auto key = lwr, auto tmp = upr; key < tmp; ++key)

--- a/compiler/test/compilable/interpret3.d
+++ b/compiler/test/compilable/interpret3.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/interpret3.d(6351): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
+compilable/interpret3.d(5308): Deprecation: `foreach` range variable `i` cannot be `ref`
+compilable/interpret3.d(5308):        use a `for` loop instead
+compilable/interpret3.d(6353): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
 ---
 */
 

--- a/compiler/test/compilable/test4090.d
+++ b/compiler/test/compilable/test4090.d
@@ -200,19 +200,7 @@ void test4090c()
     foreach (    const int x; 1..11) static assert(is(typeof(x) == const int));
     foreach (immutable int x; 1..11) static assert(is(typeof(x) == immutable int));
 
-    foreach (          ref x; 1..11) static assert(is(typeof(x) == int));
-    foreach (    const ref x; 1..11) static assert(is(typeof(x) == const int));
-  static assert(!__traits(compiles, {
-    foreach (immutable ref x; 1..11) {}
-  }));
-
     foreach (          double x; 1..11) static assert(is(typeof(x) == double));
     foreach (    const double x; 1..11) static assert(is(typeof(x) == const double));
     foreach (immutable double x; 1..11) static assert(is(typeof(x) == immutable double));
-
-    foreach (          ref double x; 1..11) static assert(is(typeof(x) == double));
-    foreach (    const ref double x; 1..11) static assert(is(typeof(x) == const double));
-  static assert(!__traits(compiles, {
-    foreach (immutable ref double x; 1..11) {}
-  }));
 }

--- a/compiler/test/fail_compilation/diag10221.d
+++ b/compiler/test/fail_compilation/diag10221.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10221.d(10): Error: cannot implicitly convert expression `256` of type `int` to `ubyte`
+fail_compilation/diag10221.d(10): Error: cannot implicitly convert expression `257` of type `int` to `ubyte`
 ---
 */
 
 void main()
 {
-    foreach(ref ubyte i; 0..256) {}
+    foreach(ubyte i; 0..257) {}
 }

--- a/compiler/test/fail_compilation/fail6652.d
+++ b/compiler/test/fail_compilation/fail6652.d
@@ -1,15 +1,14 @@
-// PERMUTE_ARGS: -w -dw -de -d
-
-/******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=6652
 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6652.d(20): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(25): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(30): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(35): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(19): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(22): Deprecation: `foreach` range variable `i` cannot be `ref`
+fail_compilation/fail6652.d(22):        use a `for` loop instead
+fail_compilation/fail6652.d(24): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(29): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(34): Error: cannot modify `const` expression `i`
 ---
 */
 

--- a/compiler/test/runnable/foreach5.d
+++ b/compiler/test/runnable/foreach5.d
@@ -233,7 +233,7 @@ void test4090b()
   static assert(!__traits(compiles, {
     foreach (immutable ref x; 1..11) {}
   }));
-    foreach (const ref x; 1..11)
+    foreach (const x; 1..11)
     {
         static assert(is(typeof(x) == const int));
         tot += x;
@@ -528,19 +528,9 @@ void test6652()
     assert(sum == 45);
 
     sum = 0;
-    foreach (ref i; 0 .. 10)
-        sum += i++; // 02468
-    assert(sum == 20);
-
-    sum = 0;
     foreach_reverse (i; 0 .. 10)
         sum += i--; // 9876543210
     assert(sum == 45);
-
-    sum = 0;
-    foreach_reverse (ref i; 0 .. 10)
-        sum += i--; // 97531
-    assert(sum == 25);
 
     enum ary = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     sum = 0;

--- a/compiler/test/runnable/test_cdstrpar.d
+++ b/compiler/test/runnable/test_cdstrpar.d
@@ -193,7 +193,7 @@ alias baselineCases = AliasSeq!(
 bool matches(const(ubyte)[] code, const(ubyte)[] exp)
 {
     assert(code.length == exp.length);
-    foreach (ref i; 0 .. code.length)
+    for (size_t i = 0; i < code.length; i++)
     {
         if (code[i] == exp[i])
             continue;


### PR DESCRIPTION
(Split out from #16381).

Fixes #18231.

Except allow a struct parameter to be `ref`:
* To avoid destructor call on each iteration (part of `runnable/foreach5.d` tests).
* This is needed for non-copyable structs, which can't be iterated by value. This is mentioned in [DIP1022](https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1022.md#rationale) (though the DIP seems to contradict itself about what to allow).