### PR TITLE
[druntime]: Fix sys.posix.sys.types.nlink_t definition

### DIFF
--- a/druntime/src/core/sys/posix/sys/types.d
+++ b/druntime/src/core/sys/posix/sys/types.d
@@ -103,7 +103,20 @@ version (linux)
     alias ulong     dev_t;
     alias uint      gid_t;
     alias uint      mode_t;
-    alias ulong_t   nlink_t;
+
+  version (X86_64)
+    alias ulong nlink_t;
+  else version (S390)
+    alias size_t nlink_t;
+  else version (PPC64)
+    alias size_t nlink_t;
+  else version (MIPS64)
+    alias size_t nlink_t;
+  else version (HPPA64)
+    alias size_t nlink_t;
+  else
+    alias uint nlink_t;
+
     alias int       pid_t;
     //size_t (defined in core.stdc.stddef)
     alias c_long    ssize_t;


### PR DESCRIPTION
I've taken the definitions from glibc's
sysdeps/unix/sysv/linux/**/bits/typesizes.h.

For convenience:
```
alpha/bits/typesizes.h       #define  __NLINK_T_TYPE  __U32_TYPE
arm/bits/typesizes.h         #define  __NLINK_T_TYPE  __UWORD_TYPE
hppa/bits/typesizes.h        #define  __NLINK_T_TYPE  __UWORD_TYPE
m68k/bits/typesizes.h        #define  __NLINK_T_TYPE  __UWORD_TYPE
microblaze/bits/typesizes.h  #define  __NLINK_T_TYPE  __UWORD_TYPE
mips/bits/typesizes.h        #define  __NLINK_T_TYPE  __UWORD_TYPE
powerpc/bits/typesizes.h     #define  __NLINK_T_TYPE  __UWORD_TYPE
s390/bits/typesizes.h        #define  __NLINK_T_TYPE  __UWORD_TYPE
sh/bits/typesizes.h          #define  __NLINK_T_TYPE  __UWORD_TYPE
sparc/bits/typesizes.h       #define  __NLINK_T_TYPE  __U32_TYPE

bits/typesizes.h             #define  __NLINK_T_TYPE  __U32_TYPE
```

And x86:
```
 // sysdeps/unix/sysv/linux/x86/bits/typesizes.h
 #ifdef __x86_64__
 # define __NLINK_T_TYPE         __SYSCALL_ULONG_TYPE
 #else
 # define __NLINK_T_TYPE         __UWORD_TYPE
 #endif
```