### PR TITLE
Improve error message for failing `override` method

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1178,8 +1178,8 @@ Linterfaces:
                     functionToBufferFull(cast(TypeFunction)(fd.type), buf1,
                         new Identifier(fd.toPrettyChars()), hgs, null);
 
-                    error(funcdecl.loc, "function `%s` does not override any function, did you mean to override `%s`?",
-                        funcdeclToChars, buf1.peekChars());
+                    error(funcdecl.loc, "function `%s` does not override any function", funcdeclToChars);
+                    errorSupplemental(fd.loc, "did you mean to override `%s`?", buf1.peekChars());
 
                     // Supplemental error for parameter scope differences
                     auto tf1 = cast(TypeFunction)funcdecl.type;
@@ -1192,8 +1192,6 @@ Linterfaces:
 
                         if (params1.length == params2.length)
                         {
-                            bool hasScopeDifference = false;
-
                             for (size_t i = 0; i < params1.length; i++)
                             {
                                 auto p1 = params1[i];
@@ -1205,14 +1203,7 @@ Linterfaces:
                                 if (!(p2.storageClass & STC.scope_))
                                     continue;
 
-                                if (!hasScopeDifference)
-                                {
-                                    // Intended signature
-                                    errorSupplemental(funcdecl.loc, "Did you intend to override:");
-                                    errorSupplemental(funcdecl.loc, "`%s`", buf1.peekChars());
-                                    hasScopeDifference = true;
-                                }
-                                errorSupplemental(funcdecl.loc, "Parameter %d is missing `scope`",
+                                errorSupplemental(funcdecl.loc, "parameter %d is missing `scope`",
                                 cast(int)(i + 1));
                             }
                         }

--- a/compiler/test/fail_compilation/covariant_override.d
+++ b/compiler/test/fail_compilation/covariant_override.d
@@ -3,9 +3,11 @@ https://issues.dlang.org/show_bug.cgi?id=21538
 
 TEST_OUTPUT:
 ---
-fail_compilation/covariant_override.d(23): Error: function `@safe void covariant_override.CI.f(void delegate() @safe dg)` does not override any function, did you mean to override `@safe void covariant_override.I.f(void delegate() @system dg)`?
-fail_compilation/covariant_override.d(34): Error: function `@safe void covariant_override.CA.f(void delegate() @safe dg)` does not override any function, did you mean to override `@safe void covariant_override.A.f(void delegate() @system dg)`?
-fail_compilation/covariant_override.d(20): Error: class `covariant_override.CI` interface function `void f(void delegate() @system dg) @safe` is not implemented
+fail_compilation/covariant_override.d(25): Error: function `@safe void covariant_override.CI.f(void delegate() @safe dg)` does not override any function
+fail_compilation/covariant_override.d(19):        did you mean to override `@safe void covariant_override.I.f(void delegate() @system dg)`?
+fail_compilation/covariant_override.d(36): Error: function `@safe void covariant_override.CA.f(void delegate() @safe dg)` does not override any function
+fail_compilation/covariant_override.d(30):        did you mean to override `@safe void covariant_override.A.f(void delegate() @system dg)`?
+fail_compilation/covariant_override.d(22): Error: class `covariant_override.CI` interface function `void f(void delegate() @system dg) @safe` is not implemented
 ---
 ++/
 

--- a/compiler/test/fail_compilation/diag9191.d
+++ b/compiler/test/fail_compilation/diag9191.d
@@ -1,10 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9191.d(16): Error: function `void diag9191.C1.aaa()` does not override any function, did you mean to override `void diag9191.B1.aa()`?
-fail_compilation/diag9191.d(22): Error: function `diag9191.C2.aaa` does not override any function
-fail_compilation/diag9191.d(33): Error: function `void diag9191.C3.foo()` does not override any function, did you mean to override `void diag9191.B2._foo()`?
-fail_compilation/diag9191.d(38): Error: function `void diag9191.C4.toStringa()` does not override any function, did you mean to override `string object.Object.toString()`?
+fail_compilation/diag9191.d(19): Error: function `void diag9191.C1.aaa()` does not override any function
+fail_compilation/diag9191.d(15):        did you mean to override `void diag9191.B1.aa()`?
+fail_compilation/diag9191.d(25): Error: function `diag9191.C2.aaa` does not override any function
+fail_compilation/diag9191.d(36): Error: function `void diag9191.C3.foo()` does not override any function
+fail_compilation/diag9191.d(31):        did you mean to override `void diag9191.B2._foo()`?
+fail_compilation/diag9191.d(41): Error: function `void diag9191.C4.toStringa()` does not override any function
+$p:druntime/import/object.d$($n$):        did you mean to override `string object.Object.toString()`?
 ---
 */
 

--- a/compiler/test/fail_compilation/fail18093.d
+++ b/compiler/test/fail_compilation/fail18093.d
@@ -1,8 +1,9 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail18093.d(19): Error: function `void fail18093.GenericTransitiveVisitor!(ASTCodegen).GenericTransitiveVisitor.ParseVisitMethods!(ASTCodegen).visit()` does not override any function, did you mean to override `extern (C++) void fail18093.ParseTimeVisitor!(ASTCodegen).ParseTimeVisitor.visit()`?
-fail_compilation/fail18093.d(24): Error: mixin `fail18093.GenericTransitiveVisitor!(ASTCodegen).GenericTransitiveVisitor.ParseVisitMethods!(ASTCodegen)` error instantiating
-fail_compilation/fail18093.d(27): Error: template instance `fail18093.GenericTransitiveVisitor!(ASTCodegen)` error instantiating
+fail_compilation/fail18093.d(20): Error: function `void fail18093.GenericTransitiveVisitor!(ASTCodegen).GenericTransitiveVisitor.ParseVisitMethods!(ASTCodegen).visit()` does not override any function
+fail_compilation/fail18093.d(16):        did you mean to override `extern (C++) void fail18093.ParseTimeVisitor!(ASTCodegen).ParseTimeVisitor.visit()`?
+fail_compilation/fail18093.d(25): Error: mixin `fail18093.GenericTransitiveVisitor!(ASTCodegen).GenericTransitiveVisitor.ParseVisitMethods!(ASTCodegen)` error instantiating
+fail_compilation/fail18093.d(28): Error: template instance `fail18093.GenericTransitiveVisitor!(ASTCodegen)` error instantiating
 ---
  * https://issues.dlang.org/show_bug.cgi?id=18093
  */

--- a/compiler/test/fail_compilation/fail22351.d
+++ b/compiler/test/fail_compilation/fail22351.d
@@ -2,9 +2,10 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/fail22351.d(18): Deprecation: overriding `extern(C++)` function `fail22351.C22351.func(int*)` with `const` qualified function `fail22351.Fail22351.func(const(int*))` is deprecated
-fail_compilation/fail22351.d(18):        Either remove `override`, or adjust the `const` qualifiers of the overriding function parameters
-fail_compilation/fail22351.d(19): Error: function `extern (C++) void fail22351.Fail22351.func(const(int*)**)` does not override any function, did you mean to override `extern (C++) void fail22351.C22351.func(int*)`?
+fail_compilation/fail22351.d(19): Deprecation: overriding `extern(C++)` function `fail22351.C22351.func(int*)` with `const` qualified function `fail22351.Fail22351.func(const(int*))` is deprecated
+fail_compilation/fail22351.d(19):        Either remove `override`, or adjust the `const` qualifiers of the overriding function parameters
+fail_compilation/fail22351.d(20): Error: function `extern (C++) void fail22351.Fail22351.func(const(int*)**)` does not override any function
+fail_compilation/fail22351.d(13):        did you mean to override `extern (C++) void fail22351.C22351.func(int*)`?
 ---
 */
 extern(C++) class C22351

--- a/compiler/test/fail_compilation/fail262.d
+++ b/compiler/test/fail_compilation/fail262.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail262.d(23): Error: function `const void fail262.B.f()` does not override any function, did you mean to override `shared const void fail262.A.f()`?
+fail_compilation/fail262.d(24): Error: function `const void fail262.B.f()` does not override any function
+fail_compilation/fail262.d(16):        did you mean to override `shared const void fail262.A.f()`?
 ---
 */
 

--- a/compiler/test/fail_compilation/fail8631.d
+++ b/compiler/test/fail_compilation/fail8631.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8631.d(14): Error: function `shared const int fail8631.D.foo()` does not override any function, did you mean to override `immutable int fail8631.B.foo()`?
+fail_compilation/fail8631.d(15): Error: function `shared const int fail8631.D.foo()` does not override any function
+fail_compilation/fail8631.d(10):        did you mean to override `immutable int fail8631.B.foo()`?
 ---
 */
 

--- a/compiler/test/fail_compilation/retref2.d
+++ b/compiler/test/fail_compilation/retref2.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retref2.d(18): Error: function `ref int retref2.D.foo(return ref int)` does not override any function, did you mean to override `ref int retref2.C.foo(ref int)`?
-fail_compilation/retref2.d(19): Error: function `ref int retref2.D.bar() scope return` does not override any function, did you mean to override `ref int retref2.C.bar()`?
+fail_compilation/retref2.d(20): Error: function `ref int retref2.D.foo(return ref int)` does not override any function
+fail_compilation/retref2.d(14):        did you mean to override `ref int retref2.C.foo(ref int)`?
+fail_compilation/retref2.d(21): Error: function `ref int retref2.D.bar() scope return` does not override any function
+fail_compilation/retref2.d(15):        did you mean to override `ref int retref2.C.bar()`?
 ---
 */
 

--- a/compiler/test/fail_compilation/test13867.d
+++ b/compiler/test/fail_compilation/test13867.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test13867.d(12): Error: function `void test13867.X.blah()` does not override any function, did you mean to override `extern (C++) void test13867.Base.blah()`?
-fail_compilation/test13867.d(19): Error: function `void test13867.Z.blah()` does not override any function, did you mean to override `extern (C++) void test13867.Base.blah()`?
+fail_compilation/test13867.d(14): Error: function `void test13867.X.blah()` does not override any function
+fail_compilation/test13867.d(11):        did you mean to override `extern (C++) void test13867.Base.blah()`?
+fail_compilation/test13867.d(21): Error: function `void test13867.Z.blah()` does not override any function
+fail_compilation/test13867.d(11):        did you mean to override `extern (C++) void test13867.Base.blah()`?
 ---
 */
 extern (C++) class Base {

--- a/compiler/test/fail_compilation/test20489.d
+++ b/compiler/test/fail_compilation/test20489.d
@@ -1,10 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test20489.d(19): Error: function `pure nothrow @nogc @safe int test20489.D.f(int delegate(int) pure nothrow @nogc @safe body)` does not override any function, did you mean to override `pure nothrow @nogc @safe int test20489.B.f(scope int delegate(int) pure nothrow @nogc @safe)`?
-fail_compilation/test20489.d(19):        Did you intend to override:
-fail_compilation/test20489.d(19):        `pure nothrow @nogc @safe int test20489.B.f(scope int delegate(int) pure nothrow @nogc @safe)`
-fail_compilation/test20489.d(19):        Parameter 1 is missing `scope`
+fail_compilation/test20489.d(18): Error: function `pure nothrow @nogc @safe int test20489.D.f(int delegate(int) pure nothrow @nogc @safe body)` does not override any function
+fail_compilation/test20489.d(14):        did you mean to override `pure nothrow @nogc @safe int test20489.B.f(scope int delegate(int) pure nothrow @nogc @safe)`?
+fail_compilation/test20489.d(18):        parameter 1 is missing `scope`
 ---
 */
 

--- a/compiler/test/fail_compilation/test21246.d
+++ b/compiler/test/fail_compilation/test21246.d
@@ -3,7 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test21246.d(16): Error: function `void test21246.C.set(Clock clock)` does not override any function, did you mean to override `void imports.test21246.B.set(imports.test21246.Clock clock)`?
+fail_compilation/test21246.d(17): Error: function `void test21246.C.set(Clock clock)` does not override any function
+fail_compilation/imports/test21246.d(7):        did you mean to override `void imports.test21246.B.set(imports.test21246.Clock clock)`?
 ---
 */
 module test21246;


### PR DESCRIPTION
Put the suggestion in a supplemental error to break the long line, and to include a source code location that makes it easy to jump to.

Remove the redundant suggestion when there is a `scope` difference.