### PR TITLE
Build druntime with `-edition=2024` compiler switch

### DIFF
--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -101,7 +101,7 @@ ifeq (osx,$(OS))
 endif
 
 # Set DFLAGS
-UDFLAGS:=-conf= -Isrc -Iimport -w -de -preview=dip1000 -preview=fieldwise $(MODEL_FLAG) $(PIC) $(OPTIONAL_COVERAGE) -preview=dtorfields
+UDFLAGS:=-conf= -Isrc -Iimport -w -de -preview=dip1000 -preview=fieldwise $(MODEL_FLAG) $(PIC) $(OPTIONAL_COVERAGE) -preview=dtorfields -edition=2024
 ifeq ($(BUILD),debug)
 	UDFLAGS += -g -debug
 	DFLAGS:=$(UDFLAGS)


### PR DESCRIPTION
Note: switch added in https://github.com/dlang/dmd/pull/22248.