### PR TITLE
Add info for string mixin statement parse error

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4870,7 +4870,10 @@ private Statements* flatten(Statement statement, Scope* sc)
             {
                 Statement s = p.parseStatement(ParseStatementFlags.curlyScope);
                 if (!s || global.errors != errors)
+                {
+                    errorSupplemental(s.loc, "while parsing string mixin statement");
                     return errorStatements();
+                }
                 a.push(s);
             }
             return a;

--- a/compiler/test/fail_compilation/fail246.d
+++ b/compiler/test/fail_compilation/fail246.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail246.d-mixin-11(11): Error: identifier expected, not `End of File`
-fail_compilation/fail246.d-mixin-11(11): Error: `;` expected after `mixin`
+fail_compilation/fail246.d-mixin-12(12): Error: identifier expected, not `End of File`
+fail_compilation/fail246.d-mixin-12(12): Error: `;` expected after `mixin`
+fail_compilation/fail246.d-mixin-12(12):        while parsing string mixin statement
 ---
 */
 

--- a/compiler/test/fail_compilation/fail265.d
+++ b/compiler/test/fail_compilation/fail265.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail265.d-mixin-10(10): Error: found `End of File` instead of statement
+fail_compilation/fail265.d-mixin-11(11): Error: found `End of File` instead of statement
+fail_compilation/fail265.d-mixin-11(11):        while parsing string mixin statement
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4375k.d
+++ b/compiler/test/fail_compilation/fail4375k.d
@@ -2,7 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375k.d-mixin-10(14): Error: else is dangling, add { } after condition at fail_compilation/fail4375k.d-mixin-10(11)
+fail_compilation/fail4375k.d-mixin-11(15): Error: else is dangling, add { } after condition at fail_compilation/fail4375k.d-mixin-11(12)
+fail_compilation/fail4375k.d-mixin-11(12):        while parsing string mixin statement
 ---
 */
 

--- a/compiler/test/fail_compilation/ice8795.d
+++ b/compiler/test/fail_compilation/ice8795.d
@@ -1,12 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8795.d-mixin-14(14): Error: found `End of File` when expecting `(`
-fail_compilation/ice8795.d-mixin-14(14): Error: expression expected, not `End of File`
-fail_compilation/ice8795.d-mixin-14(14): Error: missing closing `)` after `switch (__error`
-fail_compilation/ice8795.d-mixin-14(14): Error: found `End of File` instead of statement
-fail_compilation/ice8795.d-mixin-15(15): Error: { } expected following `interface` declaration
-fail_compilation/ice8795.d-mixin-15(15): Error: anonymous interfaces not allowed
+fail_compilation/ice8795.d-mixin-16(16): Error: found `End of File` when expecting `(`
+fail_compilation/ice8795.d-mixin-16(16): Error: expression expected, not `End of File`
+fail_compilation/ice8795.d-mixin-16(16): Error: missing closing `)` after `switch (__error`
+fail_compilation/ice8795.d-mixin-16(16): Error: found `End of File` instead of statement
+fail_compilation/ice8795.d-mixin-16(16):        while parsing string mixin statement
+fail_compilation/ice8795.d-mixin-17(17): Error: { } expected following `interface` declaration
+fail_compilation/ice8795.d-mixin-17(17): Error: anonymous interfaces not allowed
+fail_compilation/ice8795.d-mixin-17(17):        while parsing string mixin statement
 ---
 */
 void main()


### PR DESCRIPTION
This helps to explain why e.g. a semi-colon is needed inside a string mixin (expression) statement. It [confuses learners](https://forum.dlang.org/post/wcgkttwurzdmypowfkzq@forum.dlang.org).

Note: String mixin expression/type errors already show a similar supplemental message.