### PR TITLE
move hasValidType() out of Expression

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -293,19 +293,6 @@ extern (C++) abstract class Expression : ASTNode
         return a;
     }
 
-    /****************************************
-     * Check that the expression has a valid type.
-     * If not, generates an error "... has no type".
-     * Returns:
-     *      true if the expression has a valid type.
-     * Note:
-     *      When this function returns false, `checkValue()` should also return true.
-     */
-    bool hasValidType()
-    {
-        return true;
-    }
-
     /******************************
      * If this is a reference, dereference it.
      */
@@ -1564,12 +1551,6 @@ extern (C++) final class TypeExp : Expression
         return new TypeExp(loc, type.syntaxCopy());
     }
 
-    override bool hasValidType()
-    {
-        error(loc, "type `%s` is not an expression", toChars());
-        return false;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1602,27 +1583,6 @@ extern (C++) final class ScopeExp : Expression
         return new ScopeExp(loc, sds.syntaxCopy(null));
     }
 
-    override bool hasValidType()
-    {
-        if (sds.isPackage())
-        {
-            error(loc, "%s `%s` has no type", sds.kind(), sds.toChars());
-            return false;
-        }
-        auto ti = sds.isTemplateInstance();
-        if (!ti)
-            return true;
-        //assert(ti.needsTypeInference(sc));
-        if (ti.tempdecl &&
-            ti.semantictiargsdone &&
-            ti.semanticRun == PASS.initial)
-        {
-            error(loc, "partial %s `%s` has no type", sds.kind(), toChars());
-            return false;
-        }
-        return true;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1643,12 +1603,6 @@ extern (C++) final class TemplateExp : Expression
         //printf("TemplateExp(): %s\n", td.toChars());
         this.td = td;
         this.fd = fd;
-    }
-
-    override bool hasValidType()
-    {
-        error(loc, "%s `%s` has no type", td.kind(), toChars());
-        return false;
     }
 
     override void accept(Visitor v)
@@ -1879,16 +1833,6 @@ extern (C++) final class FuncExp : Expression
         // https://issues.dlang.org/show_bug.cgi?id=13481
         // Prevent multiple semantic analysis of lambda body.
         return new FuncExp(loc, fd);
-    }
-
-    override bool hasValidType()
-    {
-        if (td)
-        {
-            error(loc, "template lambda has no type");
-            return false;
-        }
-        return true;
     }
 
     override void accept(Visitor v)
@@ -2281,12 +2225,6 @@ extern (C++) final class DotTemplateExp : UnaExp
         this.td = td;
     }
 
-    override bool hasValidType()
-    {
-        error(loc, "%s `%s` has no type", td.kind(), toChars());
-        return false;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -2339,19 +2277,6 @@ extern (C++) final class DotTemplateInstanceExp : UnaExp
     override DotTemplateInstanceExp syntaxCopy()
     {
         return new DotTemplateInstanceExp(loc, e1.syntaxCopy(), ti.name, TemplateInstance.arraySyntaxCopy(ti.tiargs));
-    }
-
-    override bool hasValidType()
-    {
-        // Same logic as ScopeExp.hasValidType()
-        if (ti.tempdecl &&
-            ti.semantictiargsdone &&
-            ti.semanticRun == PASS.initial)
-        {
-            error(loc, "partial %s `%s` has no type", ti.kind(), toChars());
-            return false;
-        }
-        return true;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -106,7 +106,6 @@ public:
 
     const char* toChars() const final override;
 
-    virtual bool hasValidType();
     Expression *addressOf();
     Expression *deref();
 
@@ -451,7 +450,6 @@ class TypeExp final : public Expression
 {
 public:
     TypeExp *syntaxCopy() override;
-    bool hasValidType() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -461,7 +459,6 @@ public:
     ScopeDsymbol *sds;
 
     ScopeExp *syntaxCopy() override;
-    bool hasValidType() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -471,7 +468,6 @@ public:
     TemplateDeclaration *td;
     FuncDeclaration *fd;
 
-    bool hasValidType() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -565,7 +561,6 @@ public:
     TOK tok;
 
     FuncExp *syntaxCopy() override;
-    bool hasValidType() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -707,7 +702,6 @@ class DotTemplateExp final : public UnaExp
 public:
     TemplateDeclaration *td;
 
-    bool hasValidType() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -726,7 +720,6 @@ public:
     TemplateInstance *ti;
 
     DotTemplateInstanceExp *syntaxCopy() override;
-    bool hasValidType() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -535,8 +535,95 @@ Optional!bool toBool(Expression _this)
         case EXP.slice: return _this.isSliceExp().e1.toBool();
         case EXP.comma: return _this.isCommaExp().e2.toBool();
         // Statically evaluate this expression to a `bool` if possible
-        // Returns: an optional thath either contains the value or is empty
+        // Returns: an optional that either contains the value or is empty
         default: return typeof(return)();
+    }
+}
+
+/****************************************
+ * Check that the expression `e` has a valid type.
+ * If not, generates an error "... has no type".
+ * Params:
+ *	e = Expression to check
+ * Returns:
+ *      true if the expression has a valid type.
+ * Note:
+ *      When this function returns false, `checkValue()` should also return true.
+ */
+bool hasValidType(Expression e)
+{
+    static bool visitTypeExp(TypeExp e)
+    {
+        error(e.loc, "type `%s` is not an expression", e.toChars());
+        return false;
+    }
+
+    static bool visitScopeExp(ScopeExp e)
+    {
+        if (e.sds.isPackage())
+        {
+            error(e.loc, "%s `%s` has no type", e.sds.kind(), e.sds.toChars());
+            return false;
+        }
+        auto ti = e.sds.isTemplateInstance();
+        if (!ti)
+            return true;
+        //assert(ti.needsTypeInference(sc));
+        if (ti.tempdecl &&
+            ti.semantictiargsdone &&
+            ti.semanticRun == PASS.initial)
+        {
+            error(e.loc, "partial %s `%s` has no type", e.sds.kind(), e.toChars());
+            return false;
+        }
+        return true;
+    }
+
+    static bool visitTemplateExp(TemplateExp e)
+    {
+        error(e.loc, "%s `%s` has no type", e.td.kind(), e.toChars());
+        return false;
+    }
+
+    static bool visitFuncExp(FuncExp e)
+    {
+        if (e.td)
+        {
+            error(e.loc, "template lambda has no type");
+            return false;
+        }
+        return true;
+    }
+
+    static bool visitDotTemplateExp(DotTemplateExp e)
+    {
+        error(e.loc, "%s `%s` has no type", e.td.kind(), e.toChars());
+        return false;
+    }
+
+    static bool visitDotTemplateInstanceExp(DotTemplateInstanceExp e)
+    {
+        // Same logic as ScopeExp.hasValidType()
+        if (e.ti.tempdecl &&
+            e.ti.semantictiargsdone &&
+            e.ti.semanticRun == PASS.initial)
+        {
+            error(e.loc, "partial %s `%s` has no type", e.ti.kind(), e.toChars());
+            return false;
+        }
+        return true;
+    }
+
+    switch (e.op)
+    {
+	case EXP.type:                   return visitTypeExp(e.isTypeExp());
+	case EXP.scope_:                 return visitScopeExp(e.isScopeExp());
+	case EXP.template_:              return visitTemplateExp(e.isTemplateExp());
+	case EXP.function_:              return visitFuncExp(e.isFuncExp());
+	case EXP.dotTemplateDeclaration: return visitDotTemplateExp(e.isDotTemplateExp());
+	case EXP.dotTemplateInstance:    return visitDotTemplateInstanceExp(e.isDotTemplateInstanceExp());
+
+        default: return true;
     }
 }
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2315,7 +2315,6 @@ public:
     virtual Expression* syntaxCopy();
     DYNCAST dyncast() const final override;
     const char* toChars() const final override;
-    virtual bool hasValidType();
     Expression* deref();
     int32_t isConst();
     virtual bool hasCode();
@@ -2809,7 +2808,6 @@ class DotTemplateExp final : public UnaExp
 {
 public:
     TemplateDeclaration* td;
-    bool hasValidType() override;
     void accept(Visitor* v) override;
 };
 
@@ -2818,7 +2816,6 @@ class DotTemplateInstanceExp final : public UnaExp
 public:
     TemplateInstance* ti;
     DotTemplateInstanceExp* syntaxCopy() override;
-    bool hasValidType() override;
     void accept(Visitor* v) override;
 };
 
@@ -3104,7 +3101,6 @@ public:
     TemplateDeclaration* td;
     TOK tok;
     FuncExp* syntaxCopy() override;
-    bool hasValidType() override;
     void accept(Visitor* v) override;
 };
 
@@ -3405,7 +3401,6 @@ class ScopeExp final : public Expression
 public:
     ScopeDsymbol* sds;
     ScopeExp* syntaxCopy() override;
-    bool hasValidType() override;
     void accept(Visitor* v) override;
 };
 
@@ -3592,7 +3587,6 @@ class TemplateExp final : public Expression
 public:
     TemplateDeclaration* td;
     FuncDeclaration* fd;
-    bool hasValidType() override;
     void accept(Visitor* v) override;
 };
 
@@ -3633,7 +3627,6 @@ class TypeExp final : public Expression
 {
 public:
     TypeExp* syntaxCopy() override;
-    bool hasValidType() override;
     void accept(Visitor* v) override;
 };
 


### PR DESCRIPTION
Doesn't belong in the AST - moves error messages out of it.