### PR TITLE
Fix hash collision in CSE

### DIFF
--- a/compiler/src/dmd/backend/cgcs.d
+++ b/compiler/src/dmd/backend/cgcs.d
@@ -524,9 +524,9 @@ void ecom(ref CGCS cgcs, ref elem* pe)
                  */
                 if (!OTleaf(op))
                 {
-                    if (e.E1 != ehash.E1)
+                    if (e.E1 != ehash.E1 || !e.E1.Ecount)
                         continue;
-                    if (OTbinary(op) && e.E2 != ehash.E2)
+                    if (OTbinary(op) && (e.E2 != ehash.E2 || !e.E2.Ecount))
                         continue;
                 }
 

--- a/compiler/src/dmd/backend/cgcs.d
+++ b/compiler/src/dmd/backend/cgcs.d
@@ -513,31 +513,40 @@ void ecom(ref CGCS cgcs, ref elem* pe)
                 printf("i: %2d Hhash: %6d Helem: %p\n",
                        cast(int) i,hcs.Hhash,hcs.Helem);
 
-            elem* ehash;
-            if (hash == hcs.Hhash && (ehash = hcs.Helem) != null)
+            if (hash == hcs.Hhash && hcs.Helem != null)
             {
-                /* if elems are the same and we still have room for more    */
-                if (el_match(e,ehash) && ehash.Ecount < 0xFF)
+                elem* ehash = hcs.Helem;
+
+                /* Make sure leaves are already merged as common subexpressions
+                 * before trying to merge the current node with a candidate.
+                 * Otherwise, hash collisions can result in invalid CSE
+                 * (i.e. if a leaf has been clobbered by assignment).
+                 */
+                if (!OTleaf(op))
                 {
-                    /* Make sure leaves are also common subexpressions
-                     * to avoid false matches.
-                     */
-                    if (!OTleaf(op))
-                    {
-                        if (!e.E1.Ecount)
-                            continue;
-                        if (OTbinary(op) && !e.E2.Ecount)
-                            continue;
-                    }
-                    ehash.Ecount++;
-                    pe = ehash;
-
-                    debug if (debugx)
-                        printf("**MATCH** %p with %p\n",e,pe);
-
-                    el_free(e);
-                    return;
+                    if (e.E1 != ehash.E1)
+                        continue;
+                    if (OTbinary(op) && e.E2 != ehash.E2)
+                        continue;
                 }
+
+                /* Compare parents (the entire subtrees in fact) only when
+                 * the children are eligible, which significantly speeds up
+                 * common subexpression matching. Also, check for overflow.
+                 */
+                if (!el_match(e, ehash) || ehash.Ecount == 0xFF)
+                {
+                    continue;
+                }
+
+                ehash.Ecount++;
+                pe = ehash;
+
+                debug if (debugx)
+                    printf("**MATCH** %p with %p\n",e,pe);
+
+                el_free(e);
+                return;
             }
         }
     }


### PR DESCRIPTION
In `cgcs.d`, assignment ops clobber CSE of a symbol, but weirdly do not clobber any larger common expressions referencing it. The checks to avoid false matches are a kludge. Instead, this PR now requires all leaf nodes to have already been merged by CSE before eliminating a larger expression. As a result, DMD's CSE is now immune to hash collision (in terms of correctness). This hopefully fixes #20985 (worked for a few hundred builds on my machine yet still unsure).

On the downside, DMD's optimization is slightly weaker again. I think maybe very few people will care.