### PR TITLE
Fix #21829 - macOS x64: Fix crash in backtrace() in Fiber contexts

### DIFF
--- a/druntime/src/core/thread/fiber/package.d
+++ b/druntime/src/core/thread/fiber/package.d
@@ -1027,7 +1027,16 @@ protected:
         {
             push( 0x00000000_00000000 );                            // Return address of fiber_entryPoint call
             push( cast(size_t) &fiber_entryPoint );                 // RIP
-            push( cast(size_t) m_ctxt.bstack );                     // RBP
+            version (OSX)
+            {
+                // backtrace() needs this to be null to terminate
+                // the stack walk on macOS x86_64
+                push( 0x00000000_00000000 );                        // RBP
+            }
+            else
+            {
+                push( cast(size_t) m_ctxt.bstack );                 // RBP
+            }
             push( 0x00000000_00000000 );                            // RBX
             push( 0x00000000_00000000 );                            // R12
             push( 0x00000000_00000000 );                            // R13


### PR DESCRIPTION
This keeps backtrace() from continuing to unwind past the end of the stack. The address otherwise doesn't appear to be used anywhere.

Note that backtrace() gets called internally be some OS functions, such as CGLCreateContext, so the previous code lead to crashes that were difficult to avoid.

Fixes #21829