### PR TITLE
fix #22281 [REG master] Wrong associative array access with alias this for key

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -4279,7 +4279,13 @@ extern (D) bool keyCompatibleWithoutCasting(Expression ekey, Type t2)
             return true;
         return false;
     }
-    return implicitConvTo(ekey, t2) >= MATCH.constant;
+    if (implicitConvTo(ekey, t2) < MATCH.constant)
+        return false;
+    if (auto ts = t1.isTypeStruct())
+        return implicitConvToThroughAliasThis(ts, t2) == MATCH.nomatch;
+    if (auto tc = t1.isTypeClass())
+        return implicitConvToThroughAliasThis(tc, t2) == MATCH.nomatch;
+    return true;
 }
 
 /******************************************************************/

--- a/druntime/test/aa/src/test_aa.d
+++ b/druntime/test/aa/src/test_aa.d
@@ -45,6 +45,7 @@ void main()
     testTypeInfoCollect();
     testNew();
     testAliasThis();
+    testAliasThis2();
 }
 
 void testKeysValues1()
@@ -1020,4 +1021,30 @@ void testAliasThis()
         *p = 4;
     s.remove(1);
     assert(S.numCopies == 0);
+}
+
+void testAliasThis2()
+{
+    static struct A
+    {
+        bool extra;
+        uint id;
+    }
+
+    static struct B
+    {
+        uint id;
+
+        A toA() const pure nothrow
+        {
+            return A(false, id);
+        }
+
+        alias toA this;
+    }
+
+    bool[A] aa;
+    aa[B(5)] = true;
+    assert(B(5) in aa);
+    assert(A(false, 5) in aa);
 }


### PR DESCRIPTION
don't omit the cast in aa[cast(K)key] if key converts via alias this, so that the proper type is inferred by _d_aaGetY