### PR TITLE
wrong post index instruction generated

### DIFF
--- a/compiler/src/dmd/backend/arm/cod2.d
+++ b/compiler/src/dmd/backend/arm/cod2.d
@@ -1499,7 +1499,8 @@ private void cdmemsetn(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pr
     uint opc;
     uint imm3;
     INSTR.szToSizeOpc(szv,imm3,opc);    // shift 0..4
-    if (szv == REGSIZE * 2)
+    int is64 = szv == REGSIZE * 2;
+    if (is64)
     {
         imm3 = 3;
         opc = 0;
@@ -1509,12 +1510,12 @@ private void cdmemsetn(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pr
     if (Rp != Rd)
         genmovreg(cdb,Rp,Rd);
 
-    cdb.gen1(INSTR.ldst_immpost(imm3,0,0,0,Rp,Rv));     // L2: STR  Rv,[Rp],#0        // *Rp++ = Rv
+    cdb.gen1(INSTR.str_imm_gen_post_index(is64,szv,Rp,Rv));       // L2: STR  Rv,[Rp],#szv    // *Rp++ = Rv
     code* L2 = cdb.last();
     if (szv == REGSIZE * 2)
-        cdb.gen1(INSTR.ldst_immpost(imm3,0,0,0,Rp,Rvhi)); // L2: STR  Rvhi,[Rp],#0    // *Rp++ = Rvhi
-    cdb.gen1(INSTR.cmp_subs_addsub_shift(1,Rl,0,0,Rp));             // CMP Rp,Rl
-    genBranch(cdb,COND.ne,FL.code,cast(block*)L2);      // b.ne L2
+        cdb.gen1(INSTR.str_imm_gen_post_index(is64,szv,Rp,Rvhi)); // L2: STR  Rvhi,[Rp],#szv  // *Rp++ = Rvhi
+    cdb.gen1(INSTR.cmp_subs_addsub_shift(1,Rl,0,0,Rp));           // CMP Rp,Rl
+    genBranch(cdb,COND.ne,FL.code,cast(block*)L2);                // b.ne L2
     cdb.append(c1);
 
     fixresult(cdb,e,dregs,pretregs);

--- a/compiler/src/dmd/backend/arm/disasmarm.d
+++ b/compiler/src/dmd/backend/arm/disasmarm.d
@@ -2905,7 +2905,7 @@ const(char)[] eaString(uint op, ubyte Rn, int offset)
     switch (op)
     {
         case 1:
-            if (offset)
+            if (1 || offset)
             {
                 uint n = snprintf(EA.ptr, cast(uint)EA.length, "[%s],%s", regString(1, Rn).ptr, signedWordtostring(offset).ptr);
                 p = EA[0 .. n];
@@ -3208,8 +3208,9 @@ unittest
 unittest
 {
     int line64 = __LINE__;
-    string[93] cases64 =      // 64 bit code gen
+    string[94] cases64 =      // 64 bit code gen
     [
+        "B8 00 04 62         str    w2,[x3],#0",
         "78 64 68 23         ldrh   w3,[x1, x4]",
         "78 24 68 43         strh   w3,[x2, x4]",
         "38 64 68 23         ldrb   w3,[x1, x4]",

--- a/compiler/src/dmd/backend/arm/instr.d
+++ b/compiler/src/dmd/backend/arm/instr.d
@@ -1358,6 +1358,22 @@ struct INSTR
         return ldst_pos(1, 0, 0, imm12, Rn, Rt);
     }
 
+    /* STR (immediate) Post-index
+     * https://www.scs.stanford.edu/~zyedidia/arm64/str_imm_gen.html
+     */
+    static uint str_imm_gen_post_index(uint is64, int simm, ubyte Rn, ubyte Rt)
+    {
+        // STR Rt,[Xn],#simm
+        uint size = 2 + is64;
+        uint imm9 = simm & 0x1FF;
+        return (size << 30) |
+               (7    << 27) |
+               (imm9 << 12) |
+               (1    << 10) |
+               (Rn   <<  5) |
+                Rt;
+    }
+
     /* STR (immediate) Unsigned offset
      * https://www.scs.stanford.edu/~zyedidia/arm64/str_imm_gen.html
      */


### PR DESCRIPTION
The spec pages are not entirely consistent in having unique urls for unique instructions.

https://www.scs.stanford.edu/~zyedidia/arm64/str_imm_gen.html

has two different encodings with the same url. This tripped me up.