### PR TITLE
Fix a type mismatch in glue layer

### DIFF
--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -433,6 +433,7 @@ elem* addressElem(elem* e, Type t, bool alwaysCopy = false)
         (*pe).ET = ec.E1.ET;
 
         e.Ety = TYnptr;
+        ec.Ety = TYnptr;
         return e;
     }
 

--- a/compiler/test/runnable/opcolon.d
+++ b/compiler/test/runnable/opcolon.d
@@ -1,0 +1,24 @@
+// REQUIRED_ARGS: -betterC
+
+/* This test triggers an address miscalculation bug in DMD 2.111
+ * with -inline.
+ * May not crash if the data segment has a different layout,
+ * e.g. when pasted into with another file.
+ */
+
+struct S {
+   int i;
+}
+
+__gshared S gs = S(1);
+ref S get()
+{
+    return gs;
+}
+
+extern (C)
+int main()
+{
+    (get().i ? get() : get()).i++;
+    return 0;
+}

--- a/compiler/test/runnable/opcolon.d
+++ b/compiler/test/runnable/opcolon.d
@@ -3,7 +3,7 @@
 /* This test triggers an address miscalculation bug in DMD 2.111
  * with -inline.
  * May not crash if the data segment has a different layout,
- * e.g. when pasted into with another file.
+ * e.g. when pasted into another file.
  */
 
 struct S {


### PR DESCRIPTION
Fixes a type mismatch regarding ternary operator in glue layer. `dmd.glue.e2ir.addressElem` may cause an `OPquestion` to have a different type than the corresponding `OPcolon`, causing bad code generation in the backend.