### PR TITLE
Bump Windows 2019 to 2022 for Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,15 @@
 # Learn more: https://aka.ms/yaml
 variables:
-  VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
+  VSINSTALLDIR: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\
 
 jobs:
   - job: Windows_DMD_bootstrap
     timeoutInMinutes: 60
     pool:
-      vmImage: 'windows-2019'
+      vmImage: 'windows-2022'
     variables:
       D_COMPILER: dmd
-      HOST_DMD_VERSION: 2.079.0
+      HOST_DMD_VERSION: 2.097.1
     strategy:
       matrix:
         x64:
@@ -21,7 +21,7 @@ jobs:
   - job: Windows_DMD_latest
     timeoutInMinutes: 60
     pool:
-      vmImage: 'windows-2019'
+      vmImage: 'windows-2022'
     variables:
       D_COMPILER: dmd
       HOST_DMD_VERSION: LATEST
@@ -40,7 +40,7 @@ jobs:
   - job: Windows_Coverage
     timeoutInMinutes: 60
     pool:
-      vmImage: 'windows-2019'
+      vmImage: 'windows-2022'
     variables:
       D_COMPILER: dmd
       HOST_DMD_VERSION: LATEST
@@ -57,10 +57,10 @@ jobs:
   - job: Windows_VisualD_LDC
     timeoutInMinutes: 60
     pool:
-      vmImage: 'windows-2019'
+      vmImage: 'windows-2022'
     variables:
       D_COMPILER: ldc
-      VISUALD_VER: v0.49.0
+      VISUALD_VER: v1.4.0
       LDC_VERSION: 1.23.0
     strategy:
       matrix:


### PR DESCRIPTION
Turns out we were supposed to do this 4 months ago.

https://github.com/actions/runner-images/issues/12045