### PR TITLE
Add opUnwrapIfTrue operator overload for structs

### DIFF
--- a/changelog/dmd.unwrapiftrue.dd
+++ b/changelog/dmd.unwrapiftrue.dd
@@ -1,0 +1,42 @@
+New operator overload Unwrap if true for structs
+
+A new operator overload has been added, called ``opUnwrapIfTrue``.
+It is used with structs, for optional and error result types that will normally be marked as ``@mustuse``.
+
+Return true using ``opCast(T:bool)()`` to trigger the if branch that will automatically unwrap the value into a variable declaration.
+
+```d
+import core.attribute : mustuse;
+
+@mustuse // not required
+struct Result(Type) {
+    private {
+        Type value;
+        bool haveValue;
+    }
+
+    this(Type value) {
+        this.value = value;
+        this.haveValue = true;
+    }
+
+    bool opCast(T:bool)() => haveValue;
+
+    Type opUnwrapIfTrue() {
+        assert(haveValue);
+        return value;
+    }
+}
+
+Result!int result = Result!int(99);
+
+if (int value = result.opUnwrapIfTrue) {
+    // got a value!
+    assert(value == 99);
+} else {
+    // oh noes an error or default init state
+}
+```
+
+You may alias ``opUnwrapIfTrue`` to another name to make it more convenient.
+No standard name for this exists as of writing.

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8662,6 +8662,7 @@ struct Id final
     static Identifier* opOpAssign;
     static Identifier* opIndexOpAssign;
     static Identifier* opSliceOpAssign;
+    static Identifier* opUnwrapIfTrue;
     static Identifier* classNew;
     static Identifier* classDelete;
     static Identifier* apply;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -244,6 +244,7 @@ immutable Msgtable[] msgtable =
     { "opOpAssign" },
     { "opIndexOpAssign" },
     { "opSliceOpAssign" },
+    { "opUnwrapIfTrue" },
 
     { "classNew", "new" },
     { "classDelete", "delete" },

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1652,25 +1652,83 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         sym.parent = sc.scopesym;
         sym.endlinnum = ifs.endloc.linnum;
         Scope* scd = sc.push(sym);
+
         if (ifs.param)
         {
             /* Declare param, which we will set to be the
              * result of condition.
              */
-            // Make sure the location of the initializer reflects the condition, not the if statement.
-            auto ei = new ExpInitializer(ifs.condition.loc, ifs.condition);
-            ifs.match = new VarDeclaration(ifs.loc, ifs.param.type, ifs.param.ident, ei);
+
+            DotVarExp unwrapIfTrueCall;
+
+            // Analyze the condition, that will initialize the variable.
+            // If its a struct and that struct has a operator overload opUnwrapIfTrue,
+            //  then we'll be transforming to include unwrap support.
+            if (Expression unwrapOriginalCondition = ifs.condition.trySemantic(scd))
+            {
+                if (auto dv = unwrapOriginalCondition.isDotVarExp)
+                {
+                    if (auto fd = dv.var.isFuncDeclaration)
+                    {
+                        if (fd.ident is Id.opUnwrapIfTrue)
+                        {
+                            unwrapIfTrueCall = dv;
+                            ifs.condition = dv.e1;
+
+                            if (!ifs.condition.type.isTypeStruct)
+                                error(unwrapOriginalCondition.loc, "Operator overload `opUnwrapIfTrue` supports structs as this not %s\n", ifs.condition.type.kind);
+                        }
+                    }
+                }
+            }
+
+            // Create the variable declaration (T var = condition) or (T __unwrit = condition)
+            if(unwrapIfTrueCall is null)
+            {
+                auto ei = new ExpInitializer(ifs.loc, ifs.condition);
+                // Make sure the location of the initializer reflects the condition, not the if statement.
+                ifs.match = new VarDeclaration(ifs.condition.loc, ifs.param.type, ifs.param.ident, ei);
+                ifs.match.storage_class |= ifs.param.storageClass;
+            }
+            else
+                ifs.match = copyToTemp(STC.none, "__unwrit", ifs.condition);
+
             ifs.match.parent = scd.func;
-            ifs.match.storage_class |= ifs.param.storageClass;
             ifs.match.dsymbolSemantic(scd);
 
+            // Transform the condition expression into: (T var = condition, var)
             auto de = new DeclarationExp(ifs.loc, ifs.match);
             auto ve = new VarExp(ifs.loc, ifs.match);
             ifs.condition = new CommaExp(ifs.loc, de, ve);
             ifs.condition = ifs.condition.expressionSemantic(scd);
 
+            if (unwrapIfTrueCall !is null)
+            {
+                // T var = __unwrit.opUnwrapIfTrue();
+
+                // A wrapper will be placed around the variable declaration that was requested by the user.
+                // It'll destruct the __unwrit variable.
+                // This var will be dealt with by glue code.
+                // As a result, this goes first.
+
+                unwrapIfTrueCall.e1 = ve;
+                auto ei = new ExpInitializer(ifs.condition.loc, unwrapIfTrueCall);
+                auto vd = new VarDeclaration(ifs.condition.loc, ifs.param.type, ifs.param.ident, ei);
+
+                // Copy the storage classes from the parameter, without the unwrap call it's done earlier.
+                vd.storage_class |= ifs.param.storageClass;
+
+                // Prepend the declaration of the wanted variable to the if statements true branch.
+                ifs.ifbody = new CompoundStatement(ifs.loc, new ExpStatement(ifs.loc, new DeclarationExp(vd.loc, vd)), ifs.ifbody);
+            }
+
             if (ifs.match.edtor)
             {
+                // For variable declarations (Type val = condition)
+                //  this is for all intents and purposes before the if statement, not in it.
+                // Due to the truthiness test occuring on the variable declaration,
+                //  not the condition that initialized it.
+
                 Statement sdtor = new DtorExpStatement(ifs.loc, ifs.match.edtor, ifs.match);
                 sdtor = new ScopeGuardStatement(ifs.loc, TOK.onScopeExit, sdtor);
                 ifs.ifbody = new CompoundStatement(ifs.loc, sdtor, ifs.ifbody);
@@ -1697,6 +1755,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         if (checkNonAssignmentArrayOp(ifs.condition))
             ifs.condition = ErrorExp.get();
 
+        // Turn the condition into a truthiness check.
         // Convert to boolean after declaring param so this works:
         //  if (S param = S()) {}
         // where S is a struct that defines opCast!bool.

--- a/compiler/test/runnable/unwrapiftrue.d
+++ b/compiler/test/runnable/unwrapiftrue.d
@@ -1,0 +1,128 @@
+module unwrapiftrue;
+import core.attribute : mustuse;
+
+@mustuse // not required, part of nominal usage.
+struct Optional(Type) {
+    private {
+        // Do not do any clever tricks to prevent destructor being called when haveValue is false.
+        Type value;
+        bool haveValue;
+    }
+
+    this(Type value) {
+        this.value = value;
+        this.haveValue = true;
+    }
+
+    bool opCast(T:bool)() => haveValue;
+
+    Type opUnwrapIfTrue() {
+        assert(haveValue);
+        return value;
+    }
+
+    alias unwrap = opUnwrapIfTrue;
+}
+
+void main() {
+    auto oi = Optional!int(2);
+    auto oip = new Optional!int(52);
+
+    if (Optional!int oi2 = oi) {
+        // no unwrap!
+    } else {
+        assert(0);
+    }
+
+    if (Optional!int oi2 = *oip) {
+        // no unwrap!
+    } else {
+        assert(0);
+    }
+
+    if (int i = oi.unwrap) {
+        // got a value!
+        assert(i == 2);
+    } else {
+        assert(0); // error, there is meant to be a value
+    }
+
+    if (auto i = oi.unwrap) {
+        // got a value!
+        static assert(is(typeof(i) == int));
+        assert(i == 2);
+    } else {
+        assert(0); // error, there is meant to be a value
+    }
+
+    if (int i = oip.unwrap) {
+        // got a value!
+        assert(i == 52);
+    } else {
+        assert(0); // error, there is meant to be a value
+    }
+
+    if (auto i = oip.unwrap) {
+        // got a value!
+        static assert(is(typeof(i) == int));
+        assert(i == 52);
+    } else {
+        assert(0); // error, there is meant to be a value
+    }
+
+    checkDestructor();
+}
+
+int hadDestructor;
+
+struct Destructor {
+    ~this() {
+        hadDestructor++;
+    }
+}
+
+void checkDestructor() {
+    auto od = Optional!Destructor(Destructor());
+
+    assert(hadDestructor == 1);
+
+    {
+        if (Destructor d = od.unwrap) {
+            // got a value!
+        } else {
+            assert(0); // error, there is meant to be a value
+        }
+
+        assert(hadDestructor == 3);
+    }
+
+    {
+        try {
+            if (Destructor d = od.unwrap) {
+                // got a value!
+                throw new Exception("");
+            } else {
+                assert(0); // error, there is meant to be a value
+            }
+
+        } catch (Exception e) {
+        }
+
+        assert(hadDestructor == 5);
+    }
+
+    {
+        od = typeof(od).init;
+        assert(hadDestructor == 6);
+
+        // Verify that the pinned value that holds result type will get destroyed on false path as well.
+        if (Destructor d = od.unwrap) {
+            // got a value!
+            assert(0); // error, there is no value
+        } else {
+            // ok, no value!
+        }
+
+        assert(hadDestructor == 7);
+    }
+}


### PR DESCRIPTION
This is an improvement on ``@mustuse`` to allow only getting access to a value if it has been checked to be true.

Does not use DFA to do this, instead if statement + a var declaration in its condition.

```d
import core.attribute : mustuse;

@mustuse
struct Result(Type) {
    private {
        Type value;
        bool haveValue;
    }

    this(Type value) {
        this.value = value;
        this.haveValue = true;
    }

    bool opCast(T:bool)() => haveValue;

    Type opUnwrapIfTrue() {
        assert(haveValue);
        return value;
    }
}

Result!int result = Result!int(99);

if (int value = result) {
    // got a value!
    assert(value == 99);
} else {
    // oh noes an error or default init state
}
```

No DIP nor has it been approved at a meeting.
It is the result of my report on an alternative exception mechanism.
I was able to take an existing approach that I've been mulling over that relied on UDA's and a DFA for path sensitivity and turn it into a simple operator overload hook instead.