### PR TITLE
at least get x87 to compile on AArch64 host

### DIFF
--- a/compiler/src/dmd/backend/x86/cg87.d
+++ b/compiler/src/dmd/backend/x86/cg87.d
@@ -649,19 +649,31 @@ ubyte loadconst(elem* e, int im)
     immutable double[7] dval =
         [0.0,1.0,PI,LOG2T,LOG2E,LOG2,LN2];
 
+    enum M_PI_L        = 0x1.921fb54442d1846ap+1L;       // 3.14159 fldpi
+    enum M_LOG2T_L     = 0x1.a934f0979a3715fcp+1L;       // 3.32193 fldl2t
+    enum M_LOG2E_L     = 0x1.71547652b82fe178p+0L;       // 1.4427 fldl2e
+    enum M_LOG2_L      = 0x1.34413509f79fef32p-2L;       // 0.30103 fldlg2
+    enum M_LN2_L       = 0x1.62e42fefa39ef358p-1L;       // 0.693147 fldln2
+
     static if (real.sizeof < 10)
     {
-        import dmd.root.longdouble;
-        immutable targ_real[7] ldval =
-        [ld_zero,ld_one,ld_pi,ld_log2t,ld_log2e,ld_log2,ld_ln2];
+        version (CRuntime_Microsoft)
+        {
+            // only for longdouble_soft
+            import dmd.root.longdouble;
+            immutable targ_real[7] ldval =
+            [ld_zero,ld_one,ld_pi,ld_log2t,ld_log2e,ld_log2,ld_ln2];
+        }
+        else
+        {
+            // AArch64 cross-compiling for X86_64, but targ_real is still 64 bits instead of 80.
+            // Should fix longdouble_soft so it gives 80 emulation on AArch64
+            immutable targ_real[7] ldval =
+            [0.0,1.0,M_PI_L,M_LOG2T_L,M_LOG2E_L,M_LOG2_L,M_LN2_L];
+        }
     }
     else
     {
-        enum M_PI_L        = 0x1.921fb54442d1846ap+1L;       // 3.14159 fldpi
-        enum M_LOG2T_L     = 0x1.a934f0979a3715fcp+1L;       // 3.32193 fldl2t
-        enum M_LOG2E_L     = 0x1.71547652b82fe178p+0L;       // 1.4427 fldl2e
-        enum M_LOG2_L      = 0x1.34413509f79fef32p-2L;       // 0.30103 fldlg2
-        enum M_LN2_L       = 0x1.62e42fefa39ef358p-1L;       // 0.693147 fldln2
         immutable targ_real[7] ldval =
         [0.0,1.0,M_PI_L,M_LOG2T_L,M_LOG2E_L,M_LOG2_L,M_LN2_L];
     }

--- a/compiler/src/dmd/backend/x86/cod2.d
+++ b/compiler/src/dmd/backend/x86/cod2.d
@@ -81,7 +81,7 @@ bool movOnly(const elem* e)
  * Determine index registers used by addressing mode.
  * Index is rm of modregrm field.
  * Params:
- *	c = code with EA filled in
+ *      c = code with EA filled in
  * Returns:
  *      mask of index registers
  */

--- a/compiler/src/dmd/root/longdouble.d
+++ b/compiler/src/dmd/root/longdouble.d
@@ -16,6 +16,8 @@ version (CRuntime_Microsoft)
     static if (real.sizeof > 8)
         alias longdouble = real;
     else
+        // Need to fix longdouble_soft so it works for compiler built with AArch64 but
+        // generating X86_64 code
         alias longdouble = longdouble_soft;
 }
 else
@@ -33,6 +35,7 @@ version(D_InlineAsm_X86_64)
 else version(D_InlineAsm_X86)
     version = AsmX86;
 else
+    // yes, AArch64 host needs to emulate 80 bit real to cross compile for X86_64
     static assert(false, "longdouble_soft not supported on this platform");
 
 bool initFPU()


### PR DESCRIPTION
There's confusion in the compiler source code between what is the target `real` and what is the host `real`. For the AArch64 host compiler, the `real` code is all done as 64 bits, but then how does one cross-compile to the x87?

The current implementation does all the AArch64 80 bit math in 64 bits. Not correct, but good enough to get the compiler bootstrapped.

The same goes for the 128 bit Arm64 floating point math.