### PR TITLE
[stable] Fix #22681 - Missing _d_cast lowering for ternary expressions

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -2092,7 +2092,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         const(bool) tob_isA = ((tob.isIntegral() || tob.isFloating()) && tob.ty != Tvector);
         const(bool) t1b_isA = ((t1b.isIntegral() || t1b.isFloating()) && t1b.ty != Tvector);
 
-        Expression ok()
+        CastExp ok()
         {
             auto result = new CastExp(e.loc, e, t);
             result.type = t; // Don't call semantic()
@@ -2134,17 +2134,16 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         if (AggregateDeclaration t1ad = isAggregate(t1b))
         {
             AggregateDeclaration toad = isAggregate(tob);
-            if (t1ad != toad && t1ad.aliasthis)
+            if (t1ad != toad)
             {
                 if (t1b.ty == Tclass && tob.ty == Tclass)
                 {
-                    ClassDeclaration t1cd = t1b.isClassHandle();
-                    ClassDeclaration tocd = tob.isClassHandle();
-                    int offset;
-                    if (tocd.isBaseOf(t1cd, &offset))
-                        return ok();
+                    auto ce = ok();
+                    lowerCastExp(ce, sc);
+                    return ce;
                 }
-                hasAliasThis = true;
+
+                hasAliasThis = t1ad.aliasthis !is null;
             }
         }
         else if (tob.ty == Tvector && t1b.ty != Tvector)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4077,7 +4077,7 @@ Package resolveIsPackage(Dsymbol sym)
  *  cex = the CastExp to lower
  *  sc = the current scope
  */
-private void lowerCastExp(CastExp cex, Scope* sc)
+package void lowerCastExp(CastExp cex, Scope* sc)
 {
     Type t1b = cex.e1.type.toBasetype();
     Type tob = cex.to.toBasetype();
@@ -7631,10 +7631,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 exp.type = tf.next;
                 auto casted_exp = exp.castTo(sc, t);
-                if (auto cex = lastComma(casted_exp).isCastExp())
-                {
-                    lowerCastExp(cex, sc);
-                }
                 result = Expression.combine(argprefix, casted_exp);
                 return;
             }
@@ -10045,11 +10041,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 ex = new CastExp(exp.loc, ex, exp.to);
                 ex.type = exp.to;
             }
-        }
-
-        if (auto cex = lastComma(ex).isCastExp())
-        {
-            lowerCastExp(cex, sc);
         }
 
         result = ex;

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -4633,7 +4633,7 @@ elem* toElemCast(CastExp ce, elem* e, bool isLvalue, ref IRState irs)
             e = el_bin(OPcomma, TYnptr, e, el_long(TYnptr, 0));
             return Lret(ce, e);
         }
-        else
+        else if (cdfrom !is cdto)
         {
             assert(ce.lowering, "This case should have been rewritten to `_d_cast` in the semantic phase");
         }

--- a/compiler/test/runnable/test22422.d
+++ b/compiler/test/runnable/test22422.d
@@ -16,6 +16,12 @@ C foo() {
     return cast(C) makeS()[0];
 }
 
+// https://github.com/dlang/dmd/issues/22681
+C foo22681(Object o) {
+    return cast(C) (o ? o : null);
+}
+
 void main() {
     assert(foo() is null);
+    assert(foo22681(new Object) is null);
 }


### PR DESCRIPTION
This seems to work, and potentially fix more issues than #22681 and earlier #22422, as there seems to be something wrong in general here. I'm not happy with it for `stable` though - it's quite a risk IMO. (And master doesn't have the earlier fix yet...) - Hence a draft for now.