### PR TITLE
Lightweight getMember resolution for aggregate types

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -8351,6 +8351,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             t1 = tf;
         }
+        else if (auto dse = exp.e1.isDsymbolExp())
+        {
+            // DsymbolExp from lightweight getMember — resolve through
+            // symbolToExp to trigger functionSemantic for the callee.
+            exp.e1 = symbolToExp(dse.s, dse.loc, sc, dse.hasOverloads);
+            goto Lagain;
+        }
         else if (VarExp ve = exp.e1.isVarExp())
         {
             // Do overload resolution
@@ -10091,6 +10098,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             result = ex;
             return;
+        }
+
+        // DsymbolExp from lightweight getMember — resolve through
+        // symbolToExp so that address-of and other operations work.
+        if (auto dse = exp.e1.isDsymbolExp())
+        {
+            exp.e1 = symbolToExp(dse.s, dse.loc, sc, dse.hasOverloads);
+            if (exp.e1.op == EXP.error)
+            {
+                result = exp.e1;
+                return;
+            }
         }
 
         if (sc.inCfile)
@@ -15658,6 +15677,11 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
             {
                 DotVarExp dve = exp.e1.isDotVarExp();
                 return dotMangleof(exp.loc, sc, dve.var, dve.hasOverloads);
+            }
+            case EXP.dSymbol:
+            {
+                DsymbolExp dse = exp.e1.isDsymbolExp();
+                return dotMangleof(exp.loc, sc, dse.s, dse.hasOverloads);
             }
             case EXP.template_:
             {

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -5397,6 +5397,19 @@ bool TemplateInstance_semanticTiargs(Loc loc, Scope* sc, Objects* tiargs, int fl
                      * const substitution in TemplateValueParameter.matchArg().
                      */
                 }
+                else if (auto dse = ea.isDsymbolExp())
+                {
+                    /* A DsymbolExp wrapping a function is a symbol reference,
+                     * not a value to be CTFE-interpreted. Store directly as a
+                     * dsymbol without calling functionSemantic — the caller
+                     * only needs the symbol identity (e.g. for getAttributes).
+                     */
+                    if (dse.s.isFuncDeclaration() || dse.s.isOverDeclaration())
+                    {
+                        (*tiargs)[j] = dse.s;
+                        continue;
+                    }
+                }
                 else if (definitelyValueParameter(ea))
                 {
                     if (ea.checkValue()) // check void expression

--- a/compiler/test/compilable/test_lightweight_traits.d
+++ b/compiler/test/compilable/test_lightweight_traits.d
@@ -1,0 +1,233 @@
+/*
+ * Test that __traits(getMember, ...) resolves members via lightweight symbol
+ * lookup without triggering full expressionSemantic. This avoids eager body
+ * compilation (functionSemantic3) which causes circular dependency errors
+ * when iterating allMembers on types with auto-return methods.
+ */
+
+struct Column { string name; }
+
+/****************************************************/
+// 1. getAttributes(getMember(...)) - template struct
+
+struct Table1(T)
+{
+    @Column("id") T id;
+    @Column("data") T data;
+
+    static string[] columnNames()
+    {
+        string[] result;
+        static foreach (name; __traits(allMembers, Table1)) {{
+            static foreach (attr; __traits(getAttributes, __traits(getMember, Table1, name))) {
+                static if (is(typeof(attr) == Column))
+                    result ~= attr.name;
+            }
+        }}
+        return result;
+    }
+
+    auto save()
+    {
+        enum cols = columnNames();
+        return cols.length;
+    }
+}
+
+static assert(Table1!int.columnNames() == ["id", "data"]);
+
+/****************************************************/
+// 2. getAttributes(getMember(...)) - mixin template
+
+mixin template Model()
+{
+    static string[] modelColumnNames()
+    {
+        string[] result;
+        static foreach (name; __traits(allMembers, typeof(this))) {{
+            static foreach (attr; __traits(getAttributes, __traits(getMember, typeof(this), name))) {
+                static if (is(typeof(attr) == Column))
+                    result ~= attr.name;
+            }
+        }}
+        return result;
+    }
+
+    auto persist()
+    {
+        enum cols = modelColumnNames();
+        return cols.length;
+    }
+}
+
+struct User
+{
+    @Column("user_id") int id;
+    @Column("username") string name;
+    mixin Model;
+}
+
+static assert(User.modelColumnNames() == ["user_id", "username"]);
+
+/****************************************************/
+// 3. typeof(getMember(...)) - basic
+
+struct S
+{
+    int x;
+    int foo() { return 42; }
+}
+
+static assert(is(typeof(__traits(getMember, S, "foo")) R == return) && is(R == int));
+static assert(is(typeof(__traits(getMember, S, "x")) == int));
+
+/****************************************************/
+// 4. typeof(getMember(...)) - template struct circular dep
+
+struct Table2(T)
+{
+    @Column("id") T id;
+    @Column("data") T data;
+
+    static bool hasIntReturning()
+    {
+        static foreach (name; __traits(allMembers, Table2))
+        {{
+            static if (is(typeof(__traits(getMember, Table2, name)) R == return))
+            {
+                static if (is(R == int))
+                    return true;
+            }
+        }}
+        return false;
+    }
+
+    auto save()
+    {
+        enum h = hasIntReturning();
+        return h ? 1 : 0;
+    }
+}
+
+static assert(!Table2!int.hasIntReturning());
+
+/****************************************************/
+// 5. typeof(getMember(...)) - mixin template circular dep
+
+mixin template Model2(T)
+{
+    @Column("id") T id;
+
+    static bool hasIntReturning()
+    {
+        alias This = typeof(this);
+        static foreach (name; __traits(allMembers, This))
+        {{
+            static if (is(typeof(__traits(getMember, This, name)) R == return))
+            {
+                static if (is(R == int))
+                    return true;
+            }
+        }}
+        return false;
+    }
+
+    auto save()
+    {
+        enum h = hasIntReturning();
+        return h ? 1 : 0;
+    }
+}
+
+struct User2
+{
+    mixin Model2!int;
+    @Column("name") string name;
+}
+
+static assert(!User2.hasIntReturning());
+
+/****************************************************/
+// 6. alias + typeof(getMember(...)) - template parameter pattern
+
+struct SetInfo(T) {
+    T value;
+}
+
+struct Settings {
+    SetInfo!(string[string]) defaultRunEnvironments;
+    int x;
+}
+
+template FieldRef(alias T, string name) {
+    alias Ref = __traits(getMember, T, name);
+    alias Type = typeof(Ref);
+}
+
+alias FR = FieldRef!(Settings, "defaultRunEnvironments");
+static assert(is(FR.Type == SetInfo!(string[string])));
+
+/****************************************************/
+// 7. AliasSeq(getMember(...)) - non-auto function in template struct
+
+struct Slice(T, size_t N)
+{
+    T _iterator;
+    size_t[N] _lengths;
+
+    ptrdiff_t indexStrideValue(ptrdiff_t n) @safe scope const
+    {
+        return n;
+    }
+
+    auto save() { return this; }
+}
+
+import std.meta : AliasSeq;
+
+template isSingleMember(T, string member)
+{
+    enum isSingleMember = AliasSeq!(__traits(getMember, T, member)).length == 1;
+}
+
+static assert(isSingleMember!(Slice!(double*, 2), "indexStrideValue"));
+
+/****************************************************/
+// 8. getMember(...).mangleof - should produce full symbol mangling
+
+struct S2(T)
+{
+    static void f()
+    {
+    }
+}
+
+static assert(__traits(getMember, S2!int, "f").mangleof ==
+    S2!int.f.mangleof);
+
+/****************************************************/
+// 9. getMember(...)() - CTFE call through getMember
+
+struct S3(T)
+{
+    static int f()
+    {
+        return 42;
+    }
+}
+
+static assert(__traits(getMember, S3!int, "f")() == 42);
+
+/****************************************************/
+// 10. &getMember(...) - taking address of getMember result
+
+struct S4(T)
+{
+    static int f()
+    {
+        return 42;
+    }
+}
+
+enum fp = &__traits(getMember, S4!int, "f");
+static assert(fp() == 42);


### PR DESCRIPTION
Generated by Claude Opus 4.6, usual disclaimers apply.

Implements the idea in https://github.com/dlang/dmd/pull/22541#issuecomment-3872108656 .

Supersedes https://github.com/dlang/dmd/pull/22541, https://github.com/dlang/dmd/pull/22542, and https://github.com/dlang/dmd/pull/22545.

----

When __traits(getMember, T, name) is used inside allMembers loops on
template struct types, the normal path through expressionSemantic
triggers functionSemantic → functionSemantic3 (eager body compilation)
on member functions, causing circular dependency errors.

Add a lightweight fast path in getMember that resolves via sym.search()
and returns a DsymbolExp with the type pre-set, bypassing the cascade.
This covers both auto-return functions (inferRetType) and instantiated
functions in template structs (isInstantiated).

Also handle DsymbolExp in TemplateInstance_semanticTiargs so that
function symbols are stored directly as Dsymbols rather than being
passed to ctfeInterpret, which would fail.
