### PR TITLE
AA: don't require TypeInfo if compiling without it

### DIFF
--- a/druntime/src/core/internal/newaa.d
+++ b/druntime/src/core/internal/newaa.d
@@ -226,7 +226,8 @@ private:
         firstUsed = cast(uint) buckets.length;
 
         // only for binary compatibility
-        entryTI = typeid(Entry!(K, V));
+        version(D_TypeInfo)
+            entryTI = typeid(Entry!(K, V));
         hashFn = delegate size_t (scope ref const K key) nothrow pure @nogc @safe {
             return pure_hashOf!K(key);
         };


### PR DESCRIPTION
This allows GDC and LDC to use AAs with -no-rtti, avoiding an error deep inside a template.

GC is still used, so a similar error is generated if disabled via -betterC.
