### PR TITLE
redirect output of gc/printf test to file to avoid pollution of CI logs

### DIFF
--- a/druntime/test/gc/Makefile
+++ b/druntime/test/gc/Makefile
@@ -50,6 +50,7 @@ $(ROOT)/printf$(DOTEXE): $(src_gc)
 $(ROOT)/printf$(DOTEXE): private extra_sources = $(src_gc)
 $(ROOT)/printf$(DOTEXE): extra_dflags += \
 	-debug=PRINTF -debug=PRINTF_TO_FILE -debug=COLLECT_PRINTF -version=OnlyLowMemUnittests $(core_ut) -main
+$(ROOT)/printf.done: run_args += >$(ROOT)/printf.log
 
 $(ROOT)/memstomp$(DOTEXE): $(src_lifetime)
 $(ROOT)/memstomp$(DOTEXE): private extra_sources = $(src_lifetime)


### PR DESCRIPTION
#22004 introduced a lot of output written to the console when -debug=PRINTF is used. Avoid having these in the build logs, the test is more about being able to compile with that option.