### PR TITLE
Check member access for `__traits(getMember)` in `@safe` code

### DIFF
--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1095,6 +1095,18 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 // Prevent semantic() from replacing Symbol with its initializer
                 die.wantsym = true;
             ex = ex.expressionSemantic(scx);
+            if (ex)
+            {
+                import dmd.access : symbolIsVisible;
+                import dmd.safe : setUnsafe;
+                auto msym = getDsymbolWithoutExpCtx(ex);
+                // https://github.com/dlang/dmd/issues/19721
+                if (msym && !symbolIsVisible(sc, msym))
+                {
+                    if (sc.setUnsafe(false, e.loc, "accessing member `%s`", id))
+                        return ErrorExp.get();
+                }
+            }
             return ex;
         }
         else if (e.ident == Id.getVirtualFunctions ||

--- a/compiler/test/fail_compilation/getMember_private.d
+++ b/compiler/test/fail_compilation/getMember_private.d
@@ -1,0 +1,26 @@
+/*
+EXTRA_FILES: imports/fail5385.d
+TEST_OUTPUT:
+---
+fail_compilation/getMember_private.d(17): Error: accessing member `x` is not allowed in a `@safe` function
+fail_compilation/getMember_private.d(19): Error: accessing member `privX` is not allowed in a `@safe` function
+---
+*/
+
+import imports.a10169, imports.fail5385;
+
+B b;
+
+void f() @safe
+{
+    // instance field
+    __traits(getMember, b, "x")++;
+    // static field
+    __traits(getMember, C, "privX")++;
+}
+
+void g() @system // OK
+{
+    __traits(getMember, b, "x")++;
+    __traits(getMember, C, "privX")++;
+}


### PR DESCRIPTION
Fixes #19721.