### PR TITLE
ImportC: Support bare function-like macro calls in #define

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5752,6 +5752,44 @@ final class CParser(AST) : Parser!AST
                             }
                             break;
 
+                        case TOK.identifier:
+                        {
+                            /* Look for:
+                             *  #define ID identifier ( args )
+                             * where the macro body is exactly a function-like macro call
+                             * (no additional operators that could cause precedence issues).
+                             * Rewrite to a template function:
+                             *  auto ID()() { return identifier(args); }
+                             */
+                            if (params)
+                                break;                          // function-like macro with params handled elsewhere
+                            eLatch.sawErrors = false;
+                            auto exp = cparseExpression();
+                            if (eLatch.sawErrors)               // parsing errors
+                                break;                          // abandon this #define
+                            if (token.value != TOK.endOfFile)   // did not consume the entire line
+                                break;
+                            // Only allow bare function calls to avoid precedence issues.
+                            // E.g., `#define X FUNC(5)` is safe, but `#define X FUNC(5) + 1`
+                            // would have different semantics in D vs C when used as `X * 2`.
+                            if (!exp.isCallExp())
+                                break;
+                            auto ret = new AST.ReturnStatement(exp.loc, exp);
+                            auto parameterList = AST.ParameterList(new AST.Parameters(), VarArg.none, STC.none);
+                            STC stc = STC.auto_;
+                            auto tf = new AST.TypeFunction(parameterList, null, LINK.d, stc);
+                            auto fd = new AST.FuncDeclaration(exp.loc, exp.loc, id, stc, tf, 0);
+                            fd.fbody = ret;
+                            AST.Dsymbols* decldefs = new AST.Dsymbols();
+                            decldefs.push(fd);
+                            AST.TemplateParameters* tpl = new AST.TemplateParameters();
+                            AST.Expression constraint = null;
+                            auto tempdecl = new AST.TemplateDeclaration(exp.loc, id, tpl, constraint, decldefs, false);
+                            addSym(tempdecl);
+                            ++p;
+                            continue;
+                        }
+
                         case TOK.leftParenthesis:
                         {
                             /* Look for:

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5629,6 +5629,24 @@ final class CParser(AST) : Parser!AST
             ++p; // advance to start of next line
         }
 
+        /* Create a nullary template function from an expression:
+         *   auto id()() { return exp; }
+         */
+        void addNullaryTemplate(AST.Expression exp, Identifier id)
+        {
+            auto ret = new AST.ReturnStatement(exp.loc, exp);
+            auto parameterList = AST.ParameterList(new AST.Parameters(), VarArg.none, STC.none);
+            STC stc = STC.auto_;
+            auto tf = new AST.TypeFunction(parameterList, null, LINK.d, stc);
+            auto fd = new AST.FuncDeclaration(exp.loc, exp.loc, id, stc, tf, 0);
+            fd.fbody = ret;
+            AST.Dsymbols* decldefs = new AST.Dsymbols();
+            decldefs.push(fd);
+            AST.TemplateParameters* tpl = new AST.TemplateParameters();
+            auto tempdecl = new AST.TemplateDeclaration(exp.loc, id, tpl, null, decldefs, false);
+            addSym(tempdecl);
+        }
+
         while (p < endp)
         {
             //printf("|%s|\n", p);
@@ -5774,18 +5792,7 @@ final class CParser(AST) : Parser!AST
                             // would have different semantics in D vs C when used as `X * 2`.
                             if (!exp.isCallExp())
                                 break;
-                            auto ret = new AST.ReturnStatement(exp.loc, exp);
-                            auto parameterList = AST.ParameterList(new AST.Parameters(), VarArg.none, STC.none);
-                            STC stc = STC.auto_;
-                            auto tf = new AST.TypeFunction(parameterList, null, LINK.d, stc);
-                            auto fd = new AST.FuncDeclaration(exp.loc, exp.loc, id, stc, tf, 0);
-                            fd.fbody = ret;
-                            AST.Dsymbols* decldefs = new AST.Dsymbols();
-                            decldefs.push(fd);
-                            AST.TemplateParameters* tpl = new AST.TemplateParameters();
-                            AST.Expression constraint = null;
-                            auto tempdecl = new AST.TemplateDeclaration(exp.loc, id, tpl, constraint, decldefs, false);
-                            addSym(tempdecl);
+                            addNullaryTemplate(exp, id);
                             ++p;
                             continue;
                         }
@@ -5809,18 +5816,7 @@ final class CParser(AST) : Parser!AST
                             nextToken();
                             if (token.value != TOK.endOfFile)
                                 break;
-                            auto ret = new AST.ReturnStatement(exp.loc, exp);
-                            auto parameterList = AST.ParameterList(new AST.Parameters(), VarArg.none, STC.none);
-                            STC stc = STC.auto_;
-                            auto tf = new AST.TypeFunction(parameterList, null, LINK.d, stc);
-                            auto fd = new AST.FuncDeclaration(exp.loc, exp.loc, id, stc, tf, 0);
-                            fd.fbody = ret;
-                            AST.Dsymbols* decldefs = new AST.Dsymbols();
-                            decldefs.push(fd);
-                            AST.TemplateParameters* tpl = new AST.TemplateParameters();
-                            AST.Expression constraint = null;
-                            auto tempdecl = new AST.TemplateDeclaration(exp.loc, id, tpl, constraint, decldefs, false);
-                            addSym(tempdecl);
+                            addNullaryTemplate(exp, id);
                             ++p;
                             continue;
                         }

--- a/compiler/test/compilable/imports/defines.c
+++ b/compiler/test/compilable/imports/defines.c
@@ -63,3 +63,8 @@ int pr16199c()
 #define NEGATIVE_U64 -4LLU
 #define NEGATIVE_F32 -5.0f
 #define NEGATIVE_F64 -6.0
+
+// https://github.com/dlang/dmd/pull/22347 - bare function-like macro calls
+#define DOUBLE(x) ((x) * 2)
+#define BARE_CALL DOUBLE(5)          // bare function-like macro call (no outer parens)
+#define PAREN_CALL (DOUBLE(5))       // parenthesized call (already works)

--- a/compiler/test/compilable/testdefines.d
+++ b/compiler/test/compilable/testdefines.d
@@ -39,3 +39,8 @@ static assert(is(typeof(NEGATIVE_I64) == long));
 static assert(is(typeof(NEGATIVE_U64) == ulong));
 static assert(is(typeof(NEGATIVE_F32) == float));
 static assert(is(typeof(NEGATIVE_F64) == double));
+
+// https://github.com/dlang/dmd/pull/22347 - bare function-like macro calls
+static assert(DOUBLE(5) == 10);
+static assert(BARE_CALL == 10);      // bare call now works
+static assert(PAREN_CALL == 10);     // parenthesized already worked


### PR DESCRIPTION
LLM disclosure: this entire PR is AI-generated. It might be OK, or it might be slop. The fix looks sensible on the surface, and it passes the test suite, however, so does most slop in general. Caveat emptor.

----

## Summary

This PR enables ImportC to convert object-like macros whose value is a bare function-like macro invocation:

```c
#define FUNC(x) ((x) * 2)

#define FAILS FUNC(5)      // Previously: not converted to D
#define WORKS (FUNC(5))    // Already worked: converted to template
```

After this change, both macros are converted to D template functions.

## Problem

ImportC converts `#define` macros to D declarations where possible. For object-like macros with expressions, it creates template functions:

```c
#define X (FUNC(5))    // Converted to: auto X()() { return FUNC(5); }
```

However, when the outer parentheses are omitted, the macro was silently ignored:

```c
#define X FUNC(5)      // Was NOT converted
```

This is purely a syntactic distinction - both macros are semantically identical in C and evaluate to the same value.

## Why the outer parentheses shouldn't matter

### Function call has highest operator precedence

In C, function call `()` has the highest operator precedence. No operator can "steal" the arguments or change the grouping:

```c
#define X FUNC(5)
#define Y (FUNC(5))

int a = X * 2;  // FUNC(5) * 2 - call happens first, then multiply
int b = Y * 2;  // (FUNC(5)) * 2 - identical behavior
```

The parentheses around `FUNC(5)` are redundant when the macro body is just a function call.

### Real-world code doesn't use outer parentheses

Common C libraries define macros without redundant outer parentheses:

**ncurses attributes:**
```c
#define NCURSES_BITS(mask, shift) (/*...*/)
#define A_BOLD NCURSES_BITS(1U, 13)      // No outer parens
#define A_UNDERLINE NCURSES_BITS(1U, 9)  // No outer parens
```

**ncurses reentrant globals:**
```c
extern WINDOW* _nc_stdscr(void);
#define stdscr _nc_stdscr()              // No outer parens
```

These are idiomatic C patterns. Previously, users had to create workarounds:

```c
// Workaround: C enum shim
enum { NC_A_BOLD = A_BOLD };

// Workaround: wrapper function
static inline WINDOW* get_stdscr(void) { return stdscr; }
```

## Implementation

Added a new case in `addDefines()` to handle `TOK.identifier` when parsing macro values. The implementation:

1. Parses the expression starting with the identifier
2. Verifies the entire macro body was consumed (end of line)
3. **Crucially**: Only accepts bare function calls (`exp.isCallExp()`)
4. Creates a template function, same as the parenthesized case

### Why only bare function calls?

Expressions like `FUNC(5) + 1` are intentionally **not** supported because they would have different semantics:

```c
#define X FUNC(5) + 1
```

- **C**: `X * 2` = `FUNC(5) + 1 * 2` = `10 + 2` = `12` (textual substitution)
- **D**: `X() * 2` = `(FUNC(5) + 1) * 2` = `11 * 2` = `22` (expression in function)

By restricting to bare function calls only, we preserve C semantics. Function calls already have highest precedence, so `FUNC(5) * 2` means the same thing in both C and D.

## Test cases

Added tests to `compiler/test/compilable/imports/defines.c` and `compiler/test/compilable/testdefines.d`:

```c
#define DOUBLE(x) ((x) * 2)
#define BARE_CALL DOUBLE(5)      // Now works
#define PAREN_CALL (DOUBLE(5))   // Already worked
```

```d
static assert(DOUBLE(5) == 10);
static assert(BARE_CALL == 10);   // New
static assert(PAREN_CALL == 10);  // Existing
```

## Behavior summary

| Macro | Before | After |
|-------|--------|-------|
| `#define X FUNC(5)` | Not converted | `auto X()() { return FUNC(5); }` |
| `#define X (FUNC(5))` | Converted | Converted (unchanged) |
| `#define X FUNC(5) + 1` | Not converted | Not converted (intentional) |
| `#define X (FUNC(5) + 1)` | Converted | Converted (unchanged) |
