### PR TITLE
Move TemplateDeclaration.computeIsTrivialAlias logic to templatesem

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -299,44 +299,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         this.visibility = Visibility(Visibility.Kind.undefined);
     }
 
-    extern(D) void computeIsTrivialAlias(Dsymbol s)
-    {
-        /* Set isTrivialAliasSeq if this fits the pattern:
-         *   template AliasSeq(T...) { alias AliasSeq = T; }
-         * or set isTrivialAlias if this fits the pattern:
-         *   template Alias(T) { alias Alias = qualifiers(T); }
-         */
-        if (!(parameters && parameters.length == 1))
-            return;
-
-        auto ad = s.isAliasDeclaration();
-        if (!ad || !ad.type)
-            return;
-
-        auto ti = ad.type.isTypeIdentifier();
-
-        if (!ti || ti.idents.length != 0)
-            return;
-
-        if (auto ttp = (*parameters)[0].isTemplateTupleParameter())
-        {
-            if (ti.ident is ttp.ident &&
-                ti.mod == 0)
-            {
-                //printf("found isTrivialAliasSeq %s %s\n", s.toChars(), ad.type.toChars());
-                isTrivialAliasSeq = true;
-            }
-        }
-        else if (auto ttp = (*parameters)[0].isTemplateTypeParameter())
-        {
-            if (ti.ident is ttp.ident)
-            {
-                //printf("found isTrivialAlias %s %s\n", s.toChars(), ad.type.toChars());
-                isTrivialAlias = true;
-            }
-        }
-    }
-
     override TemplateDeclaration syntaxCopy(Dsymbol)
     {
         //printf("TemplateDeclaration.syntaxCopy()\n");

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -449,9 +449,47 @@ void computeOneMember(TemplateDeclaration td)
         {
             td.onemember = s;
             s.parent = td;
-            td.computeIsTrivialAlias(s);
+            computeIsTrivialAlias(td, s);
         }
         td.haveComputedOneMember = true;
+    }
+}
+
+private void computeIsTrivialAlias(TemplateDeclaration td, Dsymbol s)
+{
+    /* Set isTrivialAliasSeq if this fits the pattern:
+     *   template AliasSeq(T...) { alias AliasSeq = T; }
+     * or set isTrivialAlias if this fits the pattern:
+     *   template Alias(T) { alias Alias = qualifiers(T); }
+     */
+    if (!(td.parameters && td.parameters.length == 1))
+        return;
+
+    auto ad = s.isAliasDeclaration();
+    if (!ad || !ad.type)
+        return;
+
+    auto ti = ad.type.isTypeIdentifier();
+
+    if (!ti || ti.idents.length != 0)
+        return;
+
+    if (auto ttp = (*td.parameters)[0].isTemplateTupleParameter())
+    {
+        if (ti.ident is ttp.ident &&
+            ti.mod == 0)
+        {
+            //printf("found isTrivialAliasSeq %s %s\n", s.toChars(), ad.type.toChars());
+            td.isTrivialAliasSeq = true;
+        }
+    }
+    else if (auto ttp = (*td.parameters)[0].isTemplateTypeParameter())
+    {
+        if (ti.ident is ttp.ident)
+        {
+            //printf("found isTrivialAlias %s %s\n", s.toChars(), ad.type.toChars());
+            td.isTrivialAlias = true;
+        }
     }
 }
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -449,7 +449,7 @@ void computeOneMember(TemplateDeclaration td)
         {
             td.onemember = s;
             s.parent = td;
-            computeIsTrivialAlias(td, s);
+            td.computeIsTrivialAlias(s);
         }
         td.haveComputedOneMember = true;
     }


### PR DESCRIPTION
### This PR advances semantic-routine decoupling by moving template semantic logic out of the AST declaration module.

What changed
- Removed TemplateDeclaration.computeIsTrivialAlias(Dsymbol s) from [dtemplate.d](https://file+.vscode-resource.vscode-cdn.net/home/abhishekaslk/.vscode/extensions/openai.chatgpt-0.4.76-linux-x64/webview/#).
- Added a semantic-side helper in [templatesem.d](https://file+.vscode-resource.vscode-cdn.net/home/abhishekaslk/.vscode/extensions/openai.chatgpt-0.4.76-linux-x64/webview/#)
- Updated computeOneMember in [templatesem.d](https://file+.vscode-resource.vscode-cdn.net/home/abhishekaslk/.vscode/extensions/openai.chatgpt-0.4.76-linux-x64/webview/#) to call the new helper instead of a method on TemplateDeclaration.