### PR TITLE
remove duplicate import of `dmd.backend.symtab` from `ee.d`

### DIFF
--- a/compiler/src/dmd/backend/ee.d
+++ b/compiler/src/dmd/backend/ee.d
@@ -23,7 +23,6 @@ import dmd.backend.type;
 import dmd.backend.oper;
 import dmd.backend.el;
 import dmd.backend.cgcv;
-import dmd.backend.symtab;
 
 import dmd.backend.iasm;
 


### PR DESCRIPTION
This PR removed duplicate import `dmd.backend.symtab`;