### PR TITLE
Move circular inheritance helper isBaseOf2 from dclass.d to dsymbolsem.d

### DIFF
--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -260,24 +260,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         return cd;
     }
 
-    /*********************************************
-     * Determine if 'this' is a base class of cd.
-     * This is used to detect circular inheritance only.
-     */
-    extern (D) final bool isBaseOf2(ClassDeclaration cd) pure nothrow @nogc
-    {
-        if (!cd)
-            return false;
-        //printf("ClassDeclaration.isBaseOf2(this = '%s', cd = '%s')\n", toChars(), cd.toChars());
-        for (size_t i = 0; i < cd.baseclasses.length; i++)
-        {
-            BaseClass* b = (*cd.baseclasses)[i];
-            if (b.sym == this || isBaseOf2(b.sym))
-                return true;
-        }
-        return false;
-    }
-
     enum OFFSET_RUNTIME = 0x76543210;
     enum OFFSET_FWDREF = 0x76543211;
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -152,6 +152,24 @@ private void fixupInvariantIdent(InvariantDeclaration invd, size_t offset)
     invd.ident = Identifier.idPool(idBuf[]);
 }
 
+/*********************************************
+ * Determine if `_this` is a base class of `cd`.
+ * This is used to detect circular inheritance only.
+ */
+bool isBaseOf2(ClassDeclaration _this, ClassDeclaration cd) pure nothrow @nogc
+{
+    if (!cd)
+        return false;
+    //printf("ClassDeclaration.isBaseOf2(this = '%s', cd = '%s')\n", _this.toChars(), cd.toChars());
+    for (size_t i = 0; i < cd.baseclasses.length; i++)
+    {
+        BaseClass* b = (*cd.baseclasses)[i];
+        if (b.sym == _this || _this.isBaseOf2(b.sym))
+            return true;
+    }
+    return false;
+}
+
 /************************************
  * Maybe `ident` was a C or C++ name. Check for that,
  * and suggest the D equivalent.


### PR DESCRIPTION
### This PR move circular inheritance helper `isBaseOf2` from dclass.d to dsymbolsem.d

What changed
- Removed ClassDeclaration.isBaseOf2 from dclass.d
- Added semantic-side helper in dsymbolsem.d

Hi @thewilsonator, we are good for this type of changes?