### PR TITLE
Fix Issue 22614 - [Windows] tmpnam() in runPreprocessor generates roo…

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -960,8 +960,10 @@ public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, c
         // generate unique temporary file name for preprocessed output
         char[MAX_PATH] tempDir = void;
         char[MAX_PATH] tempFile = void;
-        GetTempPathA(MAX_PATH, tempDir.ptr);
-        GetTempFileNameA(tempDir.ptr, "dmd", 0, tempFile.ptr);
+        if (GetTempPathA(MAX_PATH, tempDir.ptr) == 0)
+            return STATUS_FAILED;
+        if (GetTempFileNameA(tempDir.ptr, "dmd", 0, tempFile.ptr) == 0)
+            return STATUS_FAILED;
         const(char)[] ifilename = tempFile[0 .. strlen(tempFile.ptr) + 1];
         ifilename = xarraydup(ifilename);
         const(char)[] output = ifilename;

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -958,9 +958,11 @@ public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, c
     version (Windows)
     {
         // generate unique temporary file name for preprocessed output
-        const(char)* tmpname = tmpnam(null);
-        assert(tmpname);
-        const(char)[] ifilename = tmpname[0 .. strlen(tmpname) + 1];
+        char[MAX_PATH] tempDir = void;
+        char[MAX_PATH] tempFile = void;
+        GetTempPathA(MAX_PATH, tempDir.ptr);
+        GetTempFileNameA(tempDir.ptr, "dmd", 0, tempFile.ptr);
+        const(char)[] ifilename = tempFile[0 .. strlen(tempFile.ptr) + 1];
         ifilename = xarraydup(ifilename);
         const(char)[] output = ifilename;
 


### PR DESCRIPTION
## Problem

On Windows, building druntime/phobos fails for non-admin users when DMD
preprocesses ImportC files (`.c`). The error looks like:

    src\core\stdc\errno.c: fatal error C1083: Cannot open compiler generated
    file: '\sla8.': Permission denied

## Root Cause

`runPreprocessor()` in `link.d` used `tmpnam(null)` to generate a temp
filename passed to `cl.exe`'s `/Fi` flag. On Windows, the MSVC CRT
implementation of `tmpnam()` always returns paths in the format `\sXXXXXX.`
(at the root of the current drive), regardless of the `TMP`/`TEMP`
environment variables. Non-admin users cannot write to the drive root
(`C:\`), causing `cl.exe` to fail.

## Fix

Replace `tmpnam(null)` with `GetTempPathA` + `GetTempFileNameA`, which
are the correct Windows APIs for generating temp file paths. These
respect the user's `TMP`/`TEMP` environment variables and write to
an accessible directory.

## Tested

Confirmed by successfully building druntime and phobos on Windows 11
as a non-admin user after applying this fix.

Fixes https://github.com/dlang/dmd/issues/22614
