### PR TITLE
C++: Add dmd::printInstantiationTrace to compiler interface

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -354,6 +354,11 @@ void printTemplateStats(bool listInstances, ErrorSink eSink)
     return dmd.dtemplate.printTemplateStats(listInstances, eSink);
 }
 
+void printInstantiationTrace(TemplateInstance ti)
+{
+    return ti.printInstantiationTrace();
+}
+
 /***********************************************************
  * dtoh.d
  */

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -293,5 +293,6 @@ namespace dmd
     TemplateParameter *isTemplateParameter(RootObject *o);
     bool isError(const RootObject *const o);
     void printTemplateStats(bool listInstances, ErrorSink* eSink);
+    void printInstantiationTrace(TemplateInstance *ti);
     bool declareParameter(TemplateParameter *tp, Scope *sc);
 }

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1869,6 +1869,7 @@ void template_h(TemplateParameter *tp, Scope *sc, TemplateParameters *tps,
     dmd::isTemplateParameter(o);
     dmd::isError(o);
     dmd::printTemplateStats(true, sink);
+    dmd::printInstantiationTrace (sc->tinst);
 }
 
 void typinf_h(Expression *e, Loc loc, Type *t, Scope *sc)


### PR DESCRIPTION
Because `printInstantiationTrace` is an `extern(D)` method.

---

So with the following compiler glue code for RTTI.
```c++
  if (!global.params.useTypeInfo)
    {
      if (!sc || !sc->ctfe ())
        {
          error_at (loc, "`object.TypeInfo` cannot be used with `-fno-rtti`");

          if (sc && sc->tinst)
            dmd::printInstantiationTrace (sc->tinst);

          global.errors++;
        }
    }
```

We get stack traces that link back to the originating code along with the error within the druntime template.
```d
core/internal/array/utils.d:154:41: error: ‘object.TypeInfo’ cannot be used with ‘-fno-rtti’
core/internal/array/construction.d:388:24: note: instantiated from here: ‘__arrayAlloc!(Bucket!(int, int))’
core/internal/array/construction.d:402:18: note: instantiated from here: ‘_d_newarrayU!(Bucket!(int, int))’
core/internal/newaa.d:363:16: note: instantiated from here: ‘_d_newarrayT!(Bucket!(int, int))’
core/internal/newaa.d:44:5: note: instantiated from here: ‘Impl!(int, int)’
core/internal/newaa.d:83:25: note: instantiated from here: ‘AA!(int, int)’
core/internal/newaa.d:611:27: note: instantiated from here: ‘_toAA!(int, int)’
testsuite/gdc.dg/rtti1.d:7:16: note: instantiated from here: ‘_d_aaIn!(int[int], int, int, int)’
```