### PR TITLE
fix regression from #21066: cannot assign literal of type const(int)[] to int[]

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -18856,12 +18856,16 @@ private Expression rewriteAAIndexAssign(BinExp exp, Scope* sc, ref Type[2] alias
     // extract side effects in lexical order
     for (size_t i = ekeys.length; i > 0; --i)
         ekeys[i-1] = extractSideEffect(sc, "__aakey", e0, ekeys[i-1]);
-    Expression ev = extractSideEffect(sc, "__aaval", e0, exp.e2);
+    // some implicit conversions are lost when assigning to a temporary, e.g. from array literal
+    auto taa = eaa.type.isTypeAArray();
+    auto match = exp.e2.implicitConvTo(taa.next);
+    auto e2 = match == MATCH.exact || match == MATCH.nomatch ? exp.e2 : exp.e2.implicitCastTo(sc, taa.next);
+    Expression ev = extractSideEffect(sc, "__aaval", e0, e2); // must be evaluated before the insertion
 
     // generate series of calls to _d_aaGetY
     for (size_t i = ekeys.length; i > 0; --i)
     {
-        auto taa = eaa.type.isTypeAArray();
+        taa = eaa.type.isTypeAArray();
         assert (taa); // type must not have changed during rewrite
         Expression func = new IdentifierExp(loc, Id.empty);
         func = new DotIdExp(loc, func, Id.object);

--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -371,6 +371,20 @@ void test12403()
 }
 
 /***************************************************/
+// regressions after converting AA to template
+void test21066()
+{
+    const(int) getValue() { return 0; }
+    int[] arr;
+    arr = [getValue()]; // works
+    int[][string] aa;
+    aa["a"] = [getValue()]; // fails: cannot implicitly convert expression `__aaval` of type `const(int)[]` to `int[]`
+
+    string[int[]] aa2;
+    aa2[[getValue()]] = "a"; // no problem because key type is automatically const(int)[]
+}
+
+/***************************************************/
 
 void main()
 {
@@ -396,4 +410,5 @@ void main()
     testTypeinfo();
     test12220();
     test12403();
+    test21066();
 }


### PR DESCRIPTION

implicit conversion of ArrayLiteralExp lost by assigning to temporary, so omit it. Execution order is kept as it is still evaluated last.