### PR TITLE
fix #21976: [REG 2.112.0] Array comparison performance regression

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -14050,6 +14050,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Type t1n = t1.nextOf().toBasetype();
             Type t2n = t2.nextOf().toBasetype();
 
+            if (t1.ty == Tarray && t2.ty == Tarray)
+                // the dmd backend generates 'repe cmpsb' instead of a call to memcmp,
+                //  which has (very) bad performance on a lot of processors. So restore the
+                //  dmd 2.111 condition of always lowering to __equals for arrays.
+                // Though not affected, LDC and GDC are likely to inline and optimize
+                //  whatever version is selected here, so do this unconditionally.
+                // See https://github.com/dlang/dmd/issues/21976
+                if (!t1n.ty.isSomeChar) // likely to be short
+                    return false;
+
             if (t1n.size() != t2n.size())
                 return false;
 

--- a/compiler/test/fail_compilation/verifyhookexist.d
+++ b/compiler/test/fail_compilation/verifyhookexist.d
@@ -8,11 +8,12 @@ EXTRA_SOURCES: extra-files/minimal/object.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/verifyhookexist.d(21): Error: `object.__ArrayCast` not found. The current runtime does not support casting array of structs, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(28): Error: `object.__cmp` not found. The current runtime does not support comparing arrays, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(32): Error: `object._d_assert_fail` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(35): Error: `object.__switch` not found. The current runtime does not support switch cases on strings, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(40): Error: `object.__switch_error` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(22): Error: `object.__ArrayCast` not found. The current runtime does not support casting array of structs, or the runtime is corrupt.
+fail_compilation\verifyhookexist.d(28): Error: `object.__equals` not found. The current runtime does not support equal checks on arrays, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(29): Error: `object.__cmp` not found. The current runtime does not support comparing arrays, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(33): Error: `object._d_assert_fail` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(36): Error: `object.__switch` not found. The current runtime does not support switch cases on strings, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(41): Error: `object.__switch_error` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
 ---
 */
 


### PR DESCRIPTION
restore going through __equals lowering for all arrays but strings.

No idea how to test the performance regression that doesn't manifest everywhere.