### PR TITLE
Refactoring optimization semantic3 array reserve in funcdecl

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1102,6 +1102,10 @@ private extern(C++) final class Semantic3Visitor : Visitor
             else
             {
                 auto a = new Statements();
+
+                size_t expectedSize = (funcdecl.parameters ? funcdecl.parameters.length : 0) + 7;
+                    a.reserve(expectedSize);
+
                 // Merge in initialization of 'out' parameters
                 if (funcdecl.parameters)
                 {


### PR DESCRIPTION
This PR optimizes memory management in dmd/semantic3.d by utilizing the reserve() method of the Array!T container.
What was changed:

**visit(FuncDeclaration)**: Added pre-allocation for the Statements list. The reserved size is calculated based on the number of parameters plus standard boilerplate blocks (contracts, body, returns).