### PR TITLE
Implement C++-like prvalue semantics for structs

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -681,8 +681,19 @@ bool isLvalue(Expression _this)
         if (tf && tf.isRef)
         {
             if (auto dve = _this.e1.isDotVarExp())
+            {
                 if (dve.var.isCtorDeclaration())
-                    return false;
+                {
+                    // Allow taking the address of explicit constructor calls,
+                    // but not (__stmp = S(), __stmp).__ctor().
+                    auto ve = lastComma(dve.e1).isVarExp();
+
+                    if (ve && (ve.var.storage_class & STC.temp) != 0)
+                        return false;
+
+                    return isLvalue(dve.e1);
+                }
+            }
             return true; // function returns a reference
         }
         return false;
@@ -761,6 +772,10 @@ bool isLvalue(Expression _this)
  * Determine if copy elision is allowed when copying an expression to
  * a typed storage. This basically elides a restricted subset of so-called
  * "pure" rvalues, i.e. expressions with no reference semantics.
+ *
+ * Note: Please try to keep `dmd.glue.e2ir.toElemRVO()` in sync with this.
+ * It is not destructive to fail to elide a copy, but it is always better
+ * to stay consistent.
  */
 bool canElideCopy(Expression e, Type to, bool checkMod = true)
 {
@@ -770,8 +785,20 @@ bool canElideCopy(Expression e, Type to, bool checkMod = true)
     static bool visitCallExp(CallExp e)
     {
         if (auto dve = e.e1.isDotVarExp())
+        {
             if (dve.var.isCtorDeclaration())
-                return true;
+            {
+                // Allow (__stmp = S(), __stmp).__ctor() to be elided,
+                // but force a copy for (s2 = s1.__ctor()).
+                // BUG: what about (s2 = __rvalue(s1).__ctor()) ?
+                auto ve = lastComma(dve.e1).isVarExp();
+
+                if (ve && (ve.var.storage_class & STC.temp) != 0)
+                    return true;
+
+                return !isLvalue(dve.e1);
+            }
+        }
 
         auto tb = e.e1.type.toBasetype();
         if (tb.ty == Tdelegate || tb.ty == Tpointer)
@@ -2040,6 +2067,11 @@ Expression valueNoDtor(Expression e)
                 }
             }
         }
+    }
+    else if (auto ce = ex.isCondExp())
+    {
+        ce.e1 = valueNoDtor(ce.e1);
+        ce.e2 = valueNoDtor(ce.e2);
     }
     else if (auto ve = ex.isVarExp())
     {
@@ -12298,7 +12330,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         ? cast(DotVarExp)ce.e1 : null;
                     if (sd.ctor && ce && dve && dve.var.isCtorDeclaration() &&
                         // https://issues.dlang.org/show_bug.cgi?id=19389
-                        dve.e1.op != EXP.dotVariable &&
+                        canElideCopy(ce, t1, false) &&
                         e2y.type.implicitConvTo(t1))
                     {
                         /* Look for form of constructor call which is:
@@ -12409,7 +12441,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                                 return;
                             }
                         }
-                        else if (sd.hasMoveCtor && (!e2x.isCallExp() || e2x.rvalue) && !e2x.isStructLiteralExp())
+                        else if (sd.hasMoveCtor && (e2x.rvalue || !canElideCopy(e2x, t1, false)))
                         {
                             // #move
                             /* The !e2x.isCallExp() is because it is already an rvalue
@@ -12441,14 +12473,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             result = e.expressionSemantic(sc);
                             return;
                         }
-                        else
-                        {
-                            /* The struct value returned from the function is transferred
-                             * so should not call the destructor on it.
-                             */
-                            e2x = valueNoDtor(e2x);
-                        }
                     }
+
+                    /* The struct value returned from the function is transferred
+                     * so should not call the destructor on it.
+                     */
+                    e2x = valueNoDtor(e2x);
 
                     // https://issues.dlang.org/show_bug.cgi?id=19251
                     // if e2 cannot be converted to e1.type, maybe there is an alias this

--- a/compiler/src/dmd/glue/s2ir.d
+++ b/compiler/src/dmd/glue/s2ir.d
@@ -38,7 +38,7 @@ import dmd.dsymbol;
 import dmd.dstruct;
 import dmd.dtemplate;
 import dmd.expression;
-import dmd.expressionsem : getDsymbol, toInteger;
+import dmd.expressionsem : canElideCopy, getDsymbol, toInteger;
 import dmd.func;
 import dmd.id;
 import dmd.init;
@@ -553,143 +553,95 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
     void visitReturn(ReturnStatement s)
     {
         //printf("s2ir.ReturnStatement: %s\n", toChars(s.exp));
-        BlockState* blx = irs.blx;
-        BC bc;
 
-        incUsage(irs, s.loc);
-        void finish()
+        void finish(elem* e = null)
         {
-            block* finallyBlock;
-            if (config.ehmethod != EHmethod.EH_DWARF &&
-                !irs.isNothrow() &&
-                (finallyBlock = stmtstate.getFinallyBlock()) != null)
+            BC bc = BC.ret;
+            BlockState* blx = irs.blx;
+
+            if (e)
             {
-                assert(finallyBlock.bc == BC._finally);
-                blx.curblock.appendSucc(finallyBlock);
+                elem_setLoc(e, s.loc);
+                block_appendexp(blx.curblock, e);
+                bc = BC.retexp;
+            }
+
+            if (config.ehmethod != EHmethod.EH_DWARF &&!irs.isNothrow())
+            {
+                if (block* finallyBlock = stmtstate.getFinallyBlock())
+                {
+                    assert(finallyBlock.bc == BC._finally);
+                    blx.curblock.appendSucc(finallyBlock);
+                }
             }
 
             block_setLoc(blx.curblock, s.loc);
             block_next(blx, bc, null);
         }
-        if (!s.exp)
-        {
-            bc = BC.ret;
-            return finish();
-        }
 
-        elem* e;
+        incUsage(irs, s.loc);
+
+        if (!s.exp)
+            return finish();
 
         FuncDeclaration func = irs.getFunc();
         assert(func);
         auto tf = func.type.isTypeFunction();
         assert(tf);
 
-        RET retmethod = retStyle(tf, func.needThis());
-        if (retmethod == RET.stack)
+        if (retStyle(tf, func.needThis()) == RET.stack)
         {
-            elem* es;
-            bool writetohp;
+            bool nrvo = func.isNRVO && func.nrvo_var;
+            bool urvo = !nrvo && canElideCopy(s.exp, s.exp.type, false);
 
-            /* If returning struct literal, write result
-             * directly into return value
-             */
-            if (auto sle = s.exp.isStructLiteralExp())
-            {
-                sle.sym = irs.shidden;
-                writetohp = true;
-            }
-            /* Detect function call that returns the same struct
-             * and construct directly into *shidden
-             */
-            else if (auto ce = s.exp.isCallExp())
-            {
-                if (ce.e1.op == EXP.variable || ce.e1.op == EXP.star)
-                {
-                    Type t = ce.e1.type.toBasetype();
-                    if (t.ty == Tdelegate)
-                        t = t.nextOf();
-                    if (t.ty == Tfunction && retStyle(cast(TypeFunction)t, ce.f && ce.f.needThis()) == RET.stack)
-                    {
-                        e = toElemDtor(s.exp, irs, el_var(irs.shidden));
-                        e = el_una(OPaddr, TYnptr, e);
-                        goto L1;
-                    }
-                }
-                else if (auto dve = ce.e1.isDotVarExp())
-                {
-                    auto fd = dve.var.isFuncDeclaration();
-                    if (fd && fd.isCtorDeclaration())
-                    {
-                        if (auto sle = dve.e1.isStructLiteralExp())
-                        {
-                            sle.sym = irs.shidden;
-                            writetohp = true;
-                        }
-                    }
-                    Type t = ce.e1.type.toBasetype();
-                    if (t.ty == Tdelegate)
-                        t = t.nextOf();
-                    if (t.ty == Tfunction && retStyle(cast(TypeFunction)t, fd && fd.needThis()) == RET.stack)
-                    {
-                        e = toElemDtor(s.exp, irs, el_var(irs.shidden));
-                        e = el_una(OPaddr, TYnptr, e);
-                        goto L1;
-                    }
-                }
-            }
-            e = toElemDtor(s.exp, irs);
+            // Pass shidden in ehidden for URVO
+            elem* ehidden = urvo ? el_var(irs.shidden) : null;
+            elem* e = toElemDtor(s.exp, irs, ehidden);
             assert(e);
 
-            if (writetohp ||
-                (func.isNRVO && func.nrvo_var))
+            if (nrvo || urvo)
             {
-                // Return value via hidden pointer passed as parameter
-                // Write exp; return shidden;
-                es = e;
+                // In RVO cases, toElemDtor already ensures e references
+                // the hidden pointer, so there is no need to rewrite
+                e = el_una(OPaddr, TYnptr, e);
             }
             else
             {
                 // Return value via hidden pointer passed as parameter
-                // Write *shidden=exp; return shidden;
-                es = el_una(OPind,e.Ety,el_var(irs.shidden));
+                // Rewrite to (*shidden=exp, shidden)
+                elem* es = el_una(OPind, e.Ety, el_var(irs.shidden));
                 es = elAssign(es, e, s.exp.type, null);
+                e = el_combine(es, el_var(irs.shidden));
             }
-            e = el_var(irs.shidden);
-            e = el_bin(OPcomma, e.Ety, es, e);
-        }
-        else if (tf.isRef)
-        {
-            // Reference return, so convert to a pointer
-            e = toElemDtor(s.exp, irs);
 
+            return finish(e);
+        }
+
+        elem* e = toElemDtor(s.exp, irs);
+        assert(e);
+
+        if (tf.isRef)
+        {
             /* already taken care of for vresult in buildResultVar() and semantic3.d
              * https://issues.dlang.org/show_bug.cgi?id=19384
              */
             if (func.vresult)
+            {
                 if (BlitExp be = s.exp.isBlitExp())
                 {
                      if (VarExp ve = be.e1.isVarExp())
                      {
                         if (ve.var == func.vresult)
-                            goto Lskip;
+                            return finish(e);
                      }
                 }
+            }
 
+            // Reference return, so convert to a pointer
             e = addressElem(e, s.exp.type.pointerTo());
-         Lskip:
         }
-        else
-        {
-            e = toElemDtor(s.exp, irs);
-            assert(e);
-        }
-    L1:
-        elem_setLoc(e, s.loc);
-        block_appendexp(blx.curblock, e);
-        bc = BC.retexp;
-//        if (type_zeroCopy(Type_toCtype(s.exp.type)))
-//            bc = BC.ret;
-        finish();
+
+        finish(e);
     }
 
     /**************************************

--- a/compiler/src/dmd/glue/tocsym.d
+++ b/compiler/src/dmd/glue/tocsym.d
@@ -104,6 +104,7 @@ Symbol* toSymbolX(Dsymbol ds, const(char)* prefix, SC sclass, type* t, const(cha
 }
 
 /*************************************
+ * Convert D symbol to backend symbol.
  */
 
 Symbol* toSymbol(Dsymbol s)
@@ -551,6 +552,27 @@ Symbol* toSymbol(Dsymbol s)
     return v.result;
 }
 
+/*************************************
+ * Convert D symbol to backend symbol.
+ * Unlike toSymbol, this function also resolves
+ * NRVO variables to the hidden pointer.
+ */
+Symbol* toSymbolNRVO(Dsymbol s)
+{
+    if (auto parent = s.toParent2())
+    {
+        auto fd = parent.isFuncDeclaration();
+        auto var = s.isVarDeclaration();
+        bool nrvo = fd && var && (fd.isNRVO && fd.nrvo_var == var || var.nrvo && fd.shidden);
+
+        if (nrvo)
+        {
+            return cast(Symbol*)fd.shidden;
+        }
+    }
+
+    return toSymbol(s);
+}
 
 /*************************************
  * Create Windows import symbol from backend Symbol.

--- a/compiler/test/runnable/nrvo.d
+++ b/compiler/test/runnable/nrvo.d
@@ -49,8 +49,146 @@ void test2()
 
 /***************************************************/
 
+struct S3
+{
+    S3* ptr;
+
+    this(int)
+    {
+        ptr = &this;
+    }
+
+    @disable this(this);
+
+    void check()
+    {
+        assert(this.ptr is &this);
+    }
+
+    invariant(this.ptr !is null);
+}
+
+S3 make3()
+{
+    return S3(1);
+}
+
+__gshared int i3;
+__gshared bool b3;
+
+S3 f3()
+{
+    i3++;
+    return make3();
+}
+
+S3 g3()
+{
+    return b3 ? make3() : f3();
+}
+
+void test3()
+{
+    S3 s1 = f3();
+    s1.check();
+    assert(i3 == 1);
+
+    S3 s2 = b3 ? f3() : g3();
+    s2.check();
+    assert(i3 == 2);
+
+    S3 s3 = f3();
+    auto closure = { s3.check(); };
+    closure();
+    s3.check();
+    assert(i3 == 3);
+
+    struct S3A
+    {
+        int a;
+        S3 b;
+    }
+
+    S3A s4 = S3A(1, g3());
+    s4.b.check();
+    assert(i3 == 4);
+
+    S3A f3()
+    {
+        return S3A(2, S3(1));
+    }
+
+    f3().b.check();
+}
+
+/***************************************************/
+
+// ditto
+
+struct S4
+{
+    S4* ptr;
+
+    this(int)
+    {
+        ptr = &this;
+    }
+
+    this(ref inout S4)
+    {
+        ptr = &this;
+    }
+
+    this(S4)
+    {
+        ptr = &this;
+    }
+
+    void check()
+    {
+        assert(this.ptr is &this);
+    }
+
+    invariant(this.ptr !is null);
+}
+
+struct V4
+{
+    S4 s1, s2;
+    this(int)
+    {
+        s1 = s2 = S4(1);
+    }
+}
+
+S4 f4()
+{
+    return __rvalue(V4(1).s1);
+}
+
+S4 g4()
+{
+    V4 v = V4(1);
+    v.s1.check();
+    v.s2.check();
+    S4 s = v.s1;
+    return s;
+}
+
+void test4()
+{
+    f4().check();
+
+    S4 s = g4();
+    s.check();
+}
+
+/***************************************************/
+
 void main()
 {
     test1();
     test2();
+    test3();
+    test4();
 }

--- a/compiler/test/runnable/rvalue1.d
+++ b/compiler/test/runnable/rvalue1.d
@@ -275,32 +275,6 @@ void test11()
 
 /********************************/
 
-struct S12{
-    S12* ptr;
-    this(int) { ptr = &this; }
-    this(ref inout S12) { ptr = &this; }
-    this(S12) { ptr = &this; }
-}
-
-struct V12
-{
-    S12 s;
-    this(int) { s = S12(1); }
-}
-
-S12 foo12()
-{
-    return __rvalue(V12(1).s);
-}
-
-void test12()
-{
-    S12 s = foo12();
-    assert(&s == s.ptr);
-}
-
-/********************************/
-
 int main()
 {
     test1();
@@ -314,7 +288,6 @@ int main()
     test9();
     test10();
     test11();
-    test12();
 
     return 0;
 }

--- a/compiler/test/runnable/test28.d
+++ b/compiler/test/runnable/test28.d
@@ -1273,42 +1273,6 @@ void test18576()
 }
 
 /*******************************************/
-
-struct S67
-{
-    S67* ptr;
-
-    this(int)
-    {
-        pragma(inline, false);
-        ptr = &this;
-    }
-
-    @disable this(this);
-}
-
-pragma(inline, false)
-S67 make67()
-{
-    return S67(1);
-}
-
-__gshared int i67;
-
-S67 f67()
-out (s; s.ptr == &s)
-{
-    i67++;
-    return make67();
-}
-
-void test67()
-{
-    S67 s = f67();
-    assert(s.ptr == &s);
-}
-
-/*******************************************/
 // https://github.com/dlang/dmd/issues/22160
 
 struct Vector22160(T)
@@ -1458,7 +1422,6 @@ void main()
     test64();
     test65();
     test18576();
-    test67();
     test22160();
     test22292();
 


### PR DESCRIPTION
This one is massive and messy (and hard to review, evidently). This PR ensures all construction in following forms emplaces directly to the storage, without creating any temporaries, matching C++17 semantics. Besides, this fixes `a = b = S(1)` being compiled as a blit instead of invoking copy constructor on `a`.
```d
S s = S(1);
S s = b ? S(1) : S(2);
T t = T(S(1));
this.s = S(1);
return S(1);
```

What is still missing for a working C++17 `std::basic_string` binding:
- copy/move constructors
- remaining compiler-generated blits
- druntime hooks
- inliner