### PR TITLE
Fix issue 22556 - cast() strips all qualifiers from array and AA types

### DIFF
--- a/changelog/dmd.fix-shared-aa-cast.dd
+++ b/changelog/dmd.fix-shared-aa-cast.dd
@@ -1,0 +1,20 @@
+Fix `cast()` not fully stripping qualifiers from array and associative array types
+
+`cast()` with no qualifier argument is meant to strip all qualifiers from a
+type. Due to how the compiler propagates qualifiers transitively into element
+types during semantic analysis, `cast()` on a qualified array or associative
+array was only removing qualifiers from the outer type, leaving them on the
+element/value type.
+
+-------
+shared(int[int]) a;
+// Previously yielded shared(int)[int] — now correctly yields int[int]
+static assert(is(typeof(cast() a) == int[int]));
+
+const(int[]) b;
+// Previously yielded const(int)[] — now correctly yields int[]
+static assert(is(typeof(cast() b) == int[]));
+-------
+
+This affected any code that removed `shared` or `const` from an array or AA
+using `cast()`, such as when accessing a `shared` AA protected by a mutex.

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1788,7 +1788,12 @@ extern (C++) abstract class TypeNext : Type
     {
         //printf("TypeNext::makeMutable() %p, %s\n", this, toChars());
         TypeNext t = cast(TypeNext)Type.makeMutable();
-        if (ty == Tsarray)
+        // typeSemantic calls transitive() on these types, which propagates the
+        // outer qualifier into next. Strip it from next only when the outer type
+        // has const/immutable/wild bits — plain-shared or unqualified types were
+        // never propagated into next by this path so next should not be touched.
+        if (mod & ~MODFlags.shared_ &&
+            (ty == Tsarray || ty == Tarray || ty == Taarray))
         {
             t.next = next.mutableOf();
         }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -7347,6 +7347,14 @@ Type unSharedOf(Type type)
         t = type.nullAttributes();
         t.mod = type.mod & ~MODFlags.shared_;
         t.ctype = type.ctype;
+        // typeSemantic calls transitive() on arrays and AAs, which propagates
+        // the qualifier into the element/value type. Strip shared from next
+        // here to undo that propagation.
+        if (auto tn = cast(TypeNext) t)
+        {
+            if (t.ty == Tarray || t.ty == Tsarray || t.ty == Taarray)
+                tn.next = tn.next.unSharedOf();
+        }
         t = t.merge();
         t.fixTo(type);
     }
@@ -7478,7 +7486,8 @@ Type unqualify(Type type, uint m)
                 t = new TypeSArray(utn, (cast(TypeSArray)type).dim);
             else if (type.ty == Taarray)
             {
-                t = new TypeAArray(utn, (cast(TypeAArray)type).index);
+                auto taa = cast(TypeAArray) type;
+                t = new TypeAArray(utn, taa.index.unqualify(m));
             }
             else
                 assert(0);

--- a/compiler/test/compilable/fix22556.d
+++ b/compiler/test/compilable/fix22556.d
@@ -1,0 +1,26 @@
+// https://github.com/dlang/dmd/issues/22556
+// cast() must strip all qualifiers from the entire type, not just the top-level mod.
+// typeSemantic calls transitive() on TypeNext types (arrays, AAs), which
+// propagates the qualifier into the element/value type. The qualifier-stripping
+// functions must recurse into next to undo that propagation.
+
+void testAA()
+{
+    shared(int[int]) a;
+    static assert(is(typeof(cast() a) == int[int]));
+
+    shared const(int[int]) b;
+    static assert(is(typeof(cast() b) == int[int]));
+
+    const(int[int]) c;
+    static assert(is(typeof(cast() c) == int[int]));
+}
+
+void testDynamicArray()
+{
+    shared(int[]) a;
+    static assert(is(typeof(cast() a) == int[]));
+
+    const(int[]) b;
+    static assert(is(typeof(cast() b) == int[]));
+}


### PR DESCRIPTION
## Problem

`cast()` is meant to strip all qualifiers from a type. However, `typeSemantic`
calls `transitive()` on TypeNext types (arrays, AAs), which propagates the outer
qualifier into the element/value type. The qualifier-stripping functions were not
recursing into `next` to undo that propagation.

```d
shared(int[int]) a;
auto b = cast() a; // was: shared(int)[int] — should be: int[int]

const(int[]) c;
auto d = cast() c; // was: const(int)[] — should be: int[]
