### PR TITLE
Fix Issue 22254 - ICE on nested assert(0)

### DIFF
--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -2413,7 +2413,9 @@ private void comsub(ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
                 //printf("mMSW = x%x, mLSW = x%x\n", mMSW, mLSW);
                 elem_print(e);
             }
-
+            // Check for the crash operator
+            if (e.Eoper == OPrpair)
+                return;
             assert(OTleaf(e.Eoper));        /* must have both for operators */
             goto reload;
         }

--- a/compiler/test/compilable/issue22254.d
+++ b/compiler/test/compilable/issue22254.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22254
+
+void main() 
+{
+    // This used to cause an ICE (Internal Compiler Error) in the backend
+    assert(assert(0, ""), "");
+}


### PR DESCRIPTION
fix issue #22254 

The backend optimizer (`comsub`) encountered an `OPrpair` (Register Pair) node generated by nested assertions.
Since `OPrpair` is not a leaf node, it triggered the assertion `assert(OTleaf(e.Eoper))`.

This fix explicitly checks for `OPrpair` and returns early, skipping optimization for these nodes, similar to how other non-leaf operators are handled.