### PR TITLE
druntime: Rename HaveFork to AllocSupportsShared

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -1804,7 +1804,7 @@ struct Gcx
         }
         debug(INVARIANT) initialized = true;
         version (COLLECT_FORK)
-            shouldFork = config.fork;
+            shouldFork = AllocSupportsShared && config.fork;
 
     }
 

--- a/druntime/src/core/internal/gc/os.d
+++ b/druntime/src/core/internal/gc/os.d
@@ -113,33 +113,54 @@ else static if (is(typeof(malloc)))
 else static assert(false, "No supported allocation methods available.");
 +/
 
-static if (is(typeof(VirtualAlloc))) // version (GC_Use_Alloc_Win32)
+version (CoreDdoc)
 {
-    /**
-    * Indicates if an implementation supports fork().
-    *
-    * The value shown here is just demostrative, the real value is defined based
-    * on the OS it's being compiled in.
-    * enum HaveFork = true;
-    */
-    enum HaveFork = false;
-
     /**
      * Map memory.
      */
+    void *os_mem_map(size_t nbytes) nothrow @nogc
+    {
+        return null;
+    }
+
+    /**
+     * Unmap memory allocated with os_mem_map()
+     * Returns:
+     *      0       success
+     *      !=0     failure
+     */
+    int os_mem_unmap(void *base, size_t nbytes) nothrow @nogc
+    {
+        return 0;
+    }
+
+    /**
+     * Map shared memory.
+     */
+    void *os_mem_map_shared(size_t nbytes) nothrow @nogc
+    {
+        return null;
+    }
+
+    /**
+     * Unmap memory allocated with os_mem_map_shared()
+     * Returns:
+     *      0       success
+     *      !=0     failure
+     */
+    int os_mem_unmap_shared(void *base, size_t nbytes) nothrow @nogc
+    {
+        return 0;
+    }
+}
+else static if (is(typeof(VirtualAlloc))) // version (GC_Use_Alloc_Win32)
+{
     void *os_mem_map(size_t nbytes) nothrow @nogc
     {
         return VirtualAlloc(null, nbytes, MEM_RESERVE | MEM_COMMIT,
                 PAGE_READWRITE);
     }
 
-
-    /**
-     * Unmap memory allocated with os_mem_map().
-     * Returns:
-     *      0       success
-     *      !=0     failure
-     */
     int os_mem_unmap(void *base, size_t nbytes) nothrow @nogc
     {
         return cast(int)(VirtualFree(base, 0, MEM_RELEASE) == 0);
@@ -147,26 +168,30 @@ static if (is(typeof(VirtualAlloc))) // version (GC_Use_Alloc_Win32)
 }
 else static if (is(typeof(mmap)))  // else version (GC_Use_Alloc_MMap)
 {
-    enum HaveFork = true;
-
-    void *os_mem_map(size_t nbytes, bool share = false) nothrow @nogc
-    {   void *p;
-
-        auto map_f = share ? MAP_SHARED : MAP_PRIVATE;
-        p = mmap(null, nbytes, PROT_READ | PROT_WRITE, map_f | MAP_ANON, -1, 0);
+    void *os_mem_map(size_t nbytes) nothrow @nogc
+    {
+        void* p = mmap(null, nbytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
         return (p == MAP_FAILED) ? null : p;
     }
 
-
     int os_mem_unmap(void *base, size_t nbytes) nothrow @nogc
+    {
+        return munmap(base, nbytes);
+    }
+
+    void *os_mem_map_shared(size_t nbytes) nothrow @nogc
+    {
+        void* p = mmap(null, nbytes, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANON, -1, 0);
+        return (p == MAP_FAILED) ? null : p;
+    }
+
+    int os_mem_unmap_shared(void *base, size_t nbytes) nothrow @nogc
     {
         return munmap(base, nbytes);
     }
 }
 else static if (is(typeof(valloc))) // else version (GC_Use_Alloc_Valloc)
 {
-    enum HaveFork = false;
-
     void *os_mem_map(size_t nbytes) nothrow @nogc
     {
         return valloc(nbytes);
@@ -185,8 +210,6 @@ else static if (is(typeof(malloc))) // else version (GC_Use_Alloc_Malloc)
     //       (req_size + PAGESIZE) is allocated, and the pointer is rounded up
     //       to PAGESIZE alignment, there will be space for a void* at the end
     //       after PAGESIZE bytes used by the GC.
-
-    enum HaveFork = false;
 
     import core.internal.gc.impl.conservative.gc;
 
@@ -215,6 +238,11 @@ else
 {
     static assert(false, "No supported allocation methods available.");
 }
+
+/**
+* Indicates if an allocation method supports sharing between processes.
+*/
+enum AllocSupportsShared = __traits(compiles, os_mem_map_shared);
 
 /**
    Check for any kind of memory pressure.

--- a/druntime/src/core/internal/gc/os.d
+++ b/druntime/src/core/internal/gc/os.d
@@ -135,7 +135,8 @@ version (CoreDdoc)
     }
 
     /**
-     * Map shared memory.
+     * Map memory that will be shared by child processes.
+     * Note: only available if the OS supports this feature. Use `AllocSupportsShared` to test.
      */
     void *os_mem_map_shared(size_t nbytes) nothrow @nogc
     {


### PR DESCRIPTION
Tries to simplify the logic within the implementation of GCBits.alloc, only use positive conditions instead of `!`

@rainers @schveiguy 