### PR TITLE
 Allow ref variable initialized from noreturn

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -421,6 +421,8 @@ extern (C++) final class OverDeclaration : Declaration
 }
 
 /***********************************************************
+ * Note: dsymbolSemantic turns a VarDeclaration inside a function into
+ * AssignExp(e1: VarExp, e2: ConstructExp or BlitExp).
  */
 extern (C++) class VarDeclaration : Declaration
 {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12082,10 +12082,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 e2x.checkSharedAccess(sc))
                 return setError();
 
-            auto etmp = checkNoreturnVarAccess(e2x);
-            if (etmp != e2x)
-                return setResult(etmp);
-
+            // taking address of noreturn instance is OK
+            if (!(exp.e1.isVarExp() && exp.e1.isVarExp().var.storage_class & STC.ref_))
+            {
+                auto etmp = checkNoreturnVarAccess(e2x);
+                if (etmp != e2x)
+                    return setResult(etmp);
+            }
             exp.e2 = e2x;
         }
 

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -383,6 +383,10 @@ extern (C++) class ExpStatement : Statement
         this.exp = exp;
     }
 
+    /*******************************
+     * Creates a DeclarationExp inside a statement.
+     * Use in place of *DeclarationStatement* from D grammar.
+     */
     final extern (D) this(Loc loc, Dsymbol declaration) @safe
     {
         super(loc, STMT.Exp);

--- a/compiler/test/runnable/noreturn2.d
+++ b/compiler/test/runnable/noreturn2.d
@@ -114,6 +114,20 @@ void testAccess()
         int b = a;
     });
 
+    testAssertFailure(__LINE__ + 4, msg,
+    {
+        noreturn a;
+        auto p = &a; // OK
+        int b = *p;
+    });
+
+    testAssertFailure(__LINE__ + 4, msg,
+    {
+        noreturn a;
+        ref r = a; // OK, reads &a
+        int b = r; // asserts
+    });
+
     testAssertFailure(__LINE__ + 2, msg, function noreturn()
     {
         cast(noreturn) 1;


### PR DESCRIPTION
Fixes #22431.

Also:
* Add test for taking address of noreturn (already works)
* Add some doc-comments related to variable declarations inside a function - see commit message.