### PR TITLE
Reduce reliance on __gshared BlockOpt bo

### DIFF
--- a/compiler/src/dmd/backend/blockopt.d
+++ b/compiler/src/dmd/backend/blockopt.d
@@ -31,6 +31,7 @@ import dmd.backend.code;
 import dmd.backend.ty;
 
 import dmd.backend.barray;
+import dmd.backend.var : bo;
 
 static if (NTEXCEPTIONS)
     enum SCPP_OR_NTEXCEPTIONS = true;
@@ -57,10 +58,8 @@ struct BlockOpt
     block blkzero;          // storage allocator
 }
 
-__gshared BlockOpt bo;
-
 @trusted
-pragma(inline, true) block* block_calloc_i()
+pragma(inline, true) block* block_calloc_i(ref BlockOpt bo)
 {
     block* b;
 
@@ -75,9 +74,9 @@ pragma(inline, true) block* block_calloc_i()
     return b;
 }
 
-block* block_calloc()
+block* block_calloc(ref BlockOpt bo)
 {
-    return block_calloc_i();
+    return block_calloc_i(bo);
 }
 
 /*********************************
@@ -99,7 +98,7 @@ Goal bc_goal(BC bc)
  */
 
 @trusted
-void block_term()
+void block_term(ref BlockOpt bo)
 {
     while (bo.block_freelist)
     {
@@ -114,12 +113,12 @@ void block_term()
  */
 
 @trusted
-void block_next(BlockState* bctx, BC bc, block* bn)
+void block_next(ref BlockOpt bo, BlockState* bctx, BC bc, block* bn)
 {
     bctx.curblock.bc = bc;
     bo.block_last = bctx.curblock;
     if (!bn)
-        bn = block_calloc_i();
+        bn = block_calloc_i(bo);
     bctx.curblock.Bnext = bn;                // next block
     bctx.curblock = bctx.curblock.Bnext;     // new current block
     bctx.curblock.Btry = bctx.tryblock;
@@ -130,12 +129,12 @@ void block_next(BlockState* bctx, BC bc, block* bn)
  * Finish up this block and start the next one.
  */
 
-block* block_goto(BlockState* bx, BC bc, block* bn)
+block* block_goto(ref BlockOpt bo, BlockState* bx, BC bc, block* bn)
 {
     block* b;
 
     b = bx.curblock;
-    block_next(bx,bc,bn);
+    block_next(bo, bx,bc,bn);
     b.appendSucc(bx.curblock);
     return bx.curblock;
 }
@@ -150,7 +149,7 @@ version (COMPILE)
 
 void block_goto()
 {
-    block_goto(block_calloc());
+    block_goto(block_calloc(bo));
 }
 
 void block_goto(block* bn)
@@ -179,7 +178,7 @@ void block_goto(block* bgoto,block* bnew)
  */
 
 @trusted
-void block_ptr()
+void block_ptr(ref BlockOpt bo)
 {
     //printf("block_ptr()\n");
 
@@ -196,7 +195,7 @@ void block_ptr()
  */
 
 @trusted
-void block_pred()
+void block_pred(ref BlockOpt bo)
 {
     //printf("block_pred()\n");
     for (block* b = bo.startblock; b; b = b.Bnext)       // for each block
@@ -220,7 +219,7 @@ void block_pred()
  */
 
 @trusted
-void block_clearvisit()
+void block_clearvisit(ref BlockOpt bo)
 {
     for (block* b = bo.startblock; b; b = b.Bnext)       // for each block
         b.Bflags = cast(BFL)(b.Bflags & ~cast(uint)BFL.visited); // mark as unvisited
@@ -246,24 +245,24 @@ void block_visit(block* b)
  * Compute number of parents (Bcount) of each basic block.
  */
 @trusted
-void block_compbcount(ref GlobalOptimizer go)
+void block_compbcount(ref GlobalOptimizer go, ref BlockOpt bo)
 {
-    block_clearvisit();
+    block_clearvisit(bo);
     block_visit(bo.startblock);                    // visit all reachable blocks
-    elimblks(go);                               // eliminate unvisited blocks
+    elimblks(go, bo);                               // eliminate unvisited blocks
 }
 
 /*******************************
  * Free list of blocks.
  */
 
-void blocklist_free(block** pb)
+void blocklist_free(ref BlockOpt bo, block** pb)
 {
     block* bn;
     for (block* b = *pb; b; b = bn)
     {
         bn = b.Bnext;
-        block_free(b);
+        block_free(bo, b);
     }
     *pb = null;
 }
@@ -297,7 +296,7 @@ void block_optimizer_free(block* b)
  */
 
 @trusted
-void block_free(block* b)
+void block_free(ref BlockOpt bo, block* b)
 {
     assert(b);
     if (b.Belem)
@@ -398,11 +397,11 @@ void block_initvar(Symbol* s)
  */
 
 @trusted
-void blockopt(ref GlobalOptimizer go, int iter)
+void blockopt(ref GlobalOptimizer go, ref BlockOpt bo, int iter)
 {
     if (OPTIMIZER)
     {
-        blassertsplit(go);              // only need this once
+        blassertsplit(go, bo);              // only need this once
 
         int iterationLimit = 200;
         if (iterationLimit < bo.dfo.length)
@@ -412,27 +411,27 @@ void blockopt(ref GlobalOptimizer go, int iter)
         {
             //printf("changes = %d, count = %d, dfo.length = %d\n",go.changes,count,dfo.length);
             go.changes = 0;
-            bropt(go);                  // branch optimization
-            brrear();                   // branch rearrangement
-            blident(go);                // combine identical blocks
-            blreturn(go);               // split out return blocks
-            bltailmerge(go);            // do tail merging
-            brtailrecursion(go);        // do tail recursion
-            brcombine(go);              // convert graph to expressions
-            blexit(go);
+            bropt(go, bo);                  // branch optimization
+            brrear(bo);                   // branch rearrangement
+            blident(go, bo);                // combine identical blocks
+            blreturn(go, bo);               // split out return blocks
+            bltailmerge(go, bo);            // do tail merging
+            brtailrecursion(go, bo);        // do tail recursion
+            brcombine(go, bo);              // convert graph to expressions
+            blexit(go, bo);
             if (iter >= 2)
-                brmin(go);              // minimize branching
+                brmin(go, bo);              // minimize branching
 
             // Switched to one block per Statement, do not undo it
             enum merge = false;
 
             do
             {
-                compdfo(bo.dfo, bo.startblock); // compute depth first order (DFO)
-                elimblks(go);           /* remove blocks not in DFO      */
+                compdfo(bo, bo.dfo, bo.startblock); // compute depth first order (DFO)
+                elimblks(go, bo);           /* remove blocks not in DFO      */
                 assert(count < iterationLimit);
                 count++;
-            } while (merge && mergeblks());      // merge together blocks
+            } while (merge && mergeblks(bo));      // merge together blocks
         } while (go.changes);
 
         debug if (debugw)
@@ -478,9 +477,9 @@ void blockopt(ref GlobalOptimizer go, int iter)
             bo.startblock.Belem = el_combine(e, bo.startblock.Belem);
         }
 
-        bropt(go);                      /* branch optimization           */
-        brrear();                       /* branch rearrangement          */
-        comsubs(go);                    /* eliminate common subexpressions */
+        bropt(go, bo);                      /* branch optimization           */
+        brrear(bo);                       /* branch rearrangement          */
+        comsubs(go, bo);                    /* eliminate common subexpressions */
 
         debug if (debugb)
         {
@@ -496,7 +495,7 @@ void blockopt(ref GlobalOptimizer go, int iter)
  */
 
 @trusted
-void brcombine(ref GlobalOptimizer go)
+void brcombine(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     debug if (debugc) printf("brcombine()\n");
     //WRfunc("brcombine()", funcsym_p, startblock);
@@ -627,7 +626,7 @@ void brcombine(ref GlobalOptimizer go)
  */
 
 @trusted
-private void bropt(ref GlobalOptimizer go)
+private void bropt(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     debug if (debugc) printf("bropt()\n");
     for (block* b = bo.startblock; b; b = b.Bnext)   // for each block
@@ -752,7 +751,7 @@ private void bropt(ref GlobalOptimizer go)
  */
 
 @trusted
-private void brrear()
+private void brrear(ref BlockOpt bo)
 {
     debug if (debugc) printf("brrear()\n");
     for (block* b = bo.startblock; b; b = b.Bnext)   // for each block
@@ -835,11 +834,11 @@ private void brrear()
  *      dfo = array to fill in in DFO
  *      startblock = list of blocks
  */
-void compdfo(ref Barray!(block*) dfo, block* startblock)
+void compdfo(ref BlockOpt bo, ref Barray!(block*) dfo, block* startblock)
 {
     debug if (debugc) printf("compdfo()\n");
     debug assert(OPTIMIZER);
-    block_clearvisit();
+    block_clearvisit(bo);
     dfo.setLength(0);
 
     /******************************
@@ -897,7 +896,7 @@ void compdfo(ref Barray!(block*) dfo, block* startblock)
  */
 
 @trusted
-private void elimblks(ref GlobalOptimizer go)
+private void elimblks(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     debug if (debugc) printf("elimblks()\n");
     block* bf = null;
@@ -934,7 +933,7 @@ private void elimblks(ref GlobalOptimizer go)
     for ( ; bf; bf = b)
     {
         b = bf.Bnext;
-        block_free(bf);
+        block_free(bo, bf);
     }
 
     debug if (debugc) printf("elimblks done\n");
@@ -953,7 +952,7 @@ private void elimblks(ref GlobalOptimizer go)
  */
 
 @trusted
-private int mergeblks()
+private int mergeblks(ref BlockOpt bo)
 {
     int merge = 0;
 
@@ -1022,7 +1021,7 @@ private int mergeblks()
                     bL2.Bnext = bo.startblock.Bnext;
                     bo.startblock = bL2;   // new start
 
-                    block_free(b);
+                    block_free(bo, b);
                     break;              // dfo[] is now invalid
                 }
             }
@@ -1036,7 +1035,7 @@ private int mergeblks()
  */
 
 @trusted
-private void blident(ref GlobalOptimizer go)
+private void blident(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     debug if (debugc) printf("blident()\n");
     assert(bo.startblock);
@@ -1167,7 +1166,7 @@ private void blident(ref GlobalOptimizer go)
  */
 
 @trusted
-private void blreturn(ref GlobalOptimizer go)
+private void blreturn(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     if (!(go.mfoptim & MFtime))            /* if optimized for space       */
     {
@@ -1210,7 +1209,7 @@ private void blreturn(ref GlobalOptimizer go)
                 debug if (debugc)
                     printf("blreturn: splitting block B%d\n",b.Bdfoidx);
 
-                block* bn = block_calloc();
+                block* bn = block_calloc(bo);
                 bn.bc = BC.ret;
                 bn.Bnext = b.Bnext;
                 static if(SCPP_OR_NTEXCEPTIONS)
@@ -1226,7 +1225,7 @@ private void blreturn(ref GlobalOptimizer go)
             }
         }
 
-        blident(go);                    /* combine return blocks        */
+        blident(go, bo);                    /* combine return blocks        */
     }
 }
 
@@ -1311,7 +1310,7 @@ private elem* bl_delist(list_t el)
  */
 
 @trusted
-private void bltailmerge(ref GlobalOptimizer go)
+private void bltailmerge(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     debug if (debugc) printf("bltailmerge()\n");
     assert(OPTIMIZER);
@@ -1373,7 +1372,7 @@ private void bltailmerge(ref GlobalOptimizer go)
                     debug if (debugc)
                         printf("tail merging: %p and %p\n", b, bn);
 
-                    block* bnew = block_calloc();
+                    block* bnew = block_calloc(bo);
                     bnew.Bnext = bn.Bnext;
                     bnew.bc = b.bc;
                     static if (SCPP_OR_NTEXCEPTIONS)
@@ -1445,7 +1444,7 @@ private void bltailmerge(ref GlobalOptimizer go)
  */
 
 @trusted
-private void brmin(ref GlobalOptimizer go)
+private void brmin(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     debug if (debugc) printf("brmin()\n");
     debug assert(bo.startblock);
@@ -1546,7 +1545,7 @@ private void block_check()
  */
 
 @trusted
-private void brtailrecursion(ref GlobalOptimizer go)
+private void brtailrecursion(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     if (funcsym_p.Sfunc.Fflags3 & Fnotailrecursion)
         return;
@@ -1609,8 +1608,8 @@ private void brtailrecursion(ref GlobalOptimizer go)
             {
                 /* Split OPcond into a BC.iftrue block and two return blocks
                  */
-                block* b1 = block_calloc();
-                block* b2 = block_calloc();
+                block* b1 = block_calloc(bo);
+                block* b2 = block_calloc(bo);
 
                 b1.Belem = e.E2.E1;
                 e.E2.E1 = null;
@@ -1679,7 +1678,7 @@ private void brtailrecursion(ref GlobalOptimizer go)
 
                 // Create a new startblock, bs, because startblock cannot
                 // have predecessors.
-                block* bs = block_calloc();
+                block* bs = block_calloc(bo);
                 bs.bc = BC.goto_;
                 bs.Bnext = bo.startblock;
                 list_append(&bs.Bsucc,bo.startblock);
@@ -1752,7 +1751,7 @@ private elem* assignparams(elem** pe,int* psi,elem** pe2)
  */
 
 @trusted
-private void emptyloops(ref GlobalOptimizer go)
+private void emptyloops(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     debug if (debugc) printf("emptyloops()\n");
     for (block* b = bo.startblock; b; b = b.Bnext)
@@ -1823,7 +1822,7 @@ private void emptyloops(ref GlobalOptimizer go)
  */
 
 @trusted
-private void funcsideeffects()
+private void funcsideeffects(ref BlockOpt bo)
 {
     //printf("funcsideeffects('%s')\n",funcsym_p.Sident);
     for (block* b = bo.startblock; b; b = b.Bnext)
@@ -1907,7 +1906,7 @@ private int el_anyframeptr(elem* e)
  */
 
 @trusted
-private void blassertsplit(ref GlobalOptimizer go)
+private void blassertsplit(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     debug if (debugc) printf("blassertsplit()\n");
     Barray!(elem*) elems;
@@ -1973,7 +1972,7 @@ private void blassertsplit(ref GlobalOptimizer go)
             }
 
             // Create exit block
-            block* bexit = block_calloc();
+            block* bexit = block_calloc(bo);
             bexit.bc = BC.exit;
             bexit.Belem = e.E2;
 
@@ -1997,7 +1996,7 @@ private void blassertsplit(ref GlobalOptimizer go)
 
             /* Split b into two blocks, [b,b2]
              */
-            block* b2 = block_calloc();
+            block* b2 = block_calloc(bo);
             b2.Bnext = b.Bnext;
             b.Bnext = b2;
             b2.bc = b.bc;
@@ -2048,7 +2047,7 @@ private void blassertsplit(ref GlobalOptimizer go)
  * Detect exit blocks and move them to the end.
  */
 @trusted
-private void blexit(ref GlobalOptimizer go)
+private void blexit(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     debug if (debugc)
         printf("blexit()\n");

--- a/compiler/src/dmd/backend/cgcs.d
+++ b/compiler/src/dmd/backend/cgcs.d
@@ -20,6 +20,7 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 
 import dmd.backend.cc;
+import dmd.backend.blockopt : BlockOpt;
 import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.el;
@@ -42,11 +43,11 @@ nothrow:
  */
 
 @trusted
-public void comsubs(ref GlobalOptimizer go)
+public void comsubs(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     debug if (debugx) printf("comsubs(%p)\n",bo.startblock);
 
-    comsubs2(bo.startblock, cgcsdata, go);
+    comsubs2(bo.startblock, cgcsdata, go, bo);
 
     debug if (debugx)
         printf("done with comsubs()\n");
@@ -74,10 +75,10 @@ alias hash_t = uint;    // for hash values
  * String together as many blocks as we can.
  */
 @trusted
-void comsubs2(block* startblock, ref CGCS cgcs, ref GlobalOptimizer go)
+void comsubs2(block* startblock, ref CGCS cgcs, ref GlobalOptimizer go, ref BlockOpt bo)
 {
     // No longer just compute Bcount - eliminate unreachable blocks too
-    block_compbcount(go);                 // eliminate unreachable blocks
+    block_compbcount(go, bo);                 // eliminate unreachable blocks
 
     cgcs.start();
 

--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -19,6 +19,7 @@ import core.stdc.stdio;
 import core.stdc.string;
 
 import dmd.backend.barray;
+import dmd.backend.blockopt : BlockOpt;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.cgcv;
@@ -884,14 +885,14 @@ private void out_regcand_walk(elem* e, ref bool addressOfParam)
 @trusted
 void writefunc(Symbol* sfunc)
 {
-    import dmd.backend.var : go;
+    import dmd.backend.var : go, bo;
     cstate.CSpsymtab = &globsym;
-    writefunc2(sfunc, go);
+    writefunc2(sfunc, go, bo);
     cstate.CSpsymtab = null;
 }
 
 @trusted
-private void writefunc2(Symbol* sfunc, ref GlobalOptimizer go)
+private void writefunc2(Symbol* sfunc, ref GlobalOptimizer go, ref BlockOpt bo)
 {
     func_t* f = sfunc.Sfunc;
 
@@ -1021,8 +1022,8 @@ private void writefunc2(Symbol* sfunc, ref GlobalOptimizer go)
                 s.Sflags &= ~(SFLunambig | GTregcand);
     }
 
-    block_pred();                       // compute predecessors to blocks
-    block_compbcount(go);               // eliminate unreachable blocks
+    block_pred(bo);                       // compute predecessors to blocks
+    block_compbcount(go, bo);               // eliminate unreachable blocks
 
     debug { } else
     {
@@ -1035,13 +1036,13 @@ private void writefunc2(Symbol* sfunc, ref GlobalOptimizer go)
     if (go.mfoptim)
     {
         OPTIMIZER = 1;
-        optfunc(go);                    /* optimize function            */
+        optfunc(go, bo);                    /* optimize function            */
         OPTIMIZER = 0;
     }
     else
     {
         //printf("blockopt()\n");
-        blockopt(go, 0);                /* optimize                     */
+        blockopt(go, bo, 0);                /* optimize                     */
     }
 
     assert(funcsym_p == sfunc);
@@ -1076,7 +1077,7 @@ private void writefunc2(Symbol* sfunc, ref GlobalOptimizer go)
     else
     {
         sfunc.Sfunc.Fstartblock = null;
-        blocklist_free(&bo.startblock);
+        blocklist_free(bo, &bo.startblock);
     }
 
     objmod.func_term(sfunc);

--- a/compiler/src/dmd/backend/gdag.d
+++ b/compiler/src/dmd/backend/gdag.d
@@ -18,6 +18,7 @@ import core.stdc.stdio;
 import core.stdc.time;
 
 import dmd.backend.cc;
+import dmd.backend.blockopt : BlockOpt;
 import dmd.backend.cdef;
 import dmd.backend.oper;
 import dmd.backend.global;
@@ -70,13 +71,13 @@ private bool cse_float(elem* e)
  *              (this is generally target-dependent)
  */
 @trusted
-void builddags(ref GlobalOptimizer go)
+void builddags(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     vec_t aevec;
 
     debug if (debugc) printf("builddags()\n");
     assert(bo.dfo);
-    flowae(go);                       /* compute available expressions */
+    flowae(go, bo);                   /* compute available expressions */
     if (go.exptop <= 1)             /* if no AEs                     */
         return;
     aetype = Aetype.cse;
@@ -592,15 +593,15 @@ L1:
  */
 
 @trusted
-void boolopt(ref GlobalOptimizer go)
+void boolopt(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     vec_t aevec;
     vec_t aevecval;
 
     debug if (debugc) printf("boolopt()\n");
     if (!bo.dfo.length)
-        compdfo(bo.dfo, bo.startblock);
-    flowae(go);                       /* compute available expressions */
+        compdfo(bo, bo.dfo, bo.startblock);
+    flowae(go, bo);                   /* compute available expressions */
     if (go.exptop <= 1)             /* if no AEs                     */
         return;
     static if (0)

--- a/compiler/src/dmd/backend/gflow.d
+++ b/compiler/src/dmd/backend/gflow.d
@@ -17,6 +17,7 @@ import core.stdc.stdlib;
 import core.stdc.string;
 
 import dmd.backend.cc;
+import dmd.backend.blockopt : BlockOpt;
 import dmd.backend.cdef;
 import dmd.backend.oper;
 import dmd.backend.global;
@@ -94,9 +95,9 @@ private __gshared
  */
 
 @trusted
-void flowrd(ref GlobalOptimizer go)
+void flowrd(ref GlobalOptimizer go, ref BlockOpt bo)
 {
-    rdgenkill(go);            /* Compute Bgen and Bkill for RDs       */
+    rdgenkill(go, bo);        /* Compute Bgen and Bkill for RDs       */
     if (go.defnod.length == 0)     /* if no definition elems               */
         return;             /* no analysis to be done               */
 
@@ -155,7 +156,7 @@ void flowrd(ref GlobalOptimizer go)
  */
 
 @trusted
-private void rdgenkill(ref GlobalOptimizer go)
+private void rdgenkill(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     /* Compute number of definition elems. */
     uint num_unambig_def = 0;
@@ -509,10 +510,10 @@ private void accumrd(ref GlobalOptimizer go, vec_t GEN,vec_t KILL,elem* n,uint d
  */
 
 @trusted
-void flowae(ref GlobalOptimizer go)
+void flowae(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     flowxx = AE;
-    flowaecp(go, AE);
+    flowaecp(go, bo, AE);
 }
 
 /**************************** COPY PROPAGATION ************************/
@@ -527,10 +528,10 @@ void flowae(ref GlobalOptimizer go)
  */
 
 @trusted
-void flowcp(ref GlobalOptimizer go)
+void flowcp(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     flowxx = CP;
-    flowaecp(go, CP);
+    flowaecp(go, bo, CP);
 }
 
 /*****************************************
@@ -541,9 +542,9 @@ void flowcp(ref GlobalOptimizer go)
  */
 
 @trusted
-private void flowaecp(ref GlobalOptimizer go, int flowxx)
+private void flowaecp(ref GlobalOptimizer go, ref BlockOpt bo, int flowxx)
 {
-    aecpgenkill(go, flowxx);   // Compute Bgen and Bkill for AEs or CPs
+    aecpgenkill(go, bo, flowxx);   // Compute Bgen and Bkill for AEs or CPs
     if (go.exptop <= 1)        /* if no expressions                    */
         return;
 
@@ -671,7 +672,7 @@ private void flowaecp(ref GlobalOptimizer go, int flowxx)
  */
 
 @trusted
-private void aecpgenkill(ref GlobalOptimizer go, int flowxx)
+private void aecpgenkill(ref GlobalOptimizer go, ref BlockOpt bo, int flowxx)
 {
     block* this_block;
 
@@ -1022,7 +1023,7 @@ private void defstarkill(ref GlobalOptimizer go)
  */
 
 @trusted
-void genkillae(ref GlobalOptimizer go)
+void genkillae(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     flowxx = AE;
     assert(go.exptop > 1);
@@ -1334,9 +1335,9 @@ private void accumaecpx(ref GlobalOptimizer go, elem* n)
  */
 
 @trusted
-void flowlv()
+void flowlv(ref BlockOpt bo)
 {
-    lvgenkill();            /* compute Bgen and Bkill for LVs.      */
+    lvgenkill(bo);            /* compute Bgen and Bkill for LVs.      */
     //assert(globsym.length);  /* should be at least some symbols      */
 
     /* Create a vector of all the variables that are live on exit   */
@@ -1423,7 +1424,7 @@ void flowlv()
  */
 
 @trusted
-private void lvgenkill()
+private void lvgenkill(ref BlockOpt bo)
 {
     /* Compute ambigsym, a vector of all variables that could be    */
     /* referenced by a* e or a call.                                */
@@ -1672,10 +1673,10 @@ private void accumlv(vec_t GEN, vec_t KILL, const(elem)* n, const vec_t ambigsym
  */
 
 @trusted
-void flowvbe(ref GlobalOptimizer go)
+void flowvbe(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     flowxx = VBE;
-    aecpgenkill(go, VBE);   // compute Bgen and Bkill for VBEs
+    aecpgenkill(go, bo, VBE);   // compute Bgen and Bkill for VBEs
     if (go.exptop <= 1)     /* if no candidates for VBEs            */
         return;
 

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -120,7 +120,7 @@ extern (D) regm_t mask(uint m) { return cast(regm_t)1 << m; }
 
 public import dmd.backend.var : OPTIMIZER, globsym, controlc_saw, pointertype, sytab;
 public import dmd.backend.cg : fregsaved, localgot, tls_get_addr_sym;
-public import dmd.backend.blockopt : bo;
+public import dmd.backend.var : bo;
 
 __gshared Configv configv;                // non-ph part of configuration
 

--- a/compiler/src/dmd/backend/glocal.d
+++ b/compiler/src/dmd/backend/glocal.d
@@ -20,6 +20,7 @@ import core.stdc.string;
 import core.stdc.time;
 
 import dmd.backend.cc;
+import dmd.backend.blockopt : BlockOpt;
 import dmd.backend.cdef;
 import dmd.backend.oper;
 import dmd.backend.global;
@@ -73,7 +74,7 @@ struct loc_t
 // temporary generation and register usage.
 
 @trusted
-void localize(ref GlobalOptimizer go)
+void localize(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     if (debugc) printf("localize()\n");
 

--- a/compiler/src/dmd/backend/gloop.d
+++ b/compiler/src/dmd/backend/gloop.d
@@ -19,6 +19,7 @@ import core.stdc.stdlib;
 import core.stdc.string;
 
 import dmd.backend.cc;
+import dmd.backend.blockopt : BlockOpt;
 import dmd.backend.cdef;
 import dmd.backend.evalu8 : el_toldoubled;
 import dmd.backend.oper;
@@ -203,7 +204,7 @@ private void freeloop(ref Loops loops)
  */
 
 @trusted
-bool blockinit()
+bool blockinit(ref BlockOpt bo)
 {
     bool hasasm = false;
 
@@ -242,7 +243,7 @@ bool blockinit()
  */
 
 @trusted
-void compdom()
+void compdom(ref BlockOpt bo)
 {
     compdom(bo.dfo[]);
 }
@@ -311,7 +312,7 @@ private extern (D) void compdom(block*[] dfo)
  */
 
 @trusted
-bool dom(const block* A, const block* B)
+bool dom(ref BlockOpt bo, const block* A, const block* B)
 {
     assert(A && B && bo.dfo && bo.dfo[A.Bdfoidx] == A);
     return vec_testbit(A.Bdfoidx,B.Bdom) != 0;
@@ -321,7 +322,7 @@ bool dom(const block* A, const block* B)
  * Find all the loops.
  */
 
-private extern (D) void findloops(block*[] dfo, ref Loops loops)
+private extern (D) void findloops(ref BlockOpt bo, block*[] dfo, ref Loops loops)
 {
     freeloop(loops);
 
@@ -337,8 +338,8 @@ private extern (D) void findloops(block*[] dfo, ref Loops loops)
         {
             block* s = list_block(bl);      // each successor s to b
             assert(s);
-            if (dom(s,b))                   // if s dominates b
-                buildloop(loops, s, b);     // we found a loop
+            if (dom(bo, s, b))              // if s dominates b
+                buildloop(bo, loops, s, b); // we found a loop
         }
     }
 
@@ -382,7 +383,7 @@ private uint loop_weight(uint weight, int factor) pure
  */
 
 @trusted
-private void buildloop(ref Loops ploops,block* head,block* tail)
+private void buildloop(ref BlockOpt bo, ref Loops ploops, block* head, block* tail)
 {
     //printf("buildloop()\n");
 
@@ -543,7 +544,7 @@ L1:
  */
 
 @trusted
-private bool looprotate(ref GlobalOptimizer go, ref Loop l)
+private bool looprotate(ref GlobalOptimizer go, ref BlockOpt bo, ref Loop l)
 {
     block* tail = l.Ltail;
     block* head = l.Lhead;
@@ -576,7 +577,7 @@ private bool looprotate(ref GlobalOptimizer go, ref Loop l)
         // switches would be too expensive in terms of code
         // generated).
 
-        auto head2 = block_calloc(); // create new head block
+        auto head2 = block_calloc(bo); // create new head block
         head2.Btry = head.Btry;
         head2.Bflags = head.Bflags;
         head.Bflags = BFL.nomerg;       // move flags over to head2
@@ -676,7 +677,7 @@ private __gshared
  */
 
 @trusted
-void loopopt(ref GlobalOptimizer go)
+void loopopt(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     __gshared Loops startloop_cache;
 
@@ -684,27 +685,27 @@ void loopopt(ref GlobalOptimizer go)
 
     if (debugc) printf("loopopt()\n");
 restart:
-    if (blockinit())                    // init block data
+    if (blockinit(bo))                  // init block data
     {
-        findloops(bo.dfo[], startloop);    // Compute Bweights
+        findloops(bo, bo.dfo[], startloop);    // Compute Bweights
         freeloop(startloop);            // free existing loops
         startloop_cache = startloop;
         return;                         // can't handle ASM blocks
     }
-    compdom();                          // compute dominators
-    findloops(bo.dfo[], startloop);              // find the loops
+    compdom(bo);                        // compute dominators
+    findloops(bo, bo.dfo[], startloop);        // find the loops
 
   L3:
     while (1)
     {
         foreach (ref l; startloop)
         {
-            if (looprotate(go, l))              // rotate the loop
+            if (looprotate(go, bo, l))          // rotate the loop
             {
-                compdfo(bo.dfo, bo.startblock);
-                blockinit();
-                compdom();
-                findloops(bo.dfo[], startloop);
+                compdfo(bo, bo.dfo, bo.startblock);
+                blockinit(bo);
+                compdom(bo);
+                findloops(bo, bo.dfo[], startloop);
                 continue L3;
             }
         }
@@ -722,7 +723,7 @@ restart:
         {
             if (debugc) printf("Generating preheader for loop\n");
             addblk = true;              // add one
-            block* p = block_calloc();  // the preheader
+            block* p = block_calloc(bo);  // the preheader
             block* h = l.Lhead;         // loop header
 
             /* Find parent of h */
@@ -775,10 +776,10 @@ restart:
     } /* for */
     if (addblk)                         /* if any blocks were added      */
     {
-        compdfo(bo.dfo, bo.startblock);                      /* compute depth-first order    */
-        blockinit();
-        compdom();
-        findloops(bo.dfo[], startloop);          // recompute block info
+        compdfo(bo, bo.dfo, bo.startblock);              /* compute depth-first order    */
+        blockinit(bo);
+        compdom(bo);
+        findloops(bo, bo.dfo[], startloop);    // recompute block info
         addblk = false;
     }
 
@@ -795,12 +796,12 @@ restart:
         {
             foreach (ref l; startloop)
             {
-                if (loopunroll(go, l))
+                if (loopunroll(go, bo, l))
                 {
-                    compdfo(bo.dfo, bo.startblock);                      // compute depth-first order
-                    blockinit();
-                    compdom();
-                    findloops(bo.dfo[], startloop);    // recompute block info
+                    compdfo(bo, bo.dfo, bo.startblock);  // compute depth-first order
+                    blockinit(bo);
+                    compdom(bo);
+                    findloops(bo, bo.dfo[], startloop);  // recompute block info
                     doflow = true;
                     continue L2;
                 }
@@ -822,9 +823,9 @@ restart:
         assert(l.Lpreheader);
         if (doflow)
         {
-            flowrd(go);             /* compute reaching definitions  */
-            flowlv();               /* compute live variables        */
-            flowae(go);             // compute available expressions
+            flowrd(go, bo);         /* compute reaching definitions  */
+            flowlv(bo);             /* compute live variables        */
+            flowae(go, bo);         // compute available expressions
             doflow = false;         /* no need to redo it           */
             if (go.defnod.length == 0)     /* if no definition elems       */
                 break;              /* no need to optimize          */
@@ -911,10 +912,10 @@ restart:
 
         if (go.mfoptim & MFliv)
         {
-            loopiv(go, l);          /* induction variables          */
+            loopiv(go, bo, l);      /* induction variables          */
             if (addblk)             /* if we added a block          */
             {
-                compdfo(bo.dfo, bo.startblock);
+                compdfo(bo, bo.dfo, bo.startblock);
                 goto restart;       /* play it safe and start over  */
             }
         }
@@ -1982,26 +1983,26 @@ private void newfamlist(famlist* fl, tym_t ty)
  */
 
 @trusted
-private void loopiv(ref GlobalOptimizer go, ref Loop l)
+private void loopiv(ref GlobalOptimizer go, ref BlockOpt bo, ref Loop l)
 {
     if (debugc) printf("loopiv(%p)\n", &l);
     assert(l.Livlist.length == 0 && l.Lopeqlist.length == 0);
     elimspec(go, l, bo.dfo);
     if (doflow)
     {
-        flowrd(go);             /* compute reaching defs                */
-        flowlv();               /* compute live variables               */
-        flowae(go);             // compute available expressions
+        flowrd(go, bo);         /* compute reaching defs                */
+        flowlv(bo);             /* compute live variables               */
+        flowae(go, bo);         // compute available expressions
         doflow = false;
     }
     findbasivs(go, l);          /* find basic induction variables       */
     findopeqs(go, l);           // find op= variables
-    findivfams(l);              /* find IV families                     */
-    elimfrivivs(l);             /* eliminate less useful family IVs     */
+    findivfams(bo, l);          /* find IV families                     */
+    elimfrivivs(bo, l);         /* eliminate less useful family IVs     */
     intronvars(go, l);          /* introduce new variables              */
-    elimbasivs(go, l);          /* eliminate basic IVs                  */
+    elimbasivs(go, bo, l);      /* eliminate basic IVs                  */
     if (!addblk)                // adding a block changes the Binlv
-        elimopeqs(go, l);       // eliminate op= variables
+        elimopeqs(go, bo, l);   // eliminate op= variables
 
     foreach (ref iv; l.Livlist)
         iv.reset();
@@ -2301,7 +2302,7 @@ private void findopeqs(ref GlobalOptimizer go, ref Loop l)
  */
 
 @trusted
-private void findivfams(ref Loop l)
+private void findivfams(ref BlockOpt bo, ref Loop l)
 {
     if (debugc) printf("findivfams(%p)\n", &l);
     foreach (ref biv; l.Livlist)
@@ -2511,7 +2512,7 @@ private void ivfamelems(Iv* biv,elem** pn)
  */
 
 @trusted
-private void elimfrivivs(ref Loop l)
+private void elimfrivivs(ref BlockOpt bo, ref Loop l)
 {
     foreach (ref biv; l.Livlist)
     {
@@ -2523,7 +2524,7 @@ private void elimfrivivs(ref Loop l)
         if (debugc) printf("nfams = %d\n", cast(int)nfams);
 
         /* Compute number of references to biv  */
-        if (onlyref(biv.IVbasic,l,*biv.IVincr,nrefs))
+        if (onlyref(bo, biv.IVbasic,l,*biv.IVincr,nrefs))
                 nrefs--;
         if (debugc) printf("nrefs = %d\n",nrefs);
         assert(nrefs + 1 >= nfams);
@@ -2799,7 +2800,7 @@ private bool funcprev(ref GlobalOptimizer go, ref Iv biv, ref famlist fl)
  */
 
 @trusted
-private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
+private void elimbasivs(ref GlobalOptimizer go, ref BlockOpt bo, ref Loop l)
 {
     if (debugc) printf("elimbasivs(%p)\n", &l);
     foreach (ref biv; l.Livlist)
@@ -2815,7 +2816,7 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
         assert(symbol_isintab(X));
         tym_t ty = X.ty();
         int refcount;
-        elem** pref = onlyref(X,l,einc,refcount);
+        elem** pref = onlyref(bo, X,l,einc,refcount);
 
         /* if only ref of X is of the form (X) or (X relop e) or (e relop X) */
         if (pref != null && refcount <= 1)
@@ -2823,7 +2824,7 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
             if (!biv.IVfamily.length)
                 continue;
 
-            if (catchRef(X, l))
+            if (catchRef(bo, X, l))
                 continue;
 
             elem* ref_ = *pref;
@@ -3049,7 +3050,7 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
                     /* more than one predecessor to b.      */
                     if (list_next(b.Bpred))
                     {
-                        block* bn = block_calloc();
+                        block* bn = block_calloc(bo);
                         bn.Btry = b.Btry;
                         bn.bc = BC.goto_;
                         bn.Bnext = bo.dfo[i].Bnext;
@@ -3123,7 +3124,7 @@ private void elimbasivs(ref GlobalOptimizer go, ref Loop l)
  */
 
 @trusted
-private void elimopeqs(ref GlobalOptimizer go, ref Loop l)
+private void elimopeqs(ref GlobalOptimizer go, ref BlockOpt bo, ref Loop l)
 {
     elem** pref;
     Symbol* X;
@@ -3142,7 +3143,7 @@ private void elimopeqs(ref GlobalOptimizer go, ref Loop l)
 
         X = biv.IVbasic;
         assert(symbol_isintab(X));
-        pref = onlyref(X,l,*biv.IVincr,refcount);
+        pref = onlyref(bo, X,l,*biv.IVincr,refcount);
 
         // if only ref of X is of the form (X) or (X relop e) or (e relop X)
         if (pref != null && refcount <= 1)
@@ -3335,7 +3336,7 @@ Lf2:
  *      true if x is used outside the try block
  */
 @trusted
-private bool catchRef(Symbol* x, ref Loop l)
+private bool catchRef(ref BlockOpt bo, Symbol* x, ref Loop l)
 {
     block* btry = l.Lhead.Btry;
     if (!btry)
@@ -3377,7 +3378,7 @@ private __gshared
 }
 
 @trusted
-private elem ** onlyref(Symbol* x, ref Loop l,elem* incn, out int refcount)
+private elem ** onlyref(ref BlockOpt bo, Symbol* x, ref Loop l,elem* incn, out int refcount)
 {
     uint i;
 
@@ -3690,7 +3691,7 @@ private void unrollWalker(elem* e, uint defnum, Symbol* v, targ_llong increment,
  *      true if loop was unrolled
  */
 @trusted
-bool loopunroll(ref GlobalOptimizer go, ref Loop l)
+bool loopunroll(ref GlobalOptimizer go, ref BlockOpt bo, ref Loop l)
 {
     const bool log = false;
     if (log) printf("loopunroll(%p)\n", &l);

--- a/compiler/src/dmd/backend/go.d
+++ b/compiler/src/dmd/backend/go.d
@@ -20,6 +20,7 @@ import core.stdc.string;
 import core.stdc.time;
 
 import dmd.backend.cc;
+import dmd.backend.blockopt : BlockOpt;
 import dmd.backend.cdef;
 import dmd.backend.oper;
 import dmd.backend.global;
@@ -214,7 +215,7 @@ void dbg_optprint(char* title)
  */
 
 @trusted
-void optfunc(ref GlobalOptimizer go)
+void optfunc(ref GlobalOptimizer go, ref BlockOpt bo)
 {
     if (debugc) printf("optfunc()\n");
     dbg_optprint("optfunc\n");
@@ -288,14 +289,14 @@ void optfunc(ref GlobalOptimizer go)
             scanForInlines(funcsym_p);
 
         if (go.mfoptim & MFdc)
-            blockopt(go, 0);            // do block optimization
+            blockopt(go, bo, 0);            // do block optimization
         out_regcand(&globsym);          // recompute register candidates
         go.changes = 0;                 // no changes yet
         sliceStructs(globsym, bo.startblock);
         if (go.mfoptim & MFcnp)
-            constprop(go);              /* make relationals unsigned     */
+            constprop(go, bo);              /* make relationals unsigned     */
         if (go.mfoptim & (MFli | MFliv))
-            loopopt(go);                /* remove loop invariants and    */
+            loopopt(go, bo);                /* remove loop invariants and    */
                                         /* induction vars                */
                                         /* do loop rotation              */
         else
@@ -304,14 +305,14 @@ void optfunc(ref GlobalOptimizer go)
         dbg_optprint("boolopt\n");
 
         if (go.mfoptim & MFcnp)
-            boolopt(go);                  // optimize boolean values
+            boolopt(go, bo);              // optimize boolean values
         if (go.changes && go.mfoptim & MFloop && (clock() - starttime) < 30 * CLOCKS_PER_SEC)
             continue;
 
         if (go.mfoptim & MFcnp)
-            constprop(go);              /* constant propagation          */
+            constprop(go, bo);          /* constant propagation          */
         if (go.mfoptim & MFcp)
-            copyprop(go);               /* do copy propagation           */
+            copyprop(go, bo);           /* do copy propagation           */
 
         /* Floating point constants and string literals need to be
          * replaced with loads from variables in read-only data.
@@ -342,9 +343,9 @@ void optfunc(ref GlobalOptimizer go)
          * code generation which assumes at most one (localgotoffset).
          */
         if (go.mfoptim & MFlocal)
-            localize(go);                 // improve expression locality
+            localize(go, bo);             // improve expression locality
         if (go.mfoptim & MFda)
-            rmdeadass(go);                /* remove dead assignments       */
+            rmdeadass(go, bo);            /* remove dead assignments       */
 
         if (debugc) printf("changes = %d\n", go.changes);
         if (!(go.changes && go.mfoptim & MFloop && (clock() - starttime) < 30 * CLOCKS_PER_SEC))
@@ -353,7 +354,7 @@ void optfunc(ref GlobalOptimizer go)
     if (debugc) printf("%d iterations\n",iter);
 
     if (go.mfoptim & MFdc)
-        blockopt(go, 1);                // do block optimization
+        blockopt(go, bo, 1);                // do block optimization
 
     for (block* b = bo.startblock; b; b = b.Bnext)
     {
@@ -361,9 +362,9 @@ void optfunc(ref GlobalOptimizer go)
             postoptelem(b.Belem);
     }
     if (go.mfoptim & MFvbe)
-        verybusyexp(go);              /* very busy expressions         */
+        verybusyexp(go, bo);          /* very busy expressions         */
     if (go.mfoptim & MFcse)
-        builddags(go);                /* common subexpressions         */
+        builddags(go, bo);            /* common subexpressions         */
     if (go.mfoptim & MFdv)
         deadvar();                  /* eliminate dead variables      */
 

--- a/compiler/src/dmd/backend/symbol.d
+++ b/compiler/src/dmd/backend/symbol.d
@@ -30,6 +30,7 @@ import dmd.backend.oper;
 import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
+import dmd.backend.var : bo;
 
 
 nothrow:
@@ -499,7 +500,7 @@ debug
                 func_t* f = s.Sfunc;
 
                 debug assert(f);
-                blocklist_free(&f.Fstartblock);
+                blocklist_free(bo, &f.Fstartblock);
                 freesymtab(f.Flocsym[].ptr,0,f.Flocsym.length);
 
                 f.Flocsym.dtor();

--- a/compiler/src/dmd/backend/var.d
+++ b/compiler/src/dmd/backend/var.d
@@ -20,6 +20,7 @@ import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.dlist;
 import dmd.backend.goh;
+import dmd.backend.blockopt : BlockOpt;
 import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.symtab;
@@ -168,6 +169,7 @@ Cstate cstate;                  // compiler state
 uint numcse;        // number of common subexpressions
 
 GlobalOptimizer go;
+BlockOpt bo;
 
 /* From debug.c */
 const(char)*[32] regstring = ["AX","CX","DX","BX","SP","BP","SI","DI",

--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -42,6 +42,7 @@ import dmd.backend.dt;
 import dmd.backend.el;
 import dmd.backend.global;
 import dmd.backend.obj;
+import dmd.backend.var : bo;
 import dmd.backend.oper;
 import dmd.backend.rtlsym;
 import dmd.backend.symtab;
@@ -784,7 +785,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     Statement sbody = fd.fbody;
 
     BlockState bx;
-    bx.startblock = block_calloc();
+    bx.startblock = block_calloc(bo);
     bx.curblock = bx.startblock;
     bx.funcsym = s;
     bx.scope_index = -1;
@@ -1030,7 +1031,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             newConstructor.Sclass = SC.static_;
             func_t* funcState = newConstructor.Sfunc;
             //Init start block
-            funcState.Fstartblock = block_calloc();
+            funcState.Fstartblock = block_calloc(bo);
             block* startBlk = funcState.Fstartblock;
             //Make that block run __cxa_atexit(&func);
             auto atexitSym = getRtlsym(RTLSYM.CXA_ATEXIT);
@@ -1047,7 +1048,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             auto exec = el_bin(OPcall, TYvoid, el_var(atexitSym), paramPack);
             block_appendexp(startBlk, exec); //payload
             startBlk.bc = BC.goto_;
-            auto next = block_calloc();
+            auto next = block_calloc(bo);
             startBlk.appendSucc(next);
             startBlk.Bnext = next;
             next.bc = BC.ret;
@@ -1232,7 +1233,7 @@ private Symbol* callFuncsAndGates(Module m, Symbol*[] sctors, StaticDtorDeclarat
         ector = el_combine(ector, e);
     }
 
-    block* b = block_calloc();
+    block* b = block_calloc(bo);
     b.bc = BC.ret;
     b.Belem = ector;
     sctor.Sfunc.Fstartline.Sfilename = m.arg.xarraydup.ptr;
@@ -1499,7 +1500,7 @@ private void genObjFile(Module m, bool multiobj, bool doppelganger)
         {
             localgot = glue.ictorlocalgot;
 
-            block* b = block_calloc();
+            block* b = block_calloc(bo);
             b.bc = BC.ret;
             b.Belem = glue.eictor;
             msictor.Sfunc.Fstartline.Sfilename = m.arg.xarraydup.ptr;

--- a/compiler/src/dmd/glue/s2ir.d
+++ b/compiler/src/dmd/glue/s2ir.d
@@ -53,6 +53,7 @@ import dmd.funcsem : genCfunc;
 import dmd.visitor;
 
 import dmd.backend.barray;
+import dmd.backend.blockopt : BlockOpt, block_next;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.cgcv;
@@ -64,6 +65,7 @@ import dmd.backend.dt;
 import dmd.backend.el;
 import dmd.backend.global;
 import dmd.backend.obj;
+import dmd.backend.var : bo;
 import dmd.backend.oper;
 import dmd.backend.rtlsym;
 import dmd.backend.symtab;
@@ -90,7 +92,7 @@ void Statement_toIR(Statement s, ref IRState irs)
             //printf("  KV: %s = %s\n", keyValue.key.toChars(), keyValue.value.toChars());
             LabelDsymbol label = cast(LabelDsymbol)keyValue.value;
             if (label.statement)
-                label.statement.extra = dmd.backend.global.block_calloc();
+                label.statement.extra = dmd.backend.global.block_calloc(bo);
         }
 
     StmtState stmtstate;
@@ -99,6 +101,18 @@ void Statement_toIR(Statement s, ref IRState irs)
 
 void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
 {
+    static import dmd.backend.blockopt;
+
+    void block_next(BlockState* bctx, BC bc, block* bn)
+    {
+        return dmd.backend.blockopt.block_next(bo, bctx, bc, bn);
+    }
+
+    block* block_goto(BlockState* bx, BC bc, block* bn)
+    {
+        return dmd.backend.blockopt.block_goto(bo, bx, bc, bn);
+    }
+
     /****************************************
      * This should be overridden by each statement class.
      */
@@ -129,7 +143,7 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
         StmtState mystate = StmtState(stmtstate, s);
 
         // bexit is the block that gets control after this IfStatement is done
-        block* bexit = mystate.breakBlock ? mystate.breakBlock : dmd.backend.global.block_calloc();
+        block* bexit = mystate.breakBlock ? mystate.breakBlock : dmd.backend.global.block_calloc(bo);
 
         incUsage(irs, s.loc);
         e = toElemDtor(s.condition, irs);
@@ -1230,7 +1244,7 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
                 Statement_toIR(s.finalbody, irs, &finallyState);
             block_goto(blx, BC.goto_, retblock);
 
-            block_next(blx,BC._ret,breakblock);
+            block_next(blx, BC._ret, breakblock);
         }
         else if (config.ehmethod == EHmethod.EH_NONE || blx.funcsym.Sfunc.Fflags3 & Feh_none)
         {
@@ -1512,7 +1526,7 @@ void insertFinallyBlockCalls(block* startblock)
                 // Rewrite into a BC.goto_ => BC.ret
                 if (!bcret)
                 {
-                    bcret = dmd.backend.global.block_calloc();
+                    bcret = dmd.backend.global.block_calloc(bo);
                     bcret.bc = BC.ret;
                 }
                 b.bc = BC.goto_;
@@ -1528,7 +1542,7 @@ void insertFinallyBlockCalls(block* startblock)
                     goto case BC.ret;
                 if (!bcretexp)
                 {
-                    bcretexp = dmd.backend.global.block_calloc();
+                    bcretexp = dmd.backend.global.block_calloc(bo);
                     bcretexp.bc = BC.retexp;
                     type* t;
                     if ((ty == TYstruct || ty == TYarray) && e.ET)
@@ -1599,7 +1613,7 @@ void insertFinallyBlockCalls(block* startblock)
                     blast.setNthSucc(0, bf);
 
                     // Create new block, bnew, which will replace retblock
-                    block* bnew = dmd.backend.global.block_calloc();
+                    block* bnew = dmd.backend.global.block_calloc(bo);
 
                     /* Rewrite BC._ret block as:
                      *  if (sflag == flagvalue) goto breakblock; else goto bnew;
@@ -1739,9 +1753,9 @@ private void setScopeIndex(BlockState* blx, block* b, int scope_index)
  * Allocate a new block, and set the tryblock.
  */
 
-private block* block_calloc(BlockState* blx) @safe
+private block* block_calloc(BlockState* blx) @trusted
 {
-    block* b = dmd.backend.global.block_calloc();
+    block* b = dmd.backend.global.block_calloc(bo);
     b.Btry = blx.tryblock;
     return b;
 }


### PR DESCRIPTION
Pass it as a parameter `bo` instead, similar to `GlobalOptimizer go`.