### PR TITLE
druntime integration tests: Fix musl detection with dash shell

### DIFF
--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -497,10 +497,17 @@ $(addsuffix /.run,$(filter-out test/shared,$(ADDITIONAL_TESTS))): $(DRUNTIME)
 test/shared/.run: $(DRUNTIMESO)
 endif
 
+ifeq ($(OS),linux)
+    # FIXME: detect musl libc robustly; just checking Alpine Linux' apk tool for now
+    ifeq (1,$(shell which apk >/dev/null 2>&1 && echo 1))
+        IS_MUSL := 1
+    endif
+endif
+
 test/%/.run: test/%/Makefile $(DMD)
 	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) DMD=$(abspath $(DMD)) BUILD=$(BUILD) \
 		DRUNTIME=$(abspath $(DRUNTIME)) DRUNTIMESO=$(abspath $(DRUNTIMESO)) LINKDL=$(LINKDL) \
-		QUIET=$(QUIET) TIMELIMIT='$(TIMELIMIT)' PIC=$(PIC) SHARED=$(SHARED)
+		QUIET=$(QUIET) TIMELIMIT='$(TIMELIMIT)' PIC=$(PIC) SHARED=$(SHARED) IS_MUSL=$(IS_MUSL)
 
 test/%/.clean: test/%/Makefile
 	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) BUILD=$(BUILD) clean

--- a/druntime/test/common.mak
+++ b/druntime/test/common.mak
@@ -10,6 +10,7 @@ QUIET:=
 TIMELIMIT:=
 PIC:=
 SHARED:=
+IS_MUSL:=
 
 # Variables that can be specified by users, with the same meaning as used by GNU make
 # $(CC)      $(CXX)      $(DMD)       # the compiler

--- a/druntime/test/exceptions/Makefile
+++ b/druntime/test/exceptions/Makefile
@@ -1,17 +1,9 @@
-ifndef IS_MUSL # LDC defines it externally
-    ifeq ($(OS),linux)
-        # FIXME: detect musl libc robustly; just checking Alpine Linux' apk tool for now
-        ifeq (1,$(shell which apk >/dev/null 2>&1 && echo 1))
-            IS_MUSL := 1
-        endif
-    endif
-endif
-
 TESTS=stderr_msg unittest_assert invalid_memory_operation static_dtor \
       future_message refcounted rt_trap_exceptions_drt catch_in_finally \
       message_with_null
 
 # FIXME: segfaults with musl libc
+include ../is_musl.mak
 ifneq ($(IS_MUSL),1)
 TESTS += unknown_gc
 endif

--- a/druntime/test/exceptions/Makefile
+++ b/druntime/test/exceptions/Makefile
@@ -1,7 +1,9 @@
-ifeq ($(OS),linux)
-    # FIXME: detect musl libc robustly; just checking Alpine Linux' apk tool for now
-    ifeq (1,$(shell which apk &>/dev/null && echo 1))
-        IS_MUSL:=1
+ifndef IS_MUSL # LDC defines it externally
+    ifeq ($(OS),linux)
+        # FIXME: detect musl libc robustly; just checking Alpine Linux' apk tool for now
+        ifeq (1,$(shell which apk >/dev/null 2>&1 && echo 1))
+            IS_MUSL := 1
+        endif
     endif
 endif
 

--- a/druntime/test/exceptions/Makefile
+++ b/druntime/test/exceptions/Makefile
@@ -3,7 +3,6 @@ TESTS=stderr_msg unittest_assert invalid_memory_operation static_dtor \
       message_with_null
 
 # FIXME: segfaults with musl libc
-include ../is_musl.mak
 ifneq ($(IS_MUSL),1)
 TESTS += unknown_gc
 endif

--- a/druntime/test/importc_compare/Makefile
+++ b/druntime/test/importc_compare/Makefile
@@ -1,11 +1,18 @@
 TESTS := importc_compare
 
+ifndef IS_MUSL # LDC defines it externally
+    ifeq ($(OS),linux)
+        # FIXME: detect musl libc robustly; just checking Alpine Linux' apk tool for now
+        ifeq (1,$(shell which apk >/dev/null 2>&1 && echo 1))
+            IS_MUSL := 1
+        endif
+    endif
+endif
+
 # FIXME: fails on Alpine v3.21 with conflicting struct declarations in the C headers:
 # /usr/include/asm-generic/fcntl.h(195): Error: struct `importc_includes.flock` conflicts with struct `importc_includes.flock` at /usr/include/fcntl.h(24)
-ifeq ($(OS),linux)
-    ifeq (1,$(shell which apk &>/dev/null && echo 1))
-        TESTS :=
-    endif
+ifeq ($(IS_MUSL),1)
+    TESTS :=
 endif
 
 include ../common.mak

--- a/druntime/test/importc_compare/Makefile
+++ b/druntime/test/importc_compare/Makefile
@@ -2,7 +2,6 @@ TESTS := importc_compare
 
 # FIXME: fails on Alpine v3.21 with conflicting struct declarations in the C headers:
 # /usr/include/asm-generic/fcntl.h(195): Error: struct `importc_includes.flock` conflicts with struct `importc_includes.flock` at /usr/include/fcntl.h(24)
-include ../is_musl.mak
 ifeq ($(IS_MUSL),1)
     TESTS :=
 endif

--- a/druntime/test/importc_compare/Makefile
+++ b/druntime/test/importc_compare/Makefile
@@ -1,16 +1,8 @@
 TESTS := importc_compare
 
-ifndef IS_MUSL # LDC defines it externally
-    ifeq ($(OS),linux)
-        # FIXME: detect musl libc robustly; just checking Alpine Linux' apk tool for now
-        ifeq (1,$(shell which apk >/dev/null 2>&1 && echo 1))
-            IS_MUSL := 1
-        endif
-    endif
-endif
-
 # FIXME: fails on Alpine v3.21 with conflicting struct declarations in the C headers:
 # /usr/include/asm-generic/fcntl.h(195): Error: struct `importc_includes.flock` conflicts with struct `importc_includes.flock` at /usr/include/fcntl.h(24)
+include ../is_musl.mak
 ifeq ($(IS_MUSL),1)
     TESTS :=
 endif

--- a/druntime/test/is_musl.mak
+++ b/druntime/test/is_musl.mak
@@ -1,0 +1,8 @@
+ifndef IS_MUSL # LDC defines it externally
+    ifeq ($(OS),linux)
+        # FIXME: detect musl libc robustly; just checking Alpine Linux' apk tool for now
+        ifeq (1,$(shell which apk >/dev/null 2>&1 && echo 1))
+            IS_MUSL := 1
+        endif
+    endif
+endif

--- a/druntime/test/is_musl.mak
+++ b/druntime/test/is_musl.mak
@@ -1,8 +1,0 @@
-ifndef IS_MUSL # LDC defines it externally
-    ifeq ($(OS),linux)
-        # FIXME: detect musl libc robustly; just checking Alpine Linux' apk tool for now
-        ifeq (1,$(shell which apk >/dev/null 2>&1 && echo 1))
-            IS_MUSL := 1
-        endif
-    endif
-endif


### PR DESCRIPTION
As dash apparently doesn't understand the `&>` redirection, see https://github.com/ldc-developers/ldc/pull/4970#issuecomment-3197953840, causing IS_MUSL to be wrongly set on non-musl distros.