### PR TITLE
Don't elide mutable pointers when passing a struct's static init

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -671,7 +671,8 @@ bool canElideCopy(Expression e, Type to, bool checkMod = true)
             return canElideCopy(ce.e1, to, checkMod) && canElideCopy(ce.e2, to, checkMod);
 
         case EXP.structLiteral:
-            return true;
+            auto sle = e.isStructLiteralExp();
+            return !(checkMod && sle.useStaticInit && to.isMutable());
         case EXP.dotVariable:
             // If an aggregate can be elided, so are its fields
             auto dve = e.isDotVarExp();

--- a/compiler/test/runnable/structlit_rvalue.d
+++ b/compiler/test/runnable/structlit_rvalue.d
@@ -1,0 +1,15 @@
+void refCounted(ProcessPipes val)
+{
+    val = ProcessPipes.init;
+}
+
+struct ProcessPipes
+{
+    char[33] arr;
+    ~this() @safe {}
+}
+
+void main()
+{
+    refCounted(ProcessPipes.init);
+}


### PR DESCRIPTION
Fixes #22134. With the original test case.