### PR TITLE
Fix #20825: dmd tests do not work with FreeBSD 14

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -138,6 +138,13 @@ typedef unsigned long long __uint64_t;
 #define __volatile volatile
 #define __sync_synchronize()
 #define __sync_swap(A, B) 1
+
+// For whatever reason, sys/cdefs.h has to be included first even though
+// it doesn't undef __sym_compat. But without #including sys/cdefs.h first and
+// then undefing __sym_compat, the normal __sym_compat gets used.
+#include "sys/cdefs.h"
+#undef __sym_compat
+#define __sym_compat(sym, impl, verid)
 #endif
 
 #if _MSC_VER


### PR DESCRIPTION
This also fixes https://github.com/dlang/dmd/issues/20607, which is for the druntime tests.

The core issue is that importC can't handle stdlib.h on FreeBSD 14, because it uses a macro which uses asm, which breaks our importC tests which use stdlib.h. This fixes it so that importC doesn't use the actual macro.