### PR TITLE
[internal/traits] Fix regression in `hasElaborateDestructor`

### DIFF
--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -298,7 +298,14 @@ template hasElaborateDestructor(S)
         // this should be the implementation, but until that's fixed, we need the
         // uncommented code.
         // enum hasElaborateDestructor = __traits(hasMember, S, "__xdtor");
-        enum hasElaborateDestructor = __traits(compiles, (S s) => (cast() s).__xdtor);
+        // Note: we have to avoid triggering opDispatch to placate runnable/b6400.d
+        enum hasElaborateDestructor = __traits(compiles, {
+            static struct S2
+            {
+                S s;
+                void test() => __xdtor;
+            }
+        });
     }
     else
     {

--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -294,7 +294,7 @@ template hasElaborateDestructor(S)
     }
     else static if (is(S == struct))
     {
-        enum hasElaborateDestructor = __traits(compiles, (S s) => s.__xdtor);
+        enum hasElaborateDestructor = __traits(compiles, (S s) => (cast() s).__xdtor);
     }
     else
     {
@@ -315,6 +315,7 @@ template hasElaborateDestructor(S)
     static assert( hasElaborateDestructor!(HasDestructor[42]));
     static assert(!hasElaborateDestructor!(HasDestructor[0]));
     static assert(!hasElaborateDestructor!(HasDestructor[]));
+    static assert( hasElaborateDestructor!(immutable HasDestructor));
 
     static struct HasDestructor2 { HasDestructor s; }
     static assert( hasElaborateDestructor!HasDestructor2);

--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -303,7 +303,7 @@ template hasElaborateDestructor(S)
             static struct S2
             {
                 S s;
-                void test() => __xdtor;
+                static assert(is(typeof(__xdtor)));
             }
         });
     }

--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -294,6 +294,10 @@ template hasElaborateDestructor(S)
     }
     else static if (is(S == struct))
     {
+        // Once https://issues.dlang.org/show_bug.cgi?id=24865 is fixed, then
+        // this should be the implementation, but until that's fixed, we need the
+        // uncommented code.
+        // enum hasElaborateDestructor = __traits(hasMember, S, "__xdtor");
         enum hasElaborateDestructor = __traits(compiles, (S s) => (cast() s).__xdtor);
     }
     else
@@ -351,26 +355,22 @@ template hasElaborateDestructor(S)
 }
 
 // https://github.com/dlang/dmd/issues/21967
-version (unittest)
+version (CoreUnittest)
 private struct Test21967
 {
-    struct Array(T)
-    {
-        ~this()
-        {
-           static if (hasElaborateDestructor!T) {}
-        }
-    }
-    struct B
-    {
-        Array!C c;
-    }
-    // note C must be below B
+    // Note: Foward referencing was failing due to:
+    // https://github.com/dlang/dmd/issues/22524
+    static assert(hasElaborateDestructor!C);
+    enum before = hasElaborateDestructor!C;
+    static assert(before);
+
     struct C
     {
         ~this() {}
     }
     static assert(hasElaborateDestructor!C);
+    enum after = hasElaborateDestructor!C;
+    static assert(after);
 }
 
 // std.traits.hasElaborateCopyDestructor


### PR DESCRIPTION
Fixes https://github.com/dlang/phobos/issues/10950.

I had to use `version (CoreUnittest)` to test the fix because it is dependent on the order of declarations. So it can't use a `unitest {}`.