### PR TITLE
Disallow casting array to struct with unsafe bit patterns in safe code

### DIFF
--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -175,10 +175,17 @@ bool isSafeCast(Expression e, Type tfrom, Type tto, ref string msg)
     // Implicit conversions are always safe
     if (tfrom.implicitConvTo(tto))
         return true;
-
     if (!tto.hasPointers())
+    {
+        // casting to bool is safe as it's a special op
+        // casting to struct with non-pointer @system field is not @safe
+        if (tto.ty != Tbool && tto.hasUnsafeBitpatterns())
+        {
+            msg = "Target element type has unsafe bit patterns";
+            return false;
+        }
         return true;
-
+    }
     auto tfromb = tfrom.toBasetype();
     auto ttob = tto.toBasetype();
 

--- a/compiler/test/fail_compilation/cast_system.d
+++ b/compiler/test/fail_compilation/cast_system.d
@@ -1,0 +1,32 @@
+/*
+REQUIRED_ARGS: -preview=systemVariables
+TEST_OUTPUT:
+---
+fail_compilation/cast_system.d(31): Error: cast from `int[1]` to `UniqueInt` is not allowed in a `@safe` function
+fail_compilation/cast_system.d(31):        Target element type has unsafe bit patterns
+---
+*/
+
+struct UniqueInt
+{
+    @system int n;
+
+    this(int n) @safe
+    {
+        this.n = n;
+    }
+
+    @disable this(ref inout UniqueInt) inout;
+
+    ~this() @trusted
+    {
+        this.n = 0;
+    }
+}
+
+void main() @safe
+{
+    auto s = cast(UniqueInt) 7; // OK, calls ctor
+    int[1] a;
+    s = cast(UniqueInt) a; // doesn't call ctor
+}

--- a/compiler/test/fail_compilation/cast_system.d
+++ b/compiler/test/fail_compilation/cast_system.d
@@ -30,3 +30,8 @@ void main() @safe
     int[1] a;
     s = cast(UniqueInt) a; // doesn't call ctor
 }
+
+void ok() @safe
+{
+    auto b = cast(bool) 7; // OK
+}


### PR DESCRIPTION
Casting is allowed when there's a matching constructor call.

Fixes #22272.