### PR TITLE
Fix #22427 - Premature removal of ternary of type noreturn

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -4585,7 +4585,7 @@ IntRange getIntRange(Expression e)
  * However, the dmd backend does not like a naive cast from a noreturn expression
  * (particularly an `assert(0)`) so this function generates:
  *
- * `(assert(0), value)` instead of `cast(to)(assert(0))`.
+ * `(value, assert(0))` instead of `cast(to)(assert(0))`.
  *
  * `value` is currently `to.init` however it cannot be read so could be made simpler.
  * Params:

--- a/compiler/test/runnable/test22427.d
+++ b/compiler/test/runnable/test22427.d
@@ -1,0 +1,18 @@
+// https://github.com/dlang/dmd/issues/22427
+
+void main()
+{
+    try
+    {
+        scope exitProgram = (bool failure) @trusted {
+            return failure
+                ? throw new Exception("exit(1)")
+                : throw new Exception("exit(0)");
+        };
+        exitProgram(false);
+    }
+    catch (Exception e)
+    {
+        assert(e.message == "exit(0)");
+    }
+}


### PR DESCRIPTION
Correctly handle conditional and comma expression constructs in checkNoreturnVarAccess.

When inspecting the lowering of a noreturn ternary expression, it was found to be needlessly inserting an `assert(0)` into the if-true result of the expression.

    (cond) ? noreturn(), assert(0) : noreturn();

Don't insert any casts to noreturn or void if both operands are the same type, as such casts are no-op.

Closes #22427