### PR TITLE
fix regression in #20863 triggering an assertion if TypeInfo_AssociativeArray is misdefined

### DIFF
--- a/compiler/test/fail_compilation/test20863.d
+++ b/compiler/test/fail_compilation/test20863.d
@@ -1,0 +1,23 @@
+// must not assert/crash with empty declarations
+/* TEST_OUTPUT:
+---
+fail_compilation\test20863.d(21): Error: no property `Entry` for type `object.TypeInfo_AssociativeArray`
+fail_compilation\test20863.d(17):        class `TypeInfo_AssociativeArray` defined here
+fail_compilation\test20863.d(21): Error: no property `aaGetHash` for type `object.TypeInfo_AssociativeArray`
+fail_compilation\test20863.d(17):        class `TypeInfo_AssociativeArray` defined here
+fail_compilation\test20863.d(21): Error: no property `aaOpEqual` for type `object.TypeInfo_AssociativeArray`
+fail_compilation\test20863.d(17):        class `TypeInfo_AssociativeArray` defined here
+---
+*/
+
+module object;
+
+class Object { }
+class TypeInfo { }
+class TypeInfo_AssociativeArray { }
+
+extern(C) int main()
+{
+    int[int] aa;
+    return 0;
+}


### PR DESCRIPTION
Fail gracefully with empty declaration.