### PR TITLE
Remove branch expressions if the condition is noreturn

### DIFF
--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -2144,6 +2144,10 @@ private elem* elcond(elem* e, Goal goal)
                 el_free(e1);
                 return elcond(e,goal);
             }
+            if (e1.Ety == TYnoreturn)
+            {
+                return el_selecte1(e);
+            }
             if (!OPTIMIZER)
                 break;
 
@@ -2475,6 +2479,12 @@ L2:
         goto L2;
     }
 
+    if (e1.Ety == TYnoreturn)
+    {
+        e = el_selecte1(e);
+        goto Lret;
+    }
+
     if ((OTopeq(e1op) || e1op == OPeq) &&
         (e1.E1.Eoper == OPvar || e1.E1.Eoper == OPind) &&
         !el_sideeffect(e1.E1)
@@ -2775,6 +2785,11 @@ private elem* eloror(elem* e, Goal goal)
         return eloror(e, goal);
     }
 
+    if (e1.Ety == TYnoreturn)
+    {
+        return el_selecte1(e);
+    }
+
     elem* e2 = e.E2;
     if (OTboolnop(e2.Eoper))
     {
@@ -3073,6 +3088,10 @@ private elem* elandand(elem* e, Goal goal)
         e1.E1 = null;
         el_free(e1);
         return elandand(e, goal);
+    }
+    if (e1.Ety == TYnoreturn)
+    {
+        return el_selecte1(e);
     }
     elem* e2 = e.E2;
     if (OTboolnop(e2.Eoper))

--- a/compiler/test/compilable/issue22254.d
+++ b/compiler/test/compilable/issue22254.d
@@ -1,0 +1,6 @@
+// https://github.com/dlang/dmd/issues/22254
+
+void main()
+{
+    assert(assert(0, ""), "");
+}


### PR DESCRIPTION
It's simply impossible to put `noreturn` values into a register, so this PR replaces all `noreturn() ? a : b` with `noreturn()`. Fixes #22254. Please leave a comment if anyone knows of any code that depends on execution continuing after noreturn calls.

ping @WalterBright 