### PR TITLE
fix #21718 - _Alignas specifiers cannot reduce alignment of variables

### DIFF
--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -477,7 +477,12 @@ extern (C++) struct structalign_t
   private:
     ushort value = 0;  // unknown
     enum STRUCTALIGN_DEFAULT = 1234;   // default = match whatever the corresponding C compiler does
-    bool pack;         // use #pragma pack semantics
+    ubyte flags;       // Align semantic flags
+    enum : ubyte
+    {
+        PACK = 0x1,     // use #pragma pack semantics
+        ALIGNAS = 0x2,  // use _Alignas semantics
+    }
 
   public:
   pure @safe @nogc nothrow:
@@ -487,8 +492,10 @@ extern (C++) struct structalign_t
     void setUnknown()      { value = 0; }
     void set(uint value)   { this.value = cast(ushort)value; }
     uint get() const       { return value; }
-    bool isPack() const    { return pack; }
-    void setPack(bool pack) { this.pack = pack; }
+    bool isPack() const    { return !!(flags & PACK); }
+    void setPack()         { flags |= PACK; }
+    bool fromAlignas() const { return !!(flags & ALIGNAS); }
+    void setAlignas()      { flags |= ALIGNAS; }
 }
 
 /// Use to return D arrays from C++ functions

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1059,6 +1059,23 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dsym.alignment.isDefault())
             dsym.alignment = dsym.type.alignment(); // use type's alignment
 
+        if (sc.inCfile && !dsym.alignment.isDefault())
+        {
+            /* C11 6.7.5-4 alignment declaration cannot be less strict than the
+             * type alignment of the object or member being declared.
+             */
+            if (dsym.alignment.get() < dsym.type.alignsize())
+            {
+                if (dsym.alignment.fromAlignas())
+                {
+                    error(dsym.loc, "`_Alignas` specifier cannot be less strict than alignment of `%s`",
+                          dsym.toChars());
+                }
+                if (!dsym.alignment.isPack())
+                    dsym.alignment.setDefault();
+            }
+        }
+
         //printf("sc.stc = %x\n", sc.stc);
         //printf("storage_class = x%x\n", storage_class);
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6419,7 +6419,13 @@ struct structalign_t final
 {
 private:
     uint16_t value;
-    bool pack;
+    uint8_t flags;
+    enum : uint8_t
+    {
+        PACK = 1u,
+        ALIGNAS = 2u,
+    };
+
 public:
     bool isDefault() const;
     void setDefault();
@@ -6428,15 +6434,17 @@ public:
     void set(uint32_t value);
     uint32_t get() const;
     bool isPack() const;
-    void setPack(bool pack);
+    void setPack();
+    bool fromAlignas() const;
+    void setAlignas();
     structalign_t() :
         value(0u),
-        pack()
+        flags()
     {
     }
-    structalign_t(uint16_t value, bool pack = false) :
+    structalign_t(uint16_t value, uint8_t flags = 0u) :
         value(value),
-        pack(pack)
+        flags(flags)
         {}
 };
 

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -288,9 +288,10 @@ struct Param
 
 struct structalign_t
 {
-    unsigned short value;
-    d_bool pack;
-
+private:
+    uint16_t value;
+    uint8_t flags;
+public:
     bool isDefault() const;
     void setDefault();
     bool isUnknown() const;
@@ -298,7 +299,9 @@ struct structalign_t
     void set(unsigned value);
     unsigned get() const;
     bool isPack() const;
-    void setPack(bool pack);
+    void setPack();
+    bool fromAlignas() const;
+    void setAlignas();
 };
 
 // magic value means "match whatever the underlying C compiler does"

--- a/compiler/test/fail_compilation/alignas3.c
+++ b/compiler/test/fail_compilation/alignas3.c
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/alignas3.c(12): Error: `_Alignas` specifier cannot be less strict than alignment of `c`
+fail_compilation/alignas3.c(13): Error: alignment must be an integer positive power of 2, not 0x1
+---
+*/
+struct S
+{
+    _Alignas(1) _Alignas(int) int a;
+    _Alignas(1) _Alignas(16) int b;
+    _Alignas(1) int c;
+    _Alignas((void*)1) int d;
+};

--- a/compiler/test/fail_compilation/alignas4.c
+++ b/compiler/test/fail_compilation/alignas4.c
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/alignas4.c(12): Error: `_Alignas` specifier cannot be less strict than alignment of `c`
+fail_compilation/alignas4.c(13): Error: alignment must be an integer positive power of 2, not 0x1
+---
+*/
+int main()
+{
+    _Alignas(1) _Alignas(int) int a;
+    _Alignas(1) _Alignas(16) int b;
+    _Alignas(1) int c;
+    _Alignas((void*)1) int d;
+}


### PR DESCRIPTION
Error if `_Alignas` has a less strict alignment on a member or object.

Similarly, `__attribute__` aligned only enforces a minimum alignment, don't force alignment below the alignment of its type (unless packed, where minimum alignment is 1).