### PR TITLE
Fix #22639 - opApply triggers GC allocation error with -betterC

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -975,7 +975,19 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                         if (funcdecl.vresult)
                         {
-                            Scope* scret = rs.fesFunc ? rs.fesFunc._scope : sc2;
+                            Scope* scret = sc2;
+
+                            if (rs.fesFunc)
+                            {
+                                /* Semantic of the rewritten statements should be run
+                                 * inside their respective nested function bodies,
+                                 * but function body scopes have already been lost.
+                                 * Create a new scope over definition scope and pretend.
+                                 * FIXME: find a better way and remove this hack
+                                 */
+                                scret = rs.fesFunc._scope.push();
+                                scret.parent = rs.fesFunc;
+                            }
 
                             // Create: return (vresult = exp, vresult);
                             exp = new ConstructExp(rs.loc, funcdecl.vresult, exp);

--- a/compiler/test/runnable/issue22639.d
+++ b/compiler/test/runnable/issue22639.d
@@ -1,0 +1,35 @@
+// REQUIRED_ARGS: -betterC
+
+struct Arr(T, int CAPACITY)
+{
+    int count = 0;
+    T[CAPACITY] items;
+    int opApply(scope int delegate(T) dg)
+    {
+        int result;
+        for (int i = 0; i < count; i++)
+            if ((result = dg(items[i])) != 0)
+                break;
+        return result;
+    }
+}
+
+struct Foo {}
+struct Bar {
+    Arr!(Foo*, 32) array;
+    Foo* get()
+    {
+        foreach(Foo* it; array)
+        {
+            return it;
+        }
+        return null;
+    }
+}
+
+Foo* foo;
+Bar bar;
+extern(C) void main()
+{
+    foo = bar.get();
+}


### PR DESCRIPTION
This PR is a blatant hack. A complete fix would be to run semantic of `ConstructExp` in the *body* of nested foreach function, and fix up inferred attributes accordingly. I think figuring this out needs some digging in the history. For the time being, just posting a hack here.

The test case is in runnable to prevent generating a GC call by mistake.