### PR TITLE
Implement deferred materialization for structs

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -761,6 +761,10 @@ bool isLvalue(Expression _this)
  * Determine if copy elision is allowed when copying an expression to
  * a typed storage. This basically elides a restricted subset of so-called
  * "pure" rvalues, i.e. expressions with no reference semantics.
+ *
+ * Note: Please try to keep `dmd.glue.e2ir.toElem()` in sync with this.
+ * It is not destructive to fail to elide a copy, but it is always better
+ * to stay consistent.
  */
 bool canElideCopy(Expression e, Type to, bool checkMod = true)
 {

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -2653,15 +2653,6 @@ elem* toElem(Expression e, ref IRState irs, elem* ehidden = null)
                 return setResult2(e);
             }
 
-            /* Implement:
-             *  S struct = func()
-             */
-            if (ae.op == EXP.construct && canElideCopy(ae.e2, ae.e1.type, false))
-            {
-                elem* e = toElem(ae.e2, irs, e1);
-                return setResult2(e);
-            }
-
             //printf("toElemBin() '%s'\n", ae.toChars());
 
             if (auto sle = ae.e2.isStructLiteralExp())
@@ -2707,6 +2698,15 @@ elem* toElem(Expression e, ref IRState irs, elem* ehidden = null)
             }
 
             /* Implement:
+             *  S struct = func()
+             */
+            if (ae.op == EXP.construct && canElideCopy(ae.e2, ae.e1.type, false))
+            {
+                elem* e = toElem(ae.e2, irs, e1);
+                return setResult2(e);
+            }
+
+            /* Implement:
              *  (struct = struct)
              */
             elem* e2 = toElem(ae.e2, irs);
@@ -2734,15 +2734,6 @@ elem* toElem(Expression e, ref IRState irs, elem* ehidden = null)
                 elem* e = el_param(enbytes, evalue);
                 e = el_bin(OPmemset,TYnptr,el,e);
                 e = el_combine(ey, e);
-                return setResult2(e);
-            }
-
-            /* Implement:
-             *  S[n] sarray = func()
-             */
-            if (ae.op == EXP.construct && canElideCopy(ae.e2, ae.e1.type, false))
-            {
-                elem* e = toElem(ae.e2, irs, e1);
                 return setResult2(e);
             }
 
@@ -2801,6 +2792,15 @@ elem* toElem(Expression e, ref IRState irs, elem* ehidden = null)
                     elem* e = el_bin(OPeq, e2.Ety, e1, e2);
                     return setResult2(e);
                 }
+            }
+
+            /* Implement:
+             *  S[n] sarray = func()
+             */
+            if (ae.op == EXP.construct && canElideCopy(ae.e2, ae.e1.type, false))
+            {
+                elem* e = toElem(ae.e2, irs, e1);
+                return setResult2(e);
             }
 
             /* https://issues.dlang.org/show_bug.cgi?id=13661

--- a/compiler/src/dmd/glue/tocsym.d
+++ b/compiler/src/dmd/glue/tocsym.d
@@ -104,6 +104,7 @@ Symbol* toSymbolX(Dsymbol ds, const(char)* prefix, SC sclass, type* t, const(cha
 }
 
 /*************************************
+ * Convert D symbol to backend symbol.
  */
 
 Symbol* toSymbol(Dsymbol s)
@@ -551,6 +552,27 @@ Symbol* toSymbol(Dsymbol s)
     return v.result;
 }
 
+/*************************************
+ * Convert D symbol to backend symbol.
+ * Unlike toSymbol, this function also resolves
+ * NRVO variables to the hidden pointer.
+ */
+Symbol* toSymbolNRVO(Dsymbol s)
+{
+    if (auto parent = s.toParent2())
+    {
+        auto fd = parent.isFuncDeclaration();
+        auto var = s.isVarDeclaration();
+        bool nrvo = fd && var && (fd.isNRVO && fd.nrvo_var == var || var.nrvo && fd.shidden);
+
+        if (nrvo)
+        {
+            return cast(Symbol*)fd.shidden;
+        }
+    }
+
+    return toSymbol(s);
+}
 
 /*************************************
  * Create Windows import symbol from backend Symbol.

--- a/compiler/test/runnable/nrvo.d
+++ b/compiler/test/runnable/nrvo.d
@@ -49,8 +49,127 @@ void test2()
 
 /***************************************************/
 
+struct S3
+{
+    S3* ptr;
+
+    this(int)
+    {
+        ptr = &this;
+    }
+
+    @disable this(this);
+
+    void check()
+    {
+        assert(this.ptr is &this);
+    }
+
+    invariant(this.ptr !is null);
+}
+
+S3 make3()
+{
+    return S3(1);
+}
+
+__gshared int i3;
+__gshared bool b3;
+
+S3 f3()
+{
+    i3++;
+    return make3();
+}
+
+S3 g3()
+{
+    return b3 ? make3() : f3();
+}
+
+void test3()
+{
+    S3 s1 = f3();
+    s1.check();
+    assert(i3 == 1);
+
+    S3 s2 = b3 ? f3() : g3();
+    s2.check();
+    assert(i3 == 2);
+
+    S3 s3 = f3();
+    auto closure = { s3.check(); };
+    closure();
+    s3.check();
+    assert(i3 == 3);
+}
+
+/***************************************************/
+
+// ditto
+
+struct S4
+{
+    S4* ptr;
+
+    this(int)
+    {
+        ptr = &this;
+    }
+
+    this(ref inout S4)
+    {
+        ptr = &this;
+    }
+
+    this(S4)
+    {
+        ptr = &this;
+    }
+
+    void check()
+    {
+        assert(this.ptr is &this);
+    }
+
+    invariant(this.ptr !is null);
+}
+
+struct V4
+{
+    S4 s;
+    this(int)
+    {
+        s = S4(1);
+    }
+}
+
+S4 f4()
+{
+    return __rvalue(V4(1).s);
+}
+
+S4 g4()
+{
+    V4 v = V4(1);
+    S4 s = v.s;
+    return s;
+}
+
+void test4()
+{
+    f4().check();
+
+    S4 s = g4();
+    s.check();
+}
+
+/***************************************************/
+
 void main()
 {
     test1();
     test2();
+    test3();
+    test4();
 }

--- a/compiler/test/runnable/rvalue1.d
+++ b/compiler/test/runnable/rvalue1.d
@@ -275,32 +275,6 @@ void test11()
 
 /********************************/
 
-struct S12{
-    S12* ptr;
-    this(int) { ptr = &this; }
-    this(ref inout S12) { ptr = &this; }
-    this(S12) { ptr = &this; }
-}
-
-struct V12
-{
-    S12 s;
-    this(int) { s = S12(1); }
-}
-
-S12 foo12()
-{
-    return __rvalue(V12(1).s);
-}
-
-void test12()
-{
-    S12 s = foo12();
-    assert(&s == s.ptr);
-}
-
-/********************************/
-
 int main()
 {
     test1();
@@ -314,7 +288,6 @@ int main()
     test9();
     test10();
     test11();
-    test12();
 
     return 0;
 }

--- a/compiler/test/runnable/test28.d
+++ b/compiler/test/runnable/test28.d
@@ -1273,42 +1273,6 @@ void test18576()
 }
 
 /*******************************************/
-
-struct S67
-{
-    S67* ptr;
-
-    this(int)
-    {
-        pragma(inline, false);
-        ptr = &this;
-    }
-
-    @disable this(this);
-}
-
-pragma(inline, false)
-S67 make67()
-{
-    return S67(1);
-}
-
-__gshared int i67;
-
-S67 f67()
-out (s; s.ptr == &s)
-{
-    i67++;
-    return make67();
-}
-
-void test67()
-{
-    S67 s = f67();
-    assert(s.ptr == &s);
-}
-
-/*******************************************/
 // https://github.com/dlang/dmd/issues/22160
 
 struct Vector22160(T)
@@ -1458,7 +1422,6 @@ void main()
     test64();
     test65();
     test18576();
-    test67();
     test22160();
     test22292();
 


### PR DESCRIPTION
This PR implements deferred materialization (aka. guaranteed copy elision) for struct rvalues, including in closure variables. The case for struct literals (`S s = S(func())`) is omitted, where copy construction is also not implemented and the whole situation is unclear.

Note this is not sufficient for C++17 `std::basic_string` binding to work, as much more work has to be done in fronts of copy/move constructors and in the inliner.