### PR TITLE
fix #22048 #including <windows.h> emits warnings from driverspecs.h and no_sal2.h

### DIFF
--- a/compiler/test/compilable/test22048.c
+++ b/compiler/test/compilable/test22048.c
@@ -1,0 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+#ifdef _MSCVER
+#include <windows.h>
+#endif

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -158,10 +158,9 @@ typedef unsigned long long __uint64_t;
 #define _stdcall __stdcall
 #define _declspec __declspec
 
-// This header disables the Windows API Annotations macros
-// Need to include sal.h to get the pragma once to prevent macro redefinition.
-#include "sal.h"
-#include "no_sal2.h"
+// disable the Microsoft Source Code Annotation macros in "sal.h"
+#define _USE_DECLSPECS_FOR_SAL 0
+#define _USE_ATTRIBUTES_FOR_SAL 0
 #endif
 
 /****************************


### PR DESCRIPTION
use appropriate definitions to disable Microsoft Source Code Annotation macros instead of #including the respective headers prematurely

More efficient and decouples importc from requiring an existing SDK.