### PR TITLE
Fix #22639 - opApply triggers GC allocation error with -betterC 

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -893,6 +893,7 @@ Ldone:
      */
     funcdecl._scope = sc.copy();
     funcdecl._scope.setNoFree();
+    funcdecl._scope.parent = funcdecl;
 
     __gshared bool printedMain = false; // semantic might run more than once
     if (global.params.v.verbose && !printedMain)

--- a/compiler/test/runnable/issue22639.d
+++ b/compiler/test/runnable/issue22639.d
@@ -1,0 +1,35 @@
+// REQUIRED_ARGS: -betterC
+
+struct Arr(T, int CAPACITY)
+{
+    int count = 0;
+    T[CAPACITY] items;
+    int opApply(scope int delegate(T) dg)
+    {
+        int result;
+        for (int i = 0; i < count; i++)
+            if ((result = dg(items[i])) != 0)
+                break;
+        return result;
+    }
+}
+
+struct Foo {}
+struct Bar {
+    Arr!(Foo*, 32) array;
+    Foo* get()
+    {
+        foreach(Foo* it; array)
+        {
+            return it;
+        }
+        return null;
+    }
+}
+
+Foo* foo;
+Bar bar;
+extern(C) void main()
+{
+    foo = bar.get();
+}


### PR DESCRIPTION
cc @limepoutine 

When storing _scope for a FuncDeclaration, the scope's parent was not set to the function itself. This broke the scope chain during semantic analysis, hence the false positive.


Fixes #22639 
