### PR TITLE
expressionsem: Promote truncating conversion warning to deprecation

### DIFF
--- a/changelog/dmd.truncating.conversion.dd
+++ b/changelog/dmd.truncating.conversion.dd
@@ -1,0 +1,15 @@
+Implicit integer conversions in `int op= float` assignments has been deprecated
+
+This is to prevent potential mistakes when `op=` assignment would implicitly
+truncated the right hand side expression from a non-zero value to zero.
+```
+uint a;
+float b = 0.1;
+a += b; // Deprecation: `uint += float` is performing truncating conversion
+```
+
+The corrective action if truncating was intentional is to explicitly cast the
+floating point expression to integer.
+```
+a += cast(uint)b;
+```

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -471,16 +471,19 @@ private Expression checkOpAssignTypes(BinExp binExp, Scope* sc)
     Type t1 = e1.type;
     Type t2 = e2.type;
 
+    // @@@DEPRECATED_2.122@@@
+    // Deprecated in 2.112, make it an error in 2.122
     // T opAssign floating yields a floating. Prevent truncating conversions (float to int).
     // See https://issues.dlang.org/show_bug.cgi?id=3841.
     // Should we also prevent double to float (type.isFloating() && type.size() < t2.size()) ?
-    if (op == EXP.addAssign || op == EXP.minAssign ||
-        op == EXP.mulAssign || op == EXP.divAssign || op == EXP.modAssign ||
-        op == EXP.powAssign)
+    if (!sc.inCfile &&
+        (op == EXP.addAssign || op == EXP.minAssign ||
+         op == EXP.mulAssign || op == EXP.divAssign || op == EXP.modAssign ||
+         op == EXP.powAssign))
     {
         if ((type.isIntegral() && t2.isFloating()))
         {
-            warning(loc, "`%s %s %s` is performing truncating conversion", type.toChars(), EXPtoString(op).ptr, t2.toChars());
+            deprecation(loc, "`%s %s %s` is performing truncating conversion", type.toChars(), EXPtoString(op).ptr, t2.toChars());
         }
     }
 

--- a/compiler/test/compilable/testexpression.d
+++ b/compiler/test/compilable/testexpression.d
@@ -69,7 +69,6 @@ void OpAssignCases(alias X)()
 
     X!(integral, boolean, all)();
     X!(integral, integral, all)();
-    X!(integral, floating, arith)();
 
     X!(floating, boolean, arith)();
     X!(floating, integral, arith)();

--- a/compiler/test/fail_compilation/b3841.d
+++ b/compiler/test/fail_compilation/b3841.d
@@ -1,25 +1,38 @@
-// REQUIRED_ARGS: -w -o-
+// REQUIRED_ARGS: -de
 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/b3841.d-mixin-32(32): Warning: `char += float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `int += float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `long += double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `char -= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `int -= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `long -= double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `char *= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `int *= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `long *= double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `char /= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `int /= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `long /= double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `char %= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `int %= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-32(32): Warning: `long %= double` is performing truncating conversion
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `char += float` is performing truncating conversion
+fail_compilation/b3841.d(69): Error: template instance `b3841.f!("+=", char, float)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `int += float` is performing truncating conversion
+fail_compilation/b3841.d(70): Error: template instance `b3841.f!("+=", int, float)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `long += double` is performing truncating conversion
+fail_compilation/b3841.d(71): Error: template instance `b3841.f!("+=", long, double)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `char -= float` is performing truncating conversion
+fail_compilation/b3841.d(69): Error: template instance `b3841.f!("-=", char, float)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `int -= float` is performing truncating conversion
+fail_compilation/b3841.d(70): Error: template instance `b3841.f!("-=", int, float)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `long -= double` is performing truncating conversion
+fail_compilation/b3841.d(71): Error: template instance `b3841.f!("-=", long, double)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `char *= float` is performing truncating conversion
+fail_compilation/b3841.d(69): Error: template instance `b3841.f!("*=", char, float)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `int *= float` is performing truncating conversion
+fail_compilation/b3841.d(70): Error: template instance `b3841.f!("*=", int, float)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `long *= double` is performing truncating conversion
+fail_compilation/b3841.d(71): Error: template instance `b3841.f!("*=", long, double)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `char /= float` is performing truncating conversion
+fail_compilation/b3841.d(69): Error: template instance `b3841.f!("/=", char, float)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `int /= float` is performing truncating conversion
+fail_compilation/b3841.d(70): Error: template instance `b3841.f!("/=", int, float)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `long /= double` is performing truncating conversion
+fail_compilation/b3841.d(71): Error: template instance `b3841.f!("/=", long, double)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `char %= float` is performing truncating conversion
+fail_compilation/b3841.d(69): Error: template instance `b3841.f!("%=", char, float)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `int %= float` is performing truncating conversion
+fail_compilation/b3841.d(70): Error: template instance `b3841.f!("%=", int, float)` error instantiating
+fail_compilation/b3841.d-mixin-45(45): Deprecation: `long %= double` is performing truncating conversion
+fail_compilation/b3841.d(71): Error: template instance `b3841.f!("%=", long, double)` error instantiating
 ---
 */
 

--- a/compiler/test/fail_compilation/failexpression1.d
+++ b/compiler/test/fail_compilation/failexpression1.d
@@ -1,0 +1,154 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte += float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte -= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte *= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte /= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte %= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte += double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte -= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte *= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte /= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte %= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte += real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte -= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte *= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte /= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `byte %= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte += float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte -= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte *= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte /= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte %= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte += double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte -= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte *= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte /= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte %= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte += real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte -= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte *= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte /= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ubyte %= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short += float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short -= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short *= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short /= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short %= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short += double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short -= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short *= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short /= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short %= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short += real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short -= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short *= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short /= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `short %= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort += float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort -= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort *= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort /= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort %= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort += double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort -= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort *= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort /= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort %= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort += real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort -= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort *= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort /= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ushort %= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int += float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int -= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int *= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int /= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int %= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int += double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int -= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int *= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int /= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int %= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int += real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int -= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int *= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int /= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `int %= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint += float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint -= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint *= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint /= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint %= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint += double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint -= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint *= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint /= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint %= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint += real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint -= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint *= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint /= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `uint %= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long += float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long -= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long *= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long /= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long %= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long += double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long -= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long *= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long /= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long %= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long += real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long -= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long *= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long /= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `long %= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong += float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong -= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong *= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong /= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong %= float` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong += double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong -= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong *= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong /= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong %= double` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong += real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong -= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong *= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong /= real` is performing truncating conversion
+fail_compilation/failexpression1.d-mixin-138(138): Deprecation: `ulong %= real` is performing truncating conversion
+fail_compilation/failexpression1.d(148): Error: template instance `failexpression1.X!(integral, floating, arith)` error instantiating
+fail_compilation/failexpression1.d(153):        instantiated from here: `OpAssignCases!(TestOpAssign)`
+---
+*/
+template TT(T...) { alias T TT; }
+
+void TestOpAssign(Tx, Ux, ops)()
+{
+    foreach(T; Tx.x)
+    foreach(U; Ux.x)
+    foreach(op; ops.x)
+    {
+        T a = cast(T)1;
+        mixin("a " ~ op ~ " cast(U)1;");
+    }
+}
+
+struct integral  { alias TT!(byte, ubyte, short, ushort, int, uint, long, ulong) x; }
+struct floating  { alias TT!(float, double, real) x; }
+struct arith     { alias TT!("+=", "-=", "*=", "/=", "%=") x; }
+
+void OpAssignCases(alias X)()
+{
+    X!(integral, floating, arith)();
+}
+
+void main()
+{
+    OpAssignCases!TestOpAssign();
+}

--- a/compiler/test/fail_compilation/failexpression2.d
+++ b/compiler/test/fail_compilation/failexpression2.d
@@ -1,0 +1,156 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte += float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte -= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte *= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte /= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte %= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte += double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte -= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte *= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte /= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte %= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte += real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte -= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte *= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte /= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `byte %= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte += float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte -= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte *= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte /= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte %= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte += double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte -= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte *= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte /= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte %= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte += real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte -= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte *= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte /= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ubyte %= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short += float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short -= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short *= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short /= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short %= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short += double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short -= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short *= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short /= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short %= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short += real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short -= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short *= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short /= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `short %= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort += float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort -= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort *= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort /= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort %= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort += double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort -= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort *= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort /= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort %= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort += real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort -= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort *= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort /= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ushort %= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int += float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int -= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int *= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int /= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int %= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int += double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int -= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int *= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int /= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int %= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int += real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int -= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int *= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int /= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `int %= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint += float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint -= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint *= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint /= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint %= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint += double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint -= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint *= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint /= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint %= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint += real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint -= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint *= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint /= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `uint %= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long += float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long -= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long *= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long /= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long %= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long += double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long -= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long *= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long /= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long %= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long += real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long -= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long *= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long /= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `long %= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong += float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong -= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong *= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong /= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong %= float` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong += double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong -= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong *= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong /= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong %= double` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong += real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong -= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong *= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong /= real` is performing truncating conversion
+fail_compilation/failexpression2.d-mixin-140(140): Deprecation: `ulong %= real` is performing truncating conversion
+fail_compilation/failexpression2.d(150): Error: template instance `failexpression2.X!(integral, floating, arith)` error instantiating
+fail_compilation/failexpression2.d(155):        instantiated from here: `OpAssignCases!(TestOpAssignAssign)`
+---
+*/
+template TT(T...) { alias T TT; }
+
+void TestOpAssignAssign(Tx, Ux, ops)()
+{
+    foreach(T; Tx.x)
+    foreach(U; Ux.x)
+    foreach(op; ops.x)
+    {
+        T a = cast(T)1;
+        U b = cast(U)1;
+        T r;
+        mixin("r = a " ~ op ~ " cast(U)1;");
+    }
+}
+
+struct integral  { alias TT!(byte, ubyte, short, ushort, int, uint, long, ulong) x; }
+struct floating  { alias TT!(float, double, real) x; }
+struct arith     { alias TT!("+=", "-=", "*=", "/=", "%=") x; }
+
+void OpAssignCases(alias X)()
+{
+    X!(integral, floating, arith)();
+}
+
+void main()
+{
+    OpAssignCases!TestOpAssignAssign(); // was once disabled due to bug 7436
+}

--- a/compiler/test/fail_compilation/failexpression3.d
+++ b/compiler/test/fail_compilation/failexpression3.d
@@ -1,0 +1,66 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `int += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `int -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `int *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `int /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `int %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `uint += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `uint -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `uint *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `uint /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `uint %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long += double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long -= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long *= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long /= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long %= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong += double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong -= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong *= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong /= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong %= double` is performing truncating conversion
+fail_compilation/failexpression3.d(60): Error: template instance `failexpression3.X!(integral, floating, arith)` error instantiating
+fail_compilation/failexpression3.d(65):        instantiated from here: `OpAssignCases!(TestOpAssignAuto)`
+---
+*/
+template TT(T...) { alias T TT; }
+
+void TestOpAssignAuto(Tx, Ux, ops)()
+{
+    foreach(T; Tx.x)
+    foreach(U; Ux.x)
+    static if (U.sizeof <= T.sizeof)
+    foreach(op; ops.x)
+    {
+        T a = cast(T)1;
+        U b = cast(U)1;
+        mixin("auto r = a " ~ op ~ " cast(U)1;");
+    }
+}
+
+struct integral  { alias TT!(byte, ubyte, short, ushort, int, uint, long, ulong) x; }
+struct floating  { alias TT!(float, double, real) x; }
+struct arith     { alias TT!("+=", "-=", "*=", "/=", "%=") x; }
+
+void OpAssignCases(alias X)()
+{
+    X!(integral, floating, arith)();
+}
+
+void main()
+{
+    OpAssignCases!TestOpAssignAuto(); // https://issues.dlang.org/show_bug.cgi?id=5181
+}

--- a/compiler/test/fail_compilation/failexpression4.d
+++ b/compiler/test/fail_compilation/failexpression4.d
@@ -1,0 +1,66 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `int`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `int`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `int`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `int`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `int`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `uint`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `uint`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `uint`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `uint`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `uint`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `long`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `long`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `long`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `long`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `long`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a + 1.0` of type `double` to `long`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a - 1.0` of type `double` to `long`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a * 1.0` of type `double` to `long`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a / 1.0` of type `double` to `long`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a % 1.0` of type `double` to `long`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `ulong`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `ulong`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `ulong`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `ulong`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `ulong`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a + 1.0` of type `double` to `ulong`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a - 1.0` of type `double` to `ulong`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a * 1.0` of type `double` to `ulong`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a / 1.0` of type `double` to `ulong`
+fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a % 1.0` of type `double` to `ulong`
+fail_compilation/failexpression4.d(60): Error: template instance `failexpression4.X!(integral, floating, arith)` error instantiating
+fail_compilation/failexpression4.d(65):        instantiated from here: `OpReAssignCases!(TestOpAndAssign)`
+---
+*/
+template TT(T...) { alias T TT; }
+
+void TestOpAndAssign(Tx, Ux, ops)()
+{
+    foreach(T; Tx.x)
+    foreach(U; Ux.x)
+    static if (U.sizeof <= T.sizeof && T.sizeof >= 4)
+    foreach(op; ops.x)
+    {
+        T a = cast(T)1;
+        U b = cast(U)1;
+        mixin("a = a " ~ op[0..$-1] ~ " cast(U)1;");
+    }
+}
+
+struct integral  { alias TT!(byte, ubyte, short, ushort, int, uint, long, ulong) x; }
+struct floating  { alias TT!(float, double, real) x; }
+struct arith     { alias TT!("+=", "-=", "*=", "/=", "%=") x; }
+
+void OpReAssignCases(alias X)()
+{
+    X!(integral, floating, arith)();
+}
+
+void main()
+{
+    OpReAssignCases!TestOpAndAssign();
+}

--- a/compiler/test/runnable/test42.d
+++ b/compiler/test/runnable/test42.d
@@ -6043,7 +6043,7 @@ void test7436()
 {
     ubyte a = 10;
     float f = 6;
-    ubyte b = a += f;
+    ubyte b = a += cast(ubyte)f;
     assert(b == 16);
 }
 

--- a/compiler/test/runnable/testassign.d
+++ b/compiler/test/runnable/testassign.d
@@ -1127,7 +1127,7 @@ void test13044()
 void test12500()
 {
     size_t foo;
-    ++foo *= 1.5;   // Rewrite to: (foo += 1) *= 1.5;
+    ++foo *= cast(size_t)1.5;   // Rewrite to: (foo += 1) *= 1.5;
 }
 
 /***************************************************/


### PR DESCRIPTION
Check was initially added in 0109acf3a2 as a warning.

This was added almost 10 years ago, so promote it to an deprecation when running semantic on D code only.