### PR TITLE
Increase timeouts for FreeBSD on GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,14 +191,14 @@ jobs:
             host_dmd: dmd-2.095.0
     name: ${{ matrix.job_name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # Should complete in 11 minutes
+    timeout-minutes: 20  # Should complete in 11 minutes
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: Run in VM
         uses: cross-platform-actions/action@v0.23.0
-        timeout-minutes: 14
+        timeout-minutes: 19
         with:
           operating_system: freebsd
           hypervisor: qemu


### PR DESCRIPTION
@rikkimax suggests that increasing the timeout values of our FreeBSD tests on GitHub Actions a bit might be helpful in some cases. Unlike with Phobos (where CI gets stuck at the same location about all the time), the timeout-induced cancellation is said to occur in different places here.

<https://discord.com/channels/242094594181955585/811702037532115015/1403382709438386196>