### PR TITLE
Refactoring optimization semantic3 array reserve

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1888,6 +1888,10 @@ extern (D) bool checkClosure(FuncDeclaration fd)
     }
 
     FuncDeclarations a;
+
+    if (fd.closureVars.length > 0)
+        a.reserve(fd.closureVars.length);
+
     foreach (v; fd.closureVars)
     {
         foreach (f; v.nestedrefs)


### PR DESCRIPTION
This PR optimizes memory management in **dmd/semantic3.d** by utilizing the **reserve()** method of the Array!T container.
What was changed:

- **checkClosure**: Added reserve() for the FuncDeclarations list. Since each variable in closureVars can contribute at most one unique function to the list, fd.closureVars.length provides a safe upper bound.