### PR TITLE
mtype.h: Add convenience methods back to Type class

### DIFF
--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -42,9 +42,13 @@ typedef struct TYPE type;
 
 namespace dmd
 {
+    void Type_init();
     Type *typeSemantic(Type *t, Loc loc, Scope *sc);
     Type *merge(Type *type);
     Expression *defaultInitLiteral(Type *t, Loc loc);
+    Type *toBasetype(Type *type);
+    Type *nextOf(Type* type);
+    Type *baseElemOf(Type* type);
 }
 
 enum class TY : uint8_t
@@ -215,6 +219,8 @@ public:
 
     static Type *basic[(int)TY::TMAX];
 
+    static void _init() { return dmd::Type_init(); }
+
     virtual const char *kind();
     Type *copy() const;
     virtual Type *syntaxCopy();
@@ -240,6 +246,10 @@ public:
     bool isSharedWild() const  { return (mod & (MODshared | MODwild)) == (MODshared | MODwild); }
     bool isNaked() const       { return mod == 0; }
     Type *nullAttributes() const;
+
+    Type *toBasetype() { return dmd::toBasetype(this); }
+    Type *nextOf()     { return dmd::nextOf(this); }
+    Type *baseElemOf() { return dmd::baseElemOf(this); }
 
     virtual ClassDeclaration *isClassHandle();
     virtual int hasWild() const;
@@ -732,7 +742,6 @@ namespace dmd
     Type *addMod(Type *type, MOD mod);
     Type *addStorageClass(Type *type, StorageClass stc);
     Type *substWildTo(Type *type, unsigned mod);
-    Type *toBasetype(Type *type);
     uinteger_t size(Type *type);
     uinteger_t size(Type *type, Loc loc);
     MATCH implicitConvTo(Type* from, Type* to);
@@ -740,7 +749,6 @@ namespace dmd
     bool hasUnsafeBitpatterns(Type* type);
     bool hasInvariant(Type* type);
     bool hasVoidInitPointers(Type* type);
-    void Type_init();
     void transitive(TypeNext* type);
     structalign_t alignment(Type* type);
     Type* memType(TypeEnum* type);
@@ -754,8 +762,6 @@ namespace dmd
     Type *makeWildConst(Type* type);
     Type *makeSharedWild(Type* type);
     Type *makeSharedWildConst(Type* type);
-    Type *nextOf(Type* type);
-    Type *baseElemOf(Type* type);
     Type *isLazyArray(Parameter* param);
     unsigned char deduceWild(Type* type, Type* t, bool isRef);
     bool isIntegral(Type* type);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -78,7 +78,7 @@ static void frontend_init()
     target.cpu = CPU::native;
     target._init(global.params);
 
-    dmd::Type_init();
+    Type::_init();
     Id::initialize();
     Module::_init();
     Expression::_init();
@@ -956,7 +956,7 @@ public:
     {
         s->getRelatedLabeled()->accept(this);
         s->condition->accept(this);
-        Type *condtype = dmd::baseElemOf(s->condition->type);
+        Type *condtype = s->condition->type->toBasetype();
         if (!dmd::isScalar(condtype))
             assert(0);
         if (s->cases)
@@ -1002,11 +1002,11 @@ public:
     }
     void visit(ReturnStatement *s) override
     {
-        if (s->exp == NULL || dmd::toBasetype(s->exp->type)->ty == TY::Tvoid)
+        if (s->exp == NULL || s->exp->type->toBasetype()->ty == TY::Tvoid)
             return;
         TypeFunction *tf = func->type->toTypeFunction();
-        Type *type = func->tintro != NULL ? dmd::nextOf(func->tintro) : dmd::nextOf(tf);
-        if ((func->isMain() || func->isCMain()) && dmd::toBasetype(type)->ty == TY::Tvoid)
+        Type *type = func->tintro != NULL ? func->tintro->nextOf() : tf->nextOf();
+        if ((func->isMain() || func->isCMain()) && type->toBasetype()->ty == TY::Tvoid)
             type = Type::tint32;
         if (func->shidden)
         {
@@ -1037,7 +1037,7 @@ public:
                 sle = s->exp->isStructLiteralExp();
             if (sle != NULL)
             {
-                dmd::baseElemOf(type)->isTypeStruct()->sym->accept(this);
+                type->baseElemOf()->isTypeStruct()->sym->accept(this);
                 sle->sym = (Symbol*)func->shidden;
             }
             s->exp->accept(this);
@@ -1093,7 +1093,7 @@ public:
     }
     void visit(ThrowStatement *s) override
     {
-        dmd::toBasetype(s->exp->type)->isClassHandle()->accept(this);
+        s->exp->type->toBasetype()->isClassHandle()->accept(this);
         s->exp->accept(this);
     }
     void visit(TryCatchStatement *s) override
@@ -1254,9 +1254,9 @@ public:
     {
         if (!func || !func->isAuto())
             return;
-        Type *tb = dmd::baseElemOf(dmd::nextOf(func->type));
+        Type *tb = func->type->nextOf()->baseElemOf();
         while (tb->ty == TY::Tarray || tb->ty == TY::Tpointer)
-            tb = dmd::baseElemOf(dmd::nextOf(tb));
+            tb = tb->nextOf()->baseElemOf();
         TemplateInstance *ti = NULL;
         if (tb->ty == TY::Tstruct)
             ti = tb->isTypeStruct()->sym->isInstantiated();
@@ -1481,7 +1481,7 @@ public:
             (void)fd->isGenerated();
             (void)fd->ident;
             (void)fd->storage_class;
-            (void)dmd::nextOf(fd->type)->isTypeNoreturn();
+            (void)fd->type->nextOf()->isTypeNoreturn();
         }
         else
         {


### PR DESCRIPTION
There are hundreds of uses of these throughout gdc and ldc. It's a waste of everyone's time to replace them all with `dmd::XXX`.

@kinke - Makes sense? Any others that would hurt you?

@elshorbagyx - FYI instead of breaking the build for compilers.