### PR TITLE
SAOC 25 fix #21925 importC: symbol duplication in symbol table for global redeclaration

### DIFF
--- a/compiler/test/runnable/fix21925.c
+++ b/compiler/test/runnable/fix21925.c
@@ -1,0 +1,15 @@
+//importC: symbol duplication in symbol table for global redeclared symbols #21925
+#include <assert.h>
+int a;
+int a;
+int a;
+int a;
+int a;
+int a;
+
+
+int main()
+{
+    assert(a == 0); // no duplicate symbol error
+    return 0;
+}


### PR DESCRIPTION
closes #21925 