### PR TITLE
fix regression in #21773 failing to parse some array initializers with implicit constructor calls

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -2053,6 +2053,33 @@ public:
         }
     }
 
+    static Expression interpretInitializerExpression(VarDeclaration v)
+    {
+        // It is a bit strange that the interpreter has to deal with initializers
+        // at all as they should have been converted to ConstructExp or similar
+        // during semantic analysis.
+        // Static array initialization from an element expression is a special
+        // case that used to be dealt with in initializerToExpression(), but
+        // is duplicated in ExpressionSemanticVisitor.visit(AssignExp exp). Until
+        // initializer semantics are removed from the interpreter, it has been
+        // moved here.
+        Expression iexp = v._init.initializerToExpression(v.type);
+
+        Type tb = v.type.toBasetype();
+        Expression e = (iexp.op == EXP.construct || iexp.op == EXP.blit) ? (cast(AssignExp)iexp).e2 : iexp;
+        if (tb.ty == Tsarray && e.implicitConvTo(tb.nextOf()))
+        {
+            TypeSArray tsa = cast(TypeSArray)tb;
+            size_t d = cast(size_t)tsa.dim.toInteger();
+            auto elements = new Expressions(d);
+            for (size_t j = 0; j < d; j++)
+                (*elements)[j] = e;
+            auto ae = new ArrayLiteralExp(e.loc, v.type, elements);
+            return ae;
+        }
+        return iexp;
+    }
+
     static Expression getVarExp(Loc loc, InterState* istate, Declaration d, CTFEGoal goal)
     {
         Expression e = CTFEExp.cantexp;
@@ -2083,7 +2110,7 @@ public:
                     v._init = v._init.initializerSemantic(v._scope, v.type, INITinterpret); // might not be run on aggregate members
                     v.inuse--;
                 }
-                e = v._init.initializerToExpression(v.type);
+                e = interpretInitializerExpression(v);
                 if (!e)
                     return CTFEExp.cantexp;
                 assert(e.type);
@@ -2368,7 +2395,7 @@ public:
                 }
                 else if (v._init.isArrayInitializer())
                 {
-                    result = v._init.initializerToExpression(v.type);
+                    result = interpretInitializerExpression(v);
                     if (result !is null)
                     {
                         if (v.ctfeAdrOnStack != VarDeclaration.AdrOnStackNone)

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3249,7 +3249,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         ArrayInitializer ai = dsym._init.isArrayInitializer();
                         Expression e;
                         if (ai && tb.ty == Taarray)
-                            e = ai.toAssocArrayLiteral();
+                            e = ai.toAssocArrayLiteral(tb);
                         else
                             e = dsym._init.initializerToExpression(dsym.type, sc.inCfile);
                         if (!e)

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -50,12 +50,13 @@ import dmd.typesem;
  *
  *  Params:
  *     ai = array initializer to be converted
+ *     itype = if not `null`, the AA type to coerce the initializer to
  *
  *  Returns:
  *     The converted associative array initializer or ErrorExp if `ai`
  *     is not an associative array initializer.
  */
-Expression toAssocArrayLiteral(ArrayInitializer ai)
+Expression toAssocArrayLiteral(ArrayInitializer ai, Type itype)
 {
     //printf("ArrayInitializer::toAssocArrayInitializer(%s)\n", ai.toChars());
     //static int i; if (++i == 2) assert(0);
@@ -70,12 +71,13 @@ Expression toAssocArrayLiteral(ArrayInitializer ai)
     if (!dim)
         return no("invalid associative array initializer `%s`, use `null` instead", ai);
 
+    auto vtype  = itype ? itype.nextOf() : null;
     auto keys   = new Expressions(dim);
     auto values = new Expressions(dim);
     foreach (i, iz; ai.value[])
     {
         assert(iz);
-        auto ev = iz.initializerToExpression();
+        auto ev = iz.initializerToExpression(vtype);
         if (!ev)
             return no("invalid value `%s` in initializer", iz);
         (*values)[i] = ev;
@@ -224,7 +226,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                 Expression e;
                 // note: MyStruct foo = [1:2, 3:4] is correct code if MyStruct has a this(int[int])
                 if (t.ty == Taarray || i.isAssociativeArray())
-                    e = i.toAssocArrayLiteral();
+                    e = i.toAssocArrayLiteral(t);
                 else
                     e = i.initializerToExpression();
                 // Bugzilla 13987
@@ -1408,7 +1410,7 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
         if (!itype || itype.toBasetype().isTypeAArray())
             if (!init.type || init.type.isTypeAArray())
                 if (init.isAssociativeArray())
-                    return init.toAssocArrayLiteral();
+                    return init.toAssocArrayLiteral(itype);
 
         uint edim;      // the length of the resulting array literal
         const(uint) amax = 0x80000000;
@@ -1448,10 +1450,12 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
              */
             edim = cast(uint)init.value.length;
             size_t j = 0;
+            bool hasIndex = false;
             foreach (i; 0 .. init.value.length)
             {
                 if (auto e = init.index[i])
                 {
+                    hasIndex = true;
                     if (e.op == EXP.int64)
                     {
                         const uinteger_t idxval = e.toInteger();
@@ -1466,23 +1470,18 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
                 if (j > edim)
                     edim = cast(uint)j;
             }
+            if (hasIndex && itype)
+            {
+                if (auto tsa = itype.isTypeSArray())
+                {
+                    uinteger_t adim = tsa.dim.toInteger();
+                    if (adim > edim && adim < amax)
+                        edim = cast(uint)adim;
+                }
+            }
         }
 
-        // enforce the element type only if the dimensions match, otherwise the value
-        // might be used as an initializer for the whole array at another dimension
-        Type isTypeArray(Type tn)
-        {
-            auto ty = tn ? tn.ty : Tnone;
-            return ty == Tarray || ty == Tsarray || ty == Taarray || ty == Tvector ? tn : null;
-        }
-        Type tnext = isTypeArray(itype);
-        auto initn = init;
-        while (tnext && initn)
-        {
-            tnext = isTypeArray(tnext.nextOf());
-            initn = initn.value.length ? initn.value[0].isArrayInitializer() : null;
-        }
-        Type telem = itype && !tnext && !initn ? itype.nextOf() : null;
+        Type telem = itype ? itype.nextOf() : null;
 
         auto elements = new Expressions(edim);
         elements.zero();
@@ -1508,15 +1507,17 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
 
         /* Fill in any missing elements with the default initializer
          */
+        if (!telem && t)
+            telem = t.nextOf();
         Expression defaultInit = null;  // lazily create it
         foreach (ref element; (*elements)[0 .. edim])
         {
             if (!element)
             {
-                if (!init.type) // don't know what type to use
+                if (!telem) // don't know what type to use
                     return null;
                 if (!defaultInit)
-                    defaultInit = (cast(TypeNext)t).next.defaultInit(Loc.initial, isCfile);
+                    defaultInit = telem.defaultInit(Loc.initial, isCfile);
                 element = defaultInit;
             }
         }
@@ -1561,22 +1562,6 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
 
     Expression visitExp(ExpInitializer i)
     {
-        if (itype)
-        {
-            //printf("ExpInitializer::toExpression(t = %s) exp = %s\n", itype.toChars(), i.exp.toChars());
-            Type tb = itype.toBasetype();
-            Expression e = (i.exp.op == EXP.construct || i.exp.op == EXP.blit) ? (cast(AssignExp)i.exp).e2 : i.exp;
-            if (tb.ty == Tsarray && e.implicitConvTo(tb.nextOf()))
-            {
-                TypeSArray tsa = cast(TypeSArray)tb;
-                size_t d = cast(size_t)tsa.dim.toInteger();
-                auto elements = new Expressions(d);
-                for (size_t j = 0; j < d; j++)
-                    (*elements)[j] = e;
-                auto ae = new ArrayLiteralExp(e.loc, itype, elements);
-                return ae;
-            }
-        }
         return i.exp;
     }
 

--- a/compiler/test/runnable/staticaa.d
+++ b/compiler/test/runnable/staticaa.d
@@ -167,16 +167,16 @@ void testEnumInit()
 
 // https://issues.dlang.org/show_bug.cgi?id=24370
 immutable uint[3][string] test = [
-	"oneTwoThree": [1,2,3],
-	"fourFiveSix": [4,5,6],
-	"sevenEightNine": [7,8,9],
+    "oneTwoThree": [1,2,3],
+    "fourFiveSix": [4,5,6],
+    "sevenEightNine": [7,8,9],
 ];
 
 void testStaticArray()
 {
-	assert(test["oneTwoThree"] == [1, 2, 3]);
-	assert(test["fourFiveSix"] == [4, 5, 6]);
-	assert(test["sevenEightNine"] == [7, 8, 9]);
+    assert(test["oneTwoThree"] == [1, 2, 3]);
+    assert(test["fourFiveSix"] == [4, 5, 6]);
+    assert(test["sevenEightNine"] == [7, 8, 9]);
 }
 
 /////////////////////////////////////////////
@@ -216,6 +216,54 @@ void testMultiDim()
     assert(aa1 == aa2);
     assert(aa2 == aa3);
     assert(aa3 == aa4);
+}
+
+// from https://github.com/dlang/dmd/issues/20542
+void testRegression21773()
+{
+    static struct S
+    {
+        int[string] aa;
+        this(int[string] _aa) { aa = _aa; }
+    }
+
+    S[] aa = [
+        ["x": 1, "y": 2],
+        ["x": 3, "y": 4],
+        ["x": 5, "y": 6],
+    ];
+
+    // test we did not break initialization of static array from lower dimension
+    static int[3][4] a2 = [ 1, 2, 3, 4 ]; // only works with static initializer !?
+    int[3][4] a3 = [ [1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4] ];
+    assert(a2 == a3);
+}
+
+// https://github.com/dlang/dmd/issues/19209
+void test19209()
+{
+    int[int][] a = [[1 : 2]]; // ok
+    int[int][] b = [[0 : 2]]; // expression ([[1]]) of type int[][]
+    int[int][int] c = [1 : [0 : 2]]; // expression ([1:[2]]) of type int[][int]
+    int[int][int] d = [1 : [3 : 2]]; // Error: not an associative array initializer
+
+    enum int[][] x = [[2 : 0]]; // fails
+    static assert(x[0].length == 3);
+    enum int[][int] y = [1 : [2 : 1]]; // fails
+    static assert(y[1][2] == 1);
+
+    static assert(!__traits(compiles, { immutable int[7] z = [ 2 : 1, 4 : 2, 8 : 3 ]; })); // Error: mismatched array lengths, 7 and 9
+}
+
+// https://github.com/dlang/dmd/issues/18360
+void test18360()
+{
+    alias string[string][string] sss;
+    sss stat =
+    [
+        "one" : ["a":"A", "b":"B"],
+        "two" : ["d":"D", "e":"E"],
+    ];
 }
 
 /////////////////////////////////////////////


### PR DESCRIPTION
While trying test cases from bug reports regarding AA initialization, I noticed that #21773 caused the code in #20542 to no longer compile.

Better coercing array initializer types by forwarding element types to element initializers fixes that, but that causes issues in other tests, especially regarding static array initialization by supplying only a single element type. This is dealt with in `ExpressionSemanticVisitor.visit(AssignExp)` more consistently than in `initializerToExpression()`, but unfortuately the interpreter still relies on the latter (even though semantic analysis should have made it obsolete!?). So I moved that part to the interpreter.

I have also added the tests from #19209 and #18360, showing that even more initializers are possible when the type can be coerced from the declaration.
