### PR TITLE
more changes for OSX-specific ABI

### DIFF
--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -221,7 +221,7 @@ void storeToEA(ref code cs, reg_t reg, uint sz)
         {
             // STR reg,[cs.base, #offset]
             assert(cs.index == NOREG);
-            uint imm12 = cast(uint)cs.IEV1.Voffset;
+            uint imm12 = 0; // addaddrc() will add in cast(uint)cs.IEV1.Voffset;
             uint size, opc;
             INSTR.szToSizeOpc(sz, size, opc);
             imm12 /= sz;
@@ -1627,6 +1627,9 @@ void callclib(ref CodeBuilder cdb, elem* e, uint clib, ref regm_t pretregs, regm
 
 /*******************************
  * Generate code sequence for function call.
+ * The difference between the OSX argument passing convention and the AAPCS64
+ * convention is:
+ * https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
  */
 
 @trusted

--- a/compiler/src/dmd/backend/arm/cod2.d
+++ b/compiler/src/dmd/backend/arm/cod2.d
@@ -200,7 +200,7 @@ void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
  */
 Extend tyToExtend(tym_t ty)
 {
-    //debug printf("ty: %s\n", tym_str(ty));
+    //debug printf("ty: %s x%x\n", tym_str(ty), ty);
     ty = tybasic(ty);
     assert(tyintegral(ty) || ty == TYnptr);
     Extend extend;

--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -491,6 +491,7 @@ private void epilog_restoreregs(ref CGstate cg, ref CodeBuilder cdb, regm_t topo
 void prolog_genvarargs(ref CGstate cg, ref CodeBuilder cdb, Symbol* sv)
 {
     printf("prolog_genvarargs()\n");
+    symbol_print(*sv);
 
     /* Generate code to move any arguments passed in registers into
      * the stack variable __va_argsave,
@@ -506,7 +507,7 @@ void prolog_genvarargs(ref CGstate cg, ref CodeBuilder cdb, Symbol* sv)
      *         int gr_offs;  // offset from gr_top to next GP register arg
      *         int vr_offs;  // offset from vr_top to next FP/SIMD register arg
      *     }
-     *     void* stack_args_save; // set by prolog_genvarargs()
+     *     void* stack_args_save; // set to start of variadics on stack
      *   }
      * The instructions seg fault if data is not aligned on
      * 16 bytes, so this gives us a nice check to ensure no mistakes.
@@ -528,34 +529,39 @@ void prolog_genvarargs(ref CGstate cg, ref CodeBuilder cdb, Symbol* sv)
         STR     q6,[sp, #voff+8*8+6*16]
         STR     q7,[sp, #voff+8*8+7*16]
 
-        ADD     reg,sp,Para.size+Para.offset
-        STR     reg,[sp,#voff+8*8+8*16+8*4]         // set __va_argsave.stack_args
+        ADD     reg,sp,Para.size+Para.offset        // offset of start of variadic arguments on stack
+        STR     reg,[sp,#voff+8*8+8*16+8*3+4*2]     // set __va_argsave.stack_args_save
     */
+
+    CodeBuilder cdbx; cdbx.ctor();
 
     /* Save registers into the voff area on the stack
      */
-    targ_size_t voff = cg.Auto.size + cg.BPoff + sv.Soffset;  // EBP offset of start of sv
 
-    if (!cg.hasframe || cg.enforcealign)
-        voff += cg.EBPtoESP;
-    printf("voff: %llx\n", voff);
+    code cs;
+    cs.reg = NOREG;
+    cs.base = (!cg.hasframe || cg.enforcealign) ? 31 : 29; // SP or BP
+    cs.index = NOREG;
 
     /* OSX AArch64 never passes variadic arguments in registers,
      * so no need to transfer them to memory
      */
-    if (!(config.exe & EX_OSX64))
+    if (1 || !(config.exe & EX_OSX64))
     {
+        cs.IEV1.Vsym = sv;
+        cs.IFL1 = sv.Sfl;
+        cs.Iflags = CFoff;
+        cgstate.reflocal = true;
+
         regm_t namedargs = prolog_namedArgs();
         foreach (reg_t x; 0 .. 8)
         {
             if (!(mask(x) & namedargs))  // unnamed arguments would be the ... ones
             {
-                //printf("offset: x%x %lld\n", cast(uint)voff + x * 8, voff + x * 8);
-                uint offset = cast(uint)voff + x * 8;
-                if (!cg.hasframe || cg.enforcealign)
-                    cdb.gen1(INSTR.str_imm_gen(1,x,31,offset)); // STR x,[sp,#offset]
-                else
-                    cdb.gen1(INSTR.str_imm_gen(1,x,29,offset)); // STR x,[bp,#offset]
+                cs.IEV1.Voffset = 0;
+                storeToEA(cs,x,8);                              // STR X,[sp/bp,#offset]
+                cs.IEV1.Voffset = x * 8;
+                cdbx.gen(&cs);
             }
         }
 
@@ -563,30 +569,45 @@ void prolog_genvarargs(ref CGstate cg, ref CodeBuilder cdb, Symbol* sv)
         {
             if (!(mask(q) & namedargs))  // unnamed arguments would be the ... ones
             {
-                reg_t fp = (!cg.hasframe || cg.enforcealign) ? 31 : 29; // SP : BP
-                uint offset = cast(uint)voff + 8 * 8 + (q & 31) * 16;
-                offset /= 16;                                     // saving 128 bit Q registers
-                cdb.gen1(INSTR.str_imm_fpsimd(0,2,offset,fp,q));  // STR q,[sp,#offset]
+                cs.IEV1.Voffset = 0;
+                storeToEA(cs,q,16);      // STR q,[sp/bp,#offset]
+                cs.IEV1.Voffset = 8 * 8 + (q & 31) * 16;
+                cdbx.gen(&cs);
             }
         }
     }
 
     reg_t reg = 11;
     uint imm12 = cast(uint)(cg.Para.size + cg.Para.offset);
-    assert(imm12 < 0x1000);  // BUG AArch64
-    cdb.gen1(INSTR.addsub_imm(1,0,0,0,imm12,31,reg));   // ADD reg,sp,imm12
-    uint offset = cast(uint)voff+8*8+8*16+8*4;
-    printf("voff: %llx offset: %x\n", voff, offset);
-    assert(offset < 0x1000); // BUG AArch64
-    cdb.gen1(INSTR.str_imm_gen(1,reg,31,offset));       // STR reg,[sp,#voff+8*8+8*16+8*4]
+    assert(imm12 < 0x1000);  // BUG AArch64 overflow check
+    cdbx.gen1(INSTR.addsub_imm(1,0,0,0,imm12,31,reg));   // ADD reg,sp,imm12
+
+    cs.IEV1.Voffset = 8*8+8*16+8*4;             // va_argsave_t.stack_args_save.offsetof
+    storeToEA(cs,reg,8);                        // STR reg,[sp,#va_argsave_t + 8*8+8*16+8*4]
+    cdbx.gen(&cs);
+
     useregs(mask(reg));
+
+    code* cx = cdbx.finish();
+    if (cx)
+    {
+        static if (0)
+        for (code* c = cx; c; c = code_next(c))
+        {
+            printf("Iop %08x  ", c.Iop);
+            disassemble(c.Iop);
+        }
+
+        assignaddrc(cx);
+        cdb.append(cx);
+    }
 }
 
 /********************************
- * Generate elem that implement va_start()
+ * Generate elem that implements va_start()
  * Params:
  *      sv = symbol for __va_argsave
- *      parmn = last named parameter
+ *      parmn = last named parameter (ignored for now)
  * Returns:
  *      elem that initializes all __va_list_tag fields
  */
@@ -685,29 +706,37 @@ elem* prolog_genva_start(Symbol* sv, Symbol* parmn)
      * Then, just copy from `stack_args_save` to `stack_args`.
      * Although, doing (1) might be optimal.
      */
-    elem* e1 = el_bin(OPeq, TYnptr, el_var(sv), el_var(sv)); // stack = stack_args_save
+
+
+    /*
+        sv.stack = sv.stack_args_save;
+        sv.gr_top = &sv.regs[8];
+        sv.vr_top = &sv.fpregs[8];
+        sv.gr_offs = -(8 - named_gr) * 8;
+        sv.vr_offs = -(8 - named_vr) * 16;
+     */
+
+    elem* e1 = el_bin(OPeq, TYnptr, el_var(sv), el_var(sv)); // sv.stack = sv.stack_args_save
     e1.E1.Ety = TYnptr;
     e1.E1.Voffset = OFF.stack;
     e1.E2.Ety = TYnptr;
     e1.E2.Voffset = OFF.stack_args_save;
 
-    // set gr_top to address following the general register save area
-    elem* e2 = el_bin(OPeq, TYptr, el_var(sv), el_ptr(sv));
-    e2.E1.Voffset = OFF.vr_offs;
+    elem* e2 = el_bin(OPeq, TYnptr, el_var(sv), el_ptr(sv));  // sv.gr_top = &sv.regs[8]
+    e2.E1.Ety = TYnptr;
+    e2.E1.Voffset = OFF.gr_top;
+    e2.E2.Voffset = 8*8;
 
-    // set vr_top to address following the FP/SIMD register save area
-    elem* ex3 = el_bin(OPadd, TYptr, el_ptr(sv), el_long(TYlong, 8 * 8));
-    elem* e3 = el_bin(OPeq,TYptr,el_var(sv),ex3);
-    e3.E1.Ety = TYptr;
-    e3.E1.Voffset = OFF.vr_offs;
+    elem* e3 = el_bin(OPeq,TYnptr,el_var(sv),el_ptr(sv)); // sv.vr_top = &sv.fpregs[8];
+    e3.E1.Ety = TYnptr;
+    e3.E1.Voffset = OFF.vr_top;
+    e3.E2.Voffset = 8*8 + 16*8;
 
-    // set gr_offs
-    elem* e4 = el_bin(OPeq, TYint, el_var(sv), el_long(TYint, 0 - ((8 - named_gr) * 8)));
+    elem* e4 = el_bin(OPeq, TYint, el_var(sv), el_long(TYint, 0 - ((8 - named_gr) * 8))); // sv.gr_offs = -(8 - named_gr) * 8;
     e4.E1.Ety = TYint;
     e4.E1.Voffset = OFF.gr_offs;
 
-    // set vr_offs
-    elem* e5 = el_bin(OPeq, TYint, el_var(sv), el_long(TYint, 0 - ((8 - named_vr) * 16)));
+    elem* e5 = el_bin(OPeq, TYint, el_var(sv), el_long(TYint, 0 - ((8 - named_vr) * 16))); // sv.vr_offs = -(8 - named_vr) * 16;
     e5.E1.Ety = TYint;
     e5.E1.Voffset = OFF.vr_offs;
 

--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -5540,7 +5540,9 @@ private elem* elclassinit(elem* e, Goal goal)
 }
 
 /********************************************
- * Handle OPva_start
+ * OPva_start
+ *     /  \
+ *   ap    parmn
  */
 
 @trusted
@@ -5618,14 +5620,14 @@ if (config.exe & EX_windos)
     else
         e.E2 = el_long(TYnptr, 0);
     //elem_print(e);
-
+    return e;
 }
 
 if (config.exe & EX_posix)
 {
     assert(I64); // va_start is not an intrinsic on 32-bit
     // (OPva_start &va)
-    // (OPeq (OPind E1) __va_argsave+offset)
+    // (OPeq (OPind E1) &__va_argsave+offset)
     //elem_print(e);
 
     // Find __va_argsave
@@ -5653,9 +5655,10 @@ if (config.exe & EX_posix)
     else
         e.E2 = el_long(TYnptr, 0);
     //elem_print(e);
+    return e;
 }
 
-    return e;
+    assert(0);
 }
 
 /******************************************

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -397,9 +397,9 @@ void cod3_setAArch64()
     /* Register usage per "AArch64 Procedure Call Standard"
      * r31 SP  Stack Pointer
      * r30 LR  Link Register
-     * r29 FP  Frame Pointer (BP)
+     * r29 FP  Frame Pointer (BP) (on OSX r29 must always address a valid frame record)
      * r19-r28 Callee-saved registers (if Callee modifies them)
-     * r18     Platform Register
+     * r18     Platform Register (do not use on OSX)
      * r17 IP1 intra-procedure-call temporary register
      * r16 IP0 intra-procedure-call scratch register
      * r9-r15  temporary registers (caller saved)
@@ -410,11 +410,11 @@ void cod3_setAArch64()
      * v8-v15  Callee-saved registers (only bottom 64 bits need to be saved)
      * v16-31  Temporary registers (caller saved)
      */
-    cgstate.BP = 29;
+    cgstate.BP = INSTR.BP;
 
     /* Integer registers r0-r7, r9-15, r19-28, r29(?)
      */
-    cgstate.allregs = 0x1FFF_FFFF & ~(1 << 8) & ~(1 << 16) & ~(1 << 17) & ~(1 << 18);
+    cgstate.allregs = INSTR.ALLREGS;
 
     /* Registers x19-x28, x29, v8-v15
      */
@@ -424,7 +424,7 @@ void cod3_setAArch64()
 
     /* 32 Floating point registers
      */
-    cgstate.fpregs = 0xFFFF_FFFF_0000_0000;
+    cgstate.fpregs = INSTR.FLOATREGS;
 
     /* XMM registers
      */

--- a/compiler/src/dmd/glue/toir.d
+++ b/compiler/src/dmd/glue/toir.d
@@ -590,7 +590,7 @@ int intrinsic_op(FuncDeclaration fd)
     return op;
 
 Lva_start:
-    if (target.isX86_64 &&
+    if ((target.isX86_64 || target.isAArch64) &&
         fd.toParent().isTemplateInstance() &&
         id3 == Id.va_start &&
         id2 == Id.stdarg &&


### PR DESCRIPTION
I went down the wrong path of the OSX varargs. I had to back it all out, but left these improvements. Did some updating for OSX register conventions. Redid prolog_genvarargs() to use assignaddrc() for fixing offsets rather than badly reinventing it.