### PR TITLE
use positives for configuration tests

### DIFF
--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -361,7 +361,7 @@ tym_t totym(Type tx)
                     if (target.os == Target.OS.Windows)
                     {
                     }
-                    else if (!target.isX86_64 && retStyle(tf, false) == RET.stack)
+                    else if (target.isX86 && retStyle(tf, false) == RET.stack)
                         t = TYhfunc;
                     break;
 


### PR DESCRIPTION
as in where does target.isAArch64 fit in?