### PR TITLE
Revert changes to `tystring`

### DIFF
--- a/compiler/src/dmd/backend/var.d
+++ b/compiler/src/dmd/backend/var.d
@@ -328,8 +328,8 @@ __gshared const(char)*[TYMAX] tystring =
         TYullong8   : "ulong[8]",
     ];
 
-    ret[TYullong] = "ullong"; //ret[TYulong]; // c_ulong
-    ret[TYllong]  = "llong";  //ret[TYlong]; // c_long
+    ret[TYullong] = ret[TYulong]; // c_ulong
+    ret[TYllong]  = ret[TYlong]; // c_long
 
     return ret;
 } ();


### PR DESCRIPTION
@thewilsonator This unblocks #22017.

@WalterBright I wonder if it is necessary to break type names into multiple modules depending on architecture. ~I think D's semantics also allow replacing all `long`/`ulong` with `llong`/`ullong` (thoroughly, not this hacky) in DWARF, but I don't know the situation of importC and the like.~ Nevermind, I think keeping D names is just fine.