### PR TITLE
fix issue #22556 - shared AAs with RefCounted values don't work even after removing shared

### DIFF
--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -427,6 +427,22 @@ void testShared()
     assert(2 in iprocesses);
 }
 
+// https://github.com/dlang/dmd/issues/22556
+void test22556()
+{
+    static struct RefCounted(T)
+    {
+        this(this) {}
+    }
+    struct S {}
+    alias R = RefCounted!S;
+    shared R[string] foo;
+
+    (cast (R[string]) foo).clear; // WORKS
+    (cast() foo).clear; // FAILS with 2.112.0, WORKS with 2.111.0
+    static assert(!__traits(compiles, foo.clear));
+}
+
 /***************************************************/
 
 // https://github.com/dlang/dmd/issues/22567
@@ -474,4 +490,5 @@ void main()
     test22354();
     testShared();
     test22567();
+    test22556();
 }

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2985,14 +2985,28 @@ alias AssociativeArray(Key, Value) = Value[Key];
  *      aa =     The associative array.
  */
 void clear(Value, Key)(Value[Key] aa) @trusted
+if (!is(Value == shared))
 {
     _aaClear(aa);
 }
 
 /** ditto */
 void clear(Value, Key)(Value[Key]* aa) @trusted
+if (!is(Value == shared))
 {
     (*aa).clear();
+}
+
+/** ditto */
+void clear(Value, Key)(shared(Value)[Key] aa)
+{
+    return (cast(Value[Key])aa).clear();
+}
+
+/** ditto */
+void clear(Value, Key)(shared(Value)[Key]* aa)
+{
+    (cast(Value[Key])*aa).clear();
 }
 
 ///


### PR DESCRIPTION
allow AA.clear with shared values for backward compatibility

Long term, access to shared AAs should be deprecated, there is little safe about that. clear() in the given scenario might be an exception, as it only removes the non-shared part of the AA pointing to the shared values.