### PR TITLE
fix #21757: MS Linker may fail on 32 bit debug builds: stack overflow

### DIFF
--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -460,6 +460,9 @@ private void syment_set_name(SymbolTable32* sym, const(char)* name)
     size_t len = strlen(name);
     if (len > 8)
     {   // Use offset into string table
+        // symbols larger than 64kB crash link.exe 14.44 or later
+        if (len > CV8_MAX_SYMBOL_LENGTH)
+            len = CV8_MAX_SYMBOL_LENGTH;
         IDXSTR idx = MsCoffObj_addstr(string_table, name[0 .. len]);
         sym.Zeros = 0;
         sym.Offset = idx;

--- a/compiler/test/runnable/test21757.d
+++ b/compiler/test/runnable/test21757.d
@@ -1,0 +1,10 @@
+// https://github.com/dlang/dmd/issues/21757
+
+struct S
+{
+    void*[300_000] arr; // generates stupidly large symbols for RTImfoImpl!() that crash MS link.exe
+}
+
+void main()
+{
+}


### PR DESCRIPTION
… or LNK1318 fatal error.

limit symbol names to slightly below 64 kB for mscoff