### PR TITLE
fix #22399 - Low-level threading support on Windows DLLs are broken

### DIFF
--- a/druntime/src/core/thread/types.d
+++ b/druntime/src/core/thread/types.d
@@ -29,7 +29,10 @@ struct ll_ThreadData
 {
     ThreadID tid;
     version (Windows)
+    {
         void delegate() nothrow cbDllUnload;
+        void* hMod; // HMODULE containing the unload callback
+    }
 }
 
 version (GNU)

--- a/druntime/test/shared/Makefile
+++ b/druntime/test/shared/Makefile
@@ -33,7 +33,8 @@ PATH := $(dir $(DRUNTIMESO));$(PATH)
 endif
 
 $(ROOT)/dllgc$(DOTEXE): $(ROOT)/dllgc$(DOTDLL)
-$(ROOT)/dllgc$(DOTDLL): private extra_dflags += -version=DLL -od=$(ROOT)/dll
+$(ROOT)/dllgc$(DOTDLL): private extra_dflags += -version=DLL -od=$(ROOT)/dll -L/PDB:$(ROOT)/dllgc_dll.pdb
+$(ROOT)/dynamiccast$(DOTDLL): private extra_dflags += -L/PDB:$(ROOT)/dynamiccast_dll.pdb
 endif # Windows
 
 $(ROOT)/dynamiccast.done: $(ROOT)/%.done: $(ROOT)/%$(DOTEXE) $(ROOT)/%$(DOTDLL)

--- a/druntime/test/shared/src/dllgc.d
+++ b/druntime/test/shared/src/dllgc.d
@@ -42,9 +42,9 @@ version(DLL)
 
     static ~this()
     {
-        // creating thread in shutdown should fail when statically linked
+        // creating thread in shutdown should fail (term no longer available)
         auto tsk = new Task;
-        assert((tsk.tid != ThreadID.init) == isSharedDRuntime());
+        assert(tsk.tid == ThreadID.init);
     }
 }
 else


### PR DESCRIPTION
also monitor DLLs that share the runtime and have threads with unload callbacks not in the runtime.

This is meant to fix the spurious errors for the dllgc test.