### PR TITLE
Fix #21634 - Print code locations after supplementals

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -719,8 +719,6 @@ private void printDiagnostic(const(char)* format, va_list ap, ref DiagnosticCont
     __gshared SourceLoc old_loc;
     auto loc = info.loc;
     if (global.params.v.errorPrintMode != ErrorPrintMode.simpleError &&
-        // ignore supplemental messages with same loc
-        (loc != old_loc || !info.supplemental) &&
         // ignore invalid files
         loc != SourceLoc.init &&
         // ignore mixins for now

--- a/compiler/test/fail_compilation/fail_pretty_errors.d
+++ b/compiler/test/fail_compilation/fail_pretty_errors.d
@@ -2,23 +2,25 @@
 REQUIRED_ARGS: -verrors=context
 TEST_OUTPUT:
 ---
-fail_compilation/fail_pretty_errors.d(29): Error: undefined identifier `a`
+fail_compilation/fail_pretty_errors.d(31): Error: undefined identifier `a`
     a = 1;
     ^
-fail_compilation/fail_pretty_errors.d-mixin-34(34): Error: undefined identifier `b`
+fail_compilation/fail_pretty_errors.d-mixin-36(36): Error: undefined identifier `b`
 b = 1;
 ^
-fail_compilation/fail_pretty_errors.d(39): Error: cannot implicitly convert expression `5` of type `int` to `string`
+fail_compilation/fail_pretty_errors.d(41): Error: cannot implicitly convert expression `5` of type `int` to `string`
     string x = 5;
                ^
-fail_compilation/fail_pretty_errors.d(44): Error: mixin `fail_pretty_errors.testMixin2.mixinTemplate!()` error instantiating
+fail_compilation/fail_pretty_errors.d(46): Error: mixin `fail_pretty_errors.testMixin2.mixinTemplate!()` error instantiating
     mixin mixinTemplate;
     ^
-fail_compilation/fail_pretty_errors.d(50): Error: invalid array operation `"" + ""` (possible missing [])
+fail_compilation/fail_pretty_errors.d(52): Error: invalid array operation `"" + ""` (possible missing [])
     auto x = ""+"";
                ^
-fail_compilation/fail_pretty_errors.d(50):        did you mean to concatenate (`"" ~ ""`) instead ?
-fail_compilation/fail_pretty_errors.d(53): Error: cannot implicitly convert expression `1111` of type `int` to `byte`
+fail_compilation/fail_pretty_errors.d(52):        did you mean to concatenate (`"" ~ ""`) instead ?
+    auto x = ""+"";
+               ^
+fail_compilation/fail_pretty_errors.d(55): Error: cannot implicitly convert expression `1111` of type `int` to `byte`
         byte ɑ =    1111;
                     ^
 ---

--- a/compiler/test/fail_compilation/test21634.d
+++ b/compiler/test/fail_compilation/test21634.d
@@ -1,0 +1,25 @@
+/*
+REQUIRED_ARGS: -verrors=context
+TEST_OUTPUT:
+---
+fail_compilation/test21634.d(22): Error: function literal `(int x) { }` is not callable using argument types `(string)`
+    (int x) {} ("%s");
+               ^
+fail_compilation/test21634.d(22):        cannot pass argument `"%s"` of type `string` to parameter `int x`
+    (int x) {} ("%s");
+               ^
+fail_compilation/test21634.d(24): Error: declaration `test21634.main.foo` is already defined
+    int foo;
+    ^
+fail_compilation/test21634.d(23):        `variable` `foo` is defined here
+    float foo;
+          ^
+---
+*/
+void f(int x) {}
+void main()
+{
+    (int x) {} ("%s");
+    float foo;
+    int foo;
+}


### PR DESCRIPTION
- fixed #21634
Now, Code lines will always be printed after supplementals to separate them from the next errors.

### Before:
```
test.d(14): Error: function literal `(int x) { }` is not callable using argument types `(string)`
    (int x) {} ("%s");
               ^
test.d(14):        cannot pass argument `"%s"` of type `string` to parameter `int x`
test.d(16): Error: declaration `test.main.foo` is already defined
    int foo;
    ^
test.d(15):        `variable` `foo` is defined here
    float foo;
          ^
```

### After:
```
test.d(14): Error: function literal `(int x) { }` is not callable using argument types `(string)`
    (int x) {} ("%s");
               ^
test.d(14):        cannot pass argument `"%s"` of type `string` to parameter `int x`
    (int x) {} ("%s");
               ^
test.d(16): Error: declaration `test.main.foo` is already defined
    int foo;
    ^
test.d(15):        `variable` `foo` is defined here
    float foo;
          ^
```
