### PR TITLE
change hasIndirections!void to true for consistency with TypeInfo

### DIFF
--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -157,6 +157,13 @@ void[] __arrayAlloc(T)(size_t arrSize) @trusted
     return null;
 }
 
+// https://github.com/dlang/dmd/issues/22517
+@system unittest
+{
+    auto arr = new void[10];
+    assert((GC.getAttr(&arr[0]) & BlkAttr.NO_SCAN) == 0);
+}
+
 /**
 Given an array of length `size` that needs to be expanded to `newlength`,
 compute a new capacity.

--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -587,9 +587,11 @@ template hasIndirections(T)
     else static if (__traits(isAssociativeArray, T) || is(T == class) || is(T == interface))
         enum hasIndirections = true;
     else static if (is(T == E[N], E, size_t N))
-        enum hasIndirections = T.sizeof && (is(immutable E == immutable void) || hasIndirections!(BaseElemOf!E));
+        enum hasIndirections = T.sizeof && hasIndirections!(BaseElemOf!E);
     else static if (isFunctionPointer!T)
         enum hasIndirections = false;
+    else static if (is(immutable(T) == immutable(void)))
+        enum hasIndirections = true;
     else
         enum hasIndirections = isPointer!T || isDelegate!T || isDynamicArray!T;
 }
@@ -750,11 +752,11 @@ template hasIndirections(T)
 // https://github.com/dlang/dmd/issues/20812
 @safe unittest
 {
-    static assert(!hasIndirections!void);
-    static assert(!hasIndirections!(const void));
-    static assert(!hasIndirections!(inout void));
-    static assert(!hasIndirections!(immutable void));
-    static assert(!hasIndirections!(shared void));
+    static assert( hasIndirections!void);
+    static assert( hasIndirections!(const void));
+    static assert( hasIndirections!(inout void));
+    static assert( hasIndirections!(immutable void));
+    static assert( hasIndirections!(shared void));
 
     static assert( hasIndirections!(void*));
     static assert( hasIndirections!(const void*));


### PR DESCRIPTION
See issue #22517 

An alternative fix considered was to special case `void` arrays in the array allocator. However, `TypeInfo_v` (`void` typeinfo) reports that it contains pointers. You can't create a variable of type `void`, only arrays of `void`, so this shouldn't affect any existing code except to fix bugs (which assumed the same behavior from `hasIndirections!void` as `typeid(void).flags()` as the array runtime did).

pinging @jmdavis as you added tests that needed to be reversed in #20813 last year. I'm assuming the tests added were for completeness, based on current behavior instead of an expectation of that behavior. If I'm wrong, please explain the thought behind the test.