### PR TITLE
Move `Expression.toReal` and `Expression.toComplex` to `expressionsem`

### DIFF
--- a/compiler/src/dmd/builtin.d
+++ b/compiler/src/dmd/builtin.d
@@ -17,7 +17,7 @@ import dmd.arraytypes;
 import dmd.astenums;
 import dmd.errors;
 import dmd.expression;
-import dmd.expressionsem : toInteger;
+import dmd.expressionsem : toInteger, toReal;
 import dmd.func;
 import dmd.location;
 import dmd.mangle;

--- a/compiler/src/dmd/compiler.d
+++ b/compiler/src/dmd/compiler.d
@@ -19,7 +19,7 @@ import dmd.ctfeexpr;
 import dmd.dmodule;
 import dmd.errors;
 import dmd.expression;
-import dmd.expressionsem : toInteger;
+import dmd.expressionsem : toInteger, toReal;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;

--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -25,7 +25,7 @@ import dmd.declaration;
 import dmd.dstruct;
 import dmd.errors;
 import dmd.expression;
-import dmd.expressionsem : getField, isIdentical, toBool, toInteger, toUInteger;
+import dmd.expressionsem : getField, isIdentical, toBool, toInteger, toUInteger, toReal, toComplex;
 import dmd.globals;
 import dmd.location;
 import dmd.mtype;

--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -25,7 +25,7 @@ import dmd.dstruct;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
-import dmd.expressionsem : isIdentical, getFieldIndex, toBool, toStringExp, toInteger;
+import dmd.expressionsem : isIdentical, getFieldIndex, toBool, toStringExp, toInteger, toReal, toComplex;
 import dmd.func;
 import dmd.globals : dinteger_t, sinteger_t, uinteger_t;
 import dmd.location;

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -33,6 +33,8 @@ import dmd.location : Loc;
 import dmd.mtype /*: Covariant, Type, Parameter, ParameterList*/;
 import dmd.rootobject : RootObject;
 import dmd.root.optional;
+import dmd.root.longdouble : real_t = longdouble;
+import dmd.root.complex;
 import dmd.semantic3;
 import dmd.statement : Statement, AsmStatement, GccAsmStatement;
 

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -448,6 +448,18 @@ uinteger_t toUInteger(Expression exp)
     return dmd.expressionsem.toUInteger(exp);
 }
 
+real_t toReal(Expression exp)
+{
+    import dmd.expressionsem;
+    return dmd.expressionsem.toReal(exp);
+}
+
+complex_t toComplex(Expression exp)
+{
+    import dmd.expressionsem;
+    return dmd.expressionsem.toComplex(exp);
+}
+
 /***********************************************************
  * func.d
  */

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -294,22 +294,10 @@ extern (C++) abstract class Expression : ASTNode
         return a;
     }
 
-    real_t toReal()
-    {
-        error(loc, "floating point constant expression expected instead of `%s`", toChars());
-        return CTFloat.zero;
-    }
-
     real_t toImaginary()
     {
         error(loc, "floating point constant expression expected instead of `%s`", toChars());
         return CTFloat.zero;
-    }
-
-    complex_t toComplex()
-    {
-        error(loc, "floating point constant expression expected instead of `%s`", toChars());
-        return complex_t(CTFloat.zero);
     }
 
     /****************************************
@@ -553,25 +541,9 @@ extern (C++) final class IntegerExp : Expression
         return new IntegerExp(loc, value, type);
     }
 
-    override real_t toReal()
-    {
-        // normalize() is necessary until we fix all the paints of 'type'
-        const ty = type.toBasetype().ty;
-        const val = normalize(ty, value);
-        value = val;
-        return (ty == Tuns64)
-            ? real_t(cast(ulong)val)
-            : real_t(cast(long)val);
-    }
-
     override real_t toImaginary()
     {
         return CTFloat.zero;
-    }
-
-    override complex_t toComplex()
-    {
-        return complex_t(toReal());
     }
 
     override void accept(Visitor v)
@@ -776,19 +748,9 @@ extern (C++) final class RealExp : Expression
         return new RealExp(loc, value, type);
     }
 
-    override real_t toReal()
-    {
-        return type.isReal() ? value : CTFloat.zero;
-    }
-
     override real_t toImaginary()
     {
         return type.isReal() ? CTFloat.zero : value;
-    }
-
-    override complex_t toComplex()
-    {
-        return complex_t(toReal(), toImaginary());
     }
 
     override void accept(Visitor v)
@@ -817,19 +779,9 @@ extern (C++) final class ComplexExp : Expression
         return new ComplexExp(loc, value, type);
     }
 
-    override real_t toReal()
-    {
-        return creall(value);
-    }
-
     override real_t toImaginary()
     {
         return cimagl(value);
-    }
-
-    override complex_t toComplex()
-    {
-        return value;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -68,6 +68,8 @@ namespace dmd
     StringExp *toStringExp(Expression *exp);
     dinteger_t toInteger(Expression *exp);
     uinteger_t toUInteger(Expression *exp);
+    real_t toReal(Expression *exp);
+    complex_t toComplex(Expression *exp);
 }
 
 typedef unsigned char OwnedBy;
@@ -103,9 +105,7 @@ public:
 
     const char* toChars() const final override;
 
-    virtual real_t toReal();
     virtual real_t toImaginary();
-    virtual complex_t toComplex();
     virtual bool checkType();
     Expression *addressOf();
     Expression *deref();
@@ -238,9 +238,7 @@ public:
     dinteger_t value;
 
     static IntegerExp *create(Loc loc, dinteger_t value, Type *type);
-    real_t toReal() override;
     real_t toImaginary() override;
-    complex_t toComplex() override;
     void accept(Visitor *v) override { v->visit(this); }
     dinteger_t getInteger() { return value; }
     template<int v>
@@ -261,9 +259,7 @@ public:
     real_t value;
 
     static RealExp *create(Loc loc, real_t value, Type *type);
-    real_t toReal() override;
     real_t toImaginary() override;
-    complex_t toComplex() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -273,9 +269,7 @@ public:
     complex_t value;
 
     static ComplexExp *create(Loc loc, complex_t value, Type *type);
-    real_t toReal() override;
     real_t toImaginary() override;
-    complex_t toComplex() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2298,16 +2298,6 @@ enum class EXP : uint8_t
     rvalue = 128u,
 };
 
-struct complex_t final
-{
-    _d_real re;
-    _d_real im;
-    complex_t() = delete;
-    complex_t(_d_real re);
-    complex_t(_d_real re, _d_real im);
-    int32_t opEquals(complex_t y) const;
-};
-
 class Expression : public ASTNode
 {
 public:
@@ -2710,6 +2700,16 @@ public:
     Expression* originalExp;
     void accept(Visitor* v) override;
     static void allow(Expression* exp);
+};
+
+struct complex_t final
+{
+    _d_real re;
+    _d_real im;
+    complex_t() = delete;
+    complex_t(_d_real re);
+    complex_t(_d_real re, _d_real im);
+    int32_t opEquals(complex_t y) const;
 };
 
 class ComplexExp final : public Expression

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2347,9 +2347,7 @@ public:
     virtual Expression* syntaxCopy();
     DYNCAST dyncast() const final override;
     const char* toChars() const final override;
-    virtual _d_real toReal();
     virtual _d_real toImaginary();
-    virtual complex_t toComplex();
     virtual bool checkType();
     Expression* deref();
     int32_t isConst();
@@ -2719,9 +2717,7 @@ class ComplexExp final : public Expression
 public:
     complex_t value;
     static ComplexExp* create(Loc loc, complex_t value, Type* type);
-    _d_real toReal() override;
     _d_real toImaginary() override;
-    complex_t toComplex() override;
     void accept(Visitor* v) override;
 };
 
@@ -3194,9 +3190,7 @@ class IntegerExp final : public Expression
 public:
     dinteger_t value;
     static IntegerExp* create(Loc loc, dinteger_t value, Type* type);
-    _d_real toReal() override;
     _d_real toImaginary() override;
-    complex_t toComplex() override;
     void accept(Visitor* v) override;
     dinteger_t getInteger();
     IntegerExp* syntaxCopy() override;
@@ -3422,9 +3416,7 @@ class RealExp final : public Expression
 public:
     _d_real value;
     static RealExp* create(Loc loc, _d_real value, Type* type);
-    _d_real toReal() override;
     _d_real toImaginary() override;
-    complex_t toComplex() override;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -48,7 +48,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem : include, _isZeroInit, toAlias, isPOD;
 import dmd.dtemplate;
 import dmd.expression;
-import dmd.expressionsem : fill, isIdentical, isLvalue, toInteger, toUInteger;
+import dmd.expressionsem : fill, isIdentical, isLvalue, toInteger, toUInteger, toComplex;
 import dmd.func;
 import dmd.hdrgen;
 import dmd.id;

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -146,7 +146,7 @@ import dmd.dinterpret;
 import dmd.dmodule;
 import dmd.dsymbol;
 import dmd.dsymbolsem : toAlias;
-import dmd.expressionsem : toInteger;
+import dmd.expressionsem : toInteger, toReal;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;


### PR DESCRIPTION
To be able to move `Type.toBaseType` to `typesem`