### PR TITLE
Move enum class Edition to globals.h

### DIFF
--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -66,6 +66,13 @@ enum JsonFieldFlags
     semantics    = (1 << 3)
 };
 
+enum class Edition : uint16_t
+{
+    v2023 = 2023,
+    v2024,
+    v2025,
+};
+
 enum CppStdRevision
 {
     CppStdRevisionCpp98 = 199711,
@@ -204,7 +211,7 @@ struct Param
     Help help;
     Verbose v;
 
-    unsigned short edition;      // edition year
+    Edition edition;             // edition year
     void* editionFiles;          // Edition corresponding to a filespec
 
     // Options for `-preview=/-revert=`

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -30,13 +30,6 @@ enum PKG
     PKGpackage  // already determined that's an actual package
 };
 
-enum class Edition : uint16_t
-{
-    v2023 = 2023,
-    v2024,
-    v2025,
-};
-
 class Package : public ScopeDsymbol
 {
 public:

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -72,6 +72,7 @@ static void frontend_init()
     global._init();
     global.compileEnv.vendor = "Front-End Tester";
     global.params.objname = NULL;
+    global.params.edition = Edition::v2023;
 
     target.os = Target::OS_linux;
     target.isX86_64 = true;


### PR DESCRIPTION
Allow setting the edition version from the C++ interface.