### PR TITLE
fix #21740 - UCN accepts invalid characters as part of the symbol name

### DIFF
--- a/compiler/test/fail_compilation/fail21740c.i
+++ b/compiler/test/fail_compilation/fail21740c.i
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21740c.i(9): Error: character '\' is not a valid token
+fail_compilation/fail21740c.i(10): Error: character '\' is not a valid token
+fail_compilation/fail21740c.i(10): Error: missing comma or semicolon after declaration of `é`, found `q` instead
+---
+*/
+int \uq;
+int \u00e9\q;

--- a/compiler/test/fail_compilation/fail21740d.i
+++ b/compiler/test/fail_compilation/fail21740d.i
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21740d.i(12): Error: Bidirectional control characters in universal character names are disallowed for security reasons
+fail_compilation/fail21740d.i(13): Error: Bidirectional control characters in universal character names are disallowed for security reasons
+fail_compilation/fail21740d.i(14): Error: Bidirectional control characters in universal character names are disallowed for security reasons
+fail_compilation/fail21740d.i(14): Error: character 0x200e is not allowed as a start character in an identifier
+fail_compilation/fail21740d.i(15): Error: Bidirectional control characters in universal character names are disallowed for security reasons
+fail_compilation/fail21740d.i(16): Error: Bidirectional control characters in universal character names are disallowed for security reasons
+---
+*/
+int \u061c;
+int \u061C;
+int \u200e;
+int \u202a;
+int \u2066;

--- a/compiler/test/fail_compilation/lexer23465.d
+++ b/compiler/test/fail_compilation/lexer23465.d
@@ -1,16 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/lexer23465.d(22): Error: character 0x1f37a is not allowed as a continue character in an identifier
-fail_compilation/lexer23465.d(22): Error: character 0x1f37a is not a valid token
-fail_compilation/lexer23465.d(23): Error: character '\' is not a valid token
-fail_compilation/lexer23465.d(24): Error: octal digit expected, not `9`
-fail_compilation/lexer23465.d(24): Error: octal literals larger than 7 are no longer supported
-fail_compilation/lexer23465.d(25): Error: integer overflow
-fail_compilation/lexer23465.d(26): Error: unterminated /+ +/ comment
-fail_compilation/lexer23465.d(27): Error: found `End of File` instead of array initializer
-fail_compilation/lexer23465.d(27): Error: semicolon needed to end declaration of `arr`, instead of `End of File`
-fail_compilation/lexer23465.d(20):        `arr` declared here
+fail_compilation/lexer23465.d(21): Error: character 0x1f37a is not allowed as a continue character in an identifier
+fail_compilation/lexer23465.d(22): Error: character '\' is not a valid token
+fail_compilation/lexer23465.d(23): Error: octal digit expected, not `9`
+fail_compilation/lexer23465.d(23): Error: octal literals larger than 7 are no longer supported
+fail_compilation/lexer23465.d(24): Error: integer overflow
+fail_compilation/lexer23465.d(25): Error: unterminated /+ +/ comment
+fail_compilation/lexer23465.d(26): Error: found `End of File` instead of array initializer
+fail_compilation/lexer23465.d(26): Error: semicolon needed to end declaration of `arr`, instead of `End of File`
+fail_compilation/lexer23465.d(19):        `arr` declared here
 ---
 */
 


### PR DESCRIPTION
Lexer incremented the token pointer one too many times when consuming UCN identifiers.

Closes #21740. 