### PR TITLE
Fix and enable branch minimization in backend

### DIFF
--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -1042,7 +1042,7 @@ private void writefunc2(Symbol* sfunc, ref GlobalOptimizer go, ref BlockOpt bo)
     else
     {
         //printf("blockopt()\n");
-        blockopt(go, bo, 0);                /* optimize                     */
+        blockopt(go, bo);                   /* optimize                     */
     }
 
     assert(funcsym_p == sfunc);

--- a/compiler/src/dmd/backend/go.d
+++ b/compiler/src/dmd/backend/go.d
@@ -289,7 +289,7 @@ void optfunc(ref GlobalOptimizer go, ref BlockOpt bo)
             scanForInlines(funcsym_p);
 
         if (go.mfoptim & MFdc)
-            blockopt(go, bo, 0);            // do block optimization
+            blockopt(go, bo);           // do block optimization
         out_regcand(&globsym);          // recompute register candidates
         go.changes = 0;                 // no changes yet
         sliceStructs(globsym, bo.startblock);
@@ -354,7 +354,7 @@ void optfunc(ref GlobalOptimizer go, ref BlockOpt bo)
     if (debugc) printf("%d iterations\n",iter);
 
     if (go.mfoptim & MFdc)
-        blockopt(go, bo, 1);                // do block optimization
+        blockopt(go, bo);                 // do block optimization
 
     for (block* b = bo.startblock; b; b = b.Bnext)
     {


### PR DESCRIPTION
There is an incomplete jump minimization pass in the backend, that is never used (since the first SVN revision of D2). This PR modernizes and enables the pass. The algorithm is still quadratic, but pathological case is somewhat rare because of restrictions from the glue layer. I took some care not to reorder if-chains to avoid disrupting branch prediction.

Generally, jump minimization reduces frontend stall and provides 5% improvement for branchy code. There is 2% improvement for [Jabba Laci's AoC program](https://forum.dlang.org/thread/yhparzzauqezzexeidnb@forum.dlang.org) and very tiny improvement for code in [this SO thread](https://stackoverflow.com/questions/5142366/how-fast-is-d-compared-to-c) (compiled with `-inline -O -release`, tested with `hyperfine -w 3 -r 15`, on an Intel i5-12500H with atom cores disabled):

```
Benchmark 1: ./aoc_brmin
  Time (mean ± σ):      3.548 s ±  0.007 s    [User: 3.541 s, System: 0.008 s]
  Range (min … max):    3.538 s …  3.559 s    15 runs

Benchmark 2: ./aoc_master
  Time (mean ± σ):      3.619 s ±  0.007 s    [User: 3.610 s, System: 0.010 s]
  Range (min … max):    3.606 s …  3.632 s    15 runs

Summary
  ./aoc_brmin ran
    1.02 ± 0.00 times faster than ./aoc_master

Benchmark 1: ./stackoverflow_brmin
  Time (mean ± σ):      1.037 s ±  0.010 s    [User: 1.036 s, System: 0.001 s]
  Range (min … max):    1.022 s …  1.058 s    15 runs

Benchmark 2: ./stackoverflow_master
  Time (mean ± σ):      1.044 s ±  0.005 s    [User: 1.043 s, System: 0.001 s]
  Range (min … max):    1.037 s …  1.055 s    15 runs

Summary
  ./stackoverflow_brmin ran
    1.01 ± 0.01 times faster than ./stackoverflow_master
```

Let's see if it breaks anything.
