### PR TITLE
add Array.contains and refactor checkClosure in semantic3.d

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -60,6 +60,7 @@ import dmd.opover;
 import dmd.optimize;
 import dmd.parse;
 import dmd.root.filename;
+import dmd.root.array;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
 import dmd.rootobject;
@@ -1887,21 +1888,16 @@ extern (D) bool checkClosure(FuncDeclaration fd)
                 auto fx = s.isFuncDeclaration();
                 if (!fx)
                     continue;
-                if (fx.isThis() ||
-                    fx.tookAddressOf ||
-                    checkEscapingSiblings(fx, fd))
+                if (fx.isThis() || fx.tookAddressOf || checkEscapingSiblings(fx, fd))
                 {
-                    foreach (f2; a)
+                    if (!a.contains(f))
                     {
-                        if (f2 == f)
-                            break LcheckAncestorsOfANestedRef;
+                        a.push(f);
+                        .errorSupplemental(f.loc, "%s `%s` closes over variable `%s`",
+                            f.kind, f.toErrMsg(), v.toChars());
+                        if (v.ident != Id.This)
+                            .errorSupplemental(v.loc, "`%s` declared here", v.toChars());
                     }
-                    a.push(f);
-                    .errorSupplemental(f.loc, "%s `%s` closes over variable `%s`",
-                        f.kind, f.toErrMsg(), v.toChars());
-                    if (v.ident != Id.This)
-                        .errorSupplemental(v.loc, "`%s` declared here", v.toChars());
-
                     break LcheckAncestorsOfANestedRef;
                 }
             }


### PR DESCRIPTION
### Summary
This PR adds the `contains` predicate to `Array` in `dmd.root.array` and applies it to refactor semantic analysis logic.

In the compiler's semantic stages, we often use manual `foreach` loops combined with label-breaks to avoid duplicates. By introducing `contains`, we simplify this pattern, reducing cognitive load and making the programmer's intent explicit without introducing side-effect obfuscation.

### Key Changes
- **dmd.root.array**: Added `contains` method (and underlying `find` logic) to the `Array` struct.
- **dmd.semantic3**: Refactored `checkClosure` to use `a.contains(f)`. This replaces a manual loop and a labeled `break`, significantly cleaning up the logic for tracking captured nested functions.