### PR TITLE
Fix #22322 - converting real to float uses double rounding for 64-bit code causing unexpected results

### DIFF
--- a/compiler/src/dmd/backend/x86/cod4.d
+++ b/compiler/src/dmd/backend/x86/cod4.d
@@ -3391,7 +3391,7 @@ void longcmp(ref CodeBuilder cdb, elem* e, bool jcond, FL fltarg, code* targ)
     OPld_d
  */
 @trusted
-void cdcnvt(ref CGstate cg, ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
+void cdcnvt(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     if (cg.AArch64)
     {
@@ -3457,7 +3457,7 @@ void cdcnvt(ref CGstate cg, ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
 
                 if (config.fpxmmregs && (pretregs & XMMREGS))
                 {
-                    if (I64 && e.Eoper == OPd_f && e.E1 && e.E1.Eoper == OPld_d)
+                    if (I64 && e.E1.Eoper == OPld_d)
                     {
                         // avoid double rounding for: (real -> double) -> float
                         regm_t retregsx = mST0 | (pretregs & mPSW);

--- a/compiler/src/dmd/backend/x86/cod4.d
+++ b/compiler/src/dmd/backend/x86/cod4.d
@@ -3454,9 +3454,20 @@ void cdcnvt(ref CGstate cg, ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
             case OPd_f:
                 if (tycomplex(e.E1.Ety))
                     goto Lcomplex;
-                if (config.fpxmmregs && pretregs & XMMREGS)
+
+                if (config.fpxmmregs && (pretregs & XMMREGS))
                 {
-                    xmmcnvt(cdb, e, pretregs);
+                    if (I64 && e.Eoper == OPd_f && e.E1 && e.E1.Eoper == OPld_d)
+                    {
+                        // avoid double rounding for: (real -> double) -> float
+                        regm_t retregsx = mST0 | (pretregs & mPSW);
+                        codelem(cgstate, cdb, e.E1.E1, retregsx, false);
+                        fixresult87(cdb, e, retregsx, pretregs);
+                    }
+                    else
+                    {
+                        xmmcnvt(cdb, e, pretregs);
+                    }
                     return;
                 }
 

--- a/compiler/src/dmd/backend/x86/cod4.d
+++ b/compiler/src/dmd/backend/x86/cod4.d
@@ -3457,7 +3457,7 @@ void cdcnvt(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 
                 if (config.fpxmmregs && (pretregs & XMMREGS))
                 {
-                    if (I64 && e.E1.Eoper == OPld_d)
+                    if (e.E1.Eoper == OPld_d)
                     {
                         // avoid double rounding for: (real -> double) -> float
                         regm_t retregsx = mST0 | (pretregs & mPSW);

--- a/compiler/test/runnable/real_to_float.d
+++ b/compiler/test/runnable/real_to_float.d
@@ -9,7 +9,7 @@ void main()
     {
         real r = 0.5000000894069671353303618843710864894092082977294921875;
         assert(r == 0x1.000002fffffffcp-1);
-        float d = r;
+        double d = r;
         assert(d == 0x1.000003p-1);
         float f = r;
         assert(f == 0x1.000002p-1);

--- a/compiler/test/runnable/real_to_float.d
+++ b/compiler/test/runnable/real_to_float.d
@@ -5,15 +5,13 @@
  */
 void main()
 {
-    version (X86_64)
-    // static if (real.sizeof > 8)
+    static if (real.sizeof > 8)
     {
         real r = 0.5000000894069671353303618843710864894092082977294921875;
+        assert(r == 0x1.000002fffffffcp-1);
+        float d = r;
+        assert(d == 0x1.000003p-1);
         float f = r;
-        import std.stdio, std.format;
-        stderr.writeln("real.sizeof: ", real.sizeof);
-        stderr.writefln("f: %a", f);
-        stderr.writefln("int view: %X", *(cast(uint*) &f));  // expected: 3F000001
-        assert(f == 0x1.000002p-1, format!"%a"(f));
+        assert(f == 0x1.000002p-1);
     }
 }

--- a/compiler/test/runnable/real_to_float.d
+++ b/compiler/test/runnable/real_to_float.d
@@ -9,6 +9,9 @@ void main()
     {
         real r = 0.5000000894069671353303618843710864894092082977294921875;
         float f = r;
-        assert(f == 0x1.000002p-1);
+        import std.stdio, std.format;
+        stderr.writefln("f: %a", f);
+        stderr.writefln("int view: %X", *(cast(uint*) &f));  // expected: 3F000001
+        assert(f == 0x1.000002p-1, format!"%a"(f));
     }
 }

--- a/compiler/test/runnable/real_to_float.d
+++ b/compiler/test/runnable/real_to_float.d
@@ -3,15 +3,26 @@
  * "converting real to float uses double rounding for 64-bit code
  * causing unexpected results"
  */
+pragma(inline, false)
+void test(real r)
+{
+    assert(r == 0x1.000002fffffffcp-1);
+    double d = r;
+    assert(d == 0x1.000003p-1);
+    float f = r;
+    assert(f == 0x1.000002p-1);
+    float fd = d;
+    assert(fd == 0x1.000004p-1);
+    real rd = d;
+    assert(rd == 0x1.000003p-1);
+    float frd = rd;
+    assert(frd == 0x1.000004p-1);
+}
+
 void main()
 {
     static if (real.sizeof > 8)
     {
-        real r = 0.5000000894069671353303618843710864894092082977294921875;
-        assert(r == 0x1.000002fffffffcp-1);
-        double d = r;
-        assert(d == 0x1.000003p-1);
-        float f = r;
-        assert(f == 0x1.000002p-1);
+        test(0x1.000002fffffffcp-1);
     }
 }

--- a/compiler/test/runnable/real_to_float.d
+++ b/compiler/test/runnable/real_to_float.d
@@ -6,10 +6,12 @@
 void main()
 {
     version (X86_64)
+    // static if (real.sizeof > 8)
     {
         real r = 0.5000000894069671353303618843710864894092082977294921875;
         float f = r;
         import std.stdio, std.format;
+        stderr.writeln("real.sizeof: ", real.sizeof);
         stderr.writefln("f: %a", f);
         stderr.writefln("int view: %X", *(cast(uint*) &f));  // expected: 3F000001
         assert(f == 0x1.000002p-1, format!"%a"(f));

--- a/compiler/test/runnable/real_to_float.d
+++ b/compiler/test/runnable/real_to_float.d
@@ -1,0 +1,14 @@
+/* The test related to https://github.com/dlang/dmd/issues/22322
+ * The issue title:
+ * "converting real to float uses double rounding for 64-bit code
+ * causing unexpected results"
+ */
+void main()
+{
+    version (X86_64)
+    {
+        real r = 0.5000000894069671353303618843710864894092082977294921875;
+        float f = r;
+        assert(f == 0x1.000002p-1);
+    }
+}


### PR DESCRIPTION
Related issue: #22322
The problematic pattern was lowering `real->float` as `real->double->float`, which can mis-round for values that sit between float rounding boundaries.