### PR TITLE
fix #17462 object.require modifies AA before populating value

### DIFF
--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -3515,11 +3515,8 @@ inout(V) get(K, V)(inout(V[K])* aa, K key, lazy inout(V) defaultValue)
 ref V require(K, V)(ref V[K] aa, K key, lazy V value = V.init)
 {
     bool found;
-    auto p = _aaGetX(aa, key, found);
-    if (found)
-        return *p;
-    *p = value; // Not `return (*p = value)` since if `=` is overloaded
-    return *p;  // this might not return a ref to the left-hand side.
+    auto p = _aaGetX(aa, key, found, value);
+    return *p;
 }
 
 ///
@@ -3552,10 +3549,8 @@ void update(K, V, C, U)(ref V[K] aa, K key, scope C create, scope U update)
 if (is(typeof(create()) : V) && (is(typeof(update(aa[K.init])) : V) || is(typeof(update(aa[K.init])) == void)))
 {
     bool found;
-    auto p = _aaGetX(aa, key, found);
-    if (!found)
-        *p = create();
-    else
+    auto p = _aaGetX(aa, key, found, create());
+    if (found)
     {
         static if (is(typeof(update(*p)) == void))
             update(*p);

--- a/druntime/test/aa/src/test_aa.d
+++ b/druntime/test/aa/src/test_aa.d
@@ -7,8 +7,10 @@ void main()
     testRequire1();
     testRequire2();
     testRequire3();
+    testRequire4();
     testUpdate1();
     testUpdate2();
+    testUpdate3();
     testByKey1();
     testByKey2();
     testByKey3();
@@ -227,6 +229,20 @@ void testRequire3() pure
     assert("foo" in aa);
 }
 
+void testRequire4() pure
+{
+    int[int] aa;
+    try
+        aa.require(5, {
+            if (true)
+                throw new Exception("oops");
+            else
+                return 1;
+        }());
+    catch (Exception e) {}
+    assert(5 !in aa);
+}
+
 
 void testUpdate1()
 {
@@ -290,6 +306,23 @@ void testUpdate2()
     aa.update("foo", new Creator, new Updater);
     assert(updated);
 }
+
+void testUpdate3() pure
+{
+    int[int] aa;
+    try
+        aa.update(5, {
+            if (true)
+                throw new Exception("oops");
+            else
+                return 1;
+        }, (ref int v) {
+            throw new Exception("unexpected update");
+        });
+    catch (Exception e) {}
+    assert(5 !in aa);
+}
+
 
 void testByKey1() @safe
 {


### PR DESCRIPTION
pass value lazily to _aaGetX, so it can be copied to the key-value-pair before the entry is actually added to the AA.
Also fixes a similar issue for aa.update

For normal insertion via `aa[key] = val`, the compiler should call _aaGetX instead of _aaGetY aswell, but that is a bit more involved and is listed as #17374 .