### PR TITLE
fix #21679 - ImportC: Handle C code tokens in gcc-style iasm

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1474,7 +1474,7 @@ final class CParser(AST) : Parser!AST
      *    logical-OR-expression
      *    logical-OR-expression ? expression : conditional-expression
      */
-    private AST.Expression cparseCondExp()
+    AST.Expression cparseCondExp()
     {
         const loc = token.loc;
 


### PR DESCRIPTION
Constructs either a Parser or CParser depending on whether the current scope is inCfile, and adds a private wrapper around parsing assignment, conditional, and primary expressions so that the correct D or ImportC version is called.

Closes: #21679