### PR TITLE
fix #20275 - Unicode file names are not properly handled

### DIFF
--- a/compiler/src/dmd/common/file.d
+++ b/compiler/src/dmd/common/file.d
@@ -32,10 +32,10 @@ version (Windows)
 {
     import core.stdc.wchar_;
     import core.sys.windows.winbase;
-    import core.sys.windows.winnls : CP_ACP;
+    import core.sys.windows.winnls : CP_UTF8;
     import core.sys.windows.winnt;
 
-    enum CodePage = CP_ACP; // assume filenames encoded in system default Windows ANSI code page
+    enum CodePage = CP_UTF8; // assume filenames already gone through Windows ANSI code page -> UTF8 conversion
     enum invalidHandle = INVALID_HANDLE_VALUE;
 }
 else version (Posix)

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -757,7 +757,7 @@ version (Windows)
                     GetLastError();
                 }
 
-                STARTUPINFOA startInf;
+                STARTUPINFOW startInf;
                 startInf.cb = startInf.sizeof;
                 startInf.dwFlags = STARTF_USESTDHANDLES;
                 startInf.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
@@ -765,7 +765,11 @@ version (Windows)
                 startInf.hStdError = GetStdHandle(STD_ERROR_HANDLE);
                 PROCESS_INFORMATION procInf;
 
-                BOOL b = CreateProcessA(null, cmdbuf.peekChars(), null, null, 1, NORMAL_PRIORITY_CLASS, null, null, &startInf, &procInf);
+                wchar[1024] cbuf = void;
+                auto store = SmallBuffer!wchar(cbuf.length, cbuf);
+                auto wcmd = toWStringz(cast(const(char)[])cmdbuf.peekSlice(), store);
+
+                BOOL b = CreateProcessW(null, &wcmd[0], null, null, 1, NORMAL_PRIORITY_CLASS, null, null, &startInf, &procInf);
                 CloseHandle(pipe[1]); // child does not need this end
 
                 ubyte[1024] buffer;

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -479,7 +479,7 @@ extern(C) void flushMixins()
  *
  * Params:
  *      arguments = command line arguments
- *      argc = argument count
+ *      argc = original argument count before adding from DFLAGS
  *      params = set to result of parsing `arguments`
  *      files = set to files pulled from `arguments`
  *      target = more things set to result of parsing `arguments`

--- a/compiler/test/runnable/imports/你好.d
+++ b/compiler/test/runnable/imports/你好.d
@@ -1,0 +1,6 @@
+module imports.你好;
+
+int foo()
+{
+	return 0;
+}

--- a/compiler/test/runnable/test20275.d
+++ b/compiler/test/runnable/test20275.d
@@ -1,0 +1,8 @@
+// EXTRA_SOURCES: imports/你好.d
+
+import imports.你好;
+
+int main()
+{
+	return foo();
+}


### PR DESCRIPTION
use properly converted _Dmain args instead of cArgs, always use the wide string Windows APIs with conversion from UTF-8

Any reason to keep using the C-args in `tryMain` that I forgot?