### PR TITLE
Move `Expression.toBool` to `dmd/expressionsem.d`

### DIFF
--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -20,6 +20,7 @@ import dmd.dclass;
 import dmd.declaration;
 import dmd.errorsink;
 import dmd.expression;
+import dmd.expressionsem : toBool;
 import dmd.func;
 import dmd.globals;
 import dmd.id;

--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -25,7 +25,7 @@ import dmd.declaration;
 import dmd.dstruct;
 import dmd.errors;
 import dmd.expression;
-import dmd.expressionsem : getField, isIdentical;
+import dmd.expressionsem : getField, isIdentical, toBool;
 import dmd.globals;
 import dmd.location;
 import dmd.mtype;

--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -25,7 +25,7 @@ import dmd.dstruct;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
-import dmd.expressionsem : isIdentical, getFieldIndex;
+import dmd.expressionsem : isIdentical, getFieldIndex, toBool;
 import dmd.func;
 import dmd.globals : dinteger_t, sinteger_t, uinteger_t;
 import dmd.location;

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -32,6 +32,7 @@ import dmd.init : Initializer, NeedInterpret;
 import dmd.location : Loc;
 import dmd.mtype /*: Covariant, Type, Parameter, ParameterList*/;
 import dmd.rootobject : RootObject;
+import dmd.root.optional;
 import dmd.semantic3;
 import dmd.statement : Statement, AsmStatement, GccAsmStatement;
 
@@ -421,6 +422,12 @@ void fillTupleExpExps(TupleExp te, TupleDeclaration tup)
 {
     import dmd.expressionsem;
     return dmd.expressionsem.fillTupleExpExps(te, tup);
+}
+
+Optional!bool toBool(Expression exp)
+{
+    import dmd.expressionsem;
+    return dmd.expressionsem.toBool(exp);
 }
 
 /***********************************************************

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -64,6 +64,7 @@ namespace dmd
     bool isLvalue(const Expression *exp);
     int32_t getFieldIndex(ClassReferenceExp *cre, Type *fieldtype, uint32_t fieldoffset);
     void fillTupleExpExps(TupleExp *te, TupleDeclaration *tup);
+    Optional<bool> toBool(Expression *exp);
 }
 
 typedef unsigned char OwnedBy;
@@ -110,7 +111,6 @@ public:
     Expression *deref();
 
     int isConst();
-    virtual Optional<bool> toBool();
     virtual bool hasCode()
     {
         return true;
@@ -242,7 +242,6 @@ public:
     real_t toReal() override;
     real_t toImaginary() override;
     complex_t toComplex() override;
-    Optional<bool> toBool() override;
     void accept(Visitor *v) override { v->visit(this); }
     dinteger_t getInteger() { return value; }
     template<int v>
@@ -268,7 +267,6 @@ public:
     real_t toReal() override;
     real_t toImaginary() override;
     complex_t toComplex() override;
-    Optional<bool> toBool() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -283,7 +281,6 @@ public:
     real_t toReal() override;
     real_t toImaginary() override;
     complex_t toComplex() override;
-    Optional<bool> toBool() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -318,7 +315,6 @@ public:
     VarDeclaration *var;
 
     ThisExp *syntaxCopy() override;
-    Optional<bool> toBool() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -332,7 +328,6 @@ public:
 class NullExp final : public Expression
 {
 public:
-    Optional<bool> toBool() override;
     StringExp *toStringExp() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -354,7 +349,6 @@ public:
     char32_t getCodeUnit(d_size_t i) const;
     dinteger_t getIndex(d_size_t i) const;
     StringExp *toStringExp() override;
-    Optional<bool> toBool() override;
     void accept(Visitor *v) override { v->visit(this); }
     size_t numberOfCodeUnits(int tynto = 0) const;
     void writeTo(void* dest, bool zero, int tyto = 0) const;
@@ -404,7 +398,6 @@ public:
     static ArrayLiteralExp *create(Loc loc, Expressions *elements);
     ArrayLiteralExp *syntaxCopy() override;
     Expression *getElement(d_size_t i);
-    Optional<bool> toBool() override;
     StringExp *toStringExp() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -420,7 +413,6 @@ public:
     Expression* loweringCtfe;
 
     AssocArrayLiteralExp *syntaxCopy() override;
-    Optional<bool> toBool() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -555,8 +547,6 @@ class SymOffExp final : public SymbolExp
 {
 public:
     dinteger_t offset;
-
-    Optional<bool> toBool() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -832,7 +822,6 @@ public:
 class AddrExp final : public UnaExp
 {
 public:
-    Optional<bool> toBool() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -924,7 +913,6 @@ private:
 
 public:
     SliceExp *syntaxCopy() override;
-    Optional<bool> toBool() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -987,7 +975,6 @@ public:
     d_bool isGenerated;
     d_bool allowCommaExp;
     Expression* originalExp;
-    Optional<bool> toBool() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -18,6 +18,7 @@
 
 #include "root/complex_t.h"
 #include "root/dcompat.h"
+#include "root/optional.h"
 
 class Type;
 class TypeVector;
@@ -63,6 +64,7 @@ namespace dmd
     bool isLvalue(const Expression *exp);
     int32_t getFieldIndex(ClassReferenceExp *cre, Type *fieldtype, uint32_t fieldoffset);
     void fillTupleExpExps(TupleExp *te, TupleDeclaration *tup);
+    Optional<bool> toBool(Expression *exp);
 }
 
 typedef unsigned char OwnedBy;

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -18,7 +18,6 @@
 
 #include "root/complex_t.h"
 #include "root/dcompat.h"
-#include "root/optional.h"
 
 class Type;
 class TypeVector;
@@ -64,7 +63,6 @@ namespace dmd
     bool isLvalue(const Expression *exp);
     int32_t getFieldIndex(ClassReferenceExp *cre, Type *fieldtype, uint32_t fieldoffset);
     void fillTupleExpExps(TupleExp *te, TupleDeclaration *tup);
-    Optional<bool> toBool(Expression *exp);
 }
 
 typedef unsigned char OwnedBy;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2381,7 +2381,6 @@ public:
     virtual bool checkType();
     Expression* deref();
     int32_t isConst();
-    virtual Optional<bool > toBool();
     virtual bool hasCode();
     IntegerExp* isIntegerExp();
     ErrorExp* isErrorExp();
@@ -2541,7 +2540,6 @@ public:
 class AddrExp final : public UnaExp
 {
 public:
-    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
 };
 
@@ -2608,7 +2606,6 @@ public:
     static ArrayLiteralExp* create(Loc loc, Array<Expression* >* elements);
     ArrayLiteralExp* syntaxCopy() override;
     Expression* getElement(size_t i);
-    Optional<bool > toBool() override;
     StringExp* toStringExp() override;
     void accept(Visitor* v) override;
 };
@@ -2645,7 +2642,6 @@ public:
     Expression* lowering;
     Expression* loweringCtfe;
     AssocArrayLiteralExp* syntaxCopy() override;
-    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
 };
 
@@ -2743,7 +2739,6 @@ public:
     const bool isGenerated;
     bool allowCommaExp;
     Expression* originalExp;
-    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
     static void allow(Expression* exp);
 };
@@ -2758,7 +2753,6 @@ public:
     _d_real toReal() override;
     _d_real toImaginary() override;
     complex_t toComplex() override;
-    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
 };
 
@@ -3232,7 +3226,6 @@ public:
     _d_real toReal() override;
     _d_real toImaginary() override;
     complex_t toComplex() override;
-    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
     dinteger_t getInteger();
     IntegerExp* syntaxCopy() override;
@@ -3388,7 +3381,6 @@ public:
 class NullExp final : public Expression
 {
 public:
-    Optional<bool > toBool() override;
     StringExp* toStringExp() override;
     void accept(Visitor* v) override;
 };
@@ -3465,7 +3457,6 @@ public:
     _d_real toReal() override;
     _d_real toImaginary() override;
     complex_t toComplex() override;
-    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
 };
 
@@ -3544,7 +3535,6 @@ private:
     uint8_t bitFields;
 public:
     SliceExp* syntaxCopy() override;
-    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
 };
 
@@ -3575,7 +3565,6 @@ public:
     dinteger_t getIndex(size_t i) const;
     StringExp* toStringExp() override;
     int32_t compare(const StringExp* const se2) const;
-    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
 };
 
@@ -3641,7 +3630,6 @@ public:
     VarDeclaration* var;
     ThisExp(Loc loc, const EXP tok);
     ThisExp* syntaxCopy() override;
-    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
 };
 
@@ -3664,7 +3652,6 @@ class SymOffExp final : public SymbolExp
 {
 public:
     dinteger_t offset;
-    Optional<bool > toBool() override;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2317,22 +2317,6 @@ struct complex_t final
     int32_t opEquals(complex_t y) const;
 };
 
-template <typename T>
-struct Optional final
-{
-    T value;
-    bool present;
-    Optional(T value);
-    static Optional<T > create(T val);
-    bool isPresent() const;
-    bool isEmpty() const;
-    T get();
-    bool hasValue(T exp) const;
-    Optional()
-    {
-    }
-};
-
 class Expression : public ASTNode
 {
 public:
@@ -8101,6 +8085,22 @@ extern _d_real creall(complex_t x);
 extern _d_real cimagl(complex_t x);
 
 extern void browse(const char* url);
+
+template <typename T>
+struct Optional final
+{
+    T value;
+    bool present;
+    Optional(T value);
+    static Optional<T > create(T val);
+    bool isPresent() const;
+    bool isEmpty() const;
+    T get();
+    bool hasValue(T exp) const;
+    Optional()
+    {
+    }
+};
 
 enum class IdentifierTable
 {

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -37,6 +37,7 @@ import dmd.dsymbol;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
+import dmd.expressionsem : toBool;
 import dmd.func;
 import dmd.globals;
 import dmd.init;

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -337,7 +337,7 @@ void test_expression()
     assert(e);
     assert(e->isConst());
 
-    Optional<bool> res = e->toBool();
+    Optional<bool> res = dmd::toBool(e);
     assert(res.get());
 }
 


### PR DESCRIPTION
Move `Expression.toBool` to `dmd/expressionsem.d` to remove the import of `dmd.ctfeexpr`