### PR TITLE
Fix DIP1000 scope array of arrays comparison

### DIFF
--- a/compiler/test/compilable/fix21945.d
+++ b/compiler/test/compilable/fix21945.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS: -preview=dip1000
+
+void assertEq(scope int[][3] x) @safe
+{
+	bool b = x == x;
+}

--- a/druntime/src/core/internal/array/equality.d
+++ b/druntime/src/core/internal/array/equality.d
@@ -14,7 +14,7 @@ module core.internal.array.equality;
 // * dynamic arrays,
 // * (most) arrays of different (unqualified) element types, and
 // * arrays of structs with custom opEquals.
-bool __equals(T1, T2)(scope T1[] lhs, scope T2[] rhs) @trusted
+bool __equals(TArr1 : T1[], TArr2 : T2[], T1, T2)(scope TArr1 lhs, scope TArr2 rhs) @trusted
 {
     if (lhs.length != rhs.length)
         return false;
@@ -22,9 +22,9 @@ bool __equals(T1, T2)(scope T1[] lhs, scope T2[] rhs) @trusted
     if (lhs.length == 0)
         return true;
 
-    alias PureType = bool function(scope T1[], scope T2[], size_t) @safe pure nothrow @nogc;
+    alias PureType = bool function(scope TArr1, scope TArr2, size_t) @safe pure nothrow @nogc;
 
-    return (cast(PureType)&isEqual!(T1,T2))(lhs, rhs, lhs.length);
+    return (cast(PureType)&isEqual!(TArr1,TArr2))(lhs[], rhs[], lhs.length);
 }
 
 /******************************
@@ -32,7 +32,7 @@ bool __equals(T1, T2)(scope T1[] lhs, scope T2[] rhs) @trusted
  * Outlined to enable __equals() to be inlined, as dmd cannot inline loops.
  */
 private
-bool isEqual(T1, T2)(scope T1[] lhs, scope T2[] rhs, size_t length)
+bool isEqual(TArr1 : T1[], TArr2 : T2[], T1, T2)(scope TArr1 lhs, scope TArr2 rhs, size_t length)
 {
     // Returns a reference to an array element, eliding bounds check and
     // casting void to ubyte.


### PR DESCRIPTION
This PR fixes #21945. The issue was that `__equals` accepted only  dynamic array/slice arguments, so calling it with static arrays caused an explicit cast to slice, which in turn triggered some error in the escape checking logic.