### PR TITLE
Improve dmd.dangling-else.dd

### DIFF
--- a/changelog/dmd.dangling-else.dd
+++ b/changelog/dmd.dangling-else.dd
@@ -6,6 +6,6 @@ int i, j;
 if (i)
     if (j)
         return 1;
-    else    // Error: else is dangling, add { } after condition at line 2
+    else    // Error: else is dangling, add { } after condition `if (i)`
         return 2;
 ```


### PR DESCRIPTION
The [changelog webpage](https://dlang.org/changelog/pending.html#dmd.dangling-else) does not show line numbers, so referring to them isn’t that helpful.