### PR TITLE
Fix diff-based AUTO_UPDATE for Windows

### DIFF
--- a/compiler/test/tools/d_do_test.d
+++ b/compiler/test/tools/d_do_test.d
@@ -1992,7 +1992,7 @@ int tryMain(string[] args)
                 {
                     try
                     {
-                        string diffUpdatedText = replaceFromDiff(existingText, ce.diff);
+                        string diffUpdatedText = replaceFromDiff(existingText, ce.diff.unifyDirSep("/"));
                         std.file.write(input_file, diffUpdatedText);
                         writefln("\n==> `%s_OUTPUT` of %s has been updated by applying a diff", type, input_file);
                         return Result.returnRerun;


### PR DESCRIPTION
Without this you get:

```
ERROR: Couldn't update `TEST_OUTPUT` blocks of compilable\diag20916.d through the diff: "Can't find diff line "compilable\diag20916.d(37): ..." in the text to update"
                            Please update the file manually to make the tests pass.
```

Because it's looking for a Windows path separator `\` in a TEST_OUTPUT block which uses posix separators `/`.