### PR TITLE
cparse: Replace isTypeName with startsTypeName

### DIFF
--- a/compiler/test/fail_compilation/failcstuff1.c
+++ b/compiler/test/fail_compilation/failcstuff1.c
@@ -7,9 +7,7 @@ fail_compilation/failcstuff1.c(152): Error: `;` or `,` expected
 fail_compilation/failcstuff1.c(153): Error: `void` has no value
 fail_compilation/failcstuff1.c(153): Error: missing comma
 fail_compilation/failcstuff1.c(153): Error: `;` or `,` expected
-fail_compilation/failcstuff1.c(157): Error: expression expected, not `struct`
-fail_compilation/failcstuff1.c(157): Error: found `S22028` when expecting `)`
-fail_compilation/failcstuff1.c(157): Error: missing comma or semicolon after declaration of `test22028`, found `ident` instead
+fail_compilation/failcstuff1.c(157): Error: identifier not allowed in abstract-declarator
 fail_compilation/failcstuff1.c(203): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/failcstuff1.c(204): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/failcstuff1.c(205): Error: storage class not allowed in specifier-qualified-list


### PR DESCRIPTION
When parsing _Alignof, sizeof, _Atomic, _Alignas, and typeof, there's no need to do a full lookahead, peeking the next token with a lookup in the typedef tab is enough to disambiguate between type-name and expression. Moved most blocks into their own functions to reduce the size of the huge switch statements they are located within.