### PR TITLE
fix #18018 goto across assignment to AA fails and reports false Error

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -565,20 +565,15 @@ private Expression extractOpDollarSideEffect(Scope* sc, UnaExp ue)
     // https://issues.dlang.org/show_bug.cgi?id=12585
     // Extract the side effect part if ue.e1 is comma.
 
-    if (sc.ctfe ? hasSideEffect(e1) : !isTrivialExp(e1)) // match logic in extractSideEffect()
-    {
-        /* Even if opDollar is needed, 'e1' should be evaluate only once. So
-         * Rewrite:
-         *      e1.opIndex( ... use of $ ... )
-         *      e1.opSlice( ... use of $ ... )
-         * as:
-         *      (ref __dop = e1, __dop).opIndex( ... __dop.opDollar ...)
-         *      (ref __dop = e1, __dop).opSlice( ... __dop.opDollar ...)
-         */
-        e1 = extractSideEffect(sc, "__dop", e0, e1, false);
-        assert(e1.isVarExp());
-        e1.isVarExp().var.storage_class |= STC.exptemp;     // lifetime limited to expression
-    }
+    /* Even if opDollar is needed, 'e1' should be evaluate only once. So
+        * Rewrite:
+        *      e1.opIndex( ... use of $ ... )
+        *      e1.opSlice( ... use of $ ... )
+        * as:
+        *      (ref __dop = e1, __dop).opIndex( ... __dop.opDollar ...)
+        *      (ref __dop = e1, __dop).opSlice( ... __dop.opDollar ...)
+        */
+    e1 = extractSideEffect(sc, "__dop", e0, e1, false);
     ue.e1 = e1;
     return e0;
 }
@@ -12308,14 +12303,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                      * for expressions like `a ~= a[$-1]`. Here, $ will be modified
                      * by calling `_d_arrayappendcTX`, so we need to save `a[$-1]` in
                      * a temporary variable.
+                     * `__appendtmp*` will be destroyed together with the array `exp.e1`.
                      */
-                    value2 = extractSideEffect(sc, "__appendtmp", eValue2, value2, true);
-
-                    // `__appendtmp*` will be destroyed together with the array `exp.e1`.
-                    auto vd = eValue2.isDeclarationExp().declaration.isVarDeclaration();
-                    vd.storage_class |= STC.nodtor;
-                    // Be more explicit that this "declaration" is local to the expression
-                    vd.storage_class |= STC.exptemp;
+                    value2 = extractSideEffect(sc, "__appendtmp", eValue2, value2, true, STC.nodtor | STC.exptemp);
                 }
 
                 auto ale = new ArrayLengthExp(exp.loc, value1);

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -391,6 +391,7 @@ VarDeclaration copyToTemp(STC stc, const char[] name, Expression e)
  *  e0 = a new side effect part will be appended to it.
  *  e = original expression
  *  alwaysCopy = if true, build new temporary variable even if e is trivial.
+ *  stc = storage class flags to add to new temporary variable
  * Returns:
  *  When e is trivial and alwaysCopy == false, e itself is returned.
  *  Otherwise, a new VarExp is returned.
@@ -398,7 +399,7 @@ VarDeclaration copyToTemp(STC stc, const char[] name, Expression e)
  *  e's lvalue-ness will be handled well by STC.ref_ or STC.rvalue.
  */
 Expression extractSideEffect(Scope* sc, const char[] name,
-    ref Expression e0, Expression e, bool alwaysCopy = false)
+    ref Expression e0, Expression e, bool alwaysCopy = false, STC stc = STC.exptemp)
 {
     //printf("extractSideEffect(e: %s)\n", e.toChars());
 
@@ -412,8 +413,8 @@ Expression extractSideEffect(Scope* sc, const char[] name,
         (sc.ctfe ? !hasSideEffect(e) : isTrivialExp(e)))
         return e;
 
-    auto vd = copyToTemp(STC.none, name, e);
-    vd.storage_class |= e.isLvalue() ? STC.ref_ : STC.rvalue;
+    stc |= (e.isLvalue() ? STC.ref_ : STC.rvalue);
+    auto vd = copyToTemp(stc, name, e);
 
     e0 = Expression.combine(e0, new DeclarationExp(vd.loc, vd)
                                 .expressionSemantic(sc));

--- a/compiler/test/compilable/testgotoskips.d
+++ b/compiler/test/compilable/testgotoskips.d
@@ -15,3 +15,13 @@ class A {
                 return;
         }
 }
+
+// https://github.com/dlang/dmd/issues/18018
+int main ()
+{
+   string[string] aa;
+   goto A;               // line 4
+   aa["X"] = "Y";        // line 5
+A:
+   return 0;
+}


### PR DESCRIPTION
default extractSideEffect() to set STC.exptemp on new temporary

AFAICT it isn't used otherwise anyway.