### PR TITLE
druntime: Fix build error on Darwin Powerpc

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -110,7 +110,7 @@ else version (Posix)
         else version (PPC)
         {
             import core.sys.darwin.mach.thread_act :
-             PPC_THREAD_STATE32, PPC_THREAD_STATE32_COUNT, ppc_thread_state32_t;
+             PPC_THREAD_STATE, PPC_THREAD_STATE_COUNT, ppc_thread_state_t;
         }
         else version (PPC64)
         {


### PR DESCRIPTION
osthread.d is trying to use PPC_THREAD_STATE32 which is not defined in thread_act.d (PPC_THREAD_STATE is defined for the 32b case).  This leads to a build fail for druntime.