### PR TITLE
fix #19675 - fatal error LNK1179 on windows-x86_64-dmd with MSVC

### DIFF
--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -396,9 +396,9 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
                 // Generate static initializer
                 auto sinit = toInitializer(sd);
-                if (sinit.Sclass == SC.extern_)
+                if (sinit.Sclass == SC.extern_ &&
+                    strcmp(sinit.Sident.ptr, "__bzeroBytes") != 0) // might be from another object file
                 {
-                    if (sinit == bzeroSymbol) assert(0);
                     sinit.Sclass = sd.isInstantiated() ? SC.comdat : SC.global;
                     sinit.Sfl = FL.data;
                     auto dtb = DtBuilder(0);
@@ -589,8 +589,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     scclass = SC.comdat;
 
                 // Generate static initializer
-                toInitializer(ed);
-                auto sinit = cast(Symbol*) ed.sinit;
+                auto sinit = toInitializer(ed);
                 sinit.Sclass = scclass;
                 sinit.Sfl = FL.data;
                 auto dtb = DtBuilder(0);

--- a/compiler/test/runnable/extra-files/gc19675.d
+++ b/compiler/test/runnable/extra-files/gc19675.d
@@ -1,0 +1,10 @@
+module gc19675;
+import memory19675;
+
+class ManualGC
+{
+    GC.ProfileStats profileStats()
+    {
+        return typeof(return).init;
+    }
+}

--- a/compiler/test/runnable/extra-files/main19675.d
+++ b/compiler/test/runnable/extra-files/main19675.d
@@ -1,0 +1,10 @@
+import gc19675;
+import memory19675;
+
+void main()
+{
+	auto p = new ManualGC;
+	auto s = p.profileStats();
+	auto s2 = GC.profileStats();
+	assert(s.numCollections[0] == 0);
+}

--- a/compiler/test/runnable/extra-files/memory19675.d
+++ b/compiler/test/runnable/extra-files/memory19675.d
@@ -1,0 +1,16 @@
+
+module memory19675;
+
+struct GC
+{
+    struct ProfileStats
+    {
+        size_t[10] numCollections;
+    }
+	static ProfileStats profileStats()
+    {
+        return typeof(return).init;
+    }
+
+}
+

--- a/compiler/test/runnable/test19675.sh
+++ b/compiler/test/runnable/test19675.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}/gc19675.d ${EXTRA_FILES}/memory19675.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}/main19675.d ${OUTPUT_BASE}${LIBEXT}
+
+rm_retry ${OUTPUT_BASE}{${LIBEXT},${EXE}}


### PR DESCRIPTION
don't modify and emit __bzeroBytes if it comes from a previous object file

Running the test case through CI revealed that there are still other issues on macOS and Win32 (one json unittest fails due to a bad init value).

Although the phobos library is about 1% smaller with the bzeroBytes-optimization, I suspect it only makes a difference of a few hundred bytes for a linked build with "identical COMDAT folding" enabled. I wouldn't mind removing the optimization.