### PR TITLE
Changes __traits(getPointerBitmap, S) for types without pointers to return size only

### DIFF
--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -119,7 +119,8 @@ void write_instance_pointers(Type type, Symbol* s, uint offset)
         return;
 
     Array!(ulong) data;
-    const ulong sz = getTypePointerBitmap(Loc.initial, type, data, global.errorSink);
+    ulong count;
+    const ulong sz = getTypePointerBitmap(Loc.initial, type, data, global.errorSink, count);
     if (sz == ulong.max)
         return;
 

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -165,11 +165,14 @@ ulong getTypePointerBitmap(Loc loc, Type t, ref Array!(ulong) data, ErrorSink eS
             ulong nextsize = t.next.size();
             if (nextsize == SIZE_INVALID)
                 error = true;
-            ulong dim = t.dim.toInteger();
-            for (ulong i = 0; i < dim; i++)
+            if (t.hasPointers)
             {
-                offset = arrayoff + i * nextsize;
-                visit(t.next);
+                ulong dim = t.dim.toInteger();
+                for (ulong i = 0; i < dim; i++)
+                {
+                    offset = arrayoff + i * nextsize;
+                    visit(t.next);
+                }
             }
             offset = arrayoff;
         }

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -3757,7 +3757,7 @@ template RTInfoImpl(size_t[] pointerBitmap)
 template RTInfo(T)
 {
     enum pointerBitmap = __traits(getPointerBitmap, T);
-    static if (pointerBitmap[1 .. $] == size_t[pointerBitmap.length - 1].init)
+    static if (pointerBitmap.length == 1)
         enum RTInfo = rtinfoNoPointers;
     else
         enum RTInfo = RTInfoImpl!(pointerBitmap).ptr;


### PR DESCRIPTION
Requires https://github.com/dlang/dmd/pull/22288 first.

Related spec change: https://github.com/dlang/dlang.org/pull/4353

This changes the behavior of `__traits(getPointerBitmap, S)` for types without pointers: instead of returning an array of [size type, all zeros....] it returns a 1-sized array [size type]. In other words, it no longer constructs an array with a (potentially long) list of zeros.

Greatly reduces the semantic analysis time of this testcase (from ~0.3s to ~0.04s):
```
struct S {
    int[200000000] x;
}
```

This may break existing code if it is using `__traits(getPointerBitmap, S)` with wrong assumption that array size is equal to type size/8 (i.e. code that uses unsafe array traversal, without using the array.length property).