### PR TITLE
SAOC 25: fix issue #19983: function redeclarations should be allowed in function scope

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -739,7 +739,19 @@ extern (C++) struct Scope
         if (!scopesym.symtabInsert(s)) // if already in table
         {
             Dsymbol s2 = scopesym.symtabLookup(s, s.ident); // s2 is existing entry
-            return handleTagSymbols(this, s, s2, scopesym);
+
+            auto svar = s.isVarDeclaration();
+            auto s2var = s2.isVarDeclaration();
+            if (((svar && svar.storage_class & STC.extern_) &&
+                    (s2var && s2var.storage_class & STC.extern_) && this.func) ||
+                    s.isFuncDeclaration())
+            {
+                    return handleSymbolRedeclarations(*s._scope, s, s2, scopesym);
+            }
+            else // aside externs and func decls, we should be free to handle tags
+            {
+                return handleTagSymbols(this, s, s2, scopesym);
+            }
         }
         return s; // inserted
     }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7705,7 +7705,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         //printf("inserting '%s' %p into sc = %p\n", s.toChars(), s, sc);
         // Insert into both local scope and function scope.
-        // Must be unique in both.
+        // Must be unique in both (except for importC).
         if (s.ident)
         {
             VarDeclaration v = s.isVarDeclaration();

--- a/compiler/test/compilable/fix19983.c
+++ b/compiler/test/compilable/fix19983.c
@@ -1,0 +1,30 @@
+// fix ImportC function redeclarations should be allowed in function scope
+
+void test()
+{
+
+    struct Foo;
+    struct Foo;
+    struct Foo;
+    enum bar;
+    enum bar;
+    enum bar;
+    union see;
+    union see;
+    union see;
+    int f();
+    extern int f();
+    int f();
+
+    extern int h;
+    extern int h;
+}
+
+void test1()
+{
+    extern int f();
+    int f();
+
+    extern int x;
+    extern int x;
+}


### PR DESCRIPTION
should close  #19983 

@dkorpel @WalterBright 