### PR TITLE
adjust AArch64 varargs for OSX variant

### DIFF
--- a/compiler/src/dmd/backend/arm/cod4.d
+++ b/compiler/src/dmd/backend/arm/cod4.d
@@ -56,8 +56,8 @@ nothrow:
 @trusted
 void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
-    //printf("cdeq(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
-    //elem_print(e);
+    printf("cdeq(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
+    elem_print(e);
 
     reg_t reg;
     code cs;


### PR DESCRIPTION
This isn't the optimal way to do it, but it is simple.

Apple went their own way on OSX with the AArch64 standard, here with the presumption that no variadic arguments are passed in registers, so the complex structure to deal with that is irrelevant.