### PR TITLE
Move `FuncDeclaration.isVirtualMethod` and `FuncDeclaration.hasNestedFrameRefs` to `funcsem`

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -529,6 +529,18 @@ bool needsClosure(FuncDeclaration fd)
     return dmd.funcsem.needsClosure(fd);
 }
 
+bool hasNestedFrameRefs(FuncDeclaration fd)
+{
+    import dmd.funcsem;
+    return dmd.funcsem.hasNestedFrameRefs(fd);
+}
+
+bool isVirtualMethod(FuncDeclaration fd)
+{
+    import dmd.funcsem;
+    return dmd.funcsem.isVirtualMethod(fd);
+}
+
 /***********************************************************
  * hdrgen.d
  */

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -43,6 +43,8 @@ namespace dmd
     bool isAbstract(ClassDeclaration *cd);
     bool overloadInsert(Dsymbol *ds, Dsymbol *s);
     bool equals(const Dsymbol * const ds, const Dsymbol * const s);
+    bool hasNestedFrameRefs(FuncDeclaration *fd);
+    bool isVirtualMethod(FuncDeclaration *fd);
 }
 
 //enum STC : ulong from astenums.d:
@@ -714,13 +716,11 @@ public:
     virtual bool isNested() const;
     AggregateDeclaration *isThis() override;
     bool needThis() override final;
-    bool isVirtualMethod();
     virtual bool isVirtual() const;
     bool isFinalFunc() const;
     virtual bool addPreInvariant();
     virtual bool addPostInvariant();
     const char *kind() const override;
-    bool hasNestedFrameRefs();
     ParameterList getParameterList();
 
     virtual FuncDeclaration *toAliasFunc() { return this; }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3919,13 +3919,11 @@ public:
     virtual bool isNested() const;
     AggregateDeclaration* isThis() override;
     bool needThis() final override;
-    bool isVirtualMethod();
     virtual bool isVirtual() const;
     bool isFinalFunc() const;
     virtual bool addPreInvariant();
     virtual bool addPostInvariant();
     const char* kind() const override;
-    bool hasNestedFrameRefs();
     ParameterList getParameterList();
     virtual FuncDeclaration* toAliasFunc();
     void accept(Visitor* v) override;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -631,23 +631,6 @@ extern (C++) class FuncDeclaration : Declaration
         return toAliasFunc().isThis() !is null;
     }
 
-    // Determine if a function is pedantically virtual
-    final bool isVirtualMethod()
-    {
-        if (toAliasFunc() != this)
-            return toAliasFunc().isVirtualMethod();
-
-        //printf("FuncDeclaration::isVirtualMethod() %s\n", toChars());
-        if (!isVirtual())
-            return false;
-        // If it's a final method, and does not override anything, then it is not virtual
-        if (isFinalFunc() && foverrides.length == 0)
-        {
-            return false;
-        }
-        return true;
-    }
-
     // Determine if function goes into virtual function pointer table
     bool isVirtual() const
     {

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -710,38 +710,6 @@ extern (C++) class FuncDeclaration : Declaration
         return this.isGenerated ? "generated function" : "function";
     }
 
-    /***********************************************
-     * Determine if function's variables are referenced by a function
-     * nested within it.
-     */
-    final bool hasNestedFrameRefs()
-    {
-        if (closureVars.length)
-            return true;
-
-        /* If a virtual function has contracts, assume its variables are referenced
-         * by those contracts, even if they aren't. Because they might be referenced
-         * by the overridden or overriding function's contracts.
-         * This can happen because frequire and fensure are implemented as nested functions,
-         * and they can be called directly by an overriding function and the overriding function's
-         * context had better match, or
-         * https://issues.dlang.org/show_bug.cgi?id=7335 will bite.
-         */
-        if (fdrequire || fdensure)
-            return true;
-
-        if (foverrides.length && isVirtualMethod())
-        {
-            for (size_t i = 0; i < foverrides.length; i++)
-            {
-                FuncDeclaration fdv = foverrides[i];
-                if (fdv.hasNestedFrameRefs())
-                    return true;
-            }
-        }
-        return false;
-    }
-
     /*********************************************
      * Returns: the function's parameter list, and whether
      * it is variadic or not.

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -68,6 +68,38 @@ import dmd.visitor;
 import dmd.visitor.statement_rewrite_walker;
 
 
+/***********************************************
+ * Determine if function's variables are referenced by a function
+ * nested within it.
+ */
+bool hasNestedFrameRefs(FuncDeclaration _this)
+{
+    if (_this.closureVars.length)
+        return true;
+
+    /* If a virtual function has contracts, assume its variables are referenced
+     * by those contracts, even if they aren't. Because they might be referenced
+     * by the overridden or overriding function's contracts.
+     * This can happen because frequire and fensure are implemented as nested functions,
+     * and they can be called directly by an overriding function and the overriding function's
+     * context had better match, or
+     * https://issues.dlang.org/show_bug.cgi?id=7335 will bite.
+     */
+    if (_this.fdrequire || _this.fdensure)
+        return true;
+
+    if (_this.foverrides.length && _this.isVirtualMethod())
+    {
+        for (size_t i = 0; i < _this.foverrides.length; i++)
+        {
+            FuncDeclaration fdv = _this.foverrides[i];
+            if (fdv.hasNestedFrameRefs())
+                return true;
+        }
+    }
+    return false;
+}
+
 /**********************************
  * Generate a FuncDeclaration for a runtime library function.
  */

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -67,6 +67,24 @@ import dmd.typesem;
 import dmd.visitor;
 import dmd.visitor.statement_rewrite_walker;
 
+// Determine if a function is pedantically virtual
+bool isVirtualMethod(FuncDeclaration _this)
+{
+    if (_this.toAliasFunc() != _this)
+        return _this.toAliasFunc().isVirtualMethod();
+
+    //printf("FuncDeclaration::isVirtualMethod() %s\n", toChars());
+    if (!_this.isVirtual())
+        return false;
+
+    // If it's a final method, and does not override anything, then it is not virtual
+    if (_this.isFinalFunc() && _this.foverrides.length == 0)
+    {
+        return false;
+    }
+    return true;
+}
+
 
 /***********************************************
  * Determine if function's variables are referenced by a function

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -85,7 +85,6 @@ bool isVirtualMethod(FuncDeclaration _this)
     return true;
 }
 
-
 /***********************************************
  * Determine if function's variables are referenced by a function
  * nested within it.

--- a/compiler/src/dmd/glue/tocsym.d
+++ b/compiler/src/dmd/glue/tocsym.d
@@ -39,6 +39,7 @@ import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
 import dmd.func;
+import dmd.funcsem;
 import dmd.globals;
 import dmd.glue;
 import dmd.identifier;

--- a/compiler/src/dmd/glue/tocvdebug.d
+++ b/compiler/src/dmd/glue/tocvdebug.d
@@ -35,6 +35,7 @@ import dmd.typesem;
 import dmd.dstruct;
 import dmd.dtemplate;
 import dmd.func;
+import dmd.funcsem;
 import dmd.globals;
 import dmd.id;
 import dmd.mtype;


### PR DESCRIPTION
To break dependency of `func` on `objc`