### PR TITLE
fix #21745 - ImportC: __func__ is not generated if referenced inside a __check() expression

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -860,7 +860,7 @@ final class CParser(AST) : Parser!AST
         case TOK._assert:  // __check(assign-exp) extension
             nextToken();
             check(TOK.leftParenthesis, "`__check`");
-            e = parseAssignExp();
+            e = cparseAssignExp();
             check(TOK.rightParenthesis);
             e = new AST.AssertExp(loc, e, null);
             break;

--- a/compiler/test/compilable/test21475.c
+++ b/compiler/test/compilable/test21475.c
@@ -1,0 +1,4 @@
+void test21745(void)
+{
+    __check(__func__);
+}

--- a/compiler/test/fail_compilation/fail21475.c
+++ b/compiler/test/fail_compilation/fail21475.c
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21475.c(12): Error: expression expected, not `)`
+fail_compilation/fail21475.c(12): Error: found `=>` when expecting `)`
+fail_compilation/fail21475.c(12): Error: found `0` when expecting `)`
+fail_compilation/fail21475.c(12): Error: found `)` when expecting `;` following statement
+---
+*/
+void test21745(void)
+{
+    __check(() => 0);
+}


### PR DESCRIPTION
The enclosing expression was being parsed as-if it were D code.  Fixed to call the correct parsing routing.

Closes #21745
