### PR TITLE
Improve wording of some errors around bitfields

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4505,6 +4505,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             isAliasDeclaration = true;
         }
 
+        const typeLoc = token.loc;
         AST.Type ts;
 
         if (!autodecl)
@@ -4794,7 +4795,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 {
                     if (storage_class)
                         error("storage class not allowed for bitfield declaration");
-                    s = new AST.BitFieldDeclaration(loc, t, ident, width, _init);
+                    s = new AST.BitFieldDeclaration(ident.isAnonymous() ? typeLoc : loc, t, ident, width, _init);
                 }
                 else
                 {

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -351,8 +351,14 @@ private extern(C++) final class Semantic2Visitor : Visitor
         if (!bounds.contains(value))
         {
             const uwidth = bfd.fieldWidth;
-            error(ei.loc, "bitfield initializer `%s` does not fit in %d bit%s",
-                ei.exp.toChars(), cast(int) uwidth, uwidth == 1 ? "".ptr : "s".ptr);
+            error(ei.loc, "default initializer `%s` is not representable as bitfield type `%s:%lld`",
+                  ei.exp.toChars(), bfd.type.toBasetype().toChars(), cast(long)uwidth);
+            if (isUnsigned)
+                errorSupplemental(bfd.loc, "bitfield `%s` default initializer must be a value between `%llu..%llu`",
+                                  bfd.toChars(), bounds.imin.value, bounds.imax.value);
+            else
+                errorSupplemental(bfd.loc, "bitfield `%s` default initializer must be a value between `%lld..%lld`",
+                                  bfd.toChars(), bounds.imin.value, bounds.imax.value);
         }
     }
 

--- a/compiler/test/fail_compilation/biterrors2.d
+++ b/compiler/test/fail_compilation/biterrors2.d
@@ -4,10 +4,10 @@
 fail_compilation/biterrors2.d(100): Error: variable `biterrors2.a` - bitfield must be member of struct, union, or class
 int a : 2;
     ^
-fail_compilation/biterrors2.d(104): Error: bitfield `b` has zero width
+fail_compilation/biterrors2.d(104): Error: bitfield `b` cannot have zero width
     int b:0;
-          ^
-fail_compilation/biterrors2.d(105): Error: bitfield type `float` is not an integer type
+        ^
+fail_compilation/biterrors2.d(105): Error: bitfield `c` cannot be of non-integral type `float`
     float c:3;
           ^
 ---

--- a/compiler/test/fail_compilation/biterrors6.d
+++ b/compiler/test/fail_compilation/biterrors6.d
@@ -1,0 +1,24 @@
+/* REQUIRED_ARGS: -verrors=context
+ * TEST_OUTPUT:
+---
+fail_compilation/biterrors6.d(20): Error: anonymous bitfield cannot be of non-integral type `noreturn`
+    noreturn : -1;
+    ^
+fail_compilation/biterrors6.d(21): Error: anonymous bitfield has negative width `-1`
+    int : -1;
+           ^
+fail_compilation/biterrors6.d(22): Error: bitfield `n` cannot be of non-integral type `noreturn`
+    noreturn n : -500;
+             ^
+fail_compilation/biterrors6.d(23): Error: bitfield `i` has negative width `-500`
+    int i : -500;
+             ^
+---
+*/
+struct S
+{
+    noreturn : -1;
+    int : -1;
+    noreturn n : -500;
+    int i : -500;
+}

--- a/compiler/test/fail_compilation/biterrors7.d
+++ b/compiler/test/fail_compilation/biterrors7.d
@@ -1,0 +1,15 @@
+/* REQUIRED_ARGS: -verrors=context
+ * TEST_OUTPUT:
+---
+fail_compilation/biterrors7.d(14): Error: struct `biterrors7.S` cannot have anonymous field with same struct type
+    S : S();
+    ^
+fail_compilation/biterrors7.d(14): Error: anonymous bitfield cannot be of non-integral type `S`
+    S : S();
+    ^
+---
+*/
+struct S
+{
+    S : S();
+}

--- a/compiler/test/fail_compilation/bitfields2.c
+++ b/compiler/test/fail_compilation/bitfields2.c
@@ -1,8 +1,8 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/bitfields2.c(103): Error: bitfield type `float` is not an integer type
+fail_compilation/bitfields2.c(103): Error: bitfield `a` cannot be of non-integral type `float`
 fail_compilation/bitfields2.c(104): Error: bitfield width `3.0` is not an integer constant
-fail_compilation/bitfields2.c(105): Error: bitfield `c` has zero width
+fail_compilation/bitfields2.c(105): Error: bitfield `c` cannot have zero width
 fail_compilation/bitfields2.c(106): Error: width `60` of bitfield `d` does not fit in type `int`
 ---
  */

--- a/compiler/test/fail_compilation/fail20779.d
+++ b/compiler/test/fail_compilation/fail20779.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20779.d(12): Error: struct `fail20779.X` cannot have field `x` with same struct type
+fail_compilation/fail20779.d(14): Error: struct `fail20779.X` cannot have field `x` with same struct type
 ---
 */
 

--- a/compiler/test/fail_compilation/fail22384.d
+++ b/compiler/test/fail_compilation/fail22384.d
@@ -1,20 +1,24 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22384.d(32): Error: bitfield `z` has zero width
-fail_compilation/fail22384.d(36): Error: bitfield type `float` is not an integer type
-fail_compilation/fail22384.d(36): Error: bitfield `f` has zero width
-fail_compilation/fail22384.d(37): Error: bitfield type `float` is not an integer type
-fail_compilation/fail22384.d(38): Error: bitfield type `float` is not an integer type
-fail_compilation/fail22384.d(39): Error: bitfield type `float` is not an integer type
-fail_compilation/fail22384.d(44): Error: anonymous bitfield cannot have default initializer
-fail_compilation/fail22384.d(21): Error: bitfield initializer `4294967295u` does not fit in 4 bits
-fail_compilation/fail22384.d(26): Error: bitfield initializer `E.B` does not fit in 2 bits
-fail_compilation/fail22384.d(30): Error: bitfield initializer `4` does not fit in 3 bits
-fail_compilation/fail22384.d(31): Error: bitfield initializer `65` does not fit in 7 bits
-fail_compilation/fail22384.d(43): Error: cannot implicitly convert expression `4.2F` of type `float` to `int`
-fail_compilation/fail22384.d(45): Error: bitfield initializer `65` does not fit in 7 bits
-fail_compilation/fail22384.d(46): Error: cannot implicitly convert expression `42` of type `int` to `bool`
+fail_compilation/fail22384.d(36): Error: bitfield `z` cannot have zero width
+fail_compilation/fail22384.d(40): Error: bitfield `f` cannot be of non-integral type `float`
+fail_compilation/fail22384.d(41): Error: bitfield `f2` cannot be of non-integral type `float`
+fail_compilation/fail22384.d(42): Error: bitfield `f3` cannot be of non-integral type `float`
+fail_compilation/fail22384.d(43): Error: bitfield `f4` cannot be of non-integral type `float`
+fail_compilation/fail22384.d(48): Error: anonymous bitfield cannot have default initializer
+fail_compilation/fail22384.d(25): Error: default initializer `4294967295u` is not representable as bitfield type `uint:4`
+fail_compilation/fail22384.d(25):        bitfield `d` default initializer must be a value between `0..15`
+fail_compilation/fail22384.d(30): Error: default initializer `E.B` is not representable as bitfield type `int:2`
+fail_compilation/fail22384.d(30):        bitfield `b` default initializer must be a value between `-2..1`
+fail_compilation/fail22384.d(34): Error: default initializer `4` is not representable as bitfield type `int:3`
+fail_compilation/fail22384.d(34):        bitfield `x` default initializer must be a value between `-4..3`
+fail_compilation/fail22384.d(35): Error: default initializer `65` is not representable as bitfield type `int:7`
+fail_compilation/fail22384.d(35):        bitfield `y` default initializer must be a value between `-64..63`
+fail_compilation/fail22384.d(47): Error: cannot implicitly convert expression `4.2F` of type `float` to `int`
+fail_compilation/fail22384.d(49): Error: default initializer `65` is not representable as bitfield type `int:7`
+fail_compilation/fail22384.d(49):        bitfield `j` default initializer must be a value between `-64..63`
+fail_compilation/fail22384.d(50): Error: cannot implicitly convert expression `42` of type `int` to `bool`
 ---
 */
 struct S {

--- a/compiler/test/fail_compilation/fail8691.d
+++ b/compiler/test/fail_compilation/fail8691.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8691.d(7): Error: struct `fail8691.Foo` cannot have field `f` with static array of same struct type
+fail_compilation/fail8691.d(9): Error: struct `fail8691.Foo` cannot have field `f` with static array of same struct type
 ---
 */
 struct Foo


### PR DESCRIPTION
- Don't print bitfield name if anonymous
- Some diagnostics had no location
- Guard against duplicate diagnostics
- Don't check bitfield width if type test failed
- Rephrase some of the errors