### PR TITLE
fix #21925 importC: symbol duplication in symbol table for global redeclared symbols

### DIFF
--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -520,6 +520,10 @@ Dsymbol handleSymbolRedeclarations(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsy
             sds.symtab.update(vd);      // replace vd2 with the definition
             return vd;
         }
+        else if (!i1 && !(vd2.storage_class & STC.extern_)) /* incoming has void void definition */
+        {
+            vd.storage_class |= STC.extern_;
+        }
 
         /* BUG: the types should match, which needs semantic() to be run on it
          *    extern int x;

--- a/compiler/test/runnable/fix21925.c
+++ b/compiler/test/runnable/fix21925.c
@@ -1,0 +1,14 @@
+//https://github.com/dlang/dmd/issues/21925
+
+#include <assert.h>
+int a;
+int a;
+int a;
+int a;
+int a;
+
+
+int main()
+{
+    assert(a == 0); // no duplicate symbol error
+}


### PR DESCRIPTION
attempt to fix #21925

@dkorpel @thewilsonator 

reading a lot of the code, I stumbled upon this block and I realized dmd was already trying to handle symbol duplication
by making the new symbol extern. but it didn't handle it well. make sure if multiple symbols are meeting, mark one extern so it is not emitted to object file.