### PR TITLE
fix Issue 21622 - Ambiguous template instantiation without parens crashes compiler

### DIFF
--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -11,6 +11,8 @@
 
 module dmd.sideeffect;
 
+import dmd.dtemplate;
+import dmd.dsymbol;
 import dmd.astenums;
 import dmd.declaration;
 import dmd.dscope;
@@ -391,6 +393,25 @@ bool discardValue(Expression e)
             }
         }
         return !seenSideEffect;
+    case EXP.scope_:
+        {
+            if (auto se = e.isScopeExp())
+            {
+                if (auto ti = se.sds.isTemplateInstance())
+                {
+                    if (!ti.aliasdecl && ti.tempdecl)
+                    {
+                        error(e.loc, "`%s` matches multiple overloads exactly", se.sds.toChars());
+                    }
+                }
+                else if (se.sds && se.sds.isOverloadSet())
+                {
+                    error(e.loc, "`%s` matches multiple overloads exactly", se.sds.toChars());
+                }
+            }
+            error(e.loc, "`%s` has no effect", e.toErrMsg());
+            return true;
+        }
     default:
         break;
     }

--- a/compiler/test/fail_compilation/issue21622.d
+++ b/compiler/test/fail_compilation/issue21622.d
@@ -1,0 +1,19 @@
+/*
+TEST_OUTPUT:
+---
+issue21622.d(17): Error: `foo!0` matches multiple overloads exactly
+issue21622.d(17): Error: `foo!0` has no effect
+---
+*/
+
+// https://github.com/dlang/dmd/issues/21622
+
+template foo(int N) {
+    void foo() {}
+}
+
+void foo(int N)() {}
+
+void main() {
+    foo!0;
+}


### PR DESCRIPTION
Fixes Issue 21622

### What this PR does:
It fixes a compiler crash/silent failure when an ambiguous template instantiation (e.g., `foo!0`) matches multiple overloads exactly but is not called with parentheses (which results in a `ScopeExp` instead of a `CallExp`).

### Previous Behavior:
The compiler's `sideeffect.d` logic ignored `EXP.scope_` nodes derived from these ambiguous templates. This caused the node to fall through to the backend, resulting in either a misleading "has no effect" error or an internal compiler error (`Error: unknown`) because the backend cannot generate code for a raw `ScopeExp`.

### New Behavior:
The `discardValue` function in `sideeffect.d` now intercepts `EXP.scope_`. It specifically checks if the `ScopeExp` resolves to a `TemplateInstance` that:
1.  Has no `aliasdecl` (meaning it failed to resolve to a single symbol).
2.  Has a valid `tempdecl` (meaning the template itself was found).

In this specific ambiguous state, it now correctly issues the error:
> `foo!0` matches multiple overloads exactly

This aligns the behavior with standard function call resolution and prevents the backend crash.

This patch has been verified against the reproduction case provided in the issue. I am happy to adjust the logic if there are preferred ways to handle ScopeExp resolution in this context. Thanks for reviewing!