### PR TITLE
Refactor: expose `canElideCopy` to C++ with saner default parameters

### DIFF
--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -430,6 +430,12 @@ bool isLvalue(Expression exp)
     return dmd.expressionsem.isLvalue(exp);
 }
 
+bool canElideCopy(Expression exp, Type to, bool checkMod)
+{
+    import dmd.expressionsem;
+    return dmd.expressionsem.canElideCopy(exp, to, checkMod);
+}
+
 int getFieldIndex(ClassReferenceExp cre, Type fieldtype, uint fieldoffset)
 {
     import dmd.expressionsem;

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -62,6 +62,7 @@ namespace dmd
     bool isIdentical(const Expression *exp, const Expression *e);
     bool equals(const Expression *exp, const Expression *e);
     bool isLvalue(Expression *exp);
+    bool canElideCopy(Expression *exp, Type *to, bool checkMod = false);
     int32_t getFieldIndex(ClassReferenceExp *cre, Type *fieldtype, uint32_t fieldoffset);
     void fillTupleExpExps(TupleExp *te, TupleDeclaration *tup);
     Optional<bool> toBool(Expression *exp);

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -5518,7 +5518,7 @@ elem* callfunc(Loc loc,
                 bool hasDtor = v && (v.isArgDtorVar || v.storage_class & STC.rvalue);
 
                 /* Also do not copy __rvalue expressions or temporaries that can be elided. */
-                bool copy = !(hasDtor || arg.rvalue || (param && canElideCopy(arg, param.type)));
+                bool copy = !(hasDtor || arg.rvalue || (param && canElideCopy(arg, param.type, true)));
 
                 elems[i] = addressElem(ea, arg.type, copy);
                 continue;

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -403,7 +403,7 @@ public:
             auto tf = ids.fd.type.isTypeFunction();
 
             if (exp.type.ty == Tstruct && !tf.isRef &&
-                !ids.fd.isCtorDeclaration() && !canElideCopy(s.exp, tf.nextOf()))
+                !ids.fd.isCtorDeclaration() && !canElideCopy(s.exp, tf.nextOf(), true))
             {
                 /* If the inlined function returns a copy of a struct,
                  * and then the return value is used subsequently as an

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -974,7 +974,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         if (funcdecl.vresult)
                         {
                             // Create: return vresult = exp;
-                            if (canElideCopy(exp, funcdecl.vresult.type, false))
+                            if (canElideCopy(exp, funcdecl.vresult.type))
                                 exp = new ConstructExp(rs.loc, funcdecl.vresult, exp);
                             else
                                 exp = new BlitExp(rs.loc, funcdecl.vresult, exp);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1773,6 +1773,7 @@ void expression_h(Expression *e, Scope *sc, Type *t, Loc loc, Expressions *es)
     dmd::expandTuples(es);
     dmd::optimize(e, 0);
     dmd::isLvalue(e);
+    dmd::canElideCopy(e, t);
 }
 
 void hdrgen_h(Module *m, OutBuffer &buf, Modules &ms, ParameterList pl,


### PR DESCRIPTION
This PR flips the default parameter of `checkMod` in `canElideCopy()` and exposes it to C++ as discussed in https://github.com/dlang/dmd/pull/22526#discussion_r2807269144.

The rationale is that `canElideCopy()` should define a value category rather than mess with whether the backend can really emplace a value. It was introduced without such consideration, and should eventually be unified with other value-category functions (https://github.com/dlang/dmd/pull/22412#issuecomment-3814610402). For the time being, change the default of `checkMod` to `false` and add a note on the reason.