### PR TITLE
CI: allow dmd test run arguments to be grouped with quotes …

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -121,7 +121,7 @@ test_dmd() {
     if [ "$FULL_BUILD" == "true" ] && [ "$OS_NAME" == "linux" ]; then
         local args=() # use all default ARGS
     else
-        local args=(ARGS="-O -inline -release")
+        local args=(ARGS="-inline '-O -release'")
     fi
 
     if type -P apk &>/dev/null; then


### PR DESCRIPTION
…so they don't generate as many combinations

apply to the slower CI builds by combining -O and -release