### PR TITLE
Elide a redundant jump in try-finally

### DIFF
--- a/compiler/src/dmd/glue/s2ir.d
+++ b/compiler/src/dmd/glue/s2ir.d
@@ -1566,7 +1566,7 @@ void insertFinallyBlockCalls(block* startblock)
                  *  BC.goto_     [BC._try]
                  *  BC._try     [body] [BC._finally]
                  *  body
-                 *x BC.goto_     sflag=n; [finalbody]
+                 *x BC.goto_     sflag=n; [BC._finally]
                  *  BC._finally [BC._lpad] [finalbody] [breakblock]
                  *  BC._lpad    [finalbody]
                  *  finalbody
@@ -1596,15 +1596,8 @@ void insertFinallyBlockCalls(block* startblock)
                     elem* e = el_bin(OPeq, TYint, el_var(sflag), el_long(TYint, flagvalue));
                     b.Belem = el_combine(b.Belem, e);
 
-                    if (blast.bc == BC.iftrue)
-                    {
-                        blast.setNthSucc(0, bf.nthSucc(1));
-                    }
-                    else
-                    {
-                        assert(blast.bc == BC.goto_);
-                        blast.setNthSucc(0, bf.nthSucc(1));
-                    }
+                    assert(blast.bc == BC.goto_ || blast.bc == BC.iftrue);
+                    blast.setNthSucc(0, bf);
 
                     // Create new block, bnew, which will replace retblock
                     block* bnew = dmd.backend.global.block_calloc();


### PR DESCRIPTION
During lowering of a try-finally statement, the glue layer generates a `__flag = flagvalue` block indicating no exception has occurred, that jumps to the start of finally body after the `BC._lpad` block. This PR changes it to jump to the `BC._finally` block instead, which is still lowered into a jump to finally body in the backend.

The change is only a tiny code quality improvement but mostly serves to make the graph easier to understand. Now all happy paths go through `BC._finally` and all exceptional paths land on `BC._lpad`.

CFG diff:
<pre>
 3: BC._try                                                      3: BC._try
        Bpred: B2                                                       Bpred: B2
        Bsucc: B4 B5                                                    Bsucc: B4 B5
 4: BC.goto_   Btry=B3                                           4: BC.goto_   Btry=B3
        [try body]                                                      [try body]
        Bpred: B3                                                       Bpred: B3
<b>        Bsucc: B7                                             |         Bsucc: B5</b>
 5: BC._final b_ret=B10                                          5: BC._final b_ret=B10
<b>        Bpred: B3                                             |         Bpred: B4 B3</b>
        Bsucc: B6 B7 B11                                                Bsucc: B6 B7 B11
 6: BC._lpad                                                     6: BC._lpad
        __exception_object(4) =  __EAX(3);                              __exception_object(4) =  __EAX(3);
        __flag(2) =  0L ;                                               __flag(2) =  0L ;
        Bpred: B5                                                       Bpred: B5
        Bsucc: B7                                                       Bsucc: B7
 7: BC.goto_                                                     7: BC.goto_
        [finally body]                                                  [finally body]
<b>        Bpred: B6 B5 B4                                       |         Bpred: B6 B5</b>
        Bsucc: B8                                                       Bsucc: B8
 8: BC.goto_                                                     8: BC.goto_
        Bpred: B7                                                       Bpred: B7
        Bsucc: B9                                                       Bsucc: B9
 9: BC.true                                                      9: BC.true
        ! __flag(2) &&  (_Unwind_Resume call  __exception_obj           ! __flag(2) &&  (_Unwind_Resume call  __exception_obj
        __flag(2) ==  1L ;                                              __flag(2) ==  1L ;
        Bpred: B8                                                       Bpred: B8
        Bsucc: B11 B10                                                  Bsucc: B11 B10
10: BC._ret                                                     10: BC._ret
        Bpred: B9                                                       Bpred: B9
</pre>

Assembly diff:
<pre>
C7 45 F0 01 00 00 00     mov       dword ptr -010h[RBP],1       C7 45 F0 01 00 00 00     mov       dword ptr -010h[RBP],1
EB 0D                    jmp short L1e                        | EB 0B                    jmp short L1c
<b>EB 0B                    jmp short L1e                        |</b>
48 89 45 F8              mov       -8[RBP],RAX                  48 89 45 F8              mov       -8[RBP],RAX
C7 45 F0 00 00 00 00     mov       dword ptr -010h[RBP],0       C7 45 F0 00 00 00 00     mov       dword ptr -010h[RBP],0
83 7D F0 00              cmp       dword ptr -010h[RBP],0       83 7D F0 00              cmp       dword ptr -010h[RBP],0
75 09                    jne       L2d                        | 75 09                    jne       L2b
48 8B 7D F8              mov       RDI,-8[RBP]                  48 8B 7D F8              mov       RDI,-8[RBP]
E8 00 00 00 00           call      L0                           E8 00 00 00 00           call      L0
83 7D F0 01              cmp       dword ptr -010h[RBP],1       83 7D F0 01              cmp       dword ptr -010h[RBP],1
74 00                    je        L33                        | 74 00                    je        L31
48 8B E5                 mov       RSP,RBP                      48 8B E5                 mov       RSP,RBP
</pre>