### PR TITLE
Speculatively call copy/move constructor when returning in foreach

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1687,6 +1687,15 @@ extern (D) void declareThis(FuncDeclaration fd, Scope* sc)
     fd.vthis.parent = fd;
     if (ad)
         fd.objc.selectorParameter = .objc.createSelectorParameter(fd, sc);
+
+    if (fd.fes && !fd.vthis._scope)
+    {
+        /* If foreach nested function, save the scope to allow outer semantic
+         * to access internal context pointer.
+         */
+        fd.vthis._scope = sc.copy();
+        fd.vthis._scope.setNoFree();
+    }
 }
 
 /****************************************************

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -975,7 +975,14 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                         if (funcdecl.vresult)
                         {
-                            Scope* scret = rs.fesFunc ? rs.fesFunc._scope : sc2;
+                            Scope* scret = sc2;
+
+                            if (rs.fesFunc)
+                            {
+                                // Borrow context pointer's scope for vresult.
+                                assert(rs.fesFunc.vthis);
+                                scret = rs.fesFunc.vthis._scope;
+                            }
 
                             // Create: return (vresult = exp, vresult);
                             exp = new ConstructExp(rs.loc, funcdecl.vresult, exp);

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2774,6 +2774,21 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                  *    return x; return 3;  // ok, x can be a value
                  */
             }
+
+            if (rs.fesFunc &&
+                (!tf.isRef || (fd.storage_class & STC.auto_)))
+            {
+                /* In foreach inside non-ref or auto ref functions,
+                 * invoke copy/move constructor but ignore errors.
+                 * This relaxes attributes for the nested function and
+                 * allows semantic3 to generate the copy.
+                 * If the parent's attributes reject such a copy,
+                 * semantic3 would still error out.
+                 */
+                const olderrors = global.startGagging();
+                doCopyOrMove(sc, rs.exp, rs.exp.type, false, true);
+                global.endGagging(olderrors);
+            }
         }
         else
         {

--- a/compiler/test/fail_compilation/issue22666.d
+++ b/compiler/test/fail_compilation/issue22666.d
@@ -1,0 +1,35 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/issue22666.d(25): Error: function `issue22666.V4.opApply(int delegate(Object) @safe dg)` is not callable using argument types `(int delegate(Object _) nothrow @system)`
+fail_compilation/issue22666.d(25):        cannot pass argument `int(Object _) => s` of type `int delegate(Object _) nothrow @system` to parameter `int delegate(Object) @safe dg`
+
+---
+*/
+struct S4
+{
+    this(ref inout S4) @system {}
+}
+
+struct V4
+{
+    int opApply(int delegate(Object) @safe dg)
+    {
+        return dg(null);
+    }
+}
+
+S4 h4()
+{
+    S4 s = S4();
+    foreach (_; V4())
+    {
+        return s;
+    }
+    return S4();
+}
+
+void main()
+{
+    h4();
+}

--- a/compiler/test/runnable/issue22639.d
+++ b/compiler/test/runnable/issue22639.d
@@ -1,0 +1,35 @@
+// REQUIRED_ARGS: -betterC
+
+struct Arr(T, int CAPACITY)
+{
+    int count = 0;
+    T[CAPACITY] items;
+    int opApply(scope int delegate(T) dg)
+    {
+        int result;
+        for (int i = 0; i < count; i++)
+            if ((result = dg(items[i])) != 0)
+                break;
+        return result;
+    }
+}
+
+struct Foo {}
+struct Bar {
+    Arr!(Foo*, 32) array;
+    Foo* get()
+    {
+        foreach(Foo* it; array)
+        {
+            return it;
+        }
+        return null;
+    }
+}
+
+Foo* foo;
+Bar bar;
+extern(C) void main()
+{
+    foo = bar.get();
+}


### PR DESCRIPTION
This PR speculatively calls the copy/move constructor when returning from a foreach in `auto ref` functions. This allows attribute inference to account for copy/move constructor calls in nested functions. Fixes #22639, and partially https://github.com/dlang/dmd/issues/22666#issuecomment-3979597765.

This is technically a breaking change. In the code below, the return inside foreach will assume it calls the copy constructor, even if `h4()` is eventually inferred `ref`.
```d
struct S4
{
    this(ref inout S4) @system {}
}

struct V4
{
    int opApply(int delegate(Object) @safe dg) @safe
    {
        return dg(null);
    }
}

S4 s;

auto ref h4()
{
    foreach (_; V4())
    {
        return s;
    }
    return s;
}

void main()
{
    h4();
}
```

With error output:
```
Error: function `V4.opApply(int delegate(Object) @safe dg)` is not callable using argument types `(int delegate(Object _) nothrow @system)
```

If this breakage is not desirable, I think we're temporarily stuck with #22642. Full bidirectional inference is rather hard, requiring equation solving between `h4`'s return type and `opApply`'s overload set.