### PR TITLE
Consider `v.__ctor()` an lvalue

### DIFF
--- a/compiler/test/runnable/sctor.d
+++ b/compiler/test/runnable/sctor.d
@@ -465,6 +465,40 @@ void test19389()
     assert(bar.b.x == 7); // fails
 }
 
+/***************************************************/
+// https://github.com/dlang/dmd/issues/22604
+
+struct S22604
+{
+    S22604* ptr;
+
+    this(int)
+    {
+        ptr = &this;
+    }
+
+    this(this)
+    {
+        ptr = &this;
+    }
+}
+
+struct T22604
+{
+    S22604 a, b;
+
+    this(int)
+    {
+        a = b = S22604(1);
+    }
+}
+
+void test22604()
+{
+    T22604 t = T22604(1);
+    assert(t.a.ptr is &t.a);
+    assert(t.b.ptr is &t.b);
+}
 
 /***************************************************/
 
@@ -478,6 +512,7 @@ int main()
     test14944();
     test15869();
     test19389();
+    test22604();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Fixes #22604.

This PR can be controversial because it changes `isLvalue()` to consider `lvalue.__ctor()` also an lvalue, which allows `a = (b = S()).__ctor()` to copy-initialize `a`. This appears to match Java-style initialization semantics well.

```d
a = b = S(...);

// This now has the semantics of
a = b = 0;
b.__ctor(...);
a.__cpctor(b);

// You can now also do
S* s = cast(S*)(...);
S* initializedS = &s.__ctor();
```
If this looks wrong to you, please do provide feedback.