### PR TITLE
Fix CTFE failures during inlining

### DIFF
--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -763,6 +763,7 @@ public:
                 vto.parent = ids.parent;
                 vto.csym = null;
                 vto.nrvo = ids.propagateNRVO && varIsNRVO;
+                vto.ctfeAdrOnStack = VarDeclaration.AdrOnStackNone;
 
                 ids.from.push(vd);
                 ids.to.push(vto);
@@ -850,13 +851,8 @@ public:
         {
             auto ce = cast(CastExp)e.copy();
             if (auto lowering = ce.lowering)
-            {
                 ce.lowering = doInlineAs!Expression(lowering, ids);
-            }
-            else
-            {
-                ce.e1 = doInlineAs!Expression(e.e1, ids);
-            }
+            ce.e1 = doInlineAs!Expression(e.e1, ids);
 
             result = ce;
         }
@@ -875,11 +871,8 @@ public:
 
             if (auto lowering = ce.lowering)
                 ce.lowering = doInlineAs!Expression(lowering, ids);
-            else
-            {
-                ce.e1 = doInlineAs!Expression(e.e1, ids);
-                ce.e2 = doInlineAs!Expression(e.e2, ids);
-            }
+            ce.e1 = doInlineAs!Expression(e.e1, ids);
+            ce.e2 = doInlineAs!Expression(e.e2, ids);
 
             result = ce;
         }
@@ -889,12 +882,9 @@ public:
             auto cae = cast(CatAssignExp) e.copy();
 
             if (auto lowering = cae.lowering)
-                cae.lowering = doInlineAs!Expression(cae.lowering, ids);
-            else
-            {
-                cae.e1 = doInlineAs!Expression(e.e1, ids);
-                cae.e2 = doInlineAs!Expression(e.e2, ids);
-            }
+                cae.lowering = doInlineAs!Expression(lowering, ids);
+            cae.e1 = doInlineAs!Expression(e.e1, ids);
+            cae.e2 = doInlineAs!Expression(e.e2, ids);
 
             result = cae;
         }
@@ -922,14 +912,12 @@ public:
 
         override void visit(ConstructExp e)
         {
-            if (e.lowering)
-            {
-                auto ce = cast(ConstructExp)e.copy();
+            auto ce = cast(ConstructExp)e.copy();
+            if (ce.lowering)
                 ce.lowering = doInlineAs!Expression(ce.lowering, ids);
-                result = ce;
-            }
-            else
-                visit(cast(AssignExp) e);
+            ce.e1 = doInlineAs!Expression(e.e1, ids);
+            ce.e2 = doInlineAs!Expression(e.e2, ids);
+            result = ce;
         }
 
         override void visit(LoweredAssignExp e)
@@ -977,6 +965,7 @@ public:
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
                 vto.csym = null;
+                vto.ctfeAdrOnStack = VarDeclaration.AdrOnStackNone;
 
                 ids.from.push(vd);
                 ids.to.push(vto);
@@ -1005,6 +994,7 @@ public:
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
                 vto.csym = null;
+                vto.ctfeAdrOnStack = VarDeclaration.AdrOnStackNone;
 
                 ids.from.push(vd);
                 ids.to.push(vto);


### PR DESCRIPTION
With some harmless changes to `core.demangle`, it's possible to trigger a build failure in ocean (#22533). DustMite didn't help; it seems the bug depends on module ordering. Nevertheless the issue appears to be CTFE on a function that has been inlined (`runDeferredSemantic3()` in `canInline()` trying to instantiate templates). This PR prevents the inliner from breaking CTFE.