### PR TITLE
fix #22323 - error "cannot get frame pointer" with AA in struct literal

### DIFF
--- a/compiler/test/compilable/test22323.d
+++ b/compiler/test/compilable/test22323.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -preview=dip1000
+
+struct Schema
+{
+    int[int] tables;
+}
+struct S(Schema s)
+{
+    void g() { cast(void)s.tables; }
+}
+auto makeSchema() => Schema([0: 0]);
+alias Row = S!(makeSchema());


### PR DESCRIPTION
deep copy manifest constant if it contains AA literal, so that it runs semantic again on lowered code