### PR TITLE
Refactor: Remove addComment from dsymbol.d to break semantic dependency

### DIFF
--- a/compiler/src/dmd/aliasthis.d
+++ b/compiler/src/dmd/aliasthis.d
@@ -19,6 +19,7 @@ import dmd.dsymbol;
 import dmd.identifier;
 import dmd.location;
 import dmd.visitor;
+import dmd.dsymbolsem;
 
 /***********************************************************
  * alias ident this;
@@ -41,7 +42,7 @@ extern (C++) final class AliasThis : Dsymbol
     {
         assert(!s);
         auto at = new AliasThis(loc, ident);
-        at.comment = comment;
+        at.addComment(comment);
         return at;
     }
 

--- a/compiler/src/dmd/aliasthis.d
+++ b/compiler/src/dmd/aliasthis.d
@@ -41,9 +41,7 @@ extern (C++) final class AliasThis : Dsymbol
     {
         assert(!s);
         auto at = new AliasThis(loc, ident);
-        if (const c = this.comment()){
-            commentHashTable[cast(void*)at] = c;
-        }
+        at.addComment(comment);
         return at;
     }
 

--- a/compiler/src/dmd/aliasthis.d
+++ b/compiler/src/dmd/aliasthis.d
@@ -19,7 +19,6 @@ import dmd.dsymbol;
 import dmd.identifier;
 import dmd.location;
 import dmd.visitor;
-import dmd.dsymbolsem;
 
 /***********************************************************
  * alias ident this;
@@ -42,7 +41,9 @@ extern (C++) final class AliasThis : Dsymbol
     {
         assert(!s);
         auto at = new AliasThis(loc, ident);
-        at.addComment(comment);
+        if (const c = this.comment()){
+            commentHashTable[cast(void*)at] = c;
+        }
         return at;
     }
 

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -34,7 +34,6 @@ import dmd.root.filename;
 import dmd.target;
 import dmd.targetcompiler;
 import dmd.visitor;
-import dmd.dsymbolsem;
 
 
 /******************************************
@@ -362,7 +361,9 @@ extern (C++) final class AliasDeclaration : Declaration
         //printf("AliasDeclaration::syntaxCopy()\n");
         assert(!s);
         AliasDeclaration sa = type ? new AliasDeclaration(loc, ident, type.syntaxCopy()) : new AliasDeclaration(loc, ident, aliassym.syntaxCopy(null));
-        sa.addComment(comment);
+        if (const c = this.comment()){
+            commentHashTable[cast(void*)sa] = c;
+        }
         sa.storage_class = storage_class;
         return sa;
     }
@@ -513,7 +514,9 @@ extern (C++) class VarDeclaration : Declaration
         //printf("VarDeclaration::syntaxCopy(%s)\n", toChars());
         assert(!s);
         auto v = new VarDeclaration(loc, type ? type.syntaxCopy() : null, ident, _init ? _init.syntaxCopy() : null, storage_class);
-        v.addComment(comment);
+        if (const c = this.comment()){
+            commentHashTable[cast(void*)v] = c;
+        }
         return v;
     }
 
@@ -679,7 +682,9 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
         //printf("BitFieldDeclaration::syntaxCopy(%s)\n", toChars());
         assert(!s);
         auto bf = new BitFieldDeclaration(loc, type ? type.syntaxCopy() : null, ident, width.syntaxCopy(), _init ? _init.syntaxCopy() : null);
-        bf.addComment(comment);
+        if (const c = this.comment()){
+            commentHashTable[cast(void*)bf] = c;
+        }
         return bf;
     }
 

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -34,6 +34,7 @@ import dmd.root.filename;
 import dmd.target;
 import dmd.targetcompiler;
 import dmd.visitor;
+import dmd.dsymbolsem;
 
 
 /******************************************
@@ -361,7 +362,7 @@ extern (C++) final class AliasDeclaration : Declaration
         //printf("AliasDeclaration::syntaxCopy()\n");
         assert(!s);
         AliasDeclaration sa = type ? new AliasDeclaration(loc, ident, type.syntaxCopy()) : new AliasDeclaration(loc, ident, aliassym.syntaxCopy(null));
-        sa.comment = comment;
+        sa.addComment(comment);
         sa.storage_class = storage_class;
         return sa;
     }
@@ -512,7 +513,7 @@ extern (C++) class VarDeclaration : Declaration
         //printf("VarDeclaration::syntaxCopy(%s)\n", toChars());
         assert(!s);
         auto v = new VarDeclaration(loc, type ? type.syntaxCopy() : null, ident, _init ? _init.syntaxCopy() : null, storage_class);
-        v.comment = comment;
+        v.addComment(comment);
         return v;
     }
 
@@ -678,7 +679,7 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
         //printf("BitFieldDeclaration::syntaxCopy(%s)\n", toChars());
         assert(!s);
         auto bf = new BitFieldDeclaration(loc, type ? type.syntaxCopy() : null, ident, width.syntaxCopy(), _init ? _init.syntaxCopy() : null);
-        bf.comment = comment;
+        bf.addComment(comment);
         return bf;
     }
 

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -361,9 +361,7 @@ extern (C++) final class AliasDeclaration : Declaration
         //printf("AliasDeclaration::syntaxCopy()\n");
         assert(!s);
         AliasDeclaration sa = type ? new AliasDeclaration(loc, ident, type.syntaxCopy()) : new AliasDeclaration(loc, ident, aliassym.syntaxCopy(null));
-        if (const c = this.comment()){
-            commentHashTable[cast(void*)sa] = c;
-        }
+        sa.addComment(comment);
         sa.storage_class = storage_class;
         return sa;
     }
@@ -514,9 +512,7 @@ extern (C++) class VarDeclaration : Declaration
         //printf("VarDeclaration::syntaxCopy(%s)\n", toChars());
         assert(!s);
         auto v = new VarDeclaration(loc, type ? type.syntaxCopy() : null, ident, _init ? _init.syntaxCopy() : null, storage_class);
-        if (const c = this.comment()){
-            commentHashTable[cast(void*)v] = c;
-        }
+        v.addComment(comment);
         return v;
     }
 
@@ -682,9 +678,7 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
         //printf("BitFieldDeclaration::syntaxCopy(%s)\n", toChars());
         assert(!s);
         auto bf = new BitFieldDeclaration(loc, type ? type.syntaxCopy() : null, ident, width.syntaxCopy(), _init ? _init.syntaxCopy() : null);
-        if (const c = this.comment()){
-            commentHashTable[cast(void*)bf] = c;
-        }
+        bf.addComment(comment);
         return bf;
     }
 

--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -17,6 +17,8 @@ import dmd.dsymbol;
 import dmd.identifier;
 import dmd.location;
 import dmd.visitor;
+import dmd.dsymbolsem;
+
 
 /***********************************************************
  */
@@ -95,7 +97,7 @@ extern (C++) final class Import : Dsymbol
     {
         assert(!s);
         auto si = new Import(loc, packages, id, aliasId, isstatic);
-        si.comment = comment;
+        si.addComment(comment);
         assert(!(isstatic && names.length));
         if (names.length && !si.aliasId)
             si.ident = null;

--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -17,7 +17,6 @@ import dmd.dsymbol;
 import dmd.identifier;
 import dmd.location;
 import dmd.visitor;
-import dmd.dsymbolsem;
 
 
 /***********************************************************
@@ -97,7 +96,9 @@ extern (C++) final class Import : Dsymbol
     {
         assert(!s);
         auto si = new Import(loc, packages, id, aliasId, isstatic);
-        si.addComment(comment);
+        if (const c = this.comment()){
+            commentHashTable[cast(void*)si] = c;
+        }
         assert(!(isstatic && names.length));
         if (names.length && !si.aliasId)
             si.ident = null;

--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -96,9 +96,7 @@ extern (C++) final class Import : Dsymbol
     {
         assert(!s);
         auto si = new Import(loc, packages, id, aliasId, isstatic);
-        if (const c = this.comment()){
-            commentHashTable[cast(void*)si] = c;
-        }
+        si.addComment(comment);
         assert(!(isstatic && names.length));
         if (names.length && !si.aliasId)
             si.ident = null;

--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -18,7 +18,6 @@ import dmd.identifier;
 import dmd.location;
 import dmd.visitor;
 
-
 /***********************************************************
  */
 extern (C++) final class Import : Dsymbol

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -43,7 +43,6 @@ import dmd.root.port;
 import dmd.root.string;
 import dmd.target;
 import dmd.visitor;
-import dmd.dsymbolsem;
 
 version (Windows)
 {
@@ -708,7 +707,7 @@ extern (C++) final class Module : Package
          */
         if (buf.length>= 4 && buf[0..4] == "Ddoc")
         {
-            commentHashTable[cast(void*)this] = buf.ptr + 4;
+            this.addComment(buf.ptr + 4);
             filetype = FileType.ddoc;
             if (!docfile)
                 setDocfile();
@@ -721,7 +720,7 @@ extern (C++) final class Module : Package
          */
         if (FileName.equalsExt(arg, dd_ext))
         {
-            commentHashTable[cast(void*)this] = buf.ptr; // the optional Ddoc, if present, is handled above.
+            this.addComment(buf.ptr); // the optional Ddoc, if present, is handled above.
             filetype = FileType.ddoc;
             if (!docfile)
                 setDocfile();

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -43,6 +43,7 @@ import dmd.root.port;
 import dmd.root.string;
 import dmd.target;
 import dmd.visitor;
+import dmd.dsymbolsem;
 
 version (Windows)
 {
@@ -707,7 +708,7 @@ extern (C++) final class Module : Package
          */
         if (buf.length>= 4 && buf[0..4] == "Ddoc")
         {
-            comment = buf.ptr + 4;
+            this.addComment(buf.ptr + 4);
             filetype = FileType.ddoc;
             if (!docfile)
                 setDocfile();
@@ -720,7 +721,7 @@ extern (C++) final class Module : Package
          */
         if (FileName.equalsExt(arg, dd_ext))
         {
-            comment = buf.ptr; // the optional Ddoc, if present, is handled above.
+            this.addComment(buf.ptr); // the optional Ddoc, if present, is handled above.
             filetype = FileType.ddoc;
             if (!docfile)
                 setDocfile();

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -708,7 +708,7 @@ extern (C++) final class Module : Package
          */
         if (buf.length>= 4 && buf[0..4] == "Ddoc")
         {
-            commentHashTable[cast(void*)this] = buf.ptr + 4;;
+            commentHashTable[cast(void*)this] = buf.ptr + 4;
             filetype = FileType.ddoc;
             if (!docfile)
                 setDocfile();

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -708,7 +708,7 @@ extern (C++) final class Module : Package
          */
         if (buf.length>= 4 && buf[0..4] == "Ddoc")
         {
-            this.addComment(buf.ptr + 4);
+            commentHashTable[cast(void*)this] = buf.ptr + 4;;
             filetype = FileType.ddoc;
             if (!docfile)
                 setDocfile();
@@ -721,7 +721,7 @@ extern (C++) final class Module : Package
          */
         if (FileName.equalsExt(arg, dd_ext))
         {
-            this.addComment(buf.ptr); // the optional Ddoc, if present, is handled above.
+            commentHashTable[cast(void*)this] = buf.ptr; // the optional Ddoc, if present, is handled above.
             filetype = FileType.ddoc;
             if (!docfile)
                 setDocfile();

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -47,7 +47,7 @@ import dmd.tokens;
 import dmd.visitor;
 
 import dmd.common.outbuffer;
-
+import dmd.dsymbolsem;
 /***************************************
  * Calls dg(Dsymbol* sym) for each Dsymbol.
  * If dg returns !=0, stops and returns that value else returns 0.
@@ -765,16 +765,6 @@ extern (C++) class Dsymbol : ASTNode
         assert(0);
     }
 
-    /****************************************
-     * Add documentation comment to Dsymbol.
-     * Ignore NULL comments.
-     */
-    void addComment(const(char)* comment)
-    {
-        import dmd.dsymbolsem;
-        dmd.dsymbolsem.addComment(this, comment);
-    }
-
     /// get documentation comment for this Dsymbol
     final const(char)* comment()
     {
@@ -786,9 +776,6 @@ extern (C++) class Dsymbol : ASTNode
         }
         return null;
     }
-
-    /* Shell around addComment() to avoid disruption for the moment */
-    final void comment(const(char)* comment) { addComment(comment); }
 
     extern (D) __gshared const(char)*[void*] commentHashTable;
 
@@ -1072,7 +1059,7 @@ public:
     {
         //printf("ScopeDsymbol::syntaxCopy('%s')\n", toChars());
         ScopeDsymbol sds = s ? cast(ScopeDsymbol)s : new ScopeDsymbol(ident);
-        sds.comment = comment;
+        sds.addComment(comment);
         sds.members = arraySyntaxCopy(members);
         sds.endlinnum = endlinnum;
         return sds;

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -47,7 +47,6 @@ import dmd.tokens;
 import dmd.visitor;
 
 import dmd.common.outbuffer;
-import dmd.dsymbolsem;
 /***************************************
  * Calls dg(Dsymbol* sym) for each Dsymbol.
  * If dg returns !=0, stops and returns that value else returns 0.
@@ -1059,7 +1058,9 @@ public:
     {
         //printf("ScopeDsymbol::syntaxCopy('%s')\n", toChars());
         ScopeDsymbol sds = s ? cast(ScopeDsymbol)s : new ScopeDsymbol(ident);
-        sds.addComment(comment);
+        if (const c = this.comment()){
+            commentHashTable[cast(void*)sds] = c;
+        }
         sds.members = arraySyntaxCopy(members);
         sds.endlinnum = endlinnum;
         return sds;

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -45,7 +45,6 @@ import dmd.statement;
 import dmd.staticassert;
 import dmd.tokens;
 import dmd.visitor;
-import dmd.lexer;
 import dmd.common.outbuffer;
 /***************************************
  * Calls dg(Dsymbol* sym) for each Dsymbol.
@@ -99,13 +98,13 @@ void foreachDsymbol(Dsymbols* symbols, scope void delegate(Dsymbol) dg)
     }
 }
 
-void addComment(Dsymbol d, const(char)* comment)
+private void addComment(Dsymbol d, const(char)* comment)
 {
     scope v = new AddCommentVisitor(comment);
     d.accept(v);
 }
 
-extern (C++) class AddCommentVisitor: Visitor
+extern (C++) private class AddCommentVisitor: Visitor
 {
     alias visit = Visitor.visit;
 
@@ -132,6 +131,7 @@ extern (C++) class AddCommentVisitor: Visitor
         if (strcmp(*p, comment) != 0)
         {
             // Concatenate the two
+            import dmd.lexer;
             *p = Lexer.combineComments((*p).toDString(), comment.toDString(), true);
         }
     }
@@ -832,8 +832,7 @@ extern (C++) class Dsymbol : ASTNode
     }
     final void addComment(const(char)* c)
     {
-        scope v = new AddCommentVisitor(c);
-        this.accept(v);
+        .addComment(this, c);
     }
     extern (D) __gshared const(char)*[void*] commentHashTable;
 

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -1058,7 +1058,8 @@ public:
     {
         //printf("ScopeDsymbol::syntaxCopy('%s')\n", toChars());
         ScopeDsymbol sds = s ? cast(ScopeDsymbol)s : new ScopeDsymbol(ident);
-        if (const c = this.comment()){
+        if (const c = this.comment())
+        {
             commentHashTable[cast(void*)sds] = c;
         }
         sds.members = arraySyntaxCopy(members);

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -242,7 +242,6 @@ public:
     virtual Visibility visible();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
 
-    virtual void addComment(const utf8_t *comment);
     const utf8_t *comment();                      // current value of comment
 
     UnitTestDeclaration *ddocUnittest();

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -9244,59 +9244,6 @@ Lfail:
     return false;
 }
 
-void addComment(Dsymbol d, const(char)* comment)
-{
-    scope v = new AddCommentVisitor(comment);
-    d.accept(v);
-}
-
-extern (C++) class AddCommentVisitor: Visitor
-{
-    alias visit = Visitor.visit;
-
-    const(char)* comment;
-
-    this(const(char)* comment)
-    {
-        this.comment = comment;
-    }
-
-    override void visit(Dsymbol d)
-    {
-        if (!comment || !*comment)
-            return;
-
-        //printf("addComment '%s' to Dsymbol %p '%s'\n", comment, this, toChars());
-        void* h = cast(void*)d;      // just the pointer is the key
-        auto p = h in d.commentHashTable;
-        if (!p)
-        {
-            d.commentHashTable[h] = comment;
-            return;
-        }
-        if (strcmp(*p, comment) != 0)
-        {
-            // Concatenate the two
-            *p = Lexer.combineComments((*p).toDString(), comment.toDString(), true);
-        }
-    }
-    override void visit(AttribDeclaration atd)
-    {
-        if (comment)
-        {
-            atd.include(null).foreachDsymbol( s => s.addComment(comment) );
-        }
-    }
-    override void visit(ConditionalDeclaration cd)
-    {
-        if (comment)
-        {
-            cd.decl    .foreachDsymbol( s => s.addComment(comment) );
-            cd.elsedecl.foreachDsymbol( s => s.addComment(comment) );
-        }
-    }
-    override void visit(StaticForeachDeclaration sfd) {}
-}
 
 void checkCtorConstInit(Dsymbol d)
 {

--- a/compiler/src/dmd/dversion.d
+++ b/compiler/src/dmd/dversion.d
@@ -18,7 +18,6 @@ import dmd.dsymbol;
 import dmd.identifier;
 import dmd.location;
 import dmd.visitor;
-import dmd.dsymbolsem;
 /***********************************************************
  * DebugSymbol's happen for statements like:
  *      debug = identifier;
@@ -39,7 +38,10 @@ extern (C++) final class DebugSymbol : Dsymbol
     {
         assert(!s);
         auto ds = new DebugSymbol(loc, ident);
-        ds.addComment(comment);
+        if (const c = this.comment())
+        {
+            commentHashTable[cast(void*)ds] = c;
+        }
         return ds;
     }
 
@@ -75,7 +77,10 @@ extern (C++) final class VersionSymbol : Dsymbol
     {
         assert(!s);
         auto ds = new VersionSymbol(loc, ident);
-        ds.addComment(comment);
+        if (const c = this.comment())
+        {
+            commentHashTable[cast(void*)ds] = c;
+        }
         return ds;
     }
 

--- a/compiler/src/dmd/dversion.d
+++ b/compiler/src/dmd/dversion.d
@@ -18,7 +18,7 @@ import dmd.dsymbol;
 import dmd.identifier;
 import dmd.location;
 import dmd.visitor;
-
+import dmd.dsymbolsem;
 /***********************************************************
  * DebugSymbol's happen for statements like:
  *      debug = identifier;
@@ -39,7 +39,7 @@ extern (C++) final class DebugSymbol : Dsymbol
     {
         assert(!s);
         auto ds = new DebugSymbol(loc, ident);
-        ds.comment = comment;
+        ds.addComment(comment);
         return ds;
     }
 
@@ -75,7 +75,7 @@ extern (C++) final class VersionSymbol : Dsymbol
     {
         assert(!s);
         auto ds = new VersionSymbol(loc, ident);
-        ds.comment = comment;
+        ds.addComment(comment);
         return ds;
     }
 

--- a/compiler/src/dmd/dversion.d
+++ b/compiler/src/dmd/dversion.d
@@ -38,10 +38,7 @@ extern (C++) final class DebugSymbol : Dsymbol
     {
         assert(!s);
         auto ds = new DebugSymbol(loc, ident);
-        if (const c = this.comment())
-        {
-            commentHashTable[cast(void*)ds] = c;
-        }
+        ds.addComment(comment);
         return ds;
     }
 
@@ -78,9 +75,7 @@ extern (C++) final class VersionSymbol : Dsymbol
         assert(!s);
         auto ds = new VersionSymbol(loc, ident);
         if (const c = this.comment())
-        {
-            commentHashTable[cast(void*)ds] = c;
-        }
+        ds.addComment(comment);
         return ds;
     }
 

--- a/compiler/src/dmd/dversion.d
+++ b/compiler/src/dmd/dversion.d
@@ -18,6 +18,7 @@ import dmd.dsymbol;
 import dmd.identifier;
 import dmd.location;
 import dmd.visitor;
+
 /***********************************************************
  * DebugSymbol's happen for statements like:
  *      debug = identifier;
@@ -74,7 +75,6 @@ extern (C++) final class VersionSymbol : Dsymbol
     {
         assert(!s);
         auto ds = new VersionSymbol(loc, ident);
-        if (const c = this.comment())
         ds.addComment(comment);
         return ds;
     }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -613,9 +613,7 @@ public:
     virtual bool needThis();
     virtual Visibility visible();
     virtual Dsymbol* syntaxCopy(Dsymbol* s);
-    virtual void addComment(const char* comment);
     const char* comment();
-    void comment(const char* comment);
     UnitTestDeclaration* ddocUnittest();
     void ddocUnittest(UnitTestDeclaration* utd);
     bool inNonRoot();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -129,6 +129,8 @@ class Statement;
 class TryFinallyStatement;
 class ScopeGuardStatement;
 class ErrorSink;
+class WithStatement;
+struct AA;
 class CaseStatement;
 class Catch;
 struct Designator;
@@ -138,8 +140,6 @@ class Parameter;
 class ReturnStatement;
 class ScopeStatement;
 class TemplateParameter;
-struct AA;
-class WithStatement;
 class TemplateTypeParameter;
 class TemplateValueParameter;
 class TemplateAliasParameter;
@@ -1215,6 +1215,15 @@ public:
         {}
 };
 
+template <typename K, typename V>
+struct AssocArray final
+{
+    AA* aa;
+    AssocArray()
+    {
+    }
+};
+
 template <typename AST>
 class ParseTimeVisitor
 {
@@ -1636,71 +1645,6 @@ enum class StructFlags
     hasPointers = 1,
 };
 
-class AddCommentVisitor : public Visitor
-{
-public:
-    using Visitor::visit;
-    const char* comment;
-    AddCommentVisitor(const char* comment);
-    void visit(Dsymbol* d) override;
-    void visit(AttribDeclaration* atd) override;
-    void visit(ConditionalDeclaration* cd) override;
-    void visit(StaticForeachDeclaration* sfd) override;
-};
-
-class AliasAssign final : public Dsymbol
-{
-public:
-    Identifier* ident;
-    Type* type;
-    Dsymbol* aliassym;
-    AliasAssign* syntaxCopy(Dsymbol* s) override;
-    const char* kind() const override;
-    void accept(Visitor* v) override;
-};
-
-class ArrayScopeSymbol final : public ScopeDsymbol
-{
-public:
-    RootObject* arrayContent;
-    void accept(Visitor* v) override;
-};
-
-class CAsmDeclaration final : public Dsymbol
-{
-public:
-    Expression* code;
-    void accept(Visitor* v) override;
-};
-
-template <typename K, typename V>
-struct AssocArray final
-{
-    AA* aa;
-    AssocArray()
-    {
-    }
-};
-
-class DsymbolTable final : public RootObject
-{
-public:
-    AssocArray<Identifier*, Dsymbol* > tab;
-    Dsymbol* lookup(const Identifier* const ident);
-    void update(Dsymbol* s);
-    Dsymbol* insert(Dsymbol* s);
-    Dsymbol* insert(const Identifier* const ident, Dsymbol* s);
-    size_t length() const;
-    DsymbolTable();
-};
-
-class ExpressionDsymbol final : public Dsymbol
-{
-public:
-    Expression* exp;
-    ExpressionDsymbol(Expression* exp);
-};
-
 struct FieldState final
 {
     uint32_t offset;
@@ -1728,24 +1672,6 @@ struct FieldState final
         {}
 };
 
-class ForwardingScopeDsymbol final : public ScopeDsymbol
-{
-public:
-    Dsymbol* symtabInsert(Dsymbol* s) override;
-    Dsymbol* symtabLookup(Dsymbol* s, Identifier* id) override;
-    void importScope(Dsymbol* s, Visibility visibility) override;
-    const char* kind() const override;
-};
-
-class OverloadSet final : public Dsymbol
-{
-public:
-    Array<Dsymbol* > a;
-    void push(Dsymbol* s);
-    const char* kind() const override;
-    void accept(Visitor* v) override;
-};
-
 enum class SearchOpt : uint32_t
 {
     all = 0u,
@@ -1760,13 +1686,6 @@ enum class SearchOpt : uint32_t
 };
 
 typedef uint32_t SearchOptFlags;
-
-class WithScopeSymbol final : public ScopeDsymbol
-{
-public:
-    WithStatement* withstate;
-    void accept(Visitor* v) override;
-};
 
 enum : int32_t { IDX_NOTFOUND = 305419896 };
 
@@ -5530,7 +5449,6 @@ struct ASTCodegen final
     using StructDeclaration = ::StructDeclaration;
     using StructFlags = ::StructFlags;
     using UnionDeclaration = ::UnionDeclaration;
-    using AddCommentVisitor = ::AddCommentVisitor;
     using AliasAssign = ::AliasAssign;
     using ArrayScopeSymbol = ::ArrayScopeSymbol;
     using CAsmDeclaration = ::CAsmDeclaration;
@@ -7268,6 +7186,75 @@ class UnionDeclaration final : public StructDeclaration
 public:
     UnionDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
+    void accept(Visitor* v) override;
+};
+
+class WithScopeSymbol final : public ScopeDsymbol
+{
+public:
+    WithStatement* withstate;
+    void accept(Visitor* v) override;
+};
+
+class ArrayScopeSymbol final : public ScopeDsymbol
+{
+public:
+    RootObject* arrayContent;
+    void accept(Visitor* v) override;
+};
+
+class OverloadSet final : public Dsymbol
+{
+public:
+    Array<Dsymbol* > a;
+    void push(Dsymbol* s);
+    const char* kind() const override;
+    void accept(Visitor* v) override;
+};
+
+class ForwardingScopeDsymbol final : public ScopeDsymbol
+{
+public:
+    Dsymbol* symtabInsert(Dsymbol* s) override;
+    Dsymbol* symtabLookup(Dsymbol* s, Identifier* id) override;
+    void importScope(Dsymbol* s, Visibility visibility) override;
+    const char* kind() const override;
+};
+
+class ExpressionDsymbol final : public Dsymbol
+{
+public:
+    Expression* exp;
+    ExpressionDsymbol(Expression* exp);
+};
+
+class AliasAssign final : public Dsymbol
+{
+public:
+    Identifier* ident;
+    Type* type;
+    Dsymbol* aliassym;
+    AliasAssign* syntaxCopy(Dsymbol* s) override;
+    const char* kind() const override;
+    void accept(Visitor* v) override;
+};
+
+class DsymbolTable final : public RootObject
+{
+public:
+    AssocArray<Identifier*, Dsymbol* > tab;
+    Dsymbol* lookup(const Identifier* const ident);
+    void update(Dsymbol* s);
+    Dsymbol* insert(Dsymbol* s);
+    Dsymbol* insert(const Identifier* const ident, Dsymbol* s);
+    size_t length() const;
+    DsymbolTable();
+};
+
+class CAsmDeclaration final : public Dsymbol
+{
+public:
+    Expression* code;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -29,6 +29,8 @@ import dmd.rootobject;
 import dmd.root.string;
 import dmd.tokens;
 import dmd.expression;
+import dmd.dsymbolsem;
+
 
 alias CompileEnv = dmd.lexer.CompileEnv;
 

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -29,8 +29,6 @@ import dmd.rootobject;
 import dmd.root.string;
 import dmd.tokens;
 import dmd.expression;
-import dmd.dsymbolsem;
-
 
 alias CompileEnv = dmd.lexer.CompileEnv;
 


### PR DESCRIPTION
**What I did:**
- Removed the `addComment` function inside `dsymbol.d`.
- Added `import dmd.dsymbolsem;` to files that need this function (like `aliasthis.d`, `parse.d`, `dmodule.d`, etc.).
- Updated the code to call `addComment` directly using UFCS.
- Synchronized `frontend.h`

**Why I did this:**
- To break the dependency of `dsymbol.d` (an AST node) on `dsymbolsem.d` (a semantic module).
- To make the compiler code cleaner and more modular, following the "Refactoring the DMD AST" goal.