### PR TITLE
CI: fix style check, the offending RAII variables have been moved …

### DIFF
--- a/compiler/src/.dscanner.ini
+++ b/compiler/src/.dscanner.ini
@@ -148,7 +148,7 @@ unused_variable_check="-dmd.backend.aarray,\
 -dmd.backend.symbol,\
 -dmd.expressionsem,\
 -dmd.dsymbolsem,\
--dmd.dtemplate,\
+-dmd.templatesem,\
 -dmd.dump,\
 -dmd.mars,\
 -dmd.root.longdouble"


### PR DESCRIPTION
…from dtemplate.d to templatesem.d