### PR TITLE
Fix #20578 - don't inline enum variable declaration

### DIFF
--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -736,7 +736,8 @@ public:
                         return;
                     }
                 }
-                if (vd.isStatic())
+
+                if (vd.isStatic() || (vd.storage_class & STC.manifest))
                     return;
 
                 bool varIsNRVO = ids.fd && (ids.fd.isNRVO && vd == ids.fd.nrvo_var || vd.nrvo);

--- a/compiler/test/runnable/issue20578.d
+++ b/compiler/test/runnable/issue20578.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -inline
+
+int fun(string[])
+{
+   if (false)
+      static foreach(m; [1,2,3] ) { }
+
+   return 0;
+}
+
+int main(string[] args)
+{
+   return fun(args);
+}


### PR DESCRIPTION
Enum variables should have no references after semantic, so it makes no sense to inline their declaration. This is not a general fix, but at least fixes the case of empty foreach bodies (#20578).