### PR TITLE
Fix #17198 - .dup on array of nested structs can cause null dereference if copy throws

### DIFF
--- a/compiler/test/runnable/issue17198.d
+++ b/compiler/test/runnable/issue17198.d
@@ -1,0 +1,29 @@
+// Related issue: https://github.com/dlang/dmd/issues/17198
+import core.memory : GC;
+
+void main()
+{
+    int i;
+    struct S
+    {
+        this(this) {
+            throw new Exception("!!!");
+        }
+        ~this() { ++i; }
+    }
+
+    auto a1 = [S()];
+    S[] a2;
+
+    try
+    {
+        a2 = a1.dup; // throws
+    }
+    catch (Exception e)
+    {
+    }
+
+    assert(a2.length == 0);
+
+    GC.collect();
+}

--- a/druntime/src/core/internal/array/duplication.d
+++ b/druntime/src/core/internal/array/duplication.d
@@ -55,19 +55,27 @@ U[] _dup(T, U)(T[] a) if (!__traits(isPOD, T))
     {
         import core.lifetime: copyEmplace;
         import core.internal.array.construction: _d_newarrayU;
+        import core.memory : GC;
+        import core.internal.traits : Unqual;
         U[] res = () @trusted {
             auto arr = cast(U*) _d_newarrayU!T(a.length, is(T == shared));
             size_t i;
-            scope (failure)
+            try
             {
-                import core.internal.lifetime: emplaceInitializer;
-                // Initialize all remaining elements to not destruct garbage
-                foreach (j; i .. a.length)
-                    emplaceInitializer(cast() arr[j]);
+                for (; i < a.length; i++)
+                {
+                    copyEmplace(a.ptr[i], arr[i]);
+                }
             }
-            for (; i < a.length; i++)
+            catch (Throwable t)
             {
-                copyEmplace(a.ptr[i], arr[i]);
+                while (i--)
+                {
+                    auto elem = cast(Unqual!U*) &arr[i];
+                    destroy(*elem);
+                }
+                GC.free(GC.addrOf(cast(void*) arr));
+                throw t;
             }
             return cast(U[])(arr[0..a.length]);
         } ();


### PR DESCRIPTION
Related issue: #17198
If element copying throws, `_dup` leaves a GC-managed allocation for the destination array. Later the GC collects it and calls `S.~this`, but the array may contain partially or unconstructed elements.