### PR TITLE
fix regression for GDC: make return type of _d_assocarrayliteralTX consistent with V[K] in the AST

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5187,6 +5187,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression loweredExp = new CallExp(aaExp.loc, hookFunc, arguments);
         loweredExp = loweredExp.expressionSemantic(sc);
         loweredExp = resolveProperties(sc, loweredExp);
+        loweredExp = loweredExp.castTo(sc, aaType); // Impl* might be incompatible with V[K] in the backend
         aaExp.lowering = loweredExp;
 
         semanticTypeInfo(sc, loweredExp.type);

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -976,7 +976,10 @@ private extern(C++) final class StaticAAVisitor : SemanticTimeTransitiveVisitor
         if (!(storage_class & STC.manifest)) // manifest constants create runtime copies
             if (!aaExp.loweringCtfe)
             {
-                aaExp.loweringCtfe = aaExp.lowering.ctfeInterpret();
+                auto lowering = aaExp.lowering;     // cast(V[K])_d_assocarrayliteralTX(...)
+                if (auto ce = lowering.isCastExp()) // skip the non-CTFE-able cast, Impl* is good enough
+                    lowering = ce.e1;
+                aaExp.loweringCtfe = lowering.ctfeInterpret();
                 aaExp.loweringCtfe.accept(this); // lower AAs in keys and values
             }
         semanticTypeInfo(sc, aaExp.lowering.type);


### PR DESCRIPTION
@ibuclaw good enough for https://github.com/dlang/dmd/pull/21066#issuecomment-3926547992 ?