### PR TITLE
core.sys.posix.sys.types: Fix blksize_t and nlink_t for CRuntime_Musl

### DIFF
--- a/druntime/src/core/sys/posix/sys/types.d
+++ b/druntime/src/core/sys/posix/sys/types.d
@@ -99,23 +99,58 @@ version (linux)
     alias ulong_t   ino_t;
     alias slong_t   off_t;
   }
-    alias slong_t   blksize_t;
+    // musl overrides blksize_t to int on some 64-bit architectures.
+    // Default: long (https://git.musl-libc.org/cgit/musl/tree/include/alltypes.h.in?h=v1.2.3#n32)
+    // AArch64: int (https://git.musl-libc.org/cgit/musl/tree/arch/aarch64/bits/alltypes.h.in?h=v1.2.3#n18)
+    // RISCV64: int (https://git.musl-libc.org/cgit/musl/tree/arch/riscv64/bits/alltypes.h.in?h=v1.2.3#n12)
+    // LoongArch64: int (https://git.musl-libc.org/cgit/musl/tree/arch/loongarch64/bits/alltypes.h.in?id=522bd54e#n18)
+    version (CRuntime_Musl)
+    {
+        version (AArch64)
+            alias int blksize_t;
+        else version (RISCV64)
+            alias int blksize_t;
+        else version (LoongArch64)
+            alias int blksize_t;
+        else
+            alias slong_t blksize_t;
+    }
+    else
+        alias slong_t blksize_t;
+
     alias ulong     dev_t;
     alias uint      gid_t;
     alias uint      mode_t;
 
-  version (X86_64)
-    alias ulong nlink_t;
-  else version (S390)
-    alias size_t nlink_t;
-  else version (PPC64)
-    alias size_t nlink_t;
-  else version (MIPS64)
-    alias size_t nlink_t;
-  else version (HPPA64)
-    alias size_t nlink_t;
-  else
-    alias uint nlink_t;
+    // musl defines nlink_t as unsigned _Reg (= unsigned int on 32-bit, unsigned long on 64-bit),
+    // with arch-specific overrides.
+    // Default: unsigned _Reg (https://git.musl-libc.org/cgit/musl/tree/include/alltypes.h.in?h=v1.2.3#n28)
+    // MIPS64: unsigned (uint) (https://git.musl-libc.org/cgit/musl/tree/arch/mips64/bits/alltypes.h.in?h=v1.2.3#n22)
+    // X86_64: _Reg=long, so unsigned long (https://git.musl-libc.org/cgit/musl/tree/arch/x86_64/bits/alltypes.h.in?h=v1.2.3#n3)
+    version (CRuntime_Musl)
+    {
+        version (MIPS64)
+            alias uint nlink_t;
+        else version (X86_64)
+            alias ulong nlink_t;
+        else
+            alias uint nlink_t;
+    }
+    else
+    {
+        version (X86_64)
+            alias ulong nlink_t;
+        else version (S390)
+            alias size_t nlink_t;
+        else version (PPC64)
+            alias size_t nlink_t;
+        else version (MIPS64)
+            alias size_t nlink_t;
+        else version (HPPA64)
+            alias size_t nlink_t;
+        else
+            alias uint nlink_t;
+    }
 
     alias int       pid_t;
     //size_t (defined in core.stdc.stddef)


### PR DESCRIPTION
LLM disclosure: generated by Claude Opus 4.5

----

musl overrides blksize_t to int (instead of long) on aarch64, riscv64, and loongarch64. It also overrides nlink_t to uint (instead of size_t) on mips64.

These arch-specific overrides are defined in musl's arch/*/bits/alltypes.h.in files and differ from the base definitions in include/alltypes.h.in.

Without this fix, the D type sizes don't match the C ABI on these architectures when using musl.

----

Verification: Testing is not trivial as DMD does not support this target. Claude gave me the following self-contained Nix expression which demonstrates the correct behavior with C, the current behavior in D, and the behavior in D after this fix:

<details>

```nix
# Verification script for: core.sys.posix.sys.types: Fix blksize_t and nlink_t for CRuntime_Musl
#
# Usage:
#   $(nix-build --no-out-link -A c)          # Run C test (ground truth)
#   $(nix-build --no-out-link -A d-unfixed)  # Run D test without fix
#   $(nix-build --no-out-link -A d-fixed)    # Run D test with fix
#   $(nix-build --no-out-link -A all)        # Run all tests
#
# This demonstrates that blksize_t and nlink_t sizes in D match musl's C ABI on aarch64.
# Requires: binfmt/qemu for aarch64 execution, or run on native aarch64 hardware.

{ pkgs ? import <nixpkgs> {} }:

let
  # Cross-compilation target
  crossPkgs = pkgs.pkgsCross.aarch64-multiplatform-musl;
  staticPkgs = crossPkgs.pkgsStatic;
  staticCC = staticPkgs.stdenv.cc;
  crossCC = crossPkgs.stdenv.cc;
  targetTriple = "aarch64-unknown-linux-musl";

  # C test program - shows what musl actually defines
  cTestSrc = pkgs.writeText "types_check.c" ''
    #include <stdio.h>
    #include <sys/types.h>

    int main() {
        printf("=== C (musl) type sizes on aarch64 ===\n");
        printf("sizeof(blksize_t) = %zu\n", sizeof(blksize_t));
        printf("sizeof(nlink_t)   = %zu\n", sizeof(nlink_t));
        printf("sizeof(off_t)     = %zu\n", sizeof(off_t));
        printf("sizeof(ino_t)     = %zu\n", sizeof(ino_t));
        printf("sizeof(blkcnt_t)  = %zu\n", sizeof(blkcnt_t));
        return 0;
    }
  '';

  # D test program
  dTestSrc = pkgs.writeText "types_check.d" ''
    module types_check;
    import core.sys.posix.sys.types;
    import core.stdc.stdio : printf;

    extern(C) int main() {
        printf("sizeof(blksize_t) = %zu\n", blksize_t.sizeof);
        printf("sizeof(nlink_t)   = %zu\n", nlink_t.sizeof);
        printf("sizeof(off_t)     = %zu\n", off_t.sizeof);
        printf("sizeof(ino_t)     = %zu\n", ino_t.sizeof);
        printf("sizeof(blkcnt_t)  = %zu\n", blkcnt_t.sizeof);
        return 0;
    }
  '';

  # LDC source (unpatched)
  ldcSrc = pkgs.fetchFromGitHub {
    owner = "ldc-developers";
    repo = "ldc";
    tag = "v${pkgs.ldc.version}";
    hash = "sha256-6LcpY3LSFK4KgEiGrFp/LONu5Vr+/+vI04wEEpF3s+s=";
    fetchSubmodules = true;
  };

  # LDC source with fix applied using sed
  ldcSrcFixed = pkgs.runCommand "ldc-src-fixed" {} ''
    cp -r ${ldcSrc} $out
    chmod -R u+w $out

    cd $out/runtime/druntime/src/core/sys/posix/sys

    # Replace the single-line blksize_t definition with musl-aware version
    sed -i 's/^    alias slong_t   blksize_t;$/    \/\/ musl overrides blksize_t to int on aarch64, riscv64, loongarch64\n    version (CRuntime_Musl)\n    {\n        version (AArch64)\n            alias int blksize_t;\n        else version (RISCV64)\n            alias int blksize_t;\n        else version (LoongArch64)\n            alias int blksize_t;\n        else\n            alias slong_t blksize_t;\n    }\n    else\n        alias slong_t blksize_t;/' types.d

    # Replace the single-line nlink_t definition with musl-aware version
    sed -i 's/^    alias ulong_t   nlink_t;$/    \/\/ musl uses uint for nlink_t on most arches (only x86_64 uses ulong)\n    version (CRuntime_Musl)\n    {\n        version (X86_64)\n            alias ulong nlink_t;\n        else\n            alias uint nlink_t;\n    }\n    else\n        alias ulong_t nlink_t;/' types.d
  '';

  # Build LDC runtime
  buildRuntime = ldcSource: pkgs.runCommand "ldc-runtime-aarch64" {
    nativeBuildInputs = [ pkgs.ldc pkgs.cmake pkgs.ninja crossCC ];
  } ''
    export CC=${crossCC}/bin/${crossCC.targetPrefix}cc
    export HOME=$TMPDIR
    ${pkgs.ldc}/bin/ldc-build-runtime \
      --ninja \
      --ldcSrcDir=${ldcSource} \
      --dFlags="-mtriple=${targetTriple}" \
      BUILD_SHARED_LIBS=OFF
    mkdir -p $out/lib
    cp -r ldc-build-runtime.tmp/lib/* $out/lib/
  '';

  runtimeUnfixed = buildRuntime ldcSrc;
  runtimeFixed = buildRuntime ldcSrcFixed;

  # Build D test with given runtime
  buildDTest = { runtime, ldcSource, name }: pkgs.runCommand "d-test-${name}" {
    nativeBuildInputs = [ pkgs.ldc crossCC pkgs.lld ];
  } ''
    mkdir -p $out/bin
    ${pkgs.ldc}/bin/ldc2 \
      -mtriple=${targetTriple} \
      --gcc=${crossCC}/bin/${crossCC.targetPrefix}cc \
      --linker=lld \
      -of=$out/bin/types_check \
      -I${ldcSource}/runtime/druntime/src \
      -L-L${runtime}/lib \
      -L-L${staticPkgs.stdenv.cc.libc}/lib \
      -static \
      ${dTestSrc}
  '';

  # Build C test
  cTest = pkgs.runCommand "c-test" {
    nativeBuildInputs = [ staticCC ];
  } ''
    mkdir -p $out/bin
    ${staticCC}/bin/${staticCC.targetPrefix}cc -o $out/bin/types_check ${cTestSrc}
  '';

  dTestUnfixed = buildDTest { runtime = runtimeUnfixed; ldcSource = ldcSrc; name = "unfixed"; };
  dTestFixed = buildDTest { runtime = runtimeFixed; ldcSource = ldcSrcFixed; name = "fixed"; };

in {
  c = pkgs.writeShellScript "run-c-test" ''
    echo "=== C (musl) - ground truth ==="
    ${cTest}/bin/types_check
  '';

  d-unfixed = pkgs.writeShellScript "run-d-unfixed" ''
    echo "=== D WITHOUT fix (LDC ${pkgs.ldc.version}) ==="
    ${dTestUnfixed}/bin/types_check
  '';

  d-fixed = pkgs.writeShellScript "run-d-fixed" ''
    echo "=== D WITH fix ==="
    ${dTestFixed}/bin/types_check
  '';

  all = pkgs.writeShellScript "verify-types-aarch64" ''
    echo "============================================================"
    echo "Verification: blksize_t and nlink_t for aarch64 musl"
    echo "============================================================"
    echo ""
    echo "musl on aarch64 overrides these from the base definitions:"
    echo "  blksize_t: long (8 bytes) -> int (4 bytes)"
    echo "  nlink_t:   unsigned long (8 bytes) -> unsigned int (4 bytes)"
    echo ""

    echo "1. C behavior (musl - the ground truth):"
    echo "-------------------------------------------"
    ${cTest}/bin/types_check
    echo ""

    echo "2. D WITHOUT fix (current LDC ${pkgs.ldc.version}):"
    echo "-------------------------------------------"
    ${dTestUnfixed}/bin/types_check
    echo ""

    echo "3. D WITH fix:"
    echo "-------------------------------------------"
    ${dTestFixed}/bin/types_check
    echo ""

    echo "============================================================"
    echo "Key difference (unfixed vs fixed):"
    echo "============================================================"
    echo "Without fix: blksize_t=8, nlink_t=8 (wrong for aarch64 musl)"
    echo "With fix:    blksize_t=4, nlink_t=4 (matches C)"
  '';
}
```

</details>

Usage and output:

```console
[vladimir@home druntime]$ $(nix-build --no-out-link verify-types-aarch64.nix -A c)
=== C (musl) - ground truth ===
=== C (musl) type sizes on aarch64 ===
sizeof(blksize_t) = 4
sizeof(nlink_t)   = 4
sizeof(off_t)     = 8
sizeof(ino_t)     = 8
sizeof(blkcnt_t)  = 8
[vladimir@home druntime]$ $(nix-build --no-out-link verify-types-aarch64.nix -A d-unfixed)
=== D WITHOUT fix (LDC 1.41.0) ===
sizeof(blksize_t) = 8
sizeof(nlink_t)   = 8
sizeof(off_t)     = 8
sizeof(ino_t)     = 8
sizeof(blkcnt_t)  = 8
[vladimir@home druntime]$ $(nix-build --no-out-link verify-types-aarch64.nix -A d-fixed)
=== D WITH fix ===
sizeof(blksize_t) = 4
sizeof(nlink_t)   = 4
sizeof(off_t)     = 8
sizeof(ino_t)     = 8
sizeof(blkcnt_t)  = 8
```
