### PR TITLE
Fix #22259 Allow complex float to complex double promotion

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -1604,6 +1604,13 @@ MATCH implicitConvTo(Type from, Type to)
             if (from.flags & TFlags.complex && !(tob.flags & TFlags.complex))
                 return MATCH.nomatch;
 
+            // Allow complex float to complex double promotion    
+            if ((from.flags & TFlags.complex) && (tob.flags & TFlags.complex))
+            {
+                if (from.size(Loc.initial) <= tob.size(Loc.initial))
+                    return MATCH.convert;
+            }
+            
             // Disallow implicit conversion of real or imaginary to complex
             if (from.flags & (TFlags.real_ | TFlags.imaginary) && tob.flags & TFlags.complex)
                 return MATCH.nomatch;

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -1603,13 +1603,6 @@ MATCH implicitConvTo(Type from, Type to)
             // Disallow implicit conversion from complex to non-complex
             if (from.flags & TFlags.complex && !(tob.flags & TFlags.complex))
                 return MATCH.nomatch;
-
-            // Allow complex float to complex double promotion
-            if ((from.flags & TFlags.complex) && (tob.flags & TFlags.complex))
-            {
-                if (from.size(Loc.initial) <= tob.size(Loc.initial))
-                    return MATCH.convert;
-            }
             // Disallow implicit conversion of real or imaginary to complex
             if (from.flags & (TFlags.real_ | TFlags.imaginary) && tob.flags & TFlags.complex)
                 return MATCH.nomatch;
@@ -1617,6 +1610,12 @@ MATCH implicitConvTo(Type from, Type to)
             // Disallow implicit conversion to-from real and imaginary
             if ((from.flags & (TFlags.real_ | TFlags.imaginary)) != (tob.flags & (TFlags.real_ | TFlags.imaginary)))
                 return MATCH.nomatch;
+            // Allow complex float to complex double promotion
+            if ((from.flags & TFlags.complex) && (tob.flags & TFlags.complex))
+            {
+                if (from.size(Loc.initial) < tob.size(Loc.initial))
+                    return MATCH.convert;
+            }
         }
         return MATCH.convert;
 

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -1604,13 +1604,12 @@ MATCH implicitConvTo(Type from, Type to)
             if (from.flags & TFlags.complex && !(tob.flags & TFlags.complex))
                 return MATCH.nomatch;
 
-            // Allow complex float to complex double promotion    
+            // Allow complex float to complex double promotion
             if ((from.flags & TFlags.complex) && (tob.flags & TFlags.complex))
             {
                 if (from.size(Loc.initial) <= tob.size(Loc.initial))
                     return MATCH.convert;
             }
-            
             // Disallow implicit conversion of real or imaginary to complex
             if (from.flags & (TFlags.real_ | TFlags.imaginary) && tob.flags & TFlags.complex)
                 return MATCH.nomatch;

--- a/compiler/test/compilable/importc_complex_promotion.c
+++ b/compiler/test/compilable/importc_complex_promotion.c
@@ -1,0 +1,35 @@
+// Ensure complex float can be implicitly promoted to complex double
+// Fixes issue #22259
+
+#include <complex.h>
+
+void testComplexPromotion()
+{
+    // Basic case from issue #22259
+    _Complex double x = 1 + 1.0if;
+    
+    // Float imaginary with int
+    _Complex double y = 2 + 3.0if;
+    
+    // Two float complex values
+    _Complex double z = 1.0if + 2.0if;
+    
+    // Mixed real and float imaginary
+    _Complex double w = 5.0 + 1.0if;
+}
+
+void testComplexPreservation()
+{
+    // These should still work (no change)
+    _Complex float f1 = 1.0f + 1.0if;
+    _Complex float f2 = 1.0if + 2.0if;
+    _Complex double d1 = 1.0 + 2.0i;
+    _Complex double d2 = 2.0 + 3.0i;
+}
+
+int main()
+{
+    testComplexPromotion();
+    testComplexPreservation();
+    return 0;
+}

--- a/compiler/test/compilable/importc_complex_promotion.c
+++ b/compiler/test/compilable/importc_complex_promotion.c
@@ -1,23 +1,17 @@
 // Ensure complex float can be implicitly promoted to complex double
 // Fixes issue #22259
-
 #include <complex.h>
-
 void testComplexPromotion()
 {
     // Basic case from issue #22259
     _Complex double x = 1 + 1.0if;
-    
     // Float imaginary with int
     _Complex double y = 2 + 3.0if;
-    
     // Two float complex values
     _Complex double z = 1.0if + 2.0if;
-    
     // Mixed real and float imaginary
     _Complex double w = 5.0 + 1.0if;
 }
-
 void testComplexPreservation()
 {
     // These should still work (no change)
@@ -26,7 +20,6 @@ void testComplexPreservation()
     _Complex double d1 = 1.0 + 2.0i;
     _Complex double d2 = 2.0 + 3.0i;
 }
-
 int main()
 {
     testComplexPromotion();

--- a/compiler/test/compilable/importc_complex_promotion.c
+++ b/compiler/test/compilable/importc_complex_promotion.c
@@ -1,17 +1,13 @@
 // Ensure complex float can be implicitly promoted to complex double
 // Fixes issue #22259
 #include <complex.h>
+
 void testComplexPromotion()
 {
-    // Basic case from issue #22259
-    _Complex double x = 1 + 1.0if;
-    // Float imaginary with int
-    _Complex double y = 2 + 3.0if;
-    // Two float complex values
-    _Complex double z = 1.0if + 2.0if;
-    // Mixed real and float imaginary
-    _Complex double w = 5.0 + 1.0if;
+    _Complex float yf = 1.0if;
+    _Complex double x = yf;              // promotion: _Complex float -> _Complex double
 }
+
 void testComplexPreservation()
 {
     // These should still work (no change)
@@ -20,6 +16,7 @@ void testComplexPreservation()
     _Complex double d1 = 1.0 + 2.0i;
     _Complex double d2 = 2.0 + 3.0i;
 }
+
 int main()
 {
     testComplexPromotion();


### PR DESCRIPTION
Fixes #22259 and thereby allows complex float to complex double promotion without affecting anything else.