### PR TITLE
Fix scoping and slice update in Array.reserve

### DIFF
--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -205,10 +205,13 @@ public:
                     memcpy(p, data.ptr, length * T.sizeof);
                     memset(data.ptr, 0xFF, data.length * T.sizeof);
                     mem.xfree(data.ptr);
+                    data = p[0 .. allocdim];
                 }
                 else
+                {
                     auto p = cast(T*)mem.xrealloc(data.ptr, allocdim * T.sizeof);
-                data = p[0 .. allocdim];
+                    data = p[0 .. allocdim];
+                }
             }
 
             debug (stomp)


### PR DESCRIPTION
This MR fixes a correctness issue in Array.reserve(), where the slice was rebound
using a pointer declared in a narrower scope.

The code now explicitly updates `data` to point to the newly allocated or
reallocated storage in each branch, ensuring correct variable lifetime and
well-defined behavior.

There is no behavioral change:
- debug(stomp) still uses allocate–copy–stomp–free
- the non-debug path still relies on xrealloc

This change improves correctness and robustness without affecting semantics.

https://github.com/dlang/dmd/pull/22327
https://github.com/dlang/dmd/pull/22284
