### PR TITLE
refactor: move Port.strtold as strtold_ms to strtold.d to make life easier for GDC

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -9039,7 +9039,6 @@ struct Port final
     static char* strupr(char* s);
     static bool isFloat32LiteralOutOfRange(const char* s);
     static bool isFloat64LiteralOutOfRange(const char* s);
-    static _d_real strtold(const char* p);
     static void writelongLE(uint32_t value, void* buffer);
     static uint32_t readlongLE(const void* const buffer);
     static void writelongBE(uint32_t value, void* buffer);

--- a/compiler/src/dmd/root/ctfloat.d
+++ b/compiler/src/dmd/root/ctfloat.d
@@ -25,11 +25,10 @@ import dmd.root.port;
 
 private
 {
-    version(CRuntime_DigitalMars) __gshared extern (C) extern const(char)* __locale_decpoint;
-
     version(CRuntime_Microsoft)
     {
-        public import dmd.root.longdouble : longdouble_soft, ld_sprint;
+        import dmd.root.longdouble : longdouble_soft, ld_sprint;
+        import dmd.root.strtold : strtold = strtold_ms;
     }
 }
 
@@ -172,7 +171,7 @@ extern (C++) struct CTFloat
     static real_t parse(const(char)* literal, out bool isOutOfRange)
     {
         errno = 0;
-        auto r = Port.strtold(literal);
+        auto r = strtold(literal, null);
         isOutOfRange = (errno == ERANGE);
         return r;
     }

--- a/compiler/src/dmd/root/port.d
+++ b/compiler/src/dmd/root/port.d
@@ -11,8 +11,6 @@
 
 module dmd.root.port;
 
-import dmd.root.longdouble;
-
 import core.stdc.ctype;
 import core.stdc.errno;
 import core.stdc.string;
@@ -33,8 +31,6 @@ private extern (C)
 
         int _atoflt(float*  value, const(char)* str);
         int _atodbl(double* value, const(char)* str);
-
-        int _atoldbl(longdouble_soft* value, const(char)* str);
     }
 }
 
@@ -136,41 +132,6 @@ extern (C++) struct Port
         {
             const result = strtod(s, null);
             return resultOutOfRange(result, errno);
-        }
-    }
-
-    static longdouble strtold(const(char) *p)
-    {
-        version (CRuntime_DigitalMars)
-        {
-            auto save = __locale_decpoint;
-            __locale_decpoint = ".";
-            scope(exit)
-                __locale_decpoint = save;
-        }
-        version (CRuntime_Microsoft)
-        {
-            longdouble_soft r;
-            if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X'))
-            {
-                // _atoldbl() limits hex exponents by decimal max/min eponents
-                import dmd.root.strtold;
-                r = strtold_dm(p, null);
-            }
-            else
-            {
-                // strtold_dm() does not properly round decimal numbers
-                int res = _atoldbl(&r, p);
-                if (r.exponent() == 0x7fff && r.mantissa == 0)
-                    r.mantissa = 0x8000_0000_0000_0000UL; // pseudo-infinity -> infinity
-                if (res == _UNDERFLOW || res == _OVERFLOW)
-                    errno = ERANGE;
-            }
-            return cast(longdouble) r;
-        }
-        else
-        {
-            return .strtold(p, null);
         }
     }
 


### PR DESCRIPTION
@ibuclaw fits even better in dmd.root.strtold. 

see https://github.com/dlang/dmd/pull/22343#issuecomment-3706792891 