### PR TITLE
redid parameter locations on stack for osx

### DIFF
--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -52,7 +52,11 @@ void error(T...)(Srcpos srcPos, const(char)* format, T args)
 @safe:
 
 /***********************************
- * Returns: aligned `offset` if it is of size `size`.
+ * Params:
+ *      size = alignment size
+ *      offset = increase until it is on a `size` boundary
+ * Returns:
+ *      aligned `offset`
  */
 targ_size_t _align(targ_size_t size, targ_size_t offset) @trusted
 {

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -5540,8 +5540,10 @@ elem* callfunc(Loc loc,
 
             /* Do integral promotions. This is not necessary per the C ABI, but
              * some code from the C world seems to rely on it.
+             * OSX AAPCS64 relies on no promotion.
              */
-            if (op == NotIntrinsic && tyintegral(ea.Ety) && arg.type.size(arg.loc) < 4)
+            const osx_aapcs64 = irs.target.isAArch64 && irs.target.os == Target.OS.OSX;
+            if (op == NotIntrinsic && tyintegral(ea.Ety) && arg.type.size(arg.loc) < 4 && !osx_aapcs64)
             {
                 if (ea.Eoper == OPconst)
                 {


### PR DESCRIPTION
The Apple documentation for this is rather wretched:

https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms

and it doesn't line up with how it actually works. The parameters in the C code:
```
int func(char a0, char a1, char a2, char a3, char a4, char a5, char a6, char a7, char a8, short a9, int a10) {  return a8 + a9; }

int call() { return func(0,1,2,3,4,5,6,7,8,9,10); }

```
generated code for parameters a8, a9, a10:
```
      5c: 910003e9      mov     x9, sp
      60: 52800108      mov     w8, #0x8                ; =8
      64: 39000128      strb    w8, [x9]
      68: 52800128      mov     w8, #0x9                ; =9
      6c: 79000528      strh    w8, [x9, #0x2]
      70: 52800148      mov     w8, #0xa                ; =10
      74: b9000528      str     w8, [x9, #0x4]
```
The spec says the caller pads them out to 32 bits, but the gcc generated code does not.

As usual, it is necessary to reverse engineer this protocol.