### PR TITLE
Convert ThrowStatement to ThrowExp when inlining

### DIFF
--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -471,7 +471,10 @@ public:
         static if (asStatements)
             result = new ThrowStatement(s.loc, doInlineAs!Expression(s.exp, ids));
         else
-            result = null;  // cannot be inlined as an Expression
+        {
+            result = new ThrowExp(s.loc, doInlineAs!Expression(s.exp, ids));
+            result.type = Type.tnoreturn;
+        }
     }
 
     // Expression -> (Statement | Expression)
@@ -2080,7 +2083,7 @@ private bool canInline(FuncDeclaration fd, bool hasThis, bool statementsToo, PAS
         {
             /* for the isTypeSArray() case see https://github.com/dlang/dmd/pull/16145#issuecomment-1932776873
              */
-            if (tfnext.ty != Tvoid &&
+            if (tfnext.ty != Tvoid && tfnext.ty != Tnoreturn &&
                 (!fd.hasReturnExp ||
                  hasDtor(tfnext) && (statementsToo || tfnext.isTypeSArray())))
             {
@@ -2469,7 +2472,7 @@ private void expandInline(CallExp ecall, FuncDeclaration fd, FuncDeclaration par
             e = e.toLvalue(null, "`ref` return");
 
         // https://issues.dlang.org/show_bug.cgi?id=15210
-        if (tf.next.ty == Tvoid && e && e.type.ty != Tvoid)
+        if (tf.next.ty == Tvoid && e && e.type.ty != Tvoid && e.type.ty != Tnoreturn)
         {
             e = new CastExp(callLoc, e, Type.tvoid);
             e.type = Type.tvoid;

--- a/compiler/src/dmd/inlinecost.d
+++ b/compiler/src/dmd/inlinecost.d
@@ -319,8 +319,8 @@ public:
 
     override void visit(ThrowStatement s)
     {
-        cost += STATEMENT_COST;
-        s.exp.accept(this);
+        cost++;
+        expressionInlineCost(s.exp);
     }
 
     /* -------------------------- */

--- a/compiler/test/runnable/imports/pragmainline_a.d
+++ b/compiler/test/runnable/imports/pragmainline_a.d
@@ -37,3 +37,9 @@ int value()
 {
     return 10;
 }
+
+pragma(inline, true)
+noreturn throws(T)(T param)
+{
+    throw new Exception("");
+}

--- a/compiler/test/runnable/pragmainline.d
+++ b/compiler/test/runnable/pragmainline.d
@@ -50,4 +50,11 @@ void main()
     assert(bar()() == baz());
 
     testAlwaysInline();
+
+    bool caught = false;
+    try
+        throws(throws(1));
+    catch (Exception e)
+        caught = true;
+    assert(caught);
 }


### PR DESCRIPTION
While it doesn't seem trivial to remove `ThrowStatement` from DMD altogether, inlining it is fine.