### PR TITLE
Move `arrayObjectHash` to `dmd/templatesem.d`

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1772,7 +1772,6 @@ public:
     Dsymbol* aliasdecl;
     TemplateInstance* inst;
     ScopeDsymbol* argsym;
-    size_t hash;
     Array<Expression* >* fargs;
     Array<ArgumentLabel >* fnames;
     Array<TemplateInstance* >* deferred;

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -247,7 +247,6 @@ public:
     Dsymbol *aliasdecl;                 // !=NULL if instance is an alias for its sole member
     TemplateInstance *inst;             // refer to existing instance
     ScopeDsymbol *argsym;               // argument symbol table
-    hash_t hash;                        // cached result of toHash()
     Expressions *fargs;                 // for function template, these are the function arguments
     Identifiers *fnames;                // for function template, argument names
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -187,11 +187,11 @@ struct TemplateInstanceBox
         hash = cast(size_t)cast(void*)this.ti.enclosing;
         hash += arrayObjectHash(this.ti.tdtypes);
         hash += hash == 0;
-        assert(this.hash);
     }
 
     size_t toHash() const @safe pure nothrow
     {
+        assert(hash);
         return hash;
     }
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -62,24 +62,141 @@ alias funcLeastAsSpecialized = dmd.funcsem.leastAsSpecialized;
 enum LOG = false;
 
 /************************************
+ * Return hash of Objects.
+ */
+private size_t arrayObjectHash(ref Objects oa1)
+{
+    import dmd.root.hash : mixHash;
+
+    size_t hash = 0;
+    foreach (o1; oa1)
+    {
+        /* Must follow the logic of match()
+         */
+        if (auto t1 = isType(o1))
+            hash = mixHash(hash, cast(size_t)t1.deco);
+        else if (auto e1 = getExpression(o1))
+            hash = mixHash(hash, expressionHash(e1));
+        else if (auto s1 = isDsymbol(o1))
+        {
+            if (auto fa1 = s1.isFuncAliasDeclaration())
+                s1 = fa1.toAliasFunc();
+            hash = mixHash(hash, mixHash(cast(size_t)cast(void*)s1.getIdent(), cast(size_t)cast(void*)s1.parent));
+        }
+        else if (auto u1 = isTuple(o1))
+            hash = mixHash(hash, arrayObjectHash(u1.objects));
+    }
+    return hash;
+}
+
+/************************************
+ * Computes hash of expression.
+ * Handles all Expression classes and MUST match their equals method,
+ * i.e. e1.equals(e2) implies expressionHash(e1) == expressionHash(e2).
+ */
+private size_t expressionHash(Expression e)
+{
+    import dmd.root.ctfloat : CTFloat;
+    import dmd.root.hash : calcHash, mixHash;
+
+    switch (e.op)
+    {
+    case EXP.int64:
+        return cast(size_t) e.isIntegerExp().getInteger();
+
+    case EXP.float64:
+        return CTFloat.hash(e.isRealExp().value);
+
+    case EXP.complex80:
+        auto ce = e.isComplexExp();
+        return mixHash(CTFloat.hash(ce.toReal), CTFloat.hash(ce.toImaginary));
+
+    case EXP.identifier:
+        return cast(size_t)cast(void*) e.isIdentifierExp().ident;
+
+    case EXP.null_:
+        return cast(size_t)cast(void*) e.isNullExp().type;
+
+    case EXP.string_:
+        return calcHash(e.isStringExp.peekData());
+
+    case EXP.tuple:
+    {
+        auto te = e.isTupleExp();
+        size_t hash = 0;
+        hash += te.e0 ? expressionHash(te.e0) : 0;
+        foreach (elem; *te.exps)
+            hash = mixHash(hash, expressionHash(elem));
+        return hash;
+    }
+
+    case EXP.arrayLiteral:
+    {
+        auto ae = e.isArrayLiteralExp();
+        size_t hash;
+        foreach (i; 0 .. ae.elements.length)
+            hash = mixHash(hash, expressionHash(ae[i]));
+        return hash;
+    }
+
+    case EXP.assocArrayLiteral:
+    {
+        auto ae = e.isAssocArrayLiteralExp();
+        size_t hash;
+        foreach (i; 0 .. ae.keys.length)
+            // reduction needs associative op as keys are unsorted (use XOR)
+            hash ^= mixHash(expressionHash((*ae.keys)[i]), expressionHash((*ae.values)[i]));
+        return hash;
+    }
+
+    case EXP.structLiteral:
+    {
+        auto se = e.isStructLiteralExp();
+        size_t hash;
+        foreach (elem; *se.elements)
+            hash = mixHash(hash, elem ? expressionHash(elem) : 0);
+        return hash;
+    }
+
+    case EXP.variable:
+        return cast(size_t)cast(void*) e.isVarExp().var;
+
+    case EXP.function_:
+        return cast(size_t)cast(void*) e.isFuncExp().fd;
+
+    default:
+        // no custom equals for this expression
+        //assert((&e.equals).funcptr is &Expression.equals);
+        // equals based on identity
+        return cast(size_t)cast(void*) e;
+    }
+}
+
+/************************************
  * This struct is needed for TemplateInstance to be the key in an associative array.
  * Fixing https://issues.dlang.org/show_bug.cgi?id=15813 would make it unnecessary.
  */
 struct TemplateInstanceBox
 {
     TemplateInstance ti;
+    size_t hash; // cached result of toHash()
 
     this(TemplateInstance ti)
     {
         this.ti = ti;
-        this.ti.toHash();
-        assert(this.ti.hash);
+        this.toHash();
+        assert(this.hash);
     }
 
-    size_t toHash() const @safe pure nothrow
+    size_t toHash()
     {
-        assert(ti.hash);
-        return ti.hash;
+        if (!hash)
+        {
+            hash = cast(size_t)cast(void*)this.ti.enclosing;
+            hash += arrayObjectHash(this.ti.tdtypes);
+            hash += hash == 0;
+        }
+        return hash;
     }
 
     bool opEquals(ref const TemplateInstanceBox s) @trusted const
@@ -7504,7 +7621,7 @@ private Expression getValue(Expression e)
     return e;
 }
 
-Expression getExpression(RootObject o)
+private Expression getExpression(RootObject o)
 {
     auto s = isDsymbol(o);
     return s ? .getValue(s) : .getValue(isExpression(o));

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -184,18 +184,14 @@ struct TemplateInstanceBox
     this(TemplateInstance ti)
     {
         this.ti = ti;
-        this.toHash();
+        hash = cast(size_t)cast(void*)this.ti.enclosing;
+        hash += arrayObjectHash(this.ti.tdtypes);
+        hash += hash == 0;
         assert(this.hash);
     }
 
-    size_t toHash()
+    size_t toHash() const @safe pure nothrow
     {
-        if (!hash)
-        {
-            hash = cast(size_t)cast(void*)this.ti.enclosing;
-            hash += arrayObjectHash(this.ti.tdtypes);
-            hash += hash == 0;
-        }
         return hash;
     }
 


### PR DESCRIPTION
- Moved `arrayObjectHash` and `expressionHash` to `dmd/templatesem.d`
- Inlined `TemplateInstance.toHash` inside `TemplateInstanceBox.toHash`
