### PR TITLE
Fix copy elision regression causing segfault with struct literals

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -658,6 +658,12 @@ bool canElideCopy(Expression e, Type to, bool checkMod = true)
             return canElideCopy(ce.e1, to, checkMod) && canElideCopy(ce.e2, to, checkMod);
 
         case EXP.structLiteral:
+            auto sd = e.isStructLiteralExp();
+            foreach (elem; *sd.elements)
+            {
+                if (!canElideCopy(elem, elem.type, checkMod))
+                    return false;
+            }
             return true;
         case EXP.dotVariable:
             // If an aggregate can be elided, so are its fields

--- a/compiler/test/runnable/structlit_rvalue.d
+++ b/compiler/test/runnable/structlit_rvalue.d
@@ -1,0 +1,22 @@
+void refCounted(ProcessPipes val)
+{
+    val = ProcessPipes.init;
+}
+
+struct File
+{
+    private string _name;
+    ~this() @safe {}
+}
+
+struct ProcessPipes
+{
+    enum Redirect{ stdin = 1 }
+    Redirect _redirectFlags;
+    File _stdin, _stdout;
+}
+
+void main()
+{
+	refCounted(ProcessPipes.init);
+}


### PR DESCRIPTION
Recursively check if individual elements within struct literals can be copy-elided.

Fixes regression introduced in 60982f33072de8d40128c337bd5a46cc07406e08.