### PR TITLE
Fix issue 22175 - require ref for void AA update callbacks

### DIFF
--- a/compiler/test/fail_compilation/fail22175.d
+++ b/compiler/test/fail_compilation/fail22175.d
@@ -1,0 +1,18 @@
+// https://github.com/dlang/dmd/issues/22175
+// void-returning update callback for AA must take value by ref
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail22175.d(14): Error: static assert:  "void-returning update callback must take ref parameter"
+---
+*/
+
+void main()
+{
+    int[int] aa;
+    // Regression guard: this callback shape must never compile.
+    static assert(
+        is(typeof(aa.update(1, () => 10, delegate void(int x) { x += 1; }))),
+        "void-returning update callback must take ref parameter"
+    );
+}

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -3544,10 +3544,12 @@ private enum bool isSafeCopyable(T) = is(typeof(() @safe { union U { T x; } T *x
  *      create = The callable to create a value for `key`.
  *               Must return V.
  *      update = The callable to call if `key` exists.
- *               Takes a V argument, returns a V or void.
+ *               Takes a ref V or V argument. Returns a V or void.
+ *               If it returns void, the parameter must be ref.
  */
 void update(K, V, C, U)(ref V[K] aa, K key, scope C create, scope U update)
-if (is(typeof(create()) : V) && (is(typeof(update(aa[K.init])) : V) || is(typeof(update(aa[K.init])) == void)))
+if (is(typeof(create()) : V) && (is(typeof(update(aa[K.init])) : V)
+    || (is(typeof(update(aa[K.init])) == void) && !is(typeof(update(V.init)) == void))))
 {
     bool found;
     auto p = _aaGetX(aa, key, found, create());
@@ -3568,7 +3570,7 @@ if (is(typeof(create()) : V) && (is(typeof(update(aa[K.init])) : V) || is(typeof
     // create
     aa.update("key",
         () => 1,
-        (int) {} // not executed
+        (ref int) {} // not executed
         );
     assert(aa["key"] == 1);
 
@@ -3590,7 +3592,7 @@ if (is(typeof(create()) : V) && (is(typeof(update(aa[K.init])) : V) || is(typeof
     // 'update' without changing value
     aa.update("key",
         () => 0, // not executed
-        (int) {
+        (ref int) {
             // do something else
         });
     assert(aa["key"] == 4);
@@ -3624,6 +3626,18 @@ if (is(typeof(create()) : V) && (is(typeof(update(aa[K.init])) : V) || is(typeof
     static assert(is(typeof(() { aais.update(S(1234), { return 1234; }, (ref int x) { x++; return x; }); })));
     static assert(!is(typeof(() @safe { aais.require(S(1234), 1234); })));
     static assert(!is(typeof(() @safe { aais.update(S(1234), { return 1234; }, (ref int x) { x++; return x; }); })));
+}
+
+// void-returning update callback must take parameter by ref (issue 22175)
+@safe unittest
+{
+    int[string] aa;
+    // void-returning by-value must be rejected
+    static assert(!is(typeof(() { aa.update("key", () => 0, (int v) { }); })));
+    // void-returning by-ref must be accepted
+    static assert(is(typeof(() { aa.update("key", () => 0, (ref int v) { }); })));
+    // non-void returning by-value is fine (value used to update)
+    static assert(is(typeof(() { aa.update("key", () => 0, (int v) => v * 2); })));
 }
 
 @safe unittest


### PR DESCRIPTION
Fixes dlang/dmd#22175

The update function for associative arrays currently accepts void-returning callbacks that take the value parameter by copy. This silently discards any mutations the user makes, which is a bug trap.

This change tightens the template constraint so that if the update callback returns void, it must accept its parameter by ref. Non-void-returning callbacks are unaffected, since they communicate the updated value through the return value.

Changes
druntime/src/object.d: Added && !is(typeof(update(V.init)) == void) to the template constraint for the update function. Updated the doc comment. Fixed two existing unit tests that used void+by-value callbacks, and added a regression unittest with three static asserts.
compiler/test/fail_compilation/fail22175.d: New fail_compilation test verifying that a void-returning, by-value callback is rejected at compile time.