### PR TITLE
Deprecate returning non-zero CT constant from `opApply`

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2597,6 +2597,15 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             if (checkNonAssignmentArrayOp(rs.exp))
                 rs.exp = ErrorExp.get();
 
+            if (fd.ident == Id.apply && rs.exp.isConst() && rs.exp.toInteger() != 0)
+            {
+                // @@@DEPRECATED_2.121
+                // uncomment ErrorExp and call `error`
+                deprecation(rs.exp.loc, "cannot return non-zero compile-time value from `opApply`");
+                deprecationSupplemental(rs.exp.loc, "Any non-zero value must be the result of calling its delegate");
+                //rs.exp = ErrorExp.get();
+            }
+
             // Extract side-effect part
             rs.exp = Expression.extractLast(rs.exp, e0);
             if (rs.exp.isCallExp())

--- a/compiler/test/compilable/fix22291.d
+++ b/compiler/test/compilable/fix22291.d
@@ -49,7 +49,7 @@ void nesting(double d, int i)
 
 class Tree {
     int opApply(int delegate(size_t, Tree) dg) {
-        if (dg(0, this)) return 1;
+        if (auto r = dg(0, this)) return r;
         return 0;
     }
 }

--- a/compiler/test/compilable/warn3882.d
+++ b/compiler/test/compilable/warn3882.d
@@ -66,7 +66,7 @@ const struct Foo13899
 {
     int opApply(immutable int delegate(const ref int) pure nothrow dg) pure nothrow
     {
-        return 1;
+        return 0;
     }
 }
 

--- a/compiler/test/fail_compilation/opApply_return.d
+++ b/compiler/test/fail_compilation/opApply_return.d
@@ -1,0 +1,23 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/opApply_return.d(18): Deprecation: cannot return non-zero compile-time value from `opApply`
+fail_compilation/opApply_return.d(18):        Any non-zero value must be the result of calling its delegate
+fail_compilation/opApply_return.d(19): Deprecation: cannot return non-zero compile-time value from `opApply`
+fail_compilation/opApply_return.d(19):        Any non-zero value must be the result of calling its delegate
+fail_compilation/opApply_return.d(20): Deprecation: cannot return non-zero compile-time value from `opApply`
+fail_compilation/opApply_return.d(20):        Any non-zero value must be the result of calling its delegate
+---
+*/
+
+class Tree {
+    Tree lhs;
+    Tree rhs;
+    int opApply(int delegate(Tree) dg) {
+        if (lhs && lhs.opApply(dg)) return 1;
+        if (dg(this)) return 1;
+        if (rhs && rhs.opApply(dg)) return 1;
+        return 0;
+    }
+}


### PR DESCRIPTION
E.g. `return 1;` is violating the spec - from https://dlang.org/spec/statement.html#foreach_over_struct_and_classes:

> If the result is nonzero, apply must cease iterating and return that value.

Note: Returning the wrong value could even violate `@safe` - see https://github.com/dlang/dmd/issues/20465.