### PR TITLE
Noreturn

### DIFF
--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -1822,7 +1822,7 @@ void cdfunc(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
                      * set at 0 or 1. But for parameters, a slot is used for it in
                      * either case.
                      */
-                    assert(type_size(ep.ET) <= 1); // a 0-sized struct
+                    //assert(type_size(ep.ET) <= 1); // a 0-sized struct
                     break;
 
                 default:

--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -221,6 +221,7 @@ struct CGstate
     int dfoidx;                 // which block we are in
     regm_t allregs;             // ALLREGS optionally including mBP
     regm_t fpregs;              // all floating point registers
+    regm_t mMSW,mLSW;		// hi and lo register masks
     regm_t xmmregs;             // all XMM registers
     regm_t mfuncreg;            // mask of registers preserved by function
     regm_t msavereg;            // Mask of registers that we would like to save.

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -2005,7 +2005,9 @@ private void cse_save(ref CodeBuilder cdb, regm_t ms)
 {
     //printf("cse_save() ms: %s\n", regm_str(ms));
     assert((ms & cgstate.regcon.cse.mops) == ms);
-    cgstate.regcon.cse.mops &= ~ms;
+
+    auto cg = &cgstate;
+    cg.regcon.cse.mops &= ~ms;
 
     regm_t xMSW = mMSW;
     regm_t xLSW = mLSW | mBP;

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -324,8 +324,15 @@ bool hasModregrm(scope const code* c)
 @trusted
 void cod3_setdefault()
 {
-    cgstate.BP = BP;
+    CGstate* cg = &cgstate;
+
+    cg.BP = BP;
     fregsaved = mBP | mSI | mDI;
+
+    /* hi and lo register masks
+     */
+    cg.mMSW = mMSW;
+    cg.mLSW = mLSW;
 }
 
 /********************************
@@ -334,7 +341,9 @@ void cod3_setdefault()
 @trusted
 void cod3_set32()
 {
-    cgstate.BP = BP;
+    CGstate* cg = &cgstate;
+
+    cg.BP = BP;
 
     inssize[0xA0] = T|5;
     inssize[0xA1] = T|5;
@@ -352,7 +361,12 @@ void cod3_set32()
         v = W|T|6;
 
     TARGET_STACKALIGN = config.fpxmmregs ? 16 : 4;
-    cgstate.allregs = mAX|mBX|mCX|mDX|mSI|mDI;
+    cg.allregs = mAX|mBX|mCX|mDX|mSI|mDI;
+
+    /* hi and lo register masks
+     */
+    cg.mMSW = mMSW;
+    cg.mLSW = mLSW;
 }
 
 /********************************
@@ -362,7 +376,9 @@ void cod3_set32()
 @trusted
 void cod3_set64()
 {
-    cgstate.BP = BP;
+    CGstate* cg = &cgstate;
+
+    cg.BP = BP;
 
     inssize[0xA0] = T|5;                // MOV AL,mem
     inssize[0xA1] = T|5;                // MOV RAX,mem
@@ -382,7 +398,12 @@ void cod3_set64()
         v = W|T|6;
 
     TARGET_STACKALIGN = config.fpxmmregs ? 16 : 8;
-    cgstate.allregs = mAX|mBX|mCX|mDX|mSI|mDI| mR8|mR9|mR10|mR11|mR12|mR13|mR14|mR15;
+    cg.allregs = mAX|mBX|mCX|mDX|mSI|mDI| mR8|mR9|mR10|mR11|mR12|mR13|mR14|mR15;
+
+    /* hi and lo register masks
+     */
+    cg.mMSW = mMSW;
+    cg.mLSW = mLSW;
 }
 
 /********************************
@@ -392,7 +413,8 @@ void cod3_set64()
 @trusted
 void cod3_setAArch64()
 {
-    cgstate.AArch64 = true;
+    CGstate* cg = &cgstate;
+    cg.AArch64 = true;
 
     /* Register usage per "AArch64 Procedure Call Standard"
      * r31 SP  Stack Pointer
@@ -410,11 +432,11 @@ void cod3_setAArch64()
      * v8-v15  Callee-saved registers (only bottom 64 bits need to be saved)
      * v16-31  Temporary registers (caller saved)
      */
-    cgstate.BP = INSTR.BP;
+    cg.BP = INSTR.BP;
 
     /* Integer registers r0-r7, r9-15, r19-28, r29(?)
      */
-    cgstate.allregs = INSTR.ALLREGS;
+    cg.allregs = INSTR.ALLREGS;
 
     /* Registers x19-x28, x29, v8-v15
      */
@@ -424,11 +446,16 @@ void cod3_setAArch64()
 
     /* 32 Floating point registers
      */
-    cgstate.fpregs = INSTR.FLOATREGS;
+    cg.fpregs = INSTR.FLOATREGS;
+
+    /* hi and lo register masks
+     */
+    cg.mMSW = INSTR.MSW;
+    cg.mLSW = INSTR.LSW;
 
     /* XMM registers
      */
-    cgstate.xmmregs = 0;  // implement later
+    cg.xmmregs = 0;  // TODO AArch64
 
     TARGET_STACKALIGN = 16;
 }


### PR DESCRIPTION
OPstrpar does have some sizes after all. Darn all these dependencies filter through the compiler. I'm better off just doing what the X86_64 generator does.

pull https://github.com/dlang/dmd/pull/22468 first