### PR TITLE
[stable] Fix #22501 - GC allocation for CTFE-available static array

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -14203,12 +14203,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        // When array comparison is not lowered to `__equals`, `memcmp` is used, but
-        // GC checks occur before the expression is lowered to `memcmp` in e2ir.d.
-        // Thus, we will consider the literal arrays as on-stack arrays to avoid issues
-        // during GC checks.
+        // Remaining array comparisons are trivially memcmp-able.
+        // Allocate array-literal operands on the stack, since they don't
+        // escape during the comparison; enabling @nogc for these.
         if (isArrayComparison)
         {
+            exp.e1 = exp.e1.optimize(WANTvalue);
+            exp.e2 = exp.e2.optimize(WANTvalue);
+
             if (auto ale1 = exp.e1.isArrayLiteralExp())
             {
                 ale1.onstack = true;

--- a/compiler/test/compilable/test22501.d
+++ b/compiler/test/compilable/test22501.d
@@ -1,0 +1,12 @@
+// https://github.com/dlang/dmd/issues/22501
+
+struct A {
+    ubyte[16] bytes;
+
+    enum something = A(cast(ubyte[16])[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]);
+
+    @nogc nothrow pure
+    bool isB() const {
+        return bytes[0..12] == something.bytes[0..12];
+    }
+}


### PR DESCRIPTION
Optimize the operands for trivially-memcmp-able array comparisons too (as done for non-memcmp-able arrays), so that e.g. slice-expressions of array literals are promoted to array literals.