### PR TITLE
Fix #22613 - consecutive initialization fails with postblits

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12424,7 +12424,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                                 }
 
                                 /* Rewrite as:
-                                 *  (e1 = e2).postblit();
+                                 *  (e1 = e2).postblit(), e1;
                                  *
                                  * Blit assignment e1 = e2 returns a reference to the original e1,
                                  * then call the postblit on it.
@@ -12436,6 +12436,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                                 e = new BlitExp(exp.loc, e, e2x);
                                 e = new DotVarExp(exp.loc, e, sd.postblit, false);
                                 e = new CallExp(exp.loc, e);
+                                e = new CommaExp(exp.loc, e, e1x);
                                 result = e.expressionSemantic(sc);
                                 return;
                             }

--- a/compiler/test/runnable/sctor.d
+++ b/compiler/test/runnable/sctor.d
@@ -485,11 +485,11 @@ struct S22604
 
 struct T22604
 {
-    S22604 a, b;
+    S22604 a, b, c, d;
 
     this(int)
     {
-        a = b = S22604(1);
+        a = b = c = d = S22604(1);
     }
 }
 
@@ -498,6 +498,8 @@ void test22604()
     T22604 t = T22604(1);
     assert(t.a.ptr is &t.a);
     assert(t.b.ptr is &t.b);
+    assert(t.c.ptr is &t.c);
+    assert(t.d.ptr is &t.d);
 }
 
 /***************************************************/


### PR DESCRIPTION
This is sort of high risk, since the code is ancient and governs all postblit invocations. Looks fine however.