### PR TITLE
fix issue #20425

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -3464,6 +3464,17 @@ Lagain:
 
         Type memberType = ts.sym.fields[0].type.toBasetype();
 
+        /* encure the complex member types fall under one of the complex types */
+        switch (memberType.toBasetype().ty)
+        {
+            case Tfloat32:
+            case Tfloat64:
+            case Tfloat80:
+                break;
+            default:
+                return false;
+        }
+
         switch (t2.toBasetype().ty)
         {
             case Tfloat32:

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -3445,6 +3445,49 @@ Lagain:
     t1b = t1.toBasetype();
     t2b = t2.toBasetype();
 
+    static bool isComplexStruct(Type t)
+    {
+        if (t.ty != Tstruct)
+            return false;
+
+        TypeStruct ts = t.isTypeStruct();
+
+        return ts.sym.toString() == "_Complex";
+    }
+
+    static bool isComplexStructOfType(Type t, Type t2)
+    {
+        if (!isComplexStruct(t))
+            return false;
+
+        TypeStruct ts = t.toBasetype().isTypeStruct();
+
+        Type memberType = ts.sym.fields[0].type.toBasetype();
+
+        switch (t2.toBasetype().ty)
+        {
+            case Tfloat32:
+            case Tfloat64:
+            case Tfloat80:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /* check for complex structure and an associate complex type in a single condexp */
+    if (sc && sc.inCfile)
+    {
+        if (isComplexStructOfType(t1b, t2b))
+        {
+            return Lret(e1.type.toBasetype());
+        }
+        else if (isComplexStructOfType(t2b, t1b))
+        {
+            return Lret(e2.type.toBasetype());
+        }
+    }
+
     const ty = implicitConvCommonTy(t1b.ty, t2b.ty);
     if (ty != Terror)
     {

--- a/compiler/test/compilable/fix20425.c
+++ b/compiler/test/compilable/fix20425.c
@@ -1,13 +1,9 @@
-#ifndef _MSC_VER
 #include <complex.h>
-#endif
 
 void foo() {
-#ifndef _MSC_VER
     double *a;
     double complex *b;
     double complex zden;
     double c, d;
     zden = c > d? b[0]: a[0];
-#endif
 }

--- a/compiler/test/compilable/fix20425.c
+++ b/compiler/test/compilable/fix20425.c
@@ -1,0 +1,13 @@
+#ifndef _MSC_VER
+#include <complex.h>
+#endif
+
+void foo() {
+#ifndef _MSC_VER
+    double *a;
+    double complex *b;
+    double complex zden;
+    double c, d;
+    zden = c > d? b[0]: a[0];
+#endif
+}

--- a/compiler/test/compilable/fix20425.c
+++ b/compiler/test/compilable/fix20425.c
@@ -1,3 +1,5 @@
+// DISABLED: win32 win64
+
 #include <complex.h>
 
 void foo() {

--- a/compiler/test/compilable/fix20425.c
+++ b/compiler/test/compilable/fix20425.c
@@ -2,8 +2,8 @@
 
 void foo() {
     double *a;
-    double complex *b;
-    double complex zden;
+    double _Complex *b;
+    double _Complex zden;
     double c, d;
     zden = c > d? b[0]: a[0];
 }


### PR DESCRIPTION
in the type merging for tenary operators, no handler exists yet for real to complex type conversion.
complex in C does nor follow Tcomplex family but a `_Complex` struct with floating types.

This PR handles it!

now we are able to use complex in tenary operators.

Windows disabled in testing since windows does not implement the C99 complex system.

@dkorpel @thewilsonator 