### PR TITLE
Slightly improved description of `dup` and `idup`

### DIFF
--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -3822,7 +3822,7 @@ private size_t getArrayHash(const scope TypeInfo element, const scope void* ptr,
     return hash;
 }
 
-/// Provide the .dup array property.
+/// Provide the .dup array property, which creates a duplicate.
 @property auto dup(T)(T[] a)
     if (!is(const(T) : T))
 {
@@ -3854,7 +3854,7 @@ private size_t getArrayHash(const scope TypeInfo element, const scope void* ptr,
 }
 
 
-/// Provide the .idup array property.
+/// Provide the .idup array property, which creates an immutable duplicate.
 @property immutable(T)[] idup(T)(T[] a)
 {
     import core.internal.array.duplication : _dup;


### PR DESCRIPTION
It's now easier to tell that idup stands for *immutable* duplicate from reading these descriptions if this is how you first encounter these function names.