### PR TITLE
Do semantic under nested scope when returning inside foreach body

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5179,6 +5179,7 @@ class ReturnStatement final : public Statement
 public:
     Expression* exp;
     size_t caseDim;
+    FuncDeclaration* fesFunc;
     ReturnStatement* syntaxCopy() override;
     ReturnStatement* endsWithReturnStatement() override;
     void accept(Visitor* v) override;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2780,7 +2780,7 @@ void buildResultVar(FuncDeclaration fd, Scope* sc, Type tret)
     if (sc && fd.vresult.semanticRun == PASS.initial)
     {
         TypeFunction tf = fd.type.toTypeFunction();
-        if (tf.isRef)
+        if (fd.isNRVO || tf.isRef)
             fd.vresult.storage_class |= STC.ref_;
         else if (target.isReturnOnStack(tf, fd.needThis()))
             fd.vresult.nrvo = true;

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -975,11 +975,12 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                         if (funcdecl.vresult)
                         {
+                            Scope* scret = rs.fesFunc ? rs.fesFunc._scope : sc2;
+
                             // Create: return (vresult = exp, vresult);
                             exp = new ConstructExp(rs.loc, funcdecl.vresult, exp);
-                            exp.type = funcdecl.vresult.type;
+                            exp = exp.expressionSemantic(scret);
                             exp = Expression.combine(exp, new VarExp(rs.loc, funcdecl.vresult));
-                            exp = exp.expressionSemantic(sc2);
 
                             if (rs.caseDim)
                                 exp = Expression.combine(exp, new IntegerExp(rs.caseDim));

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1308,6 +1308,7 @@ extern (C++) final class ReturnStatement : Statement
 {
     Expression exp;
     size_t caseDim;
+    FuncDeclaration fesFunc; // nested function for foreach it is in
 
     extern (D) this(Loc loc, Expression exp) @safe
     {

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -518,6 +518,7 @@ class ReturnStatement final : public Statement
 public:
     Expression *exp;
     size_t caseDim;
+    FuncDeclaration *fesFunc;   // nested function for foreach it is in
 
     ReturnStatement *syntaxCopy() override;
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2481,8 +2481,12 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         //printf("ReturnStatement.dsymbolSemantic() %s\n", toChars(rs));
 
         FuncDeclaration fd = sc.parent.isFuncDeclaration();
+
         if (fd.fes)
+        {
+            rs.fesFunc = fd;
             fd = fd.fes.func; // fd is now function enclosing foreach
+        }
 
         auto tf = fd.type.isTypeFunction();
 

--- a/compiler/test/runnable/foreach5.d
+++ b/compiler/test/runnable/foreach5.d
@@ -1209,6 +1209,36 @@ void testLDC326()
 }
 
 /***************************************/
+// https://github.com/dlang/dmd/issues/22629
+
+struct Collection2
+{
+    this(ref Collection2) {}
+
+    int opApply(int delegate(Collection2))
+    {
+        return 0;
+    }
+}
+
+Collection2 testForeach2(ref Collection2 level1, ref Collection2 level2)
+{
+    foreach (first; level1) {
+        foreach (second; level2)
+            return second;
+    }
+
+    return Collection2();
+}
+
+void test22629()
+{
+    Collection2 c1, c2;
+    testForeach2(c1, c2);
+}
+
+
+/***************************************/
 
 int main()
 {
@@ -1241,6 +1271,7 @@ int main()
     test14653();
     test17041();
     testLDC326();
+    test22629();
 
     printf("Success\n");
     return 0;

--- a/compiler/test/runnable/rvalue1.d
+++ b/compiler/test/runnable/rvalue1.d
@@ -286,6 +286,7 @@ struct V12
 {
     S12 s;
     this(int) { s = S12(1); }
+    int opApply(int delegate(Object)) { return 0; }
 }
 
 S12 foo12()
@@ -293,10 +294,33 @@ S12 foo12()
     return __rvalue(V12(1).s);
 }
 
+S12 bar12()
+{
+    S12 s = S12(1); // NRVO
+    foreach (_; V12(1))
+        return s;
+    return s;
+}
+
+S12 baz12()
+{
+    S12 s1 = S12(1);
+    S12 s2 = S12(1); // No NRVO
+    foreach (_; V12(1))
+        return s1;
+    return s2;
+}
+
 void test12()
 {
     S12 s = foo12();
     assert(&s == s.ptr);
+
+    S12 s2 = bar12();
+    assert(&s2 == s2.ptr);
+
+    S12 s3 = baz12();
+    assert(&s3 == s3.ptr);
 }
 
 /********************************/


### PR DESCRIPTION
Fixes #22628, #22629.

- #22620 was a kludge (sorry). The generated `VarExp` had been typed at that point and semantic wasn't done in the expected order. Fixed by doing semantic on the `ConstructExp` first.
- #22629 is tricky because in no scope could `doCopyOrMove()` generate correct code. The requirement is to generate the NRVO temporary under lexical parent scope, and other temporaries under nested foreach function scope. I'm making a compromise to run semantic of the `ConstructExp` under respective nested scopes and let `__result` become the NRVO variable automatically.
- In case of NRVO function with an out contract, there would be two NRVO variables and the glue can't deal with them well. Also, constructing `__result` from the NRVO variable triggers Bugzilla Issue 12686 (test case at `test/runnable/sdtor.d` line 3480). As a workaround, I set `__result` as a reference variable to preserve NRVO.

This might still affect GDC/LDC, but I have no idea at this point.