### PR TITLE
Fix expanding array with implicitly non-copyable types

### DIFF
--- a/compiler/test/compilable/test21835.d
+++ b/compiler/test/compilable/test21835.d
@@ -1,0 +1,11 @@
+// https://github.com/dlang/dmd/issues/21832
+// resize array of implicitly non-copyable items
+
+void bugGH21832()
+{
+    static struct S { @disable this(this); }
+    static struct Item { S s; }
+
+    Item[] arr;
+    arr.length++;
+}

--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -254,8 +254,8 @@ private size_t _d_arraysetlengthT_(Tarr : T[], T)(return ref scope Tarr arr, siz
     }
 
     enum sizeelem = T.sizeof;
-    enum hasPostblit = __traits(hasMember, T, "__postblit");
-    enum hasEnabledPostblit = hasPostblit && !__traits(isDisabled, T.__postblit);
+    enum hasPostblit = __traits(hasMember, T, "__xpostblit");
+    enum hasEnabledPostblit = hasPostblit && !__traits(isDisabled, T.__xpostblit);
 
     bool overflow = false;
     const newsize = mulu(sizeelem, newlength, overflow);


### PR DESCRIPTION
Fix https://github.com/dlang/dmd/issues/21832