### PR TITLE
Add missing exception handling in `_d_arrayappendT`

### DIFF
--- a/compiler/src/dmd/visitor/postorder.d
+++ b/compiler/src/dmd/visitor/postorder.d
@@ -118,6 +118,18 @@ public:
         }
     }
 
+    override void visit(CatAssignExp e)
+    {
+        if (auto lowering = e.lowering)
+        {
+            doCond(lowering) || applyTo(e);
+        }
+        else
+        {
+            visit(cast(BinExp)e);
+        }
+    }
+
     override void visit(EqualExp e)
     {
         if (auto lowering = e.lowering)


### PR DESCRIPTION
Added exception handling for postblits, similar to the one in `_d_arrayctor`. I have also introduced a visit method for `CatAssignExp` to account for the lowering. This prevents unexpected behavior for code like this:

```d
    struct S
    {
        int i;
        this(this){ throw new Exception(""); }
    }

    S[3] sarr = [S(1), S(2), S(3)];

    try {
        S[] sarr2;
        sarr2 ~= sarr;
    }
    catch (Exception){}
```
In here the catch is elided because the compiler thinks `sarr2 ~= sarr` does not throw (because it has no clue about the call to `_d_arrayappendT`).