### PR TITLE
druntime-test: memoryerror_stackoverflow try harder to avoid optimizations

### DIFF
--- a/druntime/test/exceptions/src/memoryerror_stackoverflow.d
+++ b/druntime/test/exceptions/src/memoryerror_stackoverflow.d
@@ -1,16 +1,19 @@
 import etc.linux.memoryerror;
+import core.volatile;
 
 pragma(inline, false):
 
 void f(ref ubyte[1024] buf)
 {
     ubyte[1024] cpy = buf;
+    volatileStore(&cpy[0], 1);
     g(cpy);
 }
 
 void g(ref ubyte[1024] buf)
 {
     ubyte[1024] cpy = buf;
+    volatileStore(&cpy[0], 2);
     f(cpy);
 }
 


### PR DESCRIPTION
gdc and ldc2 with llvm-20 optimize away the array declarations leading to an infinite cycle.

See-Also: https://github.com/ldc-developers/ldc/pull/4969