### PR TITLE
Don't elide copy when passing lvalue to value parameters

### DIFF
--- a/compiler/src/dmd/backend/x86/cod1.d
+++ b/compiler/src/dmd/backend/x86/cod1.d
@@ -2948,7 +2948,7 @@ void callclib(ref CodeBuilder cdb, elem* e, uint clib, ref regm_t pretregs, regm
 /*************************************************
  * Helper function for converting OPparam's into array of Parameters.
  */
-struct Parameter
+package(dmd.backend) struct Parameter
 {
     elem* e;
     reg_t reg, reg2;

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -459,25 +459,20 @@ elem* addressElem(elem* e, Type t, bool alwaysCopy = false)
         *pe = el_bin(OPcomma,e2.Ety,eeq,el_var(stmp));
     }
 
-    tym_t typ = TYnptr;
-
     if ((*pe).Eoper == OPind)
     {
         elem* pea = (*pe).E1;
-
-        if (tybasic(pea.Ety) == TYimmutPtr)
-            typ = TYimmutPtr;
 
         if (tybasic(pea.Ety) == TYnptr || tybasic(pea.Ety) == TYimmutPtr)
         {
             *pe = pea;
             for (elem* ex = e; ex.Eoper == OPcomma; ex = ex.E2)
-                ex.Ety = typ;
+                ex.Ety = pea.Ety;
             return e;
         }
     }
 
-    e = el_una(OPaddr, typ, e);
+    e = el_una(OPaddr, TYnptr, e);
     return e;
 }
 

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -468,8 +468,7 @@ elem* addressElem(elem* e, Type t, bool alwaysCopy = false)
         if (tybasic(pea.Ety) == TYimmutPtr)
             typ = TYimmutPtr;
 
-        if ((pea.Eoper == OPcall || pea.Eoper == OPucall) &&
-            (tybasic(pea.Ety) == TYnptr || tybasic(pea.Ety) == TYimmutPtr))
+        if (tybasic(pea.Ety) == TYnptr || tybasic(pea.Ety) == TYimmutPtr)
         {
             *pe = pea;
             for (elem* ex = e; ex.Eoper == OPcomma; ex = ex.E2)

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -468,7 +468,8 @@ elem* addressElem(elem* e, Type t, bool alwaysCopy = false)
         if (tybasic(pea.Ety) == TYimmutPtr)
             typ = TYimmutPtr;
 
-        if (pea.Eoper == OPcall || pea.Eoper == OPucall)
+        if ((pea.Eoper == OPcall || pea.Eoper == OPucall) &&
+            (tybasic(pea.Ety) == TYnptr || tybasic(pea.Ety) == TYimmutPtr))
         {
             *pe = pea;
             for (elem* ex = e; ex.Eoper == OPcomma; ex = ex.E2)

--- a/compiler/test/runnable/test22079.d
+++ b/compiler/test/runnable/test22079.d
@@ -1,0 +1,18 @@
+struct S {
+    ~this() {}
+}
+
+__gshared S s = S();
+
+ref S refS() {
+    return s;
+}
+
+void takeS(S s2) {
+    assert(&s !is &s2);
+}
+
+void main()
+{
+    takeS(refS());
+}


### PR DESCRIPTION
Fixes #22079 without losing optimization.