### PR TITLE
Fix #22433 - noreturn function frame did not save the PC

### DIFF
--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -1262,40 +1262,6 @@ int branch(block* bl,int flag)
                 {
                     c.Iflags &= ~CFjmp16;      // a branch is ok
                     bytesaved += I16 ? 3 : 4;
-
-                    // Replace a cond jump around a call to a function that
-                    // never returns with a cond jump to that function.
-                    if (config.flags4 & CFG4optimized &&
-                        config.target_cpu >= TARGET_80386 &&
-                        disp == (I16 ? 3 : 5) &&
-                        cn &&
-                        cn.Iop == CALL &&
-                        cn.IFL1 == FL.func &&
-                        cn.IEV1.Vsym.Sflags & SFLexit &&
-                        !(cn.Iflags & (CFtarg | CFtarg2))
-                       )
-                    {
-                        cn.Iop = 0x0F00 | ((c.Iop & 0x0F) ^ 0x81);
-                        c.Iop = INSTR.nop;
-                        c.IEV1.Vcode = null;
-                        bytesaved++;
-
-                        // If nobody else points to ct, we can remove the CFtarg
-                        if (flag && ct)
-                        {
-                            code* cx;
-                            for (cx = bl.Bcode; 1; cx = code_next(cx))
-                            {
-                                if (!cx)
-                                {
-                                    ct.Iflags &= ~CFtarg;
-                                    break;
-                                }
-                                if (cx.IEV1.Vcode == ct)
-                                    break;
-                            }
-                        }
-                    }
                 }
                 csize = calccodsize(c);
             }

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -5347,40 +5347,6 @@ int branch(block* bl,int flag)
                 {
                     c.Iflags &= ~CFjmp16;      // a branch is ok
                     bytesaved += I16 ? 3 : 4;
-
-                    // Replace a cond jump around a call to a function that
-                    // never returns with a cond jump to that function.
-                    if (config.flags4 & CFG4optimized &&
-                        config.target_cpu >= TARGET_80386 &&
-                        disp == (I16 ? 3 : 5) &&
-                        cn &&
-                        cn.Iop == CALL &&
-                        cn.IFL2 == FL.func &&
-                        cn.IEV2.Vsym.Sflags & SFLexit &&
-                        !(cn.Iflags & (CFtarg | CFtarg2))
-                       )
-                    {
-                        cn.Iop = 0x0F00 | ((c.Iop & 0x0F) ^ 0x81);
-                        c.Iop = NOP;
-                        c.IEV2.Vcode = null;
-                        bytesaved++;
-
-                        // If nobody else points to ct, we can remove the CFtarg
-                        if (flag && ct)
-                        {
-                            code* cx;
-                            for (cx = bl.Bcode; 1; cx = code_next(cx))
-                            {
-                                if (!cx)
-                                {
-                                    ct.Iflags &= ~CFtarg;
-                                    break;
-                                }
-                                if (cx.IEV2.Vcode == ct)
-                                    break;
-                            }
-                        }
-                    }
                 }
                 csize = calccodsize(c);
             }

--- a/compiler/test/runnable/test22427.d
+++ b/compiler/test/runnable/test22427.d
@@ -1,5 +1,15 @@
 // https://github.com/dlang/dmd/issues/22427
 
+noreturn exit1()
+{
+    throw new Exception("exit(1)");
+}
+
+noreturn exit0()
+{
+    throw new Exception("exit(0)");
+}
+
 void main()
 {
     try
@@ -8,6 +18,18 @@ void main()
             return failure
                 ? throw new Exception("exit(1)")
                 : throw new Exception("exit(0)");
+        };
+        exitProgram(false);
+    }
+    catch (Exception e)
+    {
+        assert(e.message == "exit(0)");
+    }
+
+    try
+    {
+        scope exitProgram = (bool failure) @trusted {
+            return failure ? exit1() : exit0();
         };
         exitProgram(false);
     }


### PR DESCRIPTION
This removes the backend optimization that converts calls to jumps to never-return functions, because `noreturn` doesn't mean no stack unwinding.

cc @WalterBright 