### PR TITLE
Optimize `getTypePointerBitmap` for large static arrays without pointers

### DIFF
--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -165,11 +165,14 @@ ulong getTypePointerBitmap(Loc loc, Type t, ref Array!(ulong) data, ErrorSink eS
             ulong nextsize = t.next.size();
             if (nextsize == SIZE_INVALID)
                 error = true;
-            ulong dim = t.dim.toInteger();
-            for (ulong i = 0; i < dim; i++)
+            if (t.hasPointers)
             {
-                offset = arrayoff + i * nextsize;
-                visit(t.next);
+                ulong dim = t.dim.toInteger();
+                for (ulong i = 0; i < dim; i++)
+                {
+                    offset = arrayoff + i * nextsize;
+                    visit(t.next);
+                }
             }
             offset = arrayoff;
         }


### PR DESCRIPTION
This change reduces semantic analysis (`-c -o-`) from ~0.8sec to ~0.3sec on my machine for the following testcase:
```
struct S {
    int[200000000] x;
}
```