### PR TITLE
Run contracts on the returned object

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2593,6 +2593,8 @@ void buildResultVar(FuncDeclaration fd, Scope* sc, Type tret)
         TypeFunction tf = fd.type.toTypeFunction();
         if (tf.isRef)
             fd.vresult.storage_class |= STC.ref_;
+        else if (target.isReturnOnStack(tf, fd.needThis()))
+            fd.vresult.nrvo = true;
         fd.vresult.type = tret;
         fd.vresult.dsymbolSemantic(sc);
         if (!sc.insert(fd.vresult))

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -969,7 +969,11 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         if (funcdecl.vresult)
                         {
                             // Create: return vresult = exp;
-                            exp = new BlitExp(rs.loc, funcdecl.vresult, exp);
+                            if (canElideCopy(exp, funcdecl.vresult.type, false))
+                                exp = new ConstructExp(rs.loc, funcdecl.vresult, exp);
+                            else
+                                exp = new BlitExp(rs.loc, funcdecl.vresult, exp);
+
                             exp.type = funcdecl.vresult.type;
 
                             if (rs.caseDim)

--- a/compiler/test/runnable/test28.d
+++ b/compiler/test/runnable/test28.d
@@ -1296,6 +1296,7 @@ S67 make67()
 __gshared int i67;
 
 S67 f67()
+out (s; s.ptr == &s)
 {
     i67++;
     return make67();


### PR DESCRIPTION
Instead of a copy. Unsure if this is an optimization or a fix.