### PR TITLE
Handle issue #20395

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -764,6 +764,7 @@ final class CParser(AST) : Parser!AST
                 else
                     importBuiltins = true;  // probably one of those compiler extensions
             }
+            token.checkKeyword();
             e = new AST.IdentifierExp(loc, token.ident);
             nextToken();
             break;
@@ -932,6 +933,7 @@ final class CParser(AST) : Parser!AST
                 nextToken();
                 if (token.value == TOK.identifier)
                 {
+                    token.checkKeyword();
                     Identifier id = token.ident;
                     e = new AST.DotIdExp(loc, e, id);
                     break;
@@ -943,6 +945,7 @@ final class CParser(AST) : Parser!AST
                 nextToken();
                 if (token.value == TOK.identifier)
                 {
+                    token.checkKeyword();
                     Identifier id = token.ident;
                     auto die = new AST.DotIdExp(loc, e, id);
                     die.arrow = true;
@@ -2860,6 +2863,7 @@ final class CParser(AST) : Parser!AST
                 switch (token.value)
                 {
                 case TOK.identifier:        // identifier
+                    token.checkKeyword();
                     //printf("identifier %s\n", token.ident.toChars());
                     if (declarator == DTR.xabstract)
                         error("identifier not allowed in abstract-declarator");
@@ -3207,6 +3211,9 @@ final class CParser(AST) : Parser!AST
          */
         while (1)
         {
+            if (token.value == TOK.identifier)
+                token.checkKeyword();
+
             if (token.value == TOK.rightParenthesis)
                 break;
             if (token.value == TOK.dotDotDot)
@@ -3291,6 +3298,9 @@ final class CParser(AST) : Parser!AST
         auto arguments = new AST.Expressions();
         while (token.value != TOK.rightParenthesis && token.value != TOK.endOfFile)
         {
+            if (token.value == TOK.identifier)
+                token.checkKeyword();
+
             auto arg = cparseAssignExp();
             arguments.push(arg);
             if (token.value != TOK.comma)
@@ -3879,6 +3889,7 @@ final class CParser(AST) : Parser!AST
         Identifier tag;
         if (token.value == TOK.identifier)
         {
+            token.checkKeyword();
             tag = token.ident;
             nextToken();
         }
@@ -4018,6 +4029,7 @@ final class CParser(AST) : Parser!AST
 
         if (token.value == TOK.identifier)
         {
+            token.checkKeyword();
             tag = token.ident;
             nextToken();
         }

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -918,6 +918,21 @@ extern (C++) struct Token
         return true;
     }());
 
+    /* importC: check D keyword in C code */
+    extern(D) void checkKeyword()
+    {
+        auto kword = ident.toString();
+        foreach(kw; keywords)
+        {
+            if (kword == "true" || kword == "false")
+                continue;
+            if (tochars[kw] == kword)
+            {
+                ident = Identifier.idPool(kword ~ "_");
+            }
+        }
+    }
+
 nothrow:
 
     extern (D) int isKeyword() pure const @safe @nogc

--- a/compiler/test/compilable/fix20395.d
+++ b/compiler/test/compilable/fix20395.d
@@ -1,0 +1,9 @@
+import imports.imp20395;
+
+void main()
+{
+    uint_ a;
+    assert(version_ == 5);
+    assert(a.sizeof == uint.sizeof);
+
+}

--- a/compiler/test/compilable/imports/imp20395.c
+++ b/compiler/test/compilable/imports/imp20395.c
@@ -1,0 +1,3 @@
+typedef unsigned int uint;
+
+int version = 5;


### PR DESCRIPTION
for typedefs with ids that are D type keywords, maybe avoid aliasing them.

this ensures D semantics are not broken.

There's a need for new check keyword functions because of the inability for the one already implemented in D work well for C code. because the C ids are not parsed as tokens but identifiers.

@dkorpel @thewilsonator 


has been discussed in forum:
https://forum.dlang.org/post/ftkpdfhykoksxlnzmmiz@forum.dlang.org