### PR TITLE
Improve scope violation error messages to show inference chain

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -293,7 +293,7 @@ bool checkAssocArrayLiteralEscape(ref Scope sc, AssocArrayLiteralExp ae, bool ga
  *    recursionLimit = recursion limit for printing the reason
  *    positive = true for telling why v is scope, false for telling why v is not scope
  */
-private
+public
 void printScopeReason(E)(E printFunc, VarDeclaration v, int recursionLimit, bool positive)
 {
     recursionLimit--;
@@ -375,8 +375,8 @@ bool checkParamArgumentEscape(ref Scope sc, FuncDeclaration fdc, Identifier parI
             (desc ~ " `%s` assigned to non-scope anonymous parameter");
 
         if (isThis ?
-            sc.setUnsafeDIP1000(gag, arg.loc, msg, arg, fdc.toParent2(), fdc) :
-            sc.setUnsafeDIP1000(gag, arg.loc, msg, v, parId ? parId : fdc, fdc))
+            sc.setUnsafeDIP1000(gag, arg.loc, vPar, msg, arg, fdc.toParent2(), fdc) :
+            sc.setUnsafeDIP1000(gag, arg.loc, vPar, msg, v, parId ? parId : fdc, fdc))
         {
             result = true;
             printScopeReason(previewSupplementalFunc(sc.isDeprecated(), sc.useDIP1000), vPar, 10, false);
@@ -2212,6 +2212,14 @@ bool setUnsafeDIP1000(ref Scope sc, bool gag, Loc loc, const(char)* msg,
     RootObject[] args...)
 {
     return setUnsafePreview(&sc, sc.useDIP1000, gag, loc, msg, args);
+}
+
+/// Overload for scope violations that also stores the variable whose scope status caused the issue
+private
+bool setUnsafeDIP1000(ref Scope sc, bool gag, Loc loc, VarDeclaration scopeVar,
+    const(char)* msg, RootObject[] args...)
+{
+    return setUnsafePreview(&sc, sc.useDIP1000, gag, loc, scopeVar, msg, args);
 }
 
 /***************************************

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3164,6 +3164,12 @@ public void errorSupplementalInferredAttr(FuncDeclaration fd, int maxDepth, bool
     if (s.action.length > 0)
     {
         errorFunc(s.loc, "and %.*s makes it fail to infer `%.*s`", s.action.fTuple.expand, attr.fTuple.expand);
+        // For scope violations, also print why the target parameter is not scope
+        if (s.scopeVar)
+        {
+            import dmd.escape : printScopeReason;
+            printScopeReason(errorFunc, s.scopeVar, 10, false);
+        }
     }
     else if (s.fd)
     {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3708,10 +3708,12 @@ struct AttributeViolation final
     Loc loc;
     FuncDeclaration* fd;
     _d_dynamicArray< const char > action;
+    VarDeclaration* scopeVar;
     AttributeViolation() :
         loc(),
         fd(),
-        action()
+        action(),
+        scopeVar()
     {
     }
 };

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1430,6 +1430,8 @@ struct AttributeViolation
 
     string action;   /// Action that made the attribute fail to get inferred
 
+    VarDeclaration scopeVar;  /// For scope violations: the parameter whose scope status caused the issue
+
     this(Loc loc, FuncDeclaration fd) { this.loc = loc; this.fd = fd; }
 
     this(Loc loc, const(char)* fmt, RootObject[] args)
@@ -1444,5 +1446,11 @@ struct AttributeViolation
             args.length > 3 && args[3] ? args[3].toErrMsg() : "",
         );
         this.action = buf.extractSlice();
+    }
+
+    this(Loc loc, const(char)* fmt, VarDeclaration scopeVar, RootObject[] args)
+    {
+        this(loc, fmt, args);
+        this.scopeVar = scopeVar;
     }
 }

--- a/compiler/test/fail_compilation/scope_infer_diagnostic.d
+++ b/compiler/test/fail_compilation/scope_infer_diagnostic.d
@@ -1,0 +1,35 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/scope_infer_diagnostic.d(34): Error: `@safe` function `scope_infer_diagnostic.outer` cannot call `@system` function `scope_infer_diagnostic.inner!(void delegate(const(char)[]) pure nothrow @nogc @safe).inner`
+fail_compilation/scope_infer_diagnostic.d(28):        and assigning scope variable `w` to non-scope parameter `w` calling `callee` makes it fail to infer `@safe`
+fail_compilation/scope_infer_diagnostic.d(21):        `w` is not `scope` because of `globalPtr = & w`
+fail_compilation/scope_infer_diagnostic.d(25):        `scope_infer_diagnostic.inner!(void delegate(const(char)[]) pure nothrow @nogc @safe).inner` is declared here
+---
+*/
+
+// Test that scope violation error messages show WHY the callee's parameter
+// is not scope when going through the @safe inference chain.
+// This is similar to how @nogc violations show the full inference chain.
+
+void* globalPtr;
+
+void callee(Writer)(Writer w) @trusted
+{
+    // This escapes w, preventing it from being inferred as scope
+    globalPtr = cast(void*)&w;
+    w("x");
+}
+
+void inner(Writer)(scope Writer w)
+{
+    // Scope violation: passing scope w to non-scope parameter
+    callee(w);
+}
+
+void outer() @safe
+{
+    int x;
+    inner((const(char)[] s) { x++; });
+}


### PR DESCRIPTION
LLM disclosure: this entire PR is AI-generated. It might be OK, or it might be slop. The fix looks sensible on the surface, and it passes the test suite, however, so does most slop in general. Caveat emptor.

Context: I was looking into a Phobos issue, and let Claude attempt some tricky refactoring involving lots of thorny attribute inference. It got blocked due to what it thought was a compiler bug; investigating the bug in DMD led to the conclusion that it's not a bug, it's just a difficult to understand situation. This patch improving diagnostics is the product.

----

## Summary

This PR improves error messages for scope violations when `-preview=dip1000` is enabled. When a `@safe` function cannot call another function due to scope violations during `@safe` inference, the error message now shows **why** the callee's parameter could not be inferred as `scope`.

This brings scope error diagnostics in line with how `@nogc` violations already show the full inference chain.

## Motivation

When working with `-preview=dip1000`, users often encounter cryptic scope violation errors that don't explain the root cause. For example, when a scope variable is passed to a parameter that cannot be inferred as `scope`, the error only shows that the assignment is unsafe—not *why* the target parameter isn't `scope`.

This forces users to manually trace through potentially deep template instantiation chains to find where the scope escapes, which is time-consuming and error-prone.

## Changes

- **func.d**: Added `scopeVar` field to `AttributeViolation` struct to track the variable whose scope status caused the violation
- **safe.d**: Added overloads of `reportSafeError`, `setUnsafe`, and `setUnsafePreview` that thread `scopeVar` through the error reporting chain
- **escape.d**: Made `printScopeReason` public and added `setUnsafeDIP1000` overload that passes `scopeVar`
- **expressionsem.d**: Modified `errorSupplementalInferredAttr` to call `printScopeReason` when a scope violation is the cause

## Before/After Example

### Test Code

```d
void* globalPtr;

void callee(Writer)(Writer w) @trusted {
    globalPtr = cast(void*)&w;  // escapes w
    w("x");
}

void inner(Writer)(scope Writer w) {
    callee(w);  // scope violation: w passed to non-scope parameter
}

void outer() @safe {
    int x;
    inner((const(char)[] s) { x++; });
}
```

### Before

```
test.d(14): Error: `@safe` function `outer` cannot call `@system` function `inner`
test.d(9):        and assigning scope variable `w` to non-scope parameter `w`
                  calling `callee` makes it fail to infer `@safe`
test.d(8):        `inner` is declared here
```

The user knows there's a scope violation but doesn't know *why* `callee`'s parameter `w` isn't `scope`.

### After

```
test.d(14): Error: `@safe` function `outer` cannot call `@system` function `inner`
test.d(9):        and assigning scope variable `w` to non-scope parameter `w`
                  calling `callee` makes it fail to infer `@safe`
test.d(4):        `w` is not `scope` because of `globalPtr = & w`
test.d(8):        `inner` is declared here
```

The new line shows exactly why the parameter isn't `scope`—because of the assignment `globalPtr = & w` that causes it to escape.

## Real-World Impact

This improvement is particularly valuable for:

1. **Template-heavy code**: Where scope violations can occur deep in instantiation chains
2. **Library development**: Where understanding why scope inference fails helps design better APIs
3. **Migration to DIP1000**: Where users need to understand and fix existing scope violations

## Test Plan

- Added `fail_compilation/scope_infer_diagnostic.d` test case that verifies the new error message format
- All existing `fail_compilation` tests pass
- All existing scope-related tests (`test17423.d`, `test23073.d`, `retscope.d`, etc.) pass unchanged
