### PR TITLE
[`core.sys` docs] Build HTML with `-os=platform` flag

### DIFF
--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -222,40 +222,40 @@ $(DOC_OUTPUT_DIR)/core_sync_%.html : import/core/sync/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_bionic_%.html : import/core/sys/bionic/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=CRuntime_Bionic -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_%.html : import/core/sys/darwin/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=Darwin -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_mach_%.html : import/core/sys/darwin/mach/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=Darwin -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_netinet_%.html : import/core/sys/darwin/netinet/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=Darwin -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_sys_%.html : import/core/sys/darwin/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=Darwin -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_dragonflybsd_%.html : import/core/sys/dragonflybsd/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=DragonFlyBSD -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_dragonflybsd_netinet_%.html : import/core/sys/dragonflybsd/netinet/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=DragonFlyBSD -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_dragonflybsd_sys_%.html : import/core/sys/dragonflybsd/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=DragonFlyBSD -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_elf_%.html : import/core/sys/elf/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_freebsd_%.html : import/core/sys/freebsd/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=FreeBSD -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_freebsd_netinet_%.html : import/core/sys/freebsd/netinet/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=FreeBSD -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_freebsd_sys_%.html : import/core/sys/freebsd/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=FreeBSD -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_linux_%.html : import/core/sys/linux/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
@@ -267,16 +267,16 @@ $(DOC_OUTPUT_DIR)/core_sys_linux_sys_%.html : import/core/sys/linux/sys/%.d $(DM
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_netbsd_%.html : import/core/sys/netbsd/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=NetBSD -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_netbsd_sys_%.html : import/core/sys/netbsd/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=NetBSD -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_openbsd_%.html : import/core/sys/openbsd/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=OpenBSD -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_openbsd_sys_%.html : import/core/sys/openbsd/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=OpenBSD -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_posix_%.html : import/core/sys/posix/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
@@ -297,16 +297,16 @@ $(DOC_OUTPUT_DIR)/core_sys_posix_sys_%.html : import/core/sys/posix/sys/%.d $(DM
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_solaris_%.html : import/core/sys/solaris/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=Solaris -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_solaris_sys_%.html : import/core/sys/solaris/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=Solaris -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_windows_%.html : import/core/sys/windows/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=Windows -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_windows_stdc_%.html : import/core/sys/windows/stdc/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -version=Windows -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_thread.html : import/core/thread/package.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<

--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -249,7 +249,7 @@ $(DOC_OUTPUT_DIR)/core_sys_elf_%.html : import/core/sys/elf/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_freebsd_%.html : import/core/sys/freebsd/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -os=freebsd $@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=freebsd -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_freebsd_netinet_%.html : import/core/sys/freebsd/netinet/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -os=freebsd -Df$@ project.ddoc $(DOCFMT) $<

--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -225,37 +225,37 @@ $(DOC_OUTPUT_DIR)/core_sys_bionic_%.html : import/core/sys/bionic/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_%.html : import/core/sys/darwin/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=Darwin -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=OSX -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_mach_%.html : import/core/sys/darwin/mach/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=Darwin -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=OSX -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_netinet_%.html : import/core/sys/darwin/netinet/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=Darwin -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=OSX -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_sys_%.html : import/core/sys/darwin/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=Darwin -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=OSX -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_dragonflybsd_%.html : import/core/sys/dragonflybsd/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=DragonFlyBSD -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=dragonflybsd -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_dragonflybsd_netinet_%.html : import/core/sys/dragonflybsd/netinet/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=DragonFlyBSD -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=dragonflybsd -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_dragonflybsd_sys_%.html : import/core/sys/dragonflybsd/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=DragonFlyBSD -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=dragonflybsd -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_elf_%.html : import/core/sys/elf/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_freebsd_%.html : import/core/sys/freebsd/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=FreeBSD -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=freebsd $@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_freebsd_netinet_%.html : import/core/sys/freebsd/netinet/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=FreeBSD -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=freebsd -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_freebsd_sys_%.html : import/core/sys/freebsd/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=FreeBSD -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=freebsd -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_linux_%.html : import/core/sys/linux/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
@@ -266,17 +266,18 @@ $(DOC_OUTPUT_DIR)/core_sys_linux_netinet_%.html : import/core/sys/linux/netinet/
 $(DOC_OUTPUT_DIR)/core_sys_linux_sys_%.html : import/core/sys/linux/sys/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+# Note: no `-os=netbsd` option
 $(DOC_OUTPUT_DIR)/core_sys_netbsd_%.html : import/core/sys/netbsd/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=NetBSD -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_netbsd_sys_%.html : import/core/sys/netbsd/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=NetBSD -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_openbsd_%.html : import/core/sys/openbsd/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=OpenBSD -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=openbsd -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_openbsd_sys_%.html : import/core/sys/openbsd/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=OpenBSD -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=openbsd -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_posix_%.html : import/core/sys/posix/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
@@ -297,16 +298,16 @@ $(DOC_OUTPUT_DIR)/core_sys_posix_sys_%.html : import/core/sys/posix/sys/%.d $(DM
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_solaris_%.html : import/core/sys/solaris/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=Solaris -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=solaris -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_solaris_sys_%.html : import/core/sys/solaris/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=Solaris -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=solaris -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_windows_%.html : import/core/sys/windows/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=Windows -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=windows -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_windows_stdc_%.html : import/core/sys/windows/stdc/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=Windows -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=windows -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_thread.html : import/core/thread/package.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<

--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -222,7 +222,7 @@ $(DOC_OUTPUT_DIR)/core_sync_%.html : import/core/sync/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_bionic_%.html : import/core/sys/bionic/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -version=CRuntime_Bionic -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_%.html : import/core/sys/darwin/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -version=Darwin -Df$@ project.ddoc $(DOCFMT) $<

--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -225,16 +225,16 @@ $(DOC_OUTPUT_DIR)/core_sys_bionic_%.html : import/core/sys/bionic/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_%.html : import/core/sys/darwin/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -os=OSX -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=osx -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_mach_%.html : import/core/sys/darwin/mach/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -os=OSX -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=osx -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_netinet_%.html : import/core/sys/darwin/netinet/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -os=OSX -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=osx -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_darwin_sys_%.html : import/core/sys/darwin/sys/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -os=OSX -Df$@ project.ddoc $(DOCFMT) $<
+	$(DMD) $(DDOCFLAGS) -os=osx -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOC_OUTPUT_DIR)/core_sys_dragonflybsd_%.html : import/core/sys/dragonflybsd/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -os=dragonflybsd -Df$@ project.ddoc $(DOCFMT) $<

--- a/druntime/src/core/sys/freebsd/config.d
+++ b/druntime/src/core/sys/freebsd/config.d
@@ -14,7 +14,8 @@ public import core.sys.posix.config;
 // NOTE: When adding newer versions of FreeBSD, verify all current versioned
 // bindings are still compatible with the release.
 
-     version (FreeBSD_16) enum __FreeBSD_version = 1600011;
+     version (CoreDdoc)   enum __FreeBSD_version = 1600011; // keep at latest
+else version (FreeBSD_16) enum __FreeBSD_version = 1600011;
 else version (FreeBSD_15) enum __FreeBSD_version = 1500063;
 else version (FreeBSD_14) enum __FreeBSD_version = 1400097;
 else version (FreeBSD_13) enum __FreeBSD_version = 1301000;


### PR DESCRIPTION
Ignore `Posix` and `linux` as Linux is used to build docs already.

The generated files aren't linked to yet - that needs https://github.com/dlang/dlang.org/pull/4412.