### PR TITLE
parser: Promote dangling else warning to error

### DIFF
--- a/changelog/dmd.dangling-else.dd
+++ b/changelog/dmd.dangling-else.dd
@@ -1,6 +1,5 @@
 An error is now issued for dangling else statements
 
-
 This used to give a warning when compiled with `-w` and now gives an error:
 ```
 int i, j;

--- a/changelog/dmd.dangling-else.dd
+++ b/changelog/dmd.dangling-else.dd
@@ -1,0 +1,12 @@
+An error is now issued for dangling else statements
+
+
+This used to give a warning when compiled with `-w` and now gives an error:
+```
+int i, j;
+if (i)
+    if (j)
+        return 1;
+    else    // Error: else is dangling, add { } after condition at line 2
+        return 2;
+```

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -5511,7 +5511,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         if (token.value != TOK.else_ && token.value != TOK.catch_ && token.value != TOK.finally_ && lookingForElse.isValid)
         {
-            eSink.warning(elseloc, "else is dangling, add { } after condition at %s", lookingForElse.toChars());
+            eSink.error(elseloc, "else is dangling, add { } after condition at %s", lookingForElse.toChars());
         }
     }
 

--- a/compiler/test/fail_compilation/fail4375a.d
+++ b/compiler/test/fail_compilation/fail4375a.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375a.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375a.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375a.d(13): Error: else is dangling, add { } after condition at fail_compilation/fail4375a.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375b.d
+++ b/compiler/test/fail_compilation/fail4375b.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375b.d(18): Warning: else is dangling, add { } after condition at fail_compilation/fail4375b.d(14)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375b.d(15): Error: else is dangling, add { } after condition at fail_compilation/fail4375b.d(11)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375c.d
+++ b/compiler/test/fail_compilation/fail4375c.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375c.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375c.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375c.d(14): Error: else is dangling, add { } after condition at fail_compilation/fail4375c.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375d.d
+++ b/compiler/test/fail_compilation/fail4375d.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375d.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375d.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375d.d(14): Error: else is dangling, add { } after condition at fail_compilation/fail4375d.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375e.d
+++ b/compiler/test/fail_compilation/fail4375e.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375e.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375e.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375e.d(13): Error: else is dangling, add { } after condition at fail_compilation/fail4375e.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375f.d
+++ b/compiler/test/fail_compilation/fail4375f.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375f.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375f.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375f.d(13): Error: else is dangling, add { } after condition at fail_compilation/fail4375f.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375g.d
+++ b/compiler/test/fail_compilation/fail4375g.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375g.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375g.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375g.d(13): Error: else is dangling, add { } after condition at fail_compilation/fail4375g.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375h.d
+++ b/compiler/test/fail_compilation/fail4375h.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375h.d(18): Warning: else is dangling, add { } after condition at fail_compilation/fail4375h.d(15)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375h.d(15): Error: else is dangling, add { } after condition at fail_compilation/fail4375h.d(12)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375i.d
+++ b/compiler/test/fail_compilation/fail4375i.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375i.d(18): Warning: else is dangling, add { } after condition at fail_compilation/fail4375i.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375i.d(15): Error: else is dangling, add { } after condition at fail_compilation/fail4375i.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375j.d
+++ b/compiler/test/fail_compilation/fail4375j.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375j.d(18): Warning: else is dangling, add { } after condition at fail_compilation/fail4375j.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375j.d(15): Error: else is dangling, add { } after condition at fail_compilation/fail4375j.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375k.d
+++ b/compiler/test/fail_compilation/fail4375k.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375k.d-mixin-13(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375k.d-mixin-13(14)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375k.d-mixin-10(14): Error: else is dangling, add { } after condition at fail_compilation/fail4375k.d-mixin-10(11)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375l.d
+++ b/compiler/test/fail_compilation/fail4375l.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375l.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375l.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375l.d(14): Error: else is dangling, add { } after condition at fail_compilation/fail4375l.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375m.d
+++ b/compiler/test/fail_compilation/fail4375m.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375m.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375m.d(14)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375m.d(14): Error: else is dangling, add { } after condition at fail_compilation/fail4375m.d(11)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375o.d
+++ b/compiler/test/fail_compilation/fail4375o.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375o.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375o.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375o.d(14): Error: else is dangling, add { } after condition at fail_compilation/fail4375o.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375p.d
+++ b/compiler/test/fail_compilation/fail4375p.d
@@ -1,10 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375p.d(19): Warning: else is dangling, add { } after condition at fail_compilation/fail4375p.d(12)
-fail_compilation/fail4375p.d(16): Error: undefined identifier `x`
+fail_compilation/fail4375p.d(17): Error: else is dangling, add { } after condition at fail_compilation/fail4375p.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375q.d
+++ b/compiler/test/fail_compilation/fail4375q.d
@@ -1,10 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375q.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375q.d(13)
-fail_compilation/fail4375q.d(14): Error: `with` expression types must be enums or aggregates or pointers to them, not `int`
+fail_compilation/fail4375q.d(15): Error: else is dangling, add { } after condition at fail_compilation/fail4375q.d(11)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375r.d
+++ b/compiler/test/fail_compilation/fail4375r.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375r.d(19): Warning: else is dangling, add { } after condition at fail_compilation/fail4375r.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375r.d(16): Error: else is dangling, add { } after condition at fail_compilation/fail4375r.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375s.d
+++ b/compiler/test/fail_compilation/fail4375s.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375s.d(19): Warning: else is dangling, add { } after condition at fail_compilation/fail4375s.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375s.d(16): Error: else is dangling, add { } after condition at fail_compilation/fail4375s.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375t.d
+++ b/compiler/test/fail_compilation/fail4375t.d
@@ -1,11 +1,9 @@
-// REQUIRED_ARGS: -w -unittest
+// REQUIRED_ARGS: -unittest
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375t.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375t.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375t.d(14): Error: else is dangling, add { } after condition at fail_compilation/fail4375t.d(11)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375u.d
+++ b/compiler/test/fail_compilation/fail4375u.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375u.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375u.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375u.d(12): Error: else is dangling, add { } after condition at fail_compilation/fail4375u.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375v.d
+++ b/compiler/test/fail_compilation/fail4375v.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375v.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375v.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375v.d(12): Error: else is dangling, add { } after condition at fail_compilation/fail4375v.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375w.d
+++ b/compiler/test/fail_compilation/fail4375w.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375w.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375w.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375w.d(12): Error: else is dangling, add { } after condition at fail_compilation/fail4375w.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375x.d
+++ b/compiler/test/fail_compilation/fail4375x.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375x.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375x.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375x.d(13): Error: else is dangling, add { } after condition at fail_compilation/fail4375x.d(10)
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375y.d
+++ b/compiler/test/fail_compilation/fail4375y.d
@@ -1,11 +1,8 @@
-// REQUIRED_ARGS: -w
 // https://issues.dlang.org/show_bug.cgi?id=4375: Dangling else
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375y.d(18): Warning: else is dangling, add { } after condition at fail_compilation/fail4375y.d(13)
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/fail4375y.d(15): Error: else is dangling, add { } after condition at fail_compilation/fail4375y.d(10)
 ---
 */
 

--- a/compiler/test/runnable/integrate.d
+++ b/compiler/test/runnable/integrate.d
@@ -63,13 +63,19 @@ ad sqr(ad x) { return x * x; }
 F pow(F x, int i)
 {
     if(i < 1) return F(1);
-    if(i & 1) if(i == 1) return x; else return x * pow(x,i-1);
+    if(i & 1)
+    {
+        if(i == 1) return x; else return x * pow(x,i-1);
+    }
     return sqr(pow(x,i/2));
 }
 ad pow(ad x, int i)
 {
     if(i < 1) return ad(1);
-    if(i & 1) if(i == 1) return x; else return x * pow(x,i-1);
+    if(i & 1)
+    {
+        if(i == 1) return x; else return x * pow(x,i-1);
+    }
     return sqr(pow(x,i/2));
 }
 

--- a/compiler/test/unit/parser/diagnostic_reporter.d
+++ b/compiler/test/unit/parser/diagnostic_reporter.d
@@ -71,34 +71,3 @@ unittest
 
     assert(reporter.supplementalCount == 1);
 }
-
-@("warnings: dangling else")
-unittest
-{
-    static class WarningCountingDiagnosticReporter : NoopDiagnosticReporter
-    {
-        int warningCount;
-
-        override bool warning(const ref SourceLoc, const(char)*, va_list, const(char)*, const(char)*)
-        {
-            warningCount++;
-            return true;
-        }
-    }
-
-    global.params.useWarnings = DiagnosticReporting.inform;
-    scope reporter = new WarningCountingDiagnosticReporter;
-
-    parseModule("test.d", q{
-        void main()
-        {
-        	if (true)
-        		if (false)
-        			assert(3);
-            else
-                assert(4);
-        }
-    });
-
-    assert(reporter.warningCount == 1);
-}


### PR DESCRIPTION
Check was initially added as an error for D2 in efcfb939fa, then demoted to a warning for both D1 and D2 in 44068a2fea.

Unlike other deprecated features, there's been no future version/deadline set for this particular removal.

Meanwhile, it's been almost 15 years that D compilers have been warning about this ambiguous style, so just promote it to error.