### PR TITLE
rename ldouble to real

### DIFF
--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -1325,7 +1325,7 @@ void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, bool saveflag)
     if (tyfloating(tym))
     {
         assert(reg & 32);
-        if (tym == TYldouble || tym == TYildouble)
+        if (tym == TYreal || tym == TYireal)
         {
             /*
                 fmov q0,reg
@@ -2401,7 +2401,7 @@ private void movParams(ref CGstate cg, ref CodeBuilder cdb, elem* e, uint funcar
     const tym_t tym = tybasic(e.Ety);
     regm_t retregs = tyfloating(tym) ? INSTR.FLOATREGS : INSTR.ALLREGS;
     scodelem(cgstate,cdb, e, retregs, 0, true);
-    if (sz <= REGSIZE || tym == TYldouble)
+    if (sz <= REGSIZE || tym == TYreal)
     {
         const reg_t reg = findreg(retregs);
         code cs;
@@ -2521,8 +2521,8 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
             if (sz == 8)
                 value = e.Vdouble;
             else if (sz == 16)
-                // cannot implicitly convert expression `(*e).EV.Vldouble` of type `longdouble_soft` to `double` [D:\a\1\s\compiler\src\vcbuild\dmd.vcxproj]
-                value = cast(double)e.Vldouble;
+                // cannot implicitly convert expression `(*e).EV.Vreal` of type `longdouble_soft` to `double` [D:\a\1\s\compiler\src\vcbuild\dmd.vcxproj]
+                value = cast(double)e.Vreal;
             loadFloatRegConst(cdb,vreg,value,sz);
             fixresult(cdb, e, forregs, outretregs);
             return;
@@ -2664,7 +2664,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
             loadea(cdb, e, cs, opmv, reg, 0, 0, 0, RM.load); // MOVSS/MOVSD reg,data
             checkSetVex(cdb.last(),tym);
         }
-        else if (sz == 16 && tym == TYldouble) // TODO complex numbers?
+        else if (sz == 16 && tym == TYreal) // TODO complex numbers?
         {
             loadea(cdb,e,cs,0,reg,0,0,0,RM.load);
             outretregs = mask(reg) | flags;

--- a/compiler/src/dmd/backend/arm/cod2.d
+++ b/compiler/src/dmd/backend/arm/cod2.d
@@ -1979,9 +1979,9 @@ void cdrelconst(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
     {
         case TYstruct:
         case TYarray:
-        case TYldouble:
-        case TYildouble:
-        case TYcldouble:
+        case TYreal:
+        case TYireal:
+        case TYcreal:
             tym = TYnptr;               // don't confuse allocreg()
             break;
 

--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -193,13 +193,13 @@ regm_t regmask(tym_t tym, tym_t tyf)
         case TYdouble:
         case TYdouble_alias:
         case TYidouble:
-        case TYldouble:
-        case TYildouble:
+        case TYreal:
+        case TYireal:
             return mask(32); // v0
 
         case TYcfloat:
         case TYcdouble:
-        case TYcldouble:
+        case TYcreal:
             return mask(33) | mask(32); // v33,v32
 
         // SIMD vector types

--- a/compiler/src/dmd/backend/arm/cod4.d
+++ b/compiler/src/dmd/backend/arm/cod4.d
@@ -39,7 +39,7 @@ import dmd.backend.el;
 import dmd.backend.global;
 import dmd.backend.oper;
 import dmd.backend.ty;
-import dmd.backend.evalu8 : el_toldoubled;
+import dmd.backend.evalu8 : el_toreald;
 import dmd.backend.x86.xmm;
 import dmd.backend.arm.cod1 : getlvalue, loadFromEA, storeToEA,CLIB_A,callclib;
 import dmd.backend.arm.cod2 : tyToExtend;
@@ -1052,7 +1052,7 @@ void cdcmp(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
         scodelem(cgstate,cdb,e2,retregs2,retregs1,true); // right leaf
         reg_t Vm = findreg(retregs1);
         reg_t Vn = findreg(retregs2);
-        if (tym == TYldouble || tym == TYildouble)
+        if (tym == TYreal || tym == TYireal)
         {
             CLIB_A clib;
             switch (jop)

--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -417,13 +417,13 @@ void out_config_debug(
 void util_set16()
 {
     // The default is 16 bits
-    _tysize[TYldouble] = 10;
-    _tysize[TYildouble] = 10;
-    _tysize[TYcldouble] = 20;
+    _tysize[TYreal] = 10;
+    _tysize[TYireal] = 10;
+    _tysize[TYcreal] = 20;
 
-    _tyalignsize[TYldouble] = 2;
-    _tyalignsize[TYildouble] = 2;
-    _tyalignsize[TYcldouble] = 2;
+    _tyalignsize[TYreal] = 2;
+    _tyalignsize[TYireal] = 2;
+    _tyalignsize[TYcreal] = 2;
 }
 
 /*******************************
@@ -448,21 +448,21 @@ void util_set32(exefmt_t exe)
     _tysize[TYnref] = LONGSIZE;
 if (exe & (EX_LINUX | EX_LINUX64 | EX_FREEBSD | EX_FREEBSD64 | EX_OPENBSD | EX_OPENBSD64 | EX_DRAGONFLYBSD64 | EX_SOLARIS | EX_SOLARIS64))
 {
-    _tysize[TYldouble] = 12;
-    _tysize[TYildouble] = 12;
-    _tysize[TYcldouble] = 24;
+    _tysize[TYreal] = 12;
+    _tysize[TYireal] = 12;
+    _tysize[TYcreal] = 24;
 }
 if (exe & (EX_OSX | EX_OSX64))
 {
-    _tysize[TYldouble] = 16;
-    _tysize[TYildouble] = 16;
-    _tysize[TYcldouble] = 32;
+    _tysize[TYreal] = 16;
+    _tysize[TYireal] = 16;
+    _tysize[TYcreal] = 32;
 }
 if (exe & EX_windos)
 {
-    _tysize[TYldouble] = 10;
-    _tysize[TYildouble] = 10;
-    _tysize[TYcldouble] = 20;
+    _tysize[TYreal] = 10;
+    _tysize[TYireal] = 10;
+    _tysize[TYcreal] = 20;
 }
 
     _tysize[TYsptr] = LONGSIZE;
@@ -479,21 +479,21 @@ if (exe & EX_windos)
     _tyalignsize[TYnptr] = LONGSIZE;
 if (exe & (EX_LINUX | EX_LINUX64 | EX_FREEBSD | EX_FREEBSD64 | EX_OPENBSD | EX_OPENBSD64 | EX_DRAGONFLYBSD64 | EX_SOLARIS | EX_SOLARIS64))
 {
-    _tyalignsize[TYldouble] = 4;
-    _tyalignsize[TYildouble] = 4;
-    _tyalignsize[TYcldouble] = 4;
+    _tyalignsize[TYreal] = 4;
+    _tyalignsize[TYireal] = 4;
+    _tyalignsize[TYcreal] = 4;
 }
 else if (exe & (EX_OSX | EX_OSX64))
 {
-    _tyalignsize[TYldouble] = 16;
-    _tyalignsize[TYildouble] = 16;
-    _tyalignsize[TYcldouble] = 16;
+    _tyalignsize[TYreal] = 16;
+    _tyalignsize[TYireal] = 16;
+    _tyalignsize[TYcreal] = 16;
 }
 if (exe & EX_windos)
 {
-    _tyalignsize[TYldouble] = 2;
-    _tyalignsize[TYildouble] = 2;
-    _tyalignsize[TYcldouble] = 2;
+    _tyalignsize[TYreal] = 2;
+    _tyalignsize[TYireal] = 2;
+    _tyalignsize[TYcreal] = 2;
 }
 
     _tyalignsize[TYsptr] = LONGSIZE;
@@ -535,15 +535,15 @@ void util_set64(exefmt_t exe)
     if (exe & (EX_LINUX | EX_LINUX64 | EX_FREEBSD | EX_FREEBSD64 | EX_OPENBSD |
                       EX_OPENBSD64 | EX_DRAGONFLYBSD64 | EX_SOLARIS | EX_SOLARIS64 | EX_OSX | EX_OSX64))
     {
-        _tysize[TYldouble] = 16;
-        _tysize[TYildouble] = 16;
-        _tysize[TYcldouble] = 32;
+        _tysize[TYreal] = 16;
+        _tysize[TYireal] = 16;
+        _tysize[TYcreal] = 32;
     }
     if (exe & EX_windos)
     {
-        _tysize[TYldouble] = 10;
-        _tysize[TYildouble] = 10;
-        _tysize[TYcldouble] = 20;
+        _tysize[TYreal] = 10;
+        _tysize[TYireal] = 10;
+        _tysize[TYcreal] = 20;
     }
     _tysize[TYsptr] = 8;
     _tysize[TYcptr] = 8;
@@ -559,21 +559,21 @@ void util_set64(exefmt_t exe)
     _tyalignsize[TYnref] = 8;
     if (exe & (EX_LINUX | EX_LINUX64 | EX_FREEBSD | EX_FREEBSD64 | EX_OPENBSD | EX_OPENBSD64 | EX_DRAGONFLYBSD64 | EX_SOLARIS | EX_SOLARIS64))
     {
-        _tyalignsize[TYldouble] = 16;
-        _tyalignsize[TYildouble] = 16;
-        _tyalignsize[TYcldouble] = 16;
+        _tyalignsize[TYreal] = 16;
+        _tyalignsize[TYireal] = 16;
+        _tyalignsize[TYcreal] = 16;
     }
     if (exe & (EX_OSX | EX_OSX64))
     {
-        _tyalignsize[TYldouble] = 16;
-        _tyalignsize[TYildouble] = 16;
-        _tyalignsize[TYcldouble] = 16;
+        _tyalignsize[TYreal] = 16;
+        _tyalignsize[TYireal] = 16;
+        _tyalignsize[TYcreal] = 16;
     }
     if (exe & EX_windos)
     {
-        _tyalignsize[TYldouble] = 2;
-        _tyalignsize[TYildouble] = 2;
-        _tyalignsize[TYcldouble] = 2;
+        _tyalignsize[TYreal] = 2;
+        _tyalignsize[TYireal] = 2;
+        _tyalignsize[TYcreal] = 2;
     }
     _tyalignsize[TYsptr] = 8;
     _tyalignsize[TYcptr] = 8;
@@ -605,27 +605,27 @@ void util_setAArch64(exefmt_t exe)
 
     if (exe & EX_windos)
     {
-        _tysize[TYldouble] = 16;
-        _tysize[TYildouble] = 16;
-        _tysize[TYcldouble] = 32;
+        _tysize[TYreal] = 16;
+        _tysize[TYireal] = 16;
+        _tysize[TYcreal] = 32;
     }
     if (exe & EX_windos)
     {
-        _tyalignsize[TYldouble] = 16;
-        _tyalignsize[TYildouble] = 16;
-        _tyalignsize[TYcldouble] = 16;
+        _tyalignsize[TYreal] = 16;
+        _tyalignsize[TYireal] = 16;
+        _tyalignsize[TYcreal] = 16;
     }
 
     if (exe & EX_OSX64)
     {
-        _tysize[TYldouble] = 8;
-        _tysize[TYildouble] = 8;
-        _tysize[TYcldouble] = 16;
+        _tysize[TYreal] = 8;
+        _tysize[TYireal] = 8;
+        _tysize[TYcreal] = 16;
     }
     if (exe & EX_OSX64)
     {
-        _tyalignsize[TYldouble] = 8;
-        _tyalignsize[TYildouble] = 8;
-        _tyalignsize[TYcldouble] = 8;
+        _tyalignsize[TYreal] = 8;
+        _tyalignsize[TYireal] = 8;
+        _tyalignsize[TYcreal] = 8;
     }
 }

--- a/compiler/src/dmd/backend/bcomplex.d
+++ b/compiler/src/dmd/backend/bcomplex.d
@@ -11,7 +11,7 @@
 
 module dmd.backend.bcomplex;
 
-public import dmd.root.longdouble : targ_ldouble = longdouble;
+public import dmd.root.longdouble : targ_real = longdouble;
 import core.stdc.math : fabs, fabsl, sqrt;
 version(CRuntime_Microsoft)
     private import dmd.root.longdouble : fabsl, sqrt; // needed if longdouble is longdouble_soft
@@ -52,20 +52,20 @@ nothrow:
                          x.im * y.re + x.re * y.im);
     }
 
-    static targ_ldouble abs(ref Complex_f z)
+    static targ_real abs(ref Complex_f z)
     {
-        const targ_ldouble x = fabs(z.re);
-        const targ_ldouble y = fabs(z.im);
+        const targ_real x = fabs(z.re);
+        const targ_real y = fabs(z.im);
         if (x == 0)
             return y;
         if (y == 0)
             return x;
         if (x > y)
         {
-            const targ_ldouble temp = y / x;
+            const targ_real temp = y / x;
             return x * sqrt(1 + temp * temp);
         }
-        const targ_ldouble temp = x / y;
+        const targ_real temp = x / y;
         return y * sqrt(1 + temp * temp);
     }
 
@@ -75,9 +75,9 @@ nothrow:
         {
             return Complex_f(0, 0);
         }
-        const targ_ldouble x = fabs(z.re);
-        const targ_ldouble y = fabs(z.im);
-        targ_ldouble r, w;
+        const targ_real x = fabs(z.re);
+        const targ_real y = fabs(z.im);
+        targ_real r, w;
         if (x >= y)
         {
             r = y / x;
@@ -110,15 +110,15 @@ nothrow:
     {
         if (fabs(y.re) < fabs(y.im))
         {
-            const targ_ldouble r = y.re / y.im;
-            const targ_ldouble den = y.im + r * y.re;
+            const targ_real r = y.re / y.im;
+            const targ_real den = y.im + r * y.re;
             return Complex_d(cast(double)((x.re * r + x.im) / den),
                              cast(double)((x.im * r - x.re) / den));
         }
         else
         {
-            const targ_ldouble r = y.im / y.re;
-            const targ_ldouble den = y.re + r * y.im;
+            const targ_real r = y.im / y.re;
+            const targ_real den = y.re + r * y.im;
             return Complex_d(cast(double)((x.re + r * x.im) / den),
                              cast(double)((x.im - r * x.re) / den));
         }
@@ -130,22 +130,22 @@ nothrow:
                          x.im * y.re + x.re * y.im);
     }
 
-    static targ_ldouble abs(ref Complex_d z)
+    static targ_real abs(ref Complex_d z)
     {
-        const targ_ldouble x = fabs(z.re);
-        const targ_ldouble y = fabs(z.im);
+        const targ_real x = fabs(z.re);
+        const targ_real y = fabs(z.im);
         if (x == 0)
             return y;
         if (y == 0)
             return x;
         if (x > y)
         {
-            const targ_ldouble temp = y / x;
+            const targ_real temp = y / x;
             return x * sqrt(1 + temp * temp);
         }
         else
         {
-            const targ_ldouble temp = x / y;
+            const targ_real temp = x / y;
             return y * sqrt(1 + temp * temp);
         }
     }
@@ -158,9 +158,9 @@ nothrow:
         }
         else
         {
-            const targ_ldouble x = fabs(z.re);
-            const targ_ldouble y = fabs(z.im);
-            targ_ldouble r, w;
+            const targ_real x = fabs(z.re);
+            const targ_real y = fabs(z.im);
+            targ_real r, w;
             if (x >= y)
             {
                 r = y / x;
@@ -189,21 +189,21 @@ nothrow:
 struct Complex_ld
 {
 nothrow:
-    targ_ldouble re, im;
+    targ_real re, im;
 
     static Complex_ld div(ref Complex_ld x, ref Complex_ld y)
     {
         if (fabsl(y.re) < fabsl(y.im))
         {
-            const targ_ldouble r = y.re / y.im;
-            const targ_ldouble den = y.im + r * y.re;
+            const targ_real r = y.re / y.im;
+            const targ_real den = y.im + r * y.re;
             return Complex_ld((x.re * r + x.im) / den,
                               (x.im * r - x.re) / den);
         }
         else
         {
-            const targ_ldouble r = y.im / y.re;
-            const targ_ldouble den = y.re + r * y.im;
+            const targ_real r = y.im / y.re;
+            const targ_real den = y.re + r * y.im;
             return Complex_ld((x.re + r * x.im) / den,
                               (x.im - r * x.re) / den);
         }
@@ -215,20 +215,20 @@ nothrow:
                           x.im * y.re + x.re * y.im);
     }
 
-    static targ_ldouble abs(ref Complex_ld z)
+    static targ_real abs(ref Complex_ld z)
     {
-        const targ_ldouble x = fabsl(z.re);
-        const targ_ldouble y = fabsl(z.im);
+        const targ_real x = fabsl(z.re);
+        const targ_real y = fabsl(z.im);
         if (x == 0)
             return y;
         if (y == 0)
             return x;
         if (x > y)
         {
-            const targ_ldouble temp = y / x;
+            const targ_real temp = y / x;
             return x * sqrt(1 + temp * temp);
         }
-        const targ_ldouble temp = x / y;
+        const targ_real temp = x / y;
         return y * sqrt(1 + temp * temp);
     }
 
@@ -236,13 +236,13 @@ nothrow:
     {
         if (z.re == 0 && z.im == 0)
         {
-            return Complex_ld(targ_ldouble(0), targ_ldouble(0));
+            return Complex_ld(targ_real(0), targ_real(0));
         }
         else
         {
-            const targ_ldouble x = fabsl(z.re);
-            const targ_ldouble y = fabsl(z.im);
-            targ_ldouble r, w;
+            const targ_real x = fabsl(z.re);
+            const targ_real y = fabsl(z.im);
+            targ_real r, w;
             if (x >= y)
             {
                 r = y / x;

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -126,7 +126,7 @@ alias targ_llong = long;
 alias targ_ullong = ulong;
 alias targ_float = float;
 alias targ_double = double;
-public import dmd.root.longdouble : targ_ldouble = longdouble;
+public import dmd.root.longdouble : targ_real = longdouble;
 
 // Extract most significant register from constant
 ulong MSREG(ulong p) { return (REGSIZE == 2) ? p >> 16 : ((targ_llong.sizeof == 8) ? p >> 32 : 0); }
@@ -638,24 +638,24 @@ import dmd.backend.bcomplex;
 
 union Vconst
 {
-        targ_char       Vchar;
+        targ_char       Vchar;          // 8 bits
         targ_schar      Vschar;
         targ_uchar      Vuchar;
-        targ_short      Vshort;
+        targ_short      Vshort;         // 16 bits
         targ_ushort     Vushort;
-        targ_int        Vint;
+        targ_int        Vint;           // 32 bits
         targ_uns        Vuns;
-        targ_long       Vlong;
+        targ_long       Vlong;          // 32 bits
         targ_ulong      Vulong;
-        targ_llong      Vllong;
+        targ_llong      Vllong;         // 64 bits
         targ_ullong     Vullong;
-        Cent            Vcent;
-        targ_float      Vfloat = void; // FIXME: Floats have a void-initializer to give
+        Cent            Vcent;          // 128 bits
+        targ_float      Vfloat = void;  // FIXME: Floats have a void-initializer so
         targ_double     Vdouble = void; // the union has an all-zero initializer, see also bugzilla #23841
-        targ_ldouble    Vldouble = void;
+        targ_real    Vreal = void;
         Complex_f       Vcfloat = void;   // 2x float
         Complex_d       Vcdouble = void;  // 2x double
-        Complex_ld      Vcldouble = void; // 2x long double
+        Complex_ld      Vcreal = void; // 2x long double
         targ_size_t     Vpointer;
         targ_ptrdiff_t  Vptrdiff;
         targ_uchar      Vreg;   // register number for OPreg elems

--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -174,9 +174,9 @@ int elemisone(elem* e)
                 if (el_tolong(e) != 1)
                     goto nomatch;
                 break;
-            case TYldouble:
-            case TYildouble:
-                if (e.Vldouble != 1)
+            case TYreal:
+            case TYireal:
+                if (e.Vreal != 1)
                     goto nomatch;
                 break;
             case TYdouble:
@@ -239,9 +239,9 @@ int elemisnegone(elem* e)
                 if (el_tolong(e) != -1)
                     goto nomatch;
                 break;
-            case TYldouble:
-            //case TYildouble:
-                if (e.Vldouble != -1)
+            case TYreal:
+            //case TYireal:
+                if (e.Vreal != -1)
                     goto nomatch;
                 break;
             case TYdouble:
@@ -3616,9 +3616,9 @@ elem* elstruct(elem* e, Goal goal)
 
         case 10:
         case 12:
-            if (tysize(TYldouble) == sz && targ1 && !targ2 && tybasic(targ1.Tty) == TYldouble)
+            if (tysize(TYreal) == sz && targ1 && !targ2 && tybasic(targ1.Tty) == TYreal)
             {
-                tym = TYldouble;
+                tym = TYreal;
                 goto L1;
             }
             goto case 9;
@@ -4548,7 +4548,7 @@ private elem* elcmp(elem* e, Goal goal)
             return optelem(e, Goal.value);
         }
 
-        if (e1.Eoper == OPd_ld && tysize(e1.Ety) == tysize(TYldouble) && cast(targ_double)e2.Vldouble == e2.Vldouble)
+        if (e1.Eoper == OPd_ld && tysize(e1.Ety) == tysize(TYreal) && cast(targ_double)e2.Vreal == e2.Vreal)
         {
             /* Remove unnecessary OPd_ld operator
              */
@@ -4556,7 +4556,7 @@ private elem* elcmp(elem* e, Goal goal)
             e1.E1 = null;
             el_free(e1);
             e2.Ety = e.E1.Ety;
-            e2.Vdouble = cast(targ_double)e2.Vldouble;
+            e2.Vdouble = cast(targ_double)e2.Vreal;
             return optelem(e, Goal.value);
         }
 
@@ -5248,7 +5248,7 @@ private elem* elu64_d(elem* e, Goal goal)
     {
         pu = &e.E1.E1;
         *pu = optelem(*pu, Goal.value);
-        ty = TYldouble;
+        ty = TYreal;
     }
     else if (e.Eoper == OPd_f && e.E1.Eoper == OPu64_d)
     {
@@ -5308,24 +5308,24 @@ private elem* elu64_d(elem* e, Goal goal)
             fixside(&u, &u1);
 
         elem* eop1 = el_una(OPs64_d, TYdouble, u1);
-        eop1 = el_una(OPd_ld, TYldouble, eop1);
+        eop1 = el_una(OPd_ld, TYreal, eop1);
 
         elem* eoff = el_calloc();
         eoff.Eoper = OPconst;
-        eoff.Ety = TYldouble;
-        eoff.Vldouble = 0x1p+64;
+        eoff.Ety = TYreal;
+        eoff.Vreal = 0x1p+64;
 
         elem* u2 = el_copytree(u1);
         u2 = el_una(OPs64_d, TYdouble, u2);
-        u2 = el_una(OPd_ld, TYldouble, u2);
+        u2 = el_una(OPd_ld, TYreal, u2);
 
-        elem* eop2 = el_bin(OPadd, TYldouble, u2, eoff);
+        elem* eop2 = el_bin(OPadd, TYreal, u2, eoff);
 
-        elem* r = el_bin(OPcond, TYldouble,
+        elem* r = el_bin(OPcond, TYreal,
                         el_bin(OPge, OPbool, u, el_long(TYllong, 0)),
-                        el_bin(OPcolon, TYldouble, eop1, eop2));
+                        el_bin(OPcolon, TYreal, eop1, eop2));
 
-        if (ty != TYldouble)
+        if (ty != TYreal)
             r = el_una(OPtoprec, e.Ety, r);
 
         *pu = null;
@@ -6512,7 +6512,7 @@ bool useOPnegass(tym_t tym)
 {
     //printf("useOPnegass() tym: %s\n", tym_str(tym));
     const ty = tybasic(tym);
-    return !(config.target_cpu == TARGET_AArch64 && (ty == TYldouble || ty == TYildouble));
+    return !(config.target_cpu == TARGET_AArch64 && (ty == TYreal || ty == TYireal));
 }
 
 /***************************************************

--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -1093,13 +1093,13 @@ L1:
         case TYfloat:
         case TYdouble:
         case TYdouble_alias:
-        case TYldouble:
+        case TYreal:
         case TYifloat:
         case TYidouble:
-        case TYildouble:
+        case TYireal:
         case TYcfloat:
         case TYcdouble:
-        case TYcldouble:
+        case TYcreal:
         case TYbool:
         case TYwchar_t:
         case TYdchar:
@@ -1978,13 +1978,13 @@ private void cv4_func(Funcsym* s, ref symtab_t symtab)
                 assert(I32);
                 goto case_edxeax;
 
-            case TYldouble:
-            case TYildouble:
+            case TYreal:
+            case TYireal:
                 goto case_st0;
 
             case TYcfloat:
             case TYcdouble:
-            case TYcldouble:
+            case TYcreal:
                 goto case_st01;
 
             case_ax:

--- a/compiler/src/dmd/backend/dtype.d
+++ b/compiler/src/dmd/backend/dtype.d
@@ -159,7 +159,7 @@ uint type_alignsize(type* t)
                         sz = t.Ttag.Sstruct.Sstructalign + 1;
                     break;
 
-                case TYldouble:
+                case TYreal:
                     assert(0);
 
                 case TYcdouble:
@@ -594,13 +594,13 @@ void type_init()
     tstypes[TYfloat]   = type_allocbasic(TYfloat);
     tstypes[TYdouble]  = type_allocbasic(TYdouble);
     tstypes[TYdouble_alias]  = type_allocbasic(TYdouble_alias);
-    tstypes[TYldouble] = type_allocbasic(TYldouble);
+    tstypes[TYreal] = type_allocbasic(TYreal);
     tstypes[TYifloat]  = type_allocbasic(TYifloat);
     tstypes[TYidouble] = type_allocbasic(TYidouble);
-    tstypes[TYildouble] = type_allocbasic(TYildouble);
+    tstypes[TYireal] = type_allocbasic(TYireal);
     tstypes[TYcfloat]   = type_allocbasic(TYcfloat);
     tstypes[TYcdouble]  = type_allocbasic(TYcdouble);
-    tstypes[TYcldouble] = type_allocbasic(TYcldouble);
+    tstypes[TYcreal] = type_allocbasic(TYcreal);
 
     if (I64)
     {

--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -2564,15 +2564,15 @@ static if (1)
             case TYdouble:
                 ate = DW_ATE_float;
                 goto Lsignedstr;
-            case TYldouble:
+            case TYreal:
             case TYifloat:
             case TYidouble:
-            case TYildouble:
+            case TYireal:
                 ate = DW_ATE_imaginary_float;
                 goto Lsignedstr;
             case TYcfloat:
             case TYcdouble:
-            case TYcldouble:
+            case TYcreal:
                 ate = DW_ATE_complex_float;
                 goto Lsignedstr;
             Lsignedstr:

--- a/compiler/src/dmd/backend/evalu8.d
+++ b/compiler/src/dmd/backend/evalu8.d
@@ -96,9 +96,9 @@ int boolres(elem* e)
                 case TYdouble:
                 case TYidouble:
                 case TYdouble_alias:
-                case TYildouble:
-                case TYldouble:
-                {   targ_ldouble ld = el_toldoubled(e);
+                case TYireal:
+                case TYreal:
+                {   targ_real ld = el_toreald(e);
 
                     if (isnan(ld))
                         b = 1;
@@ -119,11 +119,11 @@ int boolres(elem* e)
                     else
                         b = e.Vcdouble.re != 0 || e.Vcdouble.im != 0;
                     break;
-                case TYcldouble:
-                    if (isnan(e.Vcldouble.re) || isnan(e.Vcldouble.im))
+                case TYcreal:
+                    if (isnan(e.Vcreal.re) || isnan(e.Vcreal.im))
                         b = 1;
                     else
-                        b = e.Vcldouble.re != 0 || e.Vcldouble.im != 0;
+                        b = e.Vcreal.re != 0 || e.Vcreal.im != 0;
                     break;
 
                 case TYstruct:  // happens on syntax error of (struct x)0
@@ -282,7 +282,7 @@ elem* evalu8(elem* e, Goal goal)
     uint op;
     targ_int i1,i2;
     targ_llong l1,l2;
-    targ_ldouble d1,d2;
+    targ_real d1,d2;
     elem esave = void;
 
     static bool unordered(T)(T d1, T d2) { return isnan(d1) || isnan(d2); }
@@ -305,7 +305,7 @@ elem* evalu8(elem* e, Goal goal)
             if (e2.Eoper == OPconst && !tyvector(e2.Ety))
             {
                 i2 = cast(targ_int)(l2 = el_tolong(e2));
-                d2 = el_toldoubled(e2);
+                d2 = el_toreald(e2);
             }
             else
                 return e;
@@ -320,7 +320,7 @@ elem* evalu8(elem* e, Goal goal)
             d2 = 0;             // "
         }
         i1 = cast(targ_int)(l1 = el_tolong(e1));
-        d1 = el_toldoubled(e1);
+        d1 = el_toreald(e1);
         tym = tybasic(typemask(e1));    /* type of op is type of left child */
 
         // Huge pointers are always evaluated at runtime
@@ -346,8 +346,8 @@ static if (0)
       debug printf("tym1 = x%lx, tym2 = x%lx, e2 = %g\n",tym,tym2,e2.Vdouble);
 
       Vconst u;
-      debug printf("d1 = x%16llx\n", (u.Vldouble = d1, u.Vullong));
-      debug printf("d2 = x%16llx\n", (u.Vldouble = d2, u.Vullong));
+      debug printf("d1 = x%16llx\n", (u.Vreal = d1, u.Vullong));
+      debug printf("d2 = x%16llx\n", (u.Vreal = d2, u.Vullong));
   }
 }
   switch (op)
@@ -393,19 +393,19 @@ static if (0)
                         assert(0);
                 }
                 break;
-            case TYldouble:
+            case TYreal:
                 switch (tym2)
                 {
-                    case TYldouble:
-                        e.Vldouble = d1 + d2;
+                    case TYreal:
+                        e.Vreal = d1 + d2;
                         break;
-                    case TYildouble:
-                        e.Vcldouble.re = d1;
-                        e.Vcldouble.im = d2;
+                    case TYireal:
+                        e.Vcreal.re = d1;
+                        e.Vcreal.im = d2;
                         break;
-                    case TYcldouble:
-                        e.Vcldouble.re = d1 + e2.Vcldouble.re;
-                        e.Vcldouble.im = 0  + e2.Vcldouble.im;
+                    case TYcreal:
+                        e.Vcreal.re = d1 + e2.Vcreal.re;
+                        e.Vcreal.im = 0  + e2.Vcreal.im;
                         break;
                     default:
                         assert(0);
@@ -447,19 +447,19 @@ static if (0)
                         assert(0);
                 }
                 break;
-            case TYildouble:
+            case TYireal:
                 switch (tym2)
                 {
-                    case TYldouble:
-                        e.Vcldouble.re = d2;
-                        e.Vcldouble.im = d1;
+                    case TYreal:
+                        e.Vcreal.re = d2;
+                        e.Vcreal.im = d1;
                         break;
-                    case TYildouble:
-                        e.Vldouble = d1 + d2;
+                    case TYireal:
+                        e.Vreal = d1 + d2;
                         break;
-                    case TYcldouble:
-                        e.Vcldouble.re = 0  + e2.Vcldouble.re;
-                        e.Vcldouble.im = d1 + e2.Vcldouble.im;
+                    case TYcreal:
+                        e.Vcreal.re = 0  + e2.Vcreal.re;
+                        e.Vcreal.im = d1 + e2.Vcreal.im;
                         break;
                     default:
                         assert(0);
@@ -503,20 +503,20 @@ static if (0)
                         assert(0);
                 }
                 break;
-            case TYcldouble:
+            case TYcreal:
                 switch (tym2)
                 {
-                    case TYldouble:
-                        e.Vcldouble.re = e1.Vcldouble.re + d2;
-                        e.Vcldouble.im = e1.Vcldouble.im;
+                    case TYreal:
+                        e.Vcreal.re = e1.Vcreal.re + d2;
+                        e.Vcreal.im = e1.Vcreal.im;
                         break;
-                    case TYildouble:
-                        e.Vcldouble.re = e1.Vcldouble.re;
-                        e.Vcldouble.im = e1.Vcldouble.im + d2;
+                    case TYireal:
+                        e.Vcreal.re = e1.Vcreal.re;
+                        e.Vcreal.im = e1.Vcreal.im + d2;
                         break;
-                    case TYcldouble:
-                        e.Vcldouble.re = e1.Vcldouble.re + e2.Vcldouble.re;
-                        e.Vcldouble.im = e1.Vcldouble.im + e2.Vcldouble.im;
+                    case TYcreal:
+                        e.Vcreal.re = e1.Vcreal.re + e2.Vcreal.re;
+                        e.Vcreal.im = e1.Vcreal.im + e2.Vcreal.im;
                         break;
                     default:
                         assert(0);
@@ -590,19 +590,19 @@ static if (0)
                         assert(0);
                 }
                 break;
-            case TYldouble:
+            case TYreal:
                 switch (tym2)
                 {
-                    case TYldouble:
-                        e.Vldouble = d1 - d2;
+                    case TYreal:
+                        e.Vreal = d1 - d2;
                         break;
-                    case TYildouble:
-                        e.Vcldouble.re =  d1;
-                        e.Vcldouble.im = -d2;
+                    case TYireal:
+                        e.Vcreal.re =  d1;
+                        e.Vcreal.im = -d2;
                         break;
-                    case TYcldouble:
-                        e.Vcldouble.re = d1 - e2.Vcldouble.re;
-                        e.Vcldouble.im = 0  - e2.Vcldouble.im;
+                    case TYcreal:
+                        e.Vcreal.re = d1 - e2.Vcreal.re;
+                        e.Vcreal.im = 0  - e2.Vcreal.im;
                         break;
                     default:
                         assert(0);
@@ -644,19 +644,19 @@ static if (0)
                         assert(0);
                 }
                 break;
-            case TYildouble:
+            case TYireal:
                 switch (tym2)
                 {
-                    case TYldouble:
-                        e.Vcldouble.re = -d2;
-                        e.Vcldouble.im =  d1;
+                    case TYreal:
+                        e.Vcreal.re = -d2;
+                        e.Vcreal.im =  d1;
                         break;
-                    case TYildouble:
-                        e.Vldouble = d1 - d2;
+                    case TYireal:
+                        e.Vreal = d1 - d2;
                         break;
-                    case TYcldouble:
-                        e.Vcldouble.re = 0  - e2.Vcldouble.re;
-                        e.Vcldouble.im = d1 - e2.Vcldouble.im;
+                    case TYcreal:
+                        e.Vcreal.re = 0  - e2.Vcreal.re;
+                        e.Vcreal.im = d1 - e2.Vcreal.im;
                         break;
                     default:
                         assert(0);
@@ -700,20 +700,20 @@ static if (0)
                         assert(0);
                 }
                 break;
-            case TYcldouble:
+            case TYcreal:
                 switch (tym2)
                 {
-                    case TYldouble:
-                        e.Vcldouble.re = e1.Vcldouble.re - d2;
-                        e.Vcldouble.im = e1.Vcldouble.im;
+                    case TYreal:
+                        e.Vcreal.re = e1.Vcreal.re - d2;
+                        e.Vcreal.im = e1.Vcreal.im;
                         break;
-                    case TYildouble:
-                        e.Vcldouble.re = e1.Vcldouble.re;
-                        e.Vcldouble.im = e1.Vcldouble.im - d2;
+                    case TYireal:
+                        e.Vcreal.re = e1.Vcreal.re;
+                        e.Vcreal.im = e1.Vcreal.im - d2;
                         break;
-                    case TYcldouble:
-                        e.Vcldouble.re = e1.Vcldouble.re - e2.Vcldouble.re;
-                        e.Vcldouble.im = e1.Vcldouble.im - e2.Vcldouble.im;
+                    case TYcreal:
+                        e.Vcreal.re = e1.Vcreal.re - e2.Vcreal.re;
+                        e.Vcreal.im = e1.Vcreal.im - e2.Vcreal.im;
                         break;
                     default:
                         assert(0);
@@ -777,16 +777,16 @@ static if (0)
                             assert(0);
                     }
                     break;
-                case TYldouble:
+                case TYreal:
                     switch (tym2)
                     {
-                        case TYldouble:
-                        case TYildouble:
-                            e.Vldouble = d1 * d2;
+                        case TYreal:
+                        case TYireal:
+                            e.Vreal = d1 * d2;
                             break;
-                        case TYcldouble:
-                            e.Vcldouble.re = d1 * e2.Vcldouble.re;
-                            e.Vcldouble.im = d1 * e2.Vcldouble.im;
+                        case TYcreal:
+                            e.Vcreal.re = d1 * e2.Vcreal.re;
+                            e.Vcreal.im = d1 * e2.Vcreal.im;
                             break;
                         default:
                             assert(0);
@@ -826,18 +826,18 @@ static if (0)
                             assert(0);
                     }
                     break;
-                case TYildouble:
+                case TYireal:
                     switch (tym2)
                     {
-                        case TYldouble:
-                            e.Vldouble = d1 * d2;
+                        case TYreal:
+                            e.Vreal = d1 * d2;
                             break;
-                        case TYildouble:
-                            e.Vldouble = -d1 * d2;
+                        case TYireal:
+                            e.Vreal = -d1 * d2;
                             break;
-                        case TYcldouble:
-                            e.Vcldouble.re = -d1 * e2.Vcldouble.im;
-                            e.Vcldouble.im =  d1 * e2.Vcldouble.re;
+                        case TYcreal:
+                            e.Vcreal.re = -d1 * e2.Vcreal.im;
+                            e.Vcreal.im =  d1 * e2.Vcreal.re;
                             break;
                         default:
                             assert(0);
@@ -879,19 +879,19 @@ static if (0)
                             assert(0);
                     }
                     break;
-                case TYcldouble:
+                case TYcreal:
                     switch (tym2)
                     {
-                        case TYldouble:
-                            e.Vcldouble.re = e1.Vcldouble.re * d2;
-                            e.Vcldouble.im = e1.Vcldouble.im * d2;
+                        case TYreal:
+                            e.Vcreal.re = e1.Vcreal.re * d2;
+                            e.Vcreal.im = e1.Vcreal.im * d2;
                             break;
-                        case TYildouble:
-                            e.Vcldouble.re = -e1.Vcldouble.im * d2;
-                            e.Vcldouble.im =  e1.Vcldouble.re * d2;
+                        case TYireal:
+                            e.Vcreal.re = -e1.Vcreal.im * d2;
+                            e.Vcreal.im =  e1.Vcreal.re * d2;
                             break;
-                        case TYcldouble:
-                            e.Vcldouble = Complex_ld.mul(e1.Vcldouble, e2.Vcldouble);
+                        case TYcreal:
+                            e.Vcreal = Complex_ld.mul(e1.Vcreal, e2.Vcreal);
                             break;
                         default:
                             assert(0);
@@ -948,9 +948,9 @@ static if (0)
                         case TYdouble_alias:
                             e.Vdouble = e1.Vdouble / e2.Vdouble;
                             break;
-                        case TYldouble:
-                            // cast is required because Vldouble is a soft type on windows
-                            e.Vdouble = cast(double)(e1.Vdouble / e2.Vldouble);
+                        case TYreal:
+                            // cast is required because Vreal is a soft type on windows
+                            e.Vdouble = cast(double)(e1.Vdouble / e2.Vreal);
                             break;
                         case TYidouble:
                             e.Vdouble = -e1.Vdouble / e2.Vdouble;
@@ -964,19 +964,19 @@ static if (0)
                             assert(0);
                     }
                     break;
-                case TYldouble:
+                case TYreal:
                     switch (tym2)
                     {
-                        case TYldouble:
-                            e.Vldouble = d1 / d2;
+                        case TYreal:
+                            e.Vreal = d1 / d2;
                             break;
-                        case TYildouble:
-                            e.Vldouble = -d1 / d2;
+                        case TYireal:
+                            e.Vreal = -d1 / d2;
                             break;
-                        case TYcldouble:
-                            e.Vcldouble.re = d1;
-                            e.Vcldouble.im = 0;
-                            e.Vcldouble = Complex_ld.div(e.Vcldouble, e2.Vcldouble);
+                        case TYcreal:
+                            e.Vcreal.re = d1;
+                            e.Vcreal.im = 0;
+                            e.Vcreal = Complex_ld.div(e.Vcreal, e2.Vcreal);
                             break;
                         default:
                             assert(0);
@@ -1014,17 +1014,17 @@ static if (0)
                             assert(0);
                     }
                     break;
-                case TYildouble:
+                case TYireal:
                     switch (tym2)
                     {
-                        case TYldouble:
-                        case TYildouble:
-                            e.Vldouble = d1 / d2;
+                        case TYreal:
+                        case TYireal:
+                            e.Vreal = d1 / d2;
                             break;
-                        case TYcldouble:
-                            e.Vcldouble.re = 0;
-                            e.Vcldouble.im = d1;
-                            e.Vcldouble = Complex_ld.div(e.Vcldouble, e2.Vcldouble);
+                        case TYcreal:
+                            e.Vcreal.re = 0;
+                            e.Vcreal.im = d1;
+                            e.Vcreal = Complex_ld.div(e.Vcreal, e2.Vcreal);
                             break;
                         default:
                             assert(0);
@@ -1066,19 +1066,19 @@ static if (0)
                             assert(0);
                     }
                     break;
-                case TYcldouble:
+                case TYcreal:
                     switch (tym2)
                     {
-                        case TYldouble:
-                            e.Vcldouble.re = e1.Vcldouble.re / d2;
-                            e.Vcldouble.im = e1.Vcldouble.im / d2;
+                        case TYreal:
+                            e.Vcreal.re = e1.Vcreal.re / d2;
+                            e.Vcreal.im = e1.Vcreal.im / d2;
                             break;
-                        case TYildouble:
-                            e.Vcldouble.re =  e1.Vcldouble.im / d2;
-                            e.Vcldouble.im = -e1.Vcldouble.re / d2;
+                        case TYireal:
+                            e.Vcreal.re =  e1.Vcreal.im / d2;
+                            e.Vcreal.im = -e1.Vcreal.re / d2;
                             break;
-                        case TYcldouble:
-                            e.Vcldouble = Complex_ld.div(e1.Vcldouble, e2.Vcldouble);
+                        case TYcreal:
+                            e.Vcreal = Complex_ld.div(e1.Vcreal, e2.Vcreal);
                             break;
                         default:
                             assert(0);
@@ -1126,9 +1126,9 @@ static if (0)
                 case TYifloat:
                     e.Vfloat = fmodf(e1.Vfloat,e2.Vfloat);
                     break;
-                case TYldouble:
-                case TYildouble:
-                    e.Vldouble = _modulo(d1, d2);
+                case TYreal:
+                case TYireal:
+                    e.Vreal = _modulo(d1, d2);
                     break;
                 case TYcfloat:
                     switch (tym2)
@@ -1154,13 +1154,13 @@ static if (0)
                             assert(0);
                     }
                     break;
-                case TYcldouble:
+                case TYcreal:
                     switch (tym2)
                     {
-                        case TYldouble:
-                        case TYildouble:
-                            e.Vcldouble.re = _modulo(e1.Vcldouble.re, d2);
-                            e.Vcldouble.im = _modulo(e1.Vcldouble.im, d2);
+                        case TYreal:
+                        case TYireal:
+                            e.Vcreal.re = _modulo(e1.Vcreal.re, d2);
+                            e.Vcreal.im = _modulo(e1.Vcreal.im, d2);
                             break;
                         default:
                             assert(0);
@@ -1317,8 +1317,8 @@ static if (0)
             default:
                 if (tyfloating(tym))
                 {
-                    e.Vcldouble.re = d1;
-                    e.Vcldouble.im = d2;
+                    e.Vcreal.re = d1;
+                    e.Vcreal.im = d2;
                 }
                 else
                 {
@@ -1360,8 +1360,8 @@ static if (0)
             default:
                 if (tyfloating(tym))
                 {
-                    e.Vcldouble.re = d2;
-                    e.Vcldouble.im = d1;
+                    e.Vcreal.re = d2;
+                    e.Vcreal.im = d1;
                 }
                 else
                 {
@@ -1373,7 +1373,7 @@ static if (0)
 
     case OPneg:
         // Avoid converting NANS to NAN
-        memcpy(&e.Vcldouble,&e1.Vcldouble,e.Vcldouble.sizeof);
+        memcpy(&e.Vcreal,&e1.Vcreal,e.Vcreal.sizeof);
         switch (tym)
         {   case TYdouble:
             case TYidouble:
@@ -1384,9 +1384,9 @@ static if (0)
             case TYifloat:
                 e.Vfloat = -e.Vfloat;
                 break;
-            case TYldouble:
-            case TYildouble:
-                e.Vldouble = -e.Vldouble;
+            case TYreal:
+            case TYireal:
+                e.Vreal = -e.Vreal;
                 break;
             case TYcfloat:
                 e.Vcfloat.re = -e.Vcfloat.re;
@@ -1396,9 +1396,9 @@ static if (0)
                 e.Vcdouble.re = -e.Vcdouble.re;
                 e.Vcdouble.im = -e.Vcdouble.im;
                 break;
-            case TYcldouble:
-                e.Vcldouble.re = -e.Vcldouble.re;
-                e.Vcldouble.im = -e.Vcldouble.im;
+            case TYcreal:
+                e.Vcreal.re = -e.Vcreal.re;
+                e.Vcreal.im = -e.Vcreal.im;
                 break;
 
             case TYcent:
@@ -1427,9 +1427,9 @@ else
                 e.Vfloat = fabs(e1.Vfloat);
 
                 break;
-            case TYldouble:
-            case TYildouble:
-                e.Vldouble = fabsl(d1);
+            case TYreal:
+            case TYireal:
+                e.Vreal = fabsl(d1);
                 break;
             case TYcfloat:
                 e.Vfloat = cast(float)Complex_f.abs(e1.Vcfloat);
@@ -1437,8 +1437,8 @@ else
             case TYcdouble:
                 e.Vdouble = cast(double)Complex_d.abs(e1.Vcdouble);
                 break;
-            case TYcldouble:
-                e.Vldouble = Complex_ld.abs(e1.Vcldouble);
+            case TYcreal:
+                e.Vreal = Complex_ld.abs(e1.Vcreal);
                 break;
             case TYcent:
             case TYucent:
@@ -1545,19 +1545,19 @@ else
                         b = cast(int)((e1.Vcdouble.re == e2.Vcdouble.re) &&
                                       (e1.Vcdouble.im == e2.Vcdouble.im));
                     break;
-                case TYcldouble:
-                    if (isnan(e1.Vcldouble.re) || isnan(e1.Vcldouble.im) ||
-                        isnan(e2.Vcldouble.re) || isnan(e2.Vcldouble.im))
+                case TYcreal:
+                    if (isnan(e1.Vcreal.re) || isnan(e1.Vcreal.im) ||
+                        isnan(e2.Vcreal.re) || isnan(e2.Vcreal.im))
                         b = 0;
                     else
-                        b = cast(int)((e1.Vcldouble.re == e2.Vcldouble.re) &&
-                                      (e1.Vcldouble.im == e2.Vcldouble.im));
+                        b = cast(int)((e1.Vcreal.re == e2.Vcreal.re) &&
+                                      (e1.Vcreal.im == e2.Vcreal.im));
                     break;
                 default:
                     b = cast(int)(d1 == d2);
                     break;
             }
-            //printf("%Lg + %Lgi, %Lg + %Lgi\n", e1.Vcldouble.re, e1.Vcldouble.im, e2.Vcldouble.re, e2.Vcldouble.im);
+            //printf("%Lg + %Lgi, %Lg + %Lgi\n", e1.Vcreal.re, e1.Vcreal.im, e2.Vcreal.re, e2.Vcreal.im);
         }
         else if (tym == TYcent || tym == TYucent)
             b = cast(int)(e1.Vcent == e2.Vcent);
@@ -1673,14 +1673,14 @@ else
             e.Vcdouble.im = e1.Vcfloat.im;
         break;
     case OPd_ld:
-        e.Vldouble = e1.Vdouble;
+        e.Vreal = e1.Vdouble;
         if (tycomplex(tym))
-            e.Vcldouble.im = e1.Vcdouble.im;
+            e.Vcreal.im = e1.Vcdouble.im;
         break;
     case OPld_d:
-        e.Vdouble = cast(double)e1.Vldouble;
+        e.Vdouble = cast(double)e1.Vreal;
         if (tycomplex(tym))
-            e.Vcdouble.im = cast(double)e1.Vcldouble.im;
+            e.Vcdouble.im = cast(double)e1.Vcreal.im;
         break;
     case OPc_r:
         e.EV = e1.EV;
@@ -1694,8 +1694,8 @@ else
             case TYcdouble:
                 e.Vdouble = e1.Vcdouble.im;
                 break;
-            case TYcldouble:
-                e.Vldouble = e1.Vcldouble.im;
+            case TYcreal:
+                e.Vreal = e1.Vcreal.im;
                 break;
             default:
                 assert(0);
@@ -1941,9 +1941,9 @@ static if (0) // && MARS
  * instead of the soft long double ones.
  */
 
-targ_ldouble el_toldoubled(elem* e)
+targ_real el_toreald(elem* e)
 {
-    targ_ldouble result;
+    targ_real result;
 
     elem_debug(e);
     assert(e.Eoper == OPconst);
@@ -1958,9 +1958,9 @@ targ_ldouble el_toldoubled(elem* e)
         case TYdouble_alias:
             result = e.Vdouble;
             break;
-        case TYldouble:
-        case TYildouble:
-            result = e.Vldouble;
+        case TYreal:
+        case TYireal:
+            result = e.Vreal;
             break;
         default:
             result = 0;
@@ -1974,13 +1974,13 @@ targ_ldouble el_toldoubled(elem* e)
  */
 version (CRuntime_Microsoft)
 {
-    private targ_ldouble _modulo(targ_ldouble x, targ_ldouble y)
+    private targ_real _modulo(targ_real x, targ_real y)
     {
-        return cast(targ_ldouble)fmodl(cast(real)x, cast(real)y);
+        return cast(targ_real)fmodl(cast(real)x, cast(real)y);
     }
     import core.stdc.math : isnan;
-    static if (!is(targ_ldouble == real))
-        private int isnan(targ_ldouble x)
+    static if (!is(targ_real == real))
+        private int isnan(targ_real x)
         {
             return isnan(cast(real)x);
         }

--- a/compiler/src/dmd/backend/gloop.d
+++ b/compiler/src/dmd/backend/gloop.d
@@ -21,7 +21,7 @@ import core.stdc.string;
 import dmd.backend.cc;
 import dmd.backend.blockopt : BlockOpt;
 import dmd.backend.cdef;
-import dmd.backend.evalu8 : el_toldoubled;
+import dmd.backend.evalu8 : el_toreald;
 import dmd.backend.oper;
 import dmd.backend.global;
 import dmd.backend.goh;
@@ -1914,8 +1914,8 @@ private void newfamlist(famlist* fl, tym_t ty)
             c.Vdouble = 1;
             break;
 
-        case TYldouble:
-            c.Vldouble = 1;
+        case TYreal:
+            c.Vreal = 1;
             break;
 
         case TYbool:
@@ -1965,7 +1965,7 @@ private void newfamlist(famlist* fl, tym_t ty)
     }
     fl.c1 = el_const(ty, c);               /* c1 = 1               */
 
-    c.Vldouble = 0;
+    c.Vreal = 0;
     if (typtr(ty))
     {
         ty = TYint;
@@ -2914,7 +2914,7 @@ private void elimbasivs(ref GlobalOptimizer go, ref BlockOpt bo, ref Loop l)
              */
             if (!tyuns(ty) &&
                 (tyintegral(ty) && el_tolong(fl.c1) < 0 ||
-                 tyfloating(ty) && el_toldoubled(fl.c1) < 0.0))
+                 tyfloating(ty) && el_toreald(fl.c1) < 0.0))
                 refEoper = swaprel(refEoper);
 
             /* Replace (X relop e) with (X relop (short)e)
@@ -3299,9 +3299,9 @@ private bool flcmp(const ref famlist f1, const ref famlist f2)
                         goto Lf2;
                 break;
 
-            case TYldouble:
-                if (t2.Vldouble == 1.0 ||
-                    t1.Vldouble != 1.0 && f2.c2.Vldouble == 0)
+            case TYreal:
+                if (t2.Vreal == 1.0 ||
+                    t1.Vreal != 1.0 && f2.c2.Vreal == 0)
                         goto Lf2;
                 break;
 

--- a/compiler/src/dmd/backend/gsroa.d
+++ b/compiler/src/dmd/backend/gsroa.d
@@ -75,7 +75,7 @@ private void sliceStructs_Gather(ref const symtab_t symtab, SymInfo[] sia, const
                     const n = nthSlice(e);
                     const sz = getSize(e);
                     if (sz == 2 * SLICESIZE && !tyfv(e.Ety) &&
-                        tybasic(e.Ety) != TYldouble && tybasic(e.Ety) != TYildouble)
+                        tybasic(e.Ety) != TYreal && tybasic(e.Ety) != TYireal)
                     {
                         // Rewritten as OPpair later
                     }
@@ -270,7 +270,7 @@ private void sliceStructs_Replace(ref symtab_t symtab, const SymInfo[] sia, elem
                             {
                                 case TYcfloat:   tyop = TYfloat;   break;
                                 case TYcdouble:  tyop = TYdouble;  break;
-                                case TYcldouble: tyop = TYldouble; break;
+                                case TYcreal: tyop = TYreal; break;
                                 default:
                                     assert(0);
                             }

--- a/compiler/src/dmd/backend/ty.d
+++ b/compiler/src/dmd/backend/ty.d
@@ -57,15 +57,15 @@ enum
 
     // long double is mapped to either of the following at runtime:
     TYdouble_alias      = 0x13, // 64 bit real (but distinct for overload purposes)
-    TYldouble           = 0x14, // 80 bit real
+    TYreal           = 0x14, // 80 bit real
 
     // Add imaginary and complex types for D and C99
     TYifloat            = 0x15,
     TYidouble           = 0x16,
-    TYildouble          = 0x17,
+    TYireal          = 0x17,
     TYcfloat            = 0x18,
     TYcdouble           = 0x19,
-    TYcldouble          = 0x1A,
+    TYcreal          = 0x1A,
 
     TYnullptr           = 0x1C,
     TYnptr              = 0x1D, // data segment relative pointer

--- a/compiler/src/dmd/backend/var.d
+++ b/compiler/src/dmd/backend/var.d
@@ -298,15 +298,15 @@ __gshared const(char)*[TYMAX] tystring =
         TYuint      : "uint",
         TYulong     : "ulong",
 
-        TYldouble   : "real",
+        TYreal   : "real",
 
         TYifloat    : "ifloat",
         TYidouble   : "idouble",
-        TYildouble  : "ireal",
+        TYireal  : "ireal",
 
         TYcfloat    : "cfloat",
         TYcdouble   : "cdouble",
-        TYcldouble  : "creal",
+        TYcreal  : "creal",
 
         TYschar16   : "byte[16]",
         TYuchar16   : "ubyte[16]",
@@ -464,15 +464,15 @@ __gshared ubyte[TYMAX] dttab =
     TYfloat   : 0x88,
     TYdouble  : 0x89,
     TYdouble_alias : 0x89,
-    TYldouble : 0x89,
+    TYreal : 0x89,
 
     TYifloat   : 0x88,
     TYidouble  : 0x89,
-    TYildouble : 0x89,
+    TYireal : 0x89,
 
     TYcfloat   : 0x88,
     TYcdouble  : 0x89,
-    TYcldouble : 0x89,
+    TYcreal : 0x89,
 
     TYfloat4  : 0x00,
     TYdouble2 : 0x00,
@@ -575,15 +575,15 @@ __gshared ushort[TYMAX] dttab4 =
     TYfloat   : 0x40,
     TYdouble  : 0x41,
     TYdouble_alias : 0x41,
-    TYldouble : 0x42,
+    TYreal : 0x42,
 
     TYifloat   : 0x40,
     TYidouble  : 0x41,
-    TYildouble : 0x42,
+    TYireal : 0x42,
 
     TYcfloat   : 0x50,
     TYcdouble  : 0x51,
-    TYcldouble : 0x52,
+    TYcreal : 0x52,
 
     TYfloat4  : 0x00,
     TYdouble2 : 0x00,
@@ -687,15 +687,15 @@ __gshared byte[256] _tysize =
     TYfloat   : FLOATSIZE,
     TYdouble  : DOUBLESIZE,
     TYdouble_alias : 8,
-    TYldouble : -1,
+    TYreal : -1,
 
     TYifloat   : FLOATSIZE,
     TYidouble  : DOUBLESIZE,
-    TYildouble : -1,
+    TYireal : -1,
 
     TYcfloat   : 2*FLOATSIZE,
     TYcdouble  : 2*DOUBLESIZE,
-    TYcldouble : -1,
+    TYcreal : -1,
 
     TYfloat4  : 16,
     TYdouble2 : 16,
@@ -802,15 +802,15 @@ __gshared byte[256] _tyalignsize =
     TYfloat   : FLOATSIZE,
     TYdouble  : DOUBLESIZE,
     TYdouble_alias : 8,
-    TYldouble : SET_ALIGN,
+    TYreal : SET_ALIGN,
 
     TYifloat   : FLOATSIZE,
     TYidouble  : DOUBLESIZE,
-    TYildouble : SET_ALIGN,
+    TYireal : SET_ALIGN,
 
     TYcfloat   : 2*FLOATSIZE,
     TYcdouble  : DOUBLESIZE,
-    TYcldouble : SET_ALIGN,
+    TYcreal : SET_ALIGN,
 
     TYfloat4  : 16,
     TYdouble2 : 16,
@@ -892,13 +892,13 @@ extern(D):
 
 static immutable TXptr        = [ TYnptr ];
 static immutable TXptr_nflat  = [ TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,TYvptr,TYimmutPtr,TYsharePtr,TYrestrictPtr,TYfgPtr ];
-static immutable TXreal       = [ TYfloat,TYdouble,TYdouble_alias,TYldouble,
+static immutable TXreal       = [ TYfloat,TYdouble,TYdouble_alias,TYreal,
                      TYfloat4,TYdouble2,
                      TYfloat8,TYdouble4,
                      TYfloat16,TYdouble8,
                    ];
-static immutable TXimaginary  = [ TYifloat,TYidouble,TYildouble, ];
-static immutable TXcomplex    = [ TYcfloat,TYcdouble,TYcldouble, ];
+static immutable TXimaginary  = [ TYifloat,TYidouble,TYireal, ];
+static immutable TXcomplex    = [ TYcfloat,TYcdouble,TYcreal, ];
 static immutable TXintegral   = [ TYbool,TYchar,TYschar,TYuchar,TYshort,
                      TYwchar_t,TYushort,TYenum,TYint,TYuint,
                      TYlong,TYulong,TYllong,TYullong,TYdchar,

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -780,7 +780,7 @@ else
     //printf("CSoff = x%x, size = x%x, alignment = %x\n",
         //cast(int)cg.CSoff, CSE.size(), cast(int)CSE.alignment);
 
-    cg.NDPoff = alignsection(cg.CSoff - global87.save.length * tysize(TYldouble), REGSIZE, bias);
+    cg.NDPoff = alignsection(cg.CSoff - global87.save.length * tysize(TYreal), REGSIZE, bias);
 
     regm_t topush = fregsaved & ~cg.mfuncreg;          // mask of registers that need saving
     cg.pushoffuse = false;

--- a/compiler/src/dmd/backend/x86/cod1.d
+++ b/compiler/src/dmd/backend/x86/cod1.d
@@ -3335,7 +3335,7 @@ void argtypes(type* t, out type* arg1type, out type* arg2type)
                     arg1type = ts;
                     return;
                 }
-                else if (tybasic(tyn) == TYldouble || tybasic(tyn) == TYildouble)
+                else if (tybasic(tyn) == TYreal || tybasic(tyn) == TYireal)
                 {
                     // `real` parameters (and arrays of `real`)
                     // must be passed via memory
@@ -4354,8 +4354,8 @@ private void movParams(ref CodeBuilder cdb, elem* e, uint stackalign, uint funca
                 cs.IFL2 = FL.const_;
                 targ_size_t* p = cast(targ_size_t*) &(e.EV);
                 cs.IEV2.Vsize_t = *p;
-                if (I64 && tym == TYcldouble)
-                    // The alignment of EV.Vcldouble is not the same on the compiler
+                if (I64 && tym == TYcreal)
+                    // The alignment of EV.Vcreal is not the same on the compiler
                     // as on the target
                     goto Lbreak;
                 if (I64 && sz >= 8)
@@ -4450,9 +4450,9 @@ private void movParams(ref CodeBuilder cdb, elem* e, uint stackalign, uint funca
                     r = 3;
                     break;
 
-                case TYldouble:
-                case TYildouble:
-                case TYcldouble:
+                case TYreal:
+                case TYireal:
+                case TYcreal:
                     op = 0xDB;
                     r = 7;
                     break;
@@ -4736,7 +4736,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
                     !tyfloating(tym))
                     break;
 
-                if (tym == TYldouble || tym == TYildouble || tycomplex(tym))
+                if (tym == TYreal || tym == TYireal || tycomplex(tym))
                     break;
 
                 code cs;
@@ -4926,7 +4926,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
             if (I32 && szb == 10)           // special case for long double constants
             {
                 assert(sz == 12);
-                targ_int value = e.Vushort8[4]; // pick upper 2 bytes of Vldouble
+                targ_int value = e.Vushort8[4]; // pick upper 2 bytes of Vreal
                 cgstate.stackpush += sz;
                 cdb.genadjesp(cast(int)sz);
                 for (int i = 0; i < 3; ++i)
@@ -4936,13 +4936,13 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
                         cdb.genpush(reg);               // PUSH reg
                     else
                         cdb.genc2(0x68,0,value);        // PUSH value
-                    value = e.Vulong4[i ^ 1];       // treat Vldouble as 2 element array of 32 bit uint
+                    value = e.Vulong4[i ^ 1];       // treat Vreal as 2 element array of 32 bit uint
                 }
                 freenode(e);
                 return;
             }
 
-            assert(I64 || sz <= tysize(TYldouble));
+            assert(I64 || sz <= tysize(TYreal));
             int i = cast(int)sz;
             if (!I16 && i == 2)
                 flag = CFopsize;
@@ -4979,7 +4979,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
                         break;
 
                     case 4:
-                        if (tym == TYldouble || tym == TYildouble)
+                        if (tym == TYreal || tym == TYireal)
                             /* The size is 10 bytes, and since we have 2 bytes left over,
                              * just read those 2 bytes, not 4.
                              * Otherwise we're reading uninitialized data.
@@ -5130,9 +5130,9 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
                     r = 3;
                     break;
 
-                case TYldouble:
-                case TYildouble:
-                case TYcldouble:
+                case TYreal:
+                case TYireal:
+                case TYcreal:
                     op = 0xDB;
                     r = 7;
                     break;
@@ -5380,7 +5380,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
                     c.Iflags |= CFpsw;                      // need the flags on last OR
             }
         }
-        else if (sz == tysize(TYldouble))               // TYldouble
+        else if (sz == tysize(TYreal))               // TYreal
             load87(cdb, e, 0, outretregs, null, -1);
         else
         {

--- a/compiler/src/dmd/backend/x86/cod2.d
+++ b/compiler/src/dmd/backend/x86/cod2.d
@@ -202,7 +202,7 @@ void cdorth(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
             config.fpxmmregs && tyxmmreg(ty1) &&
             !(pretregs & mST0) &&
             !(pretregs & mST01) &&
-            !(ty == TYldouble || ty == TYildouble)  // watch out for shrinkLongDoubleConstantIfPossible()
+            !(ty == TYreal || ty == TYireal)  // watch out for shrinkLongDoubleConstantIfPossible()
            )
         {
             orthxmm(cdb,e,pretregs);
@@ -927,7 +927,7 @@ void cdmul(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
         if (tyvector(tyml) ||
             config.fpxmmregs && oper != OPmod && tyxmmreg(tyml) &&
             !(pretregs & mST0) &&
-            !(ty == TYldouble || ty == TYildouble) &&  // watch out for shrinkLongDoubleConstantIfPossible()
+            !(ty == TYreal || ty == TYireal) &&  // watch out for shrinkLongDoubleConstantIfPossible()
             !tycomplex(ty) && // SIMD code is not set up to deal with complex mul/div
             !(ty == TYllong)  //   or passing to function through integer register
            )
@@ -1316,7 +1316,7 @@ void cddiv(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
         if (tyvector(tyml) ||
             config.fpxmmregs && oper != OPmod && tyxmmreg(tyml) &&
             !(pretregs & mST0) &&
-            !(ty == TYldouble || ty == TYildouble) &&  // watch out for shrinkLongDoubleConstantIfPossible()
+            !(ty == TYreal || ty == TYireal) &&  // watch out for shrinkLongDoubleConstantIfPossible()
             !tycomplex(ty) && // SIMD code is not set up to deal with complex mul/div
             !(ty == TYllong)  //   or passing to function through integer register
            )
@@ -4662,9 +4662,9 @@ void cdrelconst(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
     {
         case TYstruct:
         case TYarray:
-        case TYldouble:
-        case TYildouble:
-        case TYcldouble:
+        case TYreal:
+        case TYireal:
+        case TYcreal:
             tym = TYnptr;               // don't confuse allocreg()
             if (I16 && pretregs & (mES | mCX) || e.Ety & mTYfar)
             {

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -763,8 +763,8 @@ regm_t regmask(tym_t tym, tym_t tyf)
         case TYullong:
             return I64 ? cast(regm_t) mAX : (I32 ? mDX | mAX : DOUBLEREGS);
 
-        case TYldouble:
-        case TYildouble:
+        case TYreal:
+        case TYireal:
             return mST0;
 
         case TYcfloat:
@@ -775,9 +775,9 @@ regm_t regmask(tym_t tym, tym_t tyf)
         case TYcdouble:
             if (I64)
                 return mXMM0 | mXMM1;
-            goto case TYcldouble;
+            goto case TYcreal;
 
-        case TYcldouble:
+        case TYcreal:
             return mST01;
 
         // SIMD vector types
@@ -870,7 +870,7 @@ void cgreg_set_priorities(tym_t ty, out const(reg_t)[] pseq, out const(reg_t)[] 
         if (tyfloating(ty))
         {
             tym_t tyb = tybasic(ty);
-            if (tyb == TYcfloat || tyb == TYcdouble || tyb == TYcldouble)
+            if (tyb == TYcfloat || tyb == TYcdouble || tyb == TYcreal)
             {
                 static immutable reg_t[12] fltmsw1 = [33,35,37,39,41,43,45,47,49,51,53,55];
                 static immutable reg_t[13] fltlsw1 = [32,34,36,38,40,42,44,46,48,50,52,54,56];
@@ -1677,7 +1677,7 @@ regm_t allocretregs(ref CGstate cg, const tym_t ty, type* t, const tym_t tyf, ou
                 ty1 = TYdouble;
             break;
 
-        case TYcldouble:
+        case TYcreal:
             if (tyfb == TYjfunc && I32)
                 break;
             if (I32)
@@ -1783,17 +1783,17 @@ regm_t allocretregs(ref CGstate cg, const tym_t ty, type* t, const tym_t tyf, ou
             goto case 4;
 
         case 16:
-            if (AArch64 && tym == TYldouble)
+            if (AArch64 && tym == TYreal)
                 return rralloc.fpt();
             goto default;
 
         default:
             assert(!AArch64);
-            if (tybasic(tym) == TYldouble || tybasic(tym) == TYildouble)
+            if (tybasic(tym) == TYreal || tybasic(tym) == TYireal)
             {
                 return ST0;
             }
-            else if (tybasic(tym) == TYcldouble)
+            else if (tybasic(tym) == TYcreal)
             {
                 return ST01;
             }
@@ -2602,7 +2602,7 @@ int jmpopcode(elem* e)
     op = e.Eoper;
     tym_t tymx = tybasic(e.Ety);
     bool needsNanCheck = tyfloating(tymx) && config.inline8087 &&
-        (tymx == TYldouble || tymx == TYildouble || tymx == TYcldouble ||
+        (tymx == TYreal || tymx == TYireal || tymx == TYcreal ||
          tymx == TYcdouble || tymx == TYcfloat ||
          (tyxmmreg(tymx) && config.fpxmmregs && e.Ecount != e.Ecomsub) ||
          op == OPind ||
@@ -5959,7 +5959,7 @@ void assignaddrc(code* c)
 
             case FL.ndp:
                 assert(c.IEV1.Vuns < global87.save.length);
-                c.IEV1.Vpointer = c.IEV1.Vuns * tysize(TYldouble) + cgstate.NDPoff + cgstate.BPoff;
+                c.IEV1.Vpointer = c.IEV1.Vuns * tysize(TYreal) + cgstate.NDPoff + cgstate.BPoff;
                 c.Iflags |= CFunambig;
                 goto L2;
 

--- a/compiler/src/dmd/backend/x86/cod4.d
+++ b/compiler/src/dmd/backend/x86/cod4.d
@@ -39,7 +39,7 @@ import dmd.backend.el;
 import dmd.backend.global;
 import dmd.backend.oper;
 import dmd.backend.ty;
-import dmd.backend.evalu8 : el_toldoubled;
+import dmd.backend.evalu8 : el_toreald;
 import dmd.backend.x86.xmm;
 
 
@@ -394,7 +394,7 @@ void cdeq(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
             eq87(cdb,e,pretregs);
             return;
         }
-        if (tyml == TYldouble || tyml == TYildouble)
+        if (tyml == TYreal || tyml == TYireal)
         {
             eq87(cdb,e,pretregs);
             return;

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -2395,7 +2395,6 @@ final class CParser(AST) : Parser!AST
             xllong     = 0x40,
             xfloat     = 0x80,
             xdouble    = 0x100,
-            xldouble   = 0x200,
             xtag       = 0x400,
             xident     = 0x800,
             xvoid      = 0x1000,

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -1076,9 +1076,9 @@ elem* toElem(Expression e, ref IRState irs)
                 e.Vdouble = cast(double) re.value;
                 break;
 
-            case TYldouble:
-            case TYildouble:
-                e.Vldouble = re.value;
+            case TYreal:
+            case TYireal:
+                e.Vreal = re.value;
                 break;
 
             default:
@@ -1145,9 +1145,9 @@ elem* toElem(Expression e, ref IRState irs)
                 }
                 break;
 
-            case TYcldouble:
-                e.Vcldouble.re = re;
-                e.Vcldouble.im = im;
+            case TYcreal:
+                e.Vcreal.re = re;
+                e.Vcreal.im = im;
                 break;
 
             default:
@@ -5116,7 +5116,7 @@ elem* toElemCast(CastExp ce, elem* e, bool isLvalue, ref IRState irs)
             case X(Tfloat80,Tcomplex32):
             case X(Tfloat80,Tcomplex64):
             case X(Tfloat80,Tcomplex80):
-                e = el_bin(OPadd,TYcldouble,e,el_long(TYildouble,0));
+                e = el_bin(OPadd,TYcreal,e,el_long(TYireal,0));
                 fty = Tcomplex80;
                 continue;
 
@@ -5202,7 +5202,7 @@ elem* toElemCast(CastExp ce, elem* e, bool isLvalue, ref IRState irs)
             case X(Timaginary80,Tcomplex32):
             case X(Timaginary80,Tcomplex64):
             case X(Timaginary80,Tcomplex80):
-                e = el_bin(OPadd,TYcldouble,el_long(TYldouble,0),e);
+                e = el_bin(OPadd,TYcreal,el_long(TYreal,0),e);
                 fty = Tcomplex80;
                 continue;
 
@@ -5287,13 +5287,13 @@ elem* toElemCast(CastExp ce, elem* e, bool isLvalue, ref IRState irs)
             case X(Tcomplex80,Tfloat32):
             case X(Tcomplex80,Tfloat64):
             case X(Tcomplex80,Tfloat80):
-                e = el_una(OPc_r, TYldouble, e);
+                e = el_una(OPc_r, TYreal, e);
                 fty = Tfloat80;
                 continue;
             case X(Tcomplex80,Timaginary32):
             case X(Tcomplex80,Timaginary64):
             case X(Tcomplex80,Timaginary80):
-                e = el_una(OPc_i, TYildouble, e);
+                e = el_una(OPc_i, TYireal, e);
                 fty = Timaginary80;
                 continue;
             case X(Tcomplex80,Tcomplex32):
@@ -5746,7 +5746,7 @@ elem* callfunc(Loc loc,
             {
                 elem* et = e.E1;
                 e.E1 = el_una(OPs32_d, TYdouble, e.E2);
-                e.E1 = el_una(OPd_ld, TYldouble, e.E1);
+                e.E1 = el_una(OPd_ld, TYreal, e.E1);
                 e.E2 = et;
             }
             else if (op == OPyl2x || op == OPyl2xp1)
@@ -5793,7 +5793,7 @@ elem* callfunc(Loc loc,
             {
             case X(TYfloat, TYfloat):     // float -> float
             case X(TYdouble, TYdouble):   // double -> double
-            case X(TYldouble, TYldouble): // real -> real
+            case X(TYreal, TYreal): // real -> real
                 e = ep;
                 break;
 
@@ -5801,7 +5801,7 @@ elem* callfunc(Loc loc,
                 e = el_una(OPf_d, tyret, ep);
                 break;
 
-            case X(TYfloat, TYldouble):   // float -> real
+            case X(TYfloat, TYreal):   // float -> real
                 e = el_una(OPf_d, TYdouble, ep);
                 e = el_una(OPd_ld, tyret, e);
                 break;
@@ -5810,16 +5810,16 @@ elem* callfunc(Loc loc,
                 e = el_una(OPd_f, tyret, ep);
                 break;
 
-            case X(TYdouble, TYldouble):  // double -> real
+            case X(TYdouble, TYreal):  // double -> real
                 e = el_una(OPd_ld, tyret, ep);
                 break;
 
-            case X(TYldouble, TYfloat):   // real -> float
+            case X(TYreal, TYfloat):   // real -> float
                 e = el_una(OPld_d, TYdouble, ep);
                 e = el_una(OPd_f, tyret, e);
                 break;
 
-            case X(TYldouble, TYdouble):  // real -> double
+            case X(TYreal, TYdouble):  // real -> double
                 e = el_una(OPld_d, tyret, ep);
                 break;
             }
@@ -6375,8 +6375,8 @@ Lagain:
             case RTLSYM.MEMSET16:     tym = TYshort;    break;
             case RTLSYM.MEMSET32:     tym = TYlong;     break;
             case RTLSYM.MEMSET64:     tym = TYllong;    break;
-            case RTLSYM.MEMSET80:     tym = TYldouble;  break;
-            case RTLSYM.MEMSET160:    tym = TYcldouble; break;
+            case RTLSYM.MEMSET80:     tym = TYreal;  break;
+            case RTLSYM.MEMSET160:    tym = TYcreal; break;
             case RTLSYM.MEMSET128:    tym = TYcdouble;  break;
             case RTLSYM.MEMSET128ii:  tym = TYucent;    break;
             case RTLSYM.MEMSETFLOAT:  tym = TYfloat;    break;

--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -258,13 +258,13 @@ tym_t totym(Type tx)
         case Tuns64:    t = TYullong;   break;
         case Tfloat32:  t = TYfloat;    break;
         case Tfloat64:  t = TYdouble;   break;
-        case Tfloat80:  t = RealIsDouble ? TYdouble : TYldouble;  break;
+        case Tfloat80:  t = RealIsDouble ? TYdouble : TYreal;  break;
         case Timaginary32: t = TYifloat; break;
         case Timaginary64: t = TYidouble; break;
-        case Timaginary80: t = RealIsDouble ? TYidouble : TYildouble; break;
+        case Timaginary80: t = RealIsDouble ? TYidouble : TYireal; break;
         case Tcomplex32: t = TYcfloat;  break;
         case Tcomplex64: t = TYcdouble; break;
-        case Tcomplex80: t = RealIsDouble ? TYcdouble : TYcldouble; break;
+        case Tcomplex80: t = RealIsDouble ? TYcdouble : TYcreal; break;
         case Tbool:     t = TYbool;     break;
         case Tchar:     t = TYchar;     break;
         case Twchar:    t = TYwchar_t;  break;
@@ -294,13 +294,13 @@ tym_t totym(Type tx)
             else if (id == Id.__c_ulong)
                 t = tb.ty == Tuns32 ? TYulong : TYullong;
             else if (id == Id.__c_long_double)
-                t = tb.size() == 8 ? TYdouble : TYldouble;
+                t = tb.size() == 8 ? TYdouble : TYreal;
             else if (id == Id.__c_complex_float)
                 t = TYcfloat;
             else if (id == Id.__c_complex_double)
                 t = TYcdouble;
             else if (id == Id.__c_complex_real)
-                t = tb.size() == 16 ? TYcdouble : TYcldouble;
+                t = tb.size() == 16 ? TYcdouble : TYcreal;
             else
                 t = totym(tb);
             break;

--- a/compiler/src/dmd/iasm/dmdx86.d
+++ b/compiler/src/dmd/iasm/dmdx86.d
@@ -3532,7 +3532,7 @@ code* asm_db_parse(OP* pop)
         targ_ullong ul;
         targ_float f;
         targ_double d;
-        targ_ldouble ld;
+        targ_real ld;
         byte[10] value;
     }
     DT dt;


### PR DESCRIPTION
This is a global search/replace job to replace the old C name for long doubles to D reals. It just makes it easier for me to read.