### PR TITLE
Fix the 'ambigous' typo in comment about return attachment

### DIFF
--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -150,7 +150,7 @@ enum STC : ulong  // transfer changes to declaration.h
 alias StorageClass = ulong;
 
 /********
- * Determine if it's the ambigous case of where `return` attaches to.
+ * Determine if it's the ambiguous case of where `return` attaches to.
  * Params:
  *   stc = STC flags
  * Returns:


### PR DESCRIPTION
Fixes issue number #22217
Fixes the typo 'ambigous'.
I changed it to 'ambiguous'.