### PR TITLE
Tweak placement `new` errors & forbid dynamic array PlacementExpression

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6284,13 +6284,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 error(p.loc, "PlacementExpression `%s` is an rvalue, but must be an lvalue", p.toChars());
                 return setError();
             }
-            if (sc.setUnsafe(false, p.loc, "`@safe` function `%s` cannot use placement `new`", sc.func))
+            if (sc.setUnsafe(false, p.loc, "placement `new`", sc.func))
             {
                 return setError();
             }
-            if (!exp.placement.type.isNaked)
+            if (!p.type.isNaked)
             {
-                error(p.loc, "PlacementExpression `%s` of type `%s` be unshared and mutable", p.toChars(), toChars(p.type));
+                error(p.loc, "PlacementExpression `%s` of type `%s` must be unshared and mutable", p.toChars(), toChars(p.type));
+                return setError();
+            }
+            if (p.type.ty == Tarray)
+            {
+                error(p.loc, "PlacementExpression cannot be a dynamic array");
                 return setError();
             }
             checkModifiable(exp.placement, sc);

--- a/compiler/test/fail_compilation/placenew.d
+++ b/compiler/test/fail_compilation/placenew.d
@@ -1,21 +1,24 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/placenew.d(23): Error: PlacementExpression `3` is an rvalue, but must be an lvalue
-fail_compilation/placenew.d(28): Error: undefined identifier `x`
-fail_compilation/placenew.d(36): Error: `new ( i )` PlacementExpression cannot be evaluated at compile time
-fail_compilation/placenew.d(39):        called from here: `xxx()`
-fail_compilation/placenew.d(39):        while evaluating: `static assert(xxx() == 1)`
-fail_compilation/placenew.d(48): Error: new placement size 24 must be >= object size 40
-fail_compilation/placenew.d(54): Error: placement new cannot be used with associative arrays
-fail_compilation/placenew.d(67): Error: new placement size 4 must be >= class object size $?:32=16|64=24$
-fail_compilation/placenew.d(77): Error: `@safe` function `test7` cannot use placement `new` is not allowed in a `@safe` function
+fail_compilation/placenew.d(26): Error: PlacementExpression `3` is an rvalue, but must be an lvalue
+fail_compilation/placenew.d(31): Error: undefined identifier `x`
+fail_compilation/placenew.d(39): Error: `new ( i )` PlacementExpression cannot be evaluated at compile time
+fail_compilation/placenew.d(42):        called from here: `xxx()`
+fail_compilation/placenew.d(42):        while evaluating: `static assert(xxx() == 1)`
+fail_compilation/placenew.d(51): Error: new placement size 24 must be >= object size 40
+fail_compilation/placenew.d(57): Error: placement new cannot be used with associative arrays
+fail_compilation/placenew.d(70): Error: new placement size 4 must be >= class object size $?:32=16|64=24$
+fail_compilation/placenew.d(80): Error: placement `new` is not allowed in a `@safe` function
+fail_compilation/placenew.d(89): Error: PlacementExpression cannot be a dynamic array
+fail_compilation/placenew.d(92): Error: placement new cannot be used with dynamic arrays
+fail_compilation/placenew.d(95): Error: PlacementExpression `s` of type `const(int)` must be unshared and mutable
 ---
 */
 
 void test0()
 {
     int i;
-    int* pi = new (i) int;
+    int* pi = new (i) int; // OK
 }
 
 void test1()
@@ -78,3 +81,16 @@ void test7()
 }
 
 /*************************************************/
+
+void test8()
+{
+    void[] a;
+    a.reserve(int.sizeof);
+    int* ps = new(a) int;
+
+    ubyte[a.sizeof] sa;
+    ps = new(sa) int[];
+
+    const int s;
+    ps = new(s) int;
+}

--- a/compiler/test/fail_compilation/placenew.d
+++ b/compiler/test/fail_compilation/placenew.d
@@ -89,7 +89,7 @@ void test8()
     int* ps = new(a) int;
 
     ubyte[a.sizeof] sa;
-    ps = new(sa) int[];
+    int[] ia = new(sa) int[4];
 
     const int s;
     ps = new(s) int;


### PR DESCRIPTION
Fix garbled placement `new` in safe function error message.
Fix typo for qualified PlacementExpression error, add test. 
Add error for dynamic array PlacementExpression. Fixes #22164. 
Add test for dynamic array result type (existing error).