### PR TITLE
Assert when passing `noreturn` argument to function

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -2137,6 +2137,7 @@ extern (C++) final class ImportExp : UnaExp
 extern (C++) final class AssertExp : UnaExp
 {
     Expression msg;
+    Expression loweredFrom;
 
     extern (D) this(Loc loc, Expression e, Expression msg = null) @safe
     {

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -671,6 +671,7 @@ class AssertExp final : public UnaExp
 {
 public:
     Expression *msg;
+    Expression* loweredFrom;
 
     AssertExp *syntaxCopy() override;
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4187,6 +4187,10 @@ private bool functionParameters(Loc loc, Scope* sc,
             arg = arg.resolveLoc(loc, sc);
             (*arguments)[i] = arg;
         }
+        else if (!(p.storageClass & (STC.ref_ | STC.out_)))
+        {
+            (*arguments)[i] = checkNoreturnVarAccess(arg);
+        }
 
         if (tf.parameterList.varargs == VarArg.typesafe && i + 1 == nparams) // https://dlang.org/spec/function.html#variadic
         {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2072,7 +2072,9 @@ Expression checkNoreturnVarAccess(Expression exp)
     {
         auto msg = new StringExp(exp.loc, "Accessed expression of type `noreturn`");
         msg.type = Type.tstring;
-        result = new AssertExp(exp.loc, IntegerExp.literal!0, msg);
+        auto ae = new AssertExp(exp.loc, IntegerExp.literal!0, msg);
+        ae.loweredFrom = exp;
+        result = ae;
         result.type = exp.type;
     }
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2542,6 +2542,7 @@ class AssertExp final : public UnaExp
 {
 public:
     Expression* msg;
+    Expression* loweredFrom;
     AssertExp* syntaxCopy() override;
     void accept(Visitor* v) override;
 };

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2799,6 +2799,9 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
 
     void visitAssert(AssertExp e)
     {
+        if (e.loweredFrom)
+            return e.loweredFrom.expressionPrettyPrint(buf, hgs);
+
         buf.put("assert(");
         expToBuffer(e.e1, PREC.assign, buf, hgs);
         if (e.msg)

--- a/compiler/test/runnable/noreturn2.d
+++ b/compiler/test/runnable/noreturn2.d
@@ -102,20 +102,16 @@ void testAccess()
 {
     enum msg = "Accessed expression of type `noreturn`";
 
-    // FIXME: Another assertion failure in the backend trying to generate noreturn.sizeof = 0 byte assignment
-    version (FIXME)
-    testAssertFailure(__LINE__ + 3, msg, function noreturn()
+    testAssertFailure(__LINE__ + 3, msg,
     {
         noreturn a;
         noreturn b = a;
     });
 
-    if (false) // read does not assert!
-    testAssertFailure(__LINE__ + 3, msg, function noreturn()
+    testAssertFailure(__LINE__ + 3, msg,
     {
         noreturn a;
         int b = a;
-        assert(false, "Unreachable!"); // Statement above not detected as noreturn
     });
 
     testAssertFailure(__LINE__ + 2, msg, function noreturn()
@@ -123,14 +119,12 @@ void testAccess()
         cast(noreturn) 1;
     });
 
-    version (FIXME)
-    testAssertFailure(__LINE__ + 3, msg, function noreturn()
+    testAssertFailure(__LINE__ + 3, msg,
     {
         noreturn a;
         noreturn b = cast(noreturn) 1;
     });
 
-    if (false) // Read does not assert
     testAssertFailure(__LINE__ + 3, msg, function noreturn()
     {
         noreturn a;

--- a/compiler/test/runnable/noreturn2.d
+++ b/compiler/test/runnable/noreturn2.d
@@ -131,13 +131,26 @@ void testAccess()
         return a;
     });
 
-    if (false) // Read does not assert
+    // FIXME: assertion failure in the backend in paramsize() - noreturn.sizeof = 0
+    // https://github.com/dlang/dmd/issues/20286
+    version (FIXME)
     testAssertFailure(__LINE__ + 4, msg, function noreturn()
     {
         static void foo(noreturn) {}
         noreturn a;
         foo(a);
         assert(false, "Unreachable!"); // Ditto
+    });
+
+    testAssertFailure(__LINE__ + 5, msg,
+    {
+        static fv(int) {}
+        static fr(ref noreturn a)
+        {
+            fv(a); // asserts
+        }
+        noreturn a;
+        fr(a); // OK, passes &a
     });
 
     testAssertFailure(__LINE__ + 3, msg,


### PR DESCRIPTION
Unless matching parameter is a reference.
Fixes #22249.
Note that calling a function with a noreturn parameter doesn't compile - see #20286 (added link to test file).

Also enable 4 disabled noreturn tests that were already working. I used void function literal return types to compile/simplify where applicable.