### PR TITLE
refactor: move `fixupInvariantIdent` from func.d to dsymbolsem.d

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -143,6 +143,15 @@ void addObjcSymbols(Dsymbol _this, ClassDeclarations* classes, ClassDeclarations
         objc.addSymbols(cd, classes, categories);
 }
 
+private void fixupInvariantIdent(InvariantDeclaration invd, size_t offset)
+{
+    OutBuffer idBuf;
+    idBuf.writestring("__invariant");
+    idBuf.print(offset);
+
+    invd.ident = Identifier.idPool(idBuf[]);
+}
+
 /************************************
  * Maybe `ident` was a C or C++ name. Check for that,
  * and suggest the D equivalent.

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1116,15 +1116,6 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
     {
         v.visit(this);
     }
-
-    extern (D) void fixupInvariantIdent(size_t offset)
-    {
-        OutBuffer idBuf;
-        idBuf.writestring("__invariant");
-        idBuf.print(offset);
-
-        ident = Identifier.idPool(idBuf[]);
-    }
 }
 
 


### PR DESCRIPTION
### This PR continues semantic-routine decoupling by moving invariant-specific semantic logic out of func.d into dsymbolsem.d

What changed
- Removed InvariantDeclaration.fixupInvariantIdent(size_t offset) from func.d
- Added a semantic-side helper in dsymbolsem.d
- Kept the existing call site in dsymbolsem unchanged in style (UFCS)