### PR TITLE
fix #22386 - Indexed initialization of multi dimensional const array does not compile.

### DIFF
--- a/compiler/test/runnable/b10562.d
+++ b/compiler/test/runnable/b10562.d
@@ -90,4 +90,12 @@ void main()
         // arr = slice;
         // assert(arr == [[ slice, slice, slice ], [ slice, slice, slice ]]);
     }
+    {
+        // https://github.com/dlang/dmd/issues/22386
+        const int[3][2] a = [[1:2, 3],[0: 0, 1:2, 2:3]];
+        assert(a == [ [ 0, 2, 3 ], [ 0, 2, 3 ] ]);
+
+        const int[3][2] b = [[1:2, 2:3],[0: 0, 1:2, 2:3]];
+        assert(b == [ [ 0, 2, 3 ], [ 0, 2, 3 ] ]);
+    }
 }


### PR DESCRIPTION
pass the element type to initializerToExpression() for the element if the dimensions for type and initializer match