### PR TITLE
Revert "fix #21976: [REG 2.112.0] Array comparison performance regression"

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -14050,16 +14050,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Type t1n = t1.nextOf().toBasetype();
             Type t2n = t2.nextOf().toBasetype();
 
-            if (t1.ty == Tarray && t2.ty == Tarray)
-                // the dmd backend generates 'repe cmpsb' instead of a call to memcmp,
-                //  which has (very) bad performance on a lot of processors. So restore the
-                //  dmd 2.111 condition of always lowering to __equals for arrays.
-                // Though not affected, LDC and GDC are likely to inline and optimize
-                //  whatever version is selected here, so do this unconditionally.
-                // See https://github.com/dlang/dmd/issues/21976
-                if (!t1n.ty.isSomeChar) // likely to be short
-                    return false;
-
             if (t1n.size() != t2n.size())
                 return false;
 

--- a/compiler/test/fail_compilation/verifyhookexist.d
+++ b/compiler/test/fail_compilation/verifyhookexist.d
@@ -8,12 +8,11 @@ EXTRA_SOURCES: extra-files/minimal/object.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/verifyhookexist.d(22): Error: `object.__ArrayCast` not found. The current runtime does not support casting array of structs, or the runtime is corrupt.
-fail_compilation\verifyhookexist.d(28): Error: `object.__equals` not found. The current runtime does not support equal checks on arrays, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(29): Error: `object.__cmp` not found. The current runtime does not support comparing arrays, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(33): Error: `object._d_assert_fail` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(36): Error: `object.__switch` not found. The current runtime does not support switch cases on strings, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(41): Error: `object.__switch_error` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(21): Error: `object.__ArrayCast` not found. The current runtime does not support casting array of structs, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(28): Error: `object.__cmp` not found. The current runtime does not support comparing arrays, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(32): Error: `object._d_assert_fail` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(35): Error: `object.__switch` not found. The current runtime does not support switch cases on strings, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(40): Error: `object.__switch_error` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
 ---
 */
 


### PR DESCRIPTION
Reverts dlang/dmd#22522

Failed to actually improve things, should rather happen in the backend.