### PR TITLE
SAOC 25: Fix #18057 ImportC is too permissive in allowing variable and function declarations

### DIFF
--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -528,7 +528,14 @@ Dsymbol handleSymbolRedeclarations(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsy
          *    INT x;  // match
          *    long x; // collision
          * We incorrectly ignore these collisions
+         * when their types are not matching, err on type differences
          */
+
+        if (!cTypeEquivalence(vd.type, vd2.type))
+        {
+            .error(vd.loc, "redefinition of `%s` with different type: `%s` vs `%s`",
+                vd2.ident.toChars(), vd2.type.toChars(), vd.type.toChars());
+        }
         return vd2;
     }
 

--- a/compiler/test/fail_compilation/fix18057.c
+++ b/compiler/test/fail_compilation/fix18057.c
@@ -1,0 +1,15 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fix18057.c(105): Error: redefinition of `x` with different type: `int` vs `char`
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=22316
+
+#line 100
+
+int x;
+extern int x;
+typedef int INT;
+extern INT x;
+extern char x;

--- a/compiler/test/fail_compilation/test22344.c
+++ b/compiler/test/fail_compilation/test22344.c
@@ -2,6 +2,7 @@
 ---
 fail_compilation/test22344.c(103): Error: function `test22344.func` redeclaration with different type
 fail_compilation/test22344.c(203): Error: function `test22344.test` redeclaration with different type
+fail_compilation/test22344.c(302): Error: function `test22344.foo` redeclaration with different type
 ---
  */
 
@@ -26,3 +27,8 @@ int test(int x, ...)
 {
     return x;
 }
+
+#line 300
+
+int foo();
+double foo();


### PR DESCRIPTION
make Draft first,

The previous implementation of `cFuncEquivalence` was not handling the function comparisons well.

if it checks `equals,` it quickly returns true. but equals doesn't handle the return type etc. so it didn't
guarantee that it was a right decision because some other parts of the function remains unchecked thus causing the issue. but early returns for false is the best bet as when the most basic `equal` function is not true, we are fully sure the functions do not match. additionally, we want to ensure `foo()` and `foo(void)` matches,
so even before we do variadic checks for prototypes ensure their lengths are not zero to avoid breaking `foo()` and `foo(void)` as well.