### PR TITLE
Remove redundant extern (D) linkage from backend

### DIFF
--- a/compiler/src/dmd/backend/barray.d
+++ b/compiler/src/dmd/backend/barray.d
@@ -181,12 +181,12 @@ struct Rarray(T)
         return barray[i];
     }
 
-    extern (D) inout(T)[] opSlice() inout nothrow pure @nogc
+    inout(T)[] opSlice() inout nothrow pure @nogc
     {
         return barray[0 .. length];
     }
 
-    extern (D) inout(T)[] opSlice(size_t a, size_t b) inout nothrow pure @nogc
+    inout(T)[] opSlice(size_t a, size_t b) inout nothrow pure @nogc
     {
         assert(a <= b && b <= length);
         return barray[a .. b];

--- a/compiler/src/dmd/backend/blockopt.d
+++ b/compiler/src/dmd/backend/blockopt.d
@@ -1234,7 +1234,6 @@ private void blreturn(ref GlobalOptimizer go, ref BlockOpt bo)
  */
 
 @trusted
-extern (D)
 private void bl_enlist2(ref Barray!(elem*) elems, elem* e)
 {
     if (e)
@@ -1284,7 +1283,6 @@ private list_t bl_enlist(elem* e)
  * Take a list of expressions and convert it back into an expression tree.
  */
 
-extern (D)
 private elem* bl_delist2(elem*[] elems)
 {
     elem* result = null;

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -32,7 +32,7 @@ enum VERSION = "9.00.0";        // for banner and imbedding in .OBJ file
 enum VERSIONHEX = "0x900";      // for __DMC__ macro
 enum VERSIONINT = 0x900;        // for precompiled headers and DLL version
 
-extern (D) template xversion(string s)
+template xversion(string s)
 {
     enum xversion = mixin(`{ version (` ~ s ~ `) return true; else return false; }`)();
 }

--- a/compiler/src/dmd/backend/cg.d
+++ b/compiler/src/dmd/backend/cg.d
@@ -53,7 +53,7 @@ int STACKALIGN = 2;             // varies for each function
 
 /// Is fl data?
 bool[FL.max + 1] datafl = datafl_init;
-extern (D) private enum datafl_init =
+private enum datafl_init =
 () {
     bool[FL.max + 1] datafl;
     foreach (fl; [ FL.data, FL.udata, FL.reg, FL.pseudo, FL.auto_, FL.fast, FL.para, FL.extern_,
@@ -70,7 +70,7 @@ extern (D) private enum datafl_init =
 
 /// Is fl on the stack?
 bool[FL.max + 1] stackfl = stackfl_init;
-extern (D) private enum stackfl_init =
+private enum stackfl_init =
 () {
     bool[FL.max + 1] stackfl;
     foreach (fl; [ FL.auto_, FL.fast, FL.para, FL.cs, FL.fltreg, FL.allocatmp, FL.bprel, FL.stack, FL.regsave,
@@ -85,7 +85,7 @@ extern (D) private enum stackfl_init =
 
 /// What segment register is associated with it?
 ubyte[FL.max + 1] segfl = segfl_init;
-extern (D) private enum segfl_init =
+private enum segfl_init =
 () {
     ubyte[FL.max + 1] segfl;
 
@@ -148,7 +148,7 @@ extern (D) private enum segfl_init =
 
 /// Is fl in the symbol table?
 bool[FL.max + 1] flinsymtab = flinsymtab_init;
-extern (D) private enum flinsymtab_init =
+private enum flinsymtab_init =
 () {
     bool[FL.max + 1] flinsymtab;
     foreach (fl; [ FL.data, FL.udata, FL.reg, FL.pseudo, FL.auto_, FL.fast, FL.para, FL.extern_, FL.func,

--- a/compiler/src/dmd/backend/cgsched.d
+++ b/compiler/src/dmd/backend/cgsched.d
@@ -178,7 +178,7 @@ enum
     FX    = 0x10,    /// pairable with FXCH instruction
 }
 
-extern (D) private immutable ubyte[256] pentcycl =
+private immutable ubyte[256] pentcycl =
 [
         UV,UV,UV,UV,    UV,UV,NP,NP,    // 0
         UV,UV,UV,UV,    UV,UV,NP,NP,    // 8
@@ -233,7 +233,7 @@ enum
     F     = 0x8000000,      /// flags
 }
 
-extern (D) private immutable uint[2][256] oprw =
+private immutable uint[2][256] oprw =
 [
       // 00
       [ EA|R|B, F|EA|B ],       // ADD
@@ -622,7 +622,7 @@ private immutable uint[2][8][4] grprw =
  *          [1] = write
  */
 
-extern (D) private immutable uint[2][8][8] grpf1 =
+private immutable uint[2][8][8] grpf1 =
 [
     [
         // 0xD8
@@ -719,7 +719,7 @@ extern (D) private immutable uint[2][8][8] grpf1 =
  * Micro-ops for floating point opcodes 0xD8..0xDF, with Irm < 0xC0.
  */
 
-extern (D) private immutable ubyte[8][8] uopsgrpf1 =
+private immutable ubyte[8][8] uopsgrpf1 =
 [
     [
         // 0xD8
@@ -817,7 +817,7 @@ extern (D) private immutable ubyte[8][8] uopsgrpf1 =
  * 5 means 'complex'
  */
 
-extern (D) private immutable ubyte[256] insuops =
+private immutable ubyte[256] insuops =
 [       0,0,0,0,        1,1,4,5,                /* 00 */
         0,0,0,0,        1,1,4,0,                /* 08 */
         0,0,0,0,        2,2,4,5,                /* 10 */
@@ -852,7 +852,7 @@ extern (D) private immutable ubyte[256] insuops =
         1,1,5,5,        4,4,0,0,                /* F8 */
 ];
 
-extern (D) private immutable ubyte[8] uopsx = [ 1,1,2,5,1,1,1,5 ];
+private immutable ubyte[8] uopsx = [ 1,1,2,5,1,1,1,5 ];
 
 /************************************************
  * Determine number of micro-ops for Pentium Pro and Pentium II processors.

--- a/compiler/src/dmd/backend/divcoeff.d
+++ b/compiler/src/dmd/backend/divcoeff.d
@@ -304,7 +304,7 @@ version (none)
 {
     import core.stdc.stdlib;
 
-    extern (D) int main(string[] args)
+    int main(string[] args)
     {
         if (args.length == 2)
         {

--- a/compiler/src/dmd/backend/dvarstats.d
+++ b/compiler/src/dmd/backend/dvarstats.d
@@ -117,7 +117,7 @@ private extern (C) static int cmpLifeTime(scope const void* p1, scope const void
 }
 
 // a parent scope contains the creation offset of the child scope
-private static extern(D) SYMIDX isParentScope(ref Barray!LifeTime lifetimes, SYMIDX parent, SYMIDX si)
+private static SYMIDX isParentScope(ref Barray!LifeTime lifetimes, SYMIDX parent, SYMIDX si)
 {
     if (parent == SYMIDX.max) // full function
         return true;
@@ -126,7 +126,7 @@ private static extern(D) SYMIDX isParentScope(ref Barray!LifeTime lifetimes, SYM
 }
 
 // find a symbol that includes the creation of the given symbol as part of its life time
-private static extern(D) SYMIDX findParentScope(ref Barray!LifeTime lifetimes, SYMIDX si)
+private static SYMIDX findParentScope(ref Barray!LifeTime lifetimes, SYMIDX si)
 {
     if (si != SYMIDX.max)
     {

--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -580,7 +580,7 @@ static if (1)
      *      offset = offset of the bytes in `buf` to replace
      *      data = bytes to write
      */
-    extern(D) void rewrite(T)(OutBuffer* buf, size_t offset, T data)
+    void rewrite(T)(OutBuffer* buf, size_t offset, T data)
     {
         *(cast(T*)&buf.buf[offset]) = data;
     }
@@ -1007,7 +1007,7 @@ static if (1)
         dwarf_initfile(filename ? filename[0 .. strlen(filename)] : null);
     }
 
-    extern(D) void dwarf_initfile(const(char)[] filename)
+    void dwarf_initfile(const(char)[] filename)
     {
         if (config.ehmethod == EHmethod.EH_DWARF)
         {
@@ -1377,7 +1377,7 @@ static if (1)
      *      aachars = AAchars where to add `str`
      *      str = string to add to `aachars`
      */
-    extern(D) uint addToAAchars(ref AAchars* aachars, const(char)[] str)
+    uint addToAAchars(ref AAchars* aachars, const(char)[] str)
     {
         if (!aachars)
         {
@@ -1400,7 +1400,7 @@ static if (1)
      * Returns:
      *      The directory name
      */
-    extern(D) const(char)[] retrieveDirectory(const(char)* path)
+    const(char)[] retrieveDirectory(const(char)* path)
     {
         assert(path);
         // Retrieve directory from path
@@ -1414,7 +1414,7 @@ static if (1)
                          modname ? modname[0 .. strlen(modname)] : null);
     }
 
-    extern(D) void dwarf_initmodule(const(char)[] filename, const(char)[] modname)
+    void dwarf_initmodule(const(char)[] filename, const(char)[] modname)
     {
         if (modname)
         {
@@ -3095,7 +3095,7 @@ static if (1)
 
     /* ======================= Abbreviation Codes ====================== */
 
-    extern(D) private struct DWARFAbbrev
+    private struct DWARFAbbrev
     {
         nothrow:
 

--- a/compiler/src/dmd/backend/dwarfeh.d
+++ b/compiler/src/dmd/backend/dwarfeh.d
@@ -419,7 +419,7 @@ int actionTableInsert(OutBuffer* atbuf, int ttindex, int nextoffset)
  * See_Also:
  *      https://en.wikipedia.org/wiki/LEB128
  */
-private extern(D) uint uLEB128(ref const(ubyte)[] data)
+private uint uLEB128(ref const(ubyte)[] data)
 {
     const(ubyte)* q = data.ptr;
     uint result = 0;
@@ -449,7 +449,7 @@ private extern(D) uint uLEB128(ref const(ubyte)[] data)
  * See_Also:
  *      https://en.wikipedia.org/wiki/LEB128
  */
-private extern(D) int sLEB128(ref const(ubyte)[] data)
+private int sLEB128(ref const(ubyte)[] data)
 {
     const(ubyte)* q = data.ptr;
     ubyte byte_;

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -253,7 +253,6 @@ enum
 }
 
 IDXSEC      MAP_SEG2SECIDX(int seg) { return SegData[seg].SDshtidx; }
-extern (D)
 IDXSYM      MAP_SEG2SYMIDX(int seg) { return SegData[seg].SDsymidx; }
 Elf32_Shdr* MAP_SEG2SEC(int seg)    { return &elfobj.SecHdrTab[MAP_SEG2SECIDX(seg)]; }
 int         MAP_SEG2TYP(int seg)    { return MAP_SEG2SEC(seg).sh_flags & SHF_EXECINSTR ? CODE : DATA; }
@@ -2040,7 +2039,7 @@ static if (0)
 }
 }
 
-private extern (D) char* unsstr(uint value)
+private char* unsstr(uint value)
 {
     __gshared char[64] buffer = void;
 
@@ -2057,8 +2056,7 @@ private extern (D) char* unsstr(uint value)
  *      mangled name with terminating 0
  */
 
-private extern (D)
-char[] obj_mangle2(ref Symbol s, char[] dest)
+private char[] obj_mangle2(ref Symbol s, char[] dest)
 {
     //printf("ElfObj_mangle('%s'), mangle = x%x\n",s.Sident.ptr,type_mangle(s.Stype));
     symbol_debug(&s);
@@ -3434,8 +3432,7 @@ static if (TERMCODE)
 }
 +/
 
-private extern (D)
-int elf_align(targ_size_t size,int foffset)
+private int elf_align(targ_size_t size,int foffset)
 {
     if (size <= 1)
         return foffset;

--- a/compiler/src/dmd/backend/evalu8.d
+++ b/compiler/src/dmd/backend/evalu8.d
@@ -1941,7 +1941,7 @@ static if (0) // && MARS
  * instead of the soft long double ones.
  */
 
-extern (D) targ_ldouble el_toldoubled(elem* e)
+targ_ldouble el_toldoubled(elem* e)
 {
     targ_ldouble result;
 
@@ -1974,13 +1974,13 @@ extern (D) targ_ldouble el_toldoubled(elem* e)
  */
 version (CRuntime_Microsoft)
 {
-    extern (D) private targ_ldouble _modulo(targ_ldouble x, targ_ldouble y)
+    private targ_ldouble _modulo(targ_ldouble x, targ_ldouble y)
     {
         return cast(targ_ldouble)fmodl(cast(real)x, cast(real)y);
     }
     import core.stdc.math : isnan;
     static if (!is(targ_ldouble == real))
-        extern (D) private int isnan(targ_ldouble x)
+        private int isnan(targ_ldouble x)
         {
             return isnan(cast(real)x);
         }

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -116,7 +116,7 @@ int REGSIZE() @trusted { return _tysize[TYnptr]; }
 public import dmd.backend.var : debuga, debugb, debugc, debugd, debuge, debugf,
     debugr, debugs, debugt, debugu, debugw, debugx, debugy;
 
-extern (D) regm_t mask(uint m) { return cast(regm_t)1 << m; }
+regm_t mask(uint m) { return cast(regm_t)1 << m; }
 
 public import dmd.backend.var : OPTIMIZER, globsym, controlc_saw, pointertype, sytab;
 public import dmd.backend.cg : fregsaved, localgot, tls_get_addr_sym;

--- a/compiler/src/dmd/backend/gloop.d
+++ b/compiler/src/dmd/backend/gloop.d
@@ -249,7 +249,7 @@ void compdom(ref BlockOpt bo)
 }
 
 @trusted
-private extern (D) void compdom(block*[] dfo)
+private void compdom(block*[] dfo)
 {
     assert(dfo.length);
     block* sb = dfo[0];                  // starting block
@@ -322,7 +322,7 @@ bool dom(ref BlockOpt bo, const block* A, const block* B)
  * Find all the loops.
  */
 
-private extern (D) void findloops(ref BlockOpt bo, block*[] dfo, ref Loops loops)
+private void findloops(ref BlockOpt bo, block*[] dfo, ref Loops loops)
 {
     freeloop(loops);
 
@@ -3193,7 +3193,6 @@ private void elimopeqs(ref GlobalOptimizer go, ref BlockOpt bo, ref Loop l)
  */
 
 @trusted
-extern (D)
 private size_t simfl(famlist[] fams, tym_t tym)
 {
     size_t sofar = fams.length;
@@ -3492,7 +3491,7 @@ private int countrefs2(const(elem)* e, const Symbol* s)
 
 @trusted
 private
-extern(D) void elimspec(ref GlobalOptimizer go, const ref Loop loop, block*[] dfo)
+void elimspec(ref GlobalOptimizer go, const ref Loop loop, block*[] dfo)
 {
     // Visit each block in loop
     for (size_t i = 0; (i = vec_index(i, loop.Lloop)) < dfo.length; ++i)

--- a/compiler/src/dmd/backend/gsroa.d
+++ b/compiler/src/dmd/backend/gsroa.d
@@ -60,7 +60,7 @@ struct SymInfo
  *      sia = where to put gathered information
  */
 @trusted
-extern (D) private void sliceStructs_Gather(ref const symtab_t symtab, SymInfo[] sia, const(elem)* e)
+private void sliceStructs_Gather(ref const symtab_t symtab, SymInfo[] sia, const(elem)* e)
 {
     while (1)
     {
@@ -225,7 +225,7 @@ extern (D) private void sliceStructs_Gather(ref const symtab_t symtab, SymInfo[]
  *      e = expression tree to rewrite in place
  */
 @trusted
-extern (D) private void sliceStructs_Replace(ref symtab_t symtab, const SymInfo[] sia, elem* e)
+private void sliceStructs_Replace(ref symtab_t symtab, const SymInfo[] sia, elem* e)
 {
     while (1)
     {

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -68,7 +68,7 @@ void mach_relsort(OutBuffer* buf)
     qsort(buf.buf, buf.length() / Relocation.sizeof, Relocation.sizeof, &mach_rel_fp);
 }
 
-private extern (D) __gshared OutBuffer* fobjbuf;
+private __gshared OutBuffer* fobjbuf;
 
 enum DEST_LEN = (IDMAX + IDOHD + 1);
 
@@ -97,7 +97,7 @@ void MachObj_refGOTsym()
 // The object file is built is several separate pieces
 
 // String Table  - String table for all other names
-private extern (D) __gshared OutBuffer* symtab_strings;
+private __gshared OutBuffer* symtab_strings;
 
 // Section Headers
 __gshared OutBuffer  *SECbuf;             // Buffer to build section table in
@@ -198,7 +198,7 @@ __gshared
  *
  * This section is used for the variable symbol for TLS variables.
  */
-private extern (D) int seg_tlsseg = UNKNOWN;
+private int seg_tlsseg = UNKNOWN;
 
 /**
  * Section index for the __thread_bss section.
@@ -206,7 +206,7 @@ private extern (D) int seg_tlsseg = UNKNOWN;
  * This section is used for the data symbol ($tlv$init) for TLS variables
  * without an initializer.
  */
-private extern (D) int seg_tlsseg_bss = UNKNOWN;
+private int seg_tlsseg_bss = UNKNOWN;
 
 /**
  * Section index for the __thread_data section.
@@ -2131,7 +2131,7 @@ void MachObj_alias(const(char)* n1,const(char)* n2)
 }
 
 @trusted
-private extern (D) char* unsstr (uint value)
+private char* unsstr (uint value)
 {
     __gshared char[64] buffer = void;
 
@@ -2146,7 +2146,7 @@ private extern (D) char* unsstr (uint value)
  */
 
 @trusted
-private extern (D)
+private
 char* obj_mangle2(Symbol* s,char* dest)
 {
     size_t len;
@@ -2925,8 +2925,7 @@ static if(TERMCODE)
 }+/
 
 @trusted
-private extern (D)
-int elf_align(targ_size_t size, int foffset)
+private int elf_align(targ_size_t size, int foffset)
 {
     if (size <= 1)
         return foffset;

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -62,7 +62,7 @@ char* strupr(char* s)
     return s;
 }
 
-private extern (D) __gshared OutBuffer* fobjbuf;
+private __gshared OutBuffer* fobjbuf;
 
 enum DEST_LEN = (IDMAX + IDOHD + 1);
 
@@ -102,10 +102,10 @@ IMAGE_SECTION_HEADER* ScnhdrTab() { return cast(IMAGE_SECTION_HEADER*)ScnhdrBuf.
     segidx_t segidx_xdata = UNKNOWN;
     segidx_t segidx_pdata = UNKNOWN;
 
-    extern (D) int jumpTableSeg;     // segment index for __jump_table
+    int jumpTableSeg;     // segment index for __jump_table
 
-    extern (D) OutBuffer* indirectsymbuf2;      // indirect symbol table of Symbol*'s
-    extern (D) int pointersSeg;      // segment index for __pointers
+    OutBuffer* indirectsymbuf2;      // indirect symbol table of Symbol*'s
+    int pointersSeg;      // segment index for __pointers
 
     OutBuffer* ptrref_buf;           // buffer for pointer references
     OutBuffer* impref_buf;           // buffer for import table references
@@ -117,7 +117,7 @@ IMAGE_SECTION_HEADER* ScnhdrTab() { return cast(IMAGE_SECTION_HEADER*)ScnhdrBuf.
  * to be added last to the symbol table.
  * Obviously, there can be only one.
  */
-    extern (D) IDXSTR extdef;
+    IDXSTR extdef;
 
 // Each compiler segment is a section
 // Predefined compiler segments CODE,DATA,CDATA,UDATA map to indexes
@@ -138,8 +138,8 @@ int mscoff_seg_data_isCode(const ref seg_data sd)
 
 
 
-private extern (D) segidx_t seg_tlsseg = UNKNOWN;
-private extern (D) segidx_t seg_tlsseg_bss = UNKNOWN;
+private segidx_t seg_tlsseg = UNKNOWN;
+private segidx_t seg_tlsseg_bss = UNKNOWN;
 
 }
 
@@ -396,20 +396,20 @@ void MsCoffObj_initfile(const(char)* filename, const(char)* csegname, const(char
  */
 
 @trusted
-private extern (D)
+private
 int32_t* MsCoffObj_patchAddr(int seg, targ_size_t offset)
 {
     return cast(int32_t*)(fobjbuf.buf + ScnhdrTab[SegData[seg].SDshtidx].PointerToRawData + offset);
 }
 
 @trusted
-private extern (D)
+private
 int32_t* MsCoffObj_patchAddr64(int seg, targ_size_t offset)
 {
     return cast(int32_t*)(fobjbuf.buf + ScnhdrTab[SegData[seg].SDshtidx].PointerToRawData + offset);
 }
 
-private extern (D)
+private
 static if (0)
 {
 @trusted
@@ -1019,7 +1019,6 @@ void MsCoffObj_startaddress(Symbol* s)
  */
 
 @trusted
-extern (D)
 bool MsCoffObj_includelib(scope const char[] name)
 {
     int seg = MsCoffObj_seg_drectve();
@@ -1193,7 +1192,7 @@ void MsCoffObj_ehtables(Symbol* sfunc,uint size,Symbol* ehsym)
 
 /*********************************************
  * Put out symbols that define the beginning/end of the .deh_eh section.
- * This gets called if this is the module with "extern (D) main()" in it.
+ * This gets called if this is the module with "main()" in it.
  */
 
 @trusted
@@ -1689,7 +1688,7 @@ static if (0) // NOT_DONE
 }
 
 @trusted
-private extern (D) char* unsstr(uint value)
+private char* unsstr(uint value)
 {
     __gshared char[64] buffer;
 
@@ -1705,7 +1704,7 @@ private extern (D) char* unsstr(uint value)
  */
 
 @trusted
-private extern (D)
+private
 void obj_mangle2(ref Symbol s, ref OutBuffer buf)
 {
     //printf("MsCoffObj_mangle(s = %p, '%s'), mangle = x%x\n",s,s.Sident.ptr,type_mangle(s.Stype));
@@ -2482,7 +2481,7 @@ void MsCoffObj_write_pointerRef(Symbol* s, uint soff)
  *      segments = lazy indices into tls / data pointer sections
  */
 @trusted
-extern (D) private void objflush_pointerRef(Symbol* s, uint soff, ref segidx_t[2] segments)
+private void objflush_pointerRef(Symbol* s, uint soff, ref segidx_t[2] segments)
 {
     bool isTls = (s.Sfl == FL.tlsdata);
 
@@ -2507,7 +2506,7 @@ extern (D) private void objflush_pointerRef(Symbol* s, uint soff, ref segidx_t[2
  * to the object file
  */
 @trusted
-extern (D) private void objflush_pointerRefs()
+private void objflush_pointerRefs()
 {
     if (!ptrref_buf)
         return;
@@ -2557,7 +2556,7 @@ void write_importTableRef(segidx_t seg, targ_size_t soff, Symbol* imp)
  * to the object file as a crt_constructor function
  */
 @trusted
-extern (D) private void objflush_importTableRefs()
+private void objflush_importTableRefs()
 {
     if (!impref_buf)
         return;

--- a/compiler/src/dmd/backend/obj.d
+++ b/compiler/src/dmd/backend/obj.d
@@ -500,7 +500,7 @@ public import dmd.backend.var : objmod;
  * Returns:
  *      declarations as a string suitable for mixin
  */
-private extern (D)
+private
 string ObjMemDecl(string pattern)
 {
     string r =
@@ -518,7 +518,7 @@ string ObjMemDecl(string pattern)
  * Returns:
  *      mixin string with static dispatch
  */
-private extern (D)
+private
 string genRetVal(string arg)
 {
     return
@@ -541,7 +541,7 @@ string genRetVal(string arg)
  * Returns:
  *      boilerplate string
  */
-private extern (D)
+private
 string gen(string pattern, string arg)
 {
     foreach (i; 0 .. pattern.length)

--- a/compiler/src/dmd/backend/oper.d
+++ b/compiler/src/dmd/backend/oper.d
@@ -382,8 +382,6 @@ public import dmd.backend.cgelem : swaprel;
 
 //#define EOP(e)  (!OTleaf((e)->Eoper))
 
-extern (D):
-
 immutable ubyte[OPMAX] optab1 =
 () {
     ubyte[OPMAX] tab;

--- a/compiler/src/dmd/backend/var.d
+++ b/compiler/src/dmd/backend/var.d
@@ -184,7 +184,7 @@ type* chartype;                 /* default 'char' type                  */
 Obj objmod = null;
 
 __gshared uint[256] tytab = tytab_init;
-extern (D) private enum tytab_init =
+private enum tytab_init =
 () {
     uint[256] tab;
     foreach (i; TXptr)        { tab[i] |= TYFLptr; }
@@ -338,7 +338,7 @@ __gshared const(char)*[TYMAX] tystring =
 
 /// Map to unsigned version of type
 __gshared tym_t[256] tytouns = tytouns_init;
-extern (D) private enum tytouns_init =
+private enum tytouns_init =
 () {
     tym_t[256] tab;
     foreach (ty; 0 .. TYMAX)
@@ -382,7 +382,7 @@ extern (D) private enum tytouns_init =
 
 /// Map to relaxed version of type
 __gshared ubyte[TYMAX] _tyrelax = _tyrelax_init;
-extern(D) private enum _tyrelax_init = (){
+private enum _tyrelax_init = (){
     ubyte[TYMAX] tab;
     foreach (ty; 0 .. TYMAX)
     {
@@ -418,7 +418,7 @@ extern(D) private enum _tyrelax_init = (){
 
 /// Map to equivalent version of type
 __gshared ubyte[TYMAX] tyequiv = tyequiv_init;
-extern (D) private enum tyequiv_init =
+private enum tyequiv_init =
 () {
     ubyte[TYMAX] tab;
     foreach (ty; 0 .. TYMAX)

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -3275,7 +3275,6 @@ void andregcon(const ref con_t pregconsave)
  *    code = array of instruction bytes
  */
 @trusted
-extern (D)
 void disassemble(ubyte[] code)
 {
     printf("%s:\n", funcsym_p.Sident.ptr);
@@ -3316,7 +3315,7 @@ void disassemble(ubyte[] code)
  * Params:
  *      ins = instruction to decode
  */
-@trusted extern (D) void disassemble(uint ins)
+@trusted void disassemble(uint ins)
 {
     @trusted
     void put(char c) { printf("%c", c); }

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -1666,7 +1666,7 @@ private void cmpval(CGstate cg, ref CodeBuilder cdb, ulong val, uint sz, reg_t r
     }
 }
 
-@trusted extern (D)
+@trusted
 private void ifthen(CGstate cg, ref CodeBuilder cdb, scope CaseVal[] casevals,
         uint sz, reg_t reg, reg_t reg2, reg_t sreg, block* bdefault, bool last)
 {


### PR DESCRIPTION
extern (D) attributes are now redundant because the backend is no longer extern(C++) by default (https://github.com/dlang/dmd/pull/15473)