### PR TITLE
fix #21976 Array comparison performance regression

### DIFF
--- a/compiler/src/dmd/backend/drtlsym.d
+++ b/compiler/src/dmd/backend/drtlsym.d
@@ -91,6 +91,7 @@ Symbol* getRtlsym(RTLSYM i) @trusted
         case RTLSYM.DARRAY_INDEXP:          symbolz(ps,FL.func,FREGSAVED,"_d_arraybounds_indexp", SFLexit, t); break;
         case RTLSYM.DNULLP:                 symbolz(ps,FL.func,FREGSAVED,"_d_nullpointerp", SFLexit, t); break;
         case RTLSYM.DINVARIANT:             symbolz(ps,FL.func,FREGSAVED,"_D2rt10invariant_12_d_invariantFC6ObjectZv", 0, tsdlib); break;
+        case RTLSYM.MEMCMP:                 symbolz(ps,FL.func,FREGSAVED,"memcmp",    0, t); break;
         case RTLSYM.MEMCPY:                 symbolz(ps,FL.func,FREGSAVED,"memcpy",    0, t); break;
         case RTLSYM.MEMSET8:                symbolz(ps,FL.func,FREGSAVED,"memset",    0, t); break;
         case RTLSYM.MEMSET16:               symbolz(ps,FL.func,FREGSAVED,"_memset16", 0, t); break;

--- a/compiler/src/dmd/backend/rtlsym.d
+++ b/compiler/src/dmd/backend/rtlsym.d
@@ -35,6 +35,7 @@ enum RTLSYM
     DARRAY_INDEXP,
     DNULLP,
     DINVARIANT,
+    MEMCMP,
     MEMCPY,
     MEMSET8,
     MEMSET16,


### PR DESCRIPTION
Call memcmp() instead of generating string instructions.