### PR TITLE
Fix Issue 22573 - core.sys.windows.objbase functions not marked as @nogc nothrow

### DIFF
--- a/changelog/druntime.objbase-nogc.dd
+++ b/changelog/druntime.objbase-nogc.dd
@@ -1,0 +1,9 @@
+`core.sys.windows.objbase` functions are now marked `@nogc`
+
+The Windows COM/OLE API functions declared in `core.sys.windows.objbase`
+are now annotated with `@nogc`, since they are native Windows functions
+that do not allocate via the D garbage collector. These functions were
+already marked `nothrow` for the same reason.
+
+This allows the bindings to be used in `@nogc` contexts without explicit
+`cast`s.

--- a/compiler/test/compilable/fix22573.d
+++ b/compiler/test/compilable/fix22573.d
@@ -1,0 +1,5 @@
+// https://issues.dlang.org/show_bug.cgi?id=22573
+// core.sys.windows.objbase functions should be @nogc nothrow
+version (Windows):
+@nogc nothrow:
+import core.sys.windows.objbase;

--- a/compiler/test/compilable/fix22573.d
+++ b/compiler/test/compilable/fix22573.d
@@ -1,5 +1,29 @@
 // https://issues.dlang.org/show_bug.cgi?id=22573
 // core.sys.windows.objbase functions should be @nogc nothrow
 version (Windows):
-@nogc nothrow:
 import core.sys.windows.objbase;
+
+// Verify that COM functions which do not execute user-supplied code are @nogc nothrow
+// by calling them from a @nogc nothrow context.  The following are intentionally
+// excluded because they may invoke user D code (which may allocate via the GC):
+//   CoGetClassObject, CoFreeLibrary, CoCreateInstance, CoCreateInstanceEx,
+//   DllGetClassObject, and anything else accepting LPUNKNOWN / IUnknown*.
+@nogc nothrow void testNogcNothrow()
+{
+    CoInitialize(null);
+    CoInitializeEx(null, 0);
+    CoUninitialize();
+    CoGetCurrentProcess();
+    CoRevokeMallocSpy();
+    CoRevokeClassObject(0);
+    CoCreateGuid(null);
+    CoFileTimeNow(null);
+    CoTaskMemAlloc(0);
+    CoTaskMemFree(null);
+    CoTaskMemRealloc(null, 0);
+    CoAddRefServerProcess();
+    CoReleaseServerProcess();
+    CoResumeClassObjects();
+    CoSuspendClassObjects();
+    DllCanUnloadNow();
+}

--- a/druntime/src/core/sys/windows/objbase.d
+++ b/druntime/src/core/sys/windows/objbase.d
@@ -9,6 +9,7 @@
 module core.sys.windows.objbase;
 version (Windows):
 nothrow:
+@nogc:
 pragma(lib, "ole32");
 
 import core.sys.windows.cguid, core.sys.windows.objidl, core.sys.windows.unknwn, core.sys.windows.wtypes;


### PR DESCRIPTION
Fixes https://issues.dlang.org/show_bug.cgi?id=22573

Windows COM/OLE API functions in `core.sys.windows.objbase` do not
allocate via the D garbage collector, nor throw D exceptions.
The module already had a module-level `nothrow:` attribute; this PR
adds the matching `@nogc:` attribute.
