### PR TITLE
[2024 edition] Disallow `case` with a runtime variable

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2191,6 +2191,12 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 Type t = cs.exp.type.toBasetype();
                 if (v && (t.isIntegral() || t.ty == Tclass))
                 {
+                    if (sc.hasEdition(Edition.v2024))
+                    {
+                        error(ve.loc, "`case` with a runtime variable is obsolete");
+                        errors = true;
+                        goto L1;
+                    }
                     /* Flag that we need to do special code generation
                     * for this, i.e. generate a sequence of if-then-else
                     */

--- a/compiler/test/fail_compilation/editions.d
+++ b/compiler/test/fail_compilation/editions.d
@@ -1,16 +1,26 @@
 /**
-Test language editions (currently experimental)
+Test 2024 language edition semantic errors
 
 TEST_OUTPUT:
 ---
-fail_compilation/editions.d(15): Error: scope parameter `x` may not be returned
+fail_compilation/editions.d(16): Error: scope parameter `x` may not be returned
+fail_compilation/editions.d(23): Error: `case` with a runtime variable is obsolete
 ---
 */
-@__edition_latest_do_not_use
-module editions;
+
+module editions 2024;
 
 @safe:
 int* f(scope int* x)
 {
-    return x;
+    return x; // DIP1000
+}
+
+void g(const int i)
+{
+    switch (5)
+    {
+        case i: return; // runtime case variables
+        default:
+    }
 }


### PR DESCRIPTION
@andrej-mitrovic-sociomantic:
> Error: case must be a string or an integral constant, not y + 1
> Either runtime values are fully supported, or they are not.

See https://bugzilla-archive.dlang.org/bugs/5862/.

Discussion here: https://github.com/dlang/dmd/pull/2887#issuecomment-30482440

@yebblies:
> This is the only place in the language where the choice to invoke ctfe is chosen based on the expression, not just the context.