### PR TITLE
Fix #20578 - add a placeholder value when inlining if statements

### DIFF
--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -331,6 +331,14 @@ public:
         {
             alias e1 = ifbody;
             alias e2 = elsebody;
+
+            // It is possible that one branch has no code, or that two branches
+            // have incompatible types. Use a placeholder value to prevent backend issues.
+            if (e1 && e1.type.toBasetype().ty == Tvoid)
+                e1 = Expression.combine(e1, new NullExp(econd.loc, Type.tvoid));
+            if (e2 && e2.type.toBasetype().ty == Tvoid)
+                e2 = Expression.combine(e2, new NullExp(econd.loc, Type.tvoid));
+
             if (e1 && e2)
             {
                 result = new CondExp(econd.loc, econd, e1, e2);

--- a/compiler/test/runnable/issue20578.d
+++ b/compiler/test/runnable/issue20578.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -inline
+
+int fun(string[])
+{
+   if (false)
+      static foreach(m; [1,2,3] ) { }
+
+   return 0;
+}
+
+int main(string[] args)
+{
+   return fun(args);
+}


### PR DESCRIPTION
This PR adds a `NullExp` as a placeholder value when inlining if statements. It removes two backend issues:
```d
void f(bool b)
{
    if (b) returnStruct();
    else returnValue();
}
// Previously inlined as b ? returnStruct() : returnValue(), which is a type mismatch
// Now inlined as b ? (returnStruct(), null) : (returnValue(), null)
```

```d
void f(bool b)
{
    if (b) { enum v = 0; }
}
// Previously inlined as b && (enum v = 0), which becomes a null pointer and causes segfault
// Now inlined as b && (enum v = 0, null), which is optimized away
```