### PR TITLE
Fix #22667: hdrgen: Skip using typedefIdent for basic types

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5075,17 +5075,10 @@ final class CParser(AST) : Parser!AST
             if (pt && *pt)
                 t = *pt;
         }
-        if (t.mcache && t.mcache.typedefIdent)
-        {
-            t = t.copy();
-            t.mcache = null;
-        }
-        else if (t.isTypeBasic())
-        {
-            // Basic types like void, int, etc. are global shared instances.
-            // Copy before setting typedefIdent to avoid polluting the shared type.
-            t = t.copy();
-        }
+if ((t.mcache && t.mcache.typedefIdent) || t.isTypeBasic()) {
+    t = t.copy();
+    t.mcache = null;
+}
         t.getMcache().typedefIdent = id;
         auto tab = cast(void*[void*])(typedefTab[$ - 1]);
         tab[cast(void*)id] = cast(void*)t;

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5075,10 +5075,10 @@ final class CParser(AST) : Parser!AST
             if (pt && *pt)
                 t = *pt;
         }
-if ((t.mcache && t.mcache.typedefIdent) || t.isTypeBasic()) {
-    t = t.copy();
-    t.mcache = null;
-}
+        if ((t.mcache && t.mcache.typedefIdent) || t.isTypeBasic()) {
+            t = t.copy();
+            t.mcache = null;
+        }
         t.getMcache().typedefIdent = id;
         auto tab = cast(void*[void*])(typedefTab[$ - 1]);
         tab[cast(void*)id] = cast(void*)t;

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5080,6 +5080,12 @@ final class CParser(AST) : Parser!AST
             t = t.copy();
             t.mcache = null;
         }
+        else if (t.isTypeBasic())
+        {
+            // Basic types like void, int, etc. are global shared instances.
+            // Copy before setting typedefIdent to avoid polluting the shared type.
+            t = t.copy();
+        }
         t.getMcache().typedefIdent = id;
         auto tab = cast(void*[void*])(typedefTab[$ - 1]);
         tab[cast(void*)id] = cast(void*)t;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4082,6 +4082,7 @@ struct HdrGenState final
     bool fullDump;
     bool importcHdr;
     bool inCAlias;
+    bool inFuncReturn;
     bool doFuncBodies;
     bool vcg_ast;
     bool skipConstraints;
@@ -4101,6 +4102,7 @@ struct HdrGenState final
         fullDump(),
         importcHdr(),
         inCAlias(),
+        inFuncReturn(),
         doFuncBodies(),
         vcg_ast(),
         skipConstraints(),
@@ -4116,12 +4118,13 @@ struct HdrGenState final
         inEnumDecl()
     {
     }
-    HdrGenState(bool hdrgen, bool ddoc = false, bool fullDump = false, bool importcHdr = false, bool inCAlias = false, bool doFuncBodies = false, bool vcg_ast = false, bool skipConstraints = false, bool showOneMember = true, bool errorMsg = false, bool fullQual = false, int32_t tpltMember = 0, int32_t autoMember = 0, int32_t forStmtInit = 0, int32_t insideFuncBody = 0, int32_t insideAggregate = 0, bool declstring = false, EnumDeclaration* inEnumDecl = nullptr) :
+    HdrGenState(bool hdrgen, bool ddoc = false, bool fullDump = false, bool importcHdr = false, bool inCAlias = false, bool inFuncReturn = false, bool doFuncBodies = false, bool vcg_ast = false, bool skipConstraints = false, bool showOneMember = true, bool errorMsg = false, bool fullQual = false, int32_t tpltMember = 0, int32_t autoMember = 0, int32_t forStmtInit = 0, int32_t insideFuncBody = 0, int32_t insideAggregate = 0, bool declstring = false, EnumDeclaration* inEnumDecl = nullptr) :
         hdrgen(hdrgen),
         ddoc(ddoc),
         fullDump(fullDump),
         importcHdr(importcHdr),
         inCAlias(inCAlias),
+        inFuncReturn(inFuncReturn),
         doFuncBodies(doFuncBodies),
         vcg_ast(vcg_ast),
         skipConstraints(skipConstraints),

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -4547,7 +4547,7 @@ private void typeToBufferx(Type t, ref OutBuffer buf, ref HdrGenState hgs)
         buf.put("noreturn");
     }
 
-    if (hgs.importcHdr && !hgs.inCAlias && t.mcache && t.mcache.typedefIdent)
+    if (hgs.importcHdr && !hgs.inCAlias && t.mcache && t.mcache.typedefIdent && !t.isTypeBasic())
     {
         buf.put(t.mcache.typedefIdent.toString());
         return;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -4547,7 +4547,7 @@ private void typeToBufferx(Type t, ref OutBuffer buf, ref HdrGenState hgs)
         buf.put("noreturn");
     }
 
-    if (hgs.importcHdr && !hgs.inCAlias && t.mcache && t.mcache.typedefIdent && !t.isTypeBasic())
+    if (hgs.importcHdr && !hgs.inCAlias && t.mcache && t.mcache.typedefIdent && t.ty != Tvoid)
     {
         buf.put(t.mcache.typedefIdent.toString());
         return;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -58,6 +58,7 @@ struct HdrGenState
     bool fullDump;      /// true if generating a full AST dump file
     bool importcHdr;    /// true if generating a .di file from an ImportC file
     bool inCAlias;      /// Set to prevent ImportC translating typedefs as `alias X = X`
+    bool inFuncReturn;  /// Set when printing function return type to avoid typedef name
     bool doFuncBodies;  /// include function bodies in output
     bool vcg_ast;       /// write out codegen-ast
     bool skipConstraints;  // skip constraints when doing templates
@@ -4096,7 +4097,9 @@ private void visitFuncIdentWithPostfix(TypeFunction t, const char[] ident, ref O
         buf.write("static ");
     if (t.next)
     {
+        hgs.inFuncReturn = true;
         typeToBuffer(t.next, null, buf, hgs);
+        hgs.inFuncReturn = false;
         if (ident)
             buf.put(' ');
     }
@@ -4165,7 +4168,9 @@ private void visitFuncIdentWithPrefix(TypeFunction t, const Identifier ident, Te
     }
     else if (t.next)
     {
+        hgs.inFuncReturn = true;
         typeToBuffer(t.next, null, buf, hgs);
+        hgs.inFuncReturn = false;
         if (ident)
             buf.put(' ');
     }
@@ -4547,7 +4552,7 @@ private void typeToBufferx(Type t, ref OutBuffer buf, ref HdrGenState hgs)
         buf.put("noreturn");
     }
 
-    if (hgs.importcHdr && !hgs.inCAlias && t.mcache && t.mcache.typedefIdent && t.ty != Tvoid)
+    if (hgs.importcHdr && !hgs.inCAlias && !hgs.inFuncReturn && t.mcache && t.mcache.typedefIdent)
     {
         buf.put(t.mcache.typedefIdent.toString());
         return;

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -53,6 +53,8 @@ extern (C)
 		Callback cb = void;
 	}
 	extern __gshared int[cast(ULONG)3] arr;
+	alias _IO_lock_t = void;
+	void mylib_hello();
 	/+enum int __DATE__ = 1+/;
 	/+enum int __TIME__ = 1+/;
 	/+enum int __TIMESTAMP__ = 1+/;
@@ -131,3 +133,6 @@ int arr[(ULONG) 3];
 #define DEF 123
 #define SQL_DRIVER_STMT_ATTR_BASE   0x00004000  // 32-bit
 #define ABC 64
+
+typedef void _IO_lock_t;
+void mylib_hello(void);

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -57,6 +57,8 @@ extern (C)
 	void mylib_hello1();
 	alias NOPE2 = int;
 	int mylib_hello2();
+	int mylib_hello2();
+	int mylib_hello3(void*);
 	/+enum int __DATE__ = 1+/;
 	/+enum int __TIME__ = 1+/;
 	/+enum int __TIMESTAMP__ = 1+/;
@@ -141,3 +143,5 @@ void mylib_hello1(void);
 
 typedef int NOPE2;
 int mylib_hello2(void);
+
+void mylib_hello3(void*);

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -53,8 +53,10 @@ extern (C)
 		Callback cb = void;
 	}
 	extern __gshared int[cast(ULONG)3] arr;
-	alias _IO_lock_t = void;
-	void mylib_hello();
+	alias NOPE1 = void;
+	void mylib_hello1();
+	alias NOPE2 = int;
+	int mylib_hello2();
 	/+enum int __DATE__ = 1+/;
 	/+enum int __TIME__ = 1+/;
 	/+enum int __TIMESTAMP__ = 1+/;
@@ -134,5 +136,8 @@ int arr[(ULONG) 3];
 #define SQL_DRIVER_STMT_ATTR_BASE   0x00004000  // 32-bit
 #define ABC 64
 
-typedef void _IO_lock_t;
-void mylib_hello(void);
+typedef void NOPE1;
+void mylib_hello1(void);
+
+typedef int NOPE2;
+int mylib_hello2(void);

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -57,8 +57,7 @@ extern (C)
 	void mylib_hello1();
 	alias NOPE2 = int;
 	int mylib_hello2();
-	int mylib_hello2();
-	int mylib_hello3(void*);
+	void mylib_hello3(void*);
 	/+enum int __DATE__ = 1+/;
 	/+enum int __TIME__ = 1+/;
 	/+enum int __TIMESTAMP__ = 1+/;


### PR DESCRIPTION
When generating .di files from ImportC code, a typedef like `typedef void _IO_lock_t;` would cause all subsequent uses of `void` to incorrectly print as `_IO_lock_t` in function signatures. 

Fixes #22667 

