### PR TITLE
Move `FuncDeclaration.addPreInvariant` and `FuncDeclaration.addPostInvariant` to `funcsem` 

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -541,18 +541,6 @@ bool isVirtualMethod(FuncDeclaration fd)
     return dmd.funcsem.isVirtualMethod(fd);
 }
 
-bool addPreInvariant(FuncDeclaration fd)
-{
-    import dmd.funcsem;
-    return dmd.funcsem.addPreInvariant(fd);
-}
-
-bool addPostInvariant(FuncDeclaration fd)
-{
-    import dmd.funcsem;
-    return dmd.funcsem.addPostInvariant(fd);
-}
-
 /***********************************************************
  * hdrgen.d
  */

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -541,6 +541,18 @@ bool isVirtualMethod(FuncDeclaration fd)
     return dmd.funcsem.isVirtualMethod(fd);
 }
 
+bool addPreInvariant(FuncDeclaration fd)
+{
+    import dmd.funcsem;
+    return dmd.funcsem.addPreInvariant(fd);
+}
+
+bool addPostInvariant(FuncDeclaration fd)
+{
+    import dmd.funcsem;
+    return dmd.funcsem.addPostInvariant(fd);
+}
+
 /***********************************************************
  * hdrgen.d
  */

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -45,6 +45,8 @@ namespace dmd
     bool equals(const Dsymbol * const ds, const Dsymbol * const s);
     bool hasNestedFrameRefs(FuncDeclaration *fd);
     bool isVirtualMethod(FuncDeclaration *fd);
+    bool addPreInvariant(FuncDeclaration *fd);
+    bool addPostInvariant(FuncDeclaration *fd);
 }
 
 //enum STC : ulong from astenums.d:
@@ -718,8 +720,8 @@ public:
     bool needThis() override final;
     virtual bool isVirtual() const;
     bool isFinalFunc() const;
-    virtual bool addPreInvariant();
-    virtual bool addPostInvariant();
+    bool addPreInvariant() { return dmd::addPreInvariant(this); };
+    bool addPostInvariant() { return dmd::addPostInvariant(this); };
     const char *kind() const override;
     ParameterList getParameterList();
 
@@ -752,8 +754,6 @@ public:
     bool isNested() const override;
     AggregateDeclaration *isThis() override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
 
     const char *kind() const override;
     const char *toPrettyChars(bool QualifyTypes = false) override;
@@ -768,8 +768,6 @@ public:
     CtorDeclaration *syntaxCopy(Dsymbol *) override;
     const char *kind() const override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -779,8 +777,6 @@ class PostBlitDeclaration final : public FuncDeclaration
 public:
     PostBlitDeclaration *syntaxCopy(Dsymbol *) override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -791,8 +787,6 @@ public:
     DtorDeclaration *syntaxCopy(Dsymbol *) override;
     const char *kind() const override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -803,8 +797,6 @@ public:
     StaticCtorDeclaration *syntaxCopy(Dsymbol *) override;
     AggregateDeclaration *isThis() override final;
     bool isVirtual() const override final;
-    bool addPreInvariant() override final;
-    bool addPostInvariant() override final;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -826,8 +818,6 @@ public:
     StaticDtorDeclaration *syntaxCopy(Dsymbol *) override;
     AggregateDeclaration *isThis() override final;
     bool isVirtual() const override final;
-    bool addPreInvariant() override final;
-    bool addPostInvariant() override final;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -845,8 +835,6 @@ class InvariantDeclaration final : public FuncDeclaration
 public:
     InvariantDeclaration *syntaxCopy(Dsymbol *) override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -862,8 +850,6 @@ public:
     UnitTestDeclaration *syntaxCopy(Dsymbol *) override;
     AggregateDeclaration *isThis() override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -874,8 +860,6 @@ public:
     NewDeclaration *syntaxCopy(Dsymbol *) override;
     const char *kind() const override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -45,8 +45,6 @@ namespace dmd
     bool equals(const Dsymbol * const ds, const Dsymbol * const s);
     bool hasNestedFrameRefs(FuncDeclaration *fd);
     bool isVirtualMethod(FuncDeclaration *fd);
-    bool addPreInvariant(FuncDeclaration *fd);
-    bool addPostInvariant(FuncDeclaration *fd);
 }
 
 //enum STC : ulong from astenums.d:
@@ -720,8 +718,6 @@ public:
     bool needThis() override final;
     virtual bool isVirtual() const;
     bool isFinalFunc() const;
-    bool addPreInvariant() { return dmd::addPreInvariant(this); };
-    bool addPostInvariant() { return dmd::addPostInvariant(this); };
     const char *kind() const override;
     ParameterList getParameterList();
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3921,8 +3921,6 @@ public:
     bool needThis() final override;
     virtual bool isVirtual() const;
     bool isFinalFunc() const;
-    virtual bool addPreInvariant();
-    virtual bool addPostInvariant();
     const char* kind() const override;
     ParameterList getParameterList();
     virtual FuncDeclaration* toAliasFunc();
@@ -3937,8 +3935,6 @@ public:
     CtorDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
     void accept(Visitor* v) override;
 };
 
@@ -3948,8 +3944,6 @@ public:
     DtorDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
     void accept(Visitor* v) override;
 };
 
@@ -3973,8 +3967,6 @@ public:
     bool isNested() const override;
     AggregateDeclaration* isThis() override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
     const char* kind() const override;
     const char* toPrettyChars(bool QualifyTypes = false) override;
     void accept(Visitor* v) override;
@@ -3985,8 +3977,6 @@ class InvariantDeclaration final : public FuncDeclaration
 public:
     InvariantDeclaration* syntaxCopy(Dsymbol* s) override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
     void accept(Visitor* v) override;
 };
 
@@ -3996,8 +3986,6 @@ public:
     NewDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
     void accept(Visitor* v) override;
 };
 
@@ -4050,8 +4038,6 @@ class PostBlitDeclaration final : public FuncDeclaration
 public:
     PostBlitDeclaration* syntaxCopy(Dsymbol* s) override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
     void accept(Visitor* v) override;
 };
 
@@ -4061,8 +4047,6 @@ public:
     StaticCtorDeclaration* syntaxCopy(Dsymbol* s) override;
     AggregateDeclaration* isThis() final override;
     bool isVirtual() const final override;
-    bool addPreInvariant() final override;
-    bool addPostInvariant() final override;
     void accept(Visitor* v) override;
 };
 
@@ -4081,8 +4065,6 @@ public:
     StaticDtorDeclaration* syntaxCopy(Dsymbol* s) override;
     AggregateDeclaration* isThis() final override;
     bool isVirtual() const final override;
-    bool addPreInvariant() final override;
-    bool addPostInvariant() final override;
     void accept(Visitor* v) override;
 };
 
@@ -4101,8 +4083,6 @@ public:
     UnitTestDeclaration* syntaxCopy(Dsymbol* s) override;
     AggregateDeclaration* isThis() override;
     bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -676,18 +676,6 @@ extern (C++) class FuncDeclaration : Declaration
         return (cd !is null) && (cd.storage_class & STC.final_);
     }
 
-    bool addPreInvariant()
-    {
-        auto ad = isThis();
-        return (ad && global.params.useInvariants == CHECKENABLE.on && (visibility.kind == Visibility.Kind.protected_ || visibility.kind == Visibility.Kind.public_ || visibility.kind == Visibility.Kind.export_) && !this.isNaked);
-    }
-
-    bool addPostInvariant()
-    {
-        auto ad = isThis();
-        return (ad && ad.inv && global.params.useInvariants == CHECKENABLE.on && (visibility.kind == Visibility.Kind.protected_ || visibility.kind == Visibility.Kind.public_ || visibility.kind == Visibility.Kind.export_) && !this.isNaked);
-    }
-
     override const(char)* kind() const
     {
         return this.isGenerated ? "generated function" : "function";
@@ -895,16 +883,6 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
         return false;
     }
 
-    override bool addPreInvariant()
-    {
-        return false;
-    }
-
-    override bool addPostInvariant()
-    {
-        return false;
-    }
-
     override const(char)* kind() const
     {
         // GCC requires the (char*) casts
@@ -959,16 +937,6 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
         return false;
     }
 
-    override bool addPreInvariant()
-    {
-        return false;
-    }
-
-    override bool addPostInvariant()
-    {
-        return (isThis() && vthis && global.params.useInvariants == CHECKENABLE.on);
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -996,16 +964,6 @@ extern (C++) final class PostBlitDeclaration : FuncDeclaration
     override bool isVirtual() const
     {
         return false;
-    }
-
-    override bool addPreInvariant()
-    {
-        return false;
-    }
-
-    override bool addPostInvariant()
-    {
-        return (isThis() && vthis && global.params.useInvariants == CHECKENABLE.on);
     }
 
     override void accept(Visitor v)
@@ -1050,16 +1008,6 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
         return vtblIndex != -1;
     }
 
-    override bool addPreInvariant()
-    {
-        return (isThis() && vthis && global.params.useInvariants == CHECKENABLE.on);
-    }
-
-    override bool addPostInvariant()
-    {
-        return false;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1096,16 +1044,6 @@ extern (C++) class StaticCtorDeclaration : FuncDeclaration
     }
 
     override final bool isVirtual() const @nogc nothrow pure @safe
-    {
-        return false;
-    }
-
-    override final bool addPreInvariant() @nogc nothrow pure @safe
-    {
-        return false;
-    }
-
-    override final bool addPostInvariant() @nogc nothrow pure @safe
     {
         return false;
     }
@@ -1179,16 +1117,6 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
         return false;
     }
 
-    override final bool addPreInvariant()
-    {
-        return false;
-    }
-
-    override final bool addPostInvariant()
-    {
-        return false;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1244,16 +1172,6 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
         return false;
     }
 
-    override bool addPreInvariant()
-    {
-        return false;
-    }
-
-    override bool addPostInvariant()
-    {
-        return false;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1304,16 +1222,6 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
         return false;
     }
 
-    override bool addPreInvariant()
-    {
-        return false;
-    }
-
-    override bool addPostInvariant()
-    {
-        return false;
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -1344,16 +1252,6 @@ extern (C++) final class NewDeclaration : FuncDeclaration
     }
 
     override bool isVirtual() const
-    {
-        return false;
-    }
-
-    override bool addPreInvariant()
-    {
-        return false;
-    }
-
-    override bool addPostInvariant()
     {
         return false;
     }

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -88,7 +88,9 @@ bool addPostInvariant(FuncDeclaration _this)
         case DSYM.funcLiteralDeclaration:
         case DSYM.dtorDeclaration:
         case DSYM.staticCtorDeclaration:
+        case DSYM.sharedStaticCtorDeclaration:
         case DSYM.staticDtorDeclaration:
+        case DSYM.sharedStaticDtorDeclaration:
         case DSYM.invariantDeclaration:
         case DSYM.unitTestDeclaration:
         case DSYM.newDeclaration:
@@ -127,7 +129,9 @@ bool addPreInvariant(FuncDeclaration _this)
         case DSYM.ctorDeclaration:
         case DSYM.postBlitDeclaration:
         case DSYM.staticCtorDeclaration:
+        case DSYM.sharedStaticCtorDeclaration:
         case DSYM.staticDtorDeclaration:
+        case DSYM.sharedStaticDtorDeclaration:
         case DSYM.invariantDeclaration:
         case DSYM.unitTestDeclaration:
         case DSYM.newDeclaration:

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -102,7 +102,7 @@ bool addPostInvariant(FuncDeclaration _this)
         }
         case DSYM.postBlitDeclaration:
         {
-            auto dd = _this.isDtorDeclaration();
+            auto dd = _this.isPostBlitDeclaration();
             return (dd.isThis() && dd.vthis && global.params.useInvariants == CHECKENABLE.on);
         }
         default: return visitFuncDeclaration(_this);

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -67,6 +67,80 @@ import dmd.typesem;
 import dmd.visitor;
 import dmd.visitor.statement_rewrite_walker;
 
+bool addPostInvariant(FuncDeclaration _this)
+{
+    static bool visitFuncDeclaration(FuncDeclaration _this)
+    {
+        auto ad = _this.isThis();
+        return (
+            ad &&
+            ad.inv &&
+            global.params.useInvariants == CHECKENABLE.on &&
+            (_this.visibility.kind == Visibility.Kind.protected_ ||
+            _this.visibility.kind == Visibility.Kind.public_ ||
+            _this.visibility.kind == Visibility.Kind.export_) &&
+            !_this.isNaked
+        );
+    }
+
+    switch(_this.dsym)
+    {
+        case DSYM.funcLiteralDeclaration:
+        case DSYM.dtorDeclaration:
+        case DSYM.staticCtorDeclaration:
+        case DSYM.staticDtorDeclaration:
+        case DSYM.invariantDeclaration:
+        case DSYM.unitTestDeclaration:
+        case DSYM.newDeclaration:
+            return false;
+        case DSYM.ctorDeclaration:
+        {
+            auto cd = _this.isCtorDeclaration();
+            return (cd.isThis() && cd.vthis && global.params.useInvariants == CHECKENABLE.on);
+        }
+        case DSYM.postBlitDeclaration:
+        {
+            auto dd = _this.isDtorDeclaration();
+            return (dd.isThis() && dd.vthis && global.params.useInvariants == CHECKENABLE.on);
+        }
+        default: return visitFuncDeclaration(_this);
+    }
+}
+
+bool addPreInvariant(FuncDeclaration _this)
+{
+    static bool visitFuncDeclaration(FuncDeclaration _this)
+    {
+        return (
+            _this.isThis() &&
+            global.params.useInvariants == CHECKENABLE.on &&
+            (_this.visibility.kind == Visibility.Kind.protected_ ||
+            _this.visibility.kind == Visibility.Kind.public_ ||
+            _this.visibility.kind == Visibility.Kind.export_) &&
+            !_this.isNaked
+        );
+    }
+
+    switch(_this.dsym)
+    {
+        case DSYM.funcLiteralDeclaration:
+        case DSYM.ctorDeclaration:
+        case DSYM.postBlitDeclaration:
+        case DSYM.staticCtorDeclaration:
+        case DSYM.staticDtorDeclaration:
+        case DSYM.invariantDeclaration:
+        case DSYM.unitTestDeclaration:
+        case DSYM.newDeclaration:
+            return false;
+        case DSYM.dtorDeclaration:
+        {
+            auto dd = _this.isDtorDeclaration();
+            return (dd.isThis() && dd.vthis && global.params.useInvariants == CHECKENABLE.on);
+        }
+        default: return visitFuncDeclaration(_this);
+    }
+}
+
 // Determine if a function is pedantically virtual
 bool isVirtualMethod(FuncDeclaration _this)
 {


### PR DESCRIPTION
To break the dependency of `func.d` on `objc.d`