### PR TITLE
importC: properly fix #22153 and #22365

### DIFF
--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -465,7 +465,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     scope (exit) timeTraceEndEvent(TimeTraceEventType.codegenFunction, fd);
 
     if (multiobj && !fd.isStaticDtorDeclaration() && !fd.isStaticCtorDeclaration()
-        && !(fd.isCrtCtor || fd.isCrtDtor))
+        && !(fd.isCrtCtor || fd.isCrtDtor) && !(fd.storage_class & STC.static_ && fd.isCsymbol()))
     {
         obj_append(fd);
         return;

--- a/compiler/test/compilable/fix22153.c
+++ b/compiler/test/compilable/fix22153.c
@@ -5,6 +5,8 @@
 
 static void static_fun();
 
+void (*funcptr)() = &static_fun;
+
 void lib_fun()
 {
 	static_fun();


### PR DESCRIPTION
Revert #22360 and actually this is the simple backend fix needed. make sure the static symbols actually get symbolized fully in backend to avoid unknown symbols in DMD especially when multiobj is expected. closes #22365 

@thewilsonator @dkorpel 