### PR TITLE
Fix issue #21323 - DMD miscompiles real[1]

### DIFF
--- a/compiler/src/dmd/backend/x86/cod1.d
+++ b/compiler/src/dmd/backend/x86/cod1.d
@@ -3080,10 +3080,10 @@ bool FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, out reg_t pre
         ty2 = TYdouble;
     }
 
-    // Treat array of 1 the same as its element type
-    // (Don't put volatile parameters in registers)
+    // Collapse single-element arrays to their element type, except for
+    // volatile parameters and SysV x86-64 (only Win64 or 32-bit platforms).
     if (tybasic(ty) == TYarray && tybasic(t.Tty) == TYarray && t.Tdim == 1 && !(t.Tty & mTYvolatile)
-        && type_size(t.Tnext) > 1)
+        && type_size(t.Tnext) > 1 && (I32 || config.exe == EX_WIN64))
     {
         t = t.Tnext;
         ty = t.Tty;
@@ -3331,7 +3331,8 @@ void argtypes(type* t, out type* arg1type, out type* arg2type)
                 }
                 else if (tybasic(tyn) == TYldouble || tybasic(tyn) == TYildouble)
                 {
-                    arg1type = tstypes[tybasic(tyn)];
+                    // `real` parameters (and arrays of `real`)
+                    // must be passed via memory
                     return;
                 }
             }

--- a/compiler/test/runnable/test_real_array_param.d
+++ b/compiler/test/runnable/test_real_array_param.d
@@ -1,0 +1,16 @@
+void fn(int* x, real[1] arr)
+{
+    auto y = *x;  // should not segfault
+    assert(y == 42, "x parameter corrupted");
+    assert(arr[0] == 1.0, "arr (real[1]) corrupted");
+}
+
+void main()
+{
+    real[1] arr = [1.0];
+    int x = 42;
+    fn(&x, arr);
+
+    assert(x == 42, "x value corrupted");
+    assert(arr[0] == 1.0, "arr (real[1]) value corrupted");
+}


### PR DESCRIPTION
Related issue: https://github.com/dlang/dmd/issues/21323

`real[1]` array parameters were incorrectly converted to `real` before aggregate classification. Arrays must be treated as aggregates on System V x86-64; `real[1]` should be passed via memory because `real` (`Class.x87`/`Class.x87Up`) merges to `Class.memory` in aggregates. This caused segfaults due to incorrect parameter passing.