### PR TITLE
Implement an always-inline pass in inliner

### DIFF
--- a/changelog/dmd.two-pass-inliner.dd
+++ b/changelog/dmd.two-pass-inliner.dd
@@ -1,0 +1,25 @@
+The compiler now inlines `pragma(inline, true)` functions in a separate pass
+
+The compiler now considers `pragma(inline, true)` functions for inlining in a dedicated pass
+before trying to inline other eligible functions. This provides better control of inlining
+decisions, for example:
+
+```d
+auto staticSquares(uint n)()
+{
+    int[n] arr;
+    static foreach(i; 0 .. n)
+        arr[i] = (i + 1) ^^ 2;
+    return arr;
+}
+
+pragma(inline, true) int thirtyThirty()
+{
+    return staticSquares!30[$ - 1];
+}
+```
+
+Previously, `dmd -inline` would first inline `staticSquares()` into `thirtyThirty()` and
+subsequently fail to inline `thirtyThirty()` into its callers. With the new implementation,
+the programmer can expect the compiler to replace calls to `thirtyThirty()` with
+`staticSquares!30[$ - 1]` before making other inlining decisions.

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -175,8 +175,8 @@ enum PASS : ubyte
     semantic2done,  // semantic2() done
     semantic3,      // semantic3() started
     semantic3done,  // semantic3() done
-    inline,         // inline started
-    inlinedone,     // inline done
+    inlinePragma,   // inline pragma(inline, true) functions started
+    inlineAll,      // inline all functions started
     obj,            // toObjFile() run
 }
 

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -138,8 +138,8 @@ enum class PASS : uint8_t
     semantic2done,  // semantic2() done
     semantic3,      // semantic3() started
     semantic3done,  // semantic3() done
-    inline_,         // inline started
-    inlinedone,     // inline done
+    inlinePragma,   // inline pragma(inline, true) functions started
+    inlineAll,      // inline all functions started
     obj             // toObjFile() run
 };
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -429,8 +429,8 @@ enum class PASS : uint8_t
     semantic2done = 4u,
     semantic3 = 5u,
     semantic3done = 6u,
-    inline_ = 7u,
-    inlinedone = 8u,
+    inlinePragma = 7u,
+    inlineAll = 8u,
     obj = 9u,
 };
 

--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -478,7 +478,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         .error(fd.loc, "%s `%s` errors compiling the function", fd.kind, fd.toPrettyChars);
         return;
     }
-    assert(fd.semanticRun == PASS.semantic3done);
+    assert(fd.semanticRun >= PASS.semantic3done && fd.semanticRun <= PASS.inlineAll);
     assert(fd.ident != Id.empty);
 
     for (FuncDeclaration fd2 = fd; fd2; )

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -52,39 +52,34 @@ import dmd.visitor.postorder;
 import dmd.inlinecost;
 
 /***********************************************************
- * Scan function implementations in Module m looking for functions that can be inlined,
+ * Scan for always-inline functions in Module m to be inlined,
  * and inline them in situ.
  *
  * Params:
  *    m = module to scan
  *    eSink = where to report errors
  */
-public void inlineScanModule(Module m, ErrorSink eSink)
+public void inlineScanPragmaInline(Module m, ErrorSink eSink)
 {
     if (m.semanticRun != PASS.semantic3done)
         return;
-    m.semanticRun = PASS.inline;
 
-    // Note that modules get their own scope, from scratch.
-    // This is so regardless of where in the syntax a module
-    // gets imported, it is unaffected by context.
-
-    //printf("Module = %p\n", m.sc.scopesym);
-
-    foreach (i; 0 .. m.members.length)
-    {
-        Dsymbol s = (*m.members)[i];
-        //if (global.params.v.verbose)
-        //    message("inline scan symbol %s", s.toChars());
-        inlineScanDsymbol(s, eSink);
-    }
-    m.semanticRun = PASS.inlinedone;
+    inlineScanModule(m, PASS.inlinePragma, eSink);
 }
 
-private void inlineScanDsymbol(Dsymbol s, ErrorSink eSink)
+/***********************************************************
+ * Scan all functions in Module m and try to inline them in situ.
+ *
+ * Params:
+ *    m = module to scan
+ *    eSink = where to report errors
+ */
+public void inlineScanAllFunctions(Module m, ErrorSink eSink)
 {
-    scope InlineScanVisitorDsymbol v = new InlineScanVisitorDsymbol(eSink);
-    s.accept(v);
+    if (m.semanticRun != PASS.semantic3done && m.semanticRun != PASS.inlinePragma)
+        return;
+
+    inlineScanModule(m, PASS.inlineAll, eSink);
 }
 
 /***********************************************************
@@ -1037,18 +1032,30 @@ private Result doInlineAs(Result)(Expression e, InlineDoState ids)
 private extern (C++) final class InlineScanVisitor : Visitor
 {
     alias visit = Visitor.visit;
+
 public:
     FuncDeclaration parent;     // function being scanned
+    PASS pass;
+    ErrorSink eSink;
+
     // As the visit method cannot return a value, these variables
     // are used to pass the result from 'visit' back to 'inlineScan'
     Statement sresult;
     Expression eresult;
-    ErrorSink eSink;
     bool again;
 
-    extern (D) this(ErrorSink eSink) scope @safe
+    extern (D) this(FuncDeclaration parent, PASS pass, ErrorSink eSink) scope @safe
     {
+        this.parent = parent;
+        this.pass = pass;
         this.eSink = eSink;
+    }
+
+    void reset()
+    {
+        sresult = null;
+        eresult = null;
+        again = false;
     }
 
     override void visit(Statement s)
@@ -1301,17 +1308,19 @@ public:
     {
     }
 
-    void scanVar(Dsymbol s)
+    override void visit(DeclarationExp e)
     {
-        //printf("scanVar(%s %s)\n", s.kind(), s.toPrettyChars());
-        if (VarDeclaration vd = s.isVarDeclaration())
+        if (VarDeclaration vd = e.declaration.isVarDeclaration())
         {
             if (TupleDeclaration td = vd.toAlias().isTupleDeclaration())
             {
-                td.foreachVar((s)
+                foreach (o; *td.objects)
                 {
-                    scanVar(s); // TODO
-                });
+                    if (auto te = o.isExpression())
+                    {
+                        inlineScan(te);
+                    }
+                }
             }
             else if (vd._init)
             {
@@ -1321,16 +1330,6 @@ public:
                 }
             }
         }
-        else
-        {
-            inlineScanDsymbol(s, eSink);
-        }
-    }
-
-    override void visit(DeclarationExp e)
-    {
-        //printf("DeclarationExp.inlineScan() %s\n", e.toChars());
-        scanVar(e.declaration);
     }
 
     override void visit(UnaExp e)
@@ -1477,14 +1476,14 @@ public:
             bool asStates = asStatements;
             if (asStates)
             {
-                if (fd.inlineStatusExp == ILS.yes)
+                if (fd.semanticRun == pass && fd.inlineStatusExp == ILS.yes)
                     asStates = false;           // inline as expressions
                                                 // so no need to recompute argumentsNeedDtors()
                 else if (argumentsNeedDtors(e.arguments))
                     asStates = false;
             }
 
-            if (canInline(fd, parent == fd.toParent2(), asStates, eSink))
+            if (canInline(fd, parent == fd.toParent2(), asStates, pass, eSink))
             {
                 expandInline(e, fd, parent, eret, null, asStates, eresult, sresult, again);
                 if (asStatements && eresult)
@@ -1578,7 +1577,7 @@ public:
 
         if (explicitThis)
         {
-            if (!canInline(fd, !fd.isNested(), asStatements, eSink))
+            if (!canInline(fd, !fd.isNested(), asStatements, pass, eSink))
                 return;
 
             expandInline(e, fd, parent, eret, explicitThis, asStatements, eresult, sresult, again);
@@ -1681,11 +1680,14 @@ public:
 private extern (C++) final class InlineScanVisitorDsymbol : Visitor
 {
     alias visit = Visitor.visit;
+
 public:
+    PASS pass;
     ErrorSink eSink;
 
-    extern (D) this(ErrorSink eSink) scope @safe
+    extern (D) this(PASS pass, ErrorSink eSink) scope @safe
     {
+        this.pass = pass;
         this.eSink = eSink;
     }
 
@@ -1703,33 +1705,47 @@ public:
         {
             printf("FuncDeclaration.inlineScan('%s')\n", fd.toPrettyChars());
         }
-        if (!(global.params.useInline || fd.hasAlwaysInlines))
+
+        if (!fd.fbody || fd.isNaked || fd.skipCodegen)
             return;
-        if (fd.isUnitTestDeclaration() && !global.params.useUnitTests || fd.inlineScanned)
+
+        if (fd.semanticRun < PASS.semantic3done)
             return;
-        if (fd.fbody && !fd.isNaked)
+
+        if (fd.semanticRun == pass && fd.inlineScanned)
+            return;
+
+        if (fd.isUnitTestDeclaration() && !global.params.useUnitTests)
+            return;
+
+        if (!fd.hasAlwaysInlines && pass == PASS.inlinePragma)
+            return;
+
+        fd.inlineScanned = true;
+        fd.semanticRun = pass;
+
+        scope InlineScanVisitor v = new InlineScanVisitor(fd, pass, eSink);
+
+        do
         {
-            while (1)
+            fd.inlineNest++;
+            v.reset();
+            v.inlineScan(fd.fbody);
+            fd.inlineNest--;
+        } while (v.again);
+
+        if (fd.localsymtab)
+        {
+            foreach (keyValue; fd.localsymtab.tab.asRange)
             {
-                fd.inlineNest++;
-                fd.inlineScanned = true;
-
-                scope InlineScanVisitor v = new InlineScanVisitor(eSink);
-                v.parent = fd;
-                v.inlineScan(fd.fbody);
-                bool again = v.again;
-
-                fd.inlineNest--;
-                if (!again)
-                    break;
+                keyValue.value.accept(this);
             }
         }
     }
 
     override void visit(AttribDeclaration d)
     {
-        Dsymbols* decls = d.include(null);
-        if (decls)
+        if (Dsymbols* decls = d.include(null))
         {
             foreach (i; 0 .. decls.length)
             {
@@ -1772,6 +1788,36 @@ public:
 }
 
 /***********************************************************
+ * Scan function implementations in Module m looking for functions that can be inlined,
+ * and inline them in situ.
+ *
+ * Params:
+ *    m = module to scan
+ *    pass = the current pass (inline1 or inline2)
+ *    eSink = where to report errors
+ */
+private void inlineScanModule(Module m, PASS pass, ErrorSink eSink)
+{
+    assert(pass == PASS.inlinePragma || pass == PASS.inlineAll);
+
+    // Note that modules get their own scope, from scratch.
+    // This is so regardless of where in the syntax a module
+    // gets imported, it is unaffected by context.
+
+    //printf("Module = %p\n", m.sc.scopesym);
+
+    scope v = new InlineScanVisitorDsymbol(pass, eSink);
+
+    foreach (i; 0 .. m.members.length)
+    {
+        Dsymbol s = (*m.members)[i];
+        s.accept(v);
+    }
+
+    m.semanticRun = pass;
+}
+
+/***********************************************************
  * Test that `fd` can be inlined.
  *
  * Params:
@@ -1784,7 +1830,7 @@ public:
  * Returns:
  *  true if the function body can be expanded.
  */
-private bool canInline(FuncDeclaration fd, bool hasThis, bool statementsToo, ErrorSink eSink)
+private bool canInline(FuncDeclaration fd, bool hasThis, bool statementsToo, PASS pass, ErrorSink eSink)
 {
     int cost;
 
@@ -1821,28 +1867,34 @@ private bool canInline(FuncDeclaration fd, bool hasThis, bool statementsToo, Err
     if (fd.skipCodegen)
         return false;
 
-    final switch (statementsToo ? fd.inlineStatusStmt : fd.inlineStatusExp)
+    // Ignore ILS if the decision was made in another pass
+    if (fd.semanticRun == pass)
     {
-    case ILS.yes:
-        static if (CANINLINE_LOG)
+        ILS inlineStatus = statementsToo ? fd.inlineStatusStmt : fd.inlineStatusExp;
+
+        final switch (inlineStatus)
         {
-            printf("\t1: yes %s\n", fd.toChars());
+        case ILS.yes:
+            static if (CANINLINE_LOG)
+            {
+                printf("\t1: yes %s\n", fd.toChars());
+            }
+            return true;
+        case ILS.no:
+            static if (CANINLINE_LOG)
+            {
+                printf("\t1: no %s\n", fd.toChars());
+            }
+            return false;
+        case ILS.uninitialized:
+            break;
         }
-        return true;
-    case ILS.no:
-        static if (CANINLINE_LOG)
-        {
-            printf("\t1: no %s\n", fd.toChars());
-        }
-        return false;
-    case ILS.uninitialized:
-        break;
     }
 
     final switch (fd.inlining)
     {
     case PINLINE.default_:
-        if (!global.params.useInline)
+        if (pass != PASS.inlineAll)
             return false;
         break;
     case PINLINE.always:
@@ -1965,7 +2017,10 @@ private bool canInline(FuncDeclaration fd, bool hasThis, bool statementsToo, Err
     else
         fd.inlineStatusExp = ILS.yes;
 
-    inlineScanDsymbol(fd, eSink);
+    {
+        scope v = new InlineScanVisitorDsymbol(pass, eSink);
+        fd.accept(v);
+    }
 
     if (fd.inlineStatusExp == ILS.uninitialized)
     {
@@ -1994,8 +2049,11 @@ private bool canInline(FuncDeclaration fd, bool hasThis, bool statementsToo, Err
     return true;
 
 Lno:
-    if (fd.inlining == PINLINE.always && global.params.useWarnings == DiagnosticReporting.inform)
+    if (fd.inlining == PINLINE.always && pass == PASS.inlinePragma &&
+        global.params.useWarnings == DiagnosticReporting.inform)
+    {
         eSink.warning(fd.loc, "cannot inline function `%s`", fd.toPrettyChars());
+    }
 
     if (statementsToo)
         fd.inlineStatusStmt = ILS.no;

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -661,14 +661,25 @@ private int tryMain(const(char)[][] argv, out Param params)
     if (global.errors)
         removeHdrFilesAndFail(params, modules);
 
-    // Scan for functions to inline
+    // Scan for modules with always inline functions
     foreach (m; modules)
     {
-        if (params.useInline || m.hasAlwaysInlines)
+        if (m.hasAlwaysInlines)
         {
             if (params.v.verbose)
-                message("inline scan %s", m.toChars());
-            inlineScanModule(m, global.errorSink);
+                message("scan pragma(inline) in %s", m.toChars());
+            inlineScanPragmaInline(m, global.errorSink);
+        }
+    }
+
+    if (params.useInline)
+    {
+        // Scan for functions to inline
+        foreach (m; modules)
+        {
+            if (params.v.verbose)
+                message("scan all inlines in %s", m.toChars());
+            inlineScanAllFunctions(m, global.errorSink);
         }
     }
 

--- a/compiler/test/runnable/imports/inline4a.d
+++ b/compiler/test/runnable/imports/inline4a.d
@@ -11,3 +11,29 @@ auto bar()
 {
     return &foo;
 }
+
+mixin template LengthField(alias sym)
+{
+    pragma(inline, true)
+    size_t length() const
+    {
+        return sym.length;
+    }
+}
+
+struct Data
+{
+    string data;
+    mixin LengthField!data;
+
+    pragma(inline, true)
+    int opApply(scope int delegate(const Data) dg) {
+        return dg(this);
+    }
+}
+
+pragma(inline, true)
+int value()
+{
+    return 10;
+}

--- a/compiler/test/runnable/imports/pragmainline_a.d
+++ b/compiler/test/runnable/imports/pragmainline_a.d
@@ -1,4 +1,4 @@
-module imports.inline4a;
+module imports.pragmainline_a;
 
 pragma(inline, true)
 int foo()

--- a/compiler/test/runnable/inline4.d
+++ b/compiler/test/runnable/inline4.d
@@ -349,6 +349,43 @@ void testRvalueRefReturn()
 
 /************************************/
 
+auto anonclass()
+{
+    return new class {
+        pragma(inline, true)
+        final size_t foo()
+        {
+            return value();
+        }
+    };
+}
+
+auto testAlwaysInline()
+{
+    size_t var;
+
+    foreach (d; Data("string"))
+    {
+        var = d.length();
+    }
+
+    assert(var == 6);
+
+    var = anonclass().foo();
+
+    assert(var == 10);
+
+    auto nested = (size_t i) {
+        return i - value();
+    };
+
+    var = nested(var);
+
+    assert(var == 0);
+}
+
+/************************************/
+
 void main()
 {
     immutable baz = () => 1;
@@ -360,4 +397,5 @@ void main()
     testRefReturn();
     testRvalueRefReturn();
 
+    testAlwaysInline();
 }

--- a/compiler/test/runnable/inline4.d
+++ b/compiler/test/runnable/inline4.d
@@ -1,5 +1,3 @@
-import imports.inline4a;
-
 struct S
 {
     int a;
@@ -349,53 +347,9 @@ void testRvalueRefReturn()
 
 /************************************/
 
-auto anonclass()
-{
-    return new class {
-        pragma(inline, true)
-        final size_t foo()
-        {
-            return value();
-        }
-    };
-}
-
-auto testAlwaysInline()
-{
-    size_t var;
-
-    foreach (d; Data("string"))
-    {
-        var = d.length();
-    }
-
-    assert(var == 6);
-
-    var = anonclass().foo();
-
-    assert(var == 10);
-
-    auto nested = (size_t i) {
-        return i - value();
-    };
-
-    var = nested(var);
-
-    assert(var == 0);
-}
-
-/************************************/
-
 void main()
 {
-    immutable baz = () => 1;
-    assert(foo() == bar()());
-    assert(foo() == baz());
-    assert(bar()() == baz());
-
     testValueReturn();
     testRefReturn();
     testRvalueRefReturn();
-
-    testAlwaysInline();
 }

--- a/compiler/test/runnable/pragmainline.d
+++ b/compiler/test/runnable/pragmainline.d
@@ -1,0 +1,53 @@
+// REQUIRED_ARGS: -wi
+/* TEST_OUTPUT:
+---
+---
+*/
+
+
+import imports.pragmainline_a;
+
+auto anonclass()
+{
+    return new class {
+        pragma(inline, true)
+        final size_t foo()
+        {
+            return value();
+        }
+    };
+}
+
+auto testAlwaysInline()
+{
+    size_t var;
+
+    foreach (d; Data("string"))
+    {
+        var = d.length();
+    }
+
+    assert(var == 6);
+
+    var = anonclass().foo();
+
+    assert(var == 10);
+
+    auto nested = (size_t i) {
+        return i - value();
+    };
+
+    var = nested(var);
+
+    assert(var == 0);
+}
+
+void main()
+{
+    immutable baz = () => 1;
+    assert(foo() == bar()());
+    assert(foo() == baz());
+    assert(bar()() == baz());
+
+    testAlwaysInline();
+}


### PR DESCRIPTION
I didn't expect to have to fix a dozen of other bugs to get this working. Finally, a two-pass inliner is possible. The first pass only inlines `pragma(inline, true)` functions and the second pass is identical to original inliner pass.

Expect a few regressions because this changes the original bottom-up assumptions.

Fixes #21974.

cc @rainers 