### PR TITLE
Fix circular dependency in `__traits(getAttributes, __traits(getMember, ...))`

### DIFF
--- a/compiler/test/compilable/test_getattr_getMember_fwdref.d
+++ b/compiler/test/compilable/test_getattr_getMember_fwdref.d
@@ -1,0 +1,74 @@
+/*
+ * __traits(getAttributes, __traits(getMember, ...)) should resolve member UDAs
+ * via lightweight symbol lookup without triggering full expressionSemantic on the
+ * member. This avoids eager body compilation (functionSemantic3) of method members,
+ * which can cause circular dependency errors when a method's body references the
+ * introspecting function at compile time.
+ */
+
+struct Column { string name; }
+
+/******** Template struct case ********/
+
+struct Table(T)
+{
+    @Column("id") T id;
+    @Column("data") T data;
+
+    static string[] columnNames()
+    {
+        string[] result;
+        static foreach (name; __traits(allMembers, Table)) {{
+            static foreach (attr; __traits(getAttributes, __traits(getMember, Table, name))) {
+                static if (is(typeof(attr) == Column))
+                    result ~= attr.name;
+            }
+        }}
+        return result;
+    }
+
+    // Auto-return method that references columnNames at compile time.
+    // Without the fast path, __traits(getMember, Table, "save") triggers
+    // functionSemantic3 (for return type inference) on save(), whose body
+    // tries to CTFE columnNames() while it's already being compiled,
+    // causing "circular dependency" error.
+    auto save()
+    {
+        enum cols = columnNames();
+        return cols.length;
+    }
+}
+
+static assert(Table!int.columnNames() == ["id", "data"]);
+
+/******** Mixin template case ********/
+
+mixin template Model()
+{
+    static string[] modelColumnNames()
+    {
+        string[] result;
+        static foreach (name; __traits(allMembers, typeof(this))) {{
+            static foreach (attr; __traits(getAttributes, __traits(getMember, typeof(this), name))) {
+                static if (is(typeof(attr) == Column))
+                    result ~= attr.name;
+            }
+        }}
+        return result;
+    }
+
+    auto persist()
+    {
+        enum cols = modelColumnNames();
+        return cols.length;
+    }
+}
+
+struct User
+{
+    @Column("user_id") int id;
+    @Column("username") string name;
+    mixin Model;
+}
+
+static assert(User.modelColumnNames() == ["user_id", "username"]);


### PR DESCRIPTION
Generated by Claude Opus 4.6, usual disclaimers apply.

----

### Problem

D's compile-time introspection makes it natural to build ORM-style schemas, serialization frameworks, and other metaprogramming patterns where a type's methods introspect its own members via UDAs. A typical pattern is a template struct (or mixin template) that iterates `__traits(allMembers)` to discover `@Column`-annotated fields, while also containing methods that reference the introspection results at compile time:

```d
struct Column { string name; }

struct Table(T) {
    @Column("id") T id;
    @Column("data") T data;

    static string[] columnNames() {
        string[] result;
        static foreach (name; __traits(allMembers, Table)) {{
            static foreach (attr; __traits(getAttributes, __traits(getMember, Table, name))) {
                static if (is(typeof(attr) == Column))
                    result ~= attr.name;
            }
        }}
        return result;
    }

    auto save() {
        enum cols = columnNames();
        return cols.length;
    }
}

static assert(Table!int.columnNames() == ["id", "data"]);  // Error
```

This fails with:

```
Error: function `columnNames` circular dependency.
       Functions cannot be interpreted while being compiled.
```

The same issue occurs with mixin templates that introspect their host type's members — a pattern common in D ORM libraries.

### Analysis

The root cause is that we sometimes want to read UDAs on symbols before those symbols are fully semantically resolved. The chain that produces the error is:

1. `static assert` evaluates `columnNames()` via CTFE, which starts compiling its body (`semantic3`)
2. The body iterates `allMembers`, which includes `"save"`. For that member, `__traits(getMember, Table, "save")` runs full `expressionSemantic` on a `DotIdExp`
3. This triggers `functionSemantic` on `save()`
4. `save()` has an `auto` return type, so `functionSemantic` eagerly calls `functionSemantic3` (body compilation) to infer the return type
5. `save()`'s body contains `enum cols = columnNames()`, which tries to CTFE `columnNames()`
6. But `columnNames()` is already being compiled — **circular dependency**

The fundamental issue is that `getMember` pulls in far more semantic work than what `getAttributes` actually needs. The full `expressionSemantic` → `functionSemantic` → `functionSemantic3` cascade is necessary if you intend to *call* the member or inspect its type, but `getAttributes` only wants to read UDA metadata.

### Observation

`__traits(getAttributes)` only needs the `Dsymbol` to read its `.userAttribDecl` — a field that is populated during *parsing*, long before any semantic analysis runs. It never needs a fully-resolved expression, a function's return type, or its compiled body. The expensive semantic work triggered by `getMember` is entirely wasted when the result is immediately passed to `getAttributes`.

### Proposal

Add a short-circuit in the `getAttributes` handler that detects when its argument is an unevaluated `__traits(getMember, T, "name")` and resolves the member via lightweight `sym.search()` (the same mechanism `__traits(hasMember)` uses) instead of full `expressionSemantic`. This reads UDAs directly from the symbol table without triggering any function body compilation.

### Implementation

A private helper `getAttributesOfMemberFastPath` is added to `compiler/src/dmd/traits.d`. It is called at the top of the `getAttributes` handler, before the existing `TemplateInstance_semanticTiargs` call:

1. **Pattern match**: Check that the single argument is an unevaluated `TraitsExp` with `ident == Id.getMember` and exactly 2 arguments
2. **Cheap argument resolution**: Call `TemplateInstance_semanticTiargs` on the inner `getMember`'s arguments to resolve the type and string — this is lightweight (no body compilation)
3. **Extract member name**: CTFE-interpret the second argument to get the string, convert to `Identifier`
4. **Get aggregate symbol**: `getDsymbol()` on the first argument — trivial for `TypeStruct`/`TypeClass`/`TypeEnum` (returns `.sym`)
5. **Symbol table lookup**: `sym.search(loc, id)` — pure symbol table lookup, no semantic analysis
6. **Read UDAs**: `sm.userAttribDecl.getAttributes()` — runs `arrayExpressionSemantic` only on the UDA values themselves

The helper returns `null` at any step that fails, falling back to the existing full-semantic path. This ensures no behavioral regressions — if the fast path can't handle a case, the old code takes over transparently.

### Trade-offs

This does introduce an **inconsistency** between the nested and two-step forms:

```d
// Nested form (uses fast path — no body compilation triggered):
__traits(getAttributes, __traits(getMember, T, "name"))

// Two-step form (full expressionSemantic — may trigger body compilation):
alias m = __traits(getMember, T, "name");
__traits(getAttributes, m)
```

The UDA results are identical in both cases. The difference is only in side effects: the nested form no longer triggers eager body compilation of method members. Code that relied on `getAttributes(getMember(...))` to force early body compilation (an undocumented side effect) would need to use the two-step form. In practice this is unlikely — the nested form is the idiomatic way to read UDAs, and triggering body compilation was never its intent.
