### PR TITLE
implement indirect complex loads

### DIFF
--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -85,7 +85,7 @@ void loadFromEA(ref code cs, reg_t reg, uint szw, uint szr)
             assert(cs.index == NOREG);
             uint imm12 = 0; // cast(uint)cs.IEV1.Voffset added in by assignaddrc()
             uint size, opc;
-            INSTR.szToSizeOpc(szw, size, opc);
+            INSTR.szToSizeOpcLdr(szw, size, opc);
             if (szr & (szr - 1)) // if misaligned
             {
                 cs.Iop = INSTR.ldur_imm_fpsimd(size,opc,imm12,cs.base,reg);
@@ -224,7 +224,7 @@ void storeToEA(ref code cs, reg_t reg, uint sz)
             assert(cs.index == NOREG);
             uint imm12 = 0; // addaddrc() will add in cast(uint)cs.IEV1.Voffset;
             uint size, opc;
-            INSTR.szToSizeOpc(sz, size, opc);
+            INSTR.szToSizeOpcStr(sz, size, opc);
             imm12 /= sz;
             cs.Iop = INSTR.str_imm_fpsimd(size,opc,imm12,cs.base,reg);
         }

--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -86,7 +86,7 @@ void REGSAVE_save(ref REGSAVE regsave, ref CodeBuilder cdb, reg_t reg, out uint 
         uint imm12 = idx;
         uint sz = 8;
         uint size, opc;
-        INSTR.szToSizeOpc(sz, size, opc);
+        INSTR.szToSizeOpcStr(sz, size, opc);
         imm12 /= sz;
         cs.Iop = INSTR.str_imm_fpsimd(size,opc,imm12,cs.base,reg);
     }
@@ -119,7 +119,7 @@ void REGSAVE_restore(const ref REGSAVE regsave, ref CodeBuilder cdb, reg_t reg, 
         uint imm12 = idx;
         uint sz = 8;
         uint size, opc;
-        INSTR.szToSizeOpc(sz, size, opc);
+        INSTR.szToSizeOpcLdr(sz, size, opc);
         imm12 /= sz;
         cs.Iop = INSTR.ldr_imm_fpsimd(size,opc,imm12,cs.base,reg);
     }

--- a/compiler/src/dmd/backend/arm/instr.d
+++ b/compiler/src/dmd/backend/arm/instr.d
@@ -93,10 +93,26 @@ struct INSTR
                                                       3;    // half-precision
                                    }
 
-    /* Convert size of floating point type to size,opc
+    /* Convert size of floating point type to size,opc for LDR instructions
+     * https://www.scs.stanford.edu/~zyedidia/arm64/ldr_imm_fpsimd.html
+     */
+    static void szToSizeOpcLdr(uint sz, out uint size, out uint opc)
+    {
+        switch (sz)
+        {
+            case 1:  size = 0; opc = 1; break;  // Bt byte
+            case 2:  size = 1; opc = 1; break;  // Ht half
+            case 4:  size = 2; opc = 1; break;  // St single
+            case 8:  size = 3; opc = 1; break;  // Dt double
+            case 16: size = 0; opc = 3; break;  // Qt quad
+            default: debug printf("sz: %u\n", sz); assert(0);
+        }
+    }
+
+    /* Convert size of floating point type to size,opc for STR instructions
      * https://www.scs.stanford.edu/~zyedidia/arm64/str_imm_fpsimd.html
      */
-    static void szToSizeOpc(uint sz, ref uint size, ref uint opc)
+    static void szToSizeOpcStr(uint sz, out uint size, out uint opc)
     {
         switch (sz)
         {

--- a/compiler/src/dmd/backend/codebuilder.d
+++ b/compiler/src/dmd/backend/codebuilder.d
@@ -35,7 +35,7 @@ struct CodeBuilder
     code** pTail;
 
     enum BADINS = 0x1234_5678;
-    //enum BADINS = 0xAA_20_03_E0;
+    //enum BADINS = 0x3D_C0_00_01;
 
   nothrow:
   public:

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -4623,7 +4623,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
                         {
                             // STR preg,[bp,#offset]
                             uint size, opc;
-                            INSTR.szToSizeOpc(sz, size, opc);
+                            INSTR.szToSizeOpcStr(sz, size, opc);
                             imm /= sz;
                             cdb.gen1(INSTR.str_imm_fpsimd(size,opc,imm,29,preg)); // https://www.scs.stanford.edu/~zyedidia/arm64/str_imm_fpsimd.html
                         }
@@ -4659,7 +4659,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc)
                         if (mask(preg) & INSTR.FLOATREGS)
                         {
                             uint size, opc;
-                            INSTR.szToSizeOpc(sz, size, opc);
+                            INSTR.szToSizeOpcStr(sz, size, opc);
                             imm /= sz;
                             cdb.gen1(INSTR.str_imm_fpsimd(size,opc,imm,31,preg)); // https://www.scs.stanford.edu/~zyedidia/arm64/str_imm_fpsimd.html
                         }


### PR DESCRIPTION
```d
creal test(creal* pc)
{
    return *pc;
}
```
generates:
```
_D4testQfFPcZc:
0000:   A9 BF 7B FD  stp       x29,x30,[sp,#-0x10]! // https://www.scs.stanford.edu/~zyedidia/arm64/stp_gen.html
0004:   91 00 03 FD  mov       x29,sp             // https://www.scs.stanford.edu/~zyedidia/arm64/mov_add_addsub_imm.html
0008:   FD 40 00 00  ldr       d0,[x0]            // https://www.scs.stanford.edu/~zyedidia/arm64/ldr_imm_fpsimd.html
000c:   FD 40 04 01  ldr       d1,[x0,#8]         // https://www.scs.stanford.edu/~zyedidia/arm64/ldr_imm_fpsimd.html
0010:   A8 C1 7B FD  ldp       x29,x30,[sp],#0x10 // https://www.scs.stanford.edu/~zyedidia/arm64/ldp_gen.html
0014:   D6 5F 03 C0  ret                          // https://www.scs.stanford.edu/~zyedidia/arm64/encodingindex.html#branch_reg
```
