### PR TITLE
[dtemplate.d] factor out computation of `isTrivialAlias`

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -434,11 +434,16 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         onemember = s;
         s.parent = this;
 
-        /* Set isTrivialAliasSeq if this fits the pattern:
-         *   template AliasSeq(T...) { alias AliasSeq = T; }
-         * or set isTrivialAlias if this fits the pattern:
-         *   template Alias(T) { alias Alias = qualifiers(T); }
-         */
+        computeTrivialAlias(s);
+    }
+
+    /* Set isTrivialAliasSeq if this fits the pattern:
+     *   template AliasSeq(T...) { alias AliasSeq = T; }
+     * or set isTrivialAlias if this fits the pattern:
+     *   template Alias(T) { alias Alias = qualifiers(T); }
+     */
+    extern (D) void computeTrivialAlias(Dsymbol s)
+    {
         if (!(parameters && parameters.length == 1))
             return;
 


### PR DESCRIPTION
so that further refactorings of the constructor to remove the call to `oneMembers` is less disruptive.