### PR TITLE
fix #22381 - out-of-bounds access when masking ushort

### DIFF
--- a/compiler/src/dmd/backend/x86/cod4.d
+++ b/compiler/src/dmd/backend/x86/cod4.d
@@ -1057,13 +1057,19 @@ void cdaddass(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
                 switch (op)
                 {   case OPorass:
                     case OPxorass:
-                        cs.IEV2.Vsize_t &= 0xFFFF;
-                        cs.Iflags &= ~CFopsize; // don't worry about MSW
+                        if ((cs.Irm & 0xC0) == 0xC0)    // EA is register
+                        {
+                            cs.IEV2.Vsize_t &= 0xFFFF;
+                            cs.Iflags &= ~CFopsize; // don't worry about MSW
+                        }
                         break;
 
                     case OPandass:
-                        cs.IEV2.Vsize_t |= ~0xFFFFL;
-                        cs.Iflags &= ~CFopsize; // don't worry about MSW
+                        if ((cs.Irm & 0xC0) == 0xC0)    // EA is register
+                        {
+                            cs.IEV2.Vsize_t |= ~0xFFFFL;
+                            cs.Iflags &= ~CFopsize; // don't worry about MSW
+                        }
                         break;
 
                     case OPminass:

--- a/compiler/test/compilable/test22381.d
+++ b/compiler/test/compilable/test22381.d
@@ -1,0 +1,17 @@
+/*
+DISABLED: osx
+REQUIRED_ARGS: -vasm
+TEST_OUTPUT:
+---
+_D9test223814maskFPtZv:
+0000:   $r:[0-9A-F ]*$and       word ptr [$r:[A-Z]*$],0FFFEh
+0005:   C3                       ret
+---
+*/
+
+// https://github.com/dlang/dmd/issues/22381
+
+void mask(ushort* p)
+{
+    *p &= 0xfffe;
+}


### PR DESCRIPTION
ignoring access width is only valid for registers, not for memory

Not really knowing the backend well, so better targeting master. The bug exists at least since dmd 2.066.