### PR TITLE
Fix 22397 - Internal Error: array literal with UDA cause failure

### DIFF
--- a/compiler/test/compilable/issue22397.d
+++ b/compiler/test/compilable/issue22397.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS:
+/*
+TEST_OUTPUT:
+---
+---
+*/
+void main()
+{
+    enum var = true;
+    @var string[] list = ["A", "B", "C"];
+
+    // Also test explicitly with @(value) syntax
+    @(1) int[] list2 = [1, 2, 3];
+}

--- a/compiler/test/fail_compilation/test22397.d
+++ b/compiler/test/fail_compilation/test22397.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test22397.d(13): Error: this array literal causes a GC allocation in `@nogc` function `main`
+fail_compilation/test22397.d(14): Error: this array literal causes a GC allocation in `@nogc` function `main`
+fail_compilation/test22397.d(15): Error: this array literal causes a GC allocation in `@nogc` function `main`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22397
+@nogc void main()
+{
+    @("uda") int[] a = [1, 2];      // should error
+    align(8) int[] b = [3, 4];      // should error
+    extern(C) int[] c = [5, 6];     // should error
+}


### PR DESCRIPTION
The backend expect dynamic array literals to be lowered to runtine calls by the frontend. when a variable declaration have a UDA, the lowering logic get bypassed or not get triggered, causing an assertion failure in 'e2ir.d'.