### PR TITLE
druntime: Add FreeBSD_16 version

### DIFF
--- a/druntime/src/core/sys/freebsd/config.d
+++ b/druntime/src/core/sys/freebsd/config.d
@@ -14,7 +14,8 @@ public import core.sys.posix.config;
 // NOTE: When adding newer versions of FreeBSD, verify all current versioned
 // bindings are still compatible with the release.
 
-     version (FreeBSD_15) enum __FreeBSD_version = 1500063;
+     version (FreeBSD_16) enum __FreeBSD_version = 1600011;
+else version (FreeBSD_15) enum __FreeBSD_version = 1500063;
 else version (FreeBSD_14) enum __FreeBSD_version = 1400097;
 else version (FreeBSD_13) enum __FreeBSD_version = 1301000;
 else version (FreeBSD_12) enum __FreeBSD_version = 1203000;


### PR DESCRIPTION
No observed ABI breaks between versions. Mostly additive (C23 support) that will ignore for now.