### PR TITLE
remove parse.d dependency on globals

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -6343,7 +6343,7 @@ struct ASTBase
 
     extern (C++) final class ErrorExp : Expression
     {
-        private extern (D) this()
+        extern (D) this()
         {
             super(Loc.initial, EXP.error, __traits(classInstanceSize, ErrorExp));
             type = Type.terror;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8731,7 +8731,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             error("expression expected, not `%s`", token.toChars());
         Lerr:
             // Anything for e, as long as it's not NULL
-            e = AST.ErrorExp.get();
+            e = new AST.ErrorExp();
             nextToken();
             break;
         }
@@ -8873,7 +8873,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     {
                         error("identifier expected following `%s.`, not `%s`",
                             t.toChars(), token.toChars());
-                        return AST.ErrorExp.get();
+                        return new AST.ErrorExp();
                     }
                     e = new AST.DotIdExp(loc, new AST.TypeExp(loc, t), token.ident);
                     nextToken();
@@ -8987,7 +8987,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                                     {
                                         error("identifier or new keyword expected following `(...)`.");
                                         nextToken();
-                                        return AST.ErrorExp.get();
+                                        return new AST.ErrorExp();
                                     }
                                     e = new AST.TypeExp(loc, t);
                                     e.parens = true;


### PR DESCRIPTION
Remove global dependency from parse.d which is meant to be standalone. It should not have any dependencies on global variables.

The dependencies were introduced by https://github.com/dlang/dmd/pull/17055 and https://github.com/dlang/dmd/pull/14460