### PR TITLE
fix #22510 - dup of inout aa broke with 2.112

### DIFF
--- a/compiler/test/fail_compilation/fail19898a.d
+++ b/compiler/test/fail_compilation/fail19898a.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -m64
 TEST_OUTPUT:
 ---
-fail_compilation/fail19898a.d(10): Error: expression `__key2 < __limit3` of type `__vector(int[4])` does not have a boolean value
+fail_compilation/fail19898a.d(10): Error: expression `__key$n$ < __limit$n$` of type `__vector(int[4])` does not have a boolean value
 ---
 */
 void f (__vector(int[4]) n)

--- a/compiler/test/fail_compilation/fail19898b.d
+++ b/compiler/test/fail_compilation/fail19898b.d
@@ -3,8 +3,8 @@ REQUIRED_ARGS: -m64
 TEST_OUTPUT:
 ---
 fail_compilation/fail19898b.d(17): Error: cannot implicitly convert expression `m` of type `S` to `__vector(int[4])`
-fail_compilation/fail19898b.d(17): Error: expression `__key2 != __limit3` of type `__vector(int[4])` does not have a boolean value
-fail_compilation/fail19898b.d(17): Error: cannot cast expression `__key2` of type `__vector(int[4])` to `S`
+fail_compilation/fail19898b.d(17): Error: expression `__key$n$ != __limit$n$` of type `__vector(int[4])` does not have a boolean value
+fail_compilation/fail19898b.d(17): Error: cannot cast expression `__key$n$` of type `__vector(int[4])` to `S`
 ---
 */
 struct S

--- a/compiler/test/fail_compilation/test17977.d
+++ b/compiler/test/fail_compilation/test17977.d
@@ -3,7 +3,7 @@ https://issues.dlang.org/show_bug.cgi?id=15399
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test17977.d(19): Error: assigning address of variable `__slList3` to `elem` with longer lifetime is not allowed in a `@safe` function
+fail_compilation/test17977.d(19): Error: assigning address of variable `__slList$n$` to `elem` with longer lifetime is not allowed in a `@safe` function
 ---
 */
 

--- a/compiler/test/fail_compilation/test9150.d
+++ b/compiler/test/fail_compilation/test9150.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test9150.d(14): Error: mismatched array lengths 5 and 3 for assignment `row[] = __r2[__key3]`
+fail_compilation/test9150.d(14): Error: mismatched array lengths 5 and 3 for assignment `row[] = __r$n$[__key$n$]`
 ---
 */
 

--- a/druntime/test/aa/src/test_aa.d
+++ b/druntime/test/aa/src/test_aa.d
@@ -1021,3 +1021,38 @@ void testAliasThis()
     s.remove(1);
     assert(S.numCopies == 0);
 }
+
+void test22510()
+{
+    static struct S(AA)
+    {
+        AA aa_;
+        auto aa() inout => this.aa_.dup;
+    }
+    auto testDup(AA)()
+    {
+        S!AA s;
+        return s.aa();
+    }
+    auto aa_ii = testDup!(int[int])();
+    static assert(is(typeof(aa_ii) == int[int]));
+
+    auto aa_cii = testDup!(const(int[int]))();
+    static assert(is(typeof(aa_cii) == int[int]));
+
+    static struct T
+    {
+        char[] s; // non const indirection disallows conversion of const(T) -> T when copying
+    }
+    auto aa_it = testDup!(int[T])();
+    static assert(is(typeof(aa_it) == int[T]));
+
+    auto aa_cit = testDup!(const(int[T]))();
+    static assert(is(typeof(aa_cit) == int[T]));
+
+    auto aa_ti = testDup!(T[int])();
+    static assert(is(typeof(aa_ti) == T[int]));
+
+    auto aa_cti = testDup!(const(T[int]))();
+    static assert(is(typeof(aa_cti) == const(T)[int]));
+}


### PR DESCRIPTION
handle inout in aa.dup, create mutable AA as much as possible