### PR TITLE
Move `Type.alignment` to `dmd/typesem`

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -849,6 +849,12 @@ uinteger_t size(Type type, Loc loc)
     return dmd.typesem.size(type, loc);
 }
 
+structalign_t alignment(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.alignment(type);
+}
+
 MATCH implicitConvTo(Type from, Type to)
 {
     import dmd.dcast;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -136,6 +136,7 @@ void makeNested(AggregateDeclaration _this)
     }
     if (_this.enclosing)
     {
+        import dmd.typesem : alignment;
         //printf("makeNested %s, enclosing = %s\n", toChars(), enclosing.toChars());
         assert(t);
         if (t.ty == Tstruct)
@@ -166,6 +167,8 @@ void makeNested(AggregateDeclaration _this)
  */
 void makeNested2(AggregateDeclaration _this)
 {
+    import dmd.typesem : alignment;
+
     if (_this.vthis2)
         return;
     if (!_this.vthis)
@@ -2083,6 +2086,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         /* If scope's alignment is the default, use the type's alignment,
          * otherwise the scope overrrides.
          */
+        import dmd.typesem : alignment;
         if (dsym.alignment.isDefault())
             dsym.alignment = dsym.type.alignment(); // use type's alignment
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2105,7 +2105,6 @@ public:
     Type* toBasetype();
     virtual uint8_t deduceWild(Type* t, bool isRef);
     virtual ClassDeclaration* isClassHandle();
-    virtual structalign_t alignment();
     virtual int32_t hasWild() const;
     virtual bool hasVoidInitPointers();
     virtual Type* nextOf();
@@ -4745,7 +4744,6 @@ public:
     bool isIncomplete();
     uint32_t alignsize() override;
     bool isString() override;
-    structalign_t alignment() override;
     bool hasVoidInitPointers() override;
     bool needsDestruction() override;
     bool needsCopyOrPostblit() override;
@@ -4773,7 +4771,6 @@ public:
     const char* kind() const override;
     uint32_t alignsize() override;
     TypeStruct* syntaxCopy() override;
-    structalign_t alignment() override;
     bool isBoolean() override;
     bool needsDestruction() override;
     bool needsCopyOrPostblit() override;

--- a/compiler/src/dmd/glue/tocsym.d
+++ b/compiler/src/dmd/glue/tocsym.d
@@ -50,7 +50,7 @@ import dmd.mtype;
 import dmd.safe : isSafe;
 import dmd.target;
 import dmd.tokens;
-import dmd.typesem : size;
+import dmd.typesem : size, alignment;
 import dmd.visitor;
 
 import dmd.backend.cdef;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1318,16 +1318,6 @@ extern (C++) abstract class Type : ASTNode
         return null;
     }
 
-    /************************************
-     * Return alignment to use for this type.
-     */
-    structalign_t alignment()
-    {
-        structalign_t s;
-        s.setDefault();
-        return s;
-    }
-
     /***************************************
      * Return !=0 if the type or any of its subtypes is wild.
      */
@@ -2167,11 +2157,6 @@ extern (C++) final class TypeSArray : TypeArray
         return nty.isSomeChar;
     }
 
-    override structalign_t alignment()
-    {
-        return next.alignment();
-    }
-
     override bool hasVoidInitPointers()
     {
         return next.hasVoidInitPointers();
@@ -2923,13 +2908,6 @@ extern (C++) final class TypeStruct : Type
     override TypeStruct syntaxCopy()
     {
         return this;
-    }
-
-    override structalign_t alignment()
-    {
-        if (sym.alignment.isUnknown())
-            sym.size(sym.loc);
-        return sym.alignment;
     }
 
     override bool isBoolean()

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -264,7 +264,6 @@ public:
     virtual unsigned char deduceWild(Type *t, bool isRef);
 
     virtual ClassDeclaration *isClassHandle();
-    virtual structalign_t alignment();
     virtual int hasWild() const;
     virtual bool hasVoidInitPointers();
     virtual Type *nextOf();
@@ -394,7 +393,6 @@ public:
     bool isIncomplete();
     unsigned alignsize() override;
     bool isString() override;
-    structalign_t alignment() override;
     bool hasVoidInitPointers() override;
     bool needsDestruction() override;
     bool needsCopyOrPostblit() override;
@@ -682,7 +680,6 @@ public:
     const char *kind() override;
     unsigned alignsize() override;
     TypeStruct *syntaxCopy() override;
-    structalign_t alignment() override;
     bool isBoolean() override;
     bool needsDestruction() override;
     bool needsCopyOrPostblit() override;
@@ -837,4 +834,5 @@ namespace dmd
     MATCH constConv(Type* from, Type* to);
     bool hasUnsafeBitpatterns(Type* type);
     bool hasInvariant(Type* type);
+    structalign_t alignment(Type* type);
 }

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -38,7 +38,7 @@ import dmd.root.string : fTuple;
 import dmd.target;
 import dmd.targetcompiler;
 import dmd.tokens;
-import dmd.typesem : hasPointers, arrayOf, size, hasUnsafeBitpatterns, hasInvariant;
+import dmd.typesem : hasPointers, arrayOf, size, hasUnsafeBitpatterns, hasInvariant, alignment;
 
 /*************************************************************
  * Check for unsafe access in @safe code:

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -72,6 +72,27 @@ import dmd.sideeffect;
 import dmd.target;
 import dmd.tokens;
 
+/************************************
+ * Return alignment to use for this type.
+ */
+structalign_t alignment(Type _this)
+{
+    if (auto tsa = _this.isTypeSArray())
+    {
+        return tsa.next.alignment();
+    }
+    else if (auto ts = _this.isTypeStruct())
+    {
+        import dmd.dsymbolsem : size;
+        if (ts.sym.alignment.isUnknown())
+            ts.sym.size(ts.sym.loc);
+        return ts.sym.alignment;
+    }
+    structalign_t s;
+    s.setDefault();
+    return s;
+}
+
 /***************************************
  * Returns: true if type has any invariants
  */


### PR DESCRIPTION
To remove the dependency of `mtype.d` on `dsymbolsem.size`