### PR TITLE
Fix issue #21744 - ImportC: four-digit UCN identifiers \unnnn don't match eight-digit \Unnnnnnnn

### DIFF
--- a/compiler/test/compilable/extra-files/ucn_vars.i
+++ b/compiler/test/compilable/extra-files/ucn_vars.i
@@ -1,0 +1,11 @@
+struct Vars {
+    int x²;
+    int \u2160;
+    int \u2182;
+    int \u00C0;
+    int \u00C1;
+    int \U000000C2;
+    int wh\u00ff;
+    int a\u00c4b\u0441\U000003b4e;
+    int b\u3021𗘰\u3023e;
+};

--- a/compiler/test/compilable/test21740.i
+++ b/compiler/test/compilable/test21740.i
@@ -1,0 +1,17 @@
+// https://github.com/dlang/dmd/issues/21740
+int x²;
+int \u2160;
+int \u2182;
+int \u00C0;
+int \u00C1;
+int \U000000C2;
+int wh\u00ff;
+int a\u00c4b\u0441\U000003b4e;
+int b\u3021𗘰\u3023e;
+
+int a\U000000aa[4];
+
+typedef int \u0441b\U000003b4 ;
+int a\u00c4(\u0441b\U000003b4)
+{
+}

--- a/compiler/test/compilable/ucn.d
+++ b/compiler/test/compilable/ucn.d
@@ -1,0 +1,13 @@
+/+
+REQUIRED_ARGS: -Icompilable/extra-files
+EXTRA_FILES: extra-files/ucn_vars.i
++/
+
+import ucn_vars;
+
+alias M = __traits(allMembers, Vars);
+enum expected = ["x²", "Ⅰ", "ↂ", "À", "Á", "Â", "whÿ", "aÄbсδe", "b〡𗘰〣e"];
+
+static foreach(i; 0 .. M.length) {
+    static assert(M[i] == expected[i]);
+}

--- a/compiler/test/fail_compilation/fail21740a.i
+++ b/compiler/test/fail_compilation/fail21740a.i
@@ -1,0 +1,7 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21740a.i(7): Error: `=`, `;` or `,` expected to end declaration instead of `)`
+---
+*/
+int a\U000000aa);

--- a/compiler/test/fail_compilation/fail21740b.i
+++ b/compiler/test/fail_compilation/fail21740b.i
@@ -1,0 +1,7 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21740b.i(7): Error: undefined identifier `é`
+---
+*/
+void *p = &\u00e9;

--- a/compiler/test/runnable/test21740.i
+++ b/compiler/test/runnable/test21740.i
@@ -1,0 +1,13 @@
+// https://github.com/dlang/dmd/pull/21740
+int strcmp(const char *, const char *);
+
+void  \u00e9 (void)
+{
+    __check(strcmp (__func__, "\u00e9") == 0);
+}
+
+int main (void)
+{
+    \u00e9 ();
+    return 0;
+}


### PR DESCRIPTION
…Fix issue #21740 - ImportC: UCN accepts invalid characters as part of the symbol name

@ibuclaw both should be fixed in this PR.