### PR TITLE
Fix #22690: Use correct fstatat mangling on macOS/x64

### DIFF
--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -2008,12 +2008,14 @@ else version (Darwin)
         version (AArch64)
         {
             int fstat(int, stat_t*);
+            int fstatat(int, const scope char*, stat_t*, int);
             int lstat(const scope char*, stat_t*);
             int stat(const scope char*, stat_t*);
         }
         else
         {
             pragma(mangle, "fstat$INODE64") int fstat(int, stat_t*);
+            pragma(mangle, "fstatat$INODE64") int fstatat(int, const scope char*, stat_t*, int);
             pragma(mangle, "lstat$INODE64") int lstat(const scope char*, stat_t*);
             pragma(mangle, "stat$INODE64")  int stat(const scope char*, stat_t*);
         }
@@ -2021,11 +2023,11 @@ else version (Darwin)
     else
     {
         int fstat(int, stat_t*);
+        int fstatat(int, const scope char*, stat_t*, int);
         int lstat(const scope char*, stat_t*);
         int stat(const scope char*, stat_t*);
     }
     int   fchmodat(int, const scope char*, mode_t, int);
-    int   fstatat(int, const scope char*, stat_t*, int);
     int   futimens(int, ref const(timespec)[2]);
     int   mkdirat(int, const scope char*, mode_t);
     int   mkfifoat(int, const scope char*, mode_t);


### PR DESCRIPTION
DMD 2.112.0 has introduced declarations for `fstatat`, but the x64 version for macOS needs to be mangled with the "$INODE64" suffix (like the other "stat" functions) in order to match the correct `stat_t` layout.

See https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/sys/stat.h#L573

This fixes a regression in vibe-core that lead to its `listDirectory` function returning wrong file attributes with DMD 2.112.0 and LDC 1.42.0.