### PR TITLE
Disallow assigning to struct rvalue

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11642,11 +11642,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // printf("PreExp::semantic('%s')\n", toChars());
         if (Expression e = exp.opOverloadUnary(sc))
         {
-            if (!sc.intypeof && exp.e1.type && exp.e1.type.ty == Tstruct &&
-                !exp.e1.isLvalue())
+            if (checkRvalueAssign(sc, exp.e1, "modify"))
             {
-                error(exp.e1.loc, "cannot modify struct rvalue `%s`",
-                    exp.e1.toChars());
                 e = ErrorExp.get();
             }
             result = e;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12380,6 +12380,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (exp.op == EXP.assign)
             {
+                if (!exp.e1.isLvalue())
+                {
+                    error(exp.e1.loc, "cannot assign to struct rvalue `%s`",
+                        exp.e1.toChars());
+                    return setError();
+                }
                 if (Expression e = exp.isAssignExp().opOverloadAssign(sc, aliasThisStop))
                 {
                     result = e;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12386,12 +12386,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (exp.op == EXP.assign)
             {
-                if (!sc.intypeof && !exp.e1.isLvalue())
-                {
-                    error(exp.e1.loc, "cannot assign to struct rvalue `%s`",
-                        exp.e1.toChars());
-                    return setError();
-                }
                 if (Expression e = exp.isAssignExp().opOverloadAssign(sc, aliasThisStop))
                 {
                     result = e;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11642,7 +11642,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // printf("PreExp::semantic('%s')\n", toChars());
         if (Expression e = exp.opOverloadUnary(sc))
         {
-            if (checkRvalueAssign(sc, exp.e1, "modify"))
+            if (checkRvalueAssign(sc, exp.e1, Id.opUnary))
             {
                 e = ErrorExp.get();
             }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11642,7 +11642,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // printf("PreExp::semantic('%s')\n", toChars());
         if (Expression e = exp.opOverloadUnary(sc))
         {
-            if (!sc.intypeof && exp.e1.type.ty == Tstruct && !exp.e1.isLvalue())
+            if (!sc.intypeof && exp.e1.type && exp.e1.type.ty == Tstruct &&
+                !exp.e1.isLvalue())
             {
                 error(exp.e1.loc, "cannot modify struct rvalue `%s`",
                     exp.e1.toChars());

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12380,7 +12380,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (exp.op == EXP.assign)
             {
-                if (!exp.e1.isLvalue())
+                if (!sc.intypeof && !exp.e1.isLvalue())
                 {
                     error(exp.e1.loc, "cannot assign to struct rvalue `%s`",
                         exp.e1.toChars());

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11642,6 +11642,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // printf("PreExp::semantic('%s')\n", toChars());
         if (Expression e = exp.opOverloadUnary(sc))
         {
+            if (!sc.intypeof && exp.e1.type.ty == Tstruct && !exp.e1.isLvalue())
+            {
+                error(exp.e1.loc, "cannot modify struct rvalue `%s`",
+                    exp.e1.toChars());
+                e = ErrorExp.get();
+            }
             result = e;
             return;
         }

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -537,8 +537,15 @@ Expression opOverloadAssign(AssignExp e, Scope* sc, Type[2] aliasThisStop)
 
     bool choseReverse;
     if (auto result = pickBestBinaryOverload(sc, null, s, null, e, choseReverse))
+    {
+        if (!sc.intypeof && e.e1.type.ty == Tstruct && !e.e1.isLvalue())
+        {
+            error(e.e1.loc, "cannot assign to struct rvalue `%s`",
+                e.e1.toChars());
+            return ErrorExp.get();
+        }
         return result;
-
+    }
     return binAliasThis(e, sc, aliasThisStop);
 }
 

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -549,7 +549,8 @@ Expression opOverloadAssign(AssignExp e, Scope* sc, Type[2] aliasThisStop)
 
 bool checkRvalueAssign(Scope *sc, Expression e, Identifier op)
 {
-    if (!sc.intypeof && e.type && e.type.ty == Tstruct && !e.isLvalue())
+    if (!sc.intypeof && sc.hasEdition(Edition.v2024) &&
+        e.type && e.type.ty == Tstruct && !e.isLvalue())
     {
         TypeStruct ts = cast(TypeStruct)e.type;
         // nested struct may assign data outside of the struct, e.g. ae.utils.array.list(args)

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1004,6 +1004,11 @@ Expression opOverloadBinaryAssign(BinAssignExp e, Scope* sc, Type[2] aliasThisSt
     if (e.e1.type.isTypeError() || e.e2.type.isTypeError())
         return ErrorExp.get();
 
+    if (e.e1.type.ty == Tstruct && !e.e1.isLvalue())
+    {
+        error(e.e1.loc, "cannot assign to struct rvalue `%s`", e.e1.toChars());
+        return ErrorExp.get();
+    }
     AggregateDeclaration ad1 = isAggregate(e.e1.type);
     Dsymbol s = search_function(ad1, Id.opOpAssign);
     if (s && !(s.isTemplateDeclaration() || s.isOverloadSet()))

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1004,7 +1004,7 @@ Expression opOverloadBinaryAssign(BinAssignExp e, Scope* sc, Type[2] aliasThisSt
     if (e.e1.type.isTypeError() || e.e2.type.isTypeError())
         return ErrorExp.get();
 
-    if (e.e1.type.ty == Tstruct && !e.e1.isLvalue())
+    if (!sc.intypeof && e.e1.type.ty == Tstruct && !e.e1.isLvalue())
     {
         error(e.e1.loc, "cannot assign to struct rvalue `%s`", e.e1.toChars());
         return ErrorExp.get();

--- a/compiler/test/fail_compilation/fail17491.d
+++ b/compiler/test/fail_compilation/fail17491.d
@@ -1,10 +1,10 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail17491.d(22): Error: cannot modify expression `(S17491).init` because it is not an lvalue
+fail_compilation/fail17491.d(22): Error: cannot assign to struct rvalue `S17491(0)`
 fail_compilation/fail17491.d(23): Error: cannot take address of expression `S17491(0)` because it is not an lvalue
 fail_compilation/fail17491.d(25): Error: cannot modify expression `S17491(0).field` because it is not an lvalue
 fail_compilation/fail17491.d(26): Error: cannot take address of expression `S17491(0).field` because it is not an lvalue
-fail_compilation/fail17491.d(31): Error: cannot modify expression `S17491(0)` because it is not an lvalue
+fail_compilation/fail17491.d(31): Error: cannot assign to struct rvalue `S17491(0)`
 fail_compilation/fail17491.d(32): Error: cannot take address of expression `S17491(0)` because it is not an lvalue
 fail_compilation/fail17491.d(34): Error: cannot modify expression `S17491(0).field` because it is not an lvalue
 fail_compilation/fail17491.d(35): Error: cannot take address of expression `S17491(0).field` because it is not an lvalue

--- a/compiler/test/fail_compilation/fail17491.d
+++ b/compiler/test/fail_compilation/fail17491.d
@@ -1,10 +1,10 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail17491.d(22): Error: cannot assign to struct rvalue `S17491(0)`
+fail_compilation/fail17491.d(22): Error: cannot modify expression `(S17491).init` because it is not an lvalue
 fail_compilation/fail17491.d(23): Error: cannot take address of expression `S17491(0)` because it is not an lvalue
 fail_compilation/fail17491.d(25): Error: cannot modify expression `S17491(0).field` because it is not an lvalue
 fail_compilation/fail17491.d(26): Error: cannot take address of expression `S17491(0).field` because it is not an lvalue
-fail_compilation/fail17491.d(31): Error: cannot assign to struct rvalue `S17491(0)`
+fail_compilation/fail17491.d(31): Error: cannot modify expression `S17491(0)` because it is not an lvalue
 fail_compilation/fail17491.d(32): Error: cannot take address of expression `S17491(0)` because it is not an lvalue
 fail_compilation/fail17491.d(34): Error: cannot modify expression `S17491(0).field` because it is not an lvalue
 fail_compilation/fail17491.d(35): Error: cannot take address of expression `S17491(0).field` because it is not an lvalue

--- a/compiler/test/fail_compilation/fail9936.d
+++ b/compiler/test/fail_compilation/fail9936.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail9936.d(25): Error: `S().opBinary` isn't a template
 fail_compilation/fail9936.d(26): Error: `S().opBinaryRight` isn't a template
-fail_compilation/fail9936.d(27): Error: `S().opOpAssign` isn't a template
+fail_compilation/fail9936.d(27): Error: `s.opOpAssign` isn't a template
 fail_compilation/fail9936.d(29): Error: `S().opIndexUnary` isn't a template
 fail_compilation/fail9936.d(30): Error: `S().opUnary` isn't a template
 ---
@@ -17,14 +17,14 @@ struct S
     auto opIndexUnary(S s) { return 1; }
     auto opUnary(S s) { return 1; }
 }
-void main()
+void f(S s)
 {
     static assert(!is(typeof( S() + S() )));
     static assert(!is(typeof( 100 + S() )));
-    static assert(!is(typeof( S() += S() )));
+    static assert(!is(typeof( s += S() )));
     S() + S();
     100 + S();
-    S() += S();
+    s += S();
 
     +S()[0];
     +S();

--- a/compiler/test/fail_compilation/struct_rvalue_assign.d
+++ b/compiler/test/fail_compilation/struct_rvalue_assign.d
@@ -12,22 +12,16 @@ void main ()
     foo() = S.init;
     foo() += 5;
     ++foo();
+    cast(void) ~foo(); // other unary ops are OK
 }
 
-S foo()
-{
-    return S.init;
-}
+S foo() => S.init;
 
 struct S
 {
     int i;
 
-    void opAssign(S s)
-    {
-        this.i = s.i;
-    }
-
+    void opAssign(S s) {}
     void opOpAssign(string op : "+")(int) {}
-    void opUnary(string op : "++")() {}
+    void opUnary(string op)() {}
 }

--- a/compiler/test/fail_compilation/struct_rvalue_assign.d
+++ b/compiler/test/fail_compilation/struct_rvalue_assign.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/struct_rvalue_assign.d(12): Error: cannot assign to struct rvalue `foo()`
-fail_compilation/struct_rvalue_assign.d(13): Error: cannot assign to struct rvalue `foo()`
+fail_compilation/struct_rvalue_assign.d(13): Error: cannot modify struct rvalue `foo()`
 fail_compilation/struct_rvalue_assign.d(14): Error: cannot modify struct rvalue `foo()`
 ---
 */

--- a/compiler/test/fail_compilation/struct_rvalue_assign.d
+++ b/compiler/test/fail_compilation/struct_rvalue_assign.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/struct_rvalue_assign.d(11): Error: cannot assign to struct rvalue `foo()`
 fail_compilation/struct_rvalue_assign.d(12): Error: cannot assign to struct rvalue `foo()`
+fail_compilation/struct_rvalue_assign.d(13): Error: cannot assign to struct rvalue `foo()`
+fail_compilation/struct_rvalue_assign.d(14): Error: cannot modify struct rvalue `foo()`
 ---
 */
 
@@ -10,6 +11,7 @@ void main ()
 {
     foo() = S.init;
     foo() += 5;
+    ++foo();
 }
 
 S foo()
@@ -27,4 +29,5 @@ struct S
     }
 
     void opOpAssign(string op : "+")(int) {}
+    void opUnary(string op : "++")() {}
 }

--- a/compiler/test/fail_compilation/struct_rvalue_assign.d
+++ b/compiler/test/fail_compilation/struct_rvalue_assign.d
@@ -1,0 +1,30 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/struct_rvalue_assign.d(11): Error: cannot assign to struct rvalue `foo()`
+fail_compilation/struct_rvalue_assign.d(12): Error: cannot assign to struct rvalue `foo()`
+---
+*/
+
+void main ()
+{
+    foo() = S.init;
+    foo() += 5;
+}
+
+S foo()
+{
+    return S.init;
+}
+
+struct S
+{
+    int i;
+
+    void opAssign(S s)
+    {
+        this.i = s.i;
+    }
+
+    void opOpAssign(string op : "+")(int) {}
+}

--- a/compiler/test/fail_compilation/struct_rvalue_assign.d
+++ b/compiler/test/fail_compilation/struct_rvalue_assign.d
@@ -1,13 +1,17 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/struct_rvalue_assign.d(12): Error: cannot assign to struct rvalue `foo()`
-fail_compilation/struct_rvalue_assign.d(13): Error: cannot modify struct rvalue `foo()`
-fail_compilation/struct_rvalue_assign.d(14): Error: cannot modify struct rvalue `foo()`
+fail_compilation/struct_rvalue_assign.d(16): Error: cannot assign to struct rvalue `foo()`
+fail_compilation/struct_rvalue_assign.d(16):        if the assignment is used for side-effects, call `opAssign` directly
+fail_compilation/struct_rvalue_assign.d(17): Error: cannot modify struct rvalue `foo()`
+fail_compilation/struct_rvalue_assign.d(17):        if the assignment is used for side-effects, call `opOpAssign` directly
+fail_compilation/struct_rvalue_assign.d(18): Error: cannot modify struct rvalue `foo()`
+fail_compilation/struct_rvalue_assign.d(18):        if the assignment is used for side-effects, call `opUnary` directly
 ---
 */
+module sra 2024;
 
-void main ()
+void main()
 {
     foo() = S.init;
     foo() += 5;


### PR DESCRIPTION
When assignment would call an operator overload.
Fixes #21507.

Note: This does not disallow calling e.g. `opAssign` on an rvalue, only actual assignment.