### PR TITLE
Implement loading constant into complex

### DIFF
--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -2477,7 +2477,25 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
 
         if (tyfloating(tym))
         {
-            assert(!tycomplex(tym));  // TODO AArch64
+	    forregs = outretregs & INSTR.FLOATREGS;
+	    if (tycomplex(tym))
+	    {
+                const vreg_re = allocreg(cdb, forregs, tym);     // allocate floating point register
+		const vreg_im = findreg(forregs & INSTR.LSW);
+		double value_re = e.Vcfloat.re;
+		double value_im = e.Vcfloat.im;
+		if (sz == 16)
+		{
+		    value_re = e.Vcdouble.re;
+		    value_im = e.Vcdouble.im;
+		}
+		else if (sz == 32)
+		    assert(0);		// TODO AArch64 for Linux
+                loadFloatRegConst(cdb,vreg_re,value_re,sz / 2);
+                loadFloatRegConst(cdb,vreg_im,value_im,sz / 2);
+                fixresult(cdb, e, forregs, outretregs);
+		return;
+	    }
             const vreg = allocreg(cdb, forregs, tym);     // allocate floating point register
             double value = e.Vfloat;
             if (sz == 8)

--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -2477,25 +2477,25 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
 
         if (tyfloating(tym))
         {
-	    forregs = outretregs & INSTR.FLOATREGS;
-	    if (tycomplex(tym))
-	    {
-                const vreg_re = allocreg(cdb, forregs, tym);     // allocate floating point register
-		const vreg_im = findreg(forregs & INSTR.LSW);
-		double value_re = e.Vcfloat.re;
-		double value_im = e.Vcfloat.im;
-		if (sz == 16)
-		{
-		    value_re = e.Vcdouble.re;
-		    value_im = e.Vcdouble.im;
-		}
-		else if (sz == 32)
-		    assert(0);		// TODO AArch64 for Linux
+            forregs = outretregs & INSTR.FLOATREGS;
+            if (tycomplex(tym))
+            {
+                const vreg_im = allocreg(cdb, forregs, tym);     // allocate floating point register
+                const vreg_re = findreg(forregs & INSTR.LSW);
+                double value_re = e.Vcfloat.re;
+                double value_im = e.Vcfloat.im;
+                if (sz == 16)
+                {
+                    value_re = e.Vcdouble.re;
+                    value_im = e.Vcdouble.im;
+                }
+                else if (sz == 32)
+                    assert(0);          // TODO AArch64 for Linux
                 loadFloatRegConst(cdb,vreg_re,value_re,sz / 2);
                 loadFloatRegConst(cdb,vreg_im,value_im,sz / 2);
                 fixresult(cdb, e, forregs, outretregs);
-		return;
-	    }
+                return;
+            }
             const vreg = allocreg(cdb, forregs, tym);     // allocate floating point register
             double value = e.Vfloat;
             if (sz == 8)

--- a/compiler/src/dmd/backend/codebuilder.d
+++ b/compiler/src/dmd/backend/codebuilder.d
@@ -35,7 +35,7 @@ struct CodeBuilder
     code** pTail;
 
     enum BADINS = 0x1234_5678;
-    //enum BADINS = 0x00_66_0F_6E;
+    //enum BADINS = 0xAA_20_03_E0;
 
   nothrow:
   public:

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -680,13 +680,20 @@ void cod3_buildmodulector(OutBuffer* buf, int codeOffset, int refOffset)
 /*****************************
  * Given a type, return a mask of
  * registers to hold that type.
- * Input:
- *      tyf     function type
+ * Params:
+ *      tym = type
+ *      tyf = function type
+ * Returns:
+ *      mask of registers
  */
 
 @trusted
 regm_t regmask(tym_t tym, tym_t tyf)
 {
+    bool AArch64 = cgstate.AArch64;
+    if (AArch64)
+        return dmd.backend.arm.cod3.regmask(tym, tyf);
+
     switch (tybasic(tym))
     {
         case TYvoid:


### PR DESCRIPTION
found some other omissions in the process.
```d
creal test()
{
    return 1 + 2i;
}
```
produces:
```
0000:   A9 BF 7B FD  stp       x29,x30,[sp,#-0x10]! // https://www.scs.stanford.edu/~zyedidia/arm64/stp_gen.html
0004:   91 00 03 FD  mov       x29,sp             // https://www.scs.stanford.edu/~zyedidia/arm64/mov_add_addsub_imm.html
0008:   1E 6E 10 01  fmov      d0,#1.000000e+00   // https://www.scs.stanford.edu/~zyedidia/arm64/encodingindex.html#floatimm
000c:   1E 60 10 00  fmov      d1,#2.000000e+00   // https://www.scs.stanford.edu/~zyedidia/arm64/encodingindex.html#floatimm
0010:   A8 C1 7B FD  ldp       x29,x30,[sp],#0x10 // https://www.scs.stanford.edu/~zyedidia/arm64/ldp_gen.html
0014:   D6 5F 03 C0  ret                          // https://www.scs.stanford.edu/~zyedidia/arm64/encodingindex.html#branch_reg
````