### PR TITLE
Fix issue #22697 - Template cyclic error should not happen with pointers

### DIFF
--- a/compiler/src/dmd/dfa/fast/expression.d
+++ b/compiler/src/dmd/dfa/fast/expression.d
@@ -2020,7 +2020,7 @@ struct ExpressionWalker
 
                         if (baseVar !is null)
                         {
-                            if (baseVar.isNullable && !isTypeNullable(ce.to))
+                            if (baseVar.isNullable && !isPointerLike(ce.to))
                             {
                                 // This prevents pointer integer checks from infecting pointers
 
@@ -2493,7 +2493,7 @@ struct ExpressionWalker
                 dfaCommon.printStateln("This:");
                 DFALatticeRef thisExp = this.walk(thisPointer);
 
-                if (isTypeNullable(thisPointer.type))
+                if (isPointerLike(thisPointer.type))
                     thisExp = this.seeDereference(thisPointer.loc, thisExp);
 
                 this.seeConvergeFunctionCallArgument(thisExp, thisPointerInfo,

--- a/compiler/src/dmd/dfa/fast/statement.d
+++ b/compiler/src/dmd/dfa/fast/statement.d
@@ -477,7 +477,7 @@ final:
             TypeFunction tf = fd.type.isTypeFunction();
             assert(tf !is null);
 
-            var.isNullable = tf.isRef || isTypeNullable(tf.next);
+            var.isNullable = tf.isRef || isPointerLike(tf.next);
             scv = dfaCommon.acquireScopeVar(var);
 
             dfaCommon.printStructure((ref OutBuffer ob,

--- a/compiler/src/dmd/dfa/fast/structure.d
+++ b/compiler/src/dmd/dfa/fast/structure.d
@@ -3987,7 +3987,7 @@ struct DFAConsequence
 private:
 void applyType(DFAVar* var, VarDeclaration vd)
 {
-    var.isNullable = vd.isRef || isTypeNullable(vd.type);
+    var.isNullable = vd.isRef || isPointerLike(vd.type);
     var.isTruthy = isTypeTruthy(vd.type);
 
     var.isStaticArray = vd.type.isTypeSArray !is null;

--- a/compiler/src/dmd/dfa/utils.d
+++ b/compiler/src/dmd/dfa/utils.d
@@ -15,32 +15,7 @@ import dmd.mtype;
 import dmd.visitor;
 import dmd.identifier;
 import dmd.expression;
-import dmd.typesem : isFloating;
-
-/***********************************************************
- * Checks if a type is capable of being null at runtime.
- *
- * The DFA uses this to determine if a null-check is required
- * for a specific variable.
- *
- * Returns:
- *      true if the type is a pointer, array, class, delegate, etc.
- */
-bool isTypeNullable(Type type)
-{
-    if (type is null)
-        return false;
-
-    switch (type.ty)
-    {
-    case TY.Tarray, TY.Taarray, TY.Tpointer, TY.Treference, TY.Tfunction,
-            TY.Tclass, TY.Tdelegate:
-            return true;
-
-    default:
-        return false;
-    }
-}
+import dmd.typesem : isFloating, isPointerLike;
 
 /***********************************************************
  * Checks if a type can be evaluated as a boolean (truthy/falsey).
@@ -156,7 +131,7 @@ EqualityArgType equalityArgTypes(Type lhs, Type rhs)
         return EqualityArgType.DynamicArray;
     else if (lhs.ty == Taarray && rhs.ty == Taarray)
         return EqualityArgType.AssociativeArray;
-    else if (isTypeNullable(lhs))
+    else if (isPointerLike(lhs))
         return EqualityArgType.Nullable;
     else
         return EqualityArgType.Unknown;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -702,7 +702,17 @@ Scope* scopeCreateGlobal(Module _module, ErrorSink eSink)
  */
 void dsymbolSemantic(Dsymbol dsym, Scope* sc)
 {
-    scope v = new DsymbolSemanticVisitor(sc);
+    scope v = new DsymbolSemanticVisitor(sc, false);
+    dsym.accept(v);
+}
+
+/*************************************
+ * Does shallow semantic analysis on the public face of declarations.
+ * For pointer-like types, this skips deep semantic analysis of the pointee.
+ */
+void dsymbolSemantic(Dsymbol dsym, Scope* sc, bool shallow)
+{
+    scope v = new DsymbolSemanticVisitor(sc, shallow);
     dsym.accept(v);
 }
 
@@ -2019,9 +2029,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     alias visit = Visitor.visit;
 
     Scope* sc;
-    this(Scope* sc) scope @safe
+    bool shallow;
+    this(Scope* sc, bool shallow = false) scope @safe
     {
         this.sc = sc;
+        this.shallow = shallow;
     }
 
     override void visit(Dsymbol dsym)
@@ -2179,6 +2191,24 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (!sc)
             return;
+
+        /* Shallow semantic analysis for pointer-like field types.
+         * Pointer types (T*, T[], class, T[key], function, delegate) have known size (target.ptrsize)
+         *  without needing to analyze the pointee type.
+         * This prevents false-positive cyclic reference errors for valid recursive data structures.
+         */
+        if (shallow && dsym.isField() && isPointerLike(dsym.type))
+        {
+            // For pointer-like types, just resolve the type without deep pointee analysis
+            if (dsym.type)
+            {
+                if (!dsym.originalType)
+                    dsym.originalType = dsym.type.syntaxCopy();
+                dsym.type = dsym.type.typeSemantic(dsym.loc, sc);
+            }
+            dsym.semanticRun = PASS.semanticdone;
+            return;
+        }
 
         dsym.semanticRun = PASS.semantic;
 
@@ -7054,7 +7084,17 @@ bool determineFields(AggregateDeclaration ad)
             return 0;
 
         if (v.semanticRun < PASS.semanticdone)
-            v.dsymbolSemantic(null);
+        {
+            // For pointer-like field types, use shallow semantic to avoid
+            //  false-positive cyclic reference errors.
+            // Pointer types have a known size without needing to analyze the pointee type.
+            // The semantic analysis of the type,
+            //  should be triggered through other means.
+            if (isPointerLike(v.type))
+                dsymbolSemantic(v, null, true);
+            else
+                v.dsymbolSemantic(null);
+        }
         // Return in case a recursive determineFields triggered by v.semantic already finished
         if (ad.sizeok != Sizeok.none)
             return 1;

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -711,6 +711,26 @@ bool isComplex(Type _this)
     return false;
 }
 
+/*************************************
+ * Check if a type is pointer-like (has known fixed size without analyzing pointee).
+ * Pointer types (T*, T[], class, T[key], function, delegate) all have size target.ptrsize
+ * without needing to analyze the pointed-to type.
+ */
+bool isPointerLike(Type _this)
+{
+    if (_this is null)
+        return false;
+
+    switch (_this.ty)
+    {
+        case Tarray, Taarray, Tpointer, Treference, Tfunction, Tclass, Tdelegate:
+            return true;
+
+        default:
+            return false;
+    }
+}
+
 // Exposed as it is used in `expressionsem`
 MOD typeDeduceWild(Type _this, Type t, bool isRef)
 {

--- a/compiler/test/compilable/template_pointer_cycle.d
+++ b/compiler/test/compilable/template_pointer_cycle.d
@@ -1,0 +1,28 @@
+// Based upon the fail_compilation/ice4094.d test case,
+//  adds a pointer into the cyclic dependencies,
+//  which should break the cycle.
+
+struct Zug(int Z)
+{
+    // Pointer to Bug4094 - size is known without analyzing Bug4094's fields
+    Bug4094!(0)* hof;
+    int bahn;
+
+    // Make sure we can still access the enum, even though hof wasn't fully analyzed.
+    static assert(hof.GrabIt == 99);
+}
+
+struct Bug4094(int Q)
+{
+    // Direct containment of Zug - this is fine because Zug contains Bug4094*,
+    // not Bug4094 directly (indirection breaks the cycle)
+    Zug!(0) zug;
+
+    enum GrabIt = 99;
+}
+
+// We don't actually need to run this.
+void main()
+{
+    Zug!(0) z;
+}


### PR DESCRIPTION
I'll ping Walter if it passes CI. This is a particularly "interesting" change to semantic analysis.

Note: while this is marked as AI generated I did in fact come up with the solution, I merely let Kilo with Kimi 2.5 do the work, figuring out where and what to change. I did manually audit the code, such as comments.