### PR TITLE
Fix #22647: remove iasm from excluded source files for DMDaaL

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -98,7 +98,6 @@ subPackage {
   excludedSourceFiles "compiler/src/dmd/backend/*"
   excludedSourceFiles "compiler/src/dmd/root/*"
   excludedSourceFiles "compiler/src/dmd/common/*"
-  excludedSourceFiles "compiler/src/dmd/iasm/*"
   excludedSourceFiles "compiler/src/dmd/lib/*"
   excludedSourceFiles "compiler/src/dmd/irgen/*"
   excludedSourceFiles "compiler/src/dmd/{\


### PR DESCRIPTION
I am unsure if this is the correct fix. It should work if `version = NoBackend` is set, but I don't know what it would do if it is not set.