### PR TITLE
Enable inlining of more local functions

### DIFF
--- a/compiler/test/runnable/imports/inline4a.d
+++ b/compiler/test/runnable/imports/inline4a.d
@@ -1,0 +1,13 @@
+module imports.inline4a;
+
+pragma(inline, true)
+int foo()
+{
+    return 1;
+}
+
+pragma(inline, true)
+auto bar()
+{
+    return &foo;
+}

--- a/compiler/test/runnable/inline4.d
+++ b/compiler/test/runnable/inline4.d
@@ -1,0 +1,9 @@
+import imports.inline4a;
+
+void main()
+{
+    immutable baz = () => 1;
+    assert(foo() == bar()());
+    assert(foo() == baz());
+    assert(bar()() == baz());
+}


### PR DESCRIPTION
The frontend inliner is complex but much of it is unused in fact because how the frontend lowers things changed over time. For example, it obviously used to inline local functions initialized with `BlitExp`, but now most local functions are initialized with `ConstructExp`. Since the backend inliner is not going to be finished soon, this PR refactored a bit of that logic to match current AST and enabled inlining of simple expressions like `int i = (() => 0)()`.