### PR TITLE
fix #22383 - bitfield .init value contains void elements

### DIFF
--- a/compiler/test/compilable/test22383.d
+++ b/compiler/test/compilable/test22383.d
@@ -1,0 +1,12 @@
+struct T22383
+{
+    int a = 4;
+    int b : 16;
+    int c : 8;
+    int d : 4;
+    int e : 2;
+    int f : 1;
+    int g : 1;
+    int h = 8;
+}
+static assert(T22383.init == T22383(4,0,0,0,0,0,0,8));


### PR DESCRIPTION
`defaultInit` wasn't adapted to deal with bitfields.

Closes #22383.