### PR TITLE
Account for lowering during post-order visit on `CatExp`

### DIFF
--- a/compiler/src/dmd/visitor/postorder.d
+++ b/compiler/src/dmd/visitor/postorder.d
@@ -106,6 +106,18 @@ public:
         doCond(e.e1) || doCond(e.e2) || applyTo(e);
     }
 
+    override void visit(CatExp e)
+    {
+        if (auto lowering = e.lowering)
+        {
+            doCond(lowering) || applyTo(e);
+        }
+        else
+        {
+            visit(cast(BinExp)e);
+        }
+    }
+
     override void visit(EqualExp e)
     {
         if (auto lowering = e.lowering)


### PR DESCRIPTION
This PR solves #21700. Previously, when `canThrow` was called, `walkPostorder` would go over the original expression, completely ignoring the lowering to `_d_arraycatnTX`, thus infering `nothrow`.