### PR TITLE
Mark timespec_get as @system

### DIFF
--- a/druntime/src/core/sys/posix/stdc/time.d
+++ b/druntime/src/core/sys/posix/stdc/time.d
@@ -53,7 +53,7 @@ public import core.sys.posix.sys.types : time_t, clock_t;
 public import core.sys.posix.time : timespec;
 
 /// timespec_get introduced in C11
-int timespec_get(timespec* ts, int base);
+@system int timespec_get(timespec* ts, int base);
 
 /// Base Value used for timespec_get
 enum TIME_UTC = 1;

--- a/druntime/src/core/sys/windows/stdc/time.d
+++ b/druntime/src/core/sys/windows/stdc/time.d
@@ -83,10 +83,10 @@ alias timespec = _timespec64;
 enum TIME_UTC = 1;
 
 /// 64-bit version of timespec_get for Windows
-int _timespec64_get(scope const(_timespec64)* ts, int base);
+@system int _timespec64_get(scope const(_timespec64)* ts, int base);
 
 /// 32-bit version of timespec_get for Windows
-int _timespec32_get(scope const(_timespec32)* ts, int base);
+@system int _timespec32_get(scope const(_timespec32)* ts, int base);
 
 /// timespec_get, introduced in C11
 alias timespec_get = _timespec64_get;


### PR DESCRIPTION
This function cannot be `@safe` or `@trusted` because it requires its pointer argument to be non-null. It needs an explicit `@system` attribute because the modules that contain the bindings have a blanket-applied `@trusted:` attribute at the top.