### PR TITLE
release.yml: Use the dmd-revision from the build to create releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,4 +87,4 @@ jobs:
           artifacts: ${{ steps.list-artifacts.outputs.artifacts_directory }}/*
           artifactErrorsFailBuild: true
           tag: ${{ github.event.inputs.tag }}
-          commit: ${{ github.event.inputs.branch }}
+          commit: ${{ needs.build-all-releases.outputs.dmd-revision }}


### PR DESCRIPTION
When creating a new release where the "branch" to build from is the same as the tag, the release-action step fails because it expects the argument to either be a SHA or branch name.

```
Run ncipollo/release-action@v1
  with:
    token: ***
    name: DMD v2.112.1-rc.1
    prerelease: true
    body: Release of the reference D compiler
  
  | Component | Revision                                                         |
  | --------- | ---------------------------------------------------------------- |
  | DMD       | dlang/dmd@6bb9fd7d3b32539ffe1c6d4add6988a4c72460c6           |
  | Phobos    | dlang/phobos@12eb40b29556e210bf88c2bf08152ab0f27687ba     |
  
    artifacts: /home/runner/artifacts/*
    artifactErrorsFailBuild: true
    tag: v2.112.1-rc.1
    commit: v2.112.1-rc.1
    generateReleaseNotes: false
    immutableCreate: false
    makeLatest: legacy
    omitBody: false
    omitBodyDuringUpdate: false
    omitDraftDuringUpdate: false
    omitName: false
    omitNameDuringUpdate: false
    omitPrereleaseDuringUpdate: false
    removeArtifacts: false
    replacesArtifacts: true
    skipIfReleaseExists: false
    updateOnlyUnreleased: false
Error: Error 422: Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"} - https://docs.github.com/rest/releases/releases#create-a-release
```