### PR TITLE
Generated foreach-body functions: Fix index when NOT using size_t

### DIFF
--- a/compiler/test/runnable/foreach5.d
+++ b/compiler/test/runnable/foreach5.d
@@ -1,5 +1,6 @@
 /*
 EXTRA_FILES: imports/test15777a.d imports/test15777b.d
+REQUIRED_ARGS: -verrors=simple
 TEST_OUTPUT:
 ---
 int
@@ -10,6 +11,7 @@ int
 foobar7406(T)
 int
 test7406()
+runnable/foreach5.d(1200): Deprecation: foreach: loop index implicitly converted from `size_t` to `short`
 ---
 */
 
@@ -1191,6 +1193,22 @@ void test17041()
 }
 
 /***************************************/
+// https://github.com/ldc-developers/ldc/issues/326
+
+void testLDC326()
+{
+    foreach (short i, dchar c; "ab")
+    {
+        if (c == 'a')
+            assert(i == 0);
+        else if (c == 'b')
+            assert(i == 1);
+        else
+            assert(0);
+    }
+}
+
+/***************************************/
 
 int main()
 {
@@ -1222,6 +1240,7 @@ int main()
     test13756();
     test14653();
     test17041();
+    testLDC326();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Similar to issue #21456, the druntime autodecoding helpers pass a pointer to the `size_t` array index. The generated foreach-body lambda used to load its index from that pointer, without verifying that the types match. So if the user uses an `int` index, it used to load the first 4 bytes, thus truncating to 32 bits on little-endian, but using the 32 upper bits for 64-bit big-endian targets. Solve this by adding a cast if needed.