### PR TITLE
Move `Type.hasUnsafeBitPatterns` to `dmd/typesem.d`

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -867,6 +867,12 @@ Expression defaultInitLiteral(Type t, Loc loc)
     return dmd.typesem.defaultInitLiteral(t, loc);
 }
 
+bool hasUnsafeBitpatterns(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.hasUnsafeBitpatterns(type);
+}
+
 /***********************************************************
  * typinf.d
  */

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2107,7 +2107,6 @@ public:
     virtual structalign_t alignment();
     virtual int32_t hasWild() const;
     virtual bool hasVoidInitPointers();
-    virtual bool hasUnsafeBitpatterns();
     virtual bool hasInvariant();
     virtual Type* nextOf();
     Type* baseElemOf();
@@ -4400,7 +4399,6 @@ public:
     bool isComplex() override;
     bool isScalar() override;
     bool isUnsigned() override;
-    bool hasUnsafeBitpatterns() override;
     TypeBasic* isTypeBasic() override;
     void accept(Visitor* v) override;
 };
@@ -4473,7 +4471,6 @@ public:
     bool needsCopyOrPostblit() override;
     bool needsNested() override;
     bool hasVoidInitPointers() override;
-    bool hasUnsafeBitpatterns() override;
     bool hasInvariant() override;
     Type* nextOf() override;
     void accept(Visitor* v) override;
@@ -4704,7 +4701,6 @@ public:
     uint32_t alignsize() override;
     bool isString() override;
     structalign_t alignment() override;
-    bool hasUnsafeBitpatterns() override;
     bool hasVoidInitPointers() override;
     bool hasInvariant() override;
     bool needsDestruction() override;
@@ -4739,7 +4735,6 @@ public:
     bool needsCopyOrPostblit() override;
     bool needsNested() override;
     bool hasVoidInitPointers() override;
-    bool hasUnsafeBitpatterns() override;
     bool hasInvariant() override;
     uint8_t deduceWild(Type* t, bool isRef) override;
     void accept(Visitor* v) override;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1348,16 +1348,6 @@ extern (C++) abstract class Type : ASTNode
         return false;
     }
 
-    /*************************************
-     * Detect if this is an unsafe type because of the presence of `@system` members
-     * Returns:
-     *  true if so
-     */
-    bool hasUnsafeBitpatterns()
-    {
-        return false;
-    }
-
     /***************************************
      * Returns: true if type has any invariants
      */
@@ -2026,11 +2016,6 @@ extern (C++) final class TypeBasic : Type
         return (flags & TFlags.unsigned) != 0;
     }
 
-    override bool hasUnsafeBitpatterns()
-    {
-        return ty == Tbool;
-    }
-
     // For eliminating dynamic_cast
     override TypeBasic isTypeBasic()
     {
@@ -2194,11 +2179,6 @@ extern (C++) final class TypeSArray : TypeArray
     override structalign_t alignment()
     {
         return next.alignment();
-    }
-
-    override bool hasUnsafeBitpatterns()
-    {
-        return next.hasUnsafeBitpatterns();
     }
 
     override bool hasVoidInitPointers()
@@ -3007,13 +2987,6 @@ extern (C++) final class TypeStruct : Type
         return sym.hasVoidInitPointers;
     }
 
-    override bool hasUnsafeBitpatterns()
-    {
-        sym.size(Loc.initial); // give error for forward references
-        sym.determineTypeProperties();
-        return sym.hasUnsafeBitpatterns;
-    }
-
     override bool hasInvariant()
     {
         sym.size(Loc.initial); // give error for forward references
@@ -3153,11 +3126,6 @@ extern (C++) final class TypeEnum : Type
     override bool hasVoidInitPointers()
     {
         return memType().hasVoidInitPointers();
-    }
-
-    override bool hasUnsafeBitpatterns()
-    {
-        return memType().hasUnsafeBitpatterns();
     }
 
     override bool hasInvariant()

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -267,7 +267,6 @@ public:
     virtual structalign_t alignment();
     virtual int hasWild() const;
     virtual bool hasVoidInitPointers();
-    virtual bool hasUnsafeBitpatterns();
     virtual bool hasInvariant();
     virtual Type *nextOf();
     Type *baseElemOf();
@@ -397,7 +396,6 @@ public:
     unsigned alignsize() override;
     bool isString() override;
     structalign_t alignment() override;
-    bool hasUnsafeBitpatterns() override;
     bool hasVoidInitPointers() override;
     bool hasInvariant() override;
     bool needsDestruction() override;
@@ -692,7 +690,6 @@ public:
     bool needsCopyOrPostblit() override;
     bool needsNested() override;
     bool hasVoidInitPointers() override;
-    bool hasUnsafeBitpatterns() override;
     bool hasInvariant() override;
     unsigned char deduceWild(Type *t, bool isRef) override;
 
@@ -721,7 +718,6 @@ public:
     bool needsCopyOrPostblit() override;
     bool needsNested() override;
     bool hasVoidInitPointers() override;
-    bool hasUnsafeBitpatterns() override;
     bool hasInvariant() override;
     Type *nextOf() override;
 
@@ -843,4 +839,5 @@ namespace dmd
     uinteger_t size(Type *type, Loc loc);
     MATCH implicitConvTo(Type* from, Type* to);
     MATCH constConv(Type* from, Type* to);
+    bool hasUnsafeBitpatterns(Type* type);
 }

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -38,7 +38,7 @@ import dmd.root.string : fTuple;
 import dmd.target;
 import dmd.targetcompiler;
 import dmd.tokens;
-import dmd.typesem : hasPointers, arrayOf, size;
+import dmd.typesem : hasPointers, arrayOf, size, hasUnsafeBitpatterns;
 
 /*************************************************************
  * Check for unsafe access in @safe code:

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -72,6 +72,34 @@ import dmd.sideeffect;
 import dmd.target;
 import dmd.tokens;
 
+
+/*************************************
+ * Detect if this is an unsafe type because of the presence of `@system` members
+ * Returns:
+ *  true if so
+ */
+bool hasUnsafeBitpatterns(Type _this)
+{
+    static bool tstructImpl(TypeStruct _this)
+    {
+        import dmd.dsymbolsem : size;
+        _this.sym.size(Loc.initial); // give error for forward references
+        _this.sym.determineTypeProperties();
+        return _this.sym.hasUnsafeBitpatterns();
+    }
+
+    if(auto tb = _this.isTypeBasic())
+        return tb.ty == Tbool;
+
+    switch(_this.ty)
+    {
+        case Tenum: return _this.isTypeEnum().memType().hasUnsafeBitpatterns();
+        case Tstruct: return tstructImpl(_this.isTypeStruct());
+        case Tsarray: return _this.isTypeSArray().next.hasUnsafeBitpatterns();
+        default: return false;
+    }
+}
+
 /*************************************
  * Resolve a tuple index, `s[oindex]`, by figuring out what `s[oindex]` represents.
  * Setting one of pe/pt/ps.

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -85,7 +85,7 @@ bool hasUnsafeBitpatterns(Type _this)
         import dmd.dsymbolsem : size;
         _this.sym.size(Loc.initial); // give error for forward references
         _this.sym.determineTypeProperties();
-        return _this.sym.hasUnsafeBitpatterns();
+        return _this.sym.hasUnsafeBitpatterns;
     }
 
     if(auto tb = _this.isTypeBasic())


### PR DESCRIPTION
To remove the import of `dsymbolsem.size` (More PRs to go to be able to do so).