### PR TITLE
remove `initsem` dependency from `astcodegen`

### DIFF
--- a/compiler/src/dmd/astcodegen.d
+++ b/compiler/src/dmd/astcodegen.d
@@ -27,7 +27,6 @@ struct ASTCodegen
     public import dmd.func;
     public import dmd.hdrgen;
     public import dmd.init;
-    public import dmd.initsem;
     public import dmd.mtype;
     public import dmd.nspace;
     public import dmd.statement;
@@ -36,7 +35,6 @@ struct ASTCodegen
     public import dmd.typesem;
 
     alias addSTC                    = dmd.typesem.addSTC;
-    alias initializerToExpression   = dmd.initsem.initializerToExpression;
     alias typeToExpression          = dmd.mtype.typeToExpression;
     alias UserAttributeDeclaration  = dmd.attrib.UserAttributeDeclaration;
     alias Ensure                    = dmd.func.Ensure; // workaround for bug in older DMD frontends

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -28,6 +28,7 @@ import dmd.globals;
 import dmd.hdrgen;
 import dmd.id;
 import dmd.identifier;
+import dmd.initsem : initializerToExpression;
 import dmd.location;
 import dmd.root.filename;
 import dmd.visitor;
@@ -1001,7 +1002,7 @@ public:
                     buf.writestring(" { ");
                     writeIdentifier(vd, true);
                     buf.writestring(" = ");
-                    auto ie = AST.initializerToExpression(vd._init).isIntegerExp();
+                    auto ie = initializerToExpression(vd._init).isIntegerExp();
                     visitInteger(ie.toInteger(), type);
                     buf.writestring(" };");
                     break;
@@ -1013,7 +1014,7 @@ public:
                     buf.writestring(" const ");
                     writeIdentifier(vd, true);
                     buf.writestring(" = ");
-                    auto e = AST.initializerToExpression(vd._init);
+                    auto e = initializerToExpression(vd._init);
                     printExpressionFor(target, e);
                     buf.writestring(";");
                     break;
@@ -1363,7 +1364,7 @@ public:
 
                 if (vd._init)
                 {
-                    auto e = AST.initializerToExpression(vd._init);
+                    auto e = initializerToExpression(vd._init);
                     printExpressionFor(vd.type, e, true);
                 }
                 buf.printf(")");
@@ -2801,7 +2802,7 @@ public:
     private static AST.Expression findDefaultInitializer(AST.VarDeclaration vd)
     {
         if (vd._init && !vd._init.isVoidInitializer())
-            return AST.initializerToExpression(vd._init);
+            return initializerToExpression(vd._init);
         if (auto ts = vd.type.isTypeStruct())
         {
             if (!ts.sym.noDefaultCtor && !ts.sym.isUnionDeclaration())


### PR DESCRIPTION
### Decouple `ASTCodegen` from `initsem` by removing the direct semantic-module import and moving the usage to a non-AST module (`dtoh`).

### Changes
- In `compiler/src/dmd/astcodegen.d`:
  - removed `public import dmd.initsem;`
  - removed `alias initializerToExpression = dmd.initsem.initializerToExpression;`
- In `compiler/src/dmd/dtoh.d`:
  - added selective import `import dmd.initsem : initializerToExpression;`
  - replaced calls to `AST.initializerToExpression(...)` with `initializerToExpression(...)`

### Testing
- Built with:
  - `./bootstrap.sh BUILD=debug`
- Tested with:
  - `rdmd run.d BUILD=debug`