### PR TITLE
[druntime]: Fix posix.sys.shm.shmid_ds on (some) non-x86_64

### DIFF
--- a/druntime/src/core/sys/posix/sys/shm.d
+++ b/druntime/src/core/sys/posix/sys/shm.d
@@ -66,11 +66,11 @@ version (linux)
         ipc_perm    shm_perm;
         size_t      shm_segsz;
         time_t      shm_atime;
-        version (X86_64) {} else c_ulong     __unused1;
+        static if (time_t.sizeof == 4) c_ulong     __unused1;
         time_t      shm_dtime;
-        version (X86_64) {} else c_ulong     __unused2;
+        static if (time_t.sizeof == 4) c_ulong     __unused2;
         time_t      shm_ctime;
-        version (X86_64) {} else c_ulong     __unused3;
+        static if (time_t.sizeof == 4) c_ulong     __unused3;
         pid_t       shm_cpid;
         pid_t       shm_lpid;
         shmatt_t    shm_nattch;


### PR DESCRIPTION
Check glibc's sysdeps/unix/sysv/linux/**/bits/types/struct_shmid_ds.h for correctness. Some arches still look like they have an incorrect declaration but this, at least, fixes aarch64 which is the more common one.

For convenience, the shared definition used by both x86_64 and aarch64 is:
```
 struct shmid_ds
   {
 #ifdef __USE_TIME64_REDIRECTS
 # include <bits/types/struct_shmid64_ds_helper.h>
 #else
     struct ipc_perm shm_perm;           /* operation permission struct */
     size_t shm_segsz;                   /* size of segment in bytes */
 # if __TIMESIZE == 32
     __time_t shm_atime;                 /* time of last shmat() */
     unsigned long int __shm_atime_high;
     __time_t shm_dtime;                 /* time of last shmdt() */
     unsigned long int __shm_dtime_high;
     __time_t shm_ctime;                 /* time of last change by shmctl() */
     unsigned long int __shm_ctime_high;
 # else
     __time_t shm_atime;                 /* time of last shmat() */
     __time_t shm_dtime;                 /* time of last shmdt() */
     __time_t shm_ctime;                 /* time of last change by shmctl() */
 # endif
     __pid_t shm_cpid;                   /* pid of creator */
     __pid_t shm_lpid;                   /* pid of last shmop */
     shmatt_t shm_nattch;                /* number of current attaches */
     __syscall_ulong_t __glibc_reserved5;
     __syscall_ulong_t __glibc_reserved6;
 #endif
   };
```