### PR TITLE
Fix Issue 22517 - Mark void as having indirections (handle const/immu…

### DIFF
--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -565,7 +565,9 @@ unittest
 
 template hasIndirections(T)
 {
-    static if (is(T == enum))
+    static if (is(Unqual!T == void))
+        enum hasIndirections = true;
+    else static if (is(T == enum))
         enum hasIndirections = hasIndirections!(OriginalType!T);
     else static if (is(T == struct) || is(T == union))
         enum hasIndirections = anySatisfy!(.hasIndirections, typeof(T.tupleof));
@@ -580,7 +582,8 @@ template hasIndirections(T)
 }
 
 @safe unittest
-{
+{   
+    static assert(hasIndirections!void);
     static assert(!hasIndirections!int);
     static assert(!hasIndirections!(const int));
 
@@ -735,11 +738,11 @@ template hasIndirections(T)
 // https://github.com/dlang/dmd/issues/20812
 @safe unittest
 {
-    static assert(!hasIndirections!void);
-    static assert(!hasIndirections!(const void));
-    static assert(!hasIndirections!(inout void));
-    static assert(!hasIndirections!(immutable void));
-    static assert(!hasIndirections!(shared void));
+    static assert(hasIndirections!void);
+    static assert(hasIndirections!(const void));
+    static assert(hasIndirections!(inout void));
+    static assert(hasIndirections!(immutable void));
+    static assert(hasIndirections!(shared void));
 
     static assert( hasIndirections!(void*));
     static assert( hasIndirections!(const void*));


### PR DESCRIPTION
This fixes a regression where dynamic arrays of `void` were being marked as `NO_SCAN` by the GC, potentially causing memory corruption if they contained pointers.

### The Fix
* Updated `core.internal.traits.hasIndirections` to return `true` for `void`.
* Used `Unqual!T` to ensure this applies to `const`, `immutable`, and `shared` void as well.

### Tests
* Added a static assert to verify `hasIndirections!void` is true.
* Updated existing tests in `core.internal.traits` that incorrectly asserted `void` had no indirections.

Fixes Issue 22517.