### PR TITLE
fix #20246 - cannot inline function core.bitop.Split64.this

### DIFF
--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -3160,6 +3160,13 @@ elem* toElem(Expression e, ref IRState irs)
 
     elem* visitCond(CondExp ce)
     {
+        // condition `__ctfe`/`!__ctfe` is always false/true at runtime, so skip code generation
+        //  for ce.e1/e2. This can also be the result of inlining an `if (__ctfe)` statement
+        auto ctfecond = ce.econd.op == EXP.not ? (cast(NotExp)ce.econd).e1 : ce.econd;
+        if (auto ve = ctfecond.isVarExp())
+            if (ve.var && ve.var.ident == Id.ctfe)
+                return toElem(ctfecond is ce.econd ? ce.e2 : ce.e1, irs);
+
         elem* ec = toElem(ce.econd, irs);
 
         elem* eleft = toElem(ce.e1, irs);

--- a/compiler/src/dmd/inlinecost.d
+++ b/compiler/src/dmd/inlinecost.d
@@ -265,12 +265,6 @@ public:
         }
         expressionInlineCost(s.condition);
 
-        if (s.isIfCtfeBlock())
-        {
-            cost = COST_MAX;
-            return;
-        }
-
         /* Specifically allow:
          *  if (condition)
          *      return exp1;

--- a/compiler/test/compilable/pragmainline2.d
+++ b/compiler/test/compilable/pragmainline2.d
@@ -103,6 +103,16 @@ bool test_toUByte()
     struct S { int x; }
     S sval;
     ubarr = toUbyte(sval);
-	return true;
+    return true;
 }
 static assert(test_toUByte());
+
+// https://github.com/dlang/dmd/issues/20246
+void test_split()
+{
+    // bitop.Split64 only used for 32-bit process
+    import core.bitop;
+    ulong v = 1L << 42;
+    int x = bsr(v);
+    int y = bsf(v);
+}


### PR DESCRIPTION
restore inlining `if (__ctfe)`, but remove the respective branch from `__ctfe ? e1 : e2` during code-gen.
