### PR TITLE
Add missing mbstate_t for Windows

### DIFF
--- a/druntime/src/core/stdc/locale.d
+++ b/druntime/src/core/stdc/locale.d
@@ -32,7 +32,7 @@ nothrow:
 version (Windows)
 {
     import core.stdc.wchar_ : wchar_t;
-    
+
     // ...Windows Kits\10\Include\10.0.14393.0\ucrt\locale.h
     struct lconv
     {

--- a/druntime/src/core/stdc/locale.d
+++ b/druntime/src/core/stdc/locale.d
@@ -29,32 +29,70 @@ nothrow:
 @nogc:
 
 ///
-struct lconv
+version (Windows)
 {
-    char* decimal_point;
-    char* thousands_sep;
-    char* grouping;
-    char* int_curr_symbol;
-    char* currency_symbol;
-    char* mon_decimal_point;
-    char* mon_thousands_sep;
-    char* mon_grouping;
-    char* positive_sign;
-    char* negative_sign;
-    byte  int_frac_digits;
-    byte  frac_digits;
-    byte  p_cs_precedes;
-    byte  p_sep_by_space;
-    byte  n_cs_precedes;
-    byte  n_sep_by_space;
-    byte  p_sign_posn;
-    byte  n_sign_posn;
-    byte  int_p_cs_precedes;
-    byte  int_p_sep_by_space;
-    byte  int_n_cs_precedes;
-    byte  int_n_sep_by_space;
-    byte  int_p_sign_posn;
-    byte  int_n_sign_posn;
+    import core.stdc.wchar_ : wchar_t;
+    
+    // ...Windows Kits\10\Include\10.0.14393.0\ucrt\locale.h
+    struct lconv
+    {
+        char*    decimal_point;
+        char*    thousands_sep;
+        char*    grouping;
+        char*    int_curr_symbol;
+        char*    currency_symbol;
+        char*    mon_decimal_point;
+        char*    mon_thousands_sep;
+        char*    mon_grouping;
+        char*    positive_sign;
+        char*    negative_sign;
+        char     int_frac_digits = 0; // " = 0" For zero init
+        char     frac_digits = 0;
+        char     p_cs_precedes = 0;
+        char     p_sep_by_space = 0;
+        char     n_cs_precedes = 0;
+        char     n_sep_by_space = 0;
+        char     p_sign_posn = 0;
+        char     n_sign_posn = 0;
+        wchar_t* _W_decimal_point;
+        wchar_t* _W_thousands_sep;
+        wchar_t* _W_int_curr_symbol;
+        wchar_t* _W_currency_symbol;
+        wchar_t* _W_mon_decimal_point;
+        wchar_t* _W_mon_thousands_sep;
+        wchar_t* _W_positive_sign;
+        wchar_t* _W_negative_sign;
+    }
+}
+else
+{
+    struct lconv
+    {
+        char* decimal_point;
+        char* thousands_sep;
+        char* grouping;
+        char* int_curr_symbol;
+        char* currency_symbol;
+        char* mon_decimal_point;
+        char* mon_thousands_sep;
+        char* mon_grouping;
+        char* positive_sign;
+        char* negative_sign;
+        byte  int_frac_digits;
+        byte  frac_digits;
+        byte  p_cs_precedes;
+        byte  p_sep_by_space;
+        byte  n_cs_precedes;
+        byte  n_sep_by_space;
+        byte  p_sign_posn;
+        byte  n_sign_posn;
+        byte  int_p_cs_precedes;
+        byte  int_p_sep_by_space;
+        byte  int_n_cs_precedes;
+        byte  int_n_sep_by_space;
+        byte  int_p_sign_posn;
+        byte  int_n_sign_posn;
+    }
 }
 
 version (CRuntime_Glibc)

--- a/druntime/src/core/stdc/wchar_.d
+++ b/druntime/src/core/stdc/wchar_.d
@@ -138,7 +138,7 @@ else version (Windows)
         union ___value
         {
             wint_t __wch = 0;
-            char __wchb[4];
+            char[4] __wchb;
         }
         ___value __value;
     }

--- a/druntime/src/core/stdc/wchar_.d
+++ b/druntime/src/core/stdc/wchar_.d
@@ -129,6 +129,23 @@ else version (CRuntime_UClibc)
         wchar_t __wc = 0;
     }
 }
+else version (Windows)
+{
+    ///
+    struct __mbstate_t
+    {
+        int __count;
+        union ___value
+        {
+            wint_t __wch = 0;
+            char __wchb[4];
+        }
+        ___value __value;
+    }
+
+    ///
+    alias mbstate_t = __mbstate_t;
+}
 else
 {
     ///


### PR DESCRIPTION
As defined in wchar.h

```c++
/* Work around problems with the <stddef.h> file which doesn't put
   wint_t in the std namespace.  */
#  if defined __cplusplus && defined _GLIBCPP_USE_NAMESPACES \
      && defined __WINT_TYPE__
__BEGIN_NAMESPACE_STD
typedef __WINT_TYPE__ wint_t;
__END_NAMESPACE_STD
#  endif

typedef struct
{
  int __count;
  union
  {
# ifdef __WINT_TYPE__
    __WINT_TYPE__ __wch;
# else
    wint_t __wch;
# endif
    char __wchb[4];
  } __value;		/* Value so far.  */
} __mbstate_t;
```