### PR TITLE
move error message generation out of IntegerExp()

### DIFF
--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -488,21 +488,30 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
     else if (first)
     {
         Type t;
+        bool terror;
         if (em.ed.memtype)
+        {
             t = em.ed.memtype;
+            if (!t.isScalar())
+            {
+                t = Type.terror; // print more relevant error message later
+                terror = true;
+            }
+        }
         else
         {
             t = Type.tint32;
             if (!em.ed.isAnonymous())
                 em.ed.memtype = t;
         }
+
         const errors = global.startGagging();
         Expression e = new IntegerExp(em.loc, 0, t);
         e = e.ctfeInterpret();
-        if (global.endGagging(errors))
+        if (global.endGagging(errors) || terror)
         {
             error(em.loc, "cannot generate 0 value of type `%s` for `%s`",
-                t.toChars(), em.toChars());
+                em.ed.memtype.toChars(), em.toChars());
         }
         // save origValue for better json output
         em.origValue = e;


### PR DESCRIPTION
The idea is to move all calls to error() out expressionsem.d.

As far as I can tell, the error message in IntegerExp's constructor is never printed. Fixing that will take more PRs than this one.