### PR TITLE
Refactor: Move resolvedLinkage from AST to Semantic layer

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -10277,3 +10277,8 @@ extern (D) bool oneMembers(Dsymbols* members, out Dsymbol ps, Identifier ident)
     //printf("\ttrue\n");
     return true;
 }
+
+extern (C++) LINK resolvedLinkage(const Declaration d)
+{
+    return d._linkage == LINK.system ? target.systemLinkage() : d._linkage;
+}

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -15,6 +15,7 @@ import core.stdc.stdio;
 import core.stdc.string;
 import core.stdc.ctype;
 
+import dmd.dsymbolsem;
 import dmd.astcodegen;
 import dmd.astenums;
 import dmd.arraytypes;
@@ -1030,7 +1031,7 @@ public:
         if (vd.storage_class & (AST.STC.static_ | AST.STC.extern_ | AST.STC.gshared) ||
         vd.parent && vd.parent.isModule())
         {
-            const vdLinkage = vd.resolvedLinkage();
+            const vdLinkage = dmd.dsymbolsem.resolvedLinkage(vd);
             if (vdLinkage != LINK.c && vdLinkage != LINK.cpp && !(tdparent && (this.linkage == LINK.c || this.linkage == LINK.cpp)))
             {
                 ignored("variable %s because of linkage", vd.toPrettyChars());
@@ -2888,7 +2889,7 @@ public:
         // Check against the internal information which might be missing, e.g. inside of template declarations
         if (auto dec = sym.isDeclaration())
         {
-            const l = dec.resolvedLinkage();
+            const l = dmd.dsymbolsem.resolvedLinkage(dec);
             return l == LINK.cpp || l == LINK.c;
         }
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -18,6 +18,7 @@
 
 module dmd.func;
 
+import dmd.dsymbolsem;
 import core.stdc.stdio;
 import core.stdc.string;
 import dmd.aggregate;
@@ -470,12 +471,12 @@ extern (C++) class FuncDeclaration : Declaration
 
     final bool isMain() const
     {
-        return ident == Id.main && resolvedLinkage() != LINK.c && !isMember() && !isNested();
+        return ident == Id.main && dmd.dsymbolsem.resolvedLinkage(this) != LINK.c && !isMember() && !isNested();
     }
 
     final bool isCMain() const
     {
-        return ident == Id.main && resolvedLinkage() == LINK.c && !isMember() && !isNested();
+        return ident == Id.main && dmd.dsymbolsem.resolvedLinkage(this) == LINK.c && !isMember() && !isNested();
     }
 
     final bool isWinMain() const
@@ -489,18 +490,18 @@ extern (C++) class FuncDeclaration : Declaration
         }
         else
         {
-            return ident == Id.WinMain && resolvedLinkage() != LINK.c && !isMember();
+            return ident == Id.WinMain && dmd.dsymbolsem.resolvedLinkage(this) != LINK.c && !isMember();
         }
     }
 
     final bool isDllMain() const
     {
-        return ident == Id.DllMain && resolvedLinkage() != LINK.c && !isMember();
+        return ident == Id.DllMain && dmd.dsymbolsem.resolvedLinkage(this) != LINK.c && !isMember();
     }
 
     final bool isRtInit() const
     {
-        return ident == Id.rt_init && resolvedLinkage() == LINK.c && !isMember() && !isNested();
+        return ident == Id.rt_init && dmd.dsymbolsem.resolvedLinkage(this) == LINK.c && !isMember() && !isNested();
     }
 
     override final bool isExport() const

--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -13,6 +13,7 @@
 
 module dmd.glue;
 
+import dmd.dsymbolsem;
 import core.stdc.stdio;
 import core.stdc.string;
 import core.stdc.stdlib;
@@ -549,7 +550,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         {
             // functions without D or C++ name mangling mixed in at global scope
             // shouldn't have multiple definitions
-            const linkage = fd.resolvedLinkage();
+            const linkage = dmd.dsymbolsem.resolvedLinkage(fd);
             if (p.isTemplateMixin() && (linkage == LINK.c || linkage == LINK.windows ||
                 linkage == LINK.objc))
             {

--- a/compiler/src/dmd/glue/tocsym.d
+++ b/compiler/src/dmd/glue/tocsym.d
@@ -11,6 +11,7 @@
 
 module dmd.glue.tocsym;
 
+import dmd.dsymbolsem;
 import core.stdc.stdio;
 import core.stdc.string;
 
@@ -287,7 +288,7 @@ Symbol* toSymbol(Dsymbol s)
             }
 
             Mangle m = Mangle.none;
-            final switch (vd.resolvedLinkage())
+            final switch (dmd.dsymbolsem.resolvedLinkage(vd))
             {
                 case LINK.windows:
                     m = target.isX86 ? Mangle.stdcall : Mangle.c;
@@ -439,7 +440,7 @@ Symbol* toSymbol(Dsymbol s)
             }
             else
             {
-                final switch (fd.resolvedLinkage())
+                final switch (dmd.dsymbolsem.resolvedLinkage(fd))
                 {
                     case LINK.windows:
                         t.Tmangle = target.isX86 ? Mangle.stdcall : Mangle.c;

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -11,6 +11,7 @@
 
 module dmd.glue.toobj;
 
+import dmd.dsymbolsem;
 import core.stdc.stdio;
 import core.stdc.stddef;
 import core.stdc.string;
@@ -888,7 +889,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
          */
         static Mangle mangle(const VarDeclaration vd)
         {
-            final switch (vd.resolvedLinkage())
+            final switch (dmd.dsymbolsem.resolvedLinkage(vd))
             {
                 case LINK.windows:
                     return target.isX86 ? Mangle.stdcall : Mangle.c;

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -136,6 +136,7 @@ import core.stdc.ctype;
 import core.stdc.stdio;
 import core.stdc.string;
 
+import dmd.dsymbolsem : resolvedLinkage;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astenums;
@@ -1345,7 +1346,7 @@ extern (D) const(char)[] externallyMangledIdentifier(Declaration d)
 {
     assert(!d.mangleOverride, "mangle overrides should have been handled earlier");
 
-    const linkage = d.resolvedLinkage();
+    const linkage = resolvedLinkage(d);
     const par = d.toParent(); //toParent() skips over mixin templates
     if (!par || par.isModule() || linkage == LINK.cpp ||
         (linkage == LINK.c && d.isCsymbol() &&


### PR DESCRIPTION
This PR moves the resolvedLinkage logic from dmd.declaration.Declaration to dmd.dsymbolsem.
As part of the ongoing effort to separate semantic routines from AST nodes, resolvedLinkage was identified as an "intricate" dependency. While it appeared to be a simple property, it performed target-specific resolution (target.systemLinkage()), creating a semantic "leak" in the AST layer.

**Changes**
- declaration.d: Removed final LINK resolvedLinkage() from the Declaration class.
- dsymbolsem.d: Introduced a new semantic routine LINK resolvedLinkage(const scope Declaration d) to host the resolution logic.
- func.d: Updated isMain, isCMain, isWinMain, isDllMain, and isRtInit to use the new semantic routine.
- mangle/package.d & dtoh.d: Updated the mangler and header generator to call the semantic resolution instead of the AST property.
- glue/: Synchronized the backend glue code (toobj.d, tocsym.d, package.d) with the new architectural separation.

**Impact**
This change decouples the Declaration AST node from the target configuration and allows func.d to move closer to the "Done" list in the "Separate Semantic Routines" migration tracker.