### PR TITLE
findreglsw() only works for X86_64

### DIFF
--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -1777,7 +1777,7 @@ L3:
                         assert(retregs);
                         goto L1;
                     }
-                    lsreg = findreglsw(r);
+                    lsreg = findreg(r & INSTR.LSW);
                     if (msreg == NOREG)
                     {
                         retregs &= INSTR.MSW;

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -7073,7 +7073,7 @@ nothrow:
     void flushx()
     {
         // Emit accumulated bytes to code segment
-        debug assert(index < bytes.length);
+        debug assert(index <= bytes.length);
 
         if (disasmBuf)                     // write to buffer for disassembly
         {


### PR DESCRIPTION
The other bug only showed up in debug builds.