### PR TITLE
SAOC 25: fix #20157: importC does not handle nested struct designated initializer

### DIFF
--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -820,20 +820,105 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             {
                 DesigInit di = ci.initializerList[index];
                 Designators* dlist = di.designatorList;
+                VarDeclaration field;
                 if (dlist)
                 {
                     const length = (*dlist).length;
+                    auto id = (*dlist)[0].ident;
                     if (length == 0 || !(*dlist)[0].ident)
                     {
                         error(ci.loc, "`.identifier` expected for C struct field initializer `%s`", toChars(ci));
                         return err();
                     }
+
                     if (length > 1)
                     {
-                        error(ci.loc, "only 1 designator currently allowed for C struct field initializer `%s`", toChars(ci));
-                        return err();
+                        StructDeclaration nstsd = sd; // use this for member structs we wish to traverse
+                        auto subsi = si;
+                        /*
+                         * run this for each designator in the chain until you hit the last
+                         * then perform semantic analysis on the last field in the chain using the previous struct initializer
+                         */
+                        for (size_t i = 0; i < length; i++)
+                        {
+                            int found;
+                            id = (*dlist)[i].ident;
+                            foreach (f; nstsd.fields[])
+                            {
+                                if (f.ident == id)
+                                {
+                                    field = f;
+                                    ++found;
+                                    break;
+                                }
+                            }
+                            if (!found)
+                            {
+                                error(ci.loc, "`.%s` is not a field of `%s`\n", id.toChars(), nstsd.toChars());
+                                return err();
+                            }
+
+                            auto base = field.type.toBasetype();
+
+                            if (i >= length -1)
+                            {
+                                subsi.addInit(id, di.initializer);
+                                ++index;
+                                continue Loop1;
+                            }
+
+                            auto tstr = base.isTypeStruct();
+                            auto tarr = base.isTypeSArray();
+
+                            if (tstr)
+                            {
+                                if (!overlaps(field, nstsd.fields[], subsi))
+                                {
+                                    auto innersi = new StructInitializer(ci.loc);
+                                    subsi.addInit(id, innersi);
+                                    subsi = innersi;
+                                }
+                                else {
+                                    foreach(k, ident; subsi.field[])
+                                    {
+                                        if (ident == id && subsi.value[k])
+                                            subsi = subsi.value[k].isStructInitializer();
+                                    }
+                                }
+                                nstsd = tstr.sym;
+                            }
+                            /*
+                             * once we hit an array, check & attach the array initializer to the struct initializer
+                             * move to the next initializer id and run initializer semantics on it
+                             */
+                            else if (tarr)
+                            {
+                                /*
+                                 * so tempting to check for null cases for field._init.
+                                 * but if your object is set to null on decl, you can't use designators anymore
+                                 * and D does well to default initialize for us
+                                 */
+                                auto ai = field._init.isArrayInitializer();
+
+                                if (ai is null)
+                                {
+                                    ai = new ArrayInitializer(ci.loc);
+                                    subsi.addInit(id, ai);
+                                    field._init = ai;
+                                }
+
+                                auto ndx = (*dlist)[i+1].exp;
+                                ai.addInit(ndx, di.initializer);
+                                ++index;
+                                continue Loop1;
+                            }
+                            else
+                            {
+                                error(ci.loc, "only 1 designated initializer allowed for C struct field of type `%s`", toChars(base));
+                                return err();
+                            }
+                        }
                     }
-                    auto id = (*dlist)[0].ident;
                     foreach (k, f; sd.fields[])         // linear search for now
                     {
                         if (f.ident == id)
@@ -909,7 +994,6 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                         continue Loop1;
                 }
 
-                VarDeclaration field;
                 while (1)   // skip field if it overlaps with previously seen fields
                 {
                     field = sd.fields[fieldi];

--- a/compiler/test/fail_compilation/init1.c
+++ b/compiler/test/fail_compilation/init1.c
@@ -2,7 +2,7 @@
 ---
 fail_compilation/init1.c(100): Error: array initializer has 4 elements, but array length is 3
 fail_compilation/init1.c(103): Error: `.identifier` expected for C struct field initializer `{[0]=3}`
-fail_compilation/init1.c(104): Error: only 1 designator currently allowed for C struct field initializer `{.a[0]=3}`
+fail_compilation/init1.c(104): Error: only 1 designated initializer allowed for C struct field of type `int`
 fail_compilation/init1.c(106): Error: `[ constant-expression ]` expected for C array element initializer `{.a=3}`
 fail_compilation/init1.c(107): Error: only 1 designator currently allowed for C array element initializer `{[0][1]=3}`
 fail_compilation/init1.c(110): Error: overlapping initialization for field `a` and `b`

--- a/compiler/test/runnable/issue20157.c
+++ b/compiler/test/runnable/issue20157.c
@@ -1,0 +1,51 @@
+// https://github.com/dlang/dmd/issues/20157
+// testing C intializers using designators
+
+#include <assert.h>
+
+struct top
+{
+    int a;
+    int b;
+};
+
+union t_union
+{
+    int f;
+    int g;
+};
+
+struct Foo
+{
+    int x;
+    int y;
+    struct top f;
+};
+
+struct Bar
+{
+    struct Foo b;
+    int arr[3];
+    union t_union u;
+};
+
+struct Bar test = {
+    .b.x = 5,
+    .b.y = 7,
+    .b.f = {8, 9},
+    .arr[0] = 10,
+    .arr[1] = 11,
+    .u.f = 13
+};
+
+int main()
+{
+    assert(test.b.x == 5);
+    assert(test.b.y == 7);
+    assert(test.b.f.a == 8);
+    assert(test.b.f.b == 9);
+    assert(test.arr[0] == 10);
+    assert(test.arr[1] == 11);
+    assert(test.u.f == 13);
+    assert(test.u.g == 13);
+}


### PR DESCRIPTION
This PR includes fix for issue 20157 about designated initializers.
link here: https://issues.dlang.org/show_bug.cgi?id=23374

```c
struct Foo {
    int x;
    int y;
};

struct Bar {
    struct Foo f;
};

struct Bar b = {.f.x = 3}; // Error: only 1 designator currently allowed for C struct field initializer
struct Bar b2 = {
    .f.x = 3, // Error: only 1 designator currently allowed for C struct field initializer
    .f.y = 4,
};
```

This fix also fixes it for arrays and unions. 

This fix has been tested thoroughly and tests are attached to this PR.

Additionally, the error message for not supporting more than 1 designators also has to be changed to print it for only base types since member arrays and structs can lead to multiple designators.


@dkorpel @WalterBright 