### PR TITLE
Fix zombie processes being left behind when resolving using atos

### DIFF
--- a/druntime/src/core/internal/backtrace/dwarf.d
+++ b/druntime/src/core/internal/backtrace/dwarf.d
@@ -287,6 +287,7 @@ version (Darwin) {
         import core.stdc.stdlib : exit;
         import core.sys.posix.stdio : fdopen;
         import core.sys.posix.unistd : close, dup2, execlp, fork, getpid, pipe;
+        import core.sys.posix.sys.wait : waitpid;
         // Create in/out pipes to communicate with the forked exec
         int[2] dummy_pipes; // these dummy pipes are there to prevent funny issues when stdin/stdout is closed and pipe returns id 0 or 1
         int[2] pipes_to_atos;
@@ -361,6 +362,7 @@ version (Darwin) {
         fclose(from_atos);
         close(write_to_atos);
         close(read_from_atos);
+        waitpid(child_id, null, 0);
     }
     private Location parseAtosLine(char* buffer) @nogc nothrow
     {


### PR DESCRIPTION
The code for resolving debug information using atos, which is mainly used by LDC, as it doesn't embed line information into the executable (by default), never called waitpid() on the child PID, leading to zombie processes and an eventual exhaution of open file descriptors.

Fixes #21774.