### PR TITLE
ImportC: Use the location of the declarator ident for dsymbols

### DIFF
--- a/compiler/src/dmd/astcodegen.d
+++ b/compiler/src/dmd/astcodegen.d
@@ -42,6 +42,7 @@ struct ASTCodegen
     alias UserAttributeDeclaration  = dmd.attrib.UserAttributeDeclaration;
     alias Ensure                    = dmd.func.Ensure; // workaround for bug in older DMD frontends
     alias ErrorExp                  = dmd.expression.ErrorExp;
+    alias ArgumentLabel             = dmd.expression.ArgumentLabel;
 
     alias MODFlags                  = dmd.mtype.MODFlags;
     alias Type                      = dmd.mtype.Type;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5993,6 +5993,7 @@ struct ASTCodegen final
     typedef UserAttributeDeclaration* UserAttributeDeclaration;
     typedef Ensure Ensure;
     typedef ErrorExp* ErrorExp;
+    typedef ArgumentLabel ArgumentLabel;
     typedef MODFlags MODFlags;
     typedef Type* Type;
     typedef Parameter* Parameter;

--- a/compiler/test/compilable/jsonc.i
+++ b/compiler/test/compilable/jsonc.i
@@ -25,7 +25,7 @@ TEST_OUTPUT:
                 "protection": "public"
             },
             {
-                "char": 22,
+                "char": 21,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "alias",
                 "line": 68,
@@ -50,7 +50,7 @@ TEST_OUTPUT:
                 "protection": "public"
             },
             {
-                "char": 38,
+                "char": 36,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "alias",
                 "line": 70,

--- a/compiler/test/fail_compilation/malformed_cmain.c
+++ b/compiler/test/fail_compilation/malformed_cmain.c
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/malformed_cmain.c(13): Error: function `malformed_cmain.main` parameters must match one of the following signatures
-fail_compilation/malformed_cmain.c(13):        `main()`
-fail_compilation/malformed_cmain.c(13):        `main(int argc, char** argv)`
-fail_compilation/malformed_cmain.c(13):        `main(int argc, char** argv, char** environ)` [POSIX extension]
+fail_compilation/malformed_cmain.c(12): Error: function `malformed_cmain.main` parameters must match one of the following signatures
+fail_compilation/malformed_cmain.c(12):        `main()`
+fail_compilation/malformed_cmain.c(12):        `main(int argc, char** argv)`
+fail_compilation/malformed_cmain.c(12):        `main(int argc, char** argv, char** environ)` [POSIX extension]
 ---
 
 */

--- a/compiler/test/fail_compilation/test22344.c
+++ b/compiler/test/fail_compilation/test22344.c
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test22344.c(104): Error: function `test22344.func` redeclaration with different type
-fail_compilation/test22344.c(204): Error: function `test22344.test` redeclaration with different type
+fail_compilation/test22344.c(103): Error: function `test22344.func` redeclaration with different type
+fail_compilation/test22344.c(203): Error: function `test22344.test` redeclaration with different type
 ---
  */
 

--- a/compiler/test/fail_compilation/testnothrow.c
+++ b/compiler/test/fail_compilation/testnothrow.c
@@ -1,9 +1,9 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/testnothrow.c(105): Error: function `testnothrow.throwing` is not `nothrow`
-fail_compilation/testnothrow.c(104): Error: function `testnothrow.mul` may throw but is marked as `nothrow`
+fail_compilation/testnothrow.c(103): Error: function `testnothrow.mul` may throw but is marked as `nothrow`
 fail_compilation/testnothrow.c(111): Error: function `testnothrow.throwing` is not `nothrow`
-fail_compilation/testnothrow.c(110): Error: function `testnothrow.add` may throw but is marked as `nothrow`
+fail_compilation/testnothrow.c(109): Error: function `testnothrow.add` may throw but is marked as `nothrow`
 ---
 */
 


### PR DESCRIPTION
The source location of variable and function declarations were all pointing at various odd places.
- Functions were given the location of the opening `{`.
- Parameters were given the location of the `,` separator.
- Tag types such as typedefs or enum declaration were given the location of the closing `;` in the declaration.
- Fields were given the location of the closing `;`.
- Bitfields were given the location of the width expression.

These now all point at the location of the declaration's identifier if one exists. For nameless parameters, the location points at the beginning of its type. Anonymous bitfields have a location pointing at the width expression.