### PR TITLE
druntime-test: Detect musl more robustly

### DIFF
--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -497,10 +497,15 @@ $(addsuffix /.run,$(filter-out test/shared,$(ADDITIONAL_TESTS))): $(DRUNTIME)
 test/shared/.run: $(DRUNTIMESO)
 endif
 
+ifeq (linux,$(OS))
+    LDD = ldd
+    IS_MUSL := $(shell $(LDD) --version 2>&1 | grep -q musl && echo 1)
+endif
+
 test/%/.run: test/%/Makefile $(DMD)
 	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) DMD=$(abspath $(DMD)) BUILD=$(BUILD) \
 		DRUNTIME=$(abspath $(DRUNTIME)) DRUNTIMESO=$(abspath $(DRUNTIMESO)) LINKDL=$(LINKDL) \
-		QUIET=$(QUIET) TIMELIMIT='$(TIMELIMIT)' PIC=$(PIC) SHARED=$(SHARED)
+		QUIET=$(QUIET) TIMELIMIT='$(TIMELIMIT)' PIC=$(PIC) SHARED=$(SHARED) IS_MUSL=$(IS_MUSL)
 
 test/%/.clean: test/%/Makefile
 	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) BUILD=$(BUILD) clean

--- a/druntime/test/common.mak
+++ b/druntime/test/common.mak
@@ -10,6 +10,8 @@ QUIET:=
 TIMELIMIT:=
 PIC:=
 SHARED:=
+# not empty if musl is detected, empty otherwise
+IS_MUSL:=
 
 # Variables that can be specified by users, with the same meaning as used by GNU make
 # $(CC)      $(CXX)      $(DMD)       # the compiler

--- a/druntime/test/exceptions/Makefile
+++ b/druntime/test/exceptions/Makefile
@@ -1,16 +1,9 @@
-ifeq ($(OS),linux)
-    # FIXME: detect musl libc robustly; just checking Alpine Linux' apk tool for now
-    ifeq (1,$(shell which apk &>/dev/null && echo 1))
-        IS_MUSL:=1
-    endif
-endif
-
 TESTS=stderr_msg unittest_assert invalid_memory_operation static_dtor \
       future_message refcounted rt_trap_exceptions_drt catch_in_finally \
       message_with_null
 
 # FIXME: segfaults with musl libc
-ifneq ($(IS_MUSL),1)
+ifndef IS_MUSL
 TESTS += unknown_gc
 endif
 
@@ -26,7 +19,7 @@ GDB:=gdb
 ifeq ($(OS),linux)
     TESTS+=line_trace line_trace_21656 long_backtrace_trunc rt_trap_exceptions cpp_demangle
     # registerMemoryAssertHandler requires glibc
-    ifneq ($(IS_MUSL),1)
+    ifndef IS_MUSL
         TESTS+=memoryerror_null_read memoryerror_null_write memoryerror_null_call memoryerror_stackoverflow
     endif
     line_trace_dflags:=-L--export-dynamic

--- a/druntime/test/importc_compare/Makefile
+++ b/druntime/test/importc_compare/Makefile
@@ -2,10 +2,8 @@ TESTS := importc_compare
 
 # FIXME: fails on Alpine v3.21 with conflicting struct declarations in the C headers:
 # /usr/include/asm-generic/fcntl.h(195): Error: struct `importc_includes.flock` conflicts with struct `importc_includes.flock` at /usr/include/fcntl.h(24)
-ifeq ($(OS),linux)
-    ifeq (1,$(shell which apk &>/dev/null && echo 1))
-        TESTS :=
-    endif
+ifdef IS_MUSL
+    TESTS :=
 endif
 
 include ../common.mak


### PR DESCRIPTION
Try to detect musl on more systems than just Alpine.

This also fixes an issue in the Github runners where the default shell is dash which doesn't understand the `&>` operator leading to the musl-excluded tests to also be skipped on glibc linux.