### PR TITLE
fix #22406 - [REG 2.112] Error: function '_d_aaLen' is not callable …

### DIFF
--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -393,6 +393,40 @@ void test22354()
     assert(aa["x"].length == 1);  // FAILS: length is still 0
 }
 
+// https://github.com/dlang/dmd/issues/22406
+void testShared()
+{
+    shared int[int] processes = [1: 1, 2:4, 3:9];
+
+    cast(void)processes.sizeof;
+    cast(void)processes.length;
+    cast(void)processes.dup;
+    cast(void)processes.rehash;
+    //cast(void)processes.clear;
+    //cast(void)processes.keys;
+    //cast(void)processes.values;
+    //cast(void)processes.byKey;
+    //cast(void)processes.byValue;
+    //cast(void)processes.byKeyValue;
+    processes.remove(3);
+    assert(2 in processes);
+
+    immutable int[int] iprocesses = [1: 1, 2:4, 3:9];
+
+    cast(void)iprocesses.sizeof;
+    cast(void)iprocesses.length;
+    cast(void)iprocesses.dup;
+    //cast(void)iprocesses.rehash;
+    //cast(void)iprocesses.clear;
+    cast(void)iprocesses.keys;
+    cast(void)iprocesses.values;
+    cast(void)iprocesses.byKey;
+    cast(void)iprocesses.byValue;
+    cast(void)iprocesses.byKeyValue;
+    //iprocesses.remove(3);
+    assert(2 in iprocesses);
+}
+
 /***************************************************/
 
 void main()
@@ -421,4 +455,5 @@ void main()
     test12403();
     test21066();
     test22354();
+    testShared();
 }

--- a/druntime/src/core/internal/newaa.d
+++ b/druntime/src/core/internal/newaa.d
@@ -458,6 +458,18 @@ size_t _d_aaLen(K, V)(inout V[K] a)
     auto aa = _toAA!(K, V)(a);
     return aa ? aa.length : 0;
 }
+/// ditto
+size_t _d_aaLen(K, V)(shared V[K] a)
+{
+    // accept shared for backward compatibility, should be deprecated
+    return _d_aaLen(cast(V[K]) a);
+}
+/// ditto
+size_t _d_aaLen(K, V)(const shared V[K] a)
+{
+    // accept shared for backward compatibility, should be deprecated
+    return _d_aaLen(cast(V[K]) a);
+}
 
 /******************************
  * Lookup key in aa.
@@ -625,6 +637,18 @@ auto _d_aaIn(T : V[K], K, V, K2)(inout T a, auto ref scope K2 key)
     if (auto p = aa.findSlotLookup(hash, key2))
         return &p.entry.value;
     return null;
+}
+/// ditto
+auto _d_aaIn(T : V[K], K, V, K2)(shared T a, auto ref scope K2 key)
+{
+    // accept shared for backward compatibility, should be deprecated
+    return _d_aaIn(cast(V[K]) a, key);
+}
+/// ditto
+auto _d_aaIn(T : V[K], K, V, K2)(const shared T a, auto ref scope K2 key)
+{
+    // accept shared for backward compatibility, should be deprecated
+    return _d_aaIn(cast(V[K]) a, key);
 }
 
 // fake purity for backward compatibility with runtime hooks


### PR DESCRIPTION
…using argument types '(shared(int[int]))'

add shared overloads for _d_aaLen and _d_aaIn.