### PR TITLE
Implement copy elision in frontend inliner

### DIFF
--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -433,6 +433,7 @@ elem* addressElem(elem* e, Type t, bool alwaysCopy = false)
         (*pe).ET = ec.E1.ET;
 
         e.Ety = TYnptr;
+        ec.Ety = TYnptr;
         return e;
     }
 

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -1223,7 +1223,13 @@ public:
 
     override void visit(WithStatement s)
     {
-        inlineScan(s.exp);
+        if (s.wthis && s.wthis._init)
+        {
+            if (auto ie = s.wthis._init.isExpInitializer())
+            {
+                inlineScan(ie.exp);
+            }
+        }
         inlineScan(s._body);
     }
 

--- a/compiler/test/runnable/colon.d
+++ b/compiler/test/runnable/colon.d
@@ -1,0 +1,19 @@
+// REQUIRED_ARGS: -betterC
+
+// this is an address miscalculation bug
+// may not crash if the data segment has a different layout
+// e.g. when pasted into with another file
+
+struct S {
+   int i;
+}
+
+__gshared S gs = S(1);
+ref S get() => gs;
+
+extern (C)
+int main()
+{
+    (get().i ? get() : get()).i++;
+    return 0;
+}


### PR DESCRIPTION
I hate this but this is required to implement the two-pass inliner mentioned in https://github.com/dlang/dmd/pull/21983#discussion_r2462746334.

The current inliner is strictly bottom-up and always copies returned structs, i.e. leaf functions are always inlined before parents. So such a piece of code directly emplaces `S` on the stack frame of `c()`.
```d
struct S {}
S a() => S();
pragma(inline, true) S b() => a();
void c()
{
    S s = b();
    ...
}
```
However, two-pass inlining will transform it into the following code, breaking existing code that relies on RVO.
```d
S a() => S();
void c()
{
    S __inlineretval = a();
    S s = __inlineretval;
    ...
}
```
This PR adds rather complex copy elision in the frontend inliner to help with these cases.

I am unsure if this is worth the effort (nor is my reasoning perfectly right), so review critically. Also fixed a potential type mismatch in glue layer.