### PR TITLE
WIP: Deprecate using variables declared in loops from closures

### DIFF
--- a/changelog/dmd.loop-closures.dd
+++ b/changelog/dmd.loop-closures.dd
@@ -1,0 +1,43 @@
+Using variables declared in a loop from closures has been deprecated
+
+Closures in loops use the same memory for all loop iterations. This
+can lead to unexpected results for variables declared in loops, e.g.:
+
+```D
+import std.stdio;
+void main()
+{
+    void delegate()[] funcs;
+    int[] results;
+    foreach (i; 0..3)
+    {
+        void f()
+        {
+            results ~= i;
+        }
+        funcs ~= &f;
+    }
+    foreach (dg; funcs)
+        dg();
+    writeln(results);
+}
+```
+
+This example prints `[2, 2, 2]`, but many users would expect `[0, 1, 2]`.
+The code now results in a deprecation warning:
+```
+test.d(6): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+    foreach (i; 0..3)
+    ^
+test.d(8):        Variable `i` used in possibly escaping function `f`
+        void f()
+             ^
+```
+
+Possible solutions:
+* Move variable declarations out of loops, if the closure really should
+  use the same memory.
+* Mark delegate parameters scope if they don't escape, so the compiler
+  does not need to create a closure for local functions.
+* Move the loop body into another function, so every iteration gets
+  a separate closure.

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -475,6 +475,7 @@ extern (C++) class VarDeclaration : Declaration
         bool dllExport;         /// __declspec(dllexport)
         mixin VarDeclarationExtra;
         bool systemInferred;    /// @system was inferred from initializer
+        bool inLoop;            /// variable is declared in a loop and should not be part of a closure
     }
 
     import dmd.common.bitfields : generateBitFields;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7874,6 +7874,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
         }
 
+        if (VarDeclaration v = s.isVarDeclaration())
+        {
+            v.inLoop = sc.inLoop;
+        }
+
         //printf("inserting '%s' %p into sc = %p\n", s.toChars(), s, sc);
         // Insert into both local scope and function scope.
         // Must be unique in both (except for importC).

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -3275,7 +3275,7 @@ bool needsClosure(FuncDeclaration fd)
      * is already set to `true` upon entering this function when the
      * struct/class refers to a local variable and a closure is needed.
      */
-    //printf("FuncDeclaration::needsClosure() %s\n", toPrettyChars());
+    //printf("FuncDeclaration::needsClosure() %s\n", fd.toPrettyChars());
 
     if (fd.requiresClosure)
         goto Lyes;
@@ -3290,46 +3290,9 @@ bool needsClosure(FuncDeclaration fd)
             FuncDeclaration f = v.nestedrefs[j];
             assert(f != fd);
 
-            /* __require and __ensure will always get called directly,
-             * so they never make outer functions closure.
-             */
-            if (f.ident == Id.require || f.ident == Id.ensure)
-                continue;
-
-            //printf("\t\tf = %p, %s, isVirtual=%d, isThis=%p, tookAddressOf=%d\n", f, f.toChars(), f.isVirtual(), f.isThis(), f.tookAddressOf);
-
-            /* Look to see if f escapes. We consider all parents of f within
-             * this, and also all siblings which call f; if any of them escape,
-             * so does f.
-             * Mark all affected functions as requiring closures.
-             */
-            for (Dsymbol s = f; s && s != fd; s = s.toParentP(fd))
+            if (needsClosureForNestedref(fd, f))
             {
-                FuncDeclaration fx = s.isFuncDeclaration();
-                if (!fx)
-                    continue;
-                if (fx.isThis() || fx.tookAddressOf)
-                {
-                    //printf("\t\tfx = %s, isVirtual=%d, isThis=%p, tookAddressOf=%d\n", fx.toChars(), fx.isVirtual(), fx.isThis(), fx.tookAddressOf);
-
-                    /* Mark as needing closure any functions between this and f
-                     */
-                    markAsNeedingClosure((fx == f) ? fx.toParentP(fd) : fx, fd);
-
-                    fd.requiresClosure = true;
-                }
-
-                /* We also need to check if any sibling functions that
-                 * called us, have escaped. This is recursive: we need
-                 * to check the callers of our siblings.
-                 */
-                if (checkEscapingSiblings(fx, fd))
-                    fd.requiresClosure = true;
-
-                /* https://issues.dlang.org/show_bug.cgi?id=12406
-                 * Iterate all closureVars to mark all descendant
-                 * nested functions that access to the closing context of this function.
-                 */
+                fd.requiresClosure = true;
             }
         }
     }
@@ -3340,6 +3303,55 @@ bool needsClosure(FuncDeclaration fd)
 
 Lyes:
     return true;
+}
+
+final bool needsClosureForNestedref(FuncDeclaration fd, FuncDeclaration f)
+{
+    bool result;
+    assert(f != fd);
+
+    /* __require and __ensure will always get called directly,
+     * so they never make outer functions closure.
+     */
+    if (f.ident == Id.require || f.ident == Id.ensure)
+        return false;
+
+    //printf("\t\tf = %p, %s, isVirtual=%d, isThis=%p, tookAddressOf=%d\n", f, f.toChars(), f.isVirtual(), f.isThis(), f.tookAddressOf);
+
+    /* Look to see if f escapes. We consider all parents of f within
+     * this, and also all siblings which call f; if any of them escape,
+     * so does f.
+     * Mark all affected functions as requiring closures.
+     */
+    for (Dsymbol s = f; s && s != fd; s = s.toParentP(fd))
+    {
+        FuncDeclaration fx = s.isFuncDeclaration();
+        if (!fx)
+            continue;
+        if (fx.isThis() || fx.tookAddressOf)
+        {
+            //printf("\t\tfx = %s, isVirtual=%d, isThis=%p, tookAddressOf=%d\n", fx.toChars(), fx.isVirtual(), fx.isThis(), fx.tookAddressOf);
+
+            /* Mark as needing closure any functions between this and f
+             */
+            markAsNeedingClosure((fx == f) ? fx.toParentP(fd) : fx, fd);
+
+            result = true;
+        }
+
+        /* We also need to check if any sibling functions that
+         * called us, have escaped. This is recursive: we need
+         * to check the callers of our siblings.
+         */
+        if (checkEscapingSiblings(fx, fd))
+            result = true;
+
+        /* https://issues.dlang.org/show_bug.cgi?id=12406
+         * Iterate all closureVars to mark all descendant
+         * nested functions that access to the closing context of this function.
+         */
+    }
+    return result;
 }
 
 /***********************************************

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1147,6 +1147,32 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     a.push(new ExpStatement(Loc.initial, de));
                 }
 
+                if (funcdecl.needsClosure())
+                {
+                    foreach (v; funcdecl.closureVars)
+                    {
+                        if (v.inLoop)
+                        {
+                            FuncDeclaration fescaping;
+                            foreach (fnested; v.nestedrefs)
+                            {
+                                if (funcdecl.needsClosureForNestedref(fnested))
+                                {
+                                    fescaping = fnested;
+                                    break;
+                                }
+                            }
+
+                            if (fescaping !is null)
+                            {
+                                // Deprecated in 2.113
+                                deprecation(v.loc, "Using variable `%s` declared in a loop from a closure is deprecated", v.toChars());
+                                deprecationSupplemental(fescaping.loc, "Variable `%s` used in possibly escaping %s `%s`", v.toChars(), funcdecl.kind(), fescaping.toChars());
+                            }
+                        }
+                    }
+                }
+
                 // Merge contracts together with body into one compound statement
 
                 if (freq || fpreinv)

--- a/compiler/test/fail_compilation/loopclosures.d
+++ b/compiler/test/fail_compilation/loopclosures.d
@@ -1,0 +1,278 @@
+/*
+REQUIRED_ARGS: -unittest -main -de
+TEST_OUTPUT:
+---
+fail_compilation/loopclosures.d(39): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(41):        Variable `i` used in possibly escaping function `f`
+fail_compilation/loopclosures.d(58): Deprecation: Using variable `j` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(59):        Variable `j` used in possibly escaping function `f`
+fail_compilation/loopclosures.d(74): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(76):        Variable `i` used in possibly escaping function `f`
+fail_compilation/loopclosures.d(95): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(97):        Variable `i` used in possibly escaping function `__lambda_L97_C15`
+fail_compilation/loopclosures.d(116): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(118):        Variable `i` used in possibly escaping function `__lambda_L118_C15`
+fail_compilation/loopclosures.d(137): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(139):        Variable `i` used in possibly escaping function `__lambda_L139_C16`
+fail_compilation/loopclosures.d(152): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(155):        Variable `i` used in possibly escaping function `__lambda_L155_C13`
+fail_compilation/loopclosures.d(169): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(173):        Variable `i` used in possibly escaping function `f`
+fail_compilation/loopclosures.d(190): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(194):        Variable `i` used in possibly escaping function `f`
+fail_compilation/loopclosures.d(217): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(219):        Variable `i` used in possibly escaping function `__lambda_L219_C21`
+fail_compilation/loopclosures.d(246): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(248):        Variable `i` used in possibly escaping function `__lambda_L248_C27`
+fail_compilation/loopclosures.d(264): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+fail_compilation/loopclosures.d(268):        Variable `i` used in possibly escaping function `run`
+---
+*/
+
+void delegate()[] funcsGlobal;
+int[] resultsGlobal;
+
+unittest
+{
+    void delegate()[] funcs;
+    int[] results;
+    foreach (i; 0..3)
+    {
+        void f()
+        {
+            results ~= i;
+        }
+        funcs ~= &f;
+    }
+    foreach (dg; funcs)
+        dg();
+    assert(results == [0, 1, 2]);
+}
+
+unittest
+{
+    void delegate()[] funcs;
+    int[] results;
+    for (int i = 0; i < 3; i++)
+    {
+        const j = i;
+        void f()
+        {
+            results ~= j;
+        }
+        funcs ~= &f;
+    }
+    foreach (dg; funcs)
+        dg();
+    assert(results == [0, 1, 2]);
+}
+
+unittest
+{
+    funcsGlobal = [];
+    resultsGlobal = [];
+    foreach (i; 0..3)
+    {
+        void f()
+        {
+            resultsGlobal ~= i;
+        }
+        funcsGlobal ~= &f;
+    }
+    foreach (dg; funcsGlobal)
+        dg();
+    assert(resultsGlobal == [0, 1, 2]);
+}
+
+unittest
+{
+    void delegate()[] funcs;
+    int[] results;
+    void addDg(void delegate() dg)
+    {
+        funcs ~= dg;
+    }
+    foreach (i; 0..3)
+    {
+        addDg(() {
+            results ~= i;
+        });
+    }
+    foreach (dg; funcs)
+        dg();
+    assert(results == [0, 1, 2]);
+}
+
+unittest
+{
+    void delegate()[] funcs;
+    int[] results;
+    void addDg(int delegate() dg)
+    {
+        funcs ~= () {
+            results ~= dg();
+        };
+    }
+    foreach (i; 0..3)
+    {
+        addDg(() {
+            return i;
+        });
+    }
+    foreach (dg; funcs)
+        dg();
+    assert(results == [0, 1, 2]);
+}
+
+unittest
+{
+    void delegate()[] funcs;
+    int[] results;
+    void addDg(alias F)()
+    {
+        funcs ~= () {
+            results ~= F();
+        };
+    }
+    foreach (i; 0..3)
+    {
+        addDg!(() {
+            return i;
+        })();
+    }
+    foreach (dg; funcs)
+        dg();
+    assert(results == [0, 1, 2]);
+}
+
+unittest
+{
+    void delegate()[] funcs;
+    int[] results;
+    foreach (i; 0..3)
+    {
+        funcs ~= () {
+            () {
+                results ~= i;
+            }();
+        };
+    }
+    foreach (dg; funcs)
+        dg();
+    assert(results == [0, 1, 2]);
+}
+
+unittest
+{
+    void delegate()[] funcs;
+    int[] results;
+    foreach (i; 0..3)
+    {
+        struct S
+        {
+            void f()
+            {
+                results ~= i;
+            }
+        }
+        S s;
+        funcs ~= &s.f;
+    }
+    foreach (dg; funcs)
+        dg();
+    assert(results == [0, 1, 2]);
+}
+
+unittest
+{
+    void delegate()[] funcs;
+    int[] results;
+    foreach (i; 0..3)
+    {
+        class C
+        {
+            void f()
+            {
+                results ~= i;
+            }
+        }
+        C c = new C;
+        funcs ~= &c.f;
+    }
+    foreach (dg; funcs)
+        dg();
+    assert(results == [0, 1, 2]);
+}
+
+void addDgAlias(alias F)()
+{
+    funcsGlobal ~= () {
+        resultsGlobal ~= F();
+    };
+}
+unittest
+{
+    funcsGlobal = [];
+    resultsGlobal = [];
+    foreach (i; 0..3)
+    {
+        addDgAlias!(() {
+            return i;
+        })();
+    }
+    foreach (dg; funcsGlobal)
+        dg();
+    assert(resultsGlobal == [0, 1, 2]);
+}
+
+void callRun(T)(T x)
+{
+    x.run();
+}
+auto createS(alias F)()
+{
+    struct S(alias F)
+    {
+        void run()
+        {
+            F();
+        }
+    }
+    return S!F();
+}
+unittest
+{
+    int[] results;
+    foreach (i; 0..3)
+    {
+        auto s = createS!((){
+            results ~= i;
+        })();
+        callRun(s);
+    }
+    assert(results == [0, 1, 2]);
+}
+
+abstract class Base
+{
+    abstract void run();
+}
+unittest
+{
+    Base[] instances;
+    int[] results;
+    foreach (i; 0..3)
+    {
+        class C : Base
+        {
+            override void run()
+            {
+                results ~= i;
+            }
+        }
+        instances ~= new C;
+    }
+    foreach (instance; instances)
+        instance.run();
+    assert(results == [0, 1, 2]);
+}

--- a/compiler/test/runnable/inline.d
+++ b/compiler/test/runnable/inline.d
@@ -8,6 +8,15 @@ RUN_OUTPUT:
 1.000000 2.000000 3.000000
 Success
 ---
+TEST_OUTPUT:
+---
+runnable/inline.d(625): Deprecation: Using variable `x` declared in a loop from a closure is deprecated
+    foreach (ref x; arr)
+    ^
+runnable/inline.d(627):        Variable `x` used in possibly escaping function `__lambda_L627_C34`
+        auto m = MapResult13244!(c => x[c])([0]);
+                                 ^
+---
 */
 
 import core.stdc.stdio;

--- a/compiler/test/runnable/loopclosures.d
+++ b/compiler/test/runnable/loopclosures.d
@@ -1,0 +1,60 @@
+// REQUIRED_ARGS: -unittest -main
+
+unittest
+{
+    void delegate()[] funcs;
+    int[] results;
+    foreach (i; 0..3)
+    {
+        (){
+            int j = i;
+            void f()
+            {
+                results ~= j;
+            }
+            funcs ~= &f;
+        }();
+    }
+    foreach (dg; funcs)
+        dg();
+    assert(results == [0, 1, 2]);
+}
+
+int[] delegate() test()
+{
+    void delegate()[] funcs;
+    int[] results;
+    foreach (i; 0..3)
+    {
+        void f()
+        {
+            results ~= i;
+        }
+        f();
+    }
+    assert(results == [0, 1, 2]);
+    return { return results; };
+}
+unittest
+{
+    auto dg = test();
+    assert(dg() == [0, 1, 2]);
+}
+
+unittest
+{
+    int[] results;
+    foreach (i; 0..3)
+    {
+        static if (is(typeof(() @safe
+        {
+            results ~= i;
+        })))
+        {
+            (){
+                results ~= i;
+            }();
+        }
+    }
+    assert(results == [0, 1, 2]);
+}

--- a/compiler/test/runnable/test42.d
+++ b/compiler/test/runnable/test42.d
@@ -3,6 +3,12 @@ REQUIRED_ARGS:
 TEST_OUTPUT:
 ---
 success
+runnable/test42.d(817): Deprecation: Using variable `d` declared in a loop from a closure is deprecated
+    foreach(d;k)
+    ^
+runnable/test42.d(820):        Variable `d` used in possibly escaping function `foo`
+        string foo() {assert(d!="");return d;}
+               ^
 myInt int
 myBool bool
 i
@@ -62,7 +68,7 @@ void test3()
 {
     auto i = mixin("__LINE__");
     printf("%d\n", i);
-    assert(i == 63);
+    assert(i == 69);
 }
 
 /***************************************************/

--- a/compiler/test/runnable/xtest46.d
+++ b/compiler/test/runnable/xtest46.d
@@ -22,6 +22,30 @@ double[]
 AliasSeq!("m")
 true
 TFunction1: extern (C) void function()
+runnable/xtest46.d(6523): Deprecation: Using variable `item` declared in a loop from a closure is deprecated
+    foreach (ref item; items)
+    ^
+runnable/xtest46.d(6529):        Variable `item` used in possibly escaping function `__lambda_L6529_C23`
+        takeADelegate({ auto x = &item; });
+                      ^
+runnable/xtest46.d(6532): Deprecation: Using variable `val` declared in a loop from a closure is deprecated
+    foreach(ref val; [3])
+    ^
+runnable/xtest46.d(6534):        Variable `val` used in possibly escaping function `__lambda_L6534_C19`
+        auto dg = { int j = val; };
+                  ^
+runnable/xtest46.d(6554): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+    foreach (i, j; [0])
+    ^
+runnable/xtest46.d(6556):        Variable `i` used in possibly escaping function `__lambda_L6556_C14`
+        call({
+             ^
+runnable/xtest46.d(6561): Deprecation: Using variable `n` declared in a loop from a closure is deprecated
+    foreach (n; 0..1)
+    ^
+runnable/xtest46.d(6563):        Variable `n` used in possibly escaping function `__lambda_L6563_C14`
+        call({
+             ^
 ---
 */
 

--- a/compiler/test/runnable/xtest46_gc.d
+++ b/compiler/test/runnable/xtest46_gc.d
@@ -23,6 +23,30 @@ double[]
 AliasSeq!("m")
 true
 TFunction1: extern (C) void function()
+runnable/xtest46_gc.d-mixin-53(6575): Deprecation: Using variable `item` declared in a loop from a closure is deprecated
+    foreach (ref item; items)
+    ^
+runnable/xtest46_gc.d-mixin-53(6581):        Variable `item` used in possibly escaping function `__lambda_L6581_C23`
+        takeADelegate({ auto x = &item; });
+                      ^
+runnable/xtest46_gc.d-mixin-53(6584): Deprecation: Using variable `val` declared in a loop from a closure is deprecated
+    foreach(ref val; [3])
+    ^
+runnable/xtest46_gc.d-mixin-53(6586):        Variable `val` used in possibly escaping function `__lambda_L6586_C19`
+        auto dg = { int j = val; };
+                  ^
+runnable/xtest46_gc.d-mixin-53(6606): Deprecation: Using variable `i` declared in a loop from a closure is deprecated
+    foreach (i, j; [0])
+    ^
+runnable/xtest46_gc.d-mixin-53(6608):        Variable `i` used in possibly escaping function `__lambda_L6608_C14`
+        call({
+             ^
+runnable/xtest46_gc.d-mixin-53(6613): Deprecation: Using variable `n` declared in a loop from a closure is deprecated
+    foreach (n; 0..1)
+    ^
+runnable/xtest46_gc.d-mixin-53(6615):        Variable `n` used in possibly escaping function `__lambda_L6615_C14`
+        call({
+             ^
 ---
 */
 

--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -184,7 +184,7 @@ pure @safe:
     }
 
 
-    void silent( out bool err_status, void delegate(out bool err_status) pure @safe nothrow dg ) nothrow
+    void silent( out bool err_status, scope void delegate(out bool err_status) pure @safe nothrow dg ) nothrow
     {
         debug(trace) printf( "silent+\n" );
         debug(trace) scope(success) printf( "silent-\n" );


### PR DESCRIPTION
Using variables declared in loops from a closure can have unexpected results and be unsafe (issue #19929). Fixing the problem would silently change the behaviour of code and result in more allocations, so deprecating the affected code first avoids surprises. A new implementation could later be introduced using a preview switch or editions.

Limitations:
* Loops manually created with `goto` are not detected.
* Problems involving `lazy` can be undetected, because of separate issues like #18669.
* Local functions, which don't escape, can result in false positives, because the compiler does not always know they don't escape. This can sometimes be fixed by marking delegate parameters as scope. This can also affect range based code.
* Loops with at most one iteration are still treated as loops and could be considered false positives.
* Closures, which are only used in the last iteration of a loop, still can result in the deprecation warning, which could be considered a false positive.
* There can also be false negatives, when a scope delegate escapes the loop, but not the function.