### PR TITLE
fix regression in #21066 issuing deprecation message about immutable …

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -4262,13 +4262,14 @@ void fix16997(Scope* sc, UnaExp ue)
 }
 
 /***********************************
- * See if both types are arrays that can be compared
+ * See if an AA key can be compared
  * for equality without any casting. Return true if so.
  * This is to enable comparing things like an immutable
  * array with a mutable one.
  */
-extern (D) bool arrayTypeCompatibleWithoutCasting(Type t1, Type t2)
+extern (D) bool keyCompatibleWithoutCasting(Expression ekey, Type t2)
 {
+    Type t1 = ekey.type;
     t1 = t1.toBasetype();
     t2 = t2.toBasetype();
 
@@ -4276,8 +4277,9 @@ extern (D) bool arrayTypeCompatibleWithoutCasting(Type t1, Type t2)
     {
         if (t1.nextOf().implicitConvTo(t2.nextOf()) >= MATCH.constant || t2.nextOf().implicitConvTo(t1.nextOf()) >= MATCH.constant)
             return true;
+        return false;
     }
-    return false;
+    return implicitConvTo(ekey, t2) >= MATCH.constant;
 }
 
 /******************************************************************/

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11483,7 +11483,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                  * https://issues.dlang.org/show_bug.cgi?id=2684
                  * see also bug https://issues.dlang.org/show_bug.cgi?id=2954 b
                  */
-                if (!arrayTypeCompatibleWithoutCasting(exp.e2.type, taa.index))
+                if (!keyCompatibleWithoutCasting(exp.e2, taa.index))
                 {
                     exp.e2 = exp.e2.implicitCastTo(sc, taa.index); // type checking
                     if (exp.e2.type == Type.terror)
@@ -14581,7 +14581,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 TypeAArray ta = cast(TypeAArray)t2b;
 
                 // Special handling for array keys
-                if (!arrayTypeCompatibleWithoutCasting(exp.e1.type, ta.index))
+                if (!keyCompatibleWithoutCasting(exp.e1, ta.index))
                 {
                     // Convert key to type of key
                     exp.e1 = exp.e1.implicitCastTo(sc, ta.index);
@@ -19649,7 +19649,7 @@ private Expression rewriteAAIndexAssign(BinExp exp, Scope* sc, ref Type[2] alias
     foreach (ekey; ekeys)
     {
         Type tidx = ekey.type.toBasetype();
-        if (tidx.ty == Tarray && tidx.nextOf().isMutable())
+        if (tidx.ty == Tarray && tidx.nextOf().isMutable() && !ekey.isArrayLiteralExp())
         {
             error(loc, "associative arrays can only be assigned values with immutable keys, not `%s`", tidx.toChars());
             return ErrorExp.get();

--- a/compiler/test/runnable/testaa2.d
+++ b/compiler/test/runnable/testaa2.d
@@ -328,6 +328,14 @@ void test21207()
 }
 
 /************************************************/
+void foo() @safe
+{
+    immutable key = 1;
+    int[int] aa;
+    aa[key] = 123;
+}
+
+/************************************************/
 
 void testEvaluationOrder()
 {


### PR DESCRIPTION
…keys being cast to non-immutable.

Avoid adding the cast for implicitly convertible expressions.