### PR TITLE
expression.h: Fix signature of dmd::isLvalue

### DIFF
--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -61,7 +61,7 @@ namespace dmd
     Expression *optimize(Expression *exp, int result, bool keepLvalue = false);
     bool isIdentical(const Expression *exp, const Expression *e);
     bool equals(const Expression *exp, const Expression *e);
-    bool isLvalue(const Expression *exp);
+    bool isLvalue(Expression *exp);
     int32_t getFieldIndex(ClassReferenceExp *cre, Type *fieldtype, uint32_t fieldoffset);
     void fillTupleExpExps(TupleExp *te, TupleDeclaration *tup);
     Optional<bool> toBool(Expression *exp);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1771,6 +1771,7 @@ void expression_h(Expression *e, Scope *sc, Type *t, Loc loc, Expressions *es)
     dmd::ctfeInterpret(e);
     dmd::expandTuples(es);
     dmd::optimize(e, 0);
+    dmd::isLvalue(e);
 }
 
 void hdrgen_h(Module *m, OutBuffer &buf, Modules &ms, ParameterList pl,


### PR DESCRIPTION
Function does not accept a `const` parameter.  Missing test in cxxfrontend.cc

@elshorbagyx - FYI this would have been caught by CI if link test existed. 