### PR TITLE
long doubles are 64 bits on OSX AArch64

### DIFF
--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -238,6 +238,9 @@ Symbol* getBzeroSymbol()
  */
 tym_t totym(Type tx)
 {
+    // OSX AArch64 long doubles are 64 bits
+    bool OSXAArch64 = target.os == Target.os.OSX && target.isAArch64;
+
     tym_t t;
     switch (tx.ty)
     {
@@ -252,13 +255,13 @@ tym_t totym(Type tx)
         case Tuns64:    t = TYullong;   break;
         case Tfloat32:  t = TYfloat;    break;
         case Tfloat64:  t = TYdouble;   break;
-        case Tfloat80:  t = TYldouble;  break;
+        case Tfloat80:  t = OSXAArch64 ? TYdouble : TYldouble;  break;
         case Timaginary32: t = TYifloat; break;
         case Timaginary64: t = TYidouble; break;
-        case Timaginary80: t = TYildouble; break;
+        case Timaginary80: t = OSXAArch64 ? TYidouble : TYildouble; break;
         case Tcomplex32: t = TYcfloat;  break;
         case Tcomplex64: t = TYcdouble; break;
-        case Tcomplex80: t = TYcldouble; break;
+        case Tcomplex80: t = OSXAArch64 ? TYcdouble : TYcldouble; break;
         case Tbool:     t = TYbool;     break;
         case Tchar:     t = TYchar;     break;
         case Twchar:    t = TYwchar_t;  break;


### PR DESCRIPTION
Why Apple picked that is a bit of a mystery.