### PR TITLE
core.thread: Add getter for Darwin/Windows m_reg

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -394,6 +394,21 @@ class Thread : ThreadBase
         }
     }
 
+    override final void[] savedRegisters() nothrow @nogc
+    {
+        version (Windows)
+        {
+            return m_reg;
+        }
+        else version (Darwin)
+        {
+            return m_reg;
+        }
+        else
+        {
+            return null;
+        }
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     // General Actions
@@ -1458,15 +1473,6 @@ in (fn)
 
     fn(sp);
 }
-
-version (Windows)
-private extern (D) void scanWindowsOnly(scope ScanAllThreadsTypeFn scan, ThreadBase _t) nothrow
-{
-    auto t = _t.toThread;
-
-    scan( ScanType.stack, t.m_reg.ptr, t.m_reg.ptr + t.m_reg.length );
-}
-
 
 /**
  * Returns the process ID of the calling process, which is guaranteed to be


### PR DESCRIPTION
This reverts commit https://github.com/dlang/dmd/commit/b062ff28a4d735debdcd312e4990bf438a086d62.

Spoke with @schveiguy - and probably best to keep OSX saving its registers.  As the GC scan could find these fields by dereferencing a pointer to a Thread instance via `*cast(void**)p`.

Even better if we pass this array to `scan()` directly then, same as Windows.  Add a new abstract getter to fetch this array.