### PR TITLE
Always make a copy when constructing mutable struct literals

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -808,8 +808,7 @@ bool canElideCopy(Expression e, Type to, bool checkMod = true)
         case EXP.dotVariable:
             return visitDotVarExp(e.isDotVarExp());
         case EXP.structLiteral:
-            auto sle = e.isStructLiteralExp();
-            return !(checkMod && sle.useStaticInit && to.isMutable());
+            return true;
         case EXP.variable:
             return (e.isVarExp().var.storage_class & STC.rvalue) != 0;
         default:

--- a/compiler/test/runnable/structlit_rvalue.d
+++ b/compiler/test/runnable/structlit_rvalue.d
@@ -1,15 +1,67 @@
-void refCounted(ProcessPipes val)
+struct S22585_1
 {
-    val = ProcessPipes.init;
+    char[32] a;
+    int b = 1;
+
+    this(ref S22585_1 s)
+    {
+        s.b = 2;
+    }
 }
 
-struct ProcessPipes
+struct T22585_1
 {
-    char[33] arr;
-    ~this() @safe {}
+    S22585_1 s;
+}
+
+void copyConstruct(S22585_1) {}
+
+void mutate(ref S22585_1 s)
+{
+    s.b = 2;
+}
+
+struct S22585_2
+{
+    char[32] a;
+    int b = 1;
+    ~this() {}
+}
+
+struct T22585_2
+{
+    S22585_2 s;
+}
+
+pragma(inline, true)
+S22585_2 inlinedRvalue1()
+{
+    bool b;
+    return (b ? T22585_2.init : T22585_2.init).s;
+}
+
+void mutateCopyOf(S22585_2 s)
+{
+    s.b = 2;
+}
+
+pragma(inline, true)
+S22585_2 inlinedRvalue2()
+{
+    return S22585_2.init;
+}
+
+void assignCopyOf(S22585_2 s)
+{
+    s = S22585_2.init;
 }
 
 void main()
 {
-    refCounted(ProcessPipes.init);
+    bool b;
+    copyConstruct((b ? T22585_1.init : T22585_1.init).s);
+    mutate((b ? T22585_1.init : T22585_1.init).s);
+    mutateCopyOf(inlinedRvalue1());
+    inlinedRvalue2.b = 2;
+    assignCopyOf(S22585_2.init);
 }


### PR DESCRIPTION
Fixes #22585, which is a superset of #22134. Due to (unfortunately) Rice's theorem, it's impossible to determine if an expression references a struct's static initializer symbol, so we have to disable all mutable references to it.

The performance impact is surprisingly small. Only 3 functions in druntime are affected.