### PR TITLE
fix #20114 AA in operator does not work with static if

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -21,6 +21,7 @@ import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astenums;
 import dmd.ast_node;
+import dmd.ctfeexpr : isCtfeReferenceValid;
 import dmd.dcast : implicitConvTo;
 import dmd.dclass;
 import dmd.declaration;
@@ -3427,6 +3428,13 @@ extern (C++) final class AddrExp : UnaExp
     {
         this(loc, e);
         type = t;
+    }
+
+    override Optional!bool toBool()
+    {
+        if (isCtfeReferenceValid(e1))
+            return typeof(return)(true);
+        return UnaExp.toBool();
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -852,6 +852,7 @@ public:
 class AddrExp final : public UnaExp
 {
 public:
+    Optional<bool> toBool() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2589,6 +2589,7 @@ public:
 class AddrExp final : public UnaExp
 {
 public:
+    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/test/compilable/interpret4.d
+++ b/compiler/test/compilable/interpret4.d
@@ -29,3 +29,20 @@ static if (__traits(compiles, int4))
     enum int4 F = D * E;
     static assert(F.array == [1, 4, 9, 16]);
 }
+
+// https://github.com/dlang/dmd/issues/20114
+
+int* find(int[] arr, int needle)
+{
+	foreach(ref a; arr)
+		if(a == needle)
+			return &a;
+	return null;
+}
+
+enum int[int] aa = [0: 0];
+enum int[] da = [0, 1, 2];
+static assert(0 in aa);
+static assert(&da[1]);
+static assert(find(da, 1));
+static assert(!find(da, 3));


### PR DESCRIPTION
allow conversion of AddrExp to true if it refers to a CTFE object or value

dynamic arrays affected as well (as any entity that can be taken the address of).