### PR TITLE
runnable/test20275.d: Add UNICODE_NAMES

### DIFF
--- a/compiler/test/runnable/test20275.d
+++ b/compiler/test/runnable/test20275.d
@@ -1,4 +1,5 @@
 // EXTRA_SOURCES: imports/你好.d
+// UNICODE_NAMES:
 
 import imports.你好;
 


### PR DESCRIPTION
So that this test is skipped on targets where the assembler lacks UTF8 support.

```
Assembler: test20275.d
        "/var/tmp//ccR1Muva.s", line 12 : Syntax error
        Near line: "    call    _D7imports6你好3fooFZi"
```

@rainers FYI