### PR TITLE
[stable] cxxfrontend: Add needsClosure(FuncDeclaration) as needed by LDC

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -438,6 +438,12 @@ PURE isPure(FuncDeclaration fd)
     return dmd.funcsem.isPure(fd);
 }
 
+bool needsClosure(FuncDeclaration fd)
+{
+    import dmd.funcsem;
+    return dmd.funcsem.needsClosure(fd);
+}
+
 /***********************************************************
  * hdrgen.d
  */

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -37,6 +37,7 @@ namespace dmd
     bool checkClosure(FuncDeclaration* fd);
     MATCH leastAsSpecialized(FuncDeclaration *f, FuncDeclaration *g, ArgumentLabels *names);
     PURE isPure(FuncDeclaration *f);
+    bool needsClosure(FuncDeclaration *fd);
     FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);
     FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc=0);
     bool isAbstract(ClassDeclaration *cd);


### PR DESCRIPTION
This used to be a member method before v2.112. Expose the new free-standing function to the C++ interface.