### PR TITLE
dmd.root.array: add any and all predicates to dmd.root.array

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -157,12 +157,7 @@ bool isError(const RootObject o)
  */
 bool arrayObjectIsError(const ref Objects args)
 {
-    foreach (const o; args)
-    {
-        if (isError(o))
-            return true;
-    }
-    return false;
+    return args[].any!isError;
 }
 
 /***********************

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -28,7 +28,7 @@
  *   arguments, and uses it if found.
  * - Otherwise, the rest of semantic is run on the `TemplateInstance`.
  *
- * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
+ * Copyright:   Copyright (C) 1999-2026 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dtemplate.d, _dtemplate.d)
@@ -157,7 +157,12 @@ bool isError(const RootObject o)
  */
 bool arrayObjectIsError(const ref Objects args)
 {
-    return args[].any!isError;
+    foreach (const o; args)
+    {
+        if (isError(o))
+            return true;
+    }
+    return false;
 }
 
 /***********************
@@ -292,44 +297,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         this.isstatic = true;
         this.haveComputedOneMember = false;
         this.visibility = Visibility(Visibility.Kind.undefined);
-    }
-
-    extern(D) void computeIsTrivialAlias(Dsymbol s)
-    {
-        /* Set isTrivialAliasSeq if this fits the pattern:
-         *   template AliasSeq(T...) { alias AliasSeq = T; }
-         * or set isTrivialAlias if this fits the pattern:
-         *   template Alias(T) { alias Alias = qualifiers(T); }
-         */
-        if (!(parameters && parameters.length == 1))
-            return;
-
-        auto ad = s.isAliasDeclaration();
-        if (!ad || !ad.type)
-            return;
-
-        auto ti = ad.type.isTypeIdentifier();
-
-        if (!ti || ti.idents.length != 0)
-            return;
-
-        if (auto ttp = (*parameters)[0].isTemplateTupleParameter())
-        {
-            if (ti.ident is ttp.ident &&
-                ti.mod == 0)
-            {
-                //printf("found isTrivialAliasSeq %s %s\n", s.toChars(), ad.type.toChars());
-                isTrivialAliasSeq = true;
-            }
-        }
-        else if (auto ttp = (*parameters)[0].isTemplateTypeParameter())
-        {
-            if (ti.ident is ttp.ident)
-            {
-                //printf("found isTrivialAlias %s %s\n", s.toChars(), ad.type.toChars());
-                isTrivialAlias = true;
-            }
-        }
     }
 
     override TemplateDeclaration syntaxCopy(Dsymbol)
@@ -985,8 +952,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             // Set error here as we don't want it to depend on the number of
             // entries that are being printed.
             if (cl == Classification.error ||
-                (cl == Classification.warning && global.params.useWarnings == DiagnosticReporting.error) ||
-                (cl == Classification.deprecation && global.params.useDeprecated == DiagnosticReporting.error))
+                (cl == Classification.warning && global.errorSink.useWarnings == DiagnosticReporting.error) ||
+                (cl == Classification.deprecation && global.errorSink.useDeprecated == DiagnosticReporting.error))
                 cur.errors = true;
 
             // If two instantiations use the same declaration, they are recursive.

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -640,16 +640,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
         override void visit(AttribDeclaration ad)
         {
-            Dsymbols* d = ad.include(null);
-
-            if (d)
-            {
-                for (size_t i = 0; i < d.length; i++)
-                {
-                    Dsymbol s = (*d)[i];
-                    s.accept(this);
-                }
-            }
+            ad.include(null).each!(s => s.accept(this));
         }
 
         override void visit(PragmaDeclaration pd)
@@ -1221,18 +1212,10 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
 Louter:
     for (ClassDeclaration pc = cd; pc; pc = pc.baseClass)
     {
-        if (pc.members)
+        if (pc.members.any!(sm => (cast(Dsymbol)sm).hasPointers()))
         {
-            for (size_t i = 0; i < pc.members.length; i++)
-            {
-                Dsymbol sm = (*pc.members)[i];
-                //printf("sm = %s %s\n", sm.kind(), sm.toChars());
-                if (sm.hasPointers())
-                {
-                    flags &= ~ClassFlags.noPointers;  // not no-how, not no-way
-                    break Louter;
-                }
-            }
+            flags &= ~ClassFlags.noPointers;
+            break;
         }
     }
 

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -1,7 +1,7 @@
 /**
  * Convert an AST that went through all semantic phases into an object file.
  *
- * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
+ * Copyright:   Copyright (C) 1999-2026 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/glue/toobj.d, _toobj.d)
@@ -77,13 +77,16 @@ import dmd.backend.x86.code_x86;
 import dmd.backend.cv4;
 import dmd.backend.dt;
 import dmd.backend.el;
-import dmd.backend.global;
+import dmd.backend.dout : out_readonly, outdata;
 import dmd.backend.obj;
 import dmd.backend.oper;
+import dmd.backend.symbol;
 import dmd.backend.ty;
 import dmd.backend.type;
 
 package(dmd.glue):
+
+private:
 
 /* ================================================================== */
 
@@ -95,6 +98,7 @@ package(dmd.glue):
  *      s      = symbol that contains the data
  *      offset = offset of the data inside the Symbol's memory
  */
+package(dmd.glue)
 void write_pointers(Type type, Symbol* s, uint offset)
 {
     uint ty = type.toBasetype().ty;
@@ -112,6 +116,7 @@ void write_pointers(Type type, Symbol* s, uint offset)
 *      s      = symbol that contains the data
 *      offset = offset of the data inside the Symbol's memory
 */
+package(dmd.glue)
 void write_instance_pointers(Type type, Symbol* s, uint offset)
 {
     import dmd.typesem : hasPointers;
@@ -147,6 +152,7 @@ void write_instance_pointers(Type type, Symbol* s, uint offset)
  *      loc = the location for reporting line numbers in errors
  *      t   = the type to generate the `TypeInfo` object for
  */
+package(dmd.glue)
 void TypeInfo_toObjFile(Expression e, Loc loc, Type t)
 {
     // printf("TypeInfo_toObjFIle() %s\n", torig.toChars());
@@ -159,21 +165,22 @@ void TypeInfo_toObjFile(Expression e, Loc loc, Type t)
 
 /* ================================================================== */
 
+package(dmd.glue)
 void toObjFile(Dsymbol ds, bool multiobj)
 {
     //printf("toObjFile(%s %s)\n", ds.kind(), ds.toChars());
-
-    bool isCfile = ds.isCsymbol();
 
     extern (C++) final class ToObjFile : Visitor
     {
         alias visit = Visitor.visit;
     public:
         bool multiobj;
+        bool isCfile;
 
-        this(bool multiobj) scope @safe
+        this(bool multiobj, bool isCfile) scope @safe
         {
             this.multiobj = multiobj;
+            this.isCfile = isCfile;
         }
 
         void visitNoMultiObj(Dsymbol ds)
@@ -373,6 +380,11 @@ void toObjFile(Dsymbol ds, bool multiobj)
             if (sd.type.ty == Terror)
             {
                 .error(sd.loc, "%s `%s` had semantic errors when compiling", sd.kind, sd.toPrettyChars);
+                foreach (field; sd.fields)
+                {
+                    if (field.errors)
+                        errorSupplemental(field.loc, "field `%s` failed semantic analysis", field.toChars());
+                }
                 return;
             }
 
@@ -396,9 +408,9 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
                 // Generate static initializer
                 auto sinit = toInitializer(sd);
-                if (sinit.Sclass == SC.extern_)
+                if (sinit.Sclass == SC.extern_ &&
+                    strcmp(sinit.Sident.ptr, "__bzeroBytes") != 0) // might be from another object file
                 {
-                    if (sinit == bzeroSymbol) assert(0);
                     sinit.Sclass = sd.isInstantiated() ? SC.comdat : SC.global;
                     sinit.Sfl = FL.data;
                     auto dtb = DtBuilder(0);
@@ -429,6 +441,10 @@ void toObjFile(Dsymbol ds, bool multiobj)
                  */
                 sd.members.foreachDsymbol( (s) { s.accept(this); } );
 
+                /* Emit the special __xopEquals/__xopCmp/__xtoHash member functions
+                 * required for the TypeInfo, but not added as struct members.
+                 * (Note that `postblit` and `tidtor` are struct members in `sd.members`.)
+                 */
                 if (sd.xeq && sd.xeq != StructDeclaration.xerreq)
                     sd.xeq.accept(this);
                 if (sd.xcmp && sd.xcmp != StructDeclaration.xerrcmp)
@@ -462,6 +478,11 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 return;
             }
 
+            // Check to see if we're doing special section mangling, these are not regular variables.
+            // Do not prepend an underscore to the name, it won't work.
+            if (config.objfmt == OBJ_MACH && vd.mangleOverride.length > 8 && vd.mangleOverride[0 .. 8] == "section$")
+                vd.noUnderscore = true;
+
             if (!vd.isDataseg() || vd.storage_class & STC.extern_)
                 return;
 
@@ -480,6 +501,101 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
             Dsymbol parent = vd.toParent();
             s.Sclass = SC.global;
+
+            {
+                string userDefinedSection;
+
+                // find the @section("name") uda
+                foreachUdaNoSemantic(vd, (e) {
+                    import dmd.expressionsem : toUTF8;
+
+                    if (!e.isStructLiteralExp())
+                        return 0;
+
+                    auto sle = e.isStructLiteralExp();
+                    assert(sle.sd);
+
+                    if (!isCoreUda(sle.sd, Id.udaSection))
+                        return 0;
+
+                    if (userDefinedSection)
+                    {
+                        error(vd.loc, "%s `%s` can only have one section attribute", vd.kind, vd.toPrettyChars);
+                        return 1;
+                    }
+
+                    assert(sle.elements.length == 1);
+                    auto se = (*sle.elements)[0].isStringExp();
+                    assert(se);
+
+                    userDefinedSection = cast(string)se.toUTF8(vd._scope).toStringz();
+                    return 0;
+                });
+
+                if (userDefinedSection)
+                {
+                    import core.bitop;
+                    const canBeReadOnly = !vd.type.isMutable;
+
+                    // Alignment of a type will be a power of 2 and will not be 0.
+                    const alignTo = vd.type.alignsize();
+                    const alignToPower = bsr(alignTo);
+
+                    switch (config.objfmt)
+                    {
+                        case OBJ_MACH:
+                            import dmd.backend.mach;
+
+                            // name does not start with a _
+                            //s.Sflags |= SFLnounderscore;
+
+                            s.Sseg = Obj.getsegment(
+                                userDefinedSection.ptr,
+                                canBeReadOnly ? "__TEXT" : "__DATA",
+                                alignToPower, // convert alignment to the power of
+
+                                //S_ATTR_NO_DEAD_STRIP |
+                                S_REGULAR // flags
+                            );
+                            break;
+                        case OBJ_ELF:
+                            import dmd.backend.elfobj;
+                            import dmd.backend.melf;
+
+                            s.Sseg = Obj.getsegment(
+                                userDefinedSection.ptr,
+                                null, // suffix
+                                SHT_PROGBITS, // type
+
+                                //SHF_GNU_RETAIN |
+                                SHF_ALLOC | (canBeReadOnly ? 0 : SHF_WRITE), // flags
+
+                                alignTo // align
+                            );
+                            break;
+                        case OBJ_MSCOFF:
+                            import dmd.backend.mscoff;
+
+                            const alignTo2 = IMAGE_SCN_ALIGN_1BYTES * (alignToPower + 1);
+                            const alignTo3 = alignTo2 <= IMAGE_SCN_ALIGN_8192BYTES ? alignTo2 : IMAGE_SCN_ALIGN_8192BYTES;
+
+                            // Windows will not dead strip symbols, as long as start/end are used.
+
+                            s.Sseg = Obj.getsegment(
+                                userDefinedSection.ptr,
+
+                                // flags
+                                alignTo3
+                                | IMAGE_SCN_MEM_READ
+                                | IMAGE_SCN_CNT_INITIALIZED_DATA
+                                | (canBeReadOnly ? 0 : IMAGE_SCN_MEM_WRITE)
+                            );
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
 
             /* Make C static functions SCstatic
              */
@@ -529,7 +645,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             }
             else
             {
-                Type_toDt(vd.type, dtb, vd.isCsymbol());
+                Type_toDt(vd.loc, vd.type, dtb, vd.isCsymbol());
             }
             s.Sdt = dtb.finish();
 
@@ -589,8 +705,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     scclass = SC.comdat;
 
                 // Generate static initializer
-                toInitializer(ed);
-                auto sinit = cast(Symbol*) ed.sinit;
+                auto sinit = toInitializer(ed);
                 sinit.Sclass = scclass;
                 sinit.Sfl = FL.data;
                 auto dtb = DtBuilder(0);
@@ -640,7 +755,16 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
         override void visit(AttribDeclaration ad)
         {
-            ad.include(null).each!(s => s.accept(this));
+            Dsymbols* d = ad.include(null);
+
+            if (d)
+            {
+                for (size_t i = 0; i < d.length; i++)
+                {
+                    Dsymbol s = (*d)[i];
+                    s.accept(this);
+                }
+            }
         }
 
         override void visit(PragmaDeclaration pd)
@@ -808,7 +932,9 @@ void toObjFile(Dsymbol ds, bool multiobj)
          */
         static void tlsToDt(VarDeclaration vd, Symbol* s, uint sz, ref DtBuilder dtb, bool isCfile)
         {
-            assert(config.objfmt == OBJ_MACH && target.isX86_64 && (s.Stype.Tty & mTYLINK) == mTYthread);
+            assert(config.objfmt == OBJ_MACH &&
+                (target.isX86_64 || target.isAArch64) &&
+                (s.Stype.Tty & mTYLINK) == mTYthread);
 
             Symbol* tlvInit = createTLVDataSymbol(vd, s);
             auto tlvInitDtb = DtBuilder(0);
@@ -818,13 +944,13 @@ void toObjFile(Dsymbol ds, bool multiobj)
             else if (vd._init)
                 initializerToDt(vd, tlvInitDtb, isCfile);
             else
-                Type_toDt(vd.type, tlvInitDtb);
+                Type_toDt(vd.loc, vd.type, tlvInitDtb);
 
             tlvInit.Sdt = tlvInitDtb.finish();
             outdata(tlvInit);
 
-            if (target.isX86_64)
-                tlvInit.Sclass = SC.extern_;
+            tlvInit.Sclass = SC.extern_;
+            //tlvInit.Sxtrnnum = 0; // not sure about this
 
             Symbol* tlvBootstrap = objmod.tlv_bootstrap();
             dtb.xoff(tlvBootstrap, 0, TYnptr);
@@ -899,10 +1025,61 @@ void toObjFile(Dsymbol ds, bool multiobj)
         }
     }
 
-    scope v = new ToObjFile(multiobj);
+    scope v = new ToObjFile(multiobj, ds.isCsymbol());
     ds.accept(v);
 }
 
+
+/******************************************
+ * Get offset of base class's vtbl[] initializer from start of csym.
+ * Returns ~0 if not this csym.
+ */
+
+package(dmd.glue)
+uint baseVtblOffset(ClassDeclaration cd, BaseClass* bc)
+{
+    //printf("ClassDeclaration.baseVtblOffset('%s', bc = %p)\n", cd.toChars(), bc);
+    uint csymoffset = classInfoSize();    // must be ClassInfo.size
+    //printf("classInfoSize(): %d\n", csymoffset);
+    csymoffset += cd.vtblInterfaces.length * (4 * target.ptrsize);
+
+    for (size_t i = 0; i < cd.vtblInterfaces.length; i++)
+    {
+        BaseClass* b = (*cd.vtblInterfaces)[i];
+
+        if (b == bc)
+            return csymoffset;
+        csymoffset += b.sym.vtbl.length * target.ptrsize;
+    }
+
+    // Put out the overriding interface vtbl[]s.
+    // This must be mirrored with ClassDeclaration.baseVtblOffset()
+    //printf("putting out overriding interface vtbl[]s for '%s' at offset x%x\n", toChars(), offset);
+    ClassDeclaration cd2;
+
+    for (cd2 = cd.baseClass; cd2; cd2 = cd2.baseClass)
+    {
+        foreach (k; 0 .. cd2.vtblInterfaces.length)
+        {
+            BaseClass* bs = (*cd2.vtblInterfaces)[k];
+            if (bs.fillVtbl(cd, null, 0))
+            {
+                if (bc == bs)
+                {
+                    //printf("\tcsymoffset = x%x\n", csymoffset);
+                    return csymoffset;
+                }
+                csymoffset += bs.sym.vtbl.length * target.ptrsize;
+            }
+        }
+    }
+
+    return ~0;
+}
+
+/**********************************************************************************/
+/*                         private                                                */
+/**********************************************************************************/
 
 /*********************************
  * Finish semantic analysis of functions in vtbl[].
@@ -971,50 +1148,16 @@ private bool finishVtbl(ClassDeclaration cd)
     return !hasError;
 }
 
-
-/******************************************
- * Get offset of base class's vtbl[] initializer from start of csym.
- * Returns ~0 if not this csym.
- */
-
-uint baseVtblOffset(ClassDeclaration cd, BaseClass* bc)
+/// Returns: classInstanceSize of TypeInfo_Class for `cd`
+private
+uint classInfoSize()
 {
-    //printf("ClassDeclaration.baseVtblOffset('%s', bc = %p)\n", cd.toChars(), bc);
-    uint csymoffset = target.classinfosize;    // must be ClassInfo.size
-    csymoffset += cd.vtblInterfaces.length * (4 * target.ptrsize);
-
-    for (size_t i = 0; i < cd.vtblInterfaces.length; i++)
-    {
-        BaseClass* b = (*cd.vtblInterfaces)[i];
-
-        if (b == bc)
-            return csymoffset;
-        csymoffset += b.sym.vtbl.length * target.ptrsize;
-    }
-
-    // Put out the overriding interface vtbl[]s.
-    // This must be mirrored with ClassDeclaration.baseVtblOffset()
-    //printf("putting out overriding interface vtbl[]s for '%s' at offset x%x\n", toChars(), offset);
-    ClassDeclaration cd2;
-
-    for (cd2 = cd.baseClass; cd2; cd2 = cd2.baseClass)
-    {
-        foreach (k; 0 .. cd2.vtblInterfaces.length)
-        {
-            BaseClass* bs = (*cd2.vtblInterfaces)[k];
-            if (bs.fillVtbl(cd, null, 0))
-            {
-                if (bc == bs)
-                {
-                    //printf("\tcsymoffset = x%x\n", csymoffset);
-                    return csymoffset;
-                }
-                csymoffset += bs.sym.vtbl.length * target.ptrsize;
-            }
-        }
-    }
-
-    return ~0;
+    auto obj = ClassDeclaration.object;
+    const bool hasMonitor = !obj || !obj.symtab || obj.symtab.lookup(Id.__monitor) !is null;
+    if (target.ptrsize == 8)
+        return 0x98 + 8 + (hasMonitor ? 8 : 0); // 168 with monitor
+    else
+        return 0x4C + 12 + (hasMonitor ? 4 : 0); // 92 with monitor
 }
 
 /*******************
@@ -1040,7 +1183,7 @@ private size_t emitVtbl(ref DtBuilder dtb, BaseClass* b, ref FuncDeclarations bv
     if (id.vtblOffset())
     {
         // First entry is struct Interface reference
-        dtb.xoff(toSymbol(pc), cast(uint)(target.classinfosize + k * (4 * target.ptrsize)), TYnptr);
+        dtb.xoff(toSymbol(pc), cast(uint)(classInfoSize() + k * (4 * target.ptrsize)), TYnptr);
         jstart = 1;
     }
 
@@ -1074,11 +1217,11 @@ private void genClassInfoForClass(ClassDeclaration cd, Symbol* sinit)
 {
     if (Type.typeinfoclass)
     {
-        if (Type.typeinfoclass.structsize != target.classinfosize)
+        if (Type.typeinfoclass.structsize != classInfoSize())
         {
-            debug printf("target.classinfosize = x%x, Type.typeinfoclass.structsize = x%x\n", target.classinfosize, Type.typeinfoclass.structsize);
+            debug printf("classInfoSize() = x%x, Type.typeinfoclass.structsize = x%x\n", classInfoSize(), Type.typeinfoclass.structsize);
             .error(cd.loc, "%s `%s` mismatch between compiler (%d bytes) and object.d or object.di (%d bytes) found",
-                   cd.kind, cd.toPrettyChars, cast(uint)target.classinfosize, cast(uint)Type.typeinfoclass.structsize);
+                   cd.kind, cd.toPrettyChars, cast(uint)classInfoSize(), cast(uint)Type.typeinfoclass.structsize);
             .errorSupplemental(cd.loc, "check installation and import paths with `-v` compiler switch");
             fatal();
         }
@@ -1125,7 +1268,7 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
             uint[4] nameSig;
        }
      */
-    uint offset = target.classinfosize;    // must be ClassInfo.size
+    uint offset = classInfoSize();    // must be ClassInfo.size
 
     if (auto tic = Type.typeinfoclass)
     {
@@ -1140,7 +1283,8 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
     }
 
     // m_init[]
-    assert(cd.structsize >= 8 || (cd.classKind == ClassKind.cpp && cd.structsize >= 4));
+    // Class instances always have at least a vtable pointer
+    assert(cd.structsize >= target.ptrsize || (cd.classKind == ClassKind.cpp && cd.structsize >= 4));
     dtb.size(cd.structsize);           // size
     dtb.xoff(sinit, 0, TYnptr);         // initializer
 
@@ -1149,7 +1293,7 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
     size_t namelen = strlen(name);
     if (!(namelen > 9 && memcmp(name, "TypeInfo_".ptr, 9) == 0))
     {
-        name = cd.toPrettyChars(/*QualifyTypes=*/ true);
+        name = cd.toPrettyChars(/*QualifyTypes=*/ true, true);
         namelen = strlen(name);
     }
     dtb.size(namelen);
@@ -1212,10 +1356,16 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
 Louter:
     for (ClassDeclaration pc = cd; pc; pc = pc.baseClass)
     {
-        if (pc.members.any!(sm => (cast(Dsymbol)sm).hasPointers()))
+        foreach (vd; pc.fields)
         {
-            flags &= ~ClassFlags.noPointers;
-            break;
+            //printf("vd = %s %s\n", vd.kind(), vd.toChars());
+            if (vd.ident == Id.__monitor)
+                continue;   // __monitor is not GC-managed
+            if (vd.hasPointers())
+            {
+                flags &= ~ClassFlags.noPointers;  // not no-how, not no-way
+                break Louter;
+            }
         }
     }
 
@@ -1392,7 +1542,7 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
     dtb.size(0);                        // initializer
 
     // name[]
-    const(char) *name = id.toPrettyChars(/*QualifyTypes=*/ true);
+    const(char) *name = id.toPrettyChars(/*QualifyTypes=*/ true, /*keepOneMember=*/ true);
     size_t namelen = strlen(name);
     dtb.size(namelen);
     auto csym = cast(Symbol*)id.csym;
@@ -1403,7 +1553,7 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
     dtb.size(0);
 
     // interfaces[]
-    uint offset = target.classinfosize;
+    uint offset = classInfoSize();
     dtb.size(id.vtblInterfaces.length);
     if (id.vtblInterfaces.length)
     {

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1876,6 +1876,10 @@ extern (D) bool checkClosure(FuncDeclaration fd)
     }
 
     FuncDeclarations a;
+
+    if (fd.closureVars.length > 0)
+        a.reserve(fd.closureVars.length);
+
     foreach (v; fd.closureVars)
     {
         foreach (f; v.nestedrefs)
@@ -1903,6 +1907,6 @@ extern (D) bool checkClosure(FuncDeclaration fd)
             }
         }
     }
-
+    a.shrinkToFit();
     return true;
 }

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -3,7 +3,7 @@
  * function bodies and late semantic checks for templates, mixins,
  * aggregates, and special members.
  *
- * Copyright:   Copyright (C) 1999-2025 by The D Language Foundation, All Rights Reserved
+ * Copyright:   Copyright (C) 1999-2026 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/compiler/src/dmd/semantic3.d, _semantic3.d)
@@ -38,7 +38,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.dtemplate;
 import dmd.dversion;
-import dmd.errors;
+import dmd.errorsink;
 import dmd.escape;
 import dmd.expression;
 import dmd.expressionsem;
@@ -74,9 +74,15 @@ import dmd.statement;
 import dmd.target;
 import dmd.targetcompiler;
 import dmd.templateparamsem;
+import dmd.templatesem;
 import dmd.typesem;
 import dmd.visitor;
-import dmd.dfa.entry;
+
+version (IN_GCC) { /* Not using Fast DFA */ }
+else version = FastDFA;
+
+version (FastDFA)
+    import dmd.dfa.entry;
 
 enum LOG = false;
 
@@ -95,9 +101,12 @@ private extern(C++) final class Semantic3Visitor : Visitor
     alias visit = Visitor.visit;
 
     Scope* sc;
-    this(Scope* sc) scope @safe
+    ErrorSink eSink;
+
+    this(Scope* sc) scope
     {
         this.sc = sc;
+        this.eSink = global.errorSink;
     }
 
     override void visit(Dsymbol) {}
@@ -112,6 +121,12 @@ private extern(C++) final class Semantic3Visitor : Visitor
         if (tempinst.semanticRun >= PASS.semantic3)
             return;
         tempinst.semanticRun = PASS.semantic3;
+        if (tempinst._scope && tempinst._scope.deferSemantic3InCompilerHook)
+        {
+            tempinst._scope.deferSemantic3InCompilerHook = false;
+            templateInstanceSemantic3(tempinst, tempinst._scope, tempinst._scope);
+        }
+
         if (tempinst.errors || !tempinst.members)
             return;
 
@@ -146,7 +161,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             if (!tempinst.errors)
             {
                 if (!tempdecl.literal)
-                    .error(tempinst.loc, "%s `%s` error instantiating", tempinst.kind, tempinst.toPrettyChars);
+                    eSink.error(tempinst.loc, "%s `%s` error instantiating", tempinst.kind, tempinst.toPrettyChars);
                 if (tempinst.tinst)
                     tempinst.tinst.printInstantiationTrace();
             }
@@ -183,7 +198,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         }
 
         if (global.errors != olderrors)
-            errorSupplemental(tmix.loc, "parent scope from here: `mixin %s`", tmix.toChars());
+            eSink.errorSupplemental(tmix.loc, "parent scope from here: `mixin %s`", tmix.toChars());
 
         sc = sc.pop();
         sc.pop();
@@ -289,7 +304,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             return;
         funcdecl.semanticRun = PASS.semantic3;
         funcdecl.hasSemantic3Errors = false;
-        funcdecl.saferD = sc.previews.safer;
+        funcdecl.saferD = sc.previews.safer && !sc.inCfile;
 
         if (!funcdecl.type || funcdecl.type.ty != Tfunction)
             return;
@@ -299,7 +314,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         if (!funcdecl.fbody && funcdecl.inferRetType && !f.next)
         {
-            .error(funcdecl.loc, "%s `%s` has no function body with return type inference", funcdecl.kind, funcdecl.toPrettyChars);
+            eSink.error(funcdecl.loc, "%s `%s` has no function body with return type inference", funcdecl.kind, funcdecl.toPrettyChars);
             return;
         }
 
@@ -326,6 +341,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
             Scope* sc2 = sc.push(ss);
             sc2.func = funcdecl;
             sc2.parent = funcdecl;
+            // A declaration-level pragma(inline) only applies to this function.
+            sc2.inlining = null;
             sc2.ctorflow.callSuper = CSX.none;
             sc2.sbreak = null;
             sc2.scontinue = null;
@@ -371,7 +388,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if (!sc.intypeof)
                     {
                         if (fld.tok == TOK.delegate_)
-                            .error(funcdecl.loc, "%s `%s` cannot be %s members", funcdecl.kind, funcdecl.toErrMsg, ad.kind());
+                            eSink.error(funcdecl.loc, "%s `%s` cannot be %s members", funcdecl.kind, funcdecl.toErrMsg, ad.kind());
                         else
                             fld.tok = TOK.function_;
                     }
@@ -395,7 +412,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
             // functions to be reworked as a frontend-only feature.
             if (funcdecl.hasDualContext)
             {
-                .deprecation(funcdecl.loc, "%s `%s` function requires a dual-context, which is deprecated", funcdecl.kind, funcdecl.toPrettyChars);
+                eSink.deprecation(funcdecl.loc, "%s `%s` function requires a dual-context, which is deprecated", funcdecl.kind, funcdecl.toPrettyChars);
+                import dmd.errors : Classification;
                 if (auto ti = sc2.parent ? sc2.parent.isInstantiated() : null)
                     ti.printInstantiationTrace(Classification.deprecation);
             }
@@ -412,11 +430,11 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if (!global.params.useTypeInfo || !Type.dtypeinfo || !Type.typeinfotypelist)
                     {
                         if (!global.params.useTypeInfo)
-                            .error(funcdecl.loc, "%s `%s` D-style variadic functions cannot be used with `-%s`", funcdecl.kind, funcdecl.toPrettyChars, SwitchVariadic.ptr);
+                            eSink.error(funcdecl.loc, "%s `%s` D-style variadic functions cannot be used with `-%s`", funcdecl.kind, funcdecl.toPrettyChars, SwitchVariadic.ptr);
                         else if (!Type.typeinfotypelist)
-                            .error(funcdecl.loc, "%s `%s` `object.TypeInfo_Tuple` could not be found, but is implicitly used in D-style variadic functions", funcdecl.kind, funcdecl.toPrettyChars);
+                            eSink.error(funcdecl.loc, "%s `%s` `object.TypeInfo_Tuple` could not be found, but is implicitly used in D-style variadic functions", funcdecl.kind, funcdecl.toPrettyChars);
                         else
-                            .error(funcdecl.loc, "%s `%s` `object.TypeInfo` could not be found, but is implicitly used in D-style variadic functions", funcdecl.kind, funcdecl.toPrettyChars);
+                            eSink.error(funcdecl.loc, "%s `%s` `object.TypeInfo` could not be found, but is implicitly used in D-style variadic functions", funcdecl.kind, funcdecl.toPrettyChars);
                         funcdecl.errors = true;
                     }
                 }
@@ -487,7 +505,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     v.dsymbolSemantic(sc2);
                     if (!sc2.insert(v))
                     {
-                        .error(funcdecl.loc, "%s `%s` parameter `%s.%s` is already defined", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toChars(), v.toChars());
+                        eSink.error(funcdecl.loc, "%s `%s` parameter `%s.%s` is already defined", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toErrMsg(), v.toErrMsg());
                         funcdecl.errors = true;
                     }
                     else
@@ -527,7 +545,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 //printf("declaring tuple %s\n", v.toChars());
                 v.isexp = true;
                 if (!sc2.insert(v))
-                    .error(funcdecl.loc, "%s `%s` parameter `%s.%s` is already defined", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toChars(), v.toChars());
+                    eSink.error(funcdecl.loc, "%s `%s` parameter `%s.%s` is already defined", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toErrMsg(), v.toErrMsg());
                 funcdecl.localsymtab.insert(v);
                 v.parent = funcdecl;
             }
@@ -597,9 +615,11 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 bool inferRef = (f.isRef && (funcdecl.storage_class & STC.auto_));
 
+                unpackFunctionParameters(funcdecl);
+
                 funcdecl.fbody = funcdecl.fbody.statementSemantic(sc2);
                 if (!funcdecl.fbody)
-                    funcdecl.fbody = new CompoundStatement(Loc.initial, new Statements());
+                    funcdecl.fbody = new CompoundStatement(Loc.initial);
 
                 if (funcdecl.isNaked)
                 {
@@ -616,7 +636,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if (!f.next)
                         f.next = Type.tvoid;
                     if (f.checkRetType(funcdecl.loc))
-                        funcdecl.fbody = new ErrorStatement();
+                        funcdecl.fbody = ErrorStatement.get();
                     else
                         funcdecl.checkMain(); // Check main() parameters and return type
                 }
@@ -688,19 +708,23 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                  * 2. structs should recognize delegating opAssign calls as well
                                  *    as delegating calls to other constructors
                                  */
-                                if (v.isCtorinit() && !v.type.isMutable() && cd)
-                                    .error(funcdecl.loc, "%s `%s` missing initializer for %s field `%s`", funcdecl.kind, funcdecl.toPrettyChars, MODtoChars(v.type.mod), v.toChars());
+                                if (sc2.ctorflow.fieldinit[i].csx & CSX.halt)
+                                {
+                                    // constructor always halts on this path, no initialization needed
+                                }
+                                else if (v.isCtorinit() && !v.type.isMutable() && cd)
+                                    eSink.error(funcdecl.loc, "%s `%s` missing initializer for %s field `%s`", funcdecl.kind, funcdecl.toPrettyChars, MODtoChars(v.type.mod), v.toErrMsg());
                                 else if (v.storage_class & STC.nodefaultctor)
-                                    error(funcdecl.loc, "field `%s` must be initialized in constructor", v.toChars());
+                                    eSink.error(funcdecl.loc, "field `%s` must be initialized in constructor", v.toErrMsg());
                                 else if (v.type.needsNested())
-                                    error(funcdecl.loc, "field `%s` must be initialized in constructor, because it is nested struct", v.toChars());
+                                    eSink.error(funcdecl.loc, "field `%s` must be initialized in constructor, because it is nested struct", v.toErrMsg());
                             }
                             else
                             {
                                 bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
-                                if (mustInit && !(sc2.ctorflow.fieldinit[i].csx & CSX.this_ctor))
+                                if (mustInit && !(sc2.ctorflow.fieldinit[i].csx & (CSX.this_ctor | CSX.halt)))
                                 {
-                                    .error(funcdecl.loc, "%s `%s` field `%s` must be initialized but skipped", funcdecl.kind, funcdecl.toPrettyChars, v.toChars());
+                                    eSink.error(funcdecl.loc, "%s `%s` field `%s` must be initialized but skipped", funcdecl.kind, funcdecl.toPrettyChars, v.toErrMsg());
                                 }
                             }
                         }
@@ -716,11 +740,11 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         FuncDeclaration fd = resolveFuncCall(Loc.initial, sc2, cd.baseClass.ctor, null, tthis, ArgumentList(), FuncResolveFlag.quiet);
                         if (!fd)
                         {
-                            .error(funcdecl.loc, "%s `%s` no match for implicit `super()` call in constructor", funcdecl.kind, funcdecl.toPrettyChars);
+                            eSink.error(funcdecl.loc, "%s `%s` no match for implicit `super()` call in constructor", funcdecl.kind, funcdecl.toPrettyChars);
                         }
                         else if (fd.storage_class & STC.disable)
                         {
-                            .error(funcdecl.loc, "%s `%s` cannot call `super()` implicitly because it is annotated with `@disable`", funcdecl.kind, funcdecl.toPrettyChars);
+                            eSink.error(funcdecl.loc, "%s `%s` cannot call `super()` implicitly because it is annotated with `@disable`", funcdecl.kind, funcdecl.toPrettyChars);
                         }
                         else
                         {
@@ -753,7 +777,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 // Check for errors related to 'nothrow'.
                 const blockexit = funcdecl.fbody.blockExit(funcdecl, f.isNothrow ? global.errorSink : null);
                 if (f.isNothrow && blockexit & BE.throw_)
-                    error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
+                    eSink.error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
 
                 if (!(blockexit & (BE.throw_ | BE.halt) || funcdecl.hasCatches))
                 {
@@ -806,8 +830,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     // Fallthrough despite being declared as noreturn? return is already rejected when evaluating the ReturnStatement
                     if (blockexit & BE.fallthru)
                     {
-                        .error(funcdecl.loc, "%s `%s` is typed as `%s` but does return", funcdecl.kind, funcdecl.toPrettyChars, f.next.toChars());
-                        funcdecl.loc.errorSupplemental("`noreturn` functions must either throw, abort or loop indefinitely");
+                        eSink.error(funcdecl.loc, "%s `%s` is typed as `%s` but does return", funcdecl.kind, funcdecl.toPrettyChars, f.next.toErrMsg());
+                        eSink.errorSupplemental(funcdecl.loc, "`noreturn` functions must either throw, abort or loop indefinitely");
                     }
                 }
                 else
@@ -815,9 +839,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if ((blockexit & BE.fallthru) && f.next.ty != Tvoid && !funcdecl.hasInlineAsm && !sc.inCfile)
                     {
                         if (!funcdecl.hasReturnExp)
-                            .error(funcdecl.loc, "%s `%s` has no `return` statement, but is expected to return a value of type `%s`", funcdecl.kind, funcdecl.toPrettyChars, f.next.toChars());
+                            eSink.error(funcdecl.loc, "%s `%s` has no `return` statement, but is expected to return a value of type `%s`", funcdecl.kind, funcdecl.toPrettyChars, f.next.toErrMsg());
                         else
-                            .error(funcdecl.loc, "%s `%s` no `return exp;` or `assert(0);` at end of function", funcdecl.kind, funcdecl.toPrettyChars);
+                            eSink.error(funcdecl.loc, "%s `%s` no `return exp;` or `assert(0);` at end of function", funcdecl.kind, funcdecl.toPrettyChars);
                     }
                 }
 
@@ -836,12 +860,13 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     {
                         ReturnStatement rs = (*funcdecl.returns)[i];
                         Expression exp = rs.exp;
+                        Scope* sc3 = rs.scope_;
                         if (exp.op == EXP.error)
                             continue;
                         if (tret.ty == Terror)
                         {
                             // https://issues.dlang.org/show_bug.cgi?id=13702
-                            exp = exp.checkGC(sc2);
+                            exp = exp.checkGC(sc3);
                             continue;
                         }
 
@@ -880,24 +905,24 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                 if (tclass)
                                 {
                                     if ((cast(TypeClass)(exp.type.immutableOf())).implicitConvToWithoutAliasThis(tret))
-                                        exp = exp.castTo(sc2, exp.type.immutableOf());
+                                        exp = exp.castTo(sc3, exp.type.immutableOf());
                                     else if ((cast(TypeClass)(exp.type.wildOf())).implicitConvToWithoutAliasThis(tret))
-                                        exp = exp.castTo(sc2, exp.type.wildOf());
+                                        exp = exp.castTo(sc3, exp.type.wildOf());
                                 }
                                 else
                                 {
                                     if ((cast(TypeStruct)exp.type.immutableOf()).implicitConvToWithoutAliasThis(tret))
-                                        exp = exp.castTo(sc2, exp.type.immutableOf());
-                                    else if ((cast(TypeStruct)exp.type.immutableOf()).implicitConvToWithoutAliasThis(tret))
-                                        exp = exp.castTo(sc2, exp.type.wildOf());
+                                        exp = exp.castTo(sc3, exp.type.immutableOf());
+                                    else if ((cast(TypeStruct)exp.type.wildOf()).implicitConvToWithoutAliasThis(tret))
+                                        exp = exp.castTo(sc3, exp.type.wildOf());
                                 }
                             }
                             else
                             {
                                 if (exp.type.immutableOf().implicitConvTo(tret))
-                                    exp = exp.castTo(sc2, exp.type.immutableOf());
+                                    exp = exp.castTo(sc3, exp.type.immutableOf());
                                 else if (exp.type.wildOf().implicitConvTo(tret))
-                                    exp = exp.castTo(sc2, exp.type.wildOf());
+                                    exp = exp.castTo(sc3, exp.type.wildOf());
                             }
                         }
 
@@ -905,12 +930,12 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         if (f.isRef)
                         {
                             if (!MODimplicitConv(exp.type.mod, tret.mod) && !tret.isTypeSArray())
-                                error(exp.loc, "expression `%s` of type `%s` is not implicitly convertible to return type `ref %s`",
-                                      exp.toChars(), exp.type.toChars(), tret.toChars());
+                                eSink.error(exp.loc, "expression `%s` of type `%s` is not implicitly convertible to return type `ref %s`",
+                                      exp.toErrMsg(), exp.type.toErrMsg(), tret.toErrMsg());
                             else
-                                exp = exp.implicitCastTo(sc2, tret);
+                                exp = exp.implicitCastTo(sc3, tret);
 
-                            exp = exp.toLvalue(sc2, "`ref` return");
+                            exp = exp.toLvalue(sc3, "`ref` return");
                             checkAddressable(exp, sc2, "`ref` return");
                             checkReturnEscapeRef(*sc2, exp, false);
                             exp = exp.optimize(WANTvalue, /*keepLvalue*/ true);
@@ -922,14 +947,14 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             if (!hasCopyCtor || !exp.isLvalue())
                             {
                                 const errors = global.startGagging();
-                                auto implicitlyCastedExp = exp.implicitCastTo(sc2, tret);
+                                auto implicitlyCastedExp = exp.implicitCastTo(sc3, tret);
                                 global.endGagging(errors);
 
                                 // <https://github.com/dlang/dmd/issues/20888>
                                 if (implicitlyCastedExp.isErrorExp())
                                 {
                                     auto types = toAutoQualChars(exp.type, tret);
-                                    error(
+                                    eSink.error(
                                         exp.loc,
                                         "return value `%s` of type `%s` does not match return type `%s`"
                                         ~ ", and cannot be implicitly converted",
@@ -940,7 +965,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                                     if (const func = exp.type.isFunction_Delegate_PtrToFunction())
                                         if (func.next.equals(tret))
-                                            errorSupplemental(
+                                            eSink.errorSupplemental(
                                                 exp.loc,
                                                 "Did you intend to call the %s?",
                                                 (exp.type.isPtrToFunction())
@@ -956,28 +981,46 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                             /* https://issues.dlang.org/show_bug.cgi?id=10789
                              * If NRVO is not possible, all returned lvalues should call their postblits.
+                             * For functions with a __result variable, postblits will be called later
+                             * during initialization of __result.
                              */
-                            if (!funcdecl.isNRVO)
-                                exp = doCopyOrMove(sc2, exp, f.next, true, true);
+                            if (!funcdecl.isNRVO && !funcdecl.vresult)
+                                exp = doCopyOrMove(sc3, exp, f.next, true, true);
 
                             if (tret.hasPointers())
                                 checkReturnEscape(*sc2, exp, false);
                         }
 
-                        exp = exp.checkGC(sc2);
+                        exp = exp.checkGC(sc3);
 
                         if (funcdecl.vresult)
                         {
-                            // Create: return vresult = exp;
-                            exp = new BlitExp(rs.loc, funcdecl.vresult, exp);
-                            exp.type = funcdecl.vresult.type;
+                            Scope* scret = sc3;
+
+                            if (rs.fesFunc)
+                            {
+                                // Create a scope with foreach body being `.parent`
+                                // and `funcdecl` as `.func`. So the return value
+                                // is aware of closure access, but picks up
+                                // attributes and instantiates templated copy/move
+                                // ctors in the context of `funcdecl`.
+                                // BUG: remove this fragile hack
+                                scret = rs.fesFunc._scope.push();
+                                scret.parent = rs.fesFunc;
+                                scret.func = funcdecl;
+                            }
+
+                            // Create: return (vresult = exp, vresult);
+                            exp = new ConstructExp(rs.loc, funcdecl.vresult, exp);
+                            exp = exp.expressionSemantic(scret);
+                            exp = Expression.combine(exp, new VarExp(rs.loc, funcdecl.vresult));
 
                             if (rs.caseDim)
                                 exp = Expression.combine(exp, new IntegerExp(rs.caseDim));
                         }
                         else if (funcdecl.tintro && !tret.equals(funcdecl.tintro.nextOf()))
                         {
-                            exp = exp.implicitCastTo(sc2, funcdecl.tintro.nextOf());
+                            exp = exp.implicitCastTo(sc3, funcdecl.tintro.nextOf());
                         }
                         rs.exp = exp;
                     }
@@ -1030,7 +1073,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 if (blockExit & BE.throw_)
                 {
                     if (isNothrow)
-                        error(funcdecl.loc, "`%s`: `in` contract may throw but function is marked as `nothrow`",
+                        eSink.error(funcdecl.loc, "`%s`: `in` contract may throw but function is marked as `nothrow`",
                             funcdecl.toPrettyChars());
                     else if (funcdecl.nothrowInprocess)
                         f.isNothrow = false;
@@ -1054,7 +1097,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     {
                         if (e.id)
                         {
-                            .error(e.ensure.loc, "%s `%s` `void` functions have no result", funcdecl.kind, funcdecl.toPrettyChars);
+                            eSink.error(e.ensure.loc, "%s `%s` `void` functions have no result", funcdecl.kind, funcdecl.toPrettyChars);
                             //fens = null;
                         }
                     }
@@ -1074,7 +1117,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 if (blockExit & BE.throw_)
                 {
                     if (isNothrow)
-                        error(funcdecl.loc, "`%s`: `out` contract may throw but function is marked as `nothrow`",
+                        eSink.error(funcdecl.loc, "`%s`: `out` contract may throw but function is marked as `nothrow`",
                             funcdecl.toPrettyChars());
                     else if (funcdecl.nothrowInprocess)
                         f.isNothrow = false;
@@ -1092,7 +1135,11 @@ private extern(C++) final class Semantic3Visitor : Visitor
             }
             else
             {
-                auto a = new Statements();
+                auto a = Statements();
+
+                size_t expectedSize = (funcdecl.parameters ? funcdecl.parameters.length : 0) + 7;
+                a.reserve(expectedSize);
+
                 // Merge in initialization of 'out' parameters
                 if (funcdecl.parameters)
                 {
@@ -1103,7 +1150,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         {
                             if (!v._init)
                             {
-                                .error(v.loc, "%s `%s` zero-length `out` parameters are not allowed.", v.kind, v.toPrettyChars);
+                                eSink.error(v.loc, "%s `%s` zero-length `out` parameters are not allowed.", v.kind, v.toPrettyChars);
                                 return;
                             }
                             ExpInitializer ie = v._init.isExpInitializer();
@@ -1181,7 +1228,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     a.push(s);
                 }
 
-                Statement sbody = new CompoundStatement(Loc.initial, a);
+                Statement sbody = new CompoundStatement(Loc.initial, a.move());
 
                 /* Append destructor calls for parameters as finally blocks.
                  */
@@ -1210,7 +1257,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         {
                             funcdecl.hasNoEH = false;
                             if (isNothrow)
-                                error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
+                                eSink.error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
                             else if (funcdecl.nothrowInprocess)
                                 f.isNothrow = false;
                         }
@@ -1255,7 +1302,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                     else
                     {
-                        .error(funcdecl.loc, "%s `%s` synchronized function `%s` must be a member of a class", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toChars());
+                        eSink.error(funcdecl.loc, "%s `%s` synchronized function `%s` must be a member of a class", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toErrMsg());
                     }
                 }
 
@@ -1272,7 +1319,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     LabelDsymbol label = cast(LabelDsymbol)keyValue.value;
                     if (!label.statement && (!label.deleted || label.iasm))
                     {
-                        .error(label.loc, "%s `%s` label `%s` is undefined", funcdecl.kind, funcdecl.toPrettyChars, label.toChars());
+                        eSink.error(label.loc, "%s `%s` label `%s` is undefined", funcdecl.kind, funcdecl.toPrettyChars, label.toErrMsg());
                     }
                 }
 
@@ -1286,7 +1333,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             }
 
             if (funcdecl.isNaked && (funcdecl.fensures || funcdecl.frequires))
-                .error(funcdecl.loc, "%s `%s` naked assembly functions with contracts are not supported", funcdecl.kind, funcdecl.toPrettyChars);
+                eSink.error(funcdecl.loc, "%s `%s` naked assembly functions with contracts are not supported", funcdecl.kind, funcdecl.toPrettyChars);
 
             sc2.ctorflow.callSuper = CSX.none;
             sc2.pop();
@@ -1392,18 +1439,18 @@ private extern(C++) final class Semantic3Visitor : Visitor
             }
             if (isCppNonMappableType(f.next.toBasetype()) && !funcdecl.skipCodegen)
             {
-                .error(funcdecl.loc, "%s `%s` cannot return type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toErrMsg(), f.next.toChars());
+                eSink.error(funcdecl.loc, "%s `%s` cannot return type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toErrMsg(), f.next.toErrMsg());
                 if (f.next.isTypeDArray())
-                    errorSupplemental(funcdecl.loc, "slices are specific to D and do not have a counterpart representation in C++", f.next.toChars());
+                    eSink.errorSupplemental(funcdecl.loc, "slices are specific to D and do not have a counterpart representation in C++", f.next.toChars());
                 funcdecl.errors = true;
             }
             foreach (i, param; f.parameterList)
             {
                 if (isCppNonMappableType(param.type.toBasetype(), param))
                 {
-                    .error(funcdecl.loc, "%s `%s` cannot have parameter of type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toErrMsg(), param.type.toChars());
+                    eSink.error(funcdecl.loc, "%s `%s` cannot have parameter of type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toErrMsg(), param.type.toErrMsg());
                     if (param.type.toBasetype().isTypeSArray())
-                        errorSupplemental(funcdecl.loc, "perhaps use a `%s*` type instead",
+                        eSink.errorSupplemental(funcdecl.loc, "perhaps use a `%s*` type instead",
                                           param.type.nextOf().mutableOf().unSharedOf().toChars());
                     funcdecl.errors = true;
                 }
@@ -1417,11 +1464,14 @@ private extern(C++) final class Semantic3Visitor : Visitor
             oblive(funcdecl);
         }
 
-        if (global.params.useFastDFA && global.errors == oldErrors && funcdecl.fbody && funcdecl.type.ty != Terror)
+        version (FastDFA)
         {
-            // Don't run DFA if there are errors,
-            //  this is a costly enough operation that it warrents the explicit check.
-            dfaEntry(funcdecl, sc);
+            if (global.params.useFastDFA && global.errors == oldErrors && funcdecl.fbody && funcdecl.type.ty != Terror)
+            {
+                // Don't run DFA if there are errors,
+                //  this is a costly enough operation that it warrents the explicit check.
+                dfaEntry(funcdecl, sc);
+            }
         }
 
         /* If this function had instantiated with gagging, error reproduction will be
@@ -1491,9 +1541,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     (puErr ? STC.pure_ : STC.none) |
                     (saErr ? STC.system : STC.none)
                 );
-                ctor.loc.error("`%s` has stricter attributes than its destructor (`%s`)", ctor.toPrettyChars(), ob.peekChars());
-                ctor.loc.errorSupplemental("The destructor will be called if an exception is thrown");
-                ctor.loc.errorSupplemental("Either make the constructor `nothrow` or adjust the field destructors");
+                eSink.error(ctor.loc, "`%s` has stricter attributes than its destructor (`%s`)", ctor.toPrettyChars(), ob.peekChars());
+                eSink.errorSupplemental(ctor.loc, "The destructor will be called if an exception is thrown");
+                eSink.errorSupplemental(ctor.loc, "Either make the constructor `nothrow` or adjust the field destructors");
 
                 ce.ignoreAttributes = true;
             }
@@ -1512,6 +1562,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
              */
             Identifier id = Identifier.generateId("__o");
             auto ts = new ThrowStatement(ctor.loc, new IdentifierExp(ctor.loc, id));
+            ts.internalThrow = true; // just rethrows the caught exception
             auto handler = new CompoundStatement(ctor.loc, ss, ts);
 
             auto ctch = new Catch(ctor.loc, getException(), id, handler);
@@ -1623,7 +1674,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         void notTemplateFunction(Loc loc, Identifier id)
         {
-            error(loc, "`%s` isn't a template function", id.toChars());
+            eSink.error(loc, "`%s` isn't a template function", id.toErrMsg());
         }
 
         // generate ti.entry
@@ -1701,7 +1752,8 @@ private struct FuncDeclSem3
                 FuncDeclaration fdv = funcdecl.foverrides[i];
                 if (fdv.fbody && !fdv.frequires)
                 {
-                    .error(funcdecl.loc, "%s `%s` cannot have an in contract when overridden function `%s` does not have an in contract", funcdecl.kind, funcdecl.toPrettyChars, fdv.toPrettyChars());
+                    auto eSink = global.errorSink;
+                    eSink.error(funcdecl.loc, "%s `%s` cannot have an in contract when overridden function `%s` does not have an in contract", funcdecl.kind, funcdecl.toPrettyChars, fdv.toPrettyChars());
                     break;
                 }
             }
@@ -1720,7 +1772,7 @@ private struct FuncDeclSem3
         if (sc.inCfile && funcdecl.isCMain() && f.next.ty == Tint32)
             return true;
 
-        return f.next.ty == Tvoid && (funcdecl.isMain() || funcdecl.isCMain());
+        return f.next.ty == Tvoid && (funcdecl.isDMain() || funcdecl.isCMain());
     }
 }
 
@@ -1819,7 +1871,12 @@ void semanticRTInfo(AggregateDeclaration ad)
     auto sc = ad.rtInfoScope;
     Scope* sc3 = ti.tempdecl._scope.startCTFE();
     sc3.tinst = sc.tinst;
-    sc3.minst = sc.minst;
+    // Use the root module so nested RTInfoImpl instances get codegen'd.
+    // If rtInfoScope comes from a non-root ImportC module whose minst is that
+    // module itself (see scopeCreateGlobal), so needsCodegen() would skip
+    // RTInfoImpl even though TypeInfo references it at link time.
+    // See https://github.com/dlang/dmd/issues/23166.
+    sc3.minst = sc._module.importedFrom;
     if (ad.isDeprecated())
         sc3.stc |= STC.deprecated_;
 
@@ -1857,24 +1914,48 @@ extern (D) bool checkClosure(FuncDeclaration fd)
     if (!fd.needsClosure())
         return false;
 
+    auto eSink = global.errorSink;
     if (setGC(null, fd, fd.loc, "allocating a closure for `%s()`", fd))
     {
-        .error(fd.loc, "%s `%s` is `@nogc` yet allocates closure for `%s()` with the GC", fd.kind, fd.toPrettyChars(), fd.toChars());
+        eSink.error(fd.loc, "%s `%s` is `@nogc` yet allocates closure for `%s()` with the GC", fd.kind, fd.toPrettyChars(), fd.toErrMsg());
         if (global.gag)     // need not report supplemental errors
             return true;
     }
     else if (!global.params.useGC)
     {
-        .error(fd.loc, "%s `%s` is `-betterC` yet allocates closure for `%s()` with the GC", fd.kind, fd.toPrettyChars(), fd.toChars());
+        eSink.error(fd.loc, "%s `%s` is `-betterC` yet allocates closure for `%s()` with the GC", fd.kind, fd.toPrettyChars(), fd.toErrMsg());
         if (global.gag)     // need not report supplemental errors
             return true;
     }
     else
     {
         fd.printGCUsage(fd.loc, "using closure causes GC allocation");
+
+        findClosureVars(fd, (FuncDeclaration f, VarDeclaration v) {
+            if (!fd.vgcEnabled)
+                return;
+
+            eSink.message(f.loc, "vgc: %s `%s` closes over variable `%s`",
+                f.kind, f.toErrMsg(), v.toErrMsg());
+            if (v.ident != Id.This)
+                eSink.message(v.loc, "vgc: `%s` declared here", v.toErrMsg());
+        });
         return false;
     }
 
+    findClosureVars(fd, (FuncDeclaration f, VarDeclaration v) {
+        eSink.errorSupplemental(f.loc, "%s `%s` closes over variable `%s`",
+            f.kind, f.toErrMsg(), v.toErrMsg());
+        if (v.ident != Id.This)
+            eSink.errorSupplemental(v.loc, "`%s` declared here", v.toErrMsg());
+    });
+    return true;
+}
+
+/// For an outer function `fd`, find inner functions that cause a closure to be generated for it.
+/// Pass to `sink` each nested function along with the local variable that closes over `fd`'s stackframe
+private void findClosureVars(FuncDeclaration fd, scope void delegate(FuncDeclaration, VarDeclaration) sink)
+{
     FuncDeclarations a;
 
     if (fd.closureVars.length > 0)
@@ -1897,16 +1978,11 @@ extern (D) bool checkClosure(FuncDeclaration fd)
                     if (!a.contains(f))
                     {
                         a.push(f);
-                        .errorSupplemental(f.loc, "%s `%s` closes over variable `%s`",
-                            f.kind, f.toErrMsg(), v.toChars());
-                        if (v.ident != Id.This)
-                            .errorSupplemental(v.loc, "`%s` declared here", v.toChars());
+                        sink(f, v);
                     }
                     break LcheckAncestorsOfANestedRef;
                 }
             }
         }
     }
-    a.shrinkToFit();
-    return true;
 }


### PR DESCRIPTION
Description:
Adds high-performance, inlined any and all predicates to Array in dmd.root.array. These templates use alias predicates to ensure zero-overhead execution, facilitating the refactoring of manual for loops in semantic analysis stages.