### PR TITLE
globals.h: Add missing useFastDFA field

### DIFF
--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -232,6 +232,7 @@ struct Param
     FeatureState dtorFields;     // destruct fields of partially constructed objects
                                  // https://issues.dlang.org/show_bug.cgi?id=14246
     FeatureState systemVariables; // limit access to variables marked @system from @safe code
+    d_bool useFastDFA;             // Use fast data flow analysis engine
 
     CHECKENABLE useInvariants;     // generate class invariant checks
     CHECKENABLE useIn;             // generate precondition checks


### PR DESCRIPTION
Mismatch introduced in #21965 


@rikkimax 