### PR TITLE
Replace the call to `nextOf` with `.next` as the underlying type is `TypeNext`

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1571,7 +1571,7 @@ extern (C++) final class TypeVector : Type
     {
         assert(basetype.ty == Tsarray);
         TypeSArray t = cast(TypeSArray)basetype;
-        TypeBasic tb = t.nextOf().isTypeBasic();
+        TypeBasic tb = t.next.isTypeBasic();
         assert(tb);
         return tb;
     }


### PR DESCRIPTION
To be able to move `nextOf` to `typesem`