### PR TITLE
avoid spurious Windows CI test failure in druntime/test/shared

### DIFF
--- a/druntime/test/shared/Makefile
+++ b/druntime/test/shared/Makefile
@@ -33,7 +33,7 @@ PATH := $(dir $(DRUNTIMESO));$(PATH)
 endif
 
 $(ROOT)/dllgc.done: $(ROOT)/dllgc$(DOTDLL)
-$(ROOT)/dllgc$(DOTDLL): extra_dflags += -version=DLL
+$(ROOT)/dllgc$(DOTDLL): extra_dflags += -version=DLL -od=$(ROOT)/dll
 endif # Windows
 
 $(ROOT)/dynamiccast.done: $(ROOT)/%.done: $(ROOT)/%$(DOTEXE) $(ROOT)/%$(DOTDLL)
@@ -44,7 +44,7 @@ $(ROOT)/dynamiccast.done: $(ROOT)/%.done: $(ROOT)/%$(DOTEXE) $(ROOT)/%$(DOTDLL)
 	test -f $(ROOT)/dynamiccast_endmain
 	@touch $@
 $(ROOT)/dynamiccast$(DOTEXE): private extra_ldlibs.d += $(LINKDL)
-$(ROOT)/dynamiccast$(DOTDLL): private extra_dflags += -version=DLL
+$(ROOT)/dynamiccast$(DOTDLL): private extra_dflags += -version=DLL -od=$(ROOT)/dll
 
 # Avoid a race condition that I sometimes hit with make -j8.
 # Maybe temporary file collisions when invoking the linker?


### PR DESCRIPTION
tests dllgc and dynamiccast compile both executable and shared library from the same source file, but the DLL with -version=DLL. Both targets have the same intermediate object file which can cause both build and runtime errors when building concurrently.

Solution: generate object files for DLLs to a different directory