### PR TITLE
Make sure to return the hidden pointer with RVO

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -640,6 +640,8 @@ bool isLvalue(Expression _this)
  * Determine if copy elision is allowed when copying an expression to
  * a typed storage. This basically elides a restricted subset of so-called
  * "pure" rvalues, i.e. expressions with no reference semantics.
+ *
+ * Note: Please keep `dmd.glue.e2ir.toElem()` in sync with this.
  */
 bool canElideCopy(Expression e, Type to, bool checkMod = true)
 {

--- a/compiler/src/dmd/glue/s2ir.d
+++ b/compiler/src/dmd/glue/s2ir.d
@@ -38,7 +38,7 @@ import dmd.dsymbol;
 import dmd.dstruct;
 import dmd.dtemplate;
 import dmd.expression;
-import dmd.expressionsem : getDsymbol, toInteger;
+import dmd.expressionsem : canElideCopy, getDsymbol, toInteger;
 import dmd.func;
 import dmd.id;
 import dmd.init;
@@ -538,145 +538,101 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
     void visitReturn(ReturnStatement s)
     {
         //printf("s2ir.ReturnStatement: %s\n", toChars(s.exp));
-        BlockState* blx = irs.blx;
-        BC bc;
 
-        incUsage(irs, s.loc);
-        void finish()
+        void finish(elem* e = null)
         {
-            block* finallyBlock;
-            if (config.ehmethod != EHmethod.EH_DWARF &&
-                !irs.isNothrow() &&
-                (finallyBlock = stmtstate.getFinallyBlock()) != null)
+            BC bc = BC.ret;
+            BlockState* blx = irs.blx;
+
+            if (e)
             {
-                assert(finallyBlock.bc == BC._finally);
-                blx.curblock.appendSucc(finallyBlock);
+                elem_setLoc(e, s.loc);
+                block_appendexp(blx.curblock, e);
+                bc = BC.retexp;
+            }
+
+            if (config.ehmethod != EHmethod.EH_DWARF &&!irs.isNothrow())
+            {
+                if (block* finallyBlock = stmtstate.getFinallyBlock())
+                {
+                    assert(finallyBlock.bc == BC._finally);
+                    blx.curblock.appendSucc(finallyBlock);
+                }
             }
 
             block_setLoc(blx.curblock, s.loc);
             block_next(blx, bc, null);
         }
-        if (!s.exp)
-        {
-            bc = BC.ret;
-            return finish();
-        }
 
-        elem* e;
+        incUsage(irs, s.loc);
+
+        if (!s.exp)
+            return finish();
 
         FuncDeclaration func = irs.getFunc();
         assert(func);
         auto tf = func.type.isTypeFunction();
         assert(tf);
 
-        RET retmethod = retStyle(tf, func.needThis());
-        if (retmethod == RET.stack)
+        if (retStyle(tf, func.needThis()) == RET.stack)
         {
-            elem* es;
-            bool writetohp;
+            bool nrvo = func.isNRVO && func.nrvo_var;
+            bool urvo = !nrvo && canElideCopy(s.exp, s.exp.type, false);
 
-            /* If returning struct literal, write result
-             * directly into return value
-             */
-            if (auto sle = s.exp.isStructLiteralExp())
+            if (urvo)
             {
-                sle.sym = irs.shidden;
-                writetohp = true;
+                irs.ehidden = el_var(irs.shidden);
             }
-            /* Detect function call that returns the same struct
-             * and construct directly into *shidden
-             */
-            else if (auto ce = s.exp.isCallExp())
-            {
-                if (ce.e1.op == EXP.variable || ce.e1.op == EXP.star)
-                {
-                    Type t = ce.e1.type.toBasetype();
-                    if (t.ty == Tdelegate)
-                        t = t.nextOf();
-                    if (t.ty == Tfunction && retStyle(cast(TypeFunction)t, ce.f && ce.f.needThis()) == RET.stack)
-                    {
-                        irs.ehidden = el_var(irs.shidden);
-                        e = toElemDtor(s.exp, irs);
-                        e = el_una(OPaddr, TYnptr, e);
-                        goto L1;
-                    }
-                }
-                else if (auto dve = ce.e1.isDotVarExp())
-                {
-                    auto fd = dve.var.isFuncDeclaration();
-                    if (fd && fd.isCtorDeclaration())
-                    {
-                        if (auto sle = dve.e1.isStructLiteralExp())
-                        {
-                            sle.sym = irs.shidden;
-                            writetohp = true;
-                        }
-                    }
-                    Type t = ce.e1.type.toBasetype();
-                    if (t.ty == Tdelegate)
-                        t = t.nextOf();
-                    if (t.ty == Tfunction && retStyle(cast(TypeFunction)t, fd && fd.needThis()) == RET.stack)
-                    {
-                        irs.ehidden = el_var(irs.shidden);
-                        e = toElemDtor(s.exp, irs);
-                        e = el_una(OPaddr, TYnptr, e);
-                        goto L1;
-                    }
-                }
-            }
-            e = toElemDtor(s.exp, irs);
+
+            elem* e = toElemDtor(s.exp, irs);
             assert(e);
 
-            if (writetohp ||
-                (func.isNRVO && func.nrvo_var))
+            elem* es;
+
+            if (nrvo || urvo)
             {
-                // Return value via hidden pointer passed as parameter
-                // Write exp; return shidden;
+                // Hidden pointer handled in toElem()
+                // Rewrite to (exp, shidden)
                 es = e;
             }
             else
             {
                 // Return value via hidden pointer passed as parameter
-                // Write *shidden=exp; return shidden;
-                es = el_una(OPind,e.Ety,el_var(irs.shidden));
+                // Rewrite to (*shidden=exp, shidden)
+                es = el_una(OPind, e.Ety, el_var(irs.shidden));
                 es = elAssign(es, e, s.exp.type, null);
             }
+
             e = el_var(irs.shidden);
             e = el_bin(OPcomma, e.Ety, es, e);
+            return finish(e);
         }
-        else if (tf.isRef)
-        {
-            // Reference return, so convert to a pointer
-            e = toElemDtor(s.exp, irs);
 
+        elem* e = toElemDtor(s.exp, irs);
+        assert(e);
+
+        if (tf.isRef)
+        {
             /* already taken care of for vresult in buildResultVar() and semantic3.d
              * https://issues.dlang.org/show_bug.cgi?id=19384
              */
             if (func.vresult)
+            {
                 if (BlitExp be = s.exp.isBlitExp())
                 {
                      if (VarExp ve = be.e1.isVarExp())
                      {
                         if (ve.var == func.vresult)
-                            goto Lskip;
+                            return finish(e);
                      }
                 }
+            }
 
+            // Reference return, so convert to a pointer
             e = addressElem(e, s.exp.type.pointerTo());
-         Lskip:
         }
-        else
-        {
-            e = toElemDtor(s.exp, irs);
-            assert(e);
-        }
-    L1:
-        elem_setLoc(e, s.loc);
-        block_appendexp(blx.curblock, e);
-        bc = BC.retexp;
-//        if (type_zeroCopy(Type_toCtype(s.exp.type)))
-//            bc = BC.ret;
-        finish();
+
+        finish(e);
     }
 
     /**************************************

--- a/compiler/test/runnable/test28.d
+++ b/compiler/test/runnable/test28.d
@@ -1313,7 +1313,8 @@ void foo22160(T)(Vector22160!T*, T* ptr, size_t)
 
 void bar22160(Vector22160!ubyte val)
 {
-	foo22160(&val, val.ptr, val.length);
+    ulong[16] padding = 0x1234567890123456UL;
+    foo22160(&val, val.ptr, val.length);
 }
 
 void test22160()

--- a/compiler/test/runnable/test28.d
+++ b/compiler/test/runnable/test28.d
@@ -1,3 +1,5 @@
+// PERMUTE_ARGS: -fPIC -inline -release -g -O
+
 module test;
 
 import core.stdc.stdio;
@@ -1271,6 +1273,55 @@ void test18576()
 }
 
 /*******************************************/
+// https://github.com/dlang/dmd/issues/22160
+
+struct Vector22160(T)
+{
+    T[] _payload;
+
+    ~this() const nothrow {}
+
+    @property size_t length() const
+    {
+        return _payload.length;
+    }
+
+    @property T* ptr() inout {
+        return cast(T*) _payload.ptr;
+    }
+}
+
+struct DEREncoder
+{
+    Vector22160!ubyte getContentsUnlocked()
+    {
+        return Vector22160!ubyte();
+    }
+
+    Vector22160!ubyte m_contents;
+}
+
+Vector22160!ubyte putInSequence()(const auto ref Vector22160!ubyte contents)
+{
+    return DEREncoder().getContentsUnlocked();
+}
+
+void foo22160(T)(Vector22160!T*, T* ptr, size_t)
+{
+    assert(ptr is null);
+}
+
+void bar22160(Vector22160!ubyte val)
+{
+	foo22160(&val, val.ptr, val.length);
+}
+
+void test22160()
+{
+    bar22160(putInSequence(Vector22160!ubyte()));
+}
+
+/*******************************************/
 
 void main()
 {
@@ -1336,6 +1387,7 @@ void main()
     test64();
     test65();
     test18576();
+    test22160();
 
     printf("Success\n");
 }


### PR DESCRIPTION
Fixes #22160.

Note this is not an optimization. Copying RVO'ed objects results in dangling pointers.