### PR TITLE
SAOC 2025: fix #20092: importC: can't take address of some compound-literals

### DIFF
--- a/compiler/test/runnable/fix20092.c
+++ b/compiler/test/runnable/fix20092.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+
+int *m = &(int){0};
+int *p = &(int){8880};
+int *q = &(int){9334};
+
+
+int main()
+{
+    //global symbols
+    assert(*m == 0);
+    assert(*p == 8880);
+    assert(*q == 9334);
+
+    //local symbols
+    int *a = &(int){0};
+    int *b = &(int){55};
+    int *c = &(int){90};
+    assert(*a == 0);
+    assert(*b == 55);
+    assert(*c == 90);
+    *b = 100;
+    *c = 506;
+    assert(*b == 100);
+    assert(*c == 506);
+    return 0;
+}


### PR DESCRIPTION
This PR proposes a fix for:
https://issues.dlang.org/show_bug.cgi?id=23053

@dkorpel gave me an insight into using `copyToTemp` which led to using `extractSideEffect` which creates a temporary var and then we take the address for the pointer.
for globals, I couldn't trust on them since we strictly needs `static,` `const` and `ctfe` and symbol table push. 