### PR TITLE
-preview=safer should ignore C files

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -294,7 +294,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             return;
         funcdecl.semanticRun = PASS.semantic3;
         funcdecl.hasSemantic3Errors = false;
-        funcdecl.saferD = sc.previews.safer;
+        funcdecl.saferD = sc.previews.safer && !sc.inCfile;
 
         if (!funcdecl.type || funcdecl.type.ty != Tfunction)
             return;

--- a/compiler/test/compilable/safer_cfile.c
+++ b/compiler/test/compilable/safer_cfile.c
@@ -1,0 +1,7 @@
+// https://github.com/dlang/dmd/issues/22453
+// -preview=safer should ignore C files
+// REQUIRED_ARGS: -preview=safer
+int f(int *p)
+{
+    return p[1];
+}


### PR DESCRIPTION
Close: #22453 

Skip safer checks when compiling C files by checking `sc.inCfile`