### PR TITLE
add core.internal.vararg.gnu

### DIFF
--- a/druntime/mak/COPY
+++ b/druntime/mak/COPY
@@ -90,6 +90,7 @@ COPY=\
 	\
 	$(IMPDIR)\core\internal\vararg\aarch64.d \
 	$(IMPDIR)\core\internal\vararg\sysv_x64.d \
+	$(IMPDIR)\core\internal\vararg\gnu.d \
 	\
 	$(IMPDIR)\core\stdc\assert_.d \
 	$(IMPDIR)\core\stdc\stdatomic.d \

--- a/druntime/mak/DOCS
+++ b/druntime/mak/DOCS
@@ -63,6 +63,7 @@ DOCS=\
 	\
 	$(DOCDIR)\core_internal_vararg_aarch64.html \
 	$(DOCDIR)\core_internal_vararg_sysv_x64.html \
+	$(DOCDIR)\core_internal_vararg_gnu.html \
 	\
 	$(DOCDIR)\core_internal_backtrace_dwarf.html \
 	$(DOCDIR)\core_internal_backtrace_elf.html \

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -88,6 +88,7 @@ SRCS=\
 	\
 	src\core\internal\vararg\aarch64.d \
 	src\core\internal\vararg\sysv_x64.d \
+	src\core\internal\vararg\gnu.d \
 	\
 	src\core\stdc\assert_.d \
 	src\core\stdc\stdatomic.d \

--- a/druntime/src/core/internal/vararg/gnu.d
+++ b/druntime/src/core/internal/vararg/gnu.d
@@ -1,0 +1,78 @@
+/**
+ * Varargs implementation for the GNU compilers (Gnu D Compiler)
+ * Used by core.stdc.stdarg and core.vararg.
+ *
+ * Reference: https://github.com/ARM-software/abi-aa/blob/master/aapcs64/aapcs64.rst#appendix-variable-argument-lists
+ *
+ * Copyright: Copyright D Language Foundation 2025
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Various
+ * Source: $(DRUNTIMESRC core/internal/vararg/gnu.d)
+ */
+
+module core.internal.vararg.gnu;
+
+version (GNU):
+
+// Uses gcc.builtins
+
+T alignUp(size_t alignment = size_t.sizeof, T)(T base) pure
+{
+    enum mask = alignment - 1;
+    static assert(alignment > 0 && (alignment & mask) == 0, "alignment must be a power of 2");
+    auto b = cast(size_t) base;
+    b = (b + mask) & ~mask;
+    return cast(T) b;
+}
+
+unittest
+{
+    assert(1.alignUp == size_t.sizeof);
+    assert(31.alignUp!16 == 32);
+    assert(32.alignUp!16 == 32);
+    assert(33.alignUp!16 == 48);
+    assert((-9).alignUp!8 == -8);
+}
+
+
+version (BigEndian)
+{
+    // Adjusts a size_t-aligned pointer for types smaller than size_t.
+    T* adjustForBigEndian(T)(T* p, size_t size) pure
+    {
+        return size >= size_t.sizeof ? p :
+            cast(T*) ((cast(void*) p) + (size_t.sizeof - size));
+    }
+}
+
+/**
+ * The argument pointer type.
+ */
+alias va_list = __gnuc_va_list;
+alias __gnuc_va_list = __builtin_va_list;
+
+/**
+ * Initialize ap.
+ * parmn should be the last named parameter.
+ */
+void va_start(T)(out va_list ap, ref T parmn);
+
+/**
+ * Retrieve and return the next value that is of type T.
+ */
+T va_arg(T)(ref va_list ap); // intrinsic
+
+/**
+ * Retrieve and store in parmn the next value that is of type T.
+ */
+void va_arg(T)(ref va_list ap, ref T parmn); // intrinsic
+
+/**
+ * End use of ap.
+ */
+alias va_end = __builtin_va_end;
+
+/**
+ * Make a copy of ap.
+ */
+alias va_copy = __builtin_va_copy;

--- a/druntime/src/core/stdc/stdarg.d
+++ b/druntime/src/core/stdc/stdarg.d
@@ -15,17 +15,17 @@ module core.stdc.stdarg;
 @nogc:
 nothrow:
 
+version (GNU)
+    public import core.internal.vararg.gnu;
+else:
+
 version (X86_64)
 {
     version (Windows) { /* different ABI */ }
     else version = SysV_x64;
 }
 
-version (GNU)
-{
-    import gcc.builtins;
-}
-else version (SysV_x64)
+version (SysV_x64)
 {
     static import core.internal.vararg.sysv_x64;
 
@@ -49,11 +49,7 @@ version (PPC64)   version = PPC_Any;
 version (RISCV32) version = RISCV_Any;
 version (RISCV64) version = RISCV_Any;
 
-version (GNU)
-{
-    // Uses gcc.builtins
-}
-else version (ARM_Any)
+version (ARM_Any)
 {
     // Darwin uses a simpler varargs implementation
     version (OSX) {}
@@ -107,12 +103,7 @@ version (BigEndian)
 /**
  * The argument pointer type.
  */
-version (GNU)
-{
-    alias va_list = __gnuc_va_list;
-    alias __gnuc_va_list = __builtin_va_list;
-}
-else version (SysV_x64)
+version (SysV_x64)
 {
     alias va_list = core.internal.vararg.sysv_x64.va_list;
     public import core.internal.vararg.sysv_x64 : __va_list, __va_list_tag;
@@ -149,11 +140,7 @@ else
  * Initialize ap.
  * parmn should be the last named parameter.
  */
-version (GNU)
-{
-    void va_start(T)(out va_list ap, ref T parmn);
-}
-else version (LDC)
+version (LDC)
 {
     pragma(LDC_va_start)
     void va_start(T)(out va_list ap, ref T parmn) @nogc;
@@ -177,9 +164,6 @@ else version (DigitalMars)
 /**
  * Retrieve and return the next value that is of type T.
  */
-version (GNU)
-    T va_arg(T)(ref va_list ap); // intrinsic
-else
 T va_arg(T)(ref va_list ap)
 {
     version (X86)
@@ -295,9 +279,6 @@ T va_arg(T)(ref va_list ap)
 /**
  * Retrieve and store in parmn the next value that is of type T.
  */
-version (GNU)
-    void va_arg(T)(ref va_list ap, ref T parmn); // intrinsic
-else
 void va_arg(T)(ref va_list ap, ref T parmn)
 {
     parmn = va_arg!T(ap);
@@ -307,11 +288,7 @@ void va_arg(T)(ref va_list ap, ref T parmn)
 /**
  * End use of ap.
  */
-version (GNU)
-{
-    alias va_end = __builtin_va_end;
-}
-else version (LDC)
+version (LDC)
 {
     pragma(LDC_va_end)
     void va_end(va_list ap);
@@ -325,11 +302,7 @@ else version (DigitalMars)
 /**
  * Make a copy of ap.
  */
-version (GNU)
-{
-    alias va_copy = __builtin_va_copy;
-}
-else version (LDC)
+version (LDC)
 {
     pragma(LDC_va_copy)
     void va_copy(out va_list dest, va_list src);


### PR DESCRIPTION
Instead of sprinkling GNU conditionals across the modules, move all the GNU stuff into core.internal.vararg.gnu.