### PR TITLE
Uninitialized variables in backend fixups

### DIFF
--- a/compiler/src/dmd/backend/codebuilder.d
+++ b/compiler/src/dmd/backend/codebuilder.d
@@ -109,7 +109,7 @@ struct CodeBuilder
     {
         if (c)
         {
-            CodeBuilder cdb = void;
+            CodeBuilder cdb;
 assert(c.Iop != BADINS);
             cdb.ctor(c);
             append(cdb);

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -883,7 +883,7 @@ void cgreg_set_priorities(tym_t ty, out const(reg_t)[] pseq, out const(reg_t)[] 
                     assert(msw == (INSTR.FLOATREGS & INSTR.MSW));
 
                     regm_t lsw;
-                    foreach (r; fltlsw1[]) msw |= mask(r);
+                    foreach (r; fltlsw1[]) lsw |= mask(r);
                     assert(lsw == (INSTR.FLOATREGS & INSTR.LSW));
                 }
             }


### PR DESCRIPTION
A couple of backend uninitialized variables bugs fixed, split out and was found by https://github.com/dlang/dmd/pull/22400