### PR TITLE
add patch() to encapsulate awkward patching cdb into code list

### DIFF
--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -1753,12 +1753,7 @@ void assignaddrc(code* c)
                         // https://www.scs.stanford.edu/~zyedidia/arm64/encodingindex.html#addsub_shift
                         cdb.gen1(INSTR.addsub_shift(1,0,0,0,R16,0,BPorSP,reg)); // ADD reg,BPorSP,R16 https://www.scs.stanford.edu/~zyedidia/arm64/add_addsub_shift.html
 
-                        // Awkwardly replace c with cdb
-                        code* last = cdb.last();
-                        last.next = c.next;
-                        code* h = cdb.finish();
-                        c.Iop = h.Iop;
-                        c.next = h.next;
+                        cdb.patch(c);   // Replace c with cdb
                     }
                     else
                         c.Iop = INSTR.addsub_imm(1,0,0,0,imm12,BPorSP,reg); // ADD reg,BPorSP,#imm12

--- a/compiler/src/dmd/backend/codebuilder.d
+++ b/compiler/src/dmd/backend/codebuilder.d
@@ -116,6 +116,19 @@ assert(c.Iop != BADINS);
         }
     }
 
+    /***
+     * Replace instruction `c` with the code sequence in `this`.
+     */
+    @trusted
+    void patch(code* c)
+    {
+        code* last = this.last();
+        last.next = c.next;
+        code* h = this.finish();
+        *c = *h;                // overwrite head of c with start of cdb
+        c.next = h.next;
+    }
+
     void gen(code* cs)
     {
         /* this is a high usage routine */


### PR DESCRIPTION
Tweaking the internals of a data structure should be encapsulated in a member function.