### PR TITLE
importC: Fix grammar for constant expressions

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1639,7 +1639,7 @@ final class CParser(AST) : Parser!AST
      */
     private AST.Expression cparseConstantExp()
     {
-        return cparseAssignExp();
+        return cparseCondExp();
     }
 
     /*****************************


### PR DESCRIPTION
The syntax is conditional-expression, not assignment-expression.