### PR TITLE
Break semantic dependency of `dmd/expression.d` on `dmd/typesem.d`

### DIFF
--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -23,7 +23,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem : include, toAlias;
 import dmd.errorsink;
 import dmd.expression;
-import dmd.expressionsem : errorSupplementalInferredAttr;
+import dmd.expressionsem : errorSupplementalInferredAttr, isLvalue;
 import dmd.func;
 import dmd.globals;
 import dmd.init;

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -398,6 +398,12 @@ bool equals(const Expression exp, const Expression e)
     return dmd.expressionsem.equals(exp, e);
 }
 
+bool isLvalue(Expression exp)
+{
+    import dmd.expressionsem;
+    return dmd.expressionsem.isLvalue(exp, e);
+}
+
 int getFieldIndex(ClassReferenceExp cre, Type fieldtype, uint fieldoffset)
 {
     import dmd.expressionsem;

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -401,7 +401,7 @@ bool equals(const Expression exp, const Expression e)
 bool isLvalue(Expression exp)
 {
     import dmd.expressionsem;
-    return dmd.expressionsem.isLvalue(exp, e);
+    return dmd.expressionsem.isLvalue(exp);
 }
 
 int getFieldIndex(ClassReferenceExp cre, Type fieldtype, uint fieldoffset)

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -61,6 +61,7 @@ namespace dmd
     Expression *optimize(Expression *exp, int result, bool keepLvalue = false);
     bool isIdentical(const Expression *exp, const Expression *e);
     bool equals(const Expression *exp, const Expression *e);
+    bool isLvalue(const Expression *exp);
     int32_t getFieldIndex(ClassReferenceExp *cre, Type *fieldtype, uint32_t fieldoffset);
 }
 
@@ -103,7 +104,6 @@ public:
     virtual real_t toImaginary();
     virtual complex_t toComplex();
     virtual StringExp *toStringExp();
-    virtual bool isLvalue();
     virtual bool checkType();
     Expression *addressOf();
     Expression *deref();
@@ -292,7 +292,6 @@ public:
     Identifier *ident;
 
     static IdentifierExp *create(Loc loc, Identifier *ident);
-    bool isLvalue() override final;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -309,7 +308,6 @@ public:
     d_bool hasOverloads;
 
     DsymbolExp *syntaxCopy() override;
-    bool isLvalue() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -320,7 +318,6 @@ public:
 
     ThisExp *syntaxCopy() override;
     Optional<bool> toBool() override;
-    bool isLvalue() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -357,7 +354,6 @@ public:
     dinteger_t getIndex(d_size_t i) const;
     StringExp *toStringExp() override;
     Optional<bool> toBool() override;
-    bool isLvalue() override;
     void accept(Visitor *v) override { v->visit(this); }
     size_t numberOfCodeUnits(int tynto = 0) const;
     void writeTo(void* dest, bool zero, int tyto = 0) const;
@@ -499,7 +495,6 @@ public:
     TemplateDeclaration *td;
     FuncDeclaration *fd;
 
-    bool isLvalue() override;
     bool checkType() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -572,7 +567,6 @@ class VarExp final : public SymbolExp
 public:
     d_bool delegateWasExtracted;
     static VarExp *create(Loc loc, Declaration *var, bool hasOverloads = true);
-    bool isLvalue() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -584,7 +578,6 @@ class OverExp final : public Expression
 public:
     OverloadSet *vars;
 
-    bool isLvalue() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -688,7 +681,6 @@ public:
 class BinAssignExp : public BinExp
 {
 public:
-    bool isLvalue() override final;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -751,7 +743,6 @@ public:
     Declaration *var;
     d_bool hasOverloads;
 
-    bool isLvalue() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -833,7 +824,6 @@ public:
     static CallExp *create(Loc loc, FuncDeclaration *fd, Expression *earg1);
 
     CallExp *syntaxCopy() override;
-    bool isLvalue() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -848,8 +838,6 @@ public:
 class PtrExp final : public UnaExp
 {
 public:
-    bool isLvalue() override;
-
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -895,7 +883,6 @@ public:
     Expression* lowering;
 
     CastExp *syntaxCopy() override;
-    bool isLvalue() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -915,7 +902,6 @@ public:
 class VectorArrayExp final : public UnaExp
 {
 public:
-    bool isLvalue() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -937,7 +923,6 @@ private:
 
 public:
     SliceExp *syntaxCopy() override;
-    bool isLvalue() override;
     Optional<bool> toBool() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -963,14 +948,12 @@ public:
 class DelegatePtrExp final : public UnaExp
 {
 public:
-    bool isLvalue() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DelegateFuncptrExp final : public UnaExp
 {
 public:
-    bool isLvalue() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -985,7 +968,6 @@ public:
     d_bool modifiable;
 
     ArrayExp *syntaxCopy() override;
-    bool isLvalue() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -1004,7 +986,6 @@ public:
     d_bool isGenerated;
     d_bool allowCommaExp;
     Expression* originalExp;
-    bool isLvalue() override;
     Optional<bool> toBool() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -1018,7 +999,6 @@ public:
     d_bool indexIsInBounds;       // true if 0 <= e2 && e2 <= e1.length - 1
 
     IndexExp *syntaxCopy() override;
-    bool isLvalue() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -1050,8 +1030,6 @@ class AssignExp : public BinExp
 {
 public:
     MemorySet memset;
-
-    bool isLvalue() override final;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -1298,7 +1276,6 @@ public:
     Expression *econd;
 
     CondExp *syntaxCopy() override;
-    bool isLvalue() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -96,6 +96,105 @@ import dmd.visitor.postorder;
 
 enum LOGSEMANTIC = false;
 
+bool isLvalue(Expression _this)
+{
+    static bool dotVarExpIsLvalue(DotVarExp _this)
+    {
+        if (_this.rvalue)
+            return false;
+        if (_this.e1.op != EXP.structLiteral)
+            return true;
+        auto vd = _this.var.isVarDeclaration();
+        return !(vd && vd.isField());
+    }
+
+    static bool callExpIsLvalue(CallExp _this)
+    {
+        if (_this.rvalue)
+            return false;
+        Type tb = _this.e1.type.toBasetype();
+        if (tb.ty == Tdelegate || tb.ty == Tpointer)
+            tb = tb.nextOf();
+        auto tf = tb.isTypeFunction();
+        if (tf && tf.isRef)
+        {
+            if (auto dve = _this.e1.isDotVarExp())
+                if (dve.var.isCtorDeclaration())
+                    return false;
+            return true; // function returns a reference
+        }
+        return false;
+    }
+
+    static bool castExpIsLvalue(CastExp _this)
+    {
+        //printf("e1.type = %s, to.type = %s\n", e1.type.toChars(), to.toChars());
+        if (_this.rvalue || !_this.e1.isLvalue())
+            return false;
+        return (_this.to.ty == Tsarray && (_this.e1.type.ty == Tvector || _this.e1.type.ty == Tsarray)) ||
+            (_this.to.ty == Taarray && _this.e1.type.ty == Taarray) ||
+            _this.e1.type.mutableOf.unSharedOf().equals(_this.to.mutableOf().unSharedOf());
+    }
+
+    static bool indexExpIsLvalue(IndexExp _this)
+    {
+        if (_this.rvalue)
+            return false;
+        auto t1b = _this.e1.type.toBasetype();
+        if (t1b.isTypeAArray() || t1b.isTypeSArray() ||
+            (_this.e1.isIndexExp() && t1b != t1b.isTypeDArray()))
+        {
+            return _this.e1.isLvalue();
+        }
+        return true;
+    }
+
+    static bool assignExpIsLvalue(AssignExp _this)
+    {
+        // Array-op 'x[] = y[]' should make an rvalue.
+        // Setting array length 'x.length = v' should make an rvalue.
+        if (_this.e1.op == EXP.slice || _this.e1.op == EXP.arrayLength)
+        {
+            return false;
+        }
+        return !_this.rvalue;
+    }
+
+    bool not_rvalue = _this.rvalue == false;
+
+    if (_this.isBinAssignExp())
+        return not_rvalue;
+
+    switch(_this.op)
+    {
+        case EXP.overloadSet: return true;
+        case EXP.identifier, EXP.dSymbol, EXP.star: return not_rvalue;
+        // Class `this` should be an rvalue; struct `this` should be an lvalue.
+        case EXP.this_: return not_rvalue && _this.type.toBasetype().ty != Tclass;
+        /* string literal/slice is rvalue in default, but
+         * conversion to reference of static array is only allowed.
+         */
+        case EXP.string_, EXP.slice: return not_rvalue && (_this.type && _this.type.toBasetype().ty == Tsarray);
+        case EXP.question: return not_rvalue && _this.isCondExp().e1.isLvalue() && _this.isCondExp().e2.isLvalue();
+        case EXP.array: return !( _this.rvalue || (_this.type && _this.type.toBasetype().ty == Tvoid));
+
+        case EXP.vectorArray: return not_rvalue && _this.isVectorArrayExp().e1.isLvalue();
+        case EXP.delegatePointer: return not_rvalue && _this.isDelegatePtrExp().e1.isLvalue();
+        case EXP.delegateFunctionPointer: return not_rvalue && _this.isDelegateFuncptrExp().e1.isLvalue();
+
+        case EXP.comma: return not_rvalue && _this.isCommaExp().e2.isLvalue();
+        case EXP.variable: return !(_this.rvalue || (_this.isVarExp().var.storage_class & (STC.lazy_ | STC.rvalue | STC.manifest)));
+        case EXP.template_: return _this.isTemplateExp().fd !is null;
+
+        case EXP.dotVariable: return dotVarExpIsLvalue(_this.isDotVarExp());
+        case EXP.call: return callExpIsLvalue(_this.isCallExp());
+        case EXP.cast_: return castExpIsLvalue(_this.isCastExp());
+        case EXP.index: return indexExpIsLvalue(_this.isIndexExp());
+        case EXP.assign: return assignExpIsLvalue(_this.isAssignExp());
+        default: return false;
+    }
+}
+
 // Return index of the field, or -1 if not found
 int getFieldIndex(ClassReferenceExp _this, Type fieldtype, uint fieldoffset)
 {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -168,9 +168,9 @@ bool isLvalue(Expression _this)
     switch(_this.op)
     {
         case EXP.overloadSet: return true;
-        case EXP.identifier, EXP.dSymbol, EXP.star: return not_rvalue;
+        case EXP.identifier, EXP.dollar, EXP.dSymbol, EXP.star: return not_rvalue;
         // Class `this` should be an rvalue; struct `this` should be an lvalue.
-        case EXP.this_: return not_rvalue && _this.type.toBasetype().ty != Tclass;
+        case EXP.this_, EXP.super_: return not_rvalue && _this.type.toBasetype().ty != Tclass;
         /* string literal/slice is rvalue in default, but
          * conversion to reference of static array is only allowed.
          */
@@ -190,7 +190,7 @@ bool isLvalue(Expression _this)
         case EXP.call: return callExpIsLvalue(_this.isCallExp());
         case EXP.cast_: return castExpIsLvalue(_this.isCastExp());
         case EXP.index: return indexExpIsLvalue(_this.isIndexExp());
-        case EXP.assign: return assignExpIsLvalue(_this.isAssignExp());
+        case EXP.assign, EXP.loweredAssignExp, EXP.construct, EXP.blit: return assignExpIsLvalue(cast(AssignExp) _this);
         default: return false;
     }
 }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3580,7 +3580,6 @@ public:
     int32_t compare(const StringExp* const se2) const;
     Optional<bool > toBool() override;
     void accept(Visitor* v) override;
-    void accept(Visitor* v) override;
 };
 
 class StructLiteralExp final : public Expression

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2382,7 +2382,6 @@ public:
     virtual _d_real toImaginary();
     virtual complex_t toComplex();
     virtual StringExp* toStringExp();
-    virtual bool isLvalue();
     virtual bool checkType();
     Expression* deref();
     int32_t isConst();
@@ -2519,7 +2518,6 @@ public:
 class BinAssignExp : public BinExp
 {
 public:
-    bool isLvalue() final override;
     void accept(Visitor* v) override;
 };
 
@@ -2586,7 +2584,6 @@ public:
     VarDeclaration* lengthVar;
     bool modifiable;
     ArrayExp* syntaxCopy() override;
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
@@ -2640,7 +2637,6 @@ class AssignExp : public BinExp
 public:
     MemorySet memset;
     AssignExp(Loc loc, EXP tok, Expression* e1, Expression* e2);
-    bool isLvalue() final override;
     void accept(Visitor* v) override;
 };
 
@@ -2684,7 +2680,6 @@ public:
     static CallExp* create(Loc loc, Expression* e, Expression* earg1);
     static CallExp* create(Loc loc, FuncDeclaration* fd, Expression* earg1);
     CallExp* syntaxCopy() override;
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
@@ -2696,7 +2691,6 @@ public:
     bool trusted;
     Expression* lowering;
     CastExp* syntaxCopy() override;
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
@@ -2753,7 +2747,6 @@ public:
     const bool isGenerated;
     bool allowCommaExp;
     Expression* originalExp;
-    bool isLvalue() override;
     Optional<bool > toBool() override;
     void accept(Visitor* v) override;
     static void allow(Expression* exp);
@@ -2785,7 +2778,6 @@ class CondExp final : public BinExp
 public:
     Expression* econd;
     CondExp* syntaxCopy() override;
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
@@ -2822,14 +2814,12 @@ public:
 class DelegateFuncptrExp final : public UnaExp
 {
 public:
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
 class DelegatePtrExp final : public UnaExp
 {
 public:
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
@@ -2857,7 +2847,6 @@ class IdentifierExp : public Expression
 public:
     Identifier* ident;
     static IdentifierExp* create(Loc loc, Identifier* ident);
-    bool isLvalue() final override;
     void accept(Visitor* v) override;
 };
 
@@ -2913,7 +2902,6 @@ class DotVarExp final : public UnaExp
 public:
     Declaration* var;
     bool hasOverloads;
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
@@ -2922,7 +2910,6 @@ class DsymbolExp final : public Expression
 public:
     Dsymbol* s;
     bool hasOverloads;
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
@@ -3236,7 +3223,6 @@ public:
     bool modifiable;
     bool indexIsInBounds;
     IndexExp* syntaxCopy() override;
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
@@ -3433,7 +3419,6 @@ class OverExp final : public Expression
 {
 public:
     OverloadSet* vars;
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
@@ -3470,7 +3455,6 @@ public:
 class PtrExp final : public UnaExp
 {
 public:
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
@@ -3563,7 +3547,6 @@ private:
     uint8_t bitFields;
 public:
     SliceExp* syntaxCopy() override;
-    bool isLvalue() override;
     Optional<bool > toBool() override;
     void accept(Visitor* v) override;
 };
@@ -3596,7 +3579,7 @@ public:
     StringExp* toStringExp() override;
     int32_t compare(const StringExp* const se2) const;
     Optional<bool > toBool() override;
-    bool isLvalue() override;
+    void accept(Visitor* v) override;
     void accept(Visitor* v) override;
 };
 
@@ -3663,7 +3646,6 @@ public:
     ThisExp(Loc loc, const EXP tok);
     ThisExp* syntaxCopy() override;
     Optional<bool > toBool() override;
-    bool isLvalue() final override;
     void accept(Visitor* v) override;
 };
 
@@ -3695,7 +3677,6 @@ class TemplateExp final : public Expression
 public:
     TemplateDeclaration* td;
     FuncDeclaration* fd;
-    bool isLvalue() override;
     bool checkType() override;
     void accept(Visitor* v) override;
 };
@@ -3772,14 +3753,12 @@ class VarExp final : public SymbolExp
 public:
     bool delegateWasExtracted;
     static VarExp* create(Loc loc, Declaration* var, bool hasOverloads = true);
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 
 class VectorArrayExp final : public UnaExp
 {
 public:
-    bool isLvalue() override;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -48,7 +48,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem : include, _isZeroInit, toAlias, isPOD;
 import dmd.dtemplate;
 import dmd.expression;
-import dmd.expressionsem : fill, isIdentical;
+import dmd.expressionsem : fill, isIdentical, isLvalue;
 import dmd.func;
 import dmd.hdrgen;
 import dmd.id;


### PR DESCRIPTION
Move `Expression.isLvalue` to `dmd/expressionsem.d`