### PR TITLE
Optimize test target filtering

### DIFF
--- a/compiler/test/run.d
+++ b/compiler/test/run.d
@@ -481,12 +481,16 @@ Target[] filterTargets(Target[] targets, const string[string] env)
         quitSilently(1);
 
     Target[] targetsThatNeedUpdating;
+    const dmdLastModified = env["DMD"].timeLastModified.ifThrown(SysTime.init);
     foreach (t; targets)
     {
         immutable testName = t.normalizedTestName;
-        auto resultRunTime = resultsDir.buildPath(testName ~ ".out").timeLastModified.ifThrown(SysTime.init);
-        if (!force && resultRunTime > testPath(testName).timeLastModified &&
-                resultRunTime > env["DMD"].timeLastModified.ifThrown(SysTime.init))
+        auto testResultPath = resultsDir.buildPath(testName ~ ".out");
+        auto resultRunTime = testResultPath.timeLastModified.ifThrown(SysTime.init);
+        auto testSourcePath = testPath(testName);
+        auto sourceLastModified = testSourcePath.timeLastModified.ifThrown(SysTime.init);
+        if (!force && resultRunTime > sourceLastModified &&
+                resultRunTime > dmdLastModified)
             log("%s is already up-to-date", testName);
         else
             targetsThatNeedUpdating ~= t;


### PR DESCRIPTION
**Refactor:** optimize and clarify `filterTargets` logic

* Cache `env["DMD"].timeLastModified` outside the loop to avoid redundant `stat` calls.
 * Introduce local variables (`testResultPath`, `testSourcePath`, `resultRunTime`, `sourceLastModified`) for readability and to reduce repeated path building.
* Preserve original behavior while improving clarity and efficiency.
