### PR TITLE
Fix #22512 - druntime fails to build on sparcv9-sun-solaris2.11

### DIFF
--- a/druntime/src/core/sys/posix/signal.d
+++ b/druntime/src/core/sys/posix/signal.d
@@ -133,9 +133,8 @@ union sigval
 
 version (Solaris)
 {
-    import core.sys.posix.unistd;
-
     @property int SIGRTMIN() nothrow @nogc {
+        import core.sys.posix.unistd : sysconf, _SC_SIGRT_MIN;
         __gshared int sig = -1;
         if (sig == -1) {
             sig = cast(int)sysconf(_SC_SIGRT_MIN);
@@ -144,6 +143,7 @@ version (Solaris)
     }
 
     @property int SIGRTMAX() nothrow @nogc {
+        import core.sys.posix.unistd : sysconf, _SC_SIGRT_MAX;
         __gshared int sig = -1;
         if (sig == -1) {
             sig = cast(int)sysconf(_SC_SIGRT_MAX);


### PR DESCRIPTION
An import in #22092 introduced a new circular dependency, likely triggering a facet of the issue described in #17982.

This breaks the circular module dependency by moving the import inside the function body instead.

Closes: #22512