### PR TITLE
revert #21881 Break semantic dependency of dmd/aggregate.d on dmd/dsymbolsem.d

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -25,6 +25,7 @@ import dmd.declaration;
 import dmd.dscope;
 import dmd.dstruct;
 import dmd.dsymbol;
+import dmd.dsymbolsem : determineSize;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
@@ -184,6 +185,15 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     {
         return fields.length - isNested() - (vthis2 !is null);
     }
+
+    override final ulong size(Loc loc)
+    {
+        //printf("+AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
+        bool ok = determineSize(this, loc);
+        //printf("-AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
+        return ok ? structsize : SIZE_INVALID;
+    }
+
 
     // is aggregate deprecated?
     override final bool isDeprecated() const

--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -122,6 +122,7 @@ public:
     Sizeok sizeok;              // set when structsize contains valid data
 
     virtual Scope *newScope(Scope *sc);
+    uinteger_t size(Loc loc) override final;
     bool isDeprecated() const override final; // is aggregate deprecated?
     bool isNested() const;
     bool isExport() const override final;

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -248,12 +248,6 @@ Type getType(Dsymbol ds)
     return dmd.dsymbolsem.getType(ds);
 }
 
-uinteger_t size(Dsymbol ds, Loc loc)
-{
-    import dmd.dsymbolsem;
-    return dmd.dsymbolsem.size(ds, loc);
-}
-
 void semantic3OnDependencies(Module m)
 {
     import dmd.dsymbolsem;

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -108,6 +108,16 @@ extern (C++) abstract class Declaration : Dsymbol
         return "declaration";
     }
 
+    override final ulong size(Loc loc)
+    {
+        assert(type);
+        import dmd.typesem;
+        const sz = type.size();
+        if (sz == SIZE_INVALID)
+            errors = true;
+        return sz;
+    }
+
     final bool isStatic() const pure nothrow @nogc @safe
     {
         return (storage_class & STC.static_) != 0;

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -137,6 +137,8 @@ public:
     bool noUnderscore() const;
 
     const char *kind() const override;
+    uinteger_t size(Loc loc) override final;
+
 
     bool isStatic() const { return (storage_class & STCstatic) != 0; }
     LINK resolvedLinkage() const; // returns the linkage, resolving the target-specific `System` one

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -662,6 +662,16 @@ extern (C++) class Dsymbol : ASTNode
         return "symbol";
     }
 
+    /*********************************
+     * Returns:
+     *  SIZE_INVALID when the size cannot be determined
+     */
+    ulong size(Loc loc)
+    {
+        .error(loc, "%s `%s` symbol `%s` has no size", kind, toPrettyChars, toChars());
+        return SIZE_INVALID;
+    }
+
     bool isforwardRef()
     {
         return false;

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -226,6 +226,7 @@ public:
     virtual Identifier *getIdent();
     virtual const char *toPrettyChars(bool QualifyTypes = false);
     virtual const char *kind() const;
+    virtual uinteger_t size(Loc loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration *isThis();     // is a 'this' required to access the member
     virtual bool isExport() const;              // is Dsymbol exported?
@@ -426,7 +427,6 @@ namespace dmd
     void setScope(Dsymbol *d, Scope *sc);
     void importAll(Dsymbol *d, Scope *sc);
     bool hasPointers(Dsymbol *d);
-    Type *getType(Dsymbol *d);
     uinteger_t size(Dsymbol *ds, Loc loc);
     void semantic3OnDependencies(Module *m);
     void addDeferredSemantic(Dsymbol *s);

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -232,7 +232,6 @@ void runDeferredSemantic3()
 
 bool isOverlappedWith(VarDeclaration _this, VarDeclaration v)
 {
-    import dmd.typesem : size;
     const vsz = v.type.size();
     const tsz = _this.type.size();
     assert(vsz != SIZE_INVALID && tsz != SIZE_INVALID);
@@ -368,7 +367,6 @@ private uinteger_t aggregateDeclSize(AggregateDeclaration _this, Loc loc)
 
 private uinteger_t declSize(Declaration _this, Loc loc)
 {
-    import dmd.typesem: size;
     assert(_this.type);
     const sz = _this.type.size();
     if (sz == SIZE_INVALID)
@@ -389,6 +387,7 @@ uinteger_t size(Dsymbol _this, Loc loc)
     .error(loc, "%s `%s` symbol `%s` has no size", _this.kind, _this.toPrettyChars, _this.toChars());
     return SIZE_INVALID;
 }
+import dmd.typesem : size; // alias the overload in this module to not only find size(Dsymbol)
 
 private bool funcDeclEquals(const FuncDeclaration _this, const Dsymbol s)
 {
@@ -1406,8 +1405,6 @@ private void checkImportDeprecation(Module m, Loc loc, Scope* sc)
 
 private extern(C++) final class DsymbolSemanticVisitor : Visitor
 {
-    import dmd.typesem: size;
-
     alias visit = Visitor.visit;
 
     Scope* sc;
@@ -8889,8 +8886,6 @@ void setFieldOffset(Dsymbol d, AggregateDeclaration ad, FieldState* fieldState, 
 
 private extern(C++) class SetFieldOffsetVisitor : Visitor
 {
-    import dmd.typesem: size;
-
     alias visit = Visitor.visit;
 
     AggregateDeclaration ad;
@@ -9595,8 +9590,6 @@ bool isGNUABITag(Expression e)
  */
 private Expression callScopeDtor(VarDeclaration vd, Scope* sc)
 {
-    import dmd.typesem: size;
-
     //printf("VarDeclaration::callScopeDtor() %s\n", toChars());
 
     // Destruction of STC.field's is handled by buildDtor()
@@ -10190,8 +10183,6 @@ void finalizeSize(AggregateDeclaration ad)
  */
 bool _isZeroInit(Expression exp)
 {
-    import dmd.typesem: size;
-
     switch (exp.op)
     {
         case EXP.int64:
@@ -10357,8 +10348,6 @@ private bool checkOverlappedFields(AggregateDeclaration ad)
 
 private extern(C++) class FinalizeSizeVisitor : Visitor
 {
-    import dmd.typesem: size;
-
     alias visit = Visitor.visit;
 
     override void visit(ClassDeclaration outerCd)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -599,6 +599,7 @@ public:
     virtual Identifier* getIdent();
     virtual const char* toPrettyChars(bool QualifyTypes = false);
     virtual const char* kind() const;
+    virtual uint64_t size(Loc loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration* isThis();
     virtual bool isExport() const;
@@ -6352,6 +6353,7 @@ public:
     bool disableNew;
     Sizeok sizeok;
     virtual Scope* newScope(Scope* sc);
+    uint64_t size(Loc loc) final override;
     bool isDeprecated() const final override;
     bool isNested() const;
     bool isExport() const final override;
@@ -6751,6 +6753,7 @@ private:
     uint8_t bitFields;
 public:
     const char* kind() const override;
+    uint64_t size(Loc loc) final override;
     bool isStatic() const;
     LINK resolvedLinkage() const;
     virtual bool isDelete();

--- a/compiler/src/dmd/glue/objc.d
+++ b/compiler/src/dmd/glue/objc.d
@@ -31,8 +31,6 @@ import dmd.mtype;
 import dmd.objc;
 import dmd.target;
 
-import dmd.dsymbolsem: size;
-
 import dmd.root.stringtable;
 import dmd.root.array;
 

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -26,7 +26,6 @@ import dmd.declaration;
 import dmd.denum;
 import dmd.dstruct;
 import dmd.dsymbol;
-import dmd.dsymbolsem: size;
 import dmd.dtemplate;
 import dmd.enumsem;
 import dmd.errors;
@@ -274,7 +273,6 @@ enum Covariant
  */
 extern (C++) abstract class Type : ASTNode
 {
-
     TY ty;
     MOD mod; // modifiers MODxxxx
     char* deco;
@@ -633,7 +631,6 @@ extern (C++) abstract class Type : ASTNode
 
     uint alignsize()
     {
-        import dmd.typesem: size;
         return cast(uint)size(this, Loc.initial);
     }
 
@@ -2076,7 +2073,6 @@ extern (C++) final class TypeVector : Type
 
     override uint alignsize()
     {
-        import dmd.typesem: size;
         return cast(uint)basetype.size();
     }
 

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1739,11 +1739,7 @@ uinteger_t size(Type t, Loc loc)
         case Tinstance:
         case Ttypeof:
         case Treturn:       return visitTypeQualified(cast(TypeQualified)t);
-        case Tstruct:
-        {
-            import dmd.dsymbolsem: size;
-            return t.isTypeStruct().sym.size(loc);
-        }
+        case Tstruct:       return t.isTypeStruct().sym.size(loc);
         case Tenum:         return t.isTypeEnum().sym.getMemtype(loc).size(loc);
         case Tnull:         return t.tvoidptr.size(loc);
         case Tnoreturn:     return 0;
@@ -3631,10 +3627,7 @@ Expression defaultInitLiteral(Type t, Loc loc)
         {
             printf("TypeStruct::defaultInitLiteral() '%s'\n", toChars());
         }
-        {
-            import dmd.dsymbolsem: size;
-            ts.sym.size(loc);
-        }
+        ts.sym.size(loc);
         if (ts.sym.sizeok != Sizeok.done)
             return ErrorExp.get();
 
@@ -4889,10 +4882,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                 {
                     auto ad = v.isMember();
                     objc.checkOffsetof(e, ad);
-                    {
-                        import dmd.dsymbolsem: size;
-                        ad.size(e.loc);
-                    }
+                    ad.size(e.loc);
                     if (ad.sizeok != Sizeok.done)
                         return ErrorExp.get();
                     uint value;
@@ -5744,10 +5734,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
              */
             e = e.expressionSemantic(sc); // do this before turning on noAccessCheck
 
-            {
-                import dmd.dsymbolsem: size;
-                mt.sym.size(e.loc); // do semantic of type
-            }
+            mt.sym.size(e.loc); // do semantic of type
 
             Expression e0;
             Expression ev = e.op == EXP.type ? null : e;


### PR DESCRIPTION
buildkite is broken since #21881 has been merged, see https://buildkite.com/dlang/dmd/builds?branch=master

Revert the changes to see whether that fixes it or if it was a simultaneous change elsewhere. I had to manually resolve some conflicts, though...