### PR TITLE
Improve error messages for forward/circular reference errors

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -83,6 +83,73 @@ import dmd.visitor;
 
 enum LOG = false;
 
+/***********************************************
+ * Resolution context tracking for forward/circular reference error chains.
+ *
+ * Maintains a stack of symbols currently being resolved during semantic
+ * analysis. When a forward or circular reference error occurs, the stack
+ * is walked to print supplemental messages showing the dependency chain.
+ *
+ * This is analogous to `TemplateInstance.printInstantiationTrace()` in
+ * `dtemplate.d`, but for variable type inference and struct size resolution.
+ */
+
+/// Entry in the resolution context stack.
+struct ResolutionEntry
+{
+    Dsymbol sym;        /// The symbol being resolved
+    Loc loc;            /// Where the resolution was triggered from
+}
+
+/// Stack tracking the chain of symbols currently being resolved.
+__gshared ResolutionEntry[64] resolutionStack;
+__gshared uint resolutionDepth;
+
+/// RAII helper to push/pop resolution context entries.
+struct ResolutionContext
+{
+    @disable this();
+    @disable this(this);
+
+    this(Dsymbol sym, Loc loc) nothrow
+    {
+        if (resolutionDepth < resolutionStack.length)
+            resolutionStack[resolutionDepth] = ResolutionEntry(sym, loc);
+        ++resolutionDepth;
+    }
+
+    ~this() nothrow
+    {
+        --resolutionDepth;
+    }
+}
+
+/// Print the current resolution chain as supplemental error messages.
+/// Called after a forward/circular reference error to show the dependency path.
+void printResolutionTrace()
+{
+    if (global.gag)
+        return;
+
+    const max_shown = global.params.v.errorSupplementCount();
+    const depth = resolutionDepth < resolutionStack.length
+                ? resolutionDepth : cast(uint) resolutionStack.length;
+
+    if (depth == 0)
+        return;
+
+    uint shown = 0;
+    // Walk from top of stack (most recent) to bottom (root cause)
+    for (uint i = depth; i > 0 && shown < max_shown; --i)
+    {
+        auto entry = resolutionStack[i - 1];
+        if (entry.sym is null)
+            continue;
+        errorSupplemental(entry.loc, "while resolving `%s`", entry.sym.toPrettyChars());
+        ++shown;
+    }
+}
+
 /***************************************
  * Create a new scope from sc.
  * semantic, semantic2 and semantic3 will use this for aggregate members.
@@ -2226,6 +2293,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         int inferred = 0;
         if (!dsym.type)
         {
+            auto _resolveCtx = ResolutionContext(dsym, dsym.loc);
             dsym.inuse++;
 
             // Infering the type requires running semantic,
@@ -4580,6 +4648,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (sd.type.ty != Terror)
             {
                 .error(sd.loc, "%s `%s` circular or forward reference", sd.kind, sd.toPrettyChars);
+                printResolutionTrace();
                 sd.errors = true;
                 sd.type = Type.terror;
             }
@@ -7865,7 +7934,10 @@ private extern(C++) class SearchVisitor : Visitor
         {
             // .stringof is always defined (but may be hidden by some other symbol)
             if(ident != Id.stringof && !(flags & SearchOpt.ignoreErrors) && sd.semanticRun < PASS.semanticdone)
+            {
                 .error(loc, "%s `%s` is forward referenced when looking for `%s`", sd.kind, sd.toPrettyChars, ident.toChars());
+                printResolutionTrace();
+            }
             return setResult(null);
         }
 
@@ -9205,6 +9277,8 @@ bool determineSize(AggregateDeclaration ad, Loc loc)
         return false;
     }
 
+    auto _resolveCtx = ResolutionContext(ad, loc);
+
     if (ad._scope)
         dsymbolSemantic(ad, null);
 
@@ -9231,7 +9305,10 @@ bool determineSize(AggregateDeclaration ad, Loc loc)
 Lfail:
     // There's unresolvable forward reference.
     if (ad.type != Type.terror)
+    {
         error(loc, "%s `%s` no size because of forward reference", ad.kind, ad.toPrettyChars);
+        printResolutionTrace();
+    }
     // Don't cache errors from speculative semantic, might be resolvable later.
     // https://issues.dlang.org/show_bug.cgi?id=16574
     if (!global.gag)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2721,6 +2721,7 @@ Lagain:
                 error(loc, "circular reference to %s `%s`", v.kind(), v.toPrettyChars());
             else            // variable type cannot be determined
                 error(loc, "forward reference to %s `%s`", v.kind(), v.toPrettyChars());
+            printResolutionTrace();
             return ErrorExp.get();
         }
         if (v.type.ty == Terror)
@@ -10237,6 +10238,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 else
                     error(exp.loc, "forward reference to type `%s` of expression `%s`", exp.e1.type.toChars(), exp.e1.toErrMsg());
+                printResolutionTrace();
                 return setError();
             }
         }
@@ -15833,6 +15835,7 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
                         error(exp.loc, "circular reference to %s `%s`", v.kind(), v.toPrettyChars());
                     else
                         error(exp.loc, "forward reference to %s `%s`", v.kind(), v.toPrettyChars());
+                    printResolutionTrace();
                     return ErrorExp.get();
                 }
                 if (v.type.isTypeError())

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6305,6 +6305,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (!v.type)
                 {
                     error(exp.loc, "forward reference of %s `%s`", v.kind(), v.toChars());
+                    printResolutionTrace();
                     return setError();
                 }
                 if ((v.storage_class & STC.manifest) && v._init)

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -145,7 +145,7 @@ import dmd.declaration;
 import dmd.dinterpret;
 import dmd.dmodule;
 import dmd.dsymbol;
-import dmd.dsymbolsem : toAlias;
+import dmd.dsymbolsem : printResolutionTrace, toAlias;
 import dmd.expressionsem : toInteger, toReal, toImaginary;
 import dmd.dtemplate;
 import dmd.errors;
@@ -875,6 +875,7 @@ public:
                     if (!d.type || !d.type.deco)
                     {
                         error(ti.loc, "%s `%s` forward reference of %s `%s`", ti.kind, ti.toPrettyChars, d.kind(), d.toChars());
+                        printResolutionTrace();
                         continue;
                     }
                 }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1678,6 +1678,7 @@ private void resolveHelper(TypeQualified mt, Loc loc, Scope* sc, Dsymbol s, Dsym
                 error(loc, "circular reference to %s `%s`", v.kind(), v.toPrettyChars());
             else
                 error(loc, "forward reference to %s `%s`", v.kind(), v.toPrettyChars());
+            printResolutionTrace();
             pt = Type.terror;
             return;
         }
@@ -6826,6 +6827,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                     error(e.loc, "circular reference to %s `%s`", v.kind(), v.toPrettyChars());
                 else
                     error(e.loc, "forward reference to %s `%s`", v.kind(), v.toPrettyChars());
+                printResolutionTrace();
                 return ErrorExp.get();
             }
             if (v.type.ty == Terror)
@@ -7257,6 +7259,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                     error(e.loc, "circular reference to %s `%s`", v.kind(), v.toPrettyChars());
                 else
                     error(e.loc, "forward reference to %s `%s`", v.kind(), v.toPrettyChars());
+                printResolutionTrace();
                 return ErrorExp.get();
             }
             if (v.type.ty == Terror)

--- a/compiler/test/fail_compilation/fail272.d
+++ b/compiler/test/fail_compilation/fail272.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail272.d(9): Error: circular reference to variable `fail272.Ins!(Ins).Ins`
-fail_compilation/fail272.d(10): Error: template instance `fail272.Ins!(Ins)` error instantiating
+fail_compilation/fail272.d(10): Error: circular reference to variable `fail272.Ins!(Ins).Ins`
+fail_compilation/fail272.d(10):        while resolving `fail272.Ins!(Ins).Ins`
+fail_compilation/fail272.d(11): Error: template instance `fail272.Ins!(Ins)` error instantiating
 ---
 */
 

--- a/compiler/test/fail_compilation/fail275.d
+++ b/compiler/test/fail_compilation/fail275.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail275.d(10): Error: circular reference to variable `fail275.C.x`
+fail_compilation/fail275.d(11): Error: circular reference to variable `fail275.C.x`
+fail_compilation/fail275.d(11):        while resolving `fail275.C.x`
 ---
 */
 // REQUIRED_ARGS: -d

--- a/compiler/test/fail_compilation/fail309.d
+++ b/compiler/test/fail_compilation/fail309.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail309.d(10): Error: circular reference to variable `fail309.S.x`
+fail_compilation/fail309.d(11): Error: circular reference to variable `fail309.S.x`
+fail_compilation/fail309.d(11):        while resolving `fail309.S.x`
 ---
 */
 // REQUIRED_ARGS: -d

--- a/compiler/test/fail_compilation/fail42.d
+++ b/compiler/test/fail_compilation/fail42.d
@@ -1,7 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail42.d(22): Error: struct `fail42.Qwert` no size because of forward reference
+fail_compilation/fail42.d(24): Error: struct `fail42.Qwert` no size because of forward reference
+fail_compilation/fail42.d(24):        while resolving `fail42.Qwert`
+fail_compilation/fail42.d(22):        while resolving `fail42.Yuiop`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail_circular.d
+++ b/compiler/test/fail_compilation/fail_circular.d
@@ -1,16 +1,22 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_circular.d(16): Error: circular reference to variable `fail_circular.a1`
-fail_compilation/fail_circular.d(17): Error: circular reference to variable `fail_circular.a2`
-fail_compilation/fail_circular.d(19): Error: circular reference to variable `fail_circular.b1`
-fail_compilation/fail_circular.d(20): Error: circular reference to variable `fail_circular.b2`
-fail_compilation/fail_circular.d(22): Error: circular reference to variable `fail_circular.c1`
-fail_compilation/fail_circular.d(23): Error: circular reference to variable `fail_circular.c2`
-fail_compilation/fail_circular.d(25): Error: circular initialization of variable `fail_circular.d1`
-fail_compilation/fail_circular.d(26): Error: circular initialization of variable `fail_circular.d2`
-fail_compilation/fail_circular.d(28): Error: circular initialization of variable `fail_circular.e1`
-fail_compilation/fail_circular.d(29): Error: circular initialization of variable `fail_circular.e2`
+fail_compilation/fail_circular.d(22): Error: circular reference to variable `fail_circular.a1`
+fail_compilation/fail_circular.d(22):        while resolving `fail_circular.a1`
+fail_compilation/fail_circular.d(23): Error: circular reference to variable `fail_circular.a2`
+fail_compilation/fail_circular.d(23):        while resolving `fail_circular.a2`
+fail_compilation/fail_circular.d(25): Error: circular reference to variable `fail_circular.b1`
+fail_compilation/fail_circular.d(25):        while resolving `fail_circular.b1`
+fail_compilation/fail_circular.d(26): Error: circular reference to variable `fail_circular.b2`
+fail_compilation/fail_circular.d(26):        while resolving `fail_circular.b2`
+fail_compilation/fail_circular.d(28): Error: circular reference to variable `fail_circular.c1`
+fail_compilation/fail_circular.d(28):        while resolving `fail_circular.c1`
+fail_compilation/fail_circular.d(29): Error: circular reference to variable `fail_circular.c2`
+fail_compilation/fail_circular.d(29):        while resolving `fail_circular.c2`
+fail_compilation/fail_circular.d(31): Error: circular initialization of variable `fail_circular.d1`
+fail_compilation/fail_circular.d(32): Error: circular initialization of variable `fail_circular.d2`
+fail_compilation/fail_circular.d(34): Error: circular initialization of variable `fail_circular.e1`
+fail_compilation/fail_circular.d(35): Error: circular initialization of variable `fail_circular.e2`
 ---
 */
 auto a1 =  a1;          // semantic error (cannot determine expression type)
@@ -31,16 +37,28 @@ enum int e2 = .e2;      // CTFE error
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_circular.d(47): Error: circular reference to variable `fail_circular.a1a`
-fail_compilation/fail_circular.d(49): Error: circular reference to variable `fail_circular.a2a`
-fail_compilation/fail_circular.d(52): Error: circular reference to variable `fail_circular.b1a`
-fail_compilation/fail_circular.d(54): Error: circular reference to variable `fail_circular.b2a`
-fail_compilation/fail_circular.d(57): Error: circular reference to variable `fail_circular.c1a`
-fail_compilation/fail_circular.d(59): Error: circular reference to variable `fail_circular.c2a`
-fail_compilation/fail_circular.d(62): Error: circular initialization of variable `fail_circular.d1a`
-fail_compilation/fail_circular.d(64): Error: circular initialization of variable `fail_circular.d2a`
-fail_compilation/fail_circular.d(67): Error: circular initialization of variable `fail_circular.e1a`
-fail_compilation/fail_circular.d(69): Error: circular initialization of variable `fail_circular.e2a`
+fail_compilation/fail_circular.d(65): Error: circular reference to variable `fail_circular.a1a`
+fail_compilation/fail_circular.d(65):        while resolving `fail_circular.a1b`
+fail_compilation/fail_circular.d(64):        while resolving `fail_circular.a1a`
+fail_compilation/fail_circular.d(67): Error: circular reference to variable `fail_circular.a2a`
+fail_compilation/fail_circular.d(67):        while resolving `fail_circular.a2b`
+fail_compilation/fail_circular.d(66):        while resolving `fail_circular.a2a`
+fail_compilation/fail_circular.d(70): Error: circular reference to variable `fail_circular.b1a`
+fail_compilation/fail_circular.d(70):        while resolving `fail_circular.b1b`
+fail_compilation/fail_circular.d(69):        while resolving `fail_circular.b1a`
+fail_compilation/fail_circular.d(72): Error: circular reference to variable `fail_circular.b2a`
+fail_compilation/fail_circular.d(72):        while resolving `fail_circular.b2b`
+fail_compilation/fail_circular.d(71):        while resolving `fail_circular.b2a`
+fail_compilation/fail_circular.d(75): Error: circular reference to variable `fail_circular.c1a`
+fail_compilation/fail_circular.d(75):        while resolving `fail_circular.c1b`
+fail_compilation/fail_circular.d(74):        while resolving `fail_circular.c1a`
+fail_compilation/fail_circular.d(77): Error: circular reference to variable `fail_circular.c2a`
+fail_compilation/fail_circular.d(77):        while resolving `fail_circular.c2b`
+fail_compilation/fail_circular.d(76):        while resolving `fail_circular.c2a`
+fail_compilation/fail_circular.d(80): Error: circular initialization of variable `fail_circular.d1a`
+fail_compilation/fail_circular.d(82): Error: circular initialization of variable `fail_circular.d2a`
+fail_compilation/fail_circular.d(85): Error: circular initialization of variable `fail_circular.e1a`
+fail_compilation/fail_circular.d(87): Error: circular initialization of variable `fail_circular.e2a`
 ---
 */
 auto a1a =  a1b;
@@ -71,12 +89,12 @@ enum int e2b = .e2a;    // CTFE error
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_circular.d(84): Error: circular reference to variable `fail_circular.S1.a1`
-fail_compilation/fail_circular.d(88): Error: circular reference to variable `fail_circular.S2.b1`
-fail_compilation/fail_circular.d(92): Error: circular reference to variable `fail_circular.S3.c1`
-fail_compilation/fail_circular.d(97): Error: circular reference to variable `fail_circular.S4.a1a`
-fail_compilation/fail_circular.d(102): Error: circular reference to variable `fail_circular.S5.b1a`
-fail_compilation/fail_circular.d(107): Error: circular reference to variable `fail_circular.S6.c1a`
+fail_compilation/fail_circular.d(102): Error: circular reference to variable `fail_circular.S1.a1`
+fail_compilation/fail_circular.d(106): Error: circular reference to variable `fail_circular.S2.b1`
+fail_compilation/fail_circular.d(110): Error: circular reference to variable `fail_circular.S3.c1`
+fail_compilation/fail_circular.d(115): Error: circular reference to variable `fail_circular.S4.a1a`
+fail_compilation/fail_circular.d(120): Error: circular reference to variable `fail_circular.S5.b1a`
+fail_compilation/fail_circular.d(125): Error: circular reference to variable `fail_circular.S6.c1a`
 ---
 */
 struct S1
@@ -110,15 +128,15 @@ struct S6
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_circular.d(126): Error: circular reference to variable `fail_circular.C.a1`
-fail_compilation/fail_circular.d(128): Error: circular reference to variable `fail_circular.C.b1`
-fail_compilation/fail_circular.d(130): Error: circular reference to variable `fail_circular.C.c1`
-fail_compilation/fail_circular.d(133): Error: circular reference to variable `fail_circular.C.a1a`
-fail_compilation/fail_circular.d(132): Error: type of variable `fail_circular.C.a1b` has errors
-fail_compilation/fail_circular.d(136): Error: circular reference to variable `fail_circular.C.b1a`
-fail_compilation/fail_circular.d(135): Error: type of variable `fail_circular.C.b1b` has errors
-fail_compilation/fail_circular.d(139): Error: circular reference to variable `fail_circular.C.c1a`
-fail_compilation/fail_circular.d(138): Error: type of variable `fail_circular.C.c1b` has errors
+fail_compilation/fail_circular.d(144): Error: circular reference to variable `fail_circular.C.a1`
+fail_compilation/fail_circular.d(146): Error: circular reference to variable `fail_circular.C.b1`
+fail_compilation/fail_circular.d(148): Error: circular reference to variable `fail_circular.C.c1`
+fail_compilation/fail_circular.d(151): Error: circular reference to variable `fail_circular.C.a1a`
+fail_compilation/fail_circular.d(150): Error: type of variable `fail_circular.C.a1b` has errors
+fail_compilation/fail_circular.d(154): Error: circular reference to variable `fail_circular.C.b1a`
+fail_compilation/fail_circular.d(153): Error: type of variable `fail_circular.C.b1b` has errors
+fail_compilation/fail_circular.d(157): Error: circular reference to variable `fail_circular.C.c1a`
+fail_compilation/fail_circular.d(156): Error: type of variable `fail_circular.C.c1b` has errors
 ---
 */
 class C

--- a/compiler/test/fail_compilation/fail_circular.d
+++ b/compiler/test/fail_compilation/fail_circular.d
@@ -89,12 +89,21 @@ enum int e2b = .e2a;    // CTFE error
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_circular.d(102): Error: circular reference to variable `fail_circular.S1.a1`
-fail_compilation/fail_circular.d(106): Error: circular reference to variable `fail_circular.S2.b1`
-fail_compilation/fail_circular.d(110): Error: circular reference to variable `fail_circular.S3.c1`
-fail_compilation/fail_circular.d(115): Error: circular reference to variable `fail_circular.S4.a1a`
-fail_compilation/fail_circular.d(120): Error: circular reference to variable `fail_circular.S5.b1a`
-fail_compilation/fail_circular.d(125): Error: circular reference to variable `fail_circular.S6.c1a`
+fail_compilation/fail_circular.d(111): Error: circular reference to variable `fail_circular.S1.a1`
+fail_compilation/fail_circular.d(111):        while resolving `fail_circular.S1.a1`
+fail_compilation/fail_circular.d(115): Error: circular reference to variable `fail_circular.S2.b1`
+fail_compilation/fail_circular.d(115):        while resolving `fail_circular.S2.b1`
+fail_compilation/fail_circular.d(119): Error: circular reference to variable `fail_circular.S3.c1`
+fail_compilation/fail_circular.d(119):        while resolving `fail_circular.S3.c1`
+fail_compilation/fail_circular.d(124): Error: circular reference to variable `fail_circular.S4.a1a`
+fail_compilation/fail_circular.d(124):        while resolving `fail_circular.S4.a1b`
+fail_compilation/fail_circular.d(123):        while resolving `fail_circular.S4.a1a`
+fail_compilation/fail_circular.d(129): Error: circular reference to variable `fail_circular.S5.b1a`
+fail_compilation/fail_circular.d(129):        while resolving `fail_circular.S5.b1b`
+fail_compilation/fail_circular.d(128):        while resolving `fail_circular.S5.b1a`
+fail_compilation/fail_circular.d(134): Error: circular reference to variable `fail_circular.S6.c1a`
+fail_compilation/fail_circular.d(134):        while resolving `fail_circular.S6.c1b`
+fail_compilation/fail_circular.d(133):        while resolving `fail_circular.S6.c1a`
 ---
 */
 struct S1
@@ -128,15 +137,24 @@ struct S6
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_circular.d(144): Error: circular reference to variable `fail_circular.C.a1`
-fail_compilation/fail_circular.d(146): Error: circular reference to variable `fail_circular.C.b1`
-fail_compilation/fail_circular.d(148): Error: circular reference to variable `fail_circular.C.c1`
-fail_compilation/fail_circular.d(151): Error: circular reference to variable `fail_circular.C.a1a`
-fail_compilation/fail_circular.d(150): Error: type of variable `fail_circular.C.a1b` has errors
-fail_compilation/fail_circular.d(154): Error: circular reference to variable `fail_circular.C.b1a`
-fail_compilation/fail_circular.d(153): Error: type of variable `fail_circular.C.b1b` has errors
-fail_compilation/fail_circular.d(157): Error: circular reference to variable `fail_circular.C.c1a`
-fail_compilation/fail_circular.d(156): Error: type of variable `fail_circular.C.c1b` has errors
+fail_compilation/fail_circular.d(162): Error: circular reference to variable `fail_circular.C.a1`
+fail_compilation/fail_circular.d(162):        while resolving `fail_circular.C.a1`
+fail_compilation/fail_circular.d(164): Error: circular reference to variable `fail_circular.C.b1`
+fail_compilation/fail_circular.d(164):        while resolving `fail_circular.C.b1`
+fail_compilation/fail_circular.d(166): Error: circular reference to variable `fail_circular.C.c1`
+fail_compilation/fail_circular.d(166):        while resolving `fail_circular.C.c1`
+fail_compilation/fail_circular.d(169): Error: circular reference to variable `fail_circular.C.a1a`
+fail_compilation/fail_circular.d(169):        while resolving `fail_circular.C.a1b`
+fail_compilation/fail_circular.d(168):        while resolving `fail_circular.C.a1a`
+fail_compilation/fail_circular.d(168): Error: type of variable `fail_circular.C.a1b` has errors
+fail_compilation/fail_circular.d(172): Error: circular reference to variable `fail_circular.C.b1a`
+fail_compilation/fail_circular.d(172):        while resolving `fail_circular.C.b1b`
+fail_compilation/fail_circular.d(171):        while resolving `fail_circular.C.b1a`
+fail_compilation/fail_circular.d(171): Error: type of variable `fail_circular.C.b1b` has errors
+fail_compilation/fail_circular.d(175): Error: circular reference to variable `fail_circular.C.c1a`
+fail_compilation/fail_circular.d(175):        while resolving `fail_circular.C.c1b`
+fail_compilation/fail_circular.d(174):        while resolving `fail_circular.C.c1a`
+fail_compilation/fail_circular.d(174): Error: type of variable `fail_circular.C.c1b` has errors
 ---
 */
 class C

--- a/compiler/test/fail_compilation/fwd_ref_chain_struct.d
+++ b/compiler/test/fail_compilation/fwd_ref_chain_struct.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fwd_ref_chain_struct.d(13): Error: struct `fwd_ref_chain_struct.A` no size because of forward reference
+fail_compilation/fwd_ref_chain_struct.d(13):        while resolving `fwd_ref_chain_struct.A`
+fail_compilation/fwd_ref_chain_struct.d(13):        while resolving `fwd_ref_chain_struct.B`
+---
+*/
+// https://github.com/dlang/dmd/pull/XXXX
+// Test that circular struct size dependency shows the resolution chain.
+
+struct A { B b; }
+struct B { A a; }

--- a/compiler/test/fail_compilation/fwd_ref_chain_struct3.d
+++ b/compiler/test/fail_compilation/fwd_ref_chain_struct3.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fwd_ref_chain_struct3.d(15): Error: struct `fwd_ref_chain_struct3.A` no size because of forward reference
+fail_compilation/fwd_ref_chain_struct3.d(15):        while resolving `fwd_ref_chain_struct3.A`
+fail_compilation/fwd_ref_chain_struct3.d(15):        while resolving `fwd_ref_chain_struct3.C`
+fail_compilation/fwd_ref_chain_struct3.d(14):        while resolving `fwd_ref_chain_struct3.B`
+---
+*/
+// https://github.com/dlang/dmd/pull/XXXX
+// Test that 3-way circular struct size dependency shows the full resolution chain.
+
+struct A { B b; }
+struct B { C c; }
+struct C { A a; }

--- a/compiler/test/fail_compilation/fwd_ref_chain_var.d
+++ b/compiler/test/fail_compilation/fwd_ref_chain_var.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fwd_ref_chain_var.d(13): Error: circular reference to variable `fwd_ref_chain_var.x`
+fail_compilation/fwd_ref_chain_var.d(13):        while resolving `fwd_ref_chain_var.y`
+fail_compilation/fwd_ref_chain_var.d(12):        while resolving `fwd_ref_chain_var.x`
+---
+*/
+// https://github.com/dlang/dmd/pull/XXXX
+// Test that circular variable type inference shows the resolution chain.
+
+auto x = y + 1;
+auto y = x + 1;

--- a/compiler/test/fail_compilation/fwd_ref_chain_var3.d
+++ b/compiler/test/fail_compilation/fwd_ref_chain_var3.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fwd_ref_chain_var3.d(15): Error: circular reference to variable `fwd_ref_chain_var3.x`
+fail_compilation/fwd_ref_chain_var3.d(15):        while resolving `fwd_ref_chain_var3.z`
+fail_compilation/fwd_ref_chain_var3.d(14):        while resolving `fwd_ref_chain_var3.y`
+fail_compilation/fwd_ref_chain_var3.d(13):        while resolving `fwd_ref_chain_var3.x`
+---
+*/
+// https://github.com/dlang/dmd/pull/XXXX
+// Test that 3-way circular variable type inference shows the full resolution chain.
+
+auto x = y + 1;
+auto y = z + 1;
+auto z = x + 1;

--- a/compiler/test/fail_compilation/ice4094.d
+++ b/compiler/test/fail_compilation/ice4094.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice4094.d(11): Error: circular reference to variable `ice4094.Zug!0.Zug.bahn`
-fail_compilation/ice4094.d(19): Error: template instance `ice4094.Zug!0` error instantiating
+fail_compilation/ice4094.d(13): Error: circular reference to variable `ice4094.Zug!0.Zug.bahn`
+fail_compilation/ice4094.d(13):        while resolving `ice4094.Zug!0.Zug.bahn`
+fail_compilation/ice4094.d(21):        while resolving `ice4094.a`
+fail_compilation/ice4094.d(21): Error: template instance `ice4094.Zug!0` error instantiating
 ---
 */
 // REQUIRED_ARGS: -d

--- a/compiler/test/fail_compilation/test19473.d
+++ b/compiler/test/fail_compilation/test19473.d
@@ -1,7 +1,11 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test19473.d(15): Error: union `test19473.P` no size because of forward reference
-fail_compilation/test19473.d(31):        error on member `test19473.P.p`
+fail_compilation/test19473.d(19): Error: union `test19473.P` no size because of forward reference
+fail_compilation/test19473.d(19):        while resolving `test19473.P`
+fail_compilation/test19473.d(30):        while resolving `test19473.A.UTpl!().UTpl`
+fail_compilation/test19473.d(35):        while resolving `test19473.C.D`
+fail_compilation/test19473.d(34):        while resolving `test19473.P`
+fail_compilation/test19473.d(35):        error on member `test19473.P.p`
 ---
  */
 

--- a/compiler/test/fail_compilation/test20719.d
+++ b/compiler/test/fail_compilation/test20719.d
@@ -1,9 +1,13 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test20719.d(14): Error: struct `test20719.SumType` no size because of forward reference
-fail_compilation/test20719.d(17):        error on member `test20719.SumType.storage`
-fail_compilation/test20719.d(33): Error: variable `test20719.isCopyable!(SumType).__lambda_L33_C22.foo` - size of type `SumType` is invalid
-fail_compilation/test20719.d(19): Error: template instance `test20719.isCopyable!(SumType)` error instantiating
+fail_compilation/test20719.d(18): Error: struct `test20719.SumType` no size because of forward reference
+fail_compilation/test20719.d(18):        while resolving `test20719.SumType`
+fail_compilation/test20719.d(21):        while resolving `test20719.SumType.Storage`
+       while resolving `test20719.SumType`
+fail_compilation/test20719.d(37):        while resolving `test20719.isCopyable!(SumType).isCopyable`
+fail_compilation/test20719.d(21):        error on member `test20719.SumType.storage`
+fail_compilation/test20719.d(37): Error: variable `test20719.isCopyable!(SumType).__lambda_L37_C22.foo` - size of type `SumType` is invalid
+fail_compilation/test20719.d(23): Error: template instance `test20719.isCopyable!(SumType)` error instantiating
 ---
 */
 struct SumType


### PR DESCRIPTION
LLM disclosure: this entire PR is AI-generated. It might be OK, or it might be slop. The fix looks sensible on the surface, and it passes the test suite, however, so does most slop in general. I have reviewed it to the best of my ability, but that might not mean a lot given my limited experience with this project. Caveat emptor.

---

## Show resolution chain in forward/circular reference errors

When the compiler reports a forward or circular reference error, it currently gives no indication of *why* the reference occurred — just that it did. In large codebases with indirect dependency chains, this makes these errors among the hardest to debug: you see `forward reference to variable 'x'` but have no idea which chain of resolutions led there.

This is especially painful with eponymous templates, where a single `enum pkFieldsOf(T) = ...` can trigger a deep resolution chain through struct members, template instantiations, and `__traits(compiles)` checks that is invisible in the error output.

### Before

```
app.d(3): Error: forward reference of variable `pkFieldsOf`
app.d(2): Error: template instance `pkFieldsOf!(Comment)` error instantiating
```

```
app.d(2): Error: circular reference to variable `x`
```

```
app.d(1): Error: struct `A` no size because of forward reference
```

### After

```
app.d(3): Error: forward reference of variable `pkFieldsOf`
app.d(3):        while resolving `x`
app.d(1):        while resolving `pkFieldsOf!(Comment).pkFieldsOf`
app.d(2):        while resolving `Comment.a`
app.d(2): Error: template instance `pkFieldsOf!(Comment)` error instantiating
```

```
app.d(2): Error: circular reference to variable `x`
app.d(2):        while resolving `y`
app.d(1):        while resolving `x`
```

```
app.d(3): Error: struct `A` no size because of forward reference
app.d(3):        while resolving `A`
app.d(2):        while resolving `C`
app.d(1):        while resolving `B`
```

The supplemental messages show the full dependency chain, making it immediately clear how the compiler arrived at the problematic reference. This follows the same pattern as template instantiation traces ("instantiated from here").
