### PR TITLE
fix #21690 ICE when statically initializing a multidimensional AA

### DIFF
--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -852,7 +852,11 @@ private extern(C++) final class StaticAAVisitor : SemanticTimeTransitiveVisitor
             expressionSemantic(aaExp, sc);
         assert(aaExp.lowering);
         if (!(storage_class & STC.manifest)) // manifest constants create runtime copies
-            aaExp.loweringCtfe = aaExp.lowering.ctfeInterpret();
+            if (!aaExp.loweringCtfe)
+            {
+                aaExp.loweringCtfe = aaExp.lowering.ctfeInterpret();
+                aaExp.loweringCtfe.accept(this); // lower AAs in keys and values
+            }
         semanticTypeInfo(sc, aaExp.lowering.type);
     }
 

--- a/compiler/test/runnable/staticaa.d
+++ b/compiler/test/runnable/staticaa.d
@@ -206,6 +206,18 @@ void testClassLiteral()
 
 /////////////////////////////////////////////
 
+// https://github.com/dlang/dmd/issues/21690
+void testMultiDim()
+{
+    // int[int][int] aa1 = [ 1: [2: 3] ]; // Error: invalid value `[2:3]` in initializer (see #17804)
+    int[int][int] aa2 = ([ 1: [2: 3] ]); // workaround
+    auto aa3 = [ 1: [2: 3] ]; // works, too
+    static auto aa4 = [ 1: [2: 3] ]; // Error: internal compiler error: failed to detect static initialization of associative array
+    assert(aa2 == aa3);
+    assert(aa3 == aa4);
+}
+
+/////////////////////////////////////////////
 
 void main()
 {
@@ -219,4 +231,5 @@ void main()
     testEnumInit();
     testStaticArray();
     testClassLiteral();
+    testMultiDim();
 }


### PR DESCRIPTION
static-AA lowering has to also be applied on the converted expression to also lower AAs in keys and values