### PR TITLE
Improve error message when symbol lookup fails, show where the suggested symbol is located at

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15144,7 +15144,10 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
             if (s.isPackage())
                 error(exp.loc, "undefined identifier `%s` in %s `%s`, perhaps add `static import %s;`", exp.ident.toChars(), ie.sds.kind(), ie.sds.toPrettyChars(), s.toPrettyChars());
             else
+            {
                 error(exp.loc, "undefined identifier `%s` in %s `%s`, did you mean %s `%s`?", exp.ident.toChars(), ie.sds.kind(), ie.sds.toPrettyChars(), s.kind(), s.toChars());
+                errorSupplemental(s.loc, "`%s` located here", s.toPrettyChars(true));
+            }
         }
         else
             error(exp.loc, "undefined identifier `%s` in %s `%s`", exp.ident.toChars(), ie.sds.kind(), ie.sds.toPrettyChars());

--- a/compiler/test/fail_compilation/diag14235.d
+++ b/compiler/test/fail_compilation/diag14235.d
@@ -2,9 +2,10 @@
 EXTRA_FILES: imports/a14235.d
 TEST_OUTPUT:
 ---
-fail_compilation/diag14235.d(12): Error: undefined identifier `Undefined` in module `imports.a14235`
-fail_compilation/diag14235.d(13): Error: undefined identifier `Something` in module `imports.a14235`, did you mean struct `SomeThing(T...)`?
-fail_compilation/diag14235.d(14): Error: `SomeClass` isn't a template
+fail_compilation/diag14235.d(13): Error: undefined identifier `Undefined` in module `imports.a14235`
+fail_compilation/diag14235.d(14): Error: undefined identifier `Something` in module `imports.a14235`, did you mean struct `SomeThing(T...)`?
+fail_compilation/imports/a14235.d(3):        `imports.a14235.SomeThing(T...)` located here
+fail_compilation/diag14235.d(15): Error: `SomeClass` isn't a template
 ---
 */
 


### PR DESCRIPTION
This is in response to: https://github.com/dlang/dmd/issues/22371

Improve the error message so that we get the location of the suggested symbol.

I don't think that I've got this as good as it should be. @Iskaban10 @thewilsonator 

<img width="782" height="118" alt="image" src="https://github.com/user-attachments/assets/a6e4fc88-0df2-46aa-8319-8d85066ab158" />

The only reason I'm PR'ing it now is I suspect that I won't make it be better than this.