### PR TITLE
Move `Expression.toInteger` and `Expression.toUInteger` to `expressionsem`

### DIFF
--- a/compiler/src/dmd/argtypes_aarch64.d
+++ b/compiler/src/dmd/argtypes_aarch64.d
@@ -15,6 +15,7 @@ import dmd.astenums;
 import dmd.dsymbolsem : isPOD;
 import dmd.mtype;
 import dmd.typesem;
+import dmd.expressionsem : toUInteger;
 
 /****************************************************
  * This breaks a type down into 'simpler' types that can be passed to a function

--- a/compiler/src/dmd/argtypes_sysv_x64.d
+++ b/compiler/src/dmd/argtypes_sysv_x64.d
@@ -16,6 +16,7 @@ import dmd.declaration;
 import dmd.dsymbolsem : isPOD;
 import dmd.mtype;
 import dmd.typesem;
+import dmd.expressionsem : toInteger;
 import dmd.target;
 import dmd.visitor;
 

--- a/compiler/src/dmd/argtypes_x86.d
+++ b/compiler/src/dmd/argtypes_x86.d
@@ -17,6 +17,7 @@ import core.checkedint;
 import dmd.astenums;
 import dmd.declaration;
 import dmd.dsymbolsem : isPOD;
+import dmd.expressionsem : toInteger;
 import dmd.location;
 import dmd.mtype;
 import dmd.typesem;

--- a/compiler/src/dmd/builtin.d
+++ b/compiler/src/dmd/builtin.d
@@ -17,6 +17,7 @@ import dmd.arraytypes;
 import dmd.astenums;
 import dmd.errors;
 import dmd.expression;
+import dmd.expressionsem : toInteger;
 import dmd.func;
 import dmd.location;
 import dmd.mangle;

--- a/compiler/src/dmd/compiler.d
+++ b/compiler/src/dmd/compiler.d
@@ -19,6 +19,7 @@ import dmd.ctfeexpr;
 import dmd.dmodule;
 import dmd.errors;
 import dmd.expression;
+import dmd.expressionsem : toInteger;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;

--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -25,7 +25,7 @@ import dmd.declaration;
 import dmd.dstruct;
 import dmd.errors;
 import dmd.expression;
-import dmd.expressionsem : getField, isIdentical, toBool;
+import dmd.expressionsem : getField, isIdentical, toBool, toInteger, toUInteger;
 import dmd.globals;
 import dmd.location;
 import dmd.mtype;

--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -25,7 +25,7 @@ import dmd.dstruct;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
-import dmd.expressionsem : isIdentical, getFieldIndex, toBool, toStringExp;
+import dmd.expressionsem : isIdentical, getFieldIndex, toBool, toStringExp, toInteger;
 import dmd.func;
 import dmd.globals : dinteger_t, sinteger_t, uinteger_t;
 import dmd.location;

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -436,6 +436,18 @@ StringExp toStringExp(Expression exp)
     return dmd.expressionsem.toStringExp(exp);
 }
 
+dinteger_t toInteger(Expression exp)
+{
+    import dmd.expressionsem;
+    return dmd.expressionsem.toInteger(exp);
+}
+
+uinteger_t toUInteger(Expression exp)
+{
+    import dmd.expressionsem;
+    return dmd.expressionsem.toUInteger(exp);
+}
+
 /***********************************************************
  * func.d
  */

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -20,6 +20,7 @@ import dmd.astenums;
 import dmd.arraytypes;
 import dmd.dsymbolsem;
 import dmd.templatesem : computeOneMember;
+import dmd.expressionsem : toInteger;
 import dmd.errors;
 import dmd.errorsink;
 import dmd.globals;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -294,22 +294,6 @@ extern (C++) abstract class Expression : ASTNode
         return a;
     }
 
-    dinteger_t toInteger()
-    {
-        // import dmd.hdrgen : EXPtoString;
-        //printf("Expression %s\n", EXPtoString(op).ptr);
-        if (!type || !type.isTypeError())
-            error(loc, "integer constant expression expected instead of `%s`", toChars());
-        return 0;
-    }
-
-    uinteger_t toUInteger()
-    {
-        // import dmd.hdrgen : EXPtoString;
-        //printf("Expression %s\n", EXPtoString(op).ptr);
-        return cast(uinteger_t)toInteger();
-    }
-
     real_t toReal()
     {
         error(loc, "floating point constant expression expected instead of `%s`", toChars());
@@ -569,12 +553,6 @@ extern (C++) final class IntegerExp : Expression
         return new IntegerExp(loc, value, type);
     }
 
-    override dinteger_t toInteger()
-    {
-        // normalize() is necessary until we fix all the paints of 'type'
-        return value = normalize(type.toBasetype().ty, value);
-    }
-
     override real_t toReal()
     {
         // normalize() is necessary until we fix all the paints of 'type'
@@ -611,7 +589,7 @@ extern (C++) final class IntegerExp : Expression
         this.value = normalize(type.toBasetype().ty, value);
     }
 
-    extern (D) private static dinteger_t normalize(TY ty, dinteger_t value)
+    extern (D) static dinteger_t normalize(TY ty, dinteger_t value)
     {
         /* 'Normalize' the value of the integer to be in range of the type
          */
@@ -798,16 +776,6 @@ extern (C++) final class RealExp : Expression
         return new RealExp(loc, value, type);
     }
 
-    override dinteger_t toInteger()
-    {
-        return cast(sinteger_t)toReal();
-    }
-
-    override uinteger_t toUInteger()
-    {
-        return cast(uinteger_t)toReal();
-    }
-
     override real_t toReal()
     {
         return type.isReal() ? value : CTFloat.zero;
@@ -847,16 +815,6 @@ extern (C++) final class ComplexExp : Expression
     static ComplexExp create(Loc loc, complex_t value, Type type) @safe
     {
         return new ComplexExp(loc, value, type);
-    }
-
-    override dinteger_t toInteger()
-    {
-        return cast(sinteger_t)toReal();
-    }
-
-    override uinteger_t toUInteger()
-    {
-        return cast(uinteger_t)toReal();
     }
 
     override real_t toReal()

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -66,6 +66,8 @@ namespace dmd
     void fillTupleExpExps(TupleExp *te, TupleDeclaration *tup);
     Optional<bool> toBool(Expression *exp);
     StringExp *toStringExp(Expression *exp);
+    dinteger_t toInteger(Expression *exp);
+    uinteger_t toUInteger(Expression *exp);
 }
 
 typedef unsigned char OwnedBy;
@@ -101,8 +103,6 @@ public:
 
     const char* toChars() const final override;
 
-    virtual dinteger_t toInteger();
-    virtual uinteger_t toUInteger();
     virtual real_t toReal();
     virtual real_t toImaginary();
     virtual complex_t toComplex();
@@ -238,7 +238,6 @@ public:
     dinteger_t value;
 
     static IntegerExp *create(Loc loc, dinteger_t value, Type *type);
-    dinteger_t toInteger() override;
     real_t toReal() override;
     real_t toImaginary() override;
     complex_t toComplex() override;
@@ -262,8 +261,6 @@ public:
     real_t value;
 
     static RealExp *create(Loc loc, real_t value, Type *type);
-    dinteger_t toInteger() override;
-    uinteger_t toUInteger() override;
     real_t toReal() override;
     real_t toImaginary() override;
     complex_t toComplex() override;
@@ -276,8 +273,6 @@ public:
     complex_t value;
 
     static ComplexExp *create(Loc loc, complex_t value, Type *type);
-    dinteger_t toInteger() override;
-    uinteger_t toUInteger() override;
     real_t toReal() override;
     real_t toImaginary() override;
     complex_t toComplex() override;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -100,6 +100,46 @@ import dmd.visitor.postorder;
 
 enum LOGSEMANTIC = false;
 
+dinteger_t toInteger(Expression _this)
+{
+    if (auto iexp = _this.isIntegerExp())
+    {
+        // normalize() is necessary until we fix all the paints of 'type'
+        return iexp.value = IntegerExp.normalize(iexp.type.toBasetype().ty, iexp.value);
+    }
+    else if (auto rexp = _this.isRealExp())
+    {
+        return cast(sinteger_t)rexp.toReal();
+    }
+
+    else if (auto cexp = _this.isComplexExp())
+    {
+        return cast(sinteger_t)cexp.toReal();
+    }
+
+    // import dmd.hdrgen : EXPtoString;
+    //printf("Expression %s\n", EXPtoString(op).ptr);
+    if (!_this.type || !_this.type.isTypeError())
+        error(_this.loc, "integer constant expression expected instead of `%s`", _this.toChars());
+    return 0;
+}
+
+uinteger_t toUInteger(Expression _this)
+{
+    if (auto rexp = _this.isRealExp())
+    {
+        return cast(uinteger_t)rexp.toReal();
+    }
+    else if (auto cexp = _this.isComplexExp())
+    {
+        return cast(uinteger_t)cexp.toReal();
+    }
+    // import dmd.hdrgen : EXPtoString;
+    //printf("Expression %s\n", EXPtoString(op).ptr);
+    return cast(uinteger_t)_this.toInteger();
+}
+
+
 /***************************************************
  * Given an Expression, find the variable it really is.
  *

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2351,8 +2351,6 @@ public:
     virtual Expression* syntaxCopy();
     DYNCAST dyncast() const final override;
     const char* toChars() const final override;
-    virtual dinteger_t toInteger();
-    virtual uinteger_t toUInteger();
     virtual _d_real toReal();
     virtual _d_real toImaginary();
     virtual complex_t toComplex();
@@ -2725,8 +2723,6 @@ class ComplexExp final : public Expression
 public:
     complex_t value;
     static ComplexExp* create(Loc loc, complex_t value, Type* type);
-    dinteger_t toInteger() override;
-    uinteger_t toUInteger() override;
     _d_real toReal() override;
     _d_real toImaginary() override;
     complex_t toComplex() override;
@@ -3200,7 +3196,6 @@ class IntegerExp final : public Expression
 public:
     dinteger_t value;
     static IntegerExp* create(Loc loc, dinteger_t value, Type* type);
-    dinteger_t toInteger() override;
     _d_real toReal() override;
     _d_real toImaginary() override;
     complex_t toComplex() override;
@@ -3429,8 +3424,6 @@ class RealExp final : public Expression
 public:
     _d_real value;
     static RealExp* create(Loc loc, _d_real value, Type* type);
-    dinteger_t toInteger() override;
-    uinteger_t toUInteger() override;
     _d_real toReal() override;
     _d_real toImaginary() override;
     complex_t toComplex() override;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2298,10 +2298,6 @@ enum class EXP : uint8_t
     rvalue = 128u,
 };
 
-typedef uint64_t dinteger_t;
-
-typedef uint64_t uinteger_t;
-
 struct complex_t final
 {
     _d_real re;
@@ -3190,6 +3186,8 @@ public:
     IndexExp* syntaxCopy() override;
     void accept(Visitor* v) override;
 };
+
+typedef uint64_t dinteger_t;
 
 class IntegerExp final : public Expression
 {

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -48,7 +48,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem : include, _isZeroInit, toAlias, isPOD;
 import dmd.dtemplate;
 import dmd.expression;
-import dmd.expressionsem : fill, isIdentical, isLvalue;
+import dmd.expressionsem : fill, isIdentical, isLvalue, toInteger, toUInteger;
 import dmd.func;
 import dmd.hdrgen;
 import dmd.id;

--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -58,6 +58,7 @@ import dmd.dmodule;
 import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dsymbolsem : getLocalClasses, getType;
+import dmd.expressionsem : toInteger;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;

--- a/compiler/src/dmd/glue/s2ir.d
+++ b/compiler/src/dmd/glue/s2ir.d
@@ -38,7 +38,7 @@ import dmd.dsymbol;
 import dmd.dstruct;
 import dmd.dtemplate;
 import dmd.expression;
-import dmd.expressionsem : getDsymbol;
+import dmd.expressionsem : getDsymbol, toInteger;
 import dmd.func;
 import dmd.id;
 import dmd.init;

--- a/compiler/src/dmd/glue/toctype.d
+++ b/compiler/src/dmd/glue/toctype.d
@@ -29,6 +29,7 @@ import dmd.denum;
 import dmd.dmdparams;
 import dmd.dstruct;
 import dmd.dsymbolsem : isPOD;
+import dmd.expressionsem : toInteger;
 import dmd.globals;
 import dmd.id;
 import dmd.mtype;

--- a/compiler/src/dmd/glue/tocvdebug.d
+++ b/compiler/src/dmd/glue/tocvdebug.d
@@ -30,6 +30,7 @@ import dmd.denum;
 import dmd.dmodule;
 import dmd.dsymbol;
 import dmd.dsymbolsem : apply;
+import dmd.expressionsem : toInteger;
 import dmd.dstruct;
 import dmd.dtemplate;
 import dmd.func;

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -37,7 +37,7 @@ import dmd.dsymbol;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
-import dmd.expressionsem : toBool;
+import dmd.expressionsem : toBool, toInteger;
 import dmd.func;
 import dmd.globals;
 import dmd.init;

--- a/compiler/src/dmd/glue/toir.d
+++ b/compiler/src/dmd/glue/toir.d
@@ -48,6 +48,7 @@ import dmd.dmodule;
 import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dsymbolsem : followInstantiationContext, toParentP;
+import dmd.expressionsem : toInteger;
 import dmd.dtemplate;
 import dmd.errorsink;
 import dmd.func;

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -48,7 +48,7 @@ import dmd.dtemplate;
 import dmd.errors;
 import dmd.errorsink;
 import dmd.expression;
-import dmd.expressionsem : getDsymbol;
+import dmd.expressionsem : getDsymbol, toInteger;
 import dmd.func;
 import dmd.funcsem;
 import dmd.globals;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2207,7 +2207,7 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
 
     void visitInteger(IntegerExp e)
     {
-        const ulong v = e.toInteger();
+        const ulong v = e.value;
         if (e.type)
         {
             Type t = e.type;
@@ -2222,7 +2222,7 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
                     {
                         foreach (em; *sym.members)
                         {
-                            if ((cast(EnumMember)em).value.toInteger == v)
+                            if ((cast(EnumMember)em).value.isIntegerExp().value == v)
                             {
                                 const id = em.ident.toString();
                                 buf.printf("%s.%.*s", sym.toChars(), cast(int)id.length, id.ptr);
@@ -3813,7 +3813,7 @@ private void sizeToBuffer(Expression e, ref OutBuffer buf, ref HdrGenState hgs)
     {
         Expression ex = (e.op == EXP.cast_ ? (cast(CastExp)e).e1 : e);
         ex = ex.optimize(WANTvalue);
-        const ulong uval = ex.op == EXP.int64 ? ex.toInteger() : cast(ulong)-1;
+        const ulong uval = ex.op == EXP.int64 ? ex.isIntegerExp().value : cast(ulong)-1;
         if (cast(long)uval >= 0)
         {
             if (uval <= 0xFFFFU)

--- a/compiler/src/dmd/lambdacomp.d
+++ b/compiler/src/dmd/lambdacomp.d
@@ -25,7 +25,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.dtemplate;
 import dmd.expression;
-import dmd.expressionsem : getConstInitializer;
+import dmd.expressionsem : getConstInitializer, toInteger;
 import dmd.func;
 import dmd.hdrgen;
 import dmd.mangle;

--- a/compiler/src/dmd/mangle/cpp.d
+++ b/compiler/src/dmd/mangle/cpp.d
@@ -27,7 +27,7 @@ import dmd.attrib;
 import dmd.declaration;
 import dmd.dsymbol;
 import dmd.dsymbolsem : isGNUABITag, toAlias, equals;
-import dmd.expressionsem : toStringExp;
+import dmd.expressionsem : toStringExp, toInteger, toUInteger;
 import dmd.templatesem : computeOneMember;
 import dmd.dtemplate;
 import dmd.errors;

--- a/compiler/src/dmd/mangle/cppwin.d
+++ b/compiler/src/dmd/mangle/cppwin.d
@@ -21,7 +21,7 @@ import dmd.denum : isSpecialEnumIdent;
 import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dsymbolsem : toAlias;
-import dmd.expressionsem : toStringExp;
+import dmd.expressionsem : toStringExp, toInteger, toUInteger;
 import dmd.templatesem : computeOneMember;
 import dmd.dtemplate;
 import dmd.errors;

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -146,6 +146,7 @@ import dmd.dinterpret;
 import dmd.dmodule;
 import dmd.dsymbol;
 import dmd.dsymbolsem : toAlias;
+import dmd.expressionsem : toInteger;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;

--- a/compiler/src/dmd/printast.d
+++ b/compiler/src/dmd/printast.d
@@ -14,6 +14,7 @@ module dmd.printast;
 import core.stdc.stdio;
 
 import dmd.expression;
+import dmd.expressionsem : toInteger;
 import dmd.ctfeexpr;
 import dmd.tokens;
 import dmd.visitor;

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -635,7 +635,7 @@ public:
     {
         if (t->dim->isConst() && t->dim->type->isIntegral())
         {
-            (void)t->dim->toUInteger();
+            (void)dmd::toUInteger(t->dim);
             t->next->accept(this);
             (void)t->ctype;
         }
@@ -644,7 +644,7 @@ public:
     }
     void visit(TypeVector *t) override
     {
-        (void)t->basetype->isTypeSArray()->dim->toUInteger();
+        (void)dmd::toUInteger(t->basetype->isTypeSArray()->dim);
         t->elementType()->accept(this);
         if (t->ty == TY::Tvoid)
             Type::tuns8->accept(this);
@@ -750,7 +750,7 @@ public:
                     if (member == NULL)
                         continue;
                     (void)member->ident->toChars();
-                    (void)member->value()->toInteger();
+                    (void)dmd::toInteger(member->value());
                 }
             }
         }


### PR DESCRIPTION
Depends on #22068 

To move `Type.toBaseType` to `typesem`.