### PR TITLE
do AArch64 version of mTYgprxmm and mTYxmmgpr

### DIFF
--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -2794,7 +2794,7 @@ void codelem(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs,uin
         assert(0);
     }
 
-    regm_t tmask = cg.AArch64 ? (cg.allregs | INSTR.FLOATREGS)
+    regm_t tmask = cg.AArch64 ? (INSTR.ALLREGS | INSTR.FLOATREGS)
                               : (mES | ALLREGS | mBP | XMMREGS);
     if (!(constflag & 1) && pretregs & tmask & ~cg.regcon.mvar)
         pretregs &= ~cg.regcon.mvar;                      /* can't use register vars */
@@ -2911,7 +2911,7 @@ void codelem(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs,uin
                 }
                 if (cg.AArch64)
                 {
-                    pretregs = tyfloating(e.Ety) ? INSTR.FLOATREGS : cg.allregs;
+                    pretregs = tyfloating(e.Ety) ? INSTR.FLOATREGS : INSTR.ALLREGS;
                 }
             }
             loaddata(cdb,e,pretregs);


### PR DESCRIPTION
This code is a mess dealing with the register pairs (int,float) and (float,int), as it doesn't fit in with the MSW and LSW scheme in the rest of the code generator. The general idea is it only matters for the return value.

Indent the code for X86_64, and copy/paste the code for AArch64, then go through it and change it to use AArch64 registers and delete the x87 stuff.

The saving grace of it is it works.