### PR TITLE
fix #20365 - Bitfield address escapes through ref

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1703,6 +1703,19 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                                 exp = ErrorExp.get();
                             }
                         }
+                        else if (exp.isBitField())
+                        {
+                            if (dsym.storage_class & STC.autoref)
+                            {
+                                dsym.storage_class &= ~STC.ref_;
+                                constructInit(false);
+                            }
+                            else
+                            {
+                                .error(dsym.loc, "bitfield `%s` cannot be assigned to `ref %s`", exp.toChars(), dsym.toChars());
+                                exp = ErrorExp.get();
+                            }
+                        }
                         else
                         {
                             constructInit(false);

--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -89,13 +89,13 @@ Expression arrayFuncConv(Expression e, Scope* sc)
     auto t = e.type.toBasetype();
     if (auto ta = t.isTypeDArray())
     {
-        if (!checkAddressable(e, sc))
+        if (!checkAddressable(e, sc, "take address of"))
             return ErrorExp.get();
         e = e.castTo(sc, ta.next.pointerTo());
     }
     else if (auto ts = t.isTypeSArray())
     {
-        if (!checkAddressable(e, sc))
+        if (!checkAddressable(e, sc, "take address of"))
             return ErrorExp.get();
         e = e.castTo(sc, ts.next.pointerTo());
     }

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -927,6 +927,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                 exp = exp.implicitCastTo(sc2, tret);
 
                             exp = exp.toLvalue(sc2, "`ref` return");
+                            checkAddressable(exp, sc2, "`ref` return");
                             checkReturnEscapeRef(*sc2, exp, false);
                             exp = exp.optimize(WANTvalue, /*keepLvalue*/ true);
                         }

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2715,10 +2715,13 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                      */
                     Scope* sc2 = sc.push();
                     sc2.eSink = global.errorSinkNull;
-                    bool err = checkReturnEscapeRef(*sc2, rs.exp, true);
+                    bool addressable = checkAddressable(rs.exp, sc2, "`ref` return");
+                    bool escapes = checkReturnEscapeRef(*sc2, rs.exp, true);
                     sc2.pop();
 
-                    if (err)
+                    if (!addressable)
+                        turnOffRef(() { checkAddressable(rs.exp, sc, "`ref` return"); });
+                    else if (escapes)
                         turnOffRef(() { checkReturnEscapeRef(*sc, rs.exp, false); });
                     else if (!rs.exp.type.constConv(tf.next))
                         turnOffRef(

--- a/compiler/test/compilable/test20365.d
+++ b/compiler/test/compilable/test20365.d
@@ -1,0 +1,20 @@
+// REQUIRED_ARGS: -preview=bitfields
+
+struct A { int x : 16, y : 16; }
+
+void autoref_assign(A a)
+{
+    auto ref int x = a.x;
+}
+
+void f()(auto ref int);
+
+void autoref_param(A a)
+{
+    f(a.y);
+}
+
+auto ref int autoref_return(ref A a)
+{
+    return a.y;
+}

--- a/compiler/test/fail_compilation/biterrors4.d
+++ b/compiler/test/fail_compilation/biterrors4.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=bitfields
  * TEST_OUTPUT:
 ---
-fail_compilation/biterrors4.d(109): Error: cannot take address of bitfield `a`
+fail_compilation/biterrors4.d(109): Error: cannot take address of bitfield `s.a`
 ---
 */
 

--- a/compiler/test/fail_compilation/biterrors5.d
+++ b/compiler/test/fail_compilation/biterrors5.d
@@ -3,8 +3,8 @@
 ---
 fail_compilation/biterrors5.d(25): Error: bitfield symbol expected not struct `biterrors5.S`
 fail_compilation/biterrors5.d(26): Error: bitfield symbol expected not variable `biterrors5.test0.i`
-fail_compilation/biterrors5.d(35): Error: cannot take address of bitfield `x`
-fail_compilation/biterrors5.d(35): Error: cannot take address of bitfield `y`
+fail_compilation/biterrors5.d(35): Error: cannot take address of bitfield `a.x`
+fail_compilation/biterrors5.d(35): Error: cannot take address of bitfield `a.y`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail20365.d
+++ b/compiler/test/fail_compilation/fail20365.d
@@ -1,0 +1,29 @@
+/* REQUIRED_ARGS: -preview=bitfields
+TEST_OUTPUT:
+---
+fail_compilation/fail20365.d(16): Error: bitfield `a.x` cannot be assigned to `ref x`
+fail_compilation/fail20365.d(23): Error: function `f` is not callable using argument types `(int)`
+fail_compilation/fail20365.d(23):        cannot pass bitfield argument `a.y` to parameter `ref int`
+fail_compilation/fail20365.d(19):        `fail20365.f(ref int)` declared here
+fail_compilation/fail20365.d(28): Error: cannot `ref` return bitfield `a.y`
+---
+*/
+
+struct A { int x : 16, y : 16; }
+
+void ref_assign(A a)
+{
+    ref int x = a.x;
+}
+
+void f(ref int);
+
+void ref_param(A a)
+{
+    f(a.y);
+}
+
+ref int ref_return(ref A a)
+{
+    return a.y;
+}

--- a/compiler/test/fail_compilation/fail22749.d
+++ b/compiler/test/fail_compilation/fail22749.d
@@ -1,7 +1,7 @@
 // EXTRA_FILES: imports/imp22749.c
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail22749.d(12): Error: cannot take address of bitfield `field`
+fail_compilation/fail22749.d(12): Error: cannot take address of bitfield `s.field`
 ---
 */
 import imports.imp22749;

--- a/compiler/test/fail_compilation/failcstuff2.c
+++ b/compiler/test/fail_compilation/failcstuff2.c
@@ -30,7 +30,7 @@ fail_compilation/failcstuff2.c(362): Error: cannot index through register variab
 fail_compilation/failcstuff2.c(373): Error: cannot take address of register variable `reg4`
 fail_compilation/failcstuff2.c(374): Error: cannot take address of register variable `reg4`
 fail_compilation/failcstuff2.c(375): Error: cannot take address of register variable `reg4`
-fail_compilation/failcstuff2.c(376): Error: cannot take address of bitfield `b`
+fail_compilation/failcstuff2.c(376): Error: cannot take address of bitfield `reg4.inner.b`
 fail_compilation/failcstuff2.c(377): Error: cannot index through register variable `reg4`
 fail_compilation/failcstuff2.c(378): Error: cannot index through register variable `reg4`
 fail_compilation/failcstuff2.c(381): Error: cannot take address of register variable `reg5`

--- a/compiler/test/fail_compilation/failcstuff5.c
+++ b/compiler/test/fail_compilation/failcstuff5.c
@@ -3,7 +3,7 @@
 ---
 fail_compilation/failcstuff5.c(404): Error: undefined identifier `p1`
 fail_compilation/failcstuff5.c(404): Error: undefined identifier `p2`
-fail_compilation/failcstuff5.c(458): Error: cannot take address of bitfield `field`
+fail_compilation/failcstuff5.c(458): Error: cannot take address of bitfield `s.field`
 ---
 */
 


### PR DESCRIPTION
The first part of this fix is to recognize most the places where a conversion to `ref` may occur for bitfields.

The second part is to handle `auto ref` so that those cases remove `ref` and continue to work.

The rest fixes up the error messages around the fallout to make it explicit that bitfields are the reason for rejection.