### PR TITLE
allow including core.sys.linux.net.if_ and core.sys.linux.hdlc.ioctl …

### DIFF
--- a/druntime/src/core/sys/linux/hdlc/ioctl.d
+++ b/druntime/src/core/sys/linux/hdlc/ioctl.d
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
 module core.sys.linux.hdlc.ioctl;
 
+version (linux):
 import core.sys.linux.net.if_ : IFNAMSIZ;
 
-version (linux):
 extern(C):
 @nogc:
 nothrow:

--- a/druntime/src/core/sys/linux/net/if_.d
+++ b/druntime/src/core/sys/linux/net/if_.d
@@ -6,10 +6,10 @@
  +/
 module core.sys.linux.net.if_;
 
+version (linux):
 public import core.sys.posix.sys.socket : sockaddr;
 public import core.sys.linux.hdlc.ioctl;
 
-version (linux):
 extern(C):
 @nogc:
 nothrow:


### PR DESCRIPTION
…in the build on platforms other than linux

selective imports require the requested symbol to be defined, but it is not for mismatched versions