### PR TITLE
fixed OPld_d in the wrong place

### DIFF
--- a/compiler/src/dmd/backend/arm/cod4.d
+++ b/compiler/src/dmd/backend/arm/cod4.d
@@ -1686,13 +1686,6 @@ void cdcnvt(ref CGstate cg, ref CodeBuilder cdb,elem* e, ref regm_t pretregs)
 
         case OPd_ld:    // call __extenddftf2
         case OPld_d:    // call __trunctfdf2
-            if (sz == 8 && tysize(e.E1.Ety) == 8)       // same size means no-op
-            {
-                codelem(cgstate,cdb,e.E1,pretregs,false);
-                freenode(e);
-                return;
-            }
-
             regm_t retregs1 = mask(32);
             codelem(cgstate,cdb,e.E1,retregs1,false);
             import dmd.backend.arm.cod1 : CLIB_A, callclib;

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -5770,6 +5770,7 @@ elem* callfunc(Loc loc,
                 e.E1 = el_una(OPs32_d, TYdouble, e.E2);
                 e.E1 = el_una(OPd_ld, TYreal, e.E1);
                 e.E2 = et;
+                assert(!(config.exe == EX_OSX64 && target.isAArch64)); // TODO AArch64
             }
             else if (op == OPyl2x || op == OPyl2xp1)
             {
@@ -5809,13 +5810,19 @@ elem* callfunc(Loc loc,
             e = constructVa_start(ep);
         else if (op == OPtoPrec)
         {
+            const bool RealIsDouble = _tysize[TYreal] == 8;
+            if (RealIsDouble)
+            {
+                assert(tybasic(ep.Ety) != TYreal);
+                assert(tybasic(tyret) != TYreal);
+            }
             static int X(int fty, int tty) { return fty * TMAX + tty; }
 
             final switch (X(tybasic(ep.Ety), tybasic(tyret)))
             {
             case X(TYfloat, TYfloat):     // float -> float
             case X(TYdouble, TYdouble):   // double -> double
-            case X(TYreal, TYreal): // real -> real
+            case X(TYreal, TYreal):       // real -> real
                 e = ep;
                 break;
 


### PR DESCRIPTION
I realized it was better to never generate OPd_ld or OPld_d in the first place for 8 byte reals.