### PR TITLE
Emit stack frame for try blocks with EH_DM

### DIFF
--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -1043,20 +1043,24 @@ void outblkexitcode(ref CodeBuilder cdb, block* bl, ref int anyspill, const(FL)*
         }
 
         case BC._try:
-            if (config.ehmethod == EHmethod.EH_NONE || funcsym_p.Sfunc.Fflags3 & Feh_none)
+            if (config.ehmethod == EHmethod.EH_DM || ehmethod(funcsym_p) == EHmethod.EH_NONE)
             {
                 /* Need to use frame pointer to access locals, not the stack pointer,
                  * because we'll be calling the BC._finally blocks and the stack will be off.
                  */
                 cgstate.needframe = 1;
             }
-            else if (config.ehmethod == EHmethod.EH_SEH || config.ehmethod == EHmethod.EH_WIN32)
+
+            if (config.ehmethod == EHmethod.EH_SEH || config.ehmethod == EHmethod.EH_WIN32)
             {
                 cgstate.usednteh |= NTEH_try;
                 nteh_usevars();
             }
-            else
+            else if (ehmethod(funcsym_p) != EHmethod.EH_NONE)
+            {
                 cgstate.usednteh |= EHtry;
+            }
+
             goto case_goto;
 
         case BC._finally:

--- a/compiler/test/runnable/nested.d
+++ b/compiler/test/runnable/nested.d
@@ -2526,6 +2526,27 @@ void test14846()
     foo14846({ S* p = new S(1); });
     foo14846({ S[] a = [S()]; });
     foo14846({ S[] a = [S(1)]; });
+
+    void named1()
+    {
+        S s;
+    }
+
+    foo14846(&named1);
+
+    void named2()
+    {
+        S s = S(1);
+    }
+
+    foo14846(&named2);
+
+    void named3()
+    {
+        S[3] s;
+    }
+
+    foo14846(&named3);
 }
 
 /*******************************************/


### PR DESCRIPTION
Fixes #22008. I wonder why the test misses the case of named functions, which have different code paths in the frontend inliner.