### PR TITLE
Implement `-edition=YYYY` semantics

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -437,7 +437,7 @@ extern (C++) final class Module : Package
         if (doHdrGen)
             hdrfile = setOutfilename(global.params.dihdr.name, global.params.dihdr.dir, arg, hdr_ext);
 
-        this.edition = Edition.min;
+        this.edition = global.params.edition;
     }
 
     extern (D) this(const(char)[] filename, Identifier ident, int doDocComment, int doHdrGen)

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -908,6 +908,8 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, out Param 
                 auto filename = p + 1+7+1+4;
                 files.push(filename);
                 params.editionFiles[filename] = params.edition;
+                // FIXME: params.edition should not be set when there's a filename
+                error("`-edition` is not supported with a filename yet");
             }
         }
         else if (arg == "-fIBT")

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -150,7 +150,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 error("module edition %lld must be in the range %d ... %d", edition, Edition.min, Edition.max);
                 edition = edition.min;
             }
-            mod.edition = cast(Edition)edition;
+            // ModuleDeclaration edition can't lower -edition flag's edition
+            if (edition > mod.edition)
+                mod.edition = cast(Edition)edition;
             nextToken();
         }
 

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -150,9 +150,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 error("module edition %lld must be in the range %d ... %d", edition, Edition.min, Edition.max);
                 edition = edition.min;
             }
-            // ModuleDeclaration edition can't lower -edition flag's edition
-            if (edition > mod.edition)
-                mod.edition = cast(Edition)edition;
+            mod.edition = cast(Edition)edition;
             nextToken();
         }
 

--- a/compiler/test/fail_compilation/edition_switch.d
+++ b/compiler/test/fail_compilation/edition_switch.d
@@ -1,0 +1,13 @@
+/*
+REQUIRED_ARGS: -edition=2024
+TEST_OUTPUT:
+---
+fail_compilation/edition_switch.d(13): Error: usage of identifer `body` as a keyword is obsolete. Use `do` instead.
+---
+*/
+
+// test -edition can override a lower module declaration
+module m 2023;
+
+void test()
+in { } body { }

--- a/compiler/test/fail_compilation/edition_switch.d
+++ b/compiler/test/fail_compilation/edition_switch.d
@@ -2,12 +2,9 @@
 REQUIRED_ARGS: -edition=2024
 TEST_OUTPUT:
 ---
-fail_compilation/edition_switch.d(13): Error: usage of identifer `body` as a keyword is obsolete. Use `do` instead.
+fail_compilation/edition_switch.d(10): Error: usage of identifer `body` as a keyword is obsolete. Use `do` instead.
 ---
 */
-
-// test -edition can override a lower module declaration
-module m 2023;
 
 void test()
 in { } body { }


### PR DESCRIPTION
Set `Module.edition` in constructor.
Make `-edition=YYYYfilename` an error as it does nothing (and also wrongly sets `params.edition`).
Allow a larger `-edition` value to override a module declaration's edition. (I think this is more useful than erroring). Note: this case is not mentioned in [the DIP](https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1052.md#targets) AFAICT - @atilaneves?

Fixes #22245.