### PR TITLE
fix force-inlining of a couple of methods

### DIFF
--- a/compiler/test/compilable/pragmainline2.d
+++ b/compiler/test/compilable/pragmainline2.d
@@ -106,3 +106,25 @@ bool test_toUByte()
 	return true;
 }
 static assert(test_toUByte());
+
+void test_newaa()
+{
+    // inlining of newaa.pure_keyEqual, newaa.compat_key, newaa.pure_hashOf
+    // must be disabled for nested structs
+    struct UnsafeElement
+    {
+        int i;
+        static bool b;
+        ~this(){
+            int[] arr;
+            void* p = arr.ptr + 1; // unsafe
+        }
+    }
+    UnsafeElement[int] aa1;
+    int[UnsafeElement] aa2;
+    aa1[1] = UnsafeElement();
+    assert(0 !in aa1);
+    assert(aa1 == aa1);
+    assert(UnsafeElement() !in aa2);
+    aa2[UnsafeElement()] = 1;
+}

--- a/compiler/test/compilable/pragmainline2.d
+++ b/compiler/test/compilable/pragmainline2.d
@@ -127,4 +127,12 @@ void test_newaa()
     assert(aa1 == aa1);
     assert(UnsafeElement() !in aa2);
     aa2[UnsafeElement()] = 1;
+
+    // test inlining of hashOf(Interface)
+    static interface Iface
+    {
+        void foo();
+    }
+    Iface[int] aa3;
+    int[Iface] aa4;
 }

--- a/compiler/test/compilable/warn3882.d
+++ b/compiler/test/compilable/warn3882.d
@@ -108,6 +108,7 @@ void testCkeckedInt()
 
     bool overflow;
     assert(mulu(cast(long)3, cast(uint)4, overflow) == 12);
+    assert(mulu(cast(ulong)3, cast(uint)4, overflow) == 12);
 
     assert(testCheckedUnsigned!uint(3,4) == 12);
     assert(testCheckedUnsigned!ulong(3,4) == 12);

--- a/druntime/src/core/checkedint.d
+++ b/druntime/src/core/checkedint.d
@@ -815,15 +815,13 @@ ulong mulu()(ulong x, uint y, ref bool overflow)
 {
     version (D_InlineAsm_X86_64)
     {
-        if (!__ctfe)
-            return mulu(x, ulong(y), overflow);
+        return __ctfe ? mulu_generic(x, y, overflow)
+            : mulu(x, ulong(y), overflow);
     }
-
-    ulong r = x * y;
-    if (x >> 32 &&
-            r / x != y)
-        overflow = true;
-    return r;
+    else
+    {
+        return mulu_generic(x, y, overflow);
+    }
 }
 
 /// ditto
@@ -852,6 +850,16 @@ ulong mulu()(ulong x, ulong y, ref bool overflow)
     if ((x | y) >> 32 &&
             x &&
             r / x != y)
+        overflow = true;
+    return r;
+}
+
+private ulong mulu_generic()(ulong x, uint y, ref bool overflow)
+{
+    pragma(inline, true)
+    ulong r = x * y;
+    if (x >> 32 &&
+        r / x != y)
         overflow = true;
     return r;
 }

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -2600,11 +2600,13 @@ pure nothrow @system unittest
 }
 
 // wipes source after moving
-pragma(inline, true)
 private void wipe(T, Init...)(return scope ref T source, ref const scope Init initializer) @trusted
 if (!Init.length ||
     ((Init.length == 1) && (is(immutable T == immutable Init[0]))))
 {
+    static if (!is(T == struct) || !__traits(isNested, T))
+        pragma(inline, true);
+
     static if (__traits(isStaticArray, T) && hasContextPointers!T)
     {
         for (auto i = 0; i < T.length; i++)

--- a/druntime/src/rt/util/typeinfo.d
+++ b/druntime/src/rt/util/typeinfo.d
@@ -39,9 +39,8 @@ pragma(inline, true)
 private int cmp3(T)(const T f1, const T f2)
 if (isComplex!T)
 {
-    if (int result = cmp3(f1.re, f2.re))
-        return result;
-    return cmp3(f1.im, f2.im);
+    int result;
+    return (result = cmp3(f1.re, f2.re)) != 0 ? result : cmp3(f1.im, f2.im);
 }
 
 unittest


### PR DESCRIPTION
While building dmd/druntime/phobos with -wi, I noticed a couple of methods still warned about not being inlined by dmd. These patches help the inliner and avoid the warnings for druntime methods.
