### PR TITLE
avoid azure timeouts

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -5280,6 +5280,7 @@ unittest
 // https://issues.dlang.org/show_bug.cgi?id=19281
 debug (SENTINEL) {} else // cannot allow >= 4 GB with SENTINEL
 debug (MEMSTOMP) {} else // might take too long to actually touch the memory
+version (OnlyLowMemUnittests) {} else
 version (D_LP64) unittest
 {
     static if (__traits(compiles, os_physical_mem))
@@ -5395,6 +5396,7 @@ unittest
 
 // https://github.com/dlang/dmd/issues/21615
 debug(SENTINEL) {} else // no additional capacity with SENTINEL
+version (OnlyLowMemUnittests) {} else
 @safe unittest
 {
     size_t numReallocations = 0;

--- a/druntime/test/gc/Makefile
+++ b/druntime/test/gc/Makefile
@@ -49,7 +49,7 @@ $(ROOT)/sentinel2$(DOTEXE): extra_dflags += -debug=SENTINEL -debug=GC_RECURSIVE_
 $(ROOT)/printf$(DOTEXE): $(src_gc)
 $(ROOT)/printf$(DOTEXE): private extra_sources = $(src_gc)
 $(ROOT)/printf$(DOTEXE): extra_dflags += \
-	-debug=PRINTF -debug=PRINTF_TO_FILE -debug=COLLECT_PRINTF $(core_ut) -main
+	-debug=PRINTF -debug=PRINTF_TO_FILE -debug=COLLECT_PRINTF -version=OnlyLowMemUnittests $(core_ut) -main
 
 $(ROOT)/memstomp$(DOTEXE): $(src_lifetime)
 $(ROOT)/memstomp$(DOTEXE): private extra_sources = $(src_lifetime)


### PR DESCRIPTION
only run low memory tests with the GC printf test, it sometimes takes forever