### PR TITLE
 Fix incorrect type qualifier error for incompatible `opApply`

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -839,24 +839,6 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             return setError();
         }
 
-        // If inference succeeds, proceed with post-checks
-        if (sapply && sapply.isFuncDeclaration())
-        {
-            FuncDeclaration fd = sapply.isFuncDeclaration();
-
-            if (fs.aggr && fs.aggr.type && fd.type && fs.aggr.type.isConst() && !fd.type.isConst())
-            {
-                // First error: The call site
-                error(fs.loc, "mutable method `%s.%s` is not callable using a `const` object",
-                    fd.parent ? fd.parent.toPrettyChars() : "unknown", fd.toChars());
-
-                // Second error: Suggest how to fix
-                errorSupplemental(fd.loc, "Consider adding `const` or `inout` here");
-
-                return setError();
-            }
-        }
-
         Type tab = fs.aggr.type.toBasetype();
 
         if (tab.ty == Ttuple) // don't generate new scope for tuple loops

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -810,12 +810,11 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                             foreachParamCount = tf.parameterList.length;
                             foundMismatch = true;
 
-                            if (fs.aggr && fs.aggr.type && fd.vthis &&
-                                !MODmethodConv(fs.aggr.type.mod, fd.vthis.type.mod))
+                            if (fd.isThis() &&
+                                !MODmethodConv(fs.aggr.type.mod, fd.type.mod))
                             {
-                                auto tthis = fd.vthis.type;
                                 error(fs.loc, "%s method `%s` is not callable using a `%s` foreach aggregate",
-                                    !tthis.mod ? "mutable" : tthis.modToChars(),
+                                    !fd.type.mod ? "mutable" : fd.type.modToChars(),
                                     fd.toPrettyChars(),
                                     fs.aggr.type.toChars());
                                 errorSupplemental(fd.loc, "Consider adding a method type qualifier here");

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -792,13 +792,15 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         {
             bool foundMismatch = false;
             size_t foreachParamCount = 0;
+
             if (sapplyOld)
             {
                 if (FuncDeclaration fd = sapplyOld.isFuncDeclaration())
                 {
                     auto fparameters = fd.getParameterList();
 
-                    if (fparameters.length == 1)
+                    // ignore overloads, can't determine which non-matching is closest
+                    if (!fd.overnext && fparameters.length == 1)
                     {
                         // first param should be the callback function
                         Parameter fparam = fparameters[0];

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -815,7 +815,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                             if (fd.isThis() &&
                                 !MODmethodConv(fs.aggr.type.mod, fd.type.mod))
                             {
-                                error(fs.loc, "%s method `%s` is not callable using a `%s` foreach aggregate",
+                                error(fs.aggr.loc, "%s method `%s` is not callable using a `%s` foreach aggregate",
                                     !fd.type.mod ? "mutable" : fd.type.modToChars(),
                                     fd.toPrettyChars(),
                                     fs.aggr.type.toChars());

--- a/compiler/test/fail_compilation/test24353.d
+++ b/compiler/test/fail_compilation/test24353.d
@@ -1,13 +1,24 @@
 // https://issues.dlang.org/show_bug.cgi?id=24353
 
 /*
+REQUIRED_ARGS: -verrors=context
 TEST_OUTPUT:
 ---
-fail_compilation/test24353.d(26): Error: mutable method `test24353.S.opApply` is not callable using a `const(S)` foreach aggregate
-fail_compilation/test24353.d(17):        Consider adding a method type qualifier here
-fail_compilation/test24353.d(29): Error:  shared const method `test24353.S2.opApply` is not callable using a `const(S2)` foreach aggregate
-fail_compilation/test24353.d(36):        Consider adding a method type qualifier here
-fail_compilation/test24353.d(31): Error: cannot uniquely infer `foreach` argument types
+fail_compilation/test24353.d(37): Error: mutable method `test24353.S.opApply` is not callable using a `const(S)` foreach aggregate
+    foreach (e; s) {} // mod error
+                ^
+fail_compilation/test24353.d(28):        Consider adding a method type qualifier here
+    int opApply(int delegate(int) dg)
+        ^
+fail_compilation/test24353.d(40): Error:  shared const method `test24353.S2.opApply` is not callable using a `const(S2)` foreach aggregate
+    foreach (i, e; s2) {} // mod error
+                   ^
+fail_compilation/test24353.d(47):        Consider adding a method type qualifier here
+    int opApply(int delegate(int, int) dg) const shared;
+        ^
+fail_compilation/test24353.d(42): Error: cannot uniquely infer `foreach` argument types
+    foreach (e; const S3()) {} // cannot infer
+    ^
 ---
 */
 

--- a/compiler/test/fail_compilation/test24353.d
+++ b/compiler/test/fail_compilation/test24353.d
@@ -3,8 +3,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test24353.d(23): Error: mutable method `test24353.S.opApply` is not callable using a `const(S)` foreach aggregate
-fail_compilation/test24353.d(14):        Consider adding a method type qualifier here
+fail_compilation/test24353.d(25): Error: mutable method `test24353.S.opApply` is not callable using a `const(S)` foreach aggregate
+fail_compilation/test24353.d(16):        Consider adding a method type qualifier here
+fail_compilation/test24353.d(28): Error:  shared const method `test24353.S2.opApply` is not callable using a `const(S2)` foreach aggregate
+fail_compilation/test24353.d(33):        Consider adding a method type qualifier here
 ---
 */
 
@@ -21,4 +23,15 @@ void example()
 {
     const S s;
     foreach (e; s) {} // Error expected here
+
+    const S2 s2;
+    foreach (i, e; s2) {} // Error expected here
+}
+
+struct S2
+{
+    int opApply(int delegate(int, int) dg) const shared
+    {
+        return 0;
+    }
 }

--- a/compiler/test/fail_compilation/test24353.d
+++ b/compiler/test/fail_compilation/test24353.d
@@ -17,7 +17,7 @@ fail_compilation/test24353.d(47):        Consider adding a method type qualifier
     int opApply(int delegate(int, int) dg) const shared;
         ^
 fail_compilation/test24353.d(42): Error: cannot uniquely infer `foreach` argument types
-    foreach (e; const S3()) {} // cannot infer
+    foreach (i, e; const S3()) {} // cannot infer
     ^
 ---
 */
@@ -39,7 +39,7 @@ void example()
     const S2 s2;
     foreach (i, e; s2) {} // mod error
 
-    foreach (e; const S3()) {} // cannot infer
+    foreach (i, e; const S3()) {} // cannot infer
 }
 
 struct S2

--- a/compiler/test/fail_compilation/test24353.d
+++ b/compiler/test/fail_compilation/test24353.d
@@ -1,10 +1,10 @@
 // https://issues.dlang.org/show_bug.cgi?id=24353
 
-/**
+/*
 TEST_OUTPUT:
 ---
-fail_compilation/test24353.d(23): Error: mutable method `test24353.S.opApply` is not callable using a `const` object
-fail_compilation/test24353.d(14):        Consider adding `const` or `inout` here
+fail_compilation/test24353.d(23): Error: mutable method `test24353.S.opApply` is not callable using a `const(S)` foreach aggregate
+fail_compilation/test24353.d(14):        Consider adding a method type qualifier here
 ---
 */
 

--- a/compiler/test/fail_compilation/test24353.d
+++ b/compiler/test/fail_compilation/test24353.d
@@ -3,10 +3,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test24353.d(25): Error: mutable method `test24353.S.opApply` is not callable using a `const(S)` foreach aggregate
-fail_compilation/test24353.d(16):        Consider adding a method type qualifier here
-fail_compilation/test24353.d(28): Error:  shared const method `test24353.S2.opApply` is not callable using a `const(S2)` foreach aggregate
-fail_compilation/test24353.d(33):        Consider adding a method type qualifier here
+fail_compilation/test24353.d(26): Error: mutable method `test24353.S.opApply` is not callable using a `const(S)` foreach aggregate
+fail_compilation/test24353.d(17):        Consider adding a method type qualifier here
+fail_compilation/test24353.d(29): Error:  shared const method `test24353.S2.opApply` is not callable using a `const(S2)` foreach aggregate
+fail_compilation/test24353.d(36):        Consider adding a method type qualifier here
+fail_compilation/test24353.d(31): Error: cannot uniquely infer `foreach` argument types
 ---
 */
 
@@ -22,16 +23,21 @@ struct S
 void example()
 {
     const S s;
-    foreach (e; s) {} // Error expected here
+    foreach (e; s) {} // mod error
 
     const S2 s2;
-    foreach (i, e; s2) {} // Error expected here
+    foreach (i, e; s2) {} // mod error
+
+    foreach (e; const S3()) {} // cannot infer
 }
 
 struct S2
 {
-    int opApply(int delegate(int, int) dg) const shared
-    {
-        return 0;
-    }
+    int opApply(int delegate(int, int) dg) const shared;
+}
+
+struct S3
+{
+    int opApply(int delegate(int) dg);
+    int opApply(int delegate(int, int) dg);
 }


### PR DESCRIPTION
Fixes #18207.
Fixes #21910. Don't show specific error when overloads have no match.

Due to proper type modifier checks, this no longer suggests a specific keyword fix.

Also use aggregate expression location for error message rather than `foreach` token.

Note: The original fix (#17071) repeats the check after inferring parameter types - I can't find any way of triggering that error and those lines were not exercised by the test suite. I have removed them.