### PR TITLE
set WithArgTypes for AArch64

### DIFF
--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -640,8 +640,8 @@ void getlvalue(ref CodeBuilder cdb,ref code pcs,elem* e,regm_t keepmsk,RM rm = R
     tym_t e1ty;
     Symbol* s;
 
-    printf("getlvalue(e = %p, keepmsk = %s)\n", e, regm_str(keepmsk));
-    elem_print(e);
+    //printf("getlvalue(e = %p, keepmsk = %s)\n", e, regm_str(keepmsk));
+    //elem_print(e);
     assert(e);
     elem_debug(e);
     if (e.Eoper == OPvar || e.Eoper == OPrelconst)
@@ -1862,7 +1862,7 @@ void cdfunc(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
         Parameter* p = &parameters[i];
         elem* ep = p.e;
         reg_t preg = p.reg;
-        printf("\nparameter[%d]: %s\n", i, regm_str(mask(preg)));
+        //printf("\nparameter[%d]: %s\n", i, regm_str(mask(preg)));
         if (preg == NOREG)
         {
             //elem_print(ep);

--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -1563,7 +1563,7 @@ bool orr_solution(ulong value, out uint N, out uint immr, out uint imms)
 @trusted
 void assignaddrc(code* c)
 {
-    printf("assignaddrc()\n");
+    //printf("assignaddrc()\n");
     int sn;
     Symbol* s;
     ubyte rm;
@@ -1653,7 +1653,7 @@ void assignaddrc(code* c)
         s = c.IEV1.Vsym;
         uint sz = 8;
         uint ins = c.Iop;
-        if (c.IFL1 != FL.unde)
+        if (0 && c.IFL1 != FL.unde)
         {
             printf("FL: %-8s ", fl_str(c.IFL1));
             disassemble(ins);

--- a/compiler/src/dmd/backend/arm/cod4.d
+++ b/compiler/src/dmd/backend/arm/cod4.d
@@ -56,8 +56,8 @@ nothrow:
 @trusted
 void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
-    printf("cdeq(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
-    elem_print(e);
+    //printf("cdeq(e = %p, pretregs = %s)\n",e,regm_str(pretregs));
+    //elem_print(e);
 
     reg_t reg;
     code cs;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -8398,8 +8398,8 @@ private extern(C++) class SetFieldOffsetVisitor : Visitor
             ad.structsize, ad.alignsize,
             isunion);
 
-        //printf("\t%s: memalignsize = %d\n", toChars(), memalignsize);
-        //printf(" addField '%s' to '%s' at offset %d, size = %d\n", toChars(), ad.toChars(), offset, memsize);
+        //printf("\t%s: memalignsize = %d\n", vd.toChars(), memalignsize);
+        //printf(" addField '%s' to '%s' at offset %d, size = %d\n", vd.toChars(), ad.toChars(), fieldState.offset, memsize);
     }
 
     override void visit(BitFieldDeclaration bfd)

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -990,6 +990,7 @@ uint baseVtblOffset(ClassDeclaration cd, BaseClass* bc)
 {
     //printf("ClassDeclaration.baseVtblOffset('%s', bc = %p)\n", cd.toChars(), bc);
     uint csymoffset = target.classinfosize;    // must be ClassInfo.size
+    //printf("target.classinfosize: %d\n", csymoffset);
     csymoffset += cd.vtblInterfaces.length * (4 * target.ptrsize);
 
     for (size_t i = 0; i < cd.vtblInterfaces.length; i++)

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -457,6 +457,8 @@ extern (C++) struct Target
         if (isLP64 || isAArch64)
         {
             ptrsize = 8;
+            /* This is affected by version WithArgTypes in object.d
+             */
             classinfosize = 0x98+16; // 168
         }
 

--- a/compiler/test/fail_compilation/fail_opover.d
+++ b/compiler/test/fail_compilation/fail_opover.d
@@ -4,7 +4,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail_opover.d(39): Error: no `[]` operator overload for type `object.Object`
-$p:object.d$(110):        perhaps define `auto opIndex() {}` for `object.Object`
+$p:object.d$(111):        perhaps define `auto opIndex() {}` for `object.Object`
 fail_compilation/fail_opover.d(43): Error: no `[]` operator overload for type `TestS`
 fail_compilation/fail_opover.d(41):        perhaps define `auto opIndex() {}` for `fail_opover.test1.TestS`
 fail_compilation/fail_opover.d(55): Error: no `[]` operator overload for type `S`

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -97,7 +97,8 @@ else version (X86_64)
 else version (AArch64)
 {
     // Apple uses a trivial varargs implementation
-    version (OSX) {}
+    version (DigitalMars) version = WithArgTypes; // is this needed?
+    else version (OSX) {}
     else version (iOS) {}
     else version (TVOS) {}
     else version (WatchOS) {}


### PR DESCRIPTION
This problem surfaced as a size mismatch in TypeInfo, as druntime says one thing and target.d another. There remains some question about whether WithArgTypes is needed or not.