### PR TITLE
errors: Remove toplevel warning entrypoints

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -57,7 +57,6 @@ __gshared Diagnostic[] diagnostics = [];
 class ErrorSinkCompiler : ErrorSink
 {
   nothrow:
-  extern (C++):
   override:
 
     void verror(Loc loc, const(char)* format, va_list ap)
@@ -243,55 +242,6 @@ else
         va_list ap;
         va_start(ap, format);
         vsupplementalDiagnostic(loc, format, ap, ErrorKind.error);
-        va_end(ap);
-    }
-
-/**
- * Print a warning message, increasing the global warning count.
- * Params:
- *      loc    = location of warning
- *      format = printf-style format specification
- *      ...    = printf-style variadic arguments
- */
-static if (__VERSION__ < 2092)
-    extern (C++) void warning(Loc loc, const(char)* format, ...)
-    {
-        va_list ap;
-        va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.warning);
-        va_end(ap);
-    }
-else
-    pragma(printf) extern (C++) void warning(Loc loc, const(char)* format, ...)
-    {
-        va_list ap;
-        va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.warning);
-        va_end(ap);
-    }
-
-/**
- * Print additional details about a warning message.
- * Doesn't increase the warning count or print an additional warning prefix.
- * Params:
- *      loc    = location of warning
- *      format = printf-style format specification
- *      ...    = printf-style variadic arguments
- */
-static if (__VERSION__ < 2092)
-    extern (C++) void warningSupplemental(Loc loc, const(char)* format, ...)
-    {
-        va_list ap;
-        va_start(ap, format);
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.warning);
-        va_end(ap);
-    }
-else
-    pragma(printf) extern (C++) void warningSupplemental(Loc loc, const(char)* format, ...)
-    {
-        va_list ap;
-        va_start(ap, format);
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.warning);
         va_end(ap);
     }
 

--- a/compiler/src/dmd/errors.h
+++ b/compiler/src/dmd/errors.h
@@ -31,8 +31,6 @@ enum class ErrorKind
 #endif
 
 // Print a warning, deprecation, or error, accepts printf-like format specifiers.
-D_ATTRIBUTE_FORMAT(2, 3) void warning(Loc loc, const char *format, ...);
-D_ATTRIBUTE_FORMAT(2, 3) void warningSupplemental(Loc loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void deprecation(Loc loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void deprecationSupplemental(Loc loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void error(Loc loc, const char *format, ...);

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -21,7 +21,6 @@ import dmd.location;
 abstract class ErrorSink
 {
   nothrow:
-  extern (C++):
 
     void verror(Loc loc, const(char)* format, va_list ap);
     void verrorSupplemental(Loc loc, const(char)* format, va_list ap);
@@ -103,7 +102,6 @@ abstract class ErrorSink
 class ErrorSinkNull : ErrorSink
 {
   nothrow:
-  extern (C++):
   override:
 
     void verror(Loc loc, const(char)* format, va_list ap) { }
@@ -127,7 +125,6 @@ class ErrorSinkNull : ErrorSink
 class ErrorSinkLatch : ErrorSinkNull
 {
   nothrow:
-  extern (C++):
   override:
 
     bool sawErrors;
@@ -145,7 +142,6 @@ class ErrorSinkStderr : ErrorSink
     import core.stdc.stdarg;
 
   nothrow:
-  extern (C++):
   override:
 
     void verror(Loc loc, const(char)* format, va_list ap)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8256,10 +8256,6 @@ extern void errorBackend(const char* filename, uint32_t linnum, uint32_t charnum
 
 extern void errorSupplemental(Loc loc, const char* format, ...);
 
-extern void warning(Loc loc, const char* format, ...);
-
-extern void warningSupplemental(Loc loc, const char* format, ...);
-
 extern void deprecation(Loc loc, const char* format, ...);
 
 extern void deprecationSupplemental(Loc loc, const char* format, ...);

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -3129,11 +3129,6 @@ class Lexer
         eSink.deprecation(loc, format, args);
     }
 
-    void warning(T...)(Loc loc, const(char)* format, T args)
-    {
-        eSink.warning(loc, format, args);
-    }
-
     void deprecation(T...)(const(char)* format, T args)
     {
         eSink.deprecation(token.loc, format, args);
@@ -3618,7 +3613,6 @@ unittest
     static class ErrorSinkTest : ErrorSinkNull
     {
       nothrow:
-      extern (C++):
       override:
 
         import core.stdc.stdio;

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1610,7 +1610,7 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)
     class ErrorSinkTest : ErrorSinkNull
     {
         OutBuffer result;
-        extern(C++): override:
+        override:
 
         void verror(Loc loc, const(char)* format, va_list ap)
         {


### PR DESCRIPTION
These are now unused, their removal discourages adding new warnings to the language.