### PR TITLE
fix #22354 - aa[key] ~= null discarded

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -18949,8 +18949,12 @@ private Expression rewriteAAIndexAssign(BinExp exp, Scope* sc, ref Type[2] alias
         ekeys[i-1] = extractSideEffect(sc, "__aakey", e0, ekeys[i-1]);
     // some implicit conversions are lost when assigning to a temporary, e.g. from array literal
     auto taa = eaa.type.isTypeAArray();
-    auto match = exp.e2.implicitConvTo(taa.next);
-    auto e2 = match == MATCH.exact || match == MATCH.nomatch ? exp.e2 : exp.e2.implicitCastTo(sc, taa.next);
+    Expression e2 = exp.e2;
+    if (exp.isAssignExp()) // must keep original types for op=
+    {
+        auto match = exp.e2.implicitConvTo(taa.next);
+        e2 = match == MATCH.exact || match == MATCH.nomatch ? exp.e2 : exp.e2.implicitCastTo(sc, taa.next);
+    }
     Expression ev = extractSideEffect(sc, "__aaval", e0, e2); // must be evaluated before the insertion
 
     // generate series of calls to _d_aaGetY

--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -384,6 +384,15 @@ void test21066()
     aa2[[getValue()]] = "a"; // no problem because key type is automatically const(int)[]
 }
 
+void test22354()
+{
+    int[][][string] aa;  // AA with nested array value type
+    int[] elem;
+    aa["x"] = null;
+    aa["x"] ~= null;     // This append is silently lost!
+    assert(aa["x"].length == 1);  // FAILS: length is still 0
+}
+
 /***************************************************/
 
 void main()
@@ -411,4 +420,5 @@ void main()
     test12220();
     test12403();
     test21066();
+    test22354();
 }


### PR DESCRIPTION
don't implicitly cast rhs to value-type for op=