### PR TITLE
druntime: Only use async-signal safe fork in GC

### DIFF
--- a/druntime/src/core/internal/gc/os.d
+++ b/druntime/src/core/internal/gc/os.d
@@ -33,7 +33,11 @@ else version (Posix)
     else version (WatchOS)
         version = Darwin;
 
-    public import core.sys.posix.unistd : fork, pid_t;
+    public import core.sys.posix.unistd : pid_t;
+
+    static import core.sys.posix.unistd;
+    static if (__traits(compiles, core.sys.posix.unistd._Fork))
+        public import core.sys.posix.unistd : _Fork;
 
     static import core.sys.posix.sys.mman;
     static if (__traits(compiles, core.sys.posix.sys.mman.mmap))


### PR DESCRIPTION
Removes the use of `fork` for Posix and the undocumented `__fork` for OSX, now the fork-based GC is only ran if linux/clone or Posix/_Fork is available, this removes the need to have `pthread_atfork` handler guards, as they are guaranteed to never be called.