### PR TITLE
move __va_argsave_t to sysv_x64.d

### DIFF
--- a/druntime/src/core/internal/vararg/sysv_x64.d
+++ b/druntime/src/core/internal/vararg/sysv_x64.d
@@ -41,6 +41,16 @@ alias __va_list = __va_list_tag;
  */
 alias va_list = __va_list*;
 
+version (DigitalMars)
+{
+    align(16) struct __va_argsave_t
+    {
+        size_t[6] regs;   // RDI,RSI,RDX,RCX,R8,R9
+        real[8] fpregs;   // XMM0..XMM7
+        __va_list va;
+    }
+}
+
 ///
 T va_arg(T)(va_list ap)
 {

--- a/druntime/src/core/stdc/stdarg.d
+++ b/druntime/src/core/stdc/stdarg.d
@@ -28,16 +28,6 @@ version (X86_64)
 version (SysV_x64)
 {
     static import core.internal.vararg.sysv_x64;
-
-    version (DigitalMars)
-    {
-        align(16) struct __va_argsave_t
-        {
-            size_t[6] regs;   // RDI,RSI,RDX,RCX,R8,R9
-            real[8] fpregs;   // XMM0..XMM7
-            __va_list va;
-        }
-    }
 }
 
 version (ARM)     version = ARM_Any;
@@ -105,8 +95,7 @@ version (BigEndian)
  */
 version (SysV_x64)
 {
-    alias va_list = core.internal.vararg.sysv_x64.va_list;
-    public import core.internal.vararg.sysv_x64 : __va_list, __va_list_tag;
+    public import core.internal.vararg.sysv_x64 : va_list, __va_list, __va_list_tag;
 }
 else version (AAPCS32)
 {

--- a/druntime/src/core/stdc/stdio.d
+++ b/druntime/src/core/stdc/stdio.d
@@ -1703,14 +1703,14 @@ else version (OpenBSD)
     {
         ///
         void rewind(FILE*);
-	///
-	pure void clearerr(FILE*);
-	///
-	pure int  feof(FILE*);
-	///
-	pure int  ferror(FILE*);
-	///
-	int  fileno(FILE*);
+        ///
+        pure void clearerr(FILE*);
+        ///
+        pure int  feof(FILE*);
+        ///
+        pure int  ferror(FILE*);
+        ///
+        int  fileno(FILE*);
     }
 
     ///


### PR DESCRIPTION
The idea is the declarations for sysv_x64 should all be in sysv_x64.d

My detabber caught some naughty tabs in stdio.d