### PR TITLE
rename internal.vararg.aarch64 to internal.vararg.aapcs64

### DIFF
--- a/druntime/mak/COPY
+++ b/druntime/mak/COPY
@@ -88,7 +88,7 @@ COPY=\
 	$(IMPDIR)\core\internal\util\array.d \
 	$(IMPDIR)\core\internal\util\math.d \
 	\
-	$(IMPDIR)\core\internal\vararg\aarch64.d \
+	$(IMPDIR)\core\internal\vararg\aapcs64.d \
 	$(IMPDIR)\core\internal\vararg\sysv_x64.d \
 	\
 	$(IMPDIR)\core\stdc\assert_.d \

--- a/druntime/mak/DOCS
+++ b/druntime/mak/DOCS
@@ -61,7 +61,7 @@ DOCS=\
 	$(DOCDIR)\core_internal_util_array.html \
 	$(IMPDIR)\core\internal\util\math.d \
 	\
-	$(DOCDIR)\core_internal_vararg_aarch64.html \
+	$(DOCDIR)\core_internal_vararg_aapcs64.html \
 	$(DOCDIR)\core_internal_vararg_sysv_x64.html \
 	\
 	$(DOCDIR)\core_internal_backtrace_dwarf.html \

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -86,7 +86,7 @@ SRCS=\
 	src\core\internal\util\array.d \
 	src\core\internal\util\math.d \
 	\
-	src\core\internal\vararg\aarch64.d \
+	src\core\internal\vararg\aapcs64.d \
 	src\core\internal\vararg\sysv_x64.d \
 	\
 	src\core\stdc\assert_.d \

--- a/druntime/src/core/internal/vararg/aapcs64.d
+++ b/druntime/src/core/internal/vararg/aapcs64.d
@@ -1,24 +1,25 @@
 /**
- * Varargs implementation for the AArch64 Procedure Call Standard (not followed by Apple).
+ * Varargs implementation for the AArch64 Procedure Call Standard AAPCS64 (not followed by Apple).
  * Used by core.stdc.stdarg and core.vararg.
+ * Can only be imported with version (AArch64).
  *
  * Reference: https://github.com/ARM-software/abi-aa/blob/master/aapcs64/aapcs64.rst#appendix-variable-argument-lists
  *
- * Copyright: Copyright Digital Mars 2020 - 2020.
+ * Copyright: Copyright Digital Mars 2020 - 2025.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Kinkelin
- * Source: $(DRUNTIMESRC core/internal/vararg/aarch64.d)
+ * Source: $(DRUNTIMESRC core/internal/vararg/aapcs64.d)
  */
 
-module core.internal.vararg.aarch64;
+module core.internal.vararg.aapcs64;
 
-version (AArch64):
+version (AArch64): // core.internal.vararg.aapcs64 is only for version (AArch64)
 
-// Darwin uses a simpler varargs implementation
-version (OSX) {}
-else version (iOS) {}
-else version (TVOS) {}
-else version (WatchOS) {}
+// Darwin uses a simpler varargs implementation than AAPCS64, so should not import this module
+version (OSX)          { }
+else version (iOS)     { }
+else version (TVOS)    { }
+else version (WatchOS) { }
 else:
 
 import core.stdc.stdarg : alignUp;

--- a/druntime/src/core/stdc/stdarg.d
+++ b/druntime/src/core/stdc/stdarg.d
@@ -69,7 +69,7 @@ else version (ARM_Any)
     else version (AArch64)
     {
         version = AAPCS64;
-        static import core.internal.vararg.aarch64;
+        static import core.internal.vararg.aapcs64;
     }
 }
 
@@ -129,9 +129,9 @@ else version (AAPCS32)
 }
 else version (AAPCS64)
 {
-    alias va_list = core.internal.vararg.aarch64.va_list;
+    alias va_list = core.internal.vararg.aapcs64.va_list;
     version (DigitalMars)
-        public import core.internal.vararg.aarch64 : __va_list, __va_list_tag;
+        public import core.internal.vararg.aapcs64 : __va_list, __va_list_tag;
 }
 else version (RISCV_Any)
 {
@@ -229,7 +229,7 @@ T va_arg(T)(ref va_list ap)
     }
     else version (AAPCS64)
     {
-        return core.internal.vararg.aarch64.va_arg!T(ap);
+        return core.internal.vararg.aapcs64.va_arg!T(ap);
     }
     else version (ARM_Any)
     {

--- a/druntime/src/core/vararg.d
+++ b/druntime/src/core/vararg.d
@@ -106,8 +106,8 @@ void va_arg()(ref va_list ap, TypeInfo ti, void* parmn)
     }
     else version (AAPCS64)
     {
-        static import core.internal.vararg.aarch64;
-        core.internal.vararg.aarch64.va_arg(ap, ti, parmn);
+        static import core.internal.vararg.aapcs64;
+        core.internal.vararg.aapcs64.va_arg(ap, ti, parmn);
     }
     else version (ARM_Any)
     {


### PR DESCRIPTION
Should clear up confusion over just what this module is for. In particular, it is for AAPCS64, not Aarch64.