### PR TITLE
core.sys.posix: musl 32-bit ARM support

### DIFF
--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -653,29 +653,41 @@ version (linux)
     {
         version (CRuntime_Musl)
         {
+            // Matches struct stat from musl arch/arm/bits/stat.h
+            // See: https://git.musl-libc.org/cgit/musl/tree/arch/arm/bits/stat.h?h=v1.2.3
+            //
+            // Type definitions from https://git.musl-libc.org/cgit/musl/tree/include/alltypes.h.in?h=v1.2.3
+            // with ARM-specific _Int64=long long and _Reg=int from
+            // https://git.musl-libc.org/cgit/musl/tree/arch/arm/bits/alltypes.h.in?h=v1.2.3#n3
+            //
+            // Key 64-bit LFS types (always 64-bit on musl):
+            //   dev_t     = unsigned _Int64 = unsigned long long  (line 31)
+            //   off_t     = _Int64          = long long           (line 29)
+            //   ino_t     = unsigned _Int64 = unsigned long long  (line 30)
+            //   blkcnt_t  = _Int64          = long long           (line 33)
+            //   blksize_t = long            = long (32-bit)       (line 32)
+            //   nlink_t   = unsigned _Reg   = unsigned int        (line 28)
             struct stat_t
             {
-                dev_t st_dev;
-                ushort __pad1;
-                c_long __st_ino;
+                ulong st_dev;
+                int __st_dev_padding;
+                c_long __st_ino_truncated;
                 mode_t st_mode;
-                nlink_t st_nlink;
+                uint st_nlink;
                 uid_t st_uid;
                 gid_t st_gid;
-                dev_t st_rdev;
-                ushort __pad2;
-                off_t st_size;
-                blksize_t st_blksize;
-                blkcnt_t st_blocks;
-                private struct __timespec32
+                ulong st_rdev;
+                int __st_rdev_padding;
+                long st_size;
+                c_long st_blksize;
+                long st_blocks;
+                struct __timespec32
                 {
                     c_long tv_sec;
                     c_long tv_nsec;
                 }
-                __timespec32 __st_atim32;
-                __timespec32 __st_mtim32;
-                __timespec32 __st_ctim32;
-                ino_t st_ino;
+                __timespec32 __st_atim32, __st_mtim32, __st_ctim32;
+                ulong st_ino;
                 timespec st_atim;
                 timespec st_mtim;
                 timespec st_ctim;

--- a/druntime/src/core/sys/posix/sys/types.d
+++ b/druntime/src/core/sys/posix/sys/types.d
@@ -87,7 +87,19 @@ uid_t
 
 version (linux)
 {
-  static if ( __USE_FILE_OFFSET64 )
+  // Musl always uses 64-bit off_t, blkcnt_t, ino_t on all arches (LFS by default).
+  // See: https://git.musl-libc.org/cgit/musl/tree/include/alltypes.h.in?h=v1.2.3#n29
+  //   off_t:    _Int64           -> long long (signed 64-bit)
+  //   ino_t:    unsigned _Int64  -> unsigned long long (64-bit)
+  //   blkcnt_t: _Int64           -> long long (signed 64-bit)
+  // For ARM, _Int64 = long long: https://git.musl-libc.org/cgit/musl/tree/arch/arm/bits/alltypes.h.in?h=v1.2.3#n3
+  version (CRuntime_Musl)
+  {
+    alias long      blkcnt_t;
+    alias ulong     ino_t;
+    alias long      off_t;
+  }
+  else static if ( __USE_FILE_OFFSET64 )
   {
     alias long      blkcnt_t;
     alias ulong     ino_t;
@@ -313,7 +325,17 @@ useconds_t
 
 version (linux)
 {
-  static if ( __USE_FILE_OFFSET64 )
+  // Musl always uses 64-bit fsblkcnt_t, fsfilcnt_t on all arches (LFS by default).
+  // See: https://git.musl-libc.org/cgit/musl/tree/include/alltypes.h.in?h=v1.2.3#n34
+  //   fsblkcnt_t: unsigned _Int64  -> unsigned long long (64-bit)
+  //   fsfilcnt_t: unsigned _Int64  -> unsigned long long (64-bit)
+  // For ARM, _Int64 = long long: https://git.musl-libc.org/cgit/musl/tree/arch/arm/bits/alltypes.h.in?h=v1.2.3#n3
+  version (CRuntime_Musl)
+  {
+    alias ulong     fsblkcnt_t;
+    alias ulong     fsfilcnt_t;
+  }
+  else static if ( __USE_FILE_OFFSET64 )
   {
     alias ulong     fsblkcnt_t;
     alias ulong     fsfilcnt_t;


### PR DESCRIPTION
LLM disclosure: generated by Claude Opus 4.5

----

This includes two fixes for the musl C runtime when targeting (32-bit) ARM:

1. `stat_t` is wrong and does not build (only the 64-bit struct was ported)
2. LFS types like `off_t` are wrong and fail the build (should always be 64-bit, unlike glibc)

----

Verification: Testing is not trivial as DMD does not support this target. Claude gave me the following self-contained Nix expressions which demonstrate the correct behavior with C, the current behavior in D, and the behavior in D after this fix.

### `stat_t` fixes

<details>

```nix
# Verification script for: core.sys.posix.sys.stat: Fix stat_t for CRuntime_Musl on ARM
#
# Usage:
#   $(nix-build --no-out-link -A c)          # Run C test (ground truth)
#   nix-build -A d-unfixed                   # Build D test without fix (will FAIL - demonstrates the bug)
#   $(nix-build --no-out-link -A d-fixed)    # Run D test with fix
#
# This demonstrates that the stat_t struct layout in D matches musl's C ABI on ARM.
# Requires: binfmt/qemu for ARM execution, or run on native ARM hardware.
#
# NOTE: The d-unfixed target will fail to build due to static asserts in druntime
# that check stat_t.sizeof. This demonstrates the actual bug.
#
# NOTE: d-fixed uses the already-patched DMD druntime files because multiple
# patches (stat.d, types.d, config.d) must be applied together for ARM.

{ pkgs ? import <nixpkgs> {} }:

let
  # Cross-compilation target
  crossPkgs = pkgs.pkgsCross.muslpi;
  staticPkgs = crossPkgs.pkgsStatic;
  staticCC = staticPkgs.stdenv.cc;
  crossCC = crossPkgs.stdenv.cc;
  targetTriple = "armv6l-unknown-linux-musleabihf";

  # DMD druntime files with patches applied
  dmdStatD = ./src/core/sys/posix/sys/stat.d;
  dmdTypesD = ./src/core/sys/posix/sys/types.d;
  dmdConfigD = ./src/core/sys/posix/config.d;

  # C test program - shows what musl actually defines
  cTestSrc = pkgs.writeText "stat_check.c" ''
    #include <stdio.h>
    #include <stddef.h>
    #include <sys/stat.h>

    int main() {
        printf("=== C (musl) stat struct on ARM ===\n");
        printf("sizeof(struct stat) = %zu\n", sizeof(struct stat));
        printf("  st_dev:     offset=%3zu size=%zu\n", offsetof(struct stat, st_dev), sizeof(((struct stat*)0)->st_dev));
        printf("  st_ino:     offset=%3zu size=%zu\n", offsetof(struct stat, st_ino), sizeof(((struct stat*)0)->st_ino));
        printf("  st_mode:    offset=%3zu size=%zu\n", offsetof(struct stat, st_mode), sizeof(((struct stat*)0)->st_mode));
        printf("  st_nlink:   offset=%3zu size=%zu\n", offsetof(struct stat, st_nlink), sizeof(((struct stat*)0)->st_nlink));
        printf("  st_size:    offset=%3zu size=%zu\n", offsetof(struct stat, st_size), sizeof(((struct stat*)0)->st_size));
        printf("  st_blocks:  offset=%3zu size=%zu\n", offsetof(struct stat, st_blocks), sizeof(((struct stat*)0)->st_blocks));
        return 0;
    }
  '';

  # D test program
  dTestSrc = pkgs.writeText "stat_check.d" ''
    module stat_check;
    import core.sys.posix.sys.stat;
    import core.stdc.stdio : printf;

    extern(C) int main() {
        printf("sizeof(stat_t) = %zu\n", stat_t.sizeof);
        printf("  st_dev:     offset=%3u size=%zu\n", cast(uint)stat_t.st_dev.offsetof, stat_t.st_dev.sizeof);
        printf("  st_ino:     offset=%3u size=%zu\n", cast(uint)stat_t.st_ino.offsetof, stat_t.st_ino.sizeof);
        printf("  st_mode:    offset=%3u size=%zu\n", cast(uint)stat_t.st_mode.offsetof, stat_t.st_mode.sizeof);
        printf("  st_nlink:   offset=%3u size=%zu\n", cast(uint)stat_t.st_nlink.offsetof, stat_t.st_nlink.sizeof);
        printf("  st_size:    offset=%3u size=%zu\n", cast(uint)stat_t.st_size.offsetof, stat_t.st_size.sizeof);
        printf("  st_blocks:  offset=%3u size=%zu\n", cast(uint)stat_t.st_blocks.offsetof, stat_t.st_blocks.sizeof);
        return 0;
    }
  '';

  # LDC source (unpatched)
  ldcSrc = pkgs.fetchFromGitHub {
    owner = "ldc-developers";
    repo = "ldc";
    tag = "v${pkgs.ldc.version}";
    hash = "sha256-6LcpY3LSFK4KgEiGrFp/LONu5Vr+/+vI04wEEpF3s+s=";
    fetchSubmodules = true;
  };

  # LDC source with DMD patched files overlaid
  ldcSrcFixed = pkgs.runCommand "ldc-src-fixed" {} ''
    cp -r ${ldcSrc} $out
    chmod -R u+w $out
    # Overlay the patched files from DMD druntime
    cp ${dmdStatD} $out/runtime/druntime/src/core/sys/posix/sys/stat.d
    cp ${dmdTypesD} $out/runtime/druntime/src/core/sys/posix/sys/types.d
    cp ${dmdConfigD} $out/runtime/druntime/src/core/sys/posix/config.d
  '';

  # Build LDC runtime
  buildRuntime = ldcSource: pkgs.runCommand "ldc-runtime-arm" {
    nativeBuildInputs = [ pkgs.ldc pkgs.cmake pkgs.ninja crossCC ];
  } ''
    export CC=${crossCC}/bin/${crossCC.targetPrefix}cc
    export HOME=$TMPDIR
    ${pkgs.ldc}/bin/ldc-build-runtime \
      --ninja \
      --ldcSrcDir=${ldcSource} \
      --dFlags="-mtriple=${targetTriple}" \
      BUILD_SHARED_LIBS=OFF
    mkdir -p $out/lib
    cp -r ldc-build-runtime.tmp/lib/* $out/lib/
  '';

  runtimeUnfixed = buildRuntime ldcSrc;
  runtimeFixed = buildRuntime ldcSrcFixed;

  # Build D test with given runtime
  buildDTest = { runtime, ldcSource, name }: pkgs.runCommand "d-test-${name}" {
    nativeBuildInputs = [ pkgs.ldc crossCC pkgs.lld ];
  } ''
    mkdir -p $out/bin
    ${pkgs.ldc}/bin/ldc2 \
      -mtriple=${targetTriple} \
      --gcc=${crossCC}/bin/${crossCC.targetPrefix}cc \
      --linker=lld \
      -of=$out/bin/stat_check \
      -I${ldcSource}/runtime/druntime/src \
      -L-L${runtime}/lib \
      -L-L${staticPkgs.stdenv.cc.libc}/lib \
      -static \
      ${dTestSrc}
  '';

  # Build C test
  cTest = pkgs.runCommand "c-test" {
    nativeBuildInputs = [ staticCC ];
  } ''
    mkdir -p $out/bin
    ${staticCC}/bin/${staticCC.targetPrefix}cc -o $out/bin/stat_check ${cTestSrc}
  '';

  dTestUnfixed = buildDTest { runtime = runtimeUnfixed; ldcSource = ldcSrc; name = "unfixed"; };
  dTestFixed = buildDTest { runtime = runtimeFixed; ldcSource = ldcSrcFixed; name = "fixed"; };

in {
  c = pkgs.writeShellScript "run-c-test" ''
    echo "=== C (musl) - ground truth ==="
    ${cTest}/bin/stat_check
  '';

  # This will fail to build - demonstrates the bug
  d-unfixed = pkgs.writeShellScript "run-d-unfixed" ''
    echo "=== D WITHOUT fix (LDC ${pkgs.ldc.version}) ==="
    ${dTestUnfixed}/bin/stat_check
  '';

  d-fixed = pkgs.writeShellScript "run-d-fixed" ''
    echo "=== D WITH fix ==="
    ${dTestFixed}/bin/stat_check
  '';
}
```

</details>

Usage and output:

```console
[vladimir@home druntime]$ $(nix-build --no-out-link verify-stat-arm.nix -A c)
=== C (musl) - ground truth ===
=== C (musl) stat struct on ARM ===
sizeof(struct stat) = 152
  st_dev:     offset=  0 size=8
  st_ino:     offset= 96 size=8
  st_mode:    offset= 16 size=4
  st_nlink:   offset= 20 size=4
  st_size:    offset= 48 size=8
  st_blocks:  offset= 64 size=8
[vladimir@home druntime]$ $(nix-build --no-out-link verify-stat-arm.nix -A d-unfixed)
these 3 derivations will be built:
[...]
/nix/store/1zv1d3m5gdc7pkmk5i5lnrcv3zx8y2sb-source/runtime/druntime/src/core/sys/posix/sys/stat.d(658): Error: static assert:  `112u == 88u` is false
            static assert(stat_t.sizeof == 88);
            ^
ninja: build stopped: subcommand failed.
.: Error: command failed with status 1
error: Cannot build '/nix/store/xvq9axl6c87xcalxajjbhxp61zjanp2g-ldc-runtime-arm.drv'.
[...]
[vladimir@home druntime]$ $(nix-build --no-out-link verify-stat-arm.nix -A d-fixed)
=== D WITH fix ===
sizeof(stat_t) = 152
  st_dev:     offset=  0 size=8
  st_ino:     offset= 96 size=8
  st_mode:    offset= 16 size=4
  st_nlink:   offset= 20 size=4
  st_size:    offset= 48 size=8
  st_blocks:  offset= 64 size=8
```

### LFS type fixes

<details>

```nix
# Verification script for: core.sys.posix.sys.types: Use 64-bit LFS types for CRuntime_Musl
#
# Usage:
#   $(nix-build --no-out-link -A c)          # Run C test (ground truth)
#   nix-build -A d-unfixed                   # Build D test without fix (will FAIL - demonstrates the bug)
#   $(nix-build --no-out-link -A d-fixed)    # Run D test with fix
#
# This demonstrates that off_t, blkcnt_t, ino_t are 64-bit on 32-bit ARM musl.
# Requires: binfmt/qemu for ARM execution, or run on native ARM hardware.
#
# NOTE: The d-unfixed target will fail to build due to static asserts in druntime
# that check off_t.sizeof == 8. This demonstrates the actual bug.
#
# NOTE: d-fixed uses the already-patched DMD druntime files because multiple
# patches (stat.d, types.d, config.d) must be applied together for ARM.

{ pkgs ? import <nixpkgs> {} }:

let
  # Cross-compilation target (32-bit ARM)
  crossPkgs = pkgs.pkgsCross.muslpi;
  staticPkgs = crossPkgs.pkgsStatic;
  staticCC = staticPkgs.stdenv.cc;
  crossCC = crossPkgs.stdenv.cc;
  targetTriple = "armv6l-unknown-linux-musleabihf";

  # DMD druntime files with patches applied
  dmdStatD = ./src/core/sys/posix/sys/stat.d;
  dmdTypesD = ./src/core/sys/posix/sys/types.d;
  dmdConfigD = ./src/core/sys/posix/config.d;

  # C test program - shows what musl actually defines
  cTestSrc = pkgs.writeText "lfs_check.c" ''
    #include <stdio.h>
    #include <sys/types.h>
    #include <sys/statvfs.h>

    int main() {
        printf("sizeof(off_t)      = %zu (should be 8)\n", sizeof(off_t));
        printf("sizeof(blkcnt_t)   = %zu (should be 8)\n", sizeof(blkcnt_t));
        printf("sizeof(ino_t)      = %zu (should be 8)\n", sizeof(ino_t));
        printf("sizeof(fsblkcnt_t) = %zu (should be 8)\n", sizeof(fsblkcnt_t));
        printf("sizeof(fsfilcnt_t) = %zu (should be 8)\n", sizeof(fsfilcnt_t));
        return 0;
    }
  '';

  # D test program
  dTestSrc = pkgs.writeText "lfs_check.d" ''
    module lfs_check;
    import core.sys.posix.sys.types;
    import core.stdc.stdio : printf;

    extern(C) int main() {
        printf("sizeof(off_t)      = %zu (should be 8)\n", off_t.sizeof);
        printf("sizeof(blkcnt_t)   = %zu (should be 8)\n", blkcnt_t.sizeof);
        printf("sizeof(ino_t)      = %zu (should be 8)\n", ino_t.sizeof);
        printf("sizeof(fsblkcnt_t) = %zu (should be 8)\n", fsblkcnt_t.sizeof);
        printf("sizeof(fsfilcnt_t) = %zu (should be 8)\n", fsfilcnt_t.sizeof);
        return 0;
    }
  '';

  # LDC source (unpatched)
  ldcSrc = pkgs.fetchFromGitHub {
    owner = "ldc-developers";
    repo = "ldc";
    tag = "v${pkgs.ldc.version}";
    hash = "sha256-6LcpY3LSFK4KgEiGrFp/LONu5Vr+/+vI04wEEpF3s+s=";
    fetchSubmodules = true;
  };

  # LDC source with DMD patched files overlaid
  ldcSrcFixed = pkgs.runCommand "ldc-src-fixed" {} ''
    cp -r ${ldcSrc} $out
    chmod -R u+w $out
    # Overlay the patched files from DMD druntime
    cp ${dmdStatD} $out/runtime/druntime/src/core/sys/posix/sys/stat.d
    cp ${dmdTypesD} $out/runtime/druntime/src/core/sys/posix/sys/types.d
    cp ${dmdConfigD} $out/runtime/druntime/src/core/sys/posix/config.d
  '';

  # Build LDC runtime
  buildRuntime = ldcSource: pkgs.runCommand "ldc-runtime-arm" {
    nativeBuildInputs = [ pkgs.ldc pkgs.cmake pkgs.ninja crossCC ];
  } ''
    export CC=${crossCC}/bin/${crossCC.targetPrefix}cc
    export HOME=$TMPDIR
    ${pkgs.ldc}/bin/ldc-build-runtime \
      --ninja \
      --ldcSrcDir=${ldcSource} \
      --dFlags="-mtriple=${targetTriple}" \
      BUILD_SHARED_LIBS=OFF
    mkdir -p $out/lib
    cp -r ldc-build-runtime.tmp/lib/* $out/lib/
  '';

  runtimeUnfixed = buildRuntime ldcSrc;
  runtimeFixed = buildRuntime ldcSrcFixed;

  # Build D test with given runtime
  buildDTest = { runtime, ldcSource, name }: pkgs.runCommand "d-test-${name}" {
    nativeBuildInputs = [ pkgs.ldc crossCC pkgs.lld ];
  } ''
    mkdir -p $out/bin
    ${pkgs.ldc}/bin/ldc2 \
      -mtriple=${targetTriple} \
      --gcc=${crossCC}/bin/${crossCC.targetPrefix}cc \
      --linker=lld \
      -of=$out/bin/lfs_check \
      -I${ldcSource}/runtime/druntime/src \
      -L-L${runtime}/lib \
      -L-L${staticPkgs.stdenv.cc.libc}/lib \
      -static \
      ${dTestSrc}
  '';

  # Build C test
  cTest = pkgs.runCommand "c-test" {
    nativeBuildInputs = [ staticCC ];
  } ''
    mkdir -p $out/bin
    ${staticCC}/bin/${staticCC.targetPrefix}cc -o $out/bin/lfs_check ${cTestSrc}
  '';

  dTestUnfixed = buildDTest { runtime = runtimeUnfixed; ldcSource = ldcSrc; name = "unfixed"; };
  dTestFixed = buildDTest { runtime = runtimeFixed; ldcSource = ldcSrcFixed; name = "fixed"; };

in {
  c = pkgs.writeShellScript "run-c-test" ''
    echo "=== C (musl) - ground truth ==="
    ${cTest}/bin/lfs_check
  '';

  # This will fail to build - demonstrates the bug
  d-unfixed = pkgs.writeShellScript "run-d-unfixed" ''
    echo "=== D WITHOUT fix (LDC ${pkgs.ldc.version}) ==="
    ${dTestUnfixed}/bin/lfs_check
  '';

  d-fixed = pkgs.writeShellScript "run-d-fixed" ''
    echo "=== D WITH fix ==="
    ${dTestFixed}/bin/lfs_check
  '';
}
```

</details>

Usage and output:

```console
[vladimir@home druntime]$ $(nix-build --no-out-link verify-lfs-types-arm.nix -A c)
=== C (musl) - ground truth ===
sizeof(off_t)      = 8 (should be 8)
sizeof(blkcnt_t)   = 8 (should be 8)
sizeof(ino_t)      = 8 (should be 8)
sizeof(fsblkcnt_t) = 8 (should be 8)
sizeof(fsfilcnt_t) = 8 (should be 8)
[vladimir@home druntime]$ $(nix-build --no-out-link verify-lfs-types-arm.nix -A d-unfixed)
these 3 derivations will be built:
[...]
core/sys/posix/sys/stat.d(658): Error: static assert:  `112u == 88u` is false
            static assert(stat_t.sizeof == 88);
            ^
ninja: build stopped: subcommand failed.
.: Error: command failed with status 1
error: Cannot build '/nix/store/xvq9axl6c87xcalxajjbhxp61zjanp2g-ldc-runtime-arm.drv'.
[...]
[vladimir@home druntime]$ $(nix-build --no-out-link verify-lfs-types-arm.nix -A d-fixed)
these 2 derivations will be built:
  /nix/store/78jl1smchhmqkqgh93cqs6gm4yf9i0sx-d-test-fixed.drv
  /nix/store/b7camkjsfja5zsjw9qg4p6v2kv3aalqa-run-d-fixed.drv
building '/nix/store/78jl1smchhmqkqgh93cqs6gm4yf9i0sx-d-test-fixed.drv'...
building '/nix/store/b7camkjsfja5zsjw9qg4p6v2kv3aalqa-run-d-fixed.drv'...
=== D WITH fix ===
sizeof(off_t)      = 8 (should be 8)
sizeof(blkcnt_t)   = 8 (should be 8)
sizeof(ino_t)      = 8 (should be 8)
sizeof(fsblkcnt_t) = 8 (should be 8)
sizeof(fsfilcnt_t) = 8 (should be 8)
```
