### PR TITLE
Do proper construction when initializing `__result`

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2769,6 +2769,7 @@ void buildResultVar(FuncDeclaration fd, Scope* sc, Type tret)
          * fbody.dsymbolSemantic() running, vresult.type might be modified.
          */
         fd.vresult = new VarDeclaration(loc, tret, Id.result, null);
+        fd.vresult._init = new VoidInitializer(loc); // hdrgen requires _init
         fd.vresult.storage_class |= STC.nodtor | STC.temp;
         if (!fd.isVirtual())
             fd.vresult.storage_class |= STC.const_;

--- a/compiler/src/dmd/glue/s2ir.d
+++ b/compiler/src/dmd/glue/s2ir.d
@@ -661,22 +661,7 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
         {
             // Reference return, so convert to a pointer
             e = toElemDtor(s.exp, irs);
-
-            /* already taken care of for vresult in buildResultVar() and semantic3.d
-             * https://issues.dlang.org/show_bug.cgi?id=19384
-             */
-            if (func.vresult)
-                if (BlitExp be = s.exp.isBlitExp())
-                {
-                     if (VarExp ve = be.e1.isVarExp())
-                     {
-                        if (ve.var == func.vresult)
-                            goto Lskip;
-                     }
-                }
-
             e = addressElem(e, s.exp.type.pointerTo());
-         Lskip:
         }
         else
         {

--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -61,7 +61,7 @@ class C : Object
 		}
 		__require();
 		this.__invariant();
-		__result = 2;
+		__result = 2 , __result;
 		goto __returnLabel;
 		__returnLabel:
 		this.__invariant();


### PR DESCRIPTION
Calling copy constructor is currently done through the side effect of constructing a temporary variable. It's equivalent to constructing `__result` directly without jumping through another temporary, so this PR changes returning through `__result` to construct it instead of making a temporary. This removes a special case in the backend.

This PR is also in high-risk territory because it affects all functions using out contract or `opApply`. What's worse, this PR is not easily testable because copy/move-return should behave exactly the same as copy/move-initialization.

cc @ibuclaw @kinke

This should fix GDC's bug w.r.t out contract breaking RVO in move-return. Should be fine with LDC at a first glance, but warrants a look. 