### PR TITLE
Break dependency of `dmodule` on  `doc`

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -26,7 +26,6 @@ import dmd.compiler;
 import dmd.cparse;
 import dmd.declaration;
 import dmd.dmacro;
-import dmd.doc;
 import dmd.dsymbol;
 import dmd.errors;
 import dmd.expression;
@@ -394,7 +393,7 @@ extern (C++) final class Module : Package
     Identifiers* versionidsNot; // forward referenced version identifiers
 
     MacroTable macrotable;      // document comment macros
-    Escape* _escapetable;       // document comment escapes
+    void* _escapetable;         // document comment escapes (Escape*)
 
     size_t nameoffset;          // offset of module name from start of ModuleInfo
     size_t namelen;             // length of module name in characters
@@ -1020,15 +1019,6 @@ extern (C++) final class Module : Package
         }
     }
 
-    /** Lazily initializes and returns the escape table.
-    Turns out it eats a lot of memory.
-    */
-    extern(D) Escape* escapetable() nothrow
-    {
-        if (!_escapetable)
-            _escapetable = new Escape();
-        return _escapetable;
-    }
 }
 
 /***********************************************************

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -54,16 +54,6 @@ import dmd.tokens;
 import dmd.visitor;
 
 
-/** Lazily initializes and returns the escape table.
-Turns out it eats a lot of memory.
-*/
-Escape* escapetable(Module _this) nothrow
-{
-    if (!_this._escapetable)
-        _this._escapetable = new Escape();
-    return cast(Escape*) _this._escapetable;
-}
-
 /****************************************************
  * Generate Ddoc text for Module `m` and append it to `outbuf`.
  * Params:
@@ -221,44 +211,6 @@ public
 void gendocfile(Module m, const char* ddoctext_ptr, size_t ddoctext_length, const char* datetime, ErrorSink eSink, ref OutBuffer outbuf)
 {
     gendocfile(m, ddoctext_ptr[0 .. ddoctext_length], datetime, eSink, outbuf);
-}
-
-public
-struct Escape
-{
-    const(char)[][char.max] strings;
-
-    /***************************************
-     * Find character string to replace c with.
-     */
-    const(char)[] escapeChar(char c) @safe
-    {
-        version (all)
-        {
-            //printf("escapeChar('%c') => %p, %p\n", c, strings, strings[c].ptr);
-            return strings[c];
-        }
-        else
-        {
-            const(char)[] s;
-            switch (c)
-            {
-            case '<':
-                s = "&lt;";
-                break;
-            case '>':
-                s = "&gt;";
-                break;
-            case '&':
-                s = "&amp;";
-                break;
-            default:
-                s = null;
-                break;
-            }
-            return s;
-        }
-    }
 }
 
 /***********************************************************
@@ -670,6 +622,53 @@ struct DocComment
 }
 
 private:
+
+/** Lazily initializes and returns the escape table.
+Turns out it eats a lot of memory.
+*/
+Escape* escapetable(Module _this) nothrow
+{
+    if (!_this._escapetable)
+        _this._escapetable = new Escape();
+    return cast(Escape*) _this._escapetable;
+}
+
+struct Escape
+{
+    const(char)[][char.max] strings;
+
+    /***************************************
+     * Find character string to replace c with.
+     */
+    const(char)[] escapeChar(char c) @safe
+    {
+        version (all)
+        {
+            //printf("escapeChar('%c') => %p, %p\n", c, strings, strings[c].ptr);
+            return strings[c];
+        }
+        else
+        {
+            const(char)[] s;
+            switch (c)
+            {
+            case '<':
+                s = "&lt;";
+                break;
+            case '>':
+                s = "&gt;";
+                break;
+            case '&':
+                s = "&amp;";
+                break;
+            default:
+                s = null;
+                break;
+            }
+            return s;
+        }
+    }
+}
 
 /***********************************************************
  */

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -53,6 +53,17 @@ import dmd.root.utf;
 import dmd.tokens;
 import dmd.visitor;
 
+
+/** Lazily initializes and returns the escape table.
+Turns out it eats a lot of memory.
+*/
+Escape* escapetable(Module _this) nothrow
+{
+    if (!_this._escapetable)
+        _this._escapetable = new Escape();
+    return cast(Escape*) _this._escapetable;
+}
+
 /****************************************************
  * Generate Ddoc text for Module `m` and append it to `outbuf`.
  * Params:

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -129,7 +129,6 @@ class Statement;
 class TryFinallyStatement;
 class ScopeGuardStatement;
 class ErrorSink;
-struct DocComment;
 class WithStatement;
 struct AA;
 class CaseStatement;
@@ -7088,7 +7087,7 @@ public:
         argStruct()
     {
     }
-    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* switchStatement = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tryFinally = nullptr, ScopeGuardStatement* scopeGuard = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), STC stc = (STC)0LLU, DeprecatedDeclaration* depdecl = nullptr, uint16_t bitFields = 0u, uint16_t bitFields2 = 0u, Previews previews = Previews(), UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr, StructDeclaration* argStruct = nullptr) :
+    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* switchStatement = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tryFinally = nullptr, ScopeGuardStatement* scopeGuard = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), STC stc = (STC)0LLU, DeprecatedDeclaration* depdecl = nullptr, uint16_t bitFields = 0u, uint16_t bitFields2 = 0u, Previews previews = Previews(), UserAttributeDeclaration* userAttribDecl = nullptr, void* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr, StructDeclaration* argStruct = nullptr) :
         enclosing(enclosing),
         _module(_module),
         scopesym(scopesym),

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -123,7 +123,6 @@ struct IntRange;
 struct ModuleDeclaration;
 template <typename Datum>
 struct FileMapping;
-struct Escape;
 class LabelStatement;
 class SwitchStatement;
 class Statement;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6929,7 +6929,7 @@ public:
     Array<Identifier* >* versionids;
     Array<Identifier* >* versionidsNot;
     MacroTable macrotable;
-    Escape* _escapetable;
+    void* _escapetable;
     size_t nameoffset;
     size_t namelen;
     static Module* create(const char* filename, Identifier* ident, int32_t doDocComment, int32_t doHdrGen);

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -108,7 +108,7 @@ public:
     Identifiers *versionidsNot; // forward referenced version identifiers
 
     MacroTable macrotable;      // document comment macros
-    Escape *escapetable;        // document comment escapes
+    void *escapetable;          // document comment escapes (Escape*)
 
     size_t nameoffset;          // offset of module name from start of ModuleInfo
     size_t namelen;             // length of module name in characters


### PR DESCRIPTION
Move `Module.escapetable()` to `doc` 