### PR TITLE
fix #17804 multi-dimensional AA is not an initializer

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1650,7 +1650,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         if (ai && tb.ty == Taarray)
                             e = ai.toAssocArrayLiteral();
                         else
-                            e = dsym._init.initializerToExpression(null, sc.inCfile);
+                            e = dsym._init.initializerToExpression(dsym.type, sc.inCfile);
                         if (!e)
                         {
                             // Run semantic, but don't need to interpret

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -168,7 +168,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                 // Convert initializer to Expression `ex`
                 auto tm = fieldType.addMod(t.mod);
                 auto iz = i.value[j].initializerSemantic(sc, tm, needInterpret);
-                auto ex = iz.initializerToExpression(null, sc.inCfile);
+                auto ex = iz.initializerToExpression(fieldType, sc.inCfile);
                 if (ex.op != EXP.error)
                     i.value[j] = iz;
                 return ex;
@@ -1267,6 +1267,11 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
     {
         //printf("ArrayInitializer::toExpression(), dim = %d\n", dim);
         //static int i; if (++i == 2) assert(0);
+        if (!itype || itype.toBasetype().isTypeAArray())
+            if (!init.type || init.type.isTypeAArray())
+                if (init.isAssociativeArray())
+                    return init.toAssocArrayLiteral();
+
         uint edim;      // the length of the resulting array literal
         const(uint) amax = 0x80000000;
         Type t = null;  // type of the array literal being initialized

--- a/compiler/test/runnable/staticaa.d
+++ b/compiler/test/runnable/staticaa.d
@@ -209,12 +209,45 @@ void testClassLiteral()
 // https://github.com/dlang/dmd/issues/21690
 void testMultiDim()
 {
-    // int[int][int] aa1 = [ 1: [2: 3] ]; // Error: invalid value `[2:3]` in initializer (see #17804)
+    int[int][int] aa1 = [ 1: [2: 3] ]; // Error: invalid value `[2:3]` in initializer (see #17804)
     int[int][int] aa2 = ([ 1: [2: 3] ]); // workaround
     auto aa3 = [ 1: [2: 3] ]; // works, too
     static auto aa4 = [ 1: [2: 3] ]; // Error: internal compiler error: failed to detect static initialization of associative array
+    assert(aa1 == aa2);
     assert(aa2 == aa3);
     assert(aa3 == aa4);
+}
+
+/////////////////////////////////////////////
+
+// https://github.com/dlang/dmd/issues/17804
+void testMultiDimInit()
+{
+    static struct D
+    {
+        string[string][string] aa;
+        this(string[string][string] _aa) { aa = _aa; }
+    }
+    static struct S
+    {
+        //Error: not an associative array initializer
+        D a = ["fdsa": ["fdsafd": "fdsfa"]];
+
+        // OK
+        D b = (["fdsa": ["fdsafd": "fdsfa"]]);
+    }
+    immutable string[7] a = [
+        3 : null,
+        2 : "D",
+        1 : "C",
+    ];
+    static int[char][char] arr = ['A' : ['B': 0]]; // error
+    assert(arr.length == 1);
+    assert(arr['A'] == ['B':0]);
+
+    S s;
+    assert(s.a.aa["fdsa"]["fdsafd"] == "fdsfa");
+    assert(s.b.aa["fdsa"]["fdsafd"] == "fdsfa");
 }
 
 /////////////////////////////////////////////
@@ -232,4 +265,5 @@ void main()
     testStaticArray();
     testClassLiteral();
     testMultiDim();
+    testMultiDimInit();
 }


### PR DESCRIPTION
assume an array literal initializer that looks like an AA is only a dynamic array if a respective type is provided (as expressions already do)