### PR TITLE
importC: add asm flags for inline and volatile qualifiers

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -655,8 +655,10 @@ final class CParser(AST) : Parser!AST
         case TOK.asm_:
             switch (peekNext())
             {
+                case TOK.const_:
                 case TOK.goto_:
                 case TOK.inline:
+                case TOK.restrict:
                 case TOK.volatile:
                 case TOK.leftParenthesis:
                     s = cparseGnuAsm();
@@ -3490,19 +3492,51 @@ final class CParser(AST) : Parser!AST
 
         nextToken();
 
-        // Consume all asm-qualifiers. As a future optimization, we could record
-        // the `inline` and `volatile` storage classes against the statement.
-        while (token.value == TOK.goto_ ||
-               token.value == TOK.inline ||
-               token.value == TOK.volatile)
-            nextToken();
+        // Consume all asm-qualifiers.
+        enum AsmQualifiers { none = 0, goto_ = 1, inline = 2, volatile = 4, }
+        AsmQualifiers asmQualifiers;
+        while (1)
+        {
+            AsmQualifiers qual;
+            switch (token.value)
+            {
+                case TOK.goto_:
+                    qual = AsmQualifiers.goto_;
+                    goto Lcontinue;
+
+                case TOK.inline:
+                    qual = AsmQualifiers.inline;
+                    goto Lcontinue;
+
+                case TOK.volatile:
+                    qual = AsmQualifiers.volatile;
+                    goto Lcontinue;
+
+                Lcontinue:
+                    if (asmQualifiers & qual)
+                        error(token.loc, "duplicate `asm` qualifier `%s`", token.toChars());
+                    else
+                        asmQualifiers |= qual;
+                    nextToken();
+                    continue;
+
+                case TOK.const_:
+                case TOK.restrict:
+                    error(token.loc, "`%s` is not a valid `asm` qualifier", token.toChars());
+                    nextToken();
+                    continue;
+
+                default:
+                    break;
+            }
+            break;
+        }
 
         check(TOK.leftParenthesis);
         if (token.value != TOK.string_)
             error("string literal expected for Assembler Template, not `%s`", token.toChars());
         Token* toklist = null;
         Token** ptoklist = &toklist;
-        //Identifier label = null;
         auto statements = new AST.Statements();
 
         int parens;
@@ -3540,7 +3574,11 @@ final class CParser(AST) : Parser!AST
             if (toklist)
             {
                 // Create AsmStatement from list of tokens we've saved
-                AST.Statement s = new AST.AsmStatement(token.loc, toklist);
+                auto s = new AST.AsmStatement(token.loc, toklist);
+                if (asmQualifiers & AsmQualifiers.volatile)
+                    s.isVolatile = true;
+                if (asmQualifiers & AsmQualifiers.inline)
+                    s.isInline = true;
                 statements.push(s);
             }
             break;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5059,7 +5059,33 @@ class AsmStatement : public Statement
 {
 public:
     Token* tokens;
-    bool caseSensitive;
+    struct BitFields final
+    {
+        bool caseSensitive;
+        bool isVolatile;
+        bool isInline;
+        BitFields() :
+            caseSensitive(),
+            isVolatile(),
+            isInline()
+        {
+        }
+        BitFields(bool caseSensitive, bool isVolatile = false, bool isInline = false) :
+            caseSensitive(caseSensitive),
+            isVolatile(isVolatile),
+            isInline(isInline)
+            {}
+    };
+
+    bool caseSensitive() const;
+    bool caseSensitive(bool v);
+    bool isVolatile() const;
+    bool isVolatile(bool v);
+    bool isInline() const;
+    bool isInline(bool v);
+private:
+    uint8_t bitFields;
+public:
     AsmStatement* syntaxCopy() override;
     void accept(Visitor* v) override;
 };

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1740,7 +1740,14 @@ extern (C++) final class LabelDsymbol : Dsymbol
 extern (C++) class AsmStatement : Statement
 {
     Token* tokens;       // linked list of tokens for one instruction or pseudo op
+    static struct BitFields
+    {
     bool caseSensitive;  // for register names, and only turned on when doing MASM style inline asm
+    bool isVolatile;     // ImportC asm "volatile"
+    bool isInline;       // ImportC asm "inline"
+    }
+    import dmd.common.bitfields;
+    mixin(generateBitFields!(BitFields, ubyte));
 
     extern (D) this(Loc loc, Token* tokens) @safe
     {

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -715,7 +715,15 @@ class AsmStatement : public Statement
 {
 public:
     Token *tokens;
-    d_bool caseSensitive;  // for register names
+private:
+    uint8_t bitFields;
+public:
+    bool caseSensitive() const; // for register names
+    bool caseSensitive(bool v);
+    bool isVolatile() const;    // importC asm volatile
+    bool isVolatile(bool v);
+    bool isInline() const;      // importC asm inline
+    bool isInline(bool v);
 
     AsmStatement *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/test/compilable/gccasm2.c
+++ b/compiler/test/compilable/gccasm2.c
@@ -1,0 +1,23 @@
+void test1()
+{
+    asm goto ("");
+    asm inline ("");
+    asm volatile ("");
+}
+
+void test2()
+{
+    asm volatile goto ("");
+    asm volatile inline ("");
+    asm inline volatile ("");
+    asm inline goto ("");
+    asm goto volatile ("");
+    asm goto inline ("");
+
+    asm volatile inline goto ("");
+    asm volatile goto inline ("");
+    asm inline volatile goto ("");
+    asm inline goto volatile ("");
+    asm goto volatile inline ("");
+    asm goto inline volatile ("");
+}

--- a/compiler/test/fail_compilation/gccasm2.c
+++ b/compiler/test/fail_compilation/gccasm2.c
@@ -1,0 +1,53 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/gccasm2.c(27): Error: `const` is not a valid `asm` qualifier
+fail_compilation/gccasm2.c(28): Error: `restrict` is not a valid `asm` qualifier
+fail_compilation/gccasm2.c(33): Error: duplicate `asm` qualifier `volatile`
+fail_compilation/gccasm2.c(34): Error: duplicate `asm` qualifier `volatile`
+fail_compilation/gccasm2.c(35): Error: duplicate `asm` qualifier `volatile`
+fail_compilation/gccasm2.c(36): Error: duplicate `asm` qualifier `goto`
+fail_compilation/gccasm2.c(37): Error: duplicate `asm` qualifier `goto`
+fail_compilation/gccasm2.c(38): Error: duplicate `asm` qualifier `goto`
+fail_compilation/gccasm2.c(40): Error: duplicate `asm` qualifier `volatile`
+fail_compilation/gccasm2.c(41): Error: duplicate `asm` qualifier `volatile`
+fail_compilation/gccasm2.c(42): Error: duplicate `asm` qualifier `volatile`
+fail_compilation/gccasm2.c(43): Error: duplicate `asm` qualifier `inline`
+fail_compilation/gccasm2.c(44): Error: duplicate `asm` qualifier `inline`
+fail_compilation/gccasm2.c(45): Error: duplicate `asm` qualifier `inline`
+fail_compilation/gccasm2.c(47): Error: duplicate `asm` qualifier `inline`
+fail_compilation/gccasm2.c(48): Error: duplicate `asm` qualifier `inline`
+fail_compilation/gccasm2.c(49): Error: duplicate `asm` qualifier `inline`
+fail_compilation/gccasm2.c(50): Error: duplicate `asm` qualifier `goto`
+fail_compilation/gccasm2.c(51): Error: duplicate `asm` qualifier `goto`
+fail_compilation/gccasm2.c(52): Error: duplicate `asm` qualifier `goto`
+---
+ */
+void test1()
+{
+    asm const ("");
+    asm restrict ("");
+}
+
+void test2()
+{
+    asm goto volatile volatile ("");
+    asm volatile goto volatile ("");
+    asm volatile volatile goto ("");
+    asm goto goto volatile ("");
+    asm goto volatile goto ("");
+    asm volatile goto goto ("");
+
+    asm inline volatile volatile ("");
+    asm volatile inline volatile ("");
+    asm volatile volatile inline ("");
+    asm inline inline volatile ("");
+    asm inline volatile inline ("");
+    asm volatile inline inline ("");
+
+    asm goto inline inline ("");
+    asm inline goto inline ("");
+    asm inline inline goto ("");
+    asm goto goto inline ("");
+    asm goto inline goto ("");
+    asm inline goto goto ("");
+}


### PR DESCRIPTION
This is information that can be used by GDC and LDC to give hints to their respective backends. These have been added to AsmStatement as bitfields, so the size of the type does not change.

Added errors for duplicate qualifiers, and included const and restrict in the list of C keywords to take the cparseGnuAsm path, so that errors specific to D code do not get reported when parsing C files.