### PR TITLE
Break semantic dependency of `mtype` on `enumsem`

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -837,6 +837,12 @@ Type referenceTo(Type type)
     return dmd.typesem.referenceTo(type);
 }
 
+Type memType(TypeEnum _this)
+{
+    import dmd.typesem;
+    return dmd.typesem.memType(type);
+}
+
 uinteger_t size(Type type)
 {
     import dmd.typesem;

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -837,7 +837,7 @@ Type referenceTo(Type type)
     return dmd.typesem.referenceTo(type);
 }
 
-Type memType(TypeEnum _this)
+Type memType(TypeEnum type)
 {
     import dmd.typesem;
     return dmd.typesem.memType(type);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4499,7 +4499,6 @@ public:
     EnumDeclaration* sym;
     const char* kind() const override;
     TypeEnum* syntaxCopy() override;
-    Type* memType();
     uint32_t alignsize() override;
     bool isIntegral() override;
     bool isFloating() override;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1514,7 +1514,7 @@ extern (C++) abstract class TypeNext : Type
         {
             assert(mcache.scto.mod == (MODFlags.shared_ | MODFlags.const_));
             return mcache.scto;
-    }
+        }
         TypeNext t = cast(TypeNext)Type.makeSharedConst();
         if (ty != Tfunction && next.ty != Tfunction && !next.isImmutable())
         {

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -28,7 +28,7 @@ import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dsymbolsem: size;
 import dmd.dtemplate;
-import dmd.enumsem;
+//import dmd.enumsem;
 import dmd.errors;
 import dmd.expression;
 import dmd.hdrgen;
@@ -1523,7 +1523,7 @@ extern (C++) abstract class TypeNext : Type
         {
             assert(mcache.scto.mod == (MODFlags.shared_ | MODFlags.const_));
             return mcache.scto;
-        }
+    }
         TypeNext t = cast(TypeNext)Type.makeSharedConst();
         if (ty != Tfunction && next.ty != Tfunction && !next.isImmutable())
         {
@@ -2855,14 +2855,9 @@ extern (C++) final class TypeEnum : Type
         return this;
     }
 
-    Type memType()
-    {
-        return sym.getMemtype(Loc.initial);
-    }
-
     override uint alignsize()
     {
-        Type t = memType();
+        Type t = this.memType();
         if (t.ty == Terror)
             return 4;
         return t.alignsize();
@@ -2870,62 +2865,62 @@ extern (C++) final class TypeEnum : Type
 
     override bool isIntegral()
     {
-        return memType().isIntegral();
+        return this.memType().isIntegral();
     }
 
     override bool isFloating()
     {
-        return memType().isFloating();
+        return this.memType().isFloating();
     }
 
     override bool isReal()
     {
-        return memType().isReal();
+        return this.memType().isReal();
     }
 
     override bool isImaginary()
     {
-        return memType().isImaginary();
+        return this.memType().isImaginary();
     }
 
     override bool isComplex()
     {
-        return memType().isComplex();
+        return this.memType().isComplex();
     }
 
     override bool isScalar()
     {
-        return memType().isScalar();
+        return this.memType().isScalar();
     }
 
     override bool isUnsigned()
     {
-        return memType().isUnsigned();
+        return this.memType().isUnsigned();
     }
 
     override bool isBoolean()
     {
-        return memType().isBoolean();
+        return this.memType().isBoolean();
     }
 
     override bool isString()
     {
-        return memType().isString();
+        return this.memType().isString();
     }
 
     override bool needsDestruction()
     {
-        return memType().needsDestruction();
+        return this.memType().needsDestruction();
     }
 
     override bool needsCopyOrPostblit()
     {
-        return memType().needsCopyOrPostblit();
+        return this.memType().needsCopyOrPostblit();
     }
 
     override bool needsNested()
     {
-        return memType().needsNested();
+        return this.memType().needsNested();
     }
 
     extern (D) Type toBasetype2()
@@ -2938,7 +2933,7 @@ extern (C++) final class TypeEnum : Type
 
     override Type nextOf()
     {
-        return memType().nextOf();
+        return this.memType().nextOf();
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2923,14 +2923,6 @@ extern (C++) final class TypeEnum : Type
         return this.memType().needsNested();
     }
 
-    extern (D) Type toBasetype2()
-    {
-        if (!sym.members && !sym.memtype)
-            return this;
-        auto tb = sym.getMemtype(Loc.initial).toBasetype();
-        return tb.castMod(mod);         // retain modifier bits from 'this'
-    }
-
     override Type nextOf()
     {
         return this.memType().nextOf();

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -28,7 +28,6 @@ import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dsymbolsem: size;
 import dmd.dtemplate;
-//import dmd.enumsem;
 import dmd.errors;
 import dmd.expression;
 import dmd.hdrgen;

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -694,7 +694,6 @@ public:
     const char *kind() override;
     TypeEnum *syntaxCopy() override;
     unsigned alignsize() override;
-    Type *memType(Loc loc);
     bool isIntegral() override;
     bool isFloating() override;
     bool isReal() override;
@@ -832,4 +831,5 @@ namespace dmd
     bool hasVoidInitPointers(Type* type);
     void Type_init();
     structalign_t alignment(Type* type);
+    Type* memType(TypeEnum* type);
 }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -72,6 +72,14 @@ import dmd.sideeffect;
 import dmd.target;
 import dmd.tokens;
 
+Type toBasetype2(TypeEnum _this)
+{
+    if (!_this.sym.members && !_this.sym.memtype)
+        return _this;
+    auto tb = _this.sym.getMemtype(Loc.initial).toBasetype();
+    return tb.castMod(_this.mod); // retain modifier bits from '_this'
+}
+
 Type memType(TypeEnum _this)
 {
     return _this.sym.getMemtype(Loc.initial);

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -72,6 +72,11 @@ import dmd.sideeffect;
 import dmd.target;
 import dmd.tokens;
 
+Type memType(TypeEnum _this)
+{
+    return _this.sym.getMemtype(Loc.initial);
+}
+
 /*************************************
  * Detect if type has pointer fields that are initialized to void.
  * Local stack variables with such void fields can remain uninitialized,


### PR DESCRIPTION
Move `TypeEnum.toBasetype2` and `TypeEnum.memType` to `dmd/typesem`