### PR TITLE
Remove `toLvalue` in inliner

### DIFF
--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -1708,6 +1708,8 @@ elem* toElem(Expression e, ref IRState irs)
     {
         //printf("PostExp.toElem() '%s'\n", pe.toChars());
         elem* e = toElem(pe.e1, irs);
+        if (!OTleaf(e.Eoper) && e.Eoper != OPind)
+            e = el_una(OPind, e.Ety, el_una(OPaddr, TYnptr, e));
         elem* einc = toElem(pe.e2, irs);
         e = el_bin((pe.op == EXP.plusPlus) ? OPpostinc : OPpostdec,
                     e.Ety,e,einc);

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -2271,11 +2271,6 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
         auto e = doInlineAs!Expression(fd.fbody, ids);
         fd.inlineNest--;
 
-        import dmd.expressionsem : toLvalue;
-        // https://issues.dlang.org/show_bug.cgi?id=11322
-        if (tf.isRef)
-            e = e.toLvalue(null, "`ref` return");
-
         /* If the inlined function returns a copy of a struct,
          * and then the return value is used subsequently as an
          * lvalue, as in a struct return that is then used as a 'this'.

--- a/compiler/test/compilable/dotvar_ref_return.d
+++ b/compiler/test/compilable/dotvar_ref_return.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS: -inline
+
+struct Foo
+{
+    int x;
+    int foo()
+    {
+        ref get() { return x; }
+        return get();
+    }
+}


### PR DESCRIPTION
*EDIT*: I think it is still better not to fix something not broken. I will close this PR shortly unless there is a reason not to. Consider what lies below a sidebar story.

----------

This is another approach to #22114. The situation has been tricky, explanation below.

D have always had a lispy quirk (that does not exist in other C-like languages): ternaries can have partial reference semantics, i.e. `(b ? value() : ref()).field++` can mutate the object `ref()` points to, even the expression itself is an rvalue. This weirdness mandates the use of `toLvalue()` to obtain a strictly lvalue form of such expressions `*(b ? &ref1() : &ref2())`, or error out if there is really an rvalue branch.

However, `toLvalue()` is called during semantic analysis before inlining. The inliner still generated non-lvalue forms, i.e. `(b ? ref1() : ref2()).field++`, which tripped up the backend. This caused [Issue 11322](https://issues.dlang.org/show_bug.cgi?id=11322), and the fix then was to call `toLvalue()` in the inliner.

This in turn leaved a hole in the inliner:
```d
bool b;
uint i, j;

// Good
ref uint fun1() => b ? i : j;
void inc1() { fun1()++; }

// Bad
ref uint fun2i() => i;
ref uint fun2j() => j;
void inc2() { (b ? fun2i() : fun2j())++; }
```

The good example has the ternary returned as a whole, allowing `toLvalue()` to do its work. In the bad example, two `CallExp`'s are inlined separately, forming a non-lvalue form and making the backend generate invalid code silently (#22081). This means relying on `toLvalue()` is not going to work unless the inliner does analysis more thoroughly and changes all such expressions to lvalue form carefully. Implementing such a feature will be a total waste of time.

Therefore, the only hope is to fix the backend. Because the partial reference quirk, mutating the rvalue form should still generate correct code. After several backend fixes it seems the inliner is working correctly without `toLvalue()`, hence this PR. (Alternatively, can we remove that quirk in the spec? Seems to be **very** backwards-incompatible.)