### PR TITLE
Identify force-inline functions correctly by walking local symbol table

### DIFF
--- a/compiler/test/runnable/imports/inline4a.d
+++ b/compiler/test/runnable/imports/inline4a.d
@@ -1,0 +1,27 @@
+module imports.inline4a;
+
+mixin template LengthField(alias sym)
+{
+    pragma(inline, true)
+    size_t length() const
+    {
+        return sym.length;
+    }
+}
+
+struct Data
+{
+    string data;
+    mixin LengthField!data;
+
+    pragma(inline, true)
+    int opApply(scope int delegate(const Data) dg) {
+        return dg(this);
+    }
+}
+
+pragma(inline, true)
+int value()
+{
+    return 10;
+}

--- a/compiler/test/runnable/inline4.d
+++ b/compiler/test/runnable/inline4.d
@@ -1,0 +1,36 @@
+import imports.inline4a;
+
+auto anonclass()
+{
+    return new class {
+        pragma(inline, true)
+        final size_t foo()
+        {
+            return value();
+        }
+    };
+}
+
+void main()
+{
+    size_t var;
+
+    foreach (d; Data("string"))
+    {
+        var = d.length();
+    }
+
+    assert(var == 6);
+
+    var = anonclass().foo();
+
+    assert(var == 10);
+
+    auto nested = (size_t i) {
+        return i - value();
+    };
+
+    var = nested(var);
+
+    assert(var == 0);
+}


### PR DESCRIPTION
This PR replaces #21977 and fixes many cases where `pragma(inline)` is ignored, at the cost of visiting every local symbol. Normal builds will get slowed down a bit. At least working with Phobos can be slightly more pleasant until the backend inliner gets the infrastructure for tracking `pragma(inline)`.