### PR TITLE
Replace `__ArrayCast` with pointer cast to avoid inout-related errors

### DIFF
--- a/compiler/test/compilable/fix21894.d
+++ b/compiler/test/compilable/fix21894.d
@@ -1,0 +1,15 @@
+// https://github.com/dlang/dmd/issues/21894
+
+inout(int[]) test1(inout(int[]) a, int b)
+{
+    return a ~ b;
+}
+inout(int[]) test2(inout(int[]) a, inout(int[]) b)
+{
+    return a ~ b;
+}
+void main()
+{
+    test1([1], 2);
+    test2([1], [2]);
+}

--- a/druntime/src/core/internal/array/concatenation.d
+++ b/druntime/src/core/internal/array/concatenation.d
@@ -17,7 +17,7 @@ module core.internal.array.concatenation;
  * Returns:
  *      A newly allocated array that contains all the elements from `froms`.
  */
-Tret _d_arraycatnTX(Tret, Tarr...)(auto ref Tarr froms) @trusted
+Tret _d_arraycatnTX(Tret: Tret_El[], Tret_El, Tarr...)(auto ref Tarr froms) @trusted
 {
     import core.exception : onOutOfMemoryError;
     import core.internal.array.utils : __arrayAlloc;
@@ -44,7 +44,7 @@ Tret _d_arraycatnTX(Tret, Tarr...)(auto ref Tarr froms) @trusted
         return res; // Return an empty array if no elements are present
 
     // Allocate memory for mutable arrays using __arrayAlloc
-    res = cast(Tret) __arrayAlloc!(UnqT)(elemSize * totalLen);
+    res = (cast(Tret_El*) &__arrayAlloc!(UnqT)(elemSize * totalLen)[0])[0 .. totalLen];
 
     if (res.ptr is null)
         onOutOfMemoryError(); // Abort if allocation fails


### PR DESCRIPTION
This PR addresses #21894.