### PR TITLE
Stackoffsets for function parameters

### DIFF
--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -1728,7 +1728,7 @@ void assignaddrc(code* c)
                 goto L1;
 
             case FL.para:
-                sectionOff = cast(uint)cgstate.Para.size - cgstate.BPoff;    // cancel out add of BPoff
+                sectionOff = /*cast(uint)cgstate.Para.size -*/ cgstate.BPoff;    // cancel out add of BPoff
                 goto L1;
 
             L1:
@@ -1786,10 +1786,11 @@ void assignaddrc(code* c)
 
             L2:
                 offset = cast(int)offset;       // sign extend
-//printf("offset: %lld localsize: %lld REGSIZE*2: %d\n", offset, localsize, REGSIZE*2);
+printf("offset: x%llx localsize: x%llxd REGSIZE*2: x%x\n", offset, localsize, REGSIZE*2);
                 if (cgstate.hasframe)
                     offset += REGSIZE * 2;
                 offset += localsize;
+printf("offset: x%llx\n", offset);
             L3:
                 /*
                         V 22

--- a/compiler/src/dmd/backend/arm/disasmarm.d
+++ b/compiler/src/dmd/backend/arm/disasmarm.d
@@ -2587,7 +2587,7 @@ void disassemble(uint c) @trusted
             case ldr(1,0,0): p1 = "strh";  factor = 2; goto Lldr;
             case ldr(1,0,1): p1 = "ldrh";  goto Lldr;
             case ldr(1,0,2): p1 = "ldrsh"; goto Lldr64;
-            case ldr(1,0,3): p1 = "ldrsh"; goto Lldr;
+            case ldr(1,0,3): p1 = "ldrsh"; factor = 2; goto Lldr;
             case ldr(2,0,0): p1 = "str";   format = "%s_imm_gen"; goto Lldr;
             case ldr(2,0,1): p1 = "ldr";   format = "%s_imm_gen"; goto Lldr;
             case ldr(2,0,2): p1 = "ldrsw"; goto Lldrsw;
@@ -3216,8 +3216,9 @@ unittest
 unittest
 {
     int line64 = __LINE__;
-    string[95] cases64 =      // 64 bit code gen
+    string[96] cases64 =      // 64 bit code gen
     [
+        "79 C0 47 AB         ldrsh  w11,[x29,#0x22]",
         "F8 1F 03 A8         stur   x8,[x29,#-0x10]",
         "B8 00 04 62         str    w2,[x3],#0",
         "78 64 68 23         ldrh   w3,[x1, x4]",

--- a/compiler/src/dmd/backend/dtype.d
+++ b/compiler/src/dmd/backend/dtype.d
@@ -187,7 +187,7 @@ L1:
  *      t = type of parameter
  *      tyf = function type
  * Returns:
- *      true if it is
+ *      true if t is a zero size struct
  */
 @trusted
 bool type_zeroSize(type* t, tym_t tyf)

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -1097,6 +1097,8 @@ void stackoffsets(ref CGstate cg, ref symtab_t symtab, bool estimate)
     cg.Auto.initialize();        // automatic & register offset
     cg.EEStack.initialize();     // for SCstack's
 
+    bool osx_aarch64 = (config.exe & EX_OSX64 && config.target_cpu == TARGET_AArch64);
+
     // Set if doing optimization of auto layout
     bool doAutoOpt = estimate && config.flags4 & CFG4optimized;
 
@@ -1224,7 +1226,7 @@ void stackoffsets(ref CGstate cg, ref symtab_t symtab, bool estimate)
                          (tyaggregate(s.ty()) || tyvector(s.ty())))))
                     cg.Para.offset = (cg.Para.offset + (alignsize - 1)) & ~(alignsize - 1);
                 s.Soffset = cg.Para.offset;
-                //printf("%s param offset =  x%lx, alignsize = %d\n", s.Sident, cast(long) s.Soffset, cast(int) alignsize);
+                printf("[%d] %s param offset =  x%lx, alignsize = %d\n", si, s.Sident.ptr, cast(long) s.Soffset, cast(int) alignsize);
                 cg.Para.offset += (s.Sflags & SFLdouble)
                             ? type_size(tstypes[TYdouble])   // float passed as double
                             : type_size(s.Stype);

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -1099,6 +1099,19 @@ void stackoffsets(ref CGstate cg, ref symtab_t symtab, bool estimate)
 
     bool osx_aarch64 = (config.exe & EX_OSX64 && config.target_cpu == TARGET_AArch64);
 
+    bool isVariadic = variadic(funcsym_p.Stype);
+
+    Symbol* lastParam;  // if variadic function, this is index of last parameter that goes on stack
+    if (osx_aarch64 && isVariadic)
+    {
+        foreach (s; symtab[])
+        {
+            if (s.Sclass == SC.parameter)
+                lastParam = s;
+        }
+    }
+    //if (lastParam) printf("lastParam: %s\n", lastParam.Sident.ptr);
+
     // Set if doing optimization of auto layout
     bool doAutoOpt = estimate && config.flags4 & CFG4optimized;
 
@@ -1208,7 +1221,7 @@ void stackoffsets(ref CGstate cg, ref symtab_t symtab, bool estimate)
                 cg.EEStack.offset += sz;
                 break;
 
-            case SC.shadowreg:
+            case SC.shadowreg:  // only on EX_WIN64
             case SC.parameter:
                 if (config.exe == EX_WIN64)
                 {
@@ -1217,16 +1230,31 @@ void stackoffsets(ref CGstate cg, ref symtab_t symtab, bool estimate)
                     cg.Para.offset += 8;
                     break;
                 }
-                /* Alignment on OSX 32 is odd. reals are 16 byte aligned in general,
-                 * but are 4 byte aligned on the OSX 32 stack.
-                 */
-                cg.Para.offset = _align(REGSIZE,cg.Para.offset); /* align on word stack boundary */
-                if (alignsize >= 16 &&
-                    (I64 || (config.exe == EX_OSX &&
-                         (tyaggregate(s.ty()) || tyvector(s.ty())))))
+                if (osx_aarch64)
+                {
+                    /* Alignment on OSX64 AArch64 is the same as for struct fields.
+                     * If it is a variadic function, the last parameter (lastPar) is aligned on 8 bytes.
+                     * Match behavior in backend.arm.cod1.cdfunc()
+                     */
+                    if (s is lastParam)
+                        cg.Para.offset = _align(REGSIZE,cg.Para.offset); /* align on register size */
+                    else
+                        cg.Para.offset = (cg.Para.offset + (alignsize - 1)) & ~(alignsize - 1);
+                }
+                else if (alignsize >= 16 &&
+                         (I64 || (config.exe == EX_OSX &&
+                          (tyaggregate(s.ty()) || tyvector(s.ty())))))
+                {
+                    /* Alignment on OSX 32 is odd. reals are 16 byte aligned in general,
+                     * but are 4 byte aligned on the OSX 32 stack.
+                     */
                     cg.Para.offset = (cg.Para.offset + (alignsize - 1)) & ~(alignsize - 1);
+                }
+                else
+                    cg.Para.offset = _align(REGSIZE,cg.Para.offset); /* align on register size */
+
                 s.Soffset = cg.Para.offset;
-                printf("[%d] %s param offset =  x%lx, alignsize = %d\n", si, s.Sident.ptr, cast(long) s.Soffset, cast(int) alignsize);
+                //printf("[%d] %s param offset =  x%x, alignsize = %d\n", si, s.Sident.ptr, cast(int) s.Soffset, cast(int) alignsize);
                 cg.Para.offset += (s.Sflags & SFLdouble)
                             ? type_size(tstypes[TYdouble])   // float passed as double
                             : type_size(s.Stype);

--- a/compiler/src/dmd/backend/x86/cod1.d
+++ b/compiler/src/dmd/backend/x86/cod1.d
@@ -2948,7 +2948,16 @@ void callclib(ref CodeBuilder cdb, elem* e, uint clib, ref regm_t pretregs, regm
 /*************************************************
  * Helper function for converting OPparam's into array of Parameters.
  */
-struct Parameter { elem* e; reg_t reg; reg_t reg2; uint size; uint numalign; bool isVariadic; bool isAp; }
+struct Parameter
+{
+    elem* e;
+    reg_t reg, reg2;
+    uint size;
+    uint numalign;
+    uint offset;      // [sp + offset] is where parameter is
+    bool isVariadic;
+    bool isAp;
+}
 
 @trusted
 void fillParameters(elem* e, Parameter* parameters, int* pi)


### PR DESCRIPTION
The parameter stack locations in the caller and the callee now match, and the code is much simpler.