### PR TITLE
Fix #22174:  Nanosleep mangling on musl libc

### DIFF
--- a/druntime/src/core/sys/posix/time.d
+++ b/druntime/src/core/sys/posix/time.d
@@ -489,6 +489,7 @@ else version (CRuntime_Musl)
     enum CLOCK_SGI_CYCLE = 10;
     enum CLOCK_TAI = 11;
 
+    pragma(mangle, muslRedirTime64Mangle!("nanosleep", "__nanosleep_time64"))
     int nanosleep(const scope timespec*, timespec*);
 
     pragma(mangle, muslRedirTime64Mangle!("clock_getres", "__clock_getres_time64"))


### PR DESCRIPTION
Pretty trivial. Was preventing core.thread.Thread.sleep from working.
 
Do I need to create an issue?