### PR TITLE
Fix #22481 - inliner silently removes return in loops

### DIFF
--- a/compiler/src/dmd/inlinecost.d
+++ b/compiler/src/dmd/inlinecost.d
@@ -313,7 +313,11 @@ public:
         if (s.increment)
             s.increment.accept(this);
         if (s._body)
+        {
+            nested += 1;
             s._body.accept(this);
+            nested -= 1;
+        }
         //printf("ForStatement: inlineCost = %d\n", cost);
     }
 

--- a/compiler/test/runnable/issue22481.d
+++ b/compiler/test/runnable/issue22481.d
@@ -1,0 +1,18 @@
+// REQUIRED_ARGS: -inline
+
+int v;
+
+void f()
+{
+   for (int i = 1; i < 5; i++)
+   {
+      v = i;
+      return;
+   }
+}
+
+void main()
+{
+   f();
+   assert(v == 1);
+}


### PR DESCRIPTION
Disallow `ReturnStatement` when inlining loops.