### PR TITLE
OSX AAPCS64 does integral promotions on varargs

### DIFF
--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -5542,7 +5542,7 @@ elem* callfunc(Loc loc,
              * some code from the C world seems to rely on it.
              * OSX AAPCS64 relies on no promotion.
              */
-            const osx_aapcs64 = irs.target.isAArch64 && irs.target.os == Target.OS.OSX;
+            const osx_aapcs64 = false; //irs.target.isAArch64 && irs.target.os == Target.OS.OSX;
             if (op == NotIntrinsic && tyintegral(ea.Ety) && arg.type.size(arg.loc) < 4 && !osx_aapcs64)
             {
                 if (ea.Eoper == OPconst)


### PR DESCRIPTION
I misunderstood. Fixed.