### PR TITLE
[func.d] place `inlinedNestedCallees ` under `version(MARS)`

### DIFF
--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -608,9 +608,9 @@ public:
 
     // Sibling nested functions which called this one
     FuncDeclarations siblingCallers;
-
+#if MARS
     FuncDeclarations *inlinedNestedCallees;
-
+#endif
     AttributeViolation* safetyViolation;
     AttributeViolation* nogcViolation;
     AttributeViolation* pureViolation;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3962,7 +3962,6 @@ public:
     Array<VarDeclaration* > outerVars;
     static FuncDeclaration* lastMain;
     Array<FuncDeclaration* > siblingCallers;
-    Array<FuncDeclaration* >* inlinedNestedCallees;
     AttributeViolation* safetyViolation;
     AttributeViolation* nogcViolation;
     AttributeViolation* pureViolation;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -270,6 +270,7 @@ extern (C++) class FuncDeclaration : Declaration
     /// Sibling nested functions which called this one
     FuncDeclarations siblingCallers;
 
+    version(MARS)
     FuncDeclarations* inlinedNestedCallees;
 
     /// In case of failed `@safe` inference, store the error that made the function `@system` for

--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -559,6 +559,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         }
     }
 
+    version(MARS)
     if (fd.inlinedNestedCallees)
     {
         /* https://issues.dlang.org/show_bug.cgi?id=15333

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -2033,6 +2033,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
     }
     scope ids = new InlineDoState(parent, fd);
 
+    version(MARS)
     if (fd.isNested())
     {
         if (!parent.inlinedNestedCallees)


### PR DESCRIPTION
It is unused by LDC and GDC