### PR TITLE
Add `lowering` field to `ConstructExp`

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -4702,34 +4702,6 @@ public:
                     result = CTFEExp.voidexp;
                 return;
             }
-            else if (isArrayConstruction(fd.ident))
-            {
-                // In expressionsem.d, `T[x] ea = eb;` was lowered to:
-                // `_d_array{,set}ctor(ea[], eb[]);`.
-                // The following code will rewrite it back to `ea = eb` and
-                // then interpret that expression.
-
-                if (fd.ident == Id._d_arrayctor)
-                    assert(e.arguments.length == 3);
-                else
-                    assert(e.arguments.length == 2);
-
-                Expression ea = (*e.arguments)[0];
-                if (ea.isCastExp)
-                    ea = ea.isCastExp.e1;
-
-                Expression eb = (*e.arguments)[1];
-                if (eb.isCastExp() && fd.ident == Id._d_arrayctor)
-                    eb = eb.isCastExp.e1;
-
-                ConstructExp ce = new ConstructExp(e.loc, ea, eb);
-                ce.type = ea.type;
-
-                ce.type = ea.type;
-                result = interpret(ce, istate);
-
-                return;
-            }
         }
         else if (auto soe = ecall.isSymOffExp())
         {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3641,6 +3641,8 @@ extern (C++) final class LoweredAssignExp : AssignExp
  */
 extern (C++) final class ConstructExp : AssignExp
 {
+    Expression lowering;
+
     extern (D) this(Loc loc, Expression e1, Expression e2) @safe
     {
         super(loc, EXP.construct, e1, e2);

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -1037,6 +1037,7 @@ public:
 class ConstructExp final : public AssignExp
 {
 public:
+    Expression *lowering;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12408,16 +12408,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
 
                 // Lower to object._d_array{,set}ctor(e1, e2)
-                Expression id = new IdentifierExp(exp.loc, Id.empty);
-                id = new DotIdExp(exp.loc, id, Id.object);
-                id = new DotIdExp(exp.loc, id, func);
+                Expression lowering = new IdentifierExp(ae.loc, Id.empty);
+                lowering = new DotIdExp(ae.loc, lowering, Id.object);
+                lowering = new DotIdExp(ae.loc, lowering, func);
 
                 auto arguments = new Expressions(new CastExp(ae.loc, ae.e1, t1e.arrayOf).expressionSemantic(sc));
                 if (lowerToArrayCtor)
                 {
                     arguments.push(new CastExp(ae.loc, rhs, t2b.nextOf.arrayOf).expressionSemantic(sc));
-                    Expression ce = new CallExp(exp.loc, id, arguments);
-                    res = ce.expressionSemantic(sc);
+                    lowering = new CallExp(ae.loc, lowering, arguments);
+                    lowering = lowering.expressionSemantic(sc);
                 }
                 else
                 {
@@ -12432,12 +12432,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     else
                         arguments.push(ae.e2);
 
-                    Expression ce = new CallExp(exp.loc, id, arguments);
-                    res = Expression.combine(e0, ce).expressionSemantic(sc);
+                    lowering = new CallExp(ae.loc, lowering, arguments);
+                    lowering = Expression.combine(e0, lowering).expressionSemantic(sc);
                 }
 
+                ae.lowering = lowering;
+
                 if (global.params.v.verbose)
-                    message("lowered   %s =>\n          %s", exp.toChars(), res.toChars());
+                    message("lowered   %s =>\n          %s", exp.toChars(), lowering.toChars());
             }
         }
         else if (auto ae = res.isAssignExp())

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2784,6 +2784,7 @@ public:
 class ConstructExp final : public AssignExp
 {
 public:
+    Expression* lowering;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -2834,6 +2834,59 @@ elem* toElem(Expression e, ref IRState irs)
         assert(0);
     }
 
+    /***************************************
+     */
+
+    elem* visitConstruct(ConstructExp ae)
+    {
+        Type t1b = ae.e1.type.toBasetype();
+        if (t1b.ty != Tsarray && t1b.ty != Tarray)
+            return visitAssign(ae);
+
+        // only non-trivial array constructions have been lowered (non-POD elements basically)
+        Type t1e = t1b.nextOf();
+        TypeStruct ts = t1e.baseElemOf().isTypeStruct();
+        if (!ts || !(ts.sym.postblit || ts.sym.hasCopyCtor || ts.sym.dtor))
+            return visitAssign(ae);
+
+        // ref-constructions etc. don't have lowering
+        if (!(t1b.ty == Tsarray || ae.e1.isSliceExp) ||
+            (ae.e1.isVarExp && ae.e1.isVarExp.var.isVarDeclaration.isReference))
+            return visitAssign(ae);
+
+        // Construction from an equivalent other array?
+        Type t2b = ae.e2.type.toBasetype();
+        // skip over a (possibly implicit) cast of a static array RHS to a slice
+        Expression rhs = ae.e2;
+        Type rhsType = t2b;
+        if (t2b.ty == Tarray)
+        {
+            auto ce = rhs.isCastExp();
+            auto ct = ce ? ce.e1.type.toBasetype() : null;
+            if (ct && ct.ty == Tsarray)
+            {
+                rhs = ce.e1;
+                rhsType = ct;
+            }
+        }
+        const lowerToArrayCtor =
+            ((rhsType.ty == Tarray && !rhs.isArrayLiteralExp) ||
+             (rhsType.ty == Tsarray && rhs.isLvalue)) &&
+            t1e.equivalent(t2b.nextOf);
+
+
+        // Construction from a single element?
+        const lowerToArraySetCtor = !lowerToArrayCtor && t1e.equivalent(t2b);
+
+        if (!lowerToArrayCtor && !lowerToArraySetCtor)
+            return visitAssign(ae);
+
+        const hookName = lowerToArrayCtor ? "_d_arrayctor" : "_d_arraysetctor";
+        assert(ae.lowering, "This case should have been rewritten to `" ~ hookName ~ "` in the semantic phase");
+        return toElem(ae.lowering, irs);
+    }
+
+
     elem* visitLoweredAssign(LoweredAssignExp e)
     {
         return toElem(e.lowering, irs);
@@ -4175,7 +4228,7 @@ elem* toElem(Expression e, ref IRState irs)
         case EXP.identity:      return visitIdentity(e.isIdentityExp());
         case EXP.in_:           return visitIn(e.isInExp());
         case EXP.assign:        return visitAssign(e.isAssignExp());
-        case EXP.construct:     return visitAssign(e.isConstructExp());
+        case EXP.construct:     return visitConstruct(e.isConstructExp());
         case EXP.blit:          return visitAssign(e.isBlitExp());
         case EXP.loweredAssignExp: return visitLoweredAssign(e.isLoweredAssignExp());
         case EXP.addAssign:     return visitAddAssign(e.isAddAssignExp());

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -833,6 +833,18 @@ public:
             visit(cast(BinExp)e);
         }
 
+        override void visit(ConstructExp e)
+        {
+            if (e.lowering)
+            {
+                auto ce = cast(ConstructExp)e.copy();
+                ce.lowering = doInlineAs!Expression(ce.lowering, ids);
+                result = ce;
+            }
+            else
+                visit(cast(AssignExp) e);
+        }
+
         override void visit(LoweredAssignExp e)
         {
             result = doInlineAs!Expression(e.lowering, ids);
@@ -1401,6 +1413,14 @@ public:
         }
     L1:
         visit(cast(BinExp)e);
+    }
+
+    override void visit(ConstructExp e)
+    {
+        if (auto lowering = e.lowering)
+            inlineScan(lowering);
+        else
+            visit(cast(AssignExp) e);
     }
 
     override void visit(LoweredAssignExp e)


### PR DESCRIPTION
The lowering of `ConstructExp` is now stored in a dedicated field instead of overwriting the original expression. This makes it consistent with the rest of lowered expressions.