### PR TITLE
AArch64 does not support x87 intrinsics

### DIFF
--- a/compiler/src/dmd/backend/arm/cod4.d
+++ b/compiler/src/dmd/backend/arm/cod4.d
@@ -1686,6 +1686,13 @@ void cdcnvt(ref CGstate cg, ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
 
         case OPd_ld:    // call __extenddftf2
         case OPld_d:    // call __trunctfdf2
+            if (sz == 8 && tysize(e.E1.Ety) == 8)       // same size means no-op
+            {
+                codelem(cgstate,cdb,e.E1,pretregs,false);
+                freenode(e);
+                return;
+            }
+
             regm_t retregs1 = mask(32);
             codelem(cgstate,cdb,e.E1,retregs1,false);
             import dmd.backend.arm.cod1 : CLIB_A, callclib;

--- a/compiler/src/dmd/backend/x86/cg87.d
+++ b/compiler/src/dmd/backend/x86/cg87.d
@@ -3327,6 +3327,7 @@ void cnvt87(ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 @trusted
 void cdrndtol(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
+    assert(!cg.AArch64);
     if (pretregs == 0)
     {
         codelem(cgstate,cdb,e.E1,pretregs,false);
@@ -3383,6 +3384,7 @@ void cdrndtol(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 @trusted
 void cdscale(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 {
+    assert(!cg.AArch64);
     assert(pretregs != 0);
 
     regm_t retregs = mST0;
@@ -3783,6 +3785,7 @@ void fixresult_complex87(ref CodeBuilder cdb,elem* e,regm_t retregs, ref regm_t 
 @trusted
 void cdconvt87(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
+    assert(!cg.AArch64);
     regm_t retregs = mST01;
     codelem(cgstate,cdb,e.E1, retregs, false);
     switch (e.Eoper)
@@ -3931,6 +3934,7 @@ void loadPair87(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
 void cdtoprec(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 {
     //printf("cdtoprec: pretregs = %s\n", regm_str(pretregs));
+    assert(!cg.AArch64);
     if (!pretregs)
     {
         codelem(cgstate,cdb,e.E1,pretregs,false);

--- a/compiler/src/dmd/glue/toir.d
+++ b/compiler/src/dmd/glue/toir.d
@@ -601,6 +601,9 @@ int intrinsic_op(FuncDeclaration fd)
     {
         if (op == OPbsf || op == OPbsr || op == OPbtc || op == OPbtr || op == OPbts)
             return NotIntrinsic;        // TODO AArch64
+        if (op == OPcos || op == OPsin || op == OPrint || op == OPsqrt || op == OPscale ||
+            op == OPrndtol || op == OPyl2xp1 || op == OPtoPrec)
+            return NotIntrinsic;        // x87 only
     }
     return op;
 

--- a/compiler/src/dmd/root/ctfloat.d
+++ b/compiler/src/dmd/root/ctfloat.d
@@ -41,8 +41,11 @@ extern (C++) struct CTFloat
 
     version (GNU)
         enum yl2x_supported = false;
+    else version (AArch64)
+        enum yl2x_supported = false;	// no x87 FPU
     else
         enum yl2x_supported = __traits(compiles, core.math.yl2x(1.0L, 2.0L));
+
     enum yl2xp1_supported = yl2x_supported;
 
     static void yl2x(const real_t* x, const real_t* y, real_t* res) pure


### PR DESCRIPTION
If the AArch64 native compiler is to be a cross compiler to the x86_64, it will have to emulate the x87.