### PR TITLE
fix(GC): Fix issue with GC thread cleanup routine being called with unregistered thread

### DIFF
--- a/druntime/src/core/gc/gcinterface.d
+++ b/druntime/src/core/gc/gcinterface.d
@@ -292,12 +292,10 @@ interface GC
      * (from the registry hook) should assume this function may not be called
      * on termination if the GC is never initialized.
      *
-     * Most times, this is called from the thread that is the given thread
-     * reference, but it's possible the `thread` parameter is not the same as
-     * the current thread.
-     *
-     * There is no guarantee the thread is still registered as
-     * `ThreadBase.getThis()`.
+     * This function is only called from a thread that was started from the D
+     * runtime, and is terminating. The GC can assume the thread is still in
+     * the list of running threads and can be paused for a GC cycle. This is
+     * not called for the main thread which initialized the GC.
      */
     void cleanupThread(ThreadBase thread) nothrow @nogc;
 }

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -2351,6 +2351,10 @@ version (Windows)
 
             scope (exit)
             {
+                // allow the GC to clean up any resources it allocated for this thread.
+                import core.internal.gc.proxy : gc_getProxy;
+                gc_getProxy().cleanupThread(obj);
+
                 Thread.remove(obj);
                 obj.destroyDataStorage();
             }
@@ -2482,6 +2486,10 @@ else version (Posix)
 
             scope (exit)
             {
+                // allow the GC to clean up any resources it allocated for this thread.
+                import core.internal.gc.proxy : gc_getProxy;
+                gc_getProxy().cleanupThread(obj);
+
                 Thread.remove(obj);
                 atomicStore!(MemoryOrder.raw)(obj.m_isRunning, false);
                 obj.destroyDataStorage();

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -150,10 +150,6 @@ class ThreadBase
 
     package void destroyDataStorage() nothrow @nogc
     {
-        // allow the GC to clean up any resources it allocated for this thread.
-        import core.internal.gc.proxy : gc_getProxy;
-        gc_getProxy().cleanupThread(this);
-
         rt_tlsgc_destroy(m_tlsrtdata);
         m_tlsrtdata = null;
     }


### PR DESCRIPTION
See symgc related issue: https://github.com/symmetryinvestments/symgc/issues/40 for more details on the race condition.