### PR TITLE
Emit special __xopEquals/__xopCmp/__xtoHash members *once*

### DIFF
--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -1477,31 +1477,6 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             semanticTypeInfoMembers(sd);
         }
 
-        if (TemplateInstance ti = sd.isInstantiated())
-        {
-            if (!ti.needsCodegen())
-            {
-                assert(ti.minst || sd.requestTypeInfo);
-
-                /* ti.toObjFile() won't get called. So, store these
-                 * member functions into object file in here.
-                 */
-
-                if (sd.xeq && sd.xeq != StructDeclaration.xerreq)
-                    toObjFile(sd.xeq, global.params.multiobj);
-                if (sd.xcmp && sd.xcmp != StructDeclaration.xerrcmp)
-                    toObjFile(sd.xcmp, global.params.multiobj);
-                if (FuncDeclaration ftostr = search_toString(sd))
-                    toObjFile(ftostr, global.params.multiobj);
-                if (sd.xhash)
-                    toObjFile(sd.xhash, global.params.multiobj);
-                if (sd.postblit)
-                    toObjFile(sd.postblit, global.params.multiobj);
-                if (sd.dtor)
-                    toObjFile(sd.dtor, global.params.multiobj);
-            }
-        }
-
         /* Put out:
          *  char[] mangledName;
          *  void[] init;

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -429,6 +429,10 @@ void toObjFile(Dsymbol ds, bool multiobj)
                  */
                 sd.members.foreachDsymbol( (s) { s.accept(this); } );
 
+                /* Emit the special __xopEquals/__xopCmp/__xtoHash member functions
+                 * required for the TypeInfo, but not added as struct members.
+                 * (Note that `postblit` and `tidtor` are struct members in `sd.members`.)
+                 */
                 if (sd.xeq && sd.xeq != StructDeclaration.xerreq)
                     sd.xeq.accept(this);
                 if (sd.xcmp && sd.xcmp != StructDeclaration.xerrcmp)


### PR DESCRIPTION
Along with the `StructDeclaration` (no change there).

For instantiated structs whose codegen is skipped but their TypeInfo is required, don't emit them anymore into the referencing object file - I think that is a left-over from when these special members weren't emitted as part of the StructDeclaration (and so had to be emitted whenever the TypeInfo was emitted).

This is how LDC handles these members.