### PR TITLE
[2024 edition] Disallow `alias ... ident;` syntax

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4637,9 +4637,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
             if (isAliasDeclaration)
             {
-                AST.Declaration v;
-                AST.Initializer _init = null;
-
+                if (ident && mod.edition >= Edition.v2024)
+                {
+                    eSink.error(token.loc, "use `alias %s = ...;` syntax instead of `alias ... %s;`",
+                        ident.toChars(), ident.toChars());
+                }
                 /* Aliases can no longer have multiple declarators, storage classes,
                  * linkages, or auto declarations.
                  * These never made any sense, anyway.
@@ -4650,6 +4652,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 if (udas)
                     error("user-defined attributes not allowed for `alias` declarations");
 
+                AST.Initializer _init = null;
                 if (token.value == TOK.assign)
                 {
                     nextToken();
@@ -4659,7 +4662,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 {
                     error("alias cannot have initializer");
                 }
-                v = new AST.AliasDeclaration(aliasLoc, ident, t);
+                AST.Declaration v = new AST.AliasDeclaration(aliasLoc, ident, t);
 
                 v.storage_class = storage_class;
                 if (pAttrs)

--- a/compiler/test/fail_compilation/obsolete_body.d
+++ b/compiler/test/fail_compilation/obsolete_body.d
@@ -2,10 +2,12 @@
 TEST_OUTPUT:
 ---
 fail_compilation/obsolete_body.d(11): Error: usage of identifer `body` as a keyword is obsolete. Use `do` instead.
+fail_compilation/obsolete_body.d(13): Error: use `alias i32 = ...;` syntax instead of `alias ... i32;`
 ---
 */
-@__edition_latest_do_not_use
-module m;
+module m 2024;
 
 void test()
 in { } body { }
+
+alias int i32;


### PR DESCRIPTION
Use `alias ident = ...;` form instead.

Add a parser error, similar to the `body` keyword edition error (see test).

Note: The `alias this = ...;` syntax was added [in 2023](https://github.com/dlang/dmd/commit/946079235db). Should the old `alias ... this;` syntax also be an edition error, or will that break too much code?