### PR TITLE
fix #22239: Add the FreeBSD_15 version identifier.

### DIFF
--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -83,6 +83,8 @@ ubyte defaultTargetOSMajor() @safe
             return 13;
         else version (TARGET_FREEBSD14)
             return 14;
+        else version (TARGET_FREEBSD15)
+            return 15;
         else
             return 0;
     }

--- a/druntime/src/core/sys/freebsd/config.d
+++ b/druntime/src/core/sys/freebsd/config.d
@@ -14,7 +14,8 @@ public import core.sys.posix.config;
 // NOTE: When adding newer versions of FreeBSD, verify all current versioned
 // bindings are still compatible with the release.
 
-     version (FreeBSD_14) enum __FreeBSD_version = 1400000;
+     version (FreeBSD_15) enum __FreeBSD_version = 1500063;
+else version (FreeBSD_14) enum __FreeBSD_version = 1400097;
 else version (FreeBSD_13) enum __FreeBSD_version = 1301000;
 else version (FreeBSD_12) enum __FreeBSD_version = 1203000;
 else version (FreeBSD_11) enum __FreeBSD_version = 1104000;


### PR DESCRIPTION
This adds the FreeBSD_15 version identifier to dmd (now that FreeBSD 15 has been released), and defines __FreeBSD_version in druntime accordingly.

It also fixes __FreeBSD_version for FreeBSD 14 so that it matches the initial release of FreeBSD 14 and not the value it had when development started.