### PR TITLE
[stable] Tests: Make fail_compilation/failexpression{3,4}.d work for targets with 64-bit real

### DIFF
--- a/compiler/test/fail_compilation/failexpression3.d
+++ b/compiler/test/fail_compilation/failexpression3.d
@@ -2,38 +2,128 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `int += float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `int -= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `int *= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `int /= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `int %= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `uint += float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `uint -= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `uint *= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `uint /= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `uint %= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long += float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long -= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long *= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long /= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long %= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long += double` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long -= double` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long *= double` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long /= double` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `long %= double` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong += float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong -= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong *= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong /= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong %= float` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong += double` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong -= double` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong *= double` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong /= double` is performing truncating conversion
-fail_compilation/failexpression3.d-mixin-50(50): Deprecation: `ulong %= double` is performing truncating conversion
-fail_compilation/failexpression3.d(60): Error: template instance `failexpression3.X!(integral, floating, arith)` error instantiating
-fail_compilation/failexpression3.d(65):        instantiated from here: `OpAssignCases!(TestOpAssignAuto)`
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte += double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte -= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte *= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte /= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte %= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte += real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte -= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte *= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte /= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `byte %= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte += double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte -= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte *= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte /= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte %= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte += real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte -= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte *= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte /= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ubyte %= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short += double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short -= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short *= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short /= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short %= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short += real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short -= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short *= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short /= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `short %= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort += double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort -= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort *= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort /= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort %= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort += real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort -= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort *= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort /= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ushort %= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int += double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int -= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int *= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int /= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int %= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int += real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int -= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int *= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int /= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `int %= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint += double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint -= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint *= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint /= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint %= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint += real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint -= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint *= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint /= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `uint %= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long += double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long -= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long *= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long /= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long %= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long += real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long -= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long *= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long /= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `long %= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong += float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong -= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong *= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong /= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong %= float` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong += double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong -= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong *= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong /= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong %= double` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong += real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong -= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong *= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong /= real` is performing truncating conversion
+fail_compilation/failexpression3.d-mixin-139(139): Deprecation: `ulong %= real` is performing truncating conversion
+fail_compilation/failexpression3.d(149): Error: template instance `failexpression3.X!(integral, floating, arith)` error instantiating
+fail_compilation/failexpression3.d(154):        instantiated from here: `OpAssignCases!(TestOpAssignAuto)`
 ---
 */
 template TT(T...) { alias T TT; }
@@ -42,7 +132,6 @@ void TestOpAssignAuto(Tx, Ux, ops)()
 {
     foreach(T; Tx.x)
     foreach(U; Ux.x)
-    static if (U.sizeof <= T.sizeof)
     foreach(op; ops.x)
     {
         T a = cast(T)1;

--- a/compiler/test/fail_compilation/failexpression4.d
+++ b/compiler/test/fail_compilation/failexpression4.d
@@ -2,38 +2,128 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `int`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `int`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `int`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `int`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `int`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `uint`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `uint`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `uint`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `uint`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `uint`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `long`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `long`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `long`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `long`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `long`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a + 1.0` of type `double` to `long`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a - 1.0` of type `double` to `long`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a * 1.0` of type `double` to `long`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a / 1.0` of type `double` to `long`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a % 1.0` of type `double` to `long`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `ulong`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `ulong`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `ulong`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `ulong`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `ulong`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a + 1.0` of type `double` to `ulong`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a - 1.0` of type `double` to `ulong`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a * 1.0` of type `double` to `ulong`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a / 1.0` of type `double` to `ulong`
-fail_compilation/failexpression4.d-mixin-50(50): Error: cannot implicitly convert expression `cast(double)a % 1.0` of type `double` to `ulong`
-fail_compilation/failexpression4.d(60): Error: template instance `failexpression4.X!(integral, floating, arith)` error instantiating
-fail_compilation/failexpression4.d(65):        instantiated from here: `OpReAssignCases!(TestOpAndAssign)`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a + 1.0F` of type `float` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a - 1.0F` of type `float` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a * 1.0F` of type `float` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a / 1.0F` of type `float` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a % 1.0F` of type `float` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a + 1.0` of type `double` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a - 1.0` of type `double` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a * 1.0` of type `double` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a / 1.0` of type `double` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a % 1.0` of type `double` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a + 1.0L` of type `real` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a - 1.0L` of type `real` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a * 1.0L` of type `real` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a / 1.0L` of type `real` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a % 1.0L` of type `real` to `byte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a + 1.0F` of type `float` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a - 1.0F` of type `float` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a * 1.0F` of type `float` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a / 1.0F` of type `float` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a % 1.0F` of type `float` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a + 1.0` of type `double` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a - 1.0` of type `double` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a * 1.0` of type `double` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a / 1.0` of type `double` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a % 1.0` of type `double` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a + 1.0L` of type `real` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a - 1.0L` of type `real` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a * 1.0L` of type `real` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a / 1.0L` of type `real` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a % 1.0L` of type `real` to `ubyte`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a + 1.0F` of type `float` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a - 1.0F` of type `float` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a * 1.0F` of type `float` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a / 1.0F` of type `float` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a % 1.0F` of type `float` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a + 1.0` of type `double` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a - 1.0` of type `double` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a * 1.0` of type `double` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a / 1.0` of type `double` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a % 1.0` of type `double` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a + 1.0L` of type `real` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a - 1.0L` of type `real` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a * 1.0L` of type `real` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a / 1.0L` of type `real` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a % 1.0L` of type `real` to `short`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a + 1.0F` of type `float` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a - 1.0F` of type `float` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a * 1.0F` of type `float` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a / 1.0F` of type `float` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)cast(int)a % 1.0F` of type `float` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a + 1.0` of type `double` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a - 1.0` of type `double` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a * 1.0` of type `double` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a / 1.0` of type `double` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)cast(int)a % 1.0` of type `double` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a + 1.0L` of type `real` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a - 1.0L` of type `real` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a * 1.0L` of type `real` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a / 1.0L` of type `real` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)cast(int)a % 1.0L` of type `real` to `ushort`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a + 1.0` of type `double` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a - 1.0` of type `double` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a * 1.0` of type `double` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a / 1.0` of type `double` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a % 1.0` of type `double` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a + 1.0L` of type `real` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a - 1.0L` of type `real` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a * 1.0L` of type `real` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a / 1.0L` of type `real` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a % 1.0L` of type `real` to `int`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a + 1.0` of type `double` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a - 1.0` of type `double` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a * 1.0` of type `double` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a / 1.0` of type `double` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a % 1.0` of type `double` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a + 1.0L` of type `real` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a - 1.0L` of type `real` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a * 1.0L` of type `real` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a / 1.0L` of type `real` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a % 1.0L` of type `real` to `uint`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a + 1.0` of type `double` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a - 1.0` of type `double` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a * 1.0` of type `double` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a / 1.0` of type `double` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a % 1.0` of type `double` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a + 1.0L` of type `real` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a - 1.0L` of type `real` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a * 1.0L` of type `real` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a / 1.0L` of type `real` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a % 1.0L` of type `real` to `long`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a + 1.0F` of type `float` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a - 1.0F` of type `float` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a * 1.0F` of type `float` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a / 1.0F` of type `float` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(float)a % 1.0F` of type `float` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a + 1.0` of type `double` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a - 1.0` of type `double` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a * 1.0` of type `double` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a / 1.0` of type `double` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(double)a % 1.0` of type `double` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a + 1.0L` of type `real` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a - 1.0L` of type `real` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a * 1.0L` of type `real` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a / 1.0L` of type `real` to `ulong`
+fail_compilation/failexpression4.d-mixin-139(139): Error: cannot implicitly convert expression `cast(real)a % 1.0L` of type `real` to `ulong`
+fail_compilation/failexpression4.d(149): Error: template instance `failexpression4.X!(integral, floating, arith)` error instantiating
+fail_compilation/failexpression4.d(154):        instantiated from here: `OpReAssignCases!(TestOpAndAssign)`
 ---
 */
 template TT(T...) { alias T TT; }
@@ -42,7 +132,6 @@ void TestOpAndAssign(Tx, Ux, ops)()
 {
     foreach(T; Tx.x)
     foreach(U; Ux.x)
-    static if (U.sizeof <= T.sizeof && T.sizeof >= 4)
     foreach(op; ops.x)
     {
         T a = cast(T)1;


### PR DESCRIPTION
The tested type combinations were trimmed with `static if` statements, causing `real` to effectively not be tested at all *unless* its size is 64 bits, then making the test fail because of the extra output.

Make these 2 tests target-agnostic by simply testing all combinations.