### PR TITLE
Fix 22384 - Add support for default values in C-style bitfields

### DIFF
--- a/changelog/dmd.bitfield-default-init.dd
+++ b/changelog/dmd.bitfield-default-init.dd
@@ -1,0 +1,16 @@
+Support for default values in C-style bitfields
+
+D now supports specifying default values for C-style bitfields in structs and classes.
+This brings valid D code closer to behavior allowed in C++20 and allows for more concise initialization of bitfield members.
+
+Value range checking is performed at compile-time to ensure the default value fits within the specified number of bits.
+
+-------
+struct S
+{
+    int a : 4 = 2;   // OK
+    int b : 2 = 5;   // Error: bitfield initializer `5` does not fit in 2 bits
+    uint c : 1 = 1;  // OK
+    bool d : 1 = 1;  // OK
+}
+-------

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -539,10 +539,9 @@ struct ASTBase
         uint fieldWidth;
         uint bitOffset;
 
-        final extern (D) this(Loc loc, Type type, Identifier id, Expression width)
+        final extern (D) this(Loc loc, Type type, Identifier id, Expression width, Initializer _init = null)
         {
-            super(loc, type, id, cast(Initializer)null, cast(StorageClass)STC.none);
-
+            super(loc, type, id, _init, cast(StorageClass)STC.none);
             this.width = width;
             this.storage_class |= STC.field;
         }

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -663,9 +663,9 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
     uint fieldWidth;
     uint bitOffset;
 
-    final extern (D) this(Loc loc, Type type, Identifier ident, Expression width)
+    final extern (D) this(Loc loc, Type type, Identifier ident, Expression width, Initializer _init = null)
     {
-        super(loc, type, ident, null);
+        super(loc, type, ident, _init);
         this.dsym = DSYM.bitFieldDeclaration;
         this.width = width;
         this.storage_class |= STC.field;
@@ -675,7 +675,7 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
     {
         //printf("BitFieldDeclaration::syntaxCopy(%s)\n", toChars());
         assert(!s);
-        auto bf = new BitFieldDeclaration(loc, type ? type.syntaxCopy() : null, ident, width.syntaxCopy());
+        auto bf = new BitFieldDeclaration(loc, type ? type.syntaxCopy() : null, ident, width.syntaxCopy(), _init ? _init.syntaxCopy() : null);
         bf.comment = comment;
         return bf;
     }

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3174,6 +3174,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dsym.semanticRun >= PASS.semanticdone)
             return;
 
+        if (dsym.isAnonymous() && dsym._init)
+        {
+             .error(dsym.loc, "anonymous bitfield cannot have default initializer");
+             dsym._init = null;
+        }
+
         visit(cast(VarDeclaration)dsym);
         if (dsym.errors)
             return;

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -1002,13 +1002,32 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
                 auto value = ie.getInteger();
                 const width = bf.fieldWidth;
                 const mask = (1L << width) - 1;
-                bitFieldValue = (bitFieldValue & ~(mask << bitOffset)) | ((value & mask) << bitOffset);
+                bitFieldValue = (bitFieldValue & ~(mask << bf.bitOffset)) | ((value & mask) << bf.bitOffset);
                 //printf("bitFieldValue x%llx\n", bitFieldValue);
             }
             else
                 Expression_toDt(e, dtbx);    // convert e to an initializer dt
         }
-        else if (!bf)
+        else if (bf)
+        {
+            if (Initializer init = vd._init)
+            {
+                if (init.isVoidInitializer())
+                    continue;
+
+                assert(vd.semanticRun >= PASS.semantic2done);
+                auto ei = init.isExpInitializer();
+                assert(ei);
+                auto ie = ei.exp.isIntegerExp();
+                assert(ie);
+
+                auto value = ie.getInteger();
+                const width = bf.fieldWidth;
+                const mask = (1L << width) - 1;
+                bitFieldValue = (bitFieldValue & ~(mask << bf.bitOffset)) | ((value & mask) << bf.bitOffset);
+            }
+        }
+        else
         {
             if (Initializer init = vd._init)
             {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4792,11 +4792,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 AST.Dsymbol s;
                 if (width)
                 {
-                    if (_init)
-                        error("initializer not allowed for bitfield declaration");
                     if (storage_class)
                         error("storage class not allowed for bitfield declaration");
-                    s = new AST.BitFieldDeclaration(loc, t, ident, width);
+                    s = new AST.BitFieldDeclaration(loc, t, ident, width, _init);
                 }
                 else
                 {

--- a/compiler/test/fail_compilation/biterrors.d
+++ b/compiler/test/fail_compilation/biterrors.d
@@ -1,7 +1,6 @@
 /*
  * TEST_OUTPUT:
 ---
-fail_compilation/biterrors.d(103): Error: initializer not allowed for bitfield declaration
 fail_compilation/biterrors.d(104): Error: storage class not allowed for bitfield declaration
 ---
  */

--- a/compiler/test/fail_compilation/fail22384.d
+++ b/compiler/test/fail_compilation/fail22384.d
@@ -1,0 +1,47 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail22384.d(32): Error: bitfield `z` has zero width
+fail_compilation/fail22384.d(36): Error: bitfield type `float` is not an integer type
+fail_compilation/fail22384.d(36): Error: bitfield `f` has zero width
+fail_compilation/fail22384.d(37): Error: bitfield type `float` is not an integer type
+fail_compilation/fail22384.d(38): Error: bitfield type `float` is not an integer type
+fail_compilation/fail22384.d(39): Error: bitfield type `float` is not an integer type
+fail_compilation/fail22384.d(44): Error: anonymous bitfield cannot have default initializer
+fail_compilation/fail22384.d(21): Error: bitfield initializer `4294967295u` does not fit in 4 bits
+fail_compilation/fail22384.d(26): Error: bitfield initializer `E.B` does not fit in 2 bits
+fail_compilation/fail22384.d(30): Error: bitfield initializer `4` does not fit in 3 bits
+fail_compilation/fail22384.d(31): Error: bitfield initializer `65` does not fit in 7 bits
+fail_compilation/fail22384.d(43): Error: cannot implicitly convert expression `4.2F` of type `float` to `int`
+fail_compilation/fail22384.d(45): Error: bitfield initializer `65` does not fit in 7 bits
+fail_compilation/fail22384.d(46): Error: cannot implicitly convert expression `42` of type `int` to `bool`
+---
+*/
+struct S {
+    uint d : 4 = -1;
+}
+
+enum E : int { A = 1, B = 2 }
+struct EFail {
+    E b : 2 = E.B;
+}
+
+struct IFail {
+    int x : 3 = 4;
+    int y : 7 = 65;
+    int z : 0 = 1;
+}
+
+struct FloatFail {
+    float f : 0;
+    float f2 : 7;
+    float f3 : 7 = 4;
+    float f4 : 7 = 4.2f;
+}
+
+struct InitFail {
+    int i : 7 = 4.2f;
+    ubyte : 8 = 4.2f;
+    int j : 7 = 'A';
+    bool b : 7 = 42;
+}

--- a/compiler/test/runnable/test22384.d
+++ b/compiler/test/runnable/test22384.d
@@ -1,0 +1,49 @@
+//https://github.com/dlang/dmd/issues/22384
+struct S
+{
+    int a = 1;
+    int b : 16 = 2;
+    int c : 16 = 3;
+    int d = 4;
+}
+
+struct T
+{
+    int a = 1;       // .long 1
+    int b : 4 = 2;   // .byte 0x32 (b=2, c=3 merged)
+    int c : 4 = 3;
+    int d : 8 = 4;   // .byte 0x04
+    int e : 4 = 5;   // .byte 0x65 (e=5, f_low=6 merged)
+    int f : 12 = 6;  // .byte 0x00 (f_high)
+    int g = 7;       // .long 7
+}
+
+struct M
+{
+    int a : 4 = 1;
+    int   : 4;
+    int b : 4 = 2;
+}
+
+S s;
+T t;
+M m;
+
+void main()
+{
+    assert(s.a == 1);
+    assert(s.b == 2);
+    assert(s.c == 3);
+    assert(s.d == 4);
+
+    assert(t.a == 1);
+    assert(t.b == 2);
+    assert(t.c == 3);
+    assert(t.d == 4);
+    assert(t.e == 5);
+    assert(t.f == 6);
+    assert(t.g == 7);
+
+    assert(m.a == 1);
+    assert(m.b == 2);
+}


### PR DESCRIPTION
This implements parsing, semantic analysis, and backend support for default initializers in bitfields.

- Modified 'declaration.d' & 'parse.d' to parse assignment expressions after bitfield width.
- Updated 'dsymbolsem.d' to validate initializers and check for overflows.
- Updated 'todt.d' to pack default values into the binary representation.
- Added regression tests.