### PR TITLE
Remove duplicate imports from multiple files

### DIFF
--- a/compiler/src/dmd/backend/ee.d
+++ b/compiler/src/dmd/backend/ee.d
@@ -18,7 +18,6 @@ import core.stdc.time;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.global;
-import dmd.backend.symtab;
 import dmd.backend.type;
 import dmd.backend.oper;
 import dmd.backend.el;

--- a/compiler/src/dmd/backend/ptrntab.d
+++ b/compiler/src/dmd/backend/ptrntab.d
@@ -23,7 +23,6 @@ import dmd.backend.code;
 import dmd.backend.global;
 import dmd.backend.x86.xmm;
 
-import dmd.backend.cdef;
 import dmd.backend.dlist;
 import dmd.backend.ty;
 

--- a/compiler/src/dmd/common/file.d
+++ b/compiler/src/dmd/common/file.d
@@ -21,7 +21,6 @@ import core.stdc.limits;
 
 import core.stdc.errno : errno;
 import core.stdc.stdio : fprintf, remove, rename, stderr;
-import core.stdc.stdlib;
 import core.stdc.string : strerror, strlen, memcpy;
 
 import dmd.common.smallbuffer;

--- a/compiler/src/dmd/lib/mscoff.d
+++ b/compiler/src/dmd/lib/mscoff.d
@@ -15,7 +15,6 @@ import core.stdc.stdlib;
 import core.stdc.string;
 import core.stdc.time;
 import core.stdc.stdio;
-import core.stdc.string;
 
 version (Posix)
 {

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -48,7 +48,6 @@ import dmd.expression;
 import dmd.file_manager;
 import dmd.hdrgen;
 import dmd.globals;
-import dmd.hdrgen;
 import dmd.id;
 import dmd.identifier;
 import dmd.inline;


### PR DESCRIPTION
### This PR removed duplicate imports in:
- `compiler/src/dmd/backend/ee.d`
  - `import dmd.backend.symtab;`
- `compiler/src/dmd/backend/ptrntab.d`
  - `import dmd.backend.cdef;`
- `compiler/src/dmd/common/file.d`
  - `import core.stdc.stdlib;`
- `compiler/src/dmd/lib/mscoff.d`
  - `import core.stdc.string;`
- `compiler/src/dmd/main.d`
  - `import dmd.hdrgen;`