### PR TITLE
Fix inlining of WithStatement

### DIFF
--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -1217,7 +1217,13 @@ public:
 
     override void visit(WithStatement s)
     {
-        inlineScan(s.exp);
+        if (s.wthis && s.wthis._init)
+        {
+            if (auto ie = s.wthis._init.isExpInitializer())
+            {
+                inlineScan(ie.exp);
+            }
+        }
         inlineScan(s._body);
     }
 


### PR DESCRIPTION
`WithStatement` lowers its initializer to a `VarDeclaration`, but the frontend inliner still performs inlining on the original `WithStatement.exp`.

No tests because this does not currently result in bad code generation, only silent discarding of inline results. Paving the way for a better inliner.