### PR TITLE
druntime: Add bindings for Solaris thread.h

### DIFF
--- a/druntime/mak/COPY
+++ b/druntime/mak/COPY
@@ -374,6 +374,7 @@ COPY=\
 	$(IMPDIR)\core\sys\solaris\libelf.d \
 	$(IMPDIR)\core\sys\solaris\link.d \
 	$(IMPDIR)\core\sys\solaris\stdlib.d \
+	$(IMPDIR)\core\sys\solaris\thread.d \
 	$(IMPDIR)\core\sys\solaris\time.d \
 	\
 	$(IMPDIR)\core\sys\solaris\sys\elf.d \

--- a/druntime/mak/DOCS
+++ b/druntime/mak/DOCS
@@ -329,6 +329,7 @@ DOCS=\
 	$(DOCDIR)\core_sys_solaris_execinfo.html \
 	$(DOCDIR)\core_sys_solaris_libelf.html \
 	$(DOCDIR)\core_sys_solaris_link.html \
+	$(DOCDIR)\core_sys_solaris_thread.html \
 	$(DOCDIR)\core_sys_solaris_time.html \
 	\
 	$(DOCDIR)\core_sys_solaris_sys_elf.html \

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -369,6 +369,7 @@ SRCS=\
 	src\core\sys\solaris\libelf.d \
 	src\core\sys\solaris\link.d \
 	src\core\sys\solaris\stdlib.d \
+	src\core\sys\solaris\thread.d \
 	src\core\sys\solaris\time.d \
 	src\core\sys\solaris\sys\elf.d \
 	src\core\sys\solaris\sys\elf_386.d \

--- a/druntime/src/core/sys/solaris/thread.d
+++ b/druntime/src/core/sys/solaris/thread.d
@@ -1,0 +1,66 @@
+/**
+  * D header file for Solaris thread.h.
+  *
+  * Copyright: Copyright © 2025, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.solaris.thread;
+
+version (Solaris):
+extern (C):
+nothrow:
+@nogc:
+
+import core.stdc.config : c_long;
+import core.sys.posix.signal : sigset_t, stack_t;
+
+/*
+ * definitions needed to use the thread interface except synchronization.
+ */
+alias thread_t = int;
+alias thread_key_t = int;
+
+int thr_create(void*, size_t, void* function(void*), void*, c_long, thread_t*);
+int thr_join(thread_t, thread_t*, void**);
+int thr_setconcurrency(int);
+int thr_getconcurrency();
+noreturn thr_exit(void*);
+thread_t thr_self();
+
+int thr_sigsetmask(int, const scope sigset_t*, sigset_t*);
+
+int thr_stksegment(stack_t*);
+
+int thr_main();
+int thr_kill(thread_t, int);
+int thr_suspend(thread_t);
+int thr_continue(thread_t);
+void thr_yield();
+int thr_setprio(thread_t, int);
+int thr_getprio(thread_t, int*);
+int thr_keycreate(thread_key_t*, void function(void*));
+int thr_keycreate_once(thread_key_t*, void function(void*));
+int thr_setspecific(thread_key_t, void*);
+int thr_getspecific(thread_key_t, void**);
+size_t thr_min_stack();
+
+alias THR_MIN_STACK = thr_min_stack;
+
+/*
+ * thread flags (one word bit mask)
+ */
+enum : c_long
+{
+    THR_BOUND = 0x00000001,     // = PTHREAD_SCOPE_SYSTEM
+    THR_NEW_LWP = 0x00000002,
+    THR_DETACHED = 0x00000040,  // = PTHREAD_CREATE_DETACHED
+    THR_SUSPENDED = 0x00000080,
+    THR_DAEMON = 0x00000100,
+}
+
+/*
+ * The key to be created by thr_keycreate_once()
+ * must be statically initialized with THR_ONCE_KEY.
+ */
+enum thread_key_t THR_ONCE_KEY = -1;

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -125,6 +125,7 @@ version (Solaris)
     import core.sys.posix.sys.wait : idtype_t;
     import core.sys.solaris.sys.priocntl : PC_CLNULL, PC_GETCLINFO, PC_GETPARMS, PC_SETPARMS, pcinfo_t, pcparms_t, priocntl;
     import core.sys.solaris.sys.types : P_MYID, pri_t;
+    import core.sys.solaris.thread : thr_stksegment;
 }
 
 version (GNU)
@@ -1531,7 +1532,6 @@ extern (C) @nogc nothrow
 
     version (PThread_Getattr_NP)  int pthread_getattr_np(pthread_t thread, pthread_attr_t* attr);
     version (PThread_Attr_Get_NP) int pthread_attr_get_np(pthread_t thread, pthread_attr_t* attr);
-    version (Solaris) int thr_stksegment(stack_t* stk);
     version (OpenBSD) int pthread_stackseg_np(pthread_t thread, stack_t* sinfo);
 }
 


### PR DESCRIPTION
Tested on both x86_64-pc-solaris2.11 and sparcv9-sun-solaris2.11 with `-m64` and `-m32`.