### PR TITLE
Attempt to fix all Macro issues

### DIFF
--- a/compiler/src/dmd/backend/var.d
+++ b/compiler/src/dmd/backend/var.d
@@ -164,6 +164,7 @@ int controlc_saw = 0;              /* a control C was seen         */
 symtab_t globsym;               /* global symbol table                  */
 Pstate pstate;                  // parser state
 Cstate cstate;                  // compiler state
+const(char)[][] gCsym;           // hash table for C symbol lookup
 
 uint numcse;        // number of common subexpressions
 

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -333,6 +333,7 @@ extern (C++) final class AliasDeclaration : Declaration
 
     Dsymbol overnext;   // next in overload list
     Dsymbol _import;    // !=null if unresolved internal alias for selective import
+    bool isCmacro;      // check whether it is coming from a C macro
 
     extern (D) this(Loc loc, Identifier ident, Type type) @safe
     {

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -196,6 +196,7 @@ public:
     Dsymbol *aliassym;
     Dsymbol *overnext;          // next in overload list
     Dsymbol *_import;           // !=NULL if unresolved internal alias for selective import
+    bool isCmacro;
 
     static AliasDeclaration *create(Loc loc, Identifier *id, Type *type);
     AliasDeclaration *syntaxCopy(Dsymbol *) override;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2029,6 +2029,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             // Infering the type requires running semantic,
             // so mark the scope as ctfe if required
             bool needctfe = (dsym.storage_class & (STC.manifest | STC.static_)) != 0 || !sc.func;
+
             if (needctfe)
             {
                 sc.condition = true;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6715,6 +6715,7 @@ public:
     Dsymbol* aliassym;
     Dsymbol* overnext;
     Dsymbol* _import_;
+    bool isCmacro;
     static AliasDeclaration* create(Loc loc, Identifier* id, Type* type);
     AliasDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -81,6 +81,7 @@ import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.ty;
 import dmd.backend.type;
+import dmd.backend.var;
 
 package(dmd.glue):
 
@@ -439,6 +440,19 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
         override void visit(VarDeclaration vd)
         {
+            static bool symbol_search(VarDeclaration vd)
+            {
+                auto id = vd.ident.toString();
+
+                auto length = gCsym.length;
+                foreach(ident; gCsym)
+                {
+                    if (id == ident)
+                        return true;
+                }
+                gCsym ~= id;
+                return false;
+            }
 
             //printf("VarDeclaration.toObjFile(%p '%s' type=%s) visibility %d\n", vd, vd.toChars(), vd.type.toChars(), vd.visibility);
             //printf("\talign = %d\n", vd.alignment);
@@ -462,6 +476,9 @@ void toObjFile(Dsymbol ds, bool multiobj)
             }
 
             if (!vd.isDataseg() || vd.storage_class & STC.extern_)
+                return;
+
+            if (vd.isCmacro && symbol_search(vd)) // true ==> symbol exists
                 return;
 
             Symbol* s = toSymbol(vd);

--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -490,6 +490,12 @@ Dsymbol handleSymbolRedeclarations(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsy
         if (td.isCmacro) return s2;
     }
 
+    if (auto ad = s.isAliasDeclaration())
+    {
+        if (ad.isCmacro)
+            return s2;
+    }
+
     auto vd = s.isVarDeclaration(); // new declaration
     auto vd2 = s2.isVarDeclaration(); // existing declaration
 

--- a/compiler/test/runnable/fix20410.d
+++ b/compiler/test/runnable/fix20410.d
@@ -1,0 +1,13 @@
+/*
+REQUIRED_ARGS: runnable/imports/imp20410.c
+*/
+//https://github.com/dlang/dmd/issues/20410
+import imp20410;
+
+void main()
+{
+    const _ = _RAX;
+
+    assert(num == 5);
+    assert(func() == 9);
+}

--- a/compiler/test/runnable/fix20410.d
+++ b/compiler/test/runnable/fix20410.d
@@ -16,4 +16,8 @@ void main()
     static assert(A == B);
     static assert(A == C);
     static assert(A == D);
+
+    //https://github.com/dlang/dmd/issues/20194
+    assert(test == 9);
+    assert(ABOLD == 7);
 }

--- a/compiler/test/runnable/fix20410.d
+++ b/compiler/test/runnable/fix20410.d
@@ -10,4 +10,10 @@ void main()
 
     assert(num == 5);
     assert(func() == 9);
+
+    //https://github.com/dlang/dmd/issues/20478
+
+    static assert(A == B);
+    static assert(A == C);
+    static assert(A == D);
 }

--- a/compiler/test/runnable/imports/imp20410.c
+++ b/compiler/test/runnable/imports/imp20410.c
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=24419
+
+typedef enum {
+    #define R0 _RAX
+    _RAX,
+} reg;
+
+
+int number = 5;
+#define num number;
+
+
+int function()
+{
+    return 9;
+}
+#define func function

--- a/compiler/test/runnable/imports/imp20410.c
+++ b/compiler/test/runnable/imports/imp20410.c
@@ -23,3 +23,9 @@ int function()
 #define B A
 #define C (A)
 #define D (B)
+
+//https://github.com/dlang/dmd/issues/20194
+
+#define test_func(x, y) (x + y)
+#define ABOLD test_func(2,5)
+#define test test_func(5,4)

--- a/compiler/test/runnable/imports/imp20410.c
+++ b/compiler/test/runnable/imports/imp20410.c
@@ -15,3 +15,11 @@ int function()
     return 9;
 }
 #define func function
+
+//https://github.com/dlang/dmd/issues/20478
+// similar issue
+
+#define A 1
+#define B A
+#define C (A)
+#define D (B)


### PR DESCRIPTION
In an attempt to fix `#define identifier identifier` not being resolvable in D, 
we create D aliases for these macros that refer to identifiers.
including a case check for identifiers actually caused conflicts with most of the inbuilt C compiler macros
because of them define to identifiers and some are actually having no good use
like macros that defines the same name eg. (#define if if) very common in C libs and headers.
since they break D semantics, we do not allow it to break D semantics by just ignoring them
like we have been doing.
For now, I have kept a small table of symbols that easily conflicts but I think we can handle these well to integrate fully

we get to be able import macros that point to identifiers in D whiles not getting interfered by C builtins which
D doesn't know. 

more work needs to be done accordingly to win against C macro system fully. 

@dkorpel 