### PR TITLE
importC: fix issue #20410

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5598,6 +5598,9 @@ final class CParser(AST) : Parser!AST
                 v.isCmacro = true;       // mark it as coming from a C #define
             if (auto td = s.isTemplateDeclaration())
                 td.isCmacro = true; // mark as coming from a C #define
+            if (auto ad = s.isAliasDeclaration())
+                ad.isCmacro = true; // ditto for vars and templates
+
             /* If it's already defined, replace the earlier
              * definition
              */
@@ -5772,26 +5775,68 @@ final class CParser(AST) : Parser!AST
 
                         case TOK.identifier:
                         {
-                            /* Look for:
-                             *  #define ID identifier ( args )
-                             * where the macro body is exactly a function-like macro call
-                             * (no additional operators that could cause precedence issues).
-                             * Rewrite to a template function:
-                             *  auto ID()() { return identifier(args); }
+                            if (peekNext() == TOK.leftParenthesis)
+                            {
+                                /* Look for:
+                                 *  #define ID identifier ( args )
+                                 * where the macro body is exactly a function-like macro call
+                                 * (no additional operators that could cause precedence issues).
+                                 * Rewrite to a template function:
+                                 *  auto ID()() { return identifier(args); }
+                                 */
+
+                                assert(!params);                    // would be TOK.leftParenthesis
+                                eLatch.sawErrors = false;
+                                auto exp = cparseExpression();
+                                if (eLatch.sawErrors)               // parsing errors
+                                    break;                          // abandon this #define
+                                if (token.value != TOK.endOfFile)   // did not consume the entire line
+                                    break;
+                                // Only allow bare function calls to avoid precedence issues.
+                                // E.g., `#define X FUNC(5)` is safe, but `#define X FUNC(5) + 1`
+                                // would have different semantics in D vs C when used as `X * 2`.
+                                if (!exp.isCallExp())
+                                    break;
+                                addNullaryTemplate(exp, id);
+                                ++p;
+                                continue;
+                            }
+
+                            /* for macros referencing other identifiers
+                             * so D users should avoid using custom macros beginning with __
+                             * to reference identifers
                              */
-                            assert(!params);                    // would be TOK.leftParenthesis
-                            eLatch.sawErrors = false;
-                            auto exp = cparseExpression();
-                            if (eLatch.sawErrors)               // parsing errors
-                                break;                          // abandon this #define
-                            if (token.value != TOK.endOfFile)   // did not consume the entire line
-                                break;
-                            // Only allow bare function calls to avoid precedence issues.
-                            // E.g., `#define X FUNC(5)` is safe, but `#define X FUNC(5) + 1`
-                            // would have different semantics in D vs C when used as `X * 2`.
-                            if (!exp.isCallExp())
-                                break;
-                            addNullaryTemplate(exp, id);
+                            auto ident = token.ident;
+                            Specifier sp;
+                            sp.packalign = this.packalign;
+                            auto tspec = cparseDeclarationSpecifiers(LVL.global, sp);
+                            const idx = id.toString();
+                            auto identx = ident.toString();
+
+                            // find t1spec at the base macro
+                            // type specifiers are not aliased
+                            if (!tspec.isTypeIdentifier() || (identx == idx)
+                                || (identx.length > 2 && identx[0] == '_' && identx[1] == '_')
+                                || (idx.length > 2 && idx[0] == '_' && idx[1] == '_'))
+                            {
+                                ++p;
+                                continue;
+                            }
+
+                            nextToken();
+                            if (token.value != TOK.endOfFile)
+                            {
+                                ++p;
+                                continue;
+                            }
+
+                            /*
+                             * #define identifier value where value can be an identifier.
+                             * The identifier can be anything, so treat it as an AliasDeclaration.
+                             * Mark it as coming from a C file to skip semantic resolution later.
+                             */
+                            auto als = new AST.AliasDeclaration(scanloc, id, tspec);
+                            addSym(als);
                             ++p;
                             continue;
                         }
@@ -5911,7 +5956,6 @@ final class CParser(AST) : Parser!AST
                             ++p;
                             continue;
                         }
-
                         default:
                             break;
                     }

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -333,6 +333,7 @@ extern (C++) final class AliasDeclaration : Declaration
 
     Dsymbol overnext;   // next in overload list
     Dsymbol _import;    // !=null if unresolved internal alias for selective import
+    bool isCmacro;      // check whether it is coming from a C macro
 
     extern (D) this(Loc loc, Identifier ident, Type type) @safe
     {

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -200,6 +200,7 @@ public:
     Dsymbol *aliassym;
     Dsymbol *overnext;          // next in overload list
     Dsymbol *_import;           // !=NULL if unresolved internal alias for selective import
+    d_bool isCmacro;
 
     static AliasDeclaration *create(Loc loc, Identifier *id, Type *type);
     AliasDeclaration *syntaxCopy(Dsymbol *) override;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1382,7 +1382,7 @@ Dsymbol toAlias2(Dsymbol s)
 {
     if (auto ad = s.isAliasDeclaration())
     {
-        if (ad.inuse)
+        if (ad.inuse && !ad.isCmacro) // c amcro can refer to itself and compile
         {
             .error(ad.loc, "%s `%s` recursive alias declaration", ad.kind, ad.toPrettyChars);
             return ad;
@@ -1457,7 +1457,7 @@ private Dsymbol toAliasImpl(AliasDeclaration ad)
             ad.inuse = 0;
         }
     }
-    if (ad.inuse)
+    if (ad.inuse && !ad.isCmacro) // C macros can refer to itself and compile
     {
         .error(ad.loc, "%s `%s` recursive alias declaration", ad.kind, ad.toPrettyChars);
         return err();
@@ -6028,8 +6028,9 @@ private extern(C++) class AddMemberVisitor : Visitor
             }
 
             // If using C tag/prototype/forward declaration rules
+            // remember, C allows rdececlarations of macros too
+             //(!sc.inCfie && dsym.isAliasDeclaration().isCmacro && s2.isAliasDeclaration().isCmacro)))
             if (sc && sc.inCfile && !dsym.isImport())
-            // When merging master, replace with: if (sc && sc.inCfile && !dsym.isImport())
             {
                 if (handleTagSymbols(*sc, dsym, s2, sds))
                     return;
@@ -6531,15 +6532,26 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
     // Detect `alias sym = sym;` to prevent creating loops in overload overnext lists.
     if (auto tident = ds.type.isTypeIdentifier())
     {
-        if (sc.hasEdition(Edition.v2024) && tident.idents.length)
+        if ((sc.hasEdition(Edition.v2024) && tident.idents.length) || ds.isCmacro)
         {
             alias mt = tident;
             Dsymbol pscopesym;
             Dsymbol s = sc.search(ds.loc, mt.ident, pscopesym);
+            /* if the definition of the imported macro from C that points to an identifier,
+             * doesn't exist stop processing quietely and do not emit any error as similar to C
+             */
+            if (!s && sc.inCfile && ds.isCmacro)
+            {
+                ds.aliassym = null;
+                ds.errors = false;                      // no error flag
+                ds.semanticRun = PASS.semanticdone;     // mark semantic as complete
+                ds.inuse = 0;                           // clear recursion flag
+                return;
+            }
             // detect `alias a = var1.member_var;` which confusingly resolves to
             // `typeof(var1).member_var`, which can be valid inside the aggregate type
             if (s && s.isVarDeclaration() &&
-                mt.ident != Id.This && mt.ident != Id._super)
+                mt.ident != Id.This && mt.ident != Id._super && (!ds.isCmacro && !sc.inCfile)) // don't let a C macro alias pass here
             {
                 s = tident.toDsymbol(sc);
                 // don't error for `var1.static_symbol`
@@ -6553,7 +6565,7 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
             }
         }
         // Selective imports are allowed to alias to the same name `import mod : sym=sym`.
-        if (!ds._import)
+        if (!ds._import && (!ds.isCmacro && !sc.inCfile)) // C identifier macros are not allowed here
         {
             if (tident.ident is ds.ident && !tident.idents.length)
             {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6569,6 +6569,7 @@ public:
     Dsymbol* aliassym;
     Dsymbol* overnext;
     Dsymbol* _import_;
+    bool isCmacro;
     static AliasDeclaration* create(Loc loc, Identifier* id, Type* type);
     AliasDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;

--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -490,6 +490,14 @@ Dsymbol handleSymbolRedeclarations(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsy
         if (td.isCmacro) return s2;
     }
 
+    if (auto ad = s.isAliasDeclaration())
+    {
+        if (ad.isCmacro)
+            return s2;
+        else
+            return s;
+    }
+
     auto vd = s.isVarDeclaration(); // new declaration
     auto vd2 = s2.isVarDeclaration(); // existing declaration
 

--- a/compiler/test/runnable/fix20410.d
+++ b/compiler/test/runnable/fix20410.d
@@ -1,0 +1,19 @@
+/*
+REQUIRED_ARGS: runnable/imports/imp20410.c
+*/
+//https://github.com/dlang/dmd/issues/20410
+import imp20410;
+
+void main()
+{
+    const _ = _RAX;
+
+    assert(num == 5);
+    assert(func() == 9);
+
+    //https://github.com/dlang/dmd/issues/20478
+
+    static assert(A == B);
+    static assert(A == C);
+    static assert(A == D);
+}

--- a/compiler/test/runnable/imports/imp20410.c
+++ b/compiler/test/runnable/imports/imp20410.c
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=24419
+
+typedef enum {
+    #define R0 _RAX
+    _RAX,
+} reg;
+
+
+int number = 5;
+#define num number;
+
+
+int function()
+{
+    return 9;
+}
+#define func function
+
+//https://github.com/dlang/dmd/issues/20478
+// similar issue
+
+#define A 1
+#define B A
+#define C (A)
+#define D (B)


### PR DESCRIPTION
#define identifier1 identifier2

symbolize identifier 1 so It can be used in D code.

in C, this code is valid even if identifier 2 points to no valid symbol. that is handled in DMD as not allowing the compiler to make noise about it. we also avoid aliasing specifiers. 