### PR TITLE
Break semantic dependency of `dmd/func.d` on `dmd/funcsem.d` 

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -236,6 +236,12 @@ bool overloadInsert(Dsymbol ds, Dsymbol s)
     return dmd.dsymbolsem.overloadInsert(ds, s);
 }
 
+bool equals(const Dsymbol ds, const Dsymbol s)
+{
+    import dmd.dsymbolsem;
+    return dmd.dsymbolsem.equals(ds, s);
+}
+
 /***********************************************************
  * dtemplate.d
  */

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -490,16 +490,6 @@ extern (C++) final class OverDeclaration : Declaration
         return "overload alias"; // todo
     }
 
-    override bool equals(const Dsymbol s) const
-    {
-        if (this == s)
-            return true;
-
-        if (auto od2 = s.isOverDeclaration())
-            return this.aliassym.equals(od2.aliassym);
-        return this.aliassym == s;
-    }
-
     override bool isOverloadable() const
     {
         return true;

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -218,7 +218,6 @@ public:
     Dsymbol *aliassym;
 
     const char *kind() const override;
-    bool equals(const RootObject * const o) const override;
 
     Dsymbol *isUnique();
     bool isOverloadable() const override;
@@ -697,7 +696,6 @@ public:
     FuncDeclaration *fdensure(FuncDeclaration *fde);
     Expressions *fdrequireParams(Expressions *fdrp);
     Expressions *fdensureParams(Expressions *fdep);
-    bool equals(const RootObject * const o) const override final;
 
     bool inUnittest();
     LabelDsymbol *searchLabel(Identifier *ident, Loc loc);

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -41,6 +41,7 @@ namespace dmd
     FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc=0);
     bool isAbstract(ClassDeclaration *cd);
     bool overloadInsert(Dsymbol *ds, Dsymbol *s);
+    bool equals(const Dsymbol *ds, const Dsymbol *s);
 }
 
 //enum STC : ulong from astenums.d:

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -180,15 +180,6 @@ extern (C++) class Package : ScopeDsymbol
         return "package";
     }
 
-    override bool equals(const Dsymbol s) const
-    {
-        // custom 'equals' for bug 17441. "package a" and "module a" are not equal
-        if (this == s)
-            return true;
-        auto p = cast(Package)s;
-        return p && isModule() == p.isModule() && ident.equals(p.ident);
-    }
-
     /****************************************************
      * Input:
      *      packages[]      the pkg1.pkg2 of pkg1.pkg2.mod

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -411,18 +411,6 @@ extern (C++) class Dsymbol : ASTNode
         return toChars();
     }
 
-    bool equals(const Dsymbol s) const
-    {
-        if (this == s)
-            return true;
-        // Overload sets don't have an ident
-        // Function-local declarations may have identical names
-        // if they are declared in different scopes
-        if (s && ident && s.ident && ident.equals(s.ident) && localNum == s.localNum)
-            return true;
-        return false;
-    }
-
     final bool isAnonymous() const
     {
         return ident is null || ident.isAnonymous;

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -205,7 +205,6 @@ public:
     CPPNamespaceDeclaration* cppnamespace(CPPNamespaceDeclaration* ns);
     UserAttributeDeclaration* userAttribDecl(UserAttributeDeclaration* uad);
     virtual const char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
-    virtual bool equals(const RootObject * const o) const;
     bool isAnonymous() const;
     Module *getModule();
     bool isCsymbol();

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -95,6 +95,81 @@ void dsymbolSemantic(Dsymbol dsym, Scope* sc)
     dsym.accept(v);
 }
 
+private bool funcDeclEquals(const FuncDeclaration _this, const Dsymbol s)
+{
+    if (_this == s)
+        return true;
+
+    auto fd1 = _this;
+    auto fd2 = s.isFuncDeclaration();
+    if (!fd2)
+        return false;
+
+    auto fa1 = fd1.isFuncAliasDeclaration();
+    auto faf1 = fa1 ? fa1.toAliasFunc() : fd1;
+
+    auto fa2 = fd2.isFuncAliasDeclaration();
+    auto faf2 = fa2 ? fa2.toAliasFunc() : fd2;
+
+    if (fa1 && fa2)
+        return faf1.equals(faf2) && fa1.hasOverloads == fa2.hasOverloads;
+
+    bool b1 = fa1 !is null;
+    if (b1 && faf1.isUnique() && !fa1.hasOverloads)
+        b1 = false;
+
+    bool b2 = fa2 !is null;
+    if (b2 && faf2.isUnique() && !fa2.hasOverloads)
+        b2 = false;
+
+    if (b1 != b2)
+        return false;
+
+    return faf1.toParent().equals(faf2.toParent()) &&
+           faf1.ident.equals(faf2.ident) &&
+           faf1.type.equals(faf2.type);
+}
+
+private bool overDeclEquals(const OverDeclaration _this, const Dsymbol s)
+{
+    if (_this == s)
+        return true;
+
+    if (auto od2 = s.isOverDeclaration())
+        return _this.aliassym.equals(od2.aliassym);
+    return _this.aliassym == s;
+}
+
+private bool packageEquals(const Package _this, const Dsymbol s)
+{
+    // custom 'equals' for bug 17441. "package a" and "module a" are not equal
+    if (_this == s)
+        return true;
+    auto p = cast(Package)s;
+    return p && _this.isModule() == p.isModule() && _this.ident.equals(p.ident);
+}
+
+bool equals(const Dsymbol _this, const Dsymbol s)
+{
+    if (_this == s)
+        return true;
+
+    if(auto fd = _this.isFuncDeclaration())
+        return funcDeclEquals(fd, s);
+    else if (auto od = _this.isOverDeclaration())
+        return overDeclEquals(od, s);
+    else if (auto pkg = _this.isPackage())
+        return packageEquals(pkg, s);
+
+    // Overload sets don't have an ident
+    // Function-local declarations may have identical names
+    // if they are declared in different scopes
+    if (s && _this.ident && s.ident && _this.ident.equals(s.ident) && _this.localNum == s.localNum)
+        return true;
+
+    return false;
+}
+
 private bool aliasOverloadInsert(AliasDeclaration ad, Dsymbol s)
 {
     //printf("[%s] AliasDeclaration::overloadInsert('%s') s = %s %s @ [%s]\n",

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -97,9 +97,6 @@ void dsymbolSemantic(Dsymbol dsym, Scope* sc)
 
 private bool funcDeclEquals(const FuncDeclaration _this, const Dsymbol s)
 {
-    if (_this == s)
-        return true;
-
     auto fd1 = _this;
     auto fd2 = s.isFuncDeclaration();
     if (!fd2)
@@ -132,9 +129,6 @@ private bool funcDeclEquals(const FuncDeclaration _this, const Dsymbol s)
 
 private bool overDeclEquals(const OverDeclaration _this, const Dsymbol s)
 {
-    if (_this == s)
-        return true;
-
     if (auto od2 = s.isOverDeclaration())
         return _this.aliassym.equals(od2.aliassym);
     return _this.aliassym == s;
@@ -143,8 +137,6 @@ private bool overDeclEquals(const OverDeclaration _this, const Dsymbol s)
 private bool packageEquals(const Package _this, const Dsymbol s)
 {
     // custom 'equals' for bug 17441. "package a" and "module a" are not equal
-    if (_this == s)
-        return true;
     auto p = cast(Package)s;
     return p && _this.isModule() == p.isModule() && _this.ident.equals(p.ident);
 }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -584,7 +584,6 @@ public:
     CPPNamespaceDeclaration* cppnamespace(CPPNamespaceDeclaration* ns);
     UserAttributeDeclaration* userAttribDecl(UserAttributeDeclaration* uad);
     virtual const char* toPrettyCharsHelper();
-    virtual bool equals(const Dsymbol* const s) const;
     bool isAnonymous() const;
     Module* getModule();
     bool isCsymbol();
@@ -4047,7 +4046,6 @@ public:
     Array<Expression* >* fdrequireParams(Array<Expression* >* param);
     Array<Expression* >* fdensureParams(Array<Expression* >* param);
     FuncDeclaration* syntaxCopy(Dsymbol* s) override;
-    bool equals(const Dsymbol* const s) const final override;
     bool inUnittest();
     LabelDsymbol* searchLabel(Identifier* ident, Loc loc);
     const char* toPrettyChars(bool QualifyTypes = false) override;
@@ -6838,7 +6836,6 @@ public:
     Dsymbol* overnext;
     Dsymbol* aliassym;
     const char* kind() const override;
-    bool equals(const Dsymbol* const s) const override;
     bool isOverloadable() const override;
     void accept(Visitor* v) override;
 };
@@ -7132,7 +7129,6 @@ public:
     uint32_t tag;
     Module* mod;
     const char* kind() const override;
-    bool equals(const Dsymbol* const s) const override;
     bool isAncestorPackageOf(const Package* const pkg) const;
     void accept(Visitor* v) override;
     Module* isPackageMod();

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -35,7 +35,6 @@ import dmd.dsymbol;
 import dmd.dtemplate;
 import dmd.escape;
 import dmd.expression;
-import dmd.funcsem : isUnique;
 import dmd.globals;
 import dmd.hdrgen;
 import dmd.id;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -366,41 +366,6 @@ extern (C++) class FuncDeclaration : Declaration
         return f;
     }
 
-    override final bool equals(const Dsymbol s) const
-    {
-        if (this == s)
-            return true;
-
-        auto fd1 = this;
-        auto fd2 = s.isFuncDeclaration();
-        if (!fd2)
-            return false;
-
-        auto fa1 = fd1.isFuncAliasDeclaration();
-        auto faf1 = fa1 ? fa1.toAliasFunc() : fd1;
-
-        auto fa2 = fd2.isFuncAliasDeclaration();
-        auto faf2 = fa2 ? fa2.toAliasFunc() : fd2;
-
-        if (fa1 && fa2)
-            return faf1.equals(faf2) && fa1.hasOverloads == fa2.hasOverloads;
-
-        bool b1 = fa1 !is null;
-        if (b1 && faf1.isUnique() && !fa1.hasOverloads)
-            b1 = false;
-
-        bool b2 = fa2 !is null;
-        if (b2 && faf2.isUnique() && !fa2.hasOverloads)
-            b2 = false;
-
-        if (b1 != b2)
-            return false;
-
-        return faf1.toParent().equals(faf2.toParent()) &&
-               faf1.ident.equals(faf2.ident) &&
-               faf1.type.equals(faf2.type);
-    }
-
     /********************************************
      * find function template root in overload list
      */

--- a/compiler/src/dmd/mangle/cpp.d
+++ b/compiler/src/dmd/mangle/cpp.d
@@ -26,7 +26,7 @@ import dmd.astenums;
 import dmd.attrib;
 import dmd.declaration;
 import dmd.dsymbol;
-import dmd.dsymbolsem : isGNUABITag, toAlias;
+import dmd.dsymbolsem : isGNUABITag, toAlias, equals;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -46,8 +46,6 @@ public:
 
     const char *kind() const override;
 
-    bool equals(const RootObject * const o) const override;
-
     bool isAncestorPackageOf(const Package * const pkg) const;
 
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1332,7 +1332,7 @@ public:
                 if (j == i)
                     continue;
                 FuncDeclaration *fd2 = d->vtbl[j]->isFuncDeclaration();
-                if (!fd2->ident->equals(fd->ident))
+                if (!dmd::equals((const Dsymbol*) fd2->ident, (const Dsymbol*) fd->ident))
                     continue;
                 if (fd2->isFuture())
                     continue;

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1332,7 +1332,7 @@ public:
                 if (j == i)
                     continue;
                 FuncDeclaration *fd2 = d->vtbl[j]->isFuncDeclaration();
-                if (!dmd::equals((const Dsymbol*) fd2->ident, (const Dsymbol*) fd->ident))
+                if (!fd2->ident->equals(fd->ident))
                     continue;
                 if (fd2->isFuture())
                     continue;


### PR DESCRIPTION
Now, `func.d` is independent on any semantic function. 