### PR TITLE
fix #22157 - Compiling std.utf with -inline crashes the compiler

### DIFF
--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -629,7 +629,11 @@ public:
 
         override void visit(SuperExp e)
         {
-            assert(ids.vthis);
+            if (!ids.vthis)
+            {
+                result = e;
+                return;
+            }
             result = new VarExp(e.loc, ids.vthis);
             if (ids.fd.hasDualContext)
             {

--- a/compiler/test/runnable/inline4.d
+++ b/compiler/test/runnable/inline4.d
@@ -346,6 +346,17 @@ void testRvalueRefReturn()
 }
 
 /************************************/
+// https://github.com/dlang/dmd/issues/22157
+class Test22157
+{
+    override string toString()
+	{
+        auto e = { return cast() super; } ();
+        return null;
+    }
+}
+
+/************************************/
 
 void main()
 {


### PR DESCRIPTION
don't try to optimize if super used in nested function.

Just copying what is happening for `this` a few lines above.