### PR TITLE
Set `FuncDeclaration.inferRetType` flag during semantic analysis

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4014,7 +4014,7 @@ private bool functionParameters(Loc loc, Scope* sc,
     }
 
     // If inferring return type, and semantic3() needs to be run if not already run
-    if (!tf.next && fd.inferRetType)
+    if (!tf.next && fd.FdInferRetType())
     {
         functionSemantic(fd);
     }
@@ -8359,7 +8359,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             else if (auto ve = exp.e1.isVarExp())
                 fd = cast(FuncDeclaration)ve.var;
 
-            if (fd && fd.inferRetType && sc && sc.func == fd)
+            if (fd && fd.FdInferRetType() && sc && sc.func == fd)
             {
                 error(exp.loc, "can't infer return type in function `%s`", fd.toChars());
             }
@@ -16263,7 +16263,7 @@ MATCH matchType(FuncExp funcExp, Type to, Scope* sc, FuncExp* presult, ErrorSink
     auto tfx = fd.type.isTypeFunction();
     bool convertMatch = (type.ty != to.ty);
 
-    if (fd.inferRetType && tfx.next.implicitConvTo(tof.next) == MATCH.convert)
+    if (fd.FdInferRetType() && tfx.next.implicitConvTo(tof.next) == MATCH.convert)
     {
         /* If return type is inferred and covariant return,
          * tweak return statements to required return type.

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4458,7 +4458,7 @@ enum class PURE : uint8_t
 class TypeFunction final : public TypeNext
 {
 public:
-    Type _next; // next at initialization time of this class, which should not be changed after
+    Type *_next; // next at initialization time of this class, which should not be changed after
     ParameterList parameterList;
 private:
     struct BitFields final

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4458,6 +4458,7 @@ enum class PURE : uint8_t
 class TypeFunction final : public TypeNext
 {
 public:
+    Type _next; // next at initialization time of this class, which should not be changed after
     ParameterList parameterList;
 private:
     struct BitFields final

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4458,7 +4458,7 @@ enum class PURE : uint8_t
 class TypeFunction final : public TypeNext
 {
 public:
-    Type *_next; // next at initialization time of this class, which should not be changed after
+    Type *_retType; // treturn at initialization time of this class, which should not be changed after
     ParameterList parameterList;
 private:
     struct BitFields final

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -113,6 +113,7 @@ private struct FUNCFLAG
     bool hasSemantic3Errors; /// If errors in semantic3 this function's frame ptr
     bool hasNoEH;            /// No exception unwinding is needed
     bool inferRetType;       /// Return type is to be inferred
+    bool isSetInferRetType;  /// whether inferRetType is set
     bool hasDualContext;     /// has a dual-context 'this' parameter
 
     bool hasAlwaysInlines;   /// Contains references to functions that must be inlined
@@ -328,12 +329,6 @@ extern (C++) class FuncDeclaration : Declaration
         this.endloc = endloc;
         if (noreturn)
             this.noreturn = true;
-
-        /* The type given for "infer the return type" is a TypeFunction with
-         * NULL for the return type.
-         */
-        if (type && type.nextOf() is null)
-            this.inferRetType = true;
     }
 
     static FuncDeclaration create(Loc loc, Loc endloc, Identifier id, StorageClass storage_class, Type type, bool noreturn = false)

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -327,6 +327,7 @@ extern (C++) class FuncDeclaration : Declaration
             this.storage_class &= ~(STC.TYPECTOR | STC.FUNCATTR);
         }
         this.endloc = endloc;
+        this.isSetInferRetType = false;
         if (noreturn)
             this.noreturn = true;
     }

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -67,7 +67,6 @@ import dmd.typesem;
 import dmd.visitor;
 import dmd.visitor.statement_rewrite_walker;
 
-
 bool FdInferRetType(FuncDeclaration _this)
 {
     if (_this.isSetInferRetType)
@@ -76,7 +75,15 @@ bool FdInferRetType(FuncDeclaration _this)
     /* The type given for "infer the return type" is a TypeFunction with
      * NULL for the return type.
      */
-    _this.inferRetType = _this.type && _this.type.nextOf() is null;
+    Type next = null;
+    if (_this.type)
+    {
+        if (auto tf = _this.type.isTypeFunction())
+            next = tf._next;
+        else
+            next = _this.type.nextOf();
+    }
+    _this.inferRetType = _this.type && next is null;
     _this.isSetInferRetType = true;
     return _this.inferRetType;
 }

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -79,7 +79,7 @@ bool FdInferRetType(FuncDeclaration _this)
     if (_this.type)
     {
         if (auto tf = _this.type.isTypeFunction())
-            next = tf._next;
+            next = tf._retType;
         else
             next = _this.type.nextOf();
     }

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1815,7 +1815,7 @@ extern (C++) final class TypeFunction : TypeNext
 {
     // .next is the return type
 
-    Type _next; // next during the initialization of this class, which should not be changed
+    Type _retType; // treturn during the initialization of this class, which should not be changed
 
     ParameterList parameterList;   // function parameters
 
@@ -1857,7 +1857,7 @@ extern (C++) final class TypeFunction : TypeNext
         assert(VarArg.none <= pl.varargs && pl.varargs <= VarArg.max);
         this.parameterList = pl;
         this.linkage = linkage;
-        this._next = treturn;
+        this._retType = treturn;
 
         if (stc & STC.pure_)
             this.purity = PURE.fwdref;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1815,6 +1815,8 @@ extern (C++) final class TypeFunction : TypeNext
 {
     // .next is the return type
 
+    Type _next; // next during the initialization of this class, which should not be changed
+
     ParameterList parameterList;   // function parameters
 
     // These flags can be accessed like `bool` properties,
@@ -1855,6 +1857,7 @@ extern (C++) final class TypeFunction : TypeNext
         assert(VarArg.none <= pl.varargs && pl.varargs <= VarArg.max);
         this.parameterList = pl;
         this.linkage = linkage;
+        this._next = treturn;
 
         if (stc & STC.pure_)
             this.purity = PURE.fwdref;

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -460,7 +460,7 @@ class TypeFunction final : public TypeNext
 {
 public:
     // .next is the return type
-
+    Type _next; // next at initialization time of this class, which should not be changed after
     ParameterList parameterList; // function parameters
     uint16_t bitFields;
     LINK linkage;                // calling convention

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -460,7 +460,7 @@ class TypeFunction final : public TypeNext
 {
 public:
     // .next is the return type
-    Type *_next; // next at initialization time of this class, which should not be changed after
+    Type *_retType; // treturn at initialization time of this class, which should not be changed after
     ParameterList parameterList; // function parameters
     uint16_t bitFields;
     LINK linkage;                // calling convention

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -460,7 +460,7 @@ class TypeFunction final : public TypeNext
 {
 public:
     // .next is the return type
-    Type _next; // next at initialization time of this class, which should not be changed after
+    Type *_next; // next at initialization time of this class, which should not be changed after
     ParameterList parameterList; // function parameters
     uint16_t bitFields;
     LINK linkage;                // calling convention

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -256,7 +256,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             funcdecl.errors = true;
 
             // Mark that the return type could not be inferred
-            if (funcdecl.inferRetType)
+            if (funcdecl.FdInferRetType())
             {
                 assert(funcdecl.type);
                 auto tf = funcdecl.type.isTypeFunction();
@@ -307,10 +307,10 @@ private extern(C++) final class Semantic3Visitor : Visitor
         if (!funcdecl.type || funcdecl.type.ty != Tfunction)
             return;
         TypeFunction f = cast(TypeFunction)funcdecl.type;
-        if (!funcdecl.inferRetType && f.next.ty == Terror)
+        if (!funcdecl.FdInferRetType() && f.next.ty == Terror)
             return;
 
-        if (!funcdecl.fbody && funcdecl.inferRetType && !f.next)
+        if (!funcdecl.fbody && funcdecl.FdInferRetType() && !f.next)
         {
             .error(funcdecl.loc, "%s `%s` has no function body with return type inference", funcdecl.kind, funcdecl.toPrettyChars);
             return;
@@ -623,7 +623,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 assert(funcdecl.type == f || (funcdecl.type.ty == Tfunction && f.purity == PURE.impure && (cast(TypeFunction)funcdecl.type).purity >= PURE.fwdref));
                 f = cast(TypeFunction)funcdecl.type;
 
-                if (funcdecl.inferRetType)
+                if (funcdecl.FdInferRetType())
                 {
                     // If no return type inferred yet, then infer a void
                     if (!f.next)

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2570,7 +2570,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             rs.exp = rs.exp.expressionSemantic(sc);
             rs.exp = rs.exp.arrayFuncConv(sc);
             // If we're returning by ref, allow the expression to be `shared`
-            const returnSharedRef = (tf.isRef && (fd.inferRetType || tret.isShared()));
+            const returnSharedRef = (tf.isRef && (fd.FdInferRetType() || tret.isShared()));
             rs.exp.checkSharedAccess(sc, returnSharedRef);
 
             // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
@@ -2582,7 +2582,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 rs.exp = ErrorExp.get();
             if (auto f = isFuncAddress(rs.exp))
             {
-                if (fd.inferRetType && f.checkForwardRef(rs.exp.loc))
+                if (fd.FdInferRetType() && f.checkForwardRef(rs.exp.loc))
                     rs.exp = ErrorExp.get();
             }
             if (checkNonAssignmentArrayOp(rs.exp))
@@ -2649,7 +2649,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         if (rs.exp)
         {
-            if (fd.inferRetType) // infer return type
+            if (fd.FdInferRetType()) // infer return type
             {
                 if (!tret)
                 {
@@ -2748,7 +2748,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             auto resType = e0 ? e0.type : Type.tvoid;
 
             // infer return type
-            if (fd.inferRetType)
+            if (fd.FdInferRetType())
             {
                 // 1. First `return <noreturn exp>?`
                 // 2. Potentially found a returning branch, update accordingly

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -3094,6 +3094,7 @@ MATCH matchWithInstance(Scope* sc, TemplateDeclaration td, TemplateInstance ti, 
             fd = new FuncDeclaration(fd.loc, fd.endloc, fd.ident, fd.storage_class, tf);
             fd.parent = ti;
             fd.inferRetType = true;
+            fd.isSetInferRetType = true;
 
             // Shouldn't run semantic on default arguments and return type.
             foreach (ref param; *tf.parameterList.parameters)

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -6098,7 +6098,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
          * For auto function, completion should be deferred to the end of
          * its semantic3. Should not complete it in here.
          */
-        if (tf.next && !m.lastf.inferRetType)
+        if (tf.next && !m.lastf.FdInferRetType())
         {
             m.lastf.type = tf.typeSemantic(loc, sc);
         }


### PR DESCRIPTION
To be able to move `Type.nextOf` to `typesem`