### PR TITLE
adapt to unique OSX64 AArch64 variadic args

### DIFF
--- a/compiler/src/dmd/backend/el.d
+++ b/compiler/src/dmd/backend/el.d
@@ -74,7 +74,12 @@ struct elem
     ubyte Eoper;        // operator (OPxxxx)
     ubyte Ecount;       // # of parents of this elem - 1,
                         // always 0 until CSE elimination is done
-    eflags_t Eflags;
+    union
+    {
+	eflags_t Eflags;  // I64 && config.exe != EX_WIN64
+	ubyte numParams;  // number of declared parameters for variadic functions
+			  // config.exe == EX_OSX64 && target.isAArch64;
+    }
 
     union
     {

--- a/compiler/src/dmd/backend/x86/cod1.d
+++ b/compiler/src/dmd/backend/x86/cod1.d
@@ -3081,7 +3081,7 @@ bool FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, out reg_t pre
     }
 
     if (tybasic(ty) == TYstruct && type_zeroSize(t, fpr.tyf))
-        return 0;               // don't allocate into registers
+        return false;               // don't allocate into registers
 
     ++fpr.i;
 
@@ -3124,7 +3124,7 @@ bool FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, out reg_t pre
                 }
             }
             else if (I64 && !targ2)
-                return 0;
+                return false;
         }
     }
 

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -5784,7 +5784,16 @@ elem* callfunc(Loc loc,
             e = el_una(OPucall, tyret, ec);
 
         if (tf.parameterList.varargs != VarArg.none)
-            e.Eflags |= EFLAGS_variadic;
+        {
+            if (I64 && config.exe != EX_WIN64)
+                e.Eflags |= EFLAGS_variadic;
+            if (config.exe == EX_OSX64 && target.isAArch64)
+            {
+                const length = tf.parameterList.length;
+                assert(length < ubyte.max); // 254 should be enough for anybody
+                e.numParams = cast(ubyte)(tf.parameterList.length + 1); // +1 means variadic
+            }
+        }
     }
 
     const isCPPCtor = fd && fd._linkage == LINK.cpp && fd.isCtorDeclaration();


### PR DESCRIPTION
Apple decided to not follow the variadic args specification. This adapts to the Apple calling method, it doesn't fix the callee code.

But at least printf works now.