### PR TITLE
fix #22153 cannot use forward declaration of static function when building a library

### DIFF
--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -575,16 +575,50 @@ Dsymbol handleSymbolRedeclarations(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsy
         if (fd.fbody)                   // fd is the definition
         {
             if (log) printf(" replace existing with new\n");
-            sds.symtab.update(fd);      // replace fd2 in symbol table with fd
+
+            /* transfer definition to the declaration
+             * for internal resolution for static library
+             * only if they're already matching
+             */
+
+            if (fd.storage_class & STC.static_ &&
+                fd2.storage_class & STC.static_ )
+            {
+                fd.type = typeSemantic(fd.type, fd.loc, &sc);
+                fd2.type = typeSemantic(fd2.type, fd2.loc, &sc);
+
+                auto tfunc1 = fd.type.isTypeFunction();
+                auto tfunc2 = fd2.type.isTypeFunction();
+
+                if ( !cTypeEquivalence(tfunc1.next, tfunc2.next) || !cFuncEquivalence(tfunc1, tfunc2))
+                {
+                    .error(fd.loc, "%s `%s` redeclaration with different type", fd.kind, fd.toPrettyChars);
+                }
+
+                fd2.fbody = fd.fbody;
+                fd.fbody = null;
+
+                fd2.type = fd.type;
+                fd2.parameters = fd.parameters;
+                fd2._linkage = fd._linkage;
+                fd2.storage_class |= fd.storage_class;
+
+                fd.storage_class |= STC.disable; // disable previous definition for backend
+            }
+            else
+            {
+                sds.symtab.update(fd);
+            }
+
             fd.overnext = fd2;
 
             /* If fd2 is covering a tag symbol, then fd has to cover the same one
              */
             auto ps = cast(void*)fd2 in sc._module.tagSymTab;
             if (ps)
-                sc._module.tagSymTab[cast(void*)fd] = *ps;
+                sc._module.tagSymTab[cast(void*)fd2] = *ps;
 
-            return fd;
+            return fd2;
         }
 
         /* Just like with VarDeclaration, the types should match, which needs semantic() to be run on it.

--- a/compiler/test/compilable/fix22153.c
+++ b/compiler/test/compilable/fix22153.c
@@ -1,0 +1,15 @@
+// REQUIRED_ARGS: -lib
+
+// https://github.com/dlang/dmd/issues/22153
+
+
+static void static_fun();
+
+void lib_fun()
+{
+	static_fun();
+}
+
+static void static_fun()
+{
+}


### PR DESCRIPTION
in importC, when building a static library with `-lib`, forward declarations do not get their function refs resolved even if implemented in the same module. the backend however still sticks to using the non-body declaration and hence stops importC from being able to build static libraries. transferring the function def to the top declaration as a replacement method fixes it.

@dkorpel @thewilsonator 

closes #22153 #20152 