### PR TITLE
Fix `__traits(isCopyable)` fails on static array of non-copyable struct

### DIFF
--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -588,7 +588,8 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return ErrorExp.get();
         }
 
-        t = t.toBasetype();     // get the base in case `t` is an `enum`
+        // get enum base or static array element type
+        t = t.baseElemOf();
 
         if (auto ts = t.isTypeStruct())
         {

--- a/compiler/test/compilable/traits.d
+++ b/compiler/test/compilable/traits.d
@@ -169,6 +169,7 @@ class C1 {}
 static assert( __traits(isCopyable, S1));
 static assert( __traits(isCopyable, S2));
 static assert(!__traits(isCopyable, S3));
+static assert(!__traits(isCopyable, S3[1]));
 static assert(!__traits(isCopyable, S4));
 static assert(__traits(isCopyable, C1));
 static assert(__traits(isCopyable, int));


### PR DESCRIPTION
Fixes #22658.