### PR TITLE
Update pre_commit version hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v6.0.0
   hooks:
   - id: trailing-whitespace
     exclude: >
@@ -22,6 +22,6 @@ repos:
   - id: no-commit-to-branch
     args: [--branch, master]
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.23.0
+  rev: 0.34.1
   hooks:
     - id: check-github-workflows


### PR DESCRIPTION
This MR updates the pinned versions of our pre-commit hooks to keep us aligned with the latest stable releases:

-   pre-commit-hooks: v4.4.0 → v6.0.0
-   check-jsonschema: 0.23.0 → 0.34.1


Benefits:

- Latest rule fixes and performance improvements
- Improved compatibility with recent GitHub action schema checks
- Aligns our tooling with upstream recommendations

I’ve verified that:

- All hooks run successfully using **pre-commit run --all-files**
- No regressions were detected in the existing exclusions