### PR TITLE
Fix Issue 22394 - Show instantiation trace for lambda errors

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1463,6 +1463,10 @@ extern (D) Expression incompatibleTypes(BinExp e, Scope* sc = null)
         error(e.loc, "incompatible types for `(%s) %s (%s)`: `%s` and `%s`",
             e.e1.toErrMsg(), thisOp, e.e2.toErrMsg(), ts[0], ts[1]);
     }
+
+    if (sc && sc.tinst)
+        sc.tinst.printInstantiationTrace();
+
     return ErrorExp.get();
 }
 

--- a/compiler/test/fail_compilation/ice11850.d
+++ b/compiler/test/fail_compilation/ice11850.d
@@ -1,8 +1,8 @@
 /*
-EXTRA_FILES: imports/a11850.d
 TEST_OUTPUT:
 ---
 fail_compilation/ice11850.d(15): Error: incompatible types for `(a) < ([0])`: `uint[]` and `int[]`
+fail_compilation/imports/a11850.d(23):        instantiated from here: `__lambda_L15_C13!(uint[])`
 fail_compilation/imports/a11850.d(9):        instantiated from here: `FilterResult!(__lambda_L15_C13, uint[][])`
 fail_compilation/ice11850.d(15):        instantiated from here: `filter!(uint[][])`
 ---

--- a/compiler/test/fail_compilation/issue22394.d
+++ b/compiler/test/fail_compilation/issue22394.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/issue22394.d(11): Error: incompatible types for `(a) + (1)`: `string` and `int`
+fail_compilation/issue22394.d(15):        instantiated from here: `__lambda_L11_C1!string`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22394
+
+alias l = a => a + 1;
+
+void f()
+{
+    l("");
+}


### PR DESCRIPTION
fix issue #22394 
The compiler was missing the template instantiation trace when reporting incompatible type errors inside a lambda.
This change ensures `sc.tinst.printInstantiationTrace()` is called in `incompatibleTypes` (expressionsem.d) if a template instance exists in the scope.
