### PR TITLE
improve error message for bad size/type

### DIFF
--- a/compiler/src/dmd/iasm/dmdx86.d
+++ b/compiler/src/dmd/iasm/dmdx86.d
@@ -717,7 +717,7 @@ PTRNTAB asm_classify(OP* pop, OPND[] opnds, out int outNumops)
             if(bInvalid64bit)
                 error(asmstate.loc, "operand for `%s` invalid in 64bit mode", asm_opstr(pop));
             else
-                error(asmstate.loc, "bad type/size of operands `%s`", asm_opstr(pop));
+                error(asmstate.loc, "`%s` instruction requires operands of matching type/size", asm_opstr(pop));
             return;
         }
         bRetry = true;
@@ -727,7 +727,7 @@ PTRNTAB asm_classify(OP* pop, OPND[] opnds, out int outNumops)
     {
         if (bRetry)
         {
-            error(asmstate.loc, "bad type/size of operands `%s`", asm_opstr(pop));
+            error(asmstate.loc, "`%s` instruction requires operands of matching type/size", asm_opstr(pop));
         }
         return ret;
     }

--- a/compiler/test/fail_compilation/iasm1.d
+++ b/compiler/test/fail_compilation/iasm1.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/iasm1.d(103): Error: bad type/size of operands `and`
-fail_compilation/iasm1.d(104): Error: bad type/size of operands `and`
+fail_compilation/iasm1.d(103): Error: `and` instruction requires operands of matching type/size
+fail_compilation/iasm1.d(104): Error: `and` instruction requires operands of matching type/size
 ---
 */
 


### PR DESCRIPTION
@WalterBright 
```d
asm {
    mov EBX, f; // f is a pointer on a 64bit CPU and being moved into a 32 bit wide register 
}
```
or any mismatch in operand size or types
 this is the error message we get.
`bad type/size of operands `mov``

a little unclear as the instruction is printed to refer to as 'operands'

so rather 

"'mov' instruction requires operands of matching type/size"
clearly tells me what I'm doing wrong.