### PR TITLE
Don't drop aggregate type qualifier for alias parameter

### DIFF
--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -2778,7 +2778,9 @@ private MATCH matchArg(TemplateParameter tp, Scope* sc, RootObject oarg, size_t 
             if (!sa || si != sa)
                 return matchArgNoMatch();
         }
-        dedtypes[i] = sa;
+        // Note: Dsymbol can't have type qualifiers, so use type if it has them
+        // https://github.com/dlang/dmd/issues/17959
+        dedtypes[i] = ta && ta.mod ? ta : sa;
 
         if (psparam)
         {

--- a/compiler/test/compilable/alias_param_qual.d
+++ b/compiler/test/compilable/alias_param_qual.d
@@ -1,0 +1,7 @@
+alias t(alias a) = a;
+
+static assert(is(t!(const Object) == const Object));
+static assert(is(t!(shared(Object)) == shared Object));
+static assert(is(t!(immutable S) == immutable(S)));
+
+struct S {}


### PR DESCRIPTION
Reboot of #11320.
Fixes https://github.com/dlang/dmd/issues/17959.

I'm going to see what this breaks first, then maybe enable the change from the 2024 edition.