### PR TITLE
importC: convert C complex types to use D fundamental complex and not complex library struct.

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5310,32 +5310,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         e.type = e.type.typeSemantic(e.loc, sc);
         result = e;
         return;
-
-        /* Convert to core.stdc.config.complex
-         * exempt C from this
-         */
-        /*Type t = getComplexLibraryType(e.loc, sc, e.type.ty);
-        if (t.ty == Terror)
-            return setError();
-
-        Type tf;
-        switch (e.type.ty)
-        {
-            case Timaginary32: tf = Type.tfloat32; break;
-            case Timaginary64: tf = Type.tfloat64; break;
-            case Timaginary80: tf = Type.tfloat80; break;
-            default:
-                assert(0);
-        }
-
-        /* Construct ts{re : 0.0, im : e}
-         */
-        /*TypeStruct ts = t.isTypeStruct;
-        Expressions* elements = new Expressions(2);
-        (*elements)[0] = new RealExp(e.loc,    CTFloat.zero, tf);
-        (*elements)[1] = new RealExp(e.loc, e.toImaginary(), tf);
-        Expression sle = new StructLiteralExp(e.loc, ts.sym, elements);
-        result = sle.expressionSemantic(sc);*/
     }
 
     override void visit(ComplexExp e)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5306,16 +5306,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         if (!e.type)
             e.type = Type.tfloat64;
-        else if (!e.type.isImaginary || !sc.inCfile)
-        {
-            e.type = e.type.typeSemantic(e.loc, sc);
-            result = e;
-            return;
-        }
+
+        e.type = e.type.typeSemantic(e.loc, sc);
+        result = e;
+        return;
 
         /* Convert to core.stdc.config.complex
+         * exempt C from this
          */
-        Type t = getComplexLibraryType(e.loc, sc, e.type.ty);
+        /*Type t = getComplexLibraryType(e.loc, sc, e.type.ty);
         if (t.ty == Terror)
             return setError();
 
@@ -5331,12 +5330,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         /* Construct ts{re : 0.0, im : e}
          */
-        TypeStruct ts = t.isTypeStruct;
+        /*TypeStruct ts = t.isTypeStruct;
         Expressions* elements = new Expressions(2);
         (*elements)[0] = new RealExp(e.loc,    CTFloat.zero, tf);
         (*elements)[1] = new RealExp(e.loc, e.toImaginary(), tf);
         Expression sle = new StructLiteralExp(e.loc, ts.sym, elements);
-        result = sle.expressionSemantic(sc);
+        result = sle.expressionSemantic(sc);*/
     }
 
     override void visit(ComplexExp e)

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -3135,6 +3135,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
 
     Type visitComplex(TypeBasic t)
     {
+        /* begins from here */
         if (!sc.inCfile)
             return visitType(t);
 

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -3135,11 +3135,14 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
 
     Type visitComplex(TypeBasic t)
     {
+        return visitType(t);
+
+
         //import std.stdio;
         //writeln(t);
         /* begins from here */
         //if (!sc.inCfile) //
-        return visitType(t); // both C and D gets here
+        //return visitType(t); // both C and D gets here
 
         //auto tc = getComplexLibraryType(loc, sc, t.ty);
         //if (tc.ty == Terror)

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -3136,20 +3136,6 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
     Type visitComplex(TypeBasic t)
     {
         return visitType(t);
-
-
-        //import std.stdio;
-        //writeln(t);
-        /* begins from here */
-        //if (!sc.inCfile) //
-        //return visitType(t); // both C and D gets here
-
-        //auto tc = getComplexLibraryType(loc, sc, t.ty);
-        //if (tc.ty == Terror)
-        //    return tc;
-
-        //writeln("here", tc);
-        //return tc.addMod(t.mod).merge();
     }
 
     Type visitVector(TypeVector mtype)

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -3135,14 +3135,18 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
 
     Type visitComplex(TypeBasic t)
     {
+        //import std.stdio;
+        //writeln(t);
         /* begins from here */
-        if (!sc.inCfile)
-            return visitType(t);
+        //if (!sc.inCfile) //
+        return visitType(t); // both C and D gets here
 
-        auto tc = getComplexLibraryType(loc, sc, t.ty);
-        if (tc.ty == Terror)
-            return tc;
-        return tc.addMod(t.mod).merge();
+        //auto tc = getComplexLibraryType(loc, sc, t.ty);
+        //if (tc.ty == Terror)
+        //    return tc;
+
+        //writeln("here", tc);
+        //return tc.addMod(t.mod).merge();
     }
 
     Type visitVector(TypeVector mtype)

--- a/compiler/test/compilable/testcomplex.c
+++ b/compiler/test/compilable/testcomplex.c
@@ -1,0 +1,13 @@
+#include <complex.h>
+
+void foo(_Complex double z)
+{
+    return;
+}
+
+
+int main()
+{
+    double z;
+    foo(z);
+}

--- a/compiler/test/runnable/testc22259.c
+++ b/compiler/test/runnable/testc22259.c
@@ -1,3 +1,5 @@
+// DISABLED: win32 win64
+
 // https://github.com/dlang/dmd/issues/22259
 
 #include <complex.h>

--- a/compiler/test/runnable/testc22259.c
+++ b/compiler/test/runnable/testc22259.c
@@ -1,0 +1,20 @@
+// https://github.com/dlang/dmd/issues/22259
+
+#include <complex.h>
+#include <stdio.h>
+#include <assert.h>
+
+void foo()
+{
+    _Complex double x = 1 + 1.0if;
+    assert(creal(x) == 1.000000);
+    assert(cimag(x) == 1.000000);
+    return;
+}
+
+
+int main()
+{
+    foo();
+    return 0;
+}

--- a/compiler/test/runnable/testcomplexinit.c
+++ b/compiler/test/runnable/testcomplexinit.c
@@ -1,18 +1,25 @@
 // DISABLED: win32 win64
 
-// https://github.com/dlang/dmd/issues/22259
-
 #include <complex.h>
 #include <stdio.h>
 #include <assert.h>
 
+struct com
+{
+    int r;
+    int c;
+};
+
 void foo()
 {
-    _Complex double x = 1 + 1.0if;
+    struct com obj = { 1, 3};
+    _Complex double x = { obj.r, obj.c}; //real + im*i;
+
     assert(creal(x) == 1.000000);
-    assert(cimag(x) == 1.000000);
+    assert(cimag(x) == 3.000000);
     return;
 }
+
 
 int main()
 {

--- a/druntime/test/importc_compare/src/importc_compare.d
+++ b/druntime/test/importc_compare/src/importc_compare.d
@@ -29,6 +29,8 @@ immutable string[] growingTypes = [
 // warnings for now.
 immutable ErrorFilter[] knownProblems = [
     ErrorFilter("core.stdc.config.c_long_double", "", "Windows", 32, ""),
+    ErrorFilter("core.stdc.config.c_complex_real", "", "Windows", 32, ""), // complex real is two long doubles so same for x86 Windows
+    ErrorFilter("core.stdc.config.__c_complex_real", "", "Windows", 32, ""),
     ErrorFilter("core.stdc.fenv.fenv_t", "", "FreeBSD", 0, ""),
     ErrorFilter("core.stdc.locale.lconv", "", "Apple", 0, "https://issues.dlang.org/show_bug.cgi?id=24652"),
     ErrorFilter("core.stdc.locale.lconv", "", "FreeBSD", 0, "https://issues.dlang.org/show_bug.cgi?id=24652"),


### PR DESCRIPTION
I am opening this PR to reinvent the wheel for C complex for importC.
reading few comments in DMD, and conversations with @ibuclaw , DMD has the intentions of using the D fundamental complex types which is ABI compatible with the C complex types. but the implementations in several parts of the compiler contradict that. that's the main cause of issues opened on C complex and will make it impossible to compile third party libraries. with the issues opened on complex, we could provide fixes to make them work but in the end, they would be fragile since the main internal C complex machinery is broken in DMD.

This PR is supposed to lead to C complex no longer interpreted as `_Complex!T`.


Now, s7.c file now compiles at least. these changes have been tested with s7 which was encountering a lot of compile time errors with complex code.
link to s7 : https://ccrma.stanford.edu/software/snd/snd/s7.html
I have decided to leave the unwanted code commented out with reasons stated. 
@dkorpel @thewilsonator @WalterBright @ibuclaw 

I will reference a link to a test suite for s7 compiling.