### PR TITLE
Add strerrorname_np and strerrordesc_np

### DIFF
--- a/druntime/src/core/sys/linux/string.d
+++ b/druntime/src/core/sys/linux/string.d
@@ -18,4 +18,8 @@ nothrow:
 static if (_GNU_SOURCE)
 {
     pure void* memmem(return scope const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+    /// return string describing error number
+    const(char)* strerrorname_np(int);
+    /// ditto
+    const(char)* strerrordesc_np(int);
 }


### PR DESCRIPTION
These are neat to have, i.e. `strerrordesc_np` ignores locale.