### PR TITLE
Change int8_t etc. to signed char on Solaris

### DIFF
--- a/druntime/src/core/stdc/stdint.d
+++ b/druntime/src/core/stdc/stdint.d
@@ -337,7 +337,10 @@ else version (OpenBSD)
 }
 else version (Solaris)
 {
-    alias int8_t   = char;   ///
+    version (GNU)
+        alias int8_t = byte; ///
+    else
+        alias int8_t = char; ///
     alias int16_t  = short;  ///
     alias uint8_t  = ubyte;  ///
     alias uint16_t = ushort; ///
@@ -346,7 +349,10 @@ else version (Solaris)
     alias int64_t  = long;   ///
     alias uint64_t = ulong;  ///
 
-    alias int_least8_t   = char;   ///
+    version (GNU)
+        alias int_least8_t = byte; ///
+    else
+        alias int_least8_t = char; ///
     alias uint_least8_t  = ubyte;  ///
     alias int_least16_t  = short;  ///
     alias uint_least16_t = ushort; ///
@@ -355,7 +361,10 @@ else version (Solaris)
     alias int_least64_t  = long;   ///
     alias uint_least64_t = ulong;  ///
 
-    alias int_fast8_t   = char;  ///
+    version (GNU)
+        alias int_fast8_t = byte; ///
+    else
+        alias int_fast8_t = char; ///
     alias uint_fast8_t  = ubyte; ///
     alias int_fast16_t  = int;   ///
     alias uint_fast16_t = uint;  ///


### PR DESCRIPTION
GCC recently changed `int8_t` etc. to `signed char` for C99 conformance:

	Change int8_t to signed char on Solaris [PR113450,PR123176]
	https://gcc.gnu.org/pipermail/gcc-patches/2026-February/708533.html

As documented in

	PR d/123509
	Switch int8_t etc. to byte on Solaris
	https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123509

this leads to a couple of testsuite failures with GDC since `druntime` has its own idea of those types.

This patch fixes this by adjusting those types to match GCC for GDC only. The `int8_t` change is expected to be integrated into the Solaris headers later, but for now it only exists in GCC 16+.

Tested on GCC trunk on `i386-pc-solaris2.11` and `sparc-sun-solaris2.11`.