### PR TITLE
Fix Issue #22567 - alias this and nested AAs cause compiler SIGILL

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -18884,6 +18884,25 @@ Expression revertIndexAssignToRvalues(IndexExp ie, Scope* sc)
     return lowerAAIndexRead(ie, sc);
 }
 
+private Expression revertModifiableAAIndexReads(Expression e, Scope* sc)
+{
+    // Recurse through dot-accesses (alias this produces DotVarExp on an inner IndexExp)
+    if (auto dve = e.isDotVarExp())
+    {
+        dve.e1 = revertModifiableAAIndexReads(dve.e1, sc);
+        return e;
+    }
+    if (auto ie = e.isIndexExp())
+    {
+        // Recurse first to handle deeper nesting
+        ie.e1 = revertModifiableAAIndexReads(ie.e1, sc);
+        // Lower a modifiable AA IndexExp to an rvalue read
+        if (ie.modifiable && ie.e1.type.isTypeAArray())
+            return lowerAAIndexRead(ie, sc);
+    }
+    return e;
+}
+
 // helper for rewriteAAIndexAssign
 private Expression implicitConvertToStruct(Expression ev, StructDeclaration sd, Scope* sc)
 {
@@ -18934,6 +18953,7 @@ private Expression rewriteAAIndexAssign(BinExp exp, Scope* sc, ref Type[2] alias
     // find the AA of multi dimensional access
     for (auto ieaa = ie.e1.isIndexExp(); ieaa && ieaa.e1.type.isTypeAArray(); ieaa = ieaa.e1.isIndexExp())
         eaa = ieaa.e1;
+    eaa = revertModifiableAAIndexReads(eaa, sc);
     eaa = extractSideEffect(sc, "__aatmp", e0, eaa);
     // collect all keys of multi dimensional access
     Expressions ekeys;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -18884,6 +18884,7 @@ Expression revertIndexAssignToRvalues(IndexExp ie, Scope* sc)
     return lowerAAIndexRead(ie, sc);
 }
 
+// Ditto, but traverses DotVarExp from `alias this` rewrites.
 private Expression revertModifiableAAIndexReads(Expression e, Scope* sc)
 {
     // Recurse through dot-accesses (alias this produces DotVarExp on an inner IndexExp)

--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -429,6 +429,23 @@ void testShared()
 
 /***************************************************/
 
+// https://github.com/dlang/dmd/issues/22567
+void test22567()
+{
+    struct S
+    {
+        string[string] data;
+        alias this = data;
+    }
+
+    S[string] foo;
+    foo["bar"] = S();
+    foo["bar"]["baz"] = "boom";
+    assert(foo["bar"]["baz"] == "boom");
+}
+
+/***************************************************/
+
 void main()
 {
     assert(testLiteral());
@@ -456,4 +473,5 @@ void main()
     test21066();
     test22354();
     testShared();
+    test22567();
 }


### PR DESCRIPTION
## Problem

When an `alias this` redirects a nested AA write through a struct field,
after alias this resolution the LHS `foo["bar"]["baz"]` becomes
`foo["bar"].data["baz"]`. The inner `foo["bar"]` is an `IndexExp` with
`modifiable=true` that was never lowered to `_d_aaGetRValueX` — the
modifiable flag suppresses that lowering in `visit(IndexExp)`. The IR
generator then hits the unlowered AA index expression and fires
`assert(false)` → SIGILL.

## Fix

Add `revertModifiableAAIndexReads()`, called after the multi-dim loop in
`rewriteAAIndexAssign()`. It recurses through `DotVarExp` wrappers alias
this produces and lowers any `modifiable=true` AA `IndexExp` to a proper
rvalue read via `lowerAAIndexRead()` before side-effect extraction.

The true multi-dimensional case (direct nested AAs, no alias this) is
unaffected: after the loop `eaa` is the base variable, on which the
function is a no-op.

## Regression

Introduced in 2.112, works in 2.111.

Fixes #22567
