### PR TITLE
Fix source location of bitfield declarations

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3195,7 +3195,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!dsym.type.isIntegral())
         {
             // C11 6.7.2.1-5
-            error(width.loc, "bitfield type `%s` is not an integer type", dsym.type.toChars());
+            error(dsym.loc, "bitfield type `%s` is not an integer type", dsym.type.toChars());
             dsym.errors = true;
         }
         if (!width.isIntegerExp())

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4796,7 +4796,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         error("initializer not allowed for bitfield declaration");
                     if (storage_class)
                         error("storage class not allowed for bitfield declaration");
-                    s = new AST.BitFieldDeclaration(width.loc, t, ident, width);
+                    s = new AST.BitFieldDeclaration(loc, t, ident, width);
                 }
                 else
                 {

--- a/compiler/test/fail_compilation/biterrors2.d
+++ b/compiler/test/fail_compilation/biterrors2.d
@@ -1,9 +1,15 @@
-/*
+/* REQUIRED_ARGS: -verrors=context
  * TEST_OUTPUT:
 ---
 fail_compilation/biterrors2.d(100): Error: variable `biterrors2.a` - bitfield must be member of struct, union, or class
+int a : 2;
+    ^
 fail_compilation/biterrors2.d(104): Error: bitfield `b` has zero width
+    int b:0;
+          ^
 fail_compilation/biterrors2.d(105): Error: bitfield type `float` is not an integer type
+    float c:3;
+          ^
 ---
 */
 


### PR DESCRIPTION
The declaration location should be the file source location of the identifier, not the width expression.