### PR TITLE
Fix issue 22671 - Allow GC allocations in `if (__ctfe)` blocks in `@nogc` functions

### DIFF
--- a/changelog/dmd.nogc-ctfe-alloc.dd
+++ b/changelog/dmd.nogc-ctfe-alloc.dd
@@ -1,0 +1,18 @@
+GC allocations in `if (__ctfe)` blocks are now allowed in `@nogc` functions
+
+Code inside an `if (__ctfe)` block only runs at compile time (CTFE),
+where GC allocation is the only available mechanism.
+Previously, the compiler incorrectly rejected such allocations with a
+`@nogc` violation error:
+
+---
+@nogc int[] makeArray()
+{
+    if (__ctfe)
+        return new int[](10); // was incorrectly rejected
+    return null;
+}
+---
+
+This is now accepted. The GC allocation is only reachable during CTFE,
+so no runtime GC usage occurs.

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5180,6 +5180,7 @@ public:
     Expression* exp;
     size_t caseDim;
     FuncDeclaration* fesFunc;
+    bool inCtfeBlock;
     ReturnStatement* syntaxCopy() override;
     ReturnStatement* endsWithReturnStatement() override;
     void accept(Visitor* v) override;

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -846,7 +846,13 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         if (tret.ty == Terror)
                         {
                             // https://issues.dlang.org/show_bug.cgi?id=13702
+                            // https://issues.dlang.org/show_bug.cgi?id=22671
+                            // GC allocations inside `if (__ctfe)` blocks are always allowed
+                            const prevCtfeBlock = sc2.ctfeBlock;
+                            if (rs.inCtfeBlock)
+                                sc2.ctfeBlock = true;
                             exp = exp.checkGC(sc2);
+                            sc2.ctfeBlock = prevCtfeBlock;
                             continue;
                         }
 
@@ -971,7 +977,13 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                 checkReturnEscape(*sc2, exp, false);
                         }
 
+                        // https://issues.dlang.org/show_bug.cgi?id=22671
+                        // GC allocations inside `if (__ctfe)` blocks are always allowed
+                        const prevCtfeBlock = sc2.ctfeBlock;
+                        if (rs.inCtfeBlock)
+                            sc2.ctfeBlock = true;
                         exp = exp.checkGC(sc2);
+                        sc2.ctfeBlock = prevCtfeBlock;
 
                         if (funcdecl.vresult)
                         {

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -846,13 +846,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         if (tret.ty == Terror)
                         {
                             // https://issues.dlang.org/show_bug.cgi?id=13702
-                            // https://issues.dlang.org/show_bug.cgi?id=22671
-                            // GC allocations inside `if (__ctfe)` blocks are always allowed
-                            const prevCtfeBlock = sc2.ctfeBlock;
-                            if (rs.inCtfeBlock)
-                                sc2.ctfeBlock = true;
-                            exp = exp.checkGC(sc2);
-                            sc2.ctfeBlock = prevCtfeBlock;
+                            // https://github.com/dlang/dmd/issues/22671
+                            if (!rs.inCtfeBlock)
+                                exp = exp.checkGC(sc2);
                             continue;
                         }
 
@@ -977,13 +973,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                 checkReturnEscape(*sc2, exp, false);
                         }
 
-                        // https://issues.dlang.org/show_bug.cgi?id=22671
-                        // GC allocations inside `if (__ctfe)` blocks are always allowed
-                        const prevCtfeBlock = sc2.ctfeBlock;
-                        if (rs.inCtfeBlock)
-                            sc2.ctfeBlock = true;
-                        exp = exp.checkGC(sc2);
-                        sc2.ctfeBlock = prevCtfeBlock;
+                        // https://github.com/dlang/dmd/issues/22671
+                        if (!rs.inCtfeBlock)
+                            exp = exp.checkGC(sc2);
 
                         if (funcdecl.vresult)
                         {

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1309,6 +1309,7 @@ extern (C++) final class ReturnStatement : Statement
     Expression exp;
     size_t caseDim;
     FuncDeclaration fesFunc; // nested function for foreach it is in
+    bool inCtfeBlock;        /// set if return is inside an `if (__ctfe)` block
 
     extern (D) this(Loc loc, Expression exp) @safe
     {

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -519,6 +519,7 @@ public:
     Expression *exp;
     size_t caseDim;
     FuncDeclaration *fesFunc;   // nested function for foreach it is in
+    d_bool inCtfeBlock;
 
     ReturnStatement *syntaxCopy() override;
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2480,6 +2480,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         //printf("ReturnStatement.dsymbolSemantic() %s\n", toChars(rs));
 
+        rs.inCtfeBlock = sc.ctfeBlock;
+
         FuncDeclaration fd = sc.parent.isFuncDeclaration();
 
         if (fd.fes)

--- a/compiler/test/compilable/fix22671.d
+++ b/compiler/test/compilable/fix22671.d
@@ -1,0 +1,51 @@
+// https://issues.dlang.org/show_bug.cgi?id=22671
+// GC allocations inside `if (__ctfe)` blocks should be allowed in @nogc functions
+
+class Foo {}
+
+// Test 1: new class in @nogc function returning via if (__ctfe)
+@nogc Foo bar()
+{
+    if (__ctfe)
+    {
+        return new Foo();  // allowed - only runs at compile time
+    }
+    return null;
+}
+
+// Test 2: new array in @nogc void function
+@nogc void test_array()
+{
+    if (__ctfe)
+    {
+        int[] a = new int[](10);  // allowed
+    }
+}
+
+// Test 3: if (__ctfe) with else branch
+@nogc int test_with_else()
+{
+    if (__ctfe)
+    {
+        int[] a = new int[](5);  // allowed
+        return a[0];
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+// Test 4: rewritten `if (!__ctfe)` (compiler rewrites to `if (__ctfe)` internally)
+@nogc int test_not_ctfe()
+{
+    if (!__ctfe)
+    {
+        return 0;
+    }
+    else
+    {
+        int[] a = new int[](3);  // allowed - this is the ctfe branch
+        return cast(int) a.length;
+    }
+}

--- a/compiler/test/compilable/fix22671.d
+++ b/compiler/test/compilable/fix22671.d
@@ -1,4 +1,4 @@
-// https://issues.dlang.org/show_bug.cgi?id=22671
+// https://github.com/dlang/dmd/issues/22671
 // GC allocations inside `if (__ctfe)` blocks should be allowed in @nogc functions
 
 class Foo {}


### PR DESCRIPTION
## Problem

`@nogc` functions that allocate memory via the GC inside an `if (__ctfe)` block
were incorrectly rejected with a `@nogc` violation:

```d
@nogc int[] makeArray()
{
    if (__ctfe)
        return new int[](10); // Error: allocating with `new` causes a GC allocation in `@nogc` function
    return null;
}
```

Since `if (__ctfe)` code only ever runs at compile time (CTFE), and GC allocation
is the only way to allocate memory during CTFE, this should be allowed.

## Root Cause

`semantic3.d` has a post-pass loop over all `ReturnStatement`s collected in
`fd.returns`. It calls `checkGC(sc2)` using the function-level scope `sc2`,
which does **not** have `ctfeBlock = true` — even if the return statement was
inside an `if (__ctfe)` block. This caused the GC check to fire incorrectly.

The analogous `ExpressionStatement` path (e.g. `if (__ctfe) { new Foo(); }`)
was already correct, because those `checkGC` calls happen during statement
semantics with a scope that *does* have `ctfeBlock = true`.

## Fix

Added `bool inCtfeBlock` to `ReturnStatement` (following the same pattern
already used by `GotoStatement` and `LabelStatement`).

- **`statement.d`**: Added `inCtfeBlock` field to `ReturnStatement`
- **`statementsem.d`**: Set `rs.inCtfeBlock = sc.ctfeBlock` at the top of
  `visitReturn()`, capturing the scope state at the time the return statement
  is semantically analyzed
- **`semantic3.d`**: In the `fd.returns` post-pass loop, save/restore
  `sc2.ctfeBlock` and temporarily set it to `true` when `rs.inCtfeBlock` is
  set, before calling `checkGC`

## Test

`compiler/test/compilable/fix22671.d` covers:
- `return new ClassName()` inside `if (__ctfe)` in a `@nogc` function
- `new int[]()` array allocation inside `if (__ctfe)` in a `@nogc void` function
- `if (__ctfe) ... else ...` form
- `if (!__ctfe) ... else ...` form (which the compiler rewrites internally)

Verified that `@nogc` still correctly rejects GC allocations outside
`if (__ctfe)` blocks.

Fixes #22671
