### PR TITLE
fix #22463 - SOURCE_DATE_EPOCH parsing incorrectly affected by system timezone

### DIFF
--- a/compiler/test/dshell/issue20444_SOURCE_DATE_EPOCH.d
+++ b/compiler/test/dshell/issue20444_SOURCE_DATE_EPOCH.d
@@ -10,7 +10,6 @@ void main ()
 {
     string[string] env = [
         "SOURCE_DATE_EPOCH": "704124840",
-        "TZ": "UTC",
         "LC_ALL": "C",
     ];
 


### PR DESCRIPTION
Use `asctime(gmtime())` instead of `ctime()`.  Setting `SOURCE_DATE_EPOCH` implies UTC.

Closes #22463.