### PR TITLE
Allow NRVO across `CommaExp`

### DIFF
--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -371,11 +371,12 @@ void toTraceGC(ref IRState irs, elem* e, Loc loc)
  * Params:
  *      e = Expression to convert
  *      irs = context
+ *      ehidden = hidden pointer to place the value, if any
  * Returns:
  *      generated elem tree
  */
 
-elem* toElemDtor(Expression e, ref IRState irs)
+elem* toElemDtor(Expression e, ref IRState irs, elem* ehidden = null)
 {
     //printf("Expression.toElemDtor() %s\n", e.toChars());
 
@@ -393,7 +394,7 @@ elem* toElemDtor(Expression e, ref IRState irs)
         irs.mayThrow = false;
 
     const starti = irs.varsInScope.length;
-    elem* er = toElem(e, irs);
+    elem* er = toElem(e, irs, ehidden);
     const endi = irs.varsInScope.length;
 
     irs.mayThrow = mayThrowSave;
@@ -635,10 +636,11 @@ private elem* toEfilenamePtr(Module m)
  * Params:
  *      e = expression tree
  *      irs = context
+ *      ehidden = hidden pointer to place the value, if any
  * Returns:
  *      backend elem tree
  */
-elem* toElem(Expression e, ref IRState irs)
+elem* toElem(Expression e, ref IRState irs, elem* ehidden = null)
 {
     elem* visit(Expression e)
     {
@@ -2610,37 +2612,36 @@ elem* toElem(Expression e, ref IRState irs)
          * If the former, because of aliasing of the return value with
          * function arguments, it'll fail.
          */
-        if (ae.op == EXP.construct && ae.e2.op == EXP.call)
+        if (ae.op == EXP.construct)
         {
-            CallExp ce = cast(CallExp)ae.e2;
-            TypeFunction tf = cast(TypeFunction)ce.e1.type.toBasetype();
-            if (tf.ty == Tfunction && retStyle(tf, ce.f && ce.f.needThis()) == RET.stack)
+            if (CallExp ce = lastComma(ae.e2).isCallExp())
             {
-                elem* ehidden = e1;
-                ehidden = el_una(OPaddr, TYnptr, ehidden);
-                assert(!irs.ehidden);
-                irs.ehidden = ehidden;
-                elem* e = toElem(ae.e2, irs);
-                return setResult2(e);
-            }
-
-            /* Look for:
-             *  v = structliteral.ctor(args)
-             * and have the structliteral write into v, rather than create a temporary
-             * and copy the temporary into v
-             */
-            if (e1.Eoper == OPvar && // no closure variables https://issues.dlang.org/show_bug.cgi?id=17622
-                ae.e1.op == EXP.variable && ce.e1.op == EXP.dotVariable)
-            {
-                auto dve = cast(DotVarExp)ce.e1;
-                auto fd = dve.var.isFuncDeclaration();
-                if (fd && fd.isCtorDeclaration())
+                TypeFunction tf = cast(TypeFunction)ce.e1.type.toBasetype();
+                if (tf.ty == Tfunction && retStyle(tf, ce.f && ce.f.needThis()) == RET.stack)
                 {
-                    if (auto sle = dve.e1.isStructLiteralExp())
+                    elem* eh = el_una(OPaddr, TYnptr, e1);
+                    elem* e = toElem(ae.e2, irs, eh);
+                    return setResult2(e);
+                }
+
+                /* Look for:
+                 *  v = structliteral.ctor(args)
+                 * and have the structliteral write into v, rather than create a temporary
+                 * and copy the temporary into v
+                 */
+                if (e1.Eoper == OPvar && // no closure variables https://issues.dlang.org/show_bug.cgi?id=17622
+                    ae.e1.op == EXP.variable && ce.e1.op == EXP.dotVariable)
+                {
+                    auto dve = cast(DotVarExp)ce.e1;
+                    auto fd = dve.var.isFuncDeclaration();
+                    if (fd && fd.isCtorDeclaration())
                     {
-                        sle.sym = toSymbol((cast(VarExp)ae.e1).var);
-                        elem* e = toElem(ae.e2, irs);
-                        return setResult2(e);
+                        if (auto sle = dve.e1.isStructLiteralExp())
+                        {
+                            sle.sym = toSymbol((cast(VarExp)ae.e1).var);
+                            elem* e = toElem(ae.e2, irs);
+                            return setResult2(e);
+                        }
                     }
                 }
             }
@@ -3160,7 +3161,7 @@ elem* toElem(Expression e, ref IRState irs)
     {
         assert(ce.e1 && ce.e2);
         elem* eleft  = toElem(ce.e1, irs);
-        elem* eright = toElem(ce.e2, irs);
+        elem* eright = toElem(ce.e2, irs, ehidden);
         elem* e = el_combine(eleft, eright);
         if (e)
             elem_setLoc(e, ce.loc);
@@ -3443,9 +3444,6 @@ elem* toElem(Expression e, ref IRState irs)
         Type t1 = ce.e1.type.toBasetype();
         Type ectype = t1;
         elem* eeq = null;
-
-        elem* ehidden = irs.ehidden;
-        irs.ehidden = null;
 
         elem* ec;
         FuncDeclaration fd = null;

--- a/compiler/src/dmd/glue/s2ir.d
+++ b/compiler/src/dmd/glue/s2ir.d
@@ -595,8 +595,7 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
                         t = t.nextOf();
                     if (t.ty == Tfunction && retStyle(cast(TypeFunction)t, ce.f && ce.f.needThis()) == RET.stack)
                     {
-                        irs.ehidden = el_var(irs.shidden);
-                        e = toElemDtor(s.exp, irs);
+                        e = toElemDtor(s.exp, irs, el_var(irs.shidden));
                         e = el_una(OPaddr, TYnptr, e);
                         goto L1;
                     }
@@ -617,8 +616,7 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
                         t = t.nextOf();
                     if (t.ty == Tfunction && retStyle(cast(TypeFunction)t, fd && fd.needThis()) == RET.stack)
                     {
-                        irs.ehidden = el_var(irs.shidden);
-                        e = toElemDtor(s.exp, irs);
+                        e = toElemDtor(s.exp, irs, el_var(irs.shidden));
                         e = el_una(OPaddr, TYnptr, e);
                         goto L1;
                     }

--- a/compiler/src/dmd/glue/toir.d
+++ b/compiler/src/dmd/glue/toir.d
@@ -85,7 +85,6 @@ struct IRState
     Symbol* sclosure;               // pointer to closure instance
     BlockState* blx;
     Dsymbols* deferToObj;           // array of Dsymbol's to run toObjFile(bool multiobj) on later
-    elem* ehidden;                  // transmit hidden pointer to CallExp::toElem()
     Symbol* startaddress;
     Array!(elem*)* varsInScope;     // variables that are in scope that will need destruction later
     Label*[void*]* labels;          // table of labels used/declared in function

--- a/compiler/test/runnable/test28.d
+++ b/compiler/test/runnable/test28.d
@@ -1272,6 +1272,41 @@ void test18576()
 
 /*******************************************/
 
+struct S67
+{
+    S67* ptr;
+
+    this(int)
+    {
+        pragma(inline, false);
+        ptr = &this;
+    }
+
+    @disable this(this);
+}
+
+pragma(inline, false)
+S67 make67()
+{
+    return S67(1);
+}
+
+__gshared int i67;
+
+S67 f67()
+{
+    i67++;
+    return make67();
+}
+
+void test67()
+{
+    S67 s = f67();
+    assert(s.ptr == &s);
+}
+
+/*******************************************/
+
 void main()
 {
     printf("Start\n");
@@ -1336,6 +1371,7 @@ void main()
     test64();
     test65();
     test18576();
+    test67();
 
     printf("Success\n");
 }


### PR DESCRIPTION
An optimization, but not a particularly useful optimization in itself. The plan to fix (github, don't really close that) #22160 is to ensure RVO are fully done in `toElem()` and avoid interference from `appendDtors()`. This is just a start.