### PR TITLE
Add prototype script for measuring clean build time (Performance Regression Publisher exploration)

### DIFF
--- a/tools/performance/measure_build.sh
+++ b/tools/performance/measure_build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+runs=3
+times=()
+
+echo "Running $runs clean builds..."
+
+for i in $(seq 1 $runs)
+do
+    echo "Run $i..."
+    make clean > /dev/null 2>&1
+
+    start=$(date +%s)
+    ci/run.sh build > /dev/null 2>&1
+    end=$(date +%s)
+
+    duration=$((end - start))
+    echo "Build $i: $duration seconds"
+
+    times+=($duration)
+done
+
+# Sort times
+sorted=($(printf '%s\n' "${times[@]}" | sort -n))
+median=${sorted[1]}
+
+echo "Median build time: $median seconds"
+
+# Save to JSON
+echo "{ \"median_build_time\": $median }" > build_result.json
+
+echo "Saved result to build_result.json"


### PR DESCRIPTION
This PR adds a small prototype script to explore measuring
clean build performance for dmd.

The script runs multiple clean builds and reports the median time.
It also stores the result in a simple json file.

=>Example usage:

    tools/performance/measure_build.sh

=> output:

    Running 3 clean builds...
    Build 1: 134 seconds
    Build 2: 130 seconds
    Build 3: 129 seconds
    Median build time: 130 seconds
    { "median_build_time": 130 }

The goal is to start a discussion around how performance metrics
could be collected and published for the Performance Regression Publisher project.

This prototype has only been tested locally on Ubuntu (WSL) for now,
before integrating with CI or GitHub Actions.