### PR TITLE
Makefile: Add support for HOST_DFLAGS, and a new dmd-unittest target

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -72,9 +72,8 @@ if [[ "$HOST_DMD_VERSION" == "2.079.0" ]]; then
 fi
 
 cd "$DMD_DIR"
-"$HOST_DC" -m$MODEL compiler/src/build.d -ofgenerated/build.exe
-generated/build.exe -j$N MODEL=$MODEL HOST_DMD=$HOST_DC BUILD=debug "${disable_debug_for_unittests[@]}" unittest
-generated/build.exe -j$N MODEL=$MODEL HOST_DMD=$HOST_DC DFLAGS="-L-LARGEADDRESSAWARE" ENABLE_RELEASE=1 ENABLE_ASSERTS=1 dmd
+"$GNU_MAKE" -j$N MODEL=$MODEL HOST_DMD=$HOST_DC BUILD=debug "${disable_debug_for_unittests[@]}" dmd-unittest
+"$GNU_MAKE" -j$N MODEL=$MODEL HOST_DMD=$HOST_DC COMPILER_DFLAGS="-L-LARGEADDRESSAWARE" ENABLE_RELEASE=1 ENABLE_ASSERTS=1 dmd
 
 DMD_BIN_PATH="$DMD_DIR/generated/windows/release/$MODEL/dmd.exe"
 
@@ -94,11 +93,9 @@ cd "$DMD_DIR/compiler/test"
 
 # Rebuild dmd with ENABLE_COVERAGE for coverage tests
 if [ "${DMD_TEST_COVERAGE:-0}" = "1" ] ; then
-
     # Recompile debug dmd + unittests
     rm -rf "$DMD_DIR/generated/windows"
-    ../../generated/build.exe -j$N MODEL=$MODEL DFLAGS="-L-LARGEADDRESSAWARE" ENABLE_DEBUG=1 ENABLE_COVERAGE=1 dmd
-    ../../generated/build.exe -j$N MODEL=$MODEL DFLAGS="-L-LARGEADDRESSAWARE" ENABLE_DEBUG=1 ENABLE_COVERAGE=1 unittest
+    "$GNU_MAKE" -j$N -C "$DMD_DIR" MODEL=$MODEL HOST_DMD=$HOST_DC COMPILER_DFLAGS="-L-LARGEADDRESSAWARE" ENABLE_DEBUG=1 ENABLE_COVERAGE=1 dmd dmd-unittest
 fi
 
 "$HOST_DC" -m$MODEL -g -i run.d

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -73,7 +73,7 @@ fi
 
 cd "$DMD_DIR"
 "$GNU_MAKE" -j$N MODEL=$MODEL HOST_DMD=$HOST_DC BUILD=debug "${disable_debug_for_unittests[@]}" dmd-unittest
-"$GNU_MAKE" -j$N MODEL=$MODEL HOST_DMD=$HOST_DC COMPILER_DFLAGS="-L-LARGEADDRESSAWARE" ENABLE_RELEASE=1 ENABLE_ASSERTS=1 dmd
+"$GNU_MAKE" -j$N MODEL=$MODEL HOST_DMD=$HOST_DC HOST_DFLAGS="-L-LARGEADDRESSAWARE" ENABLE_RELEASE=1 ENABLE_ASSERTS=1 dmd
 
 DMD_BIN_PATH="$DMD_DIR/generated/windows/release/$MODEL/dmd.exe"
 
@@ -95,7 +95,7 @@ cd "$DMD_DIR/compiler/test"
 if [ "${DMD_TEST_COVERAGE:-0}" = "1" ] ; then
     # Recompile debug dmd + unittests
     rm -rf "$DMD_DIR/generated/windows"
-    "$GNU_MAKE" -j$N -C "$DMD_DIR" MODEL=$MODEL HOST_DMD=$HOST_DC COMPILER_DFLAGS="-L-LARGEADDRESSAWARE" ENABLE_DEBUG=1 ENABLE_COVERAGE=1 dmd dmd-unittest
+    "$GNU_MAKE" -j$N -C "$DMD_DIR" MODEL=$MODEL HOST_DMD=$HOST_DC HOST_DFLAGS="-L-LARGEADDRESSAWARE" ENABLE_DEBUG=1 ENABLE_COVERAGE=1 dmd dmd-unittest
 fi
 
 "$HOST_DC" -m$MODEL -g -i run.d

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -197,7 +197,7 @@ jobs:
         if [[ '${{ matrix.os }}' == macos-14 ]]; then
           # DMD doesn't work on arm64 yet. Make LDC host compiler cross-compile
           # DMD to x86_64, and then use implicit Rosetta emulation.
-          extraFlags=(COMPILER_DFLAGS="-mtriple=x86_64-apple-macos14")
+          extraFlags=(HOST_DFLAGS="-mtriple=x86_64-apple-macos14")
         fi
         make -C dmd    -j$N "${extraFlags[@]}"
         make -C phobos -j$N

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -193,11 +193,13 @@ jobs:
     - name: Build compiler & standard library
       run: |
         set -eux
+        extraFlags=()
         if [[ '${{ matrix.os }}' == macos-14 ]]; then
-          # don't try compiling a native arm64 DMD on macOS (doesn't work)
-          make -C dmd  -j$N dmd DFLAGS="-mtriple=x86_64-apple-macos14"
+          # DMD doesn't work on arm64 yet. Make LDC host compiler cross-compile
+          # DMD to x86_64, and then use implicit Rosetta emulation.
+          extraFlags=(COMPILER_DFLAGS="-mtriple=x86_64-apple-macos14")
         fi
-        make -C dmd    -j$N
+        make -C dmd    -j$N "${extraFlags[@]}"
         make -C phobos -j$N
 
     ########################################

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -215,10 +215,8 @@ jobs:
       if: runner.os != 'Windows' # not supported by build.d yet
       run: |
         set -eux
+        extraFlags=()
         if [[ '${{ matrix.os }}' == macos-14 ]]; then
-          # switch from LDC to freshly built DMD as host compiler
-          export HOST_DMD="$PWD/dmd/generated/osx/release/64/dmd"
-          export CXXFLAGS="-arch x86_64"
-          rm ./dmd/generated/osx/release/64/*.o
+          extraFlags=(HOST_DMD=ldmd2 DFLAGS="-mtriple=x86_64-apple-macos14" CXXFLAGS="-arch x86_64")
         fi
-        ./dmd/generated/build cxx-unittest
+        ./dmd/generated/build cxx-unittest "${extraFlags[@]}"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
 #     make -j$(nproc) dmd-test
 #
 # See compiler/src/build.d for variables affecting the compiler build.
+# Use COMPILER_DFLAGS (not DFLAGS) for extra flags (for the host compiler) to be used for the compiler build.
 
 include compiler/src/osmodel.mak
 
@@ -48,8 +49,15 @@ GENERATED:=generated
 BUILD_EXE:=$(GENERATED)/build$(EXE)
 RUN_EXE:=$(GENERATED)/run$(EXE)
 
+# forward any COMPILER_DFLAGS as DFLAGS for the build tool
+ifeq (,$(COMPILER_DFLAGS))
+    BUILD_CMD:=$(BUILD_EXE)
+else
+    BUILD_CMD:=$(BUILD_EXE) DFLAGS='$(COMPILER_DFLAGS)'
+endif
+
 .PHONY: all clean test html install \
-        dmd dmd-test druntime druntime-test \
+        dmd dmd-unittest dmd-test druntime druntime-test \
         auto-tester-build auto-tester-test buildkite-test \
         toolchain-info check-clean-git style
 
@@ -70,7 +78,7 @@ auto-tester-test:
 buildkite-test: test
 
 toolchain-info: $(BUILD_EXE)
-	$(BUILD_EXE) $@
+	$(BUILD_CMD) $@
 
 clean:
 	rm -rf $(GENERATED)
@@ -79,10 +87,12 @@ clean:
 	$(QUIET)"$(MAKE)" -C druntime clean
 
 dmd: $(BUILD_EXE)
-	$(BUILD_EXE) $@
+	$(BUILD_CMD) $@
 
-dmd-test: dmd druntime $(BUILD_EXE) $(RUN_EXE)
-	$(BUILD_EXE) unittest
+dmd-unittest: $(BUILD_EXE)
+	$(BUILD_CMD) unittest
+
+dmd-test: dmd-unittest dmd druntime $(RUN_EXE)
 	$(RUN_EXE) --environment
 
 druntime: dmd
@@ -94,7 +104,7 @@ druntime-test: dmd
 test: dmd-test druntime-test
 
 html: $(BUILD_EXE)
-	$(BUILD_EXE) $@
+	$(BUILD_CMD) $@
 
 # Creates Exuberant Ctags tags file
 tags: Makefile $(ECTAGS_FILES)
@@ -106,8 +116,8 @@ install:
 	echo "Darwin_64_32_disabled"
 else
 install: $(BUILD_EXE)
-	$(BUILD_EXE) man
-	$(BUILD_EXE) install INSTALL_DIR='$(if $(findstring $(OS),windows),$(shell cygpath -w '$(INSTALL_DIR)'),$(INSTALL_DIR))'
+	$(BUILD_CMD) man
+	$(BUILD_CMD) install INSTALL_DIR='$(if $(findstring $(OS),windows),$(shell cygpath -w '$(INSTALL_DIR)'),$(INSTALL_DIR))'
 	mkdir -p '$(INSTALL_DIR)'/man
 	cp -r $(GENERATED)/docs/man/* '$(INSTALL_DIR)'/man/
 	$(QUIET)"$(MAKE)" -C druntime install INSTALL_DIR='$(INSTALL_DIR)'
@@ -124,7 +134,7 @@ check-clean-git:
 	fi
 
 style: $(BUILD_EXE)
-	$(BUILD_EXE) $@
+	$(BUILD_CMD) $@
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 #     make -j$(nproc) dmd-test
 #
 # See compiler/src/build.d for variables affecting the compiler build.
-# Use COMPILER_DFLAGS (not DFLAGS) for extra flags (for the host compiler) to be used for the compiler build.
+# Use HOST_DFLAGS (not DFLAGS) for extra flags (for the host compiler) to be used for the compiler build.
 
 include compiler/src/osmodel.mak
 
@@ -49,11 +49,11 @@ GENERATED:=generated
 BUILD_EXE:=$(GENERATED)/build$(EXE)
 RUN_EXE:=$(GENERATED)/run$(EXE)
 
-# forward any COMPILER_DFLAGS as DFLAGS for the build tool
-ifeq (,$(COMPILER_DFLAGS))
+# forward any HOST_DFLAGS as DFLAGS for the build tool
+ifeq (,$(HOST_DFLAGS))
     BUILD_CMD:=$(BUILD_EXE)
 else
-    BUILD_CMD:=$(BUILD_EXE) DFLAGS='$(COMPILER_DFLAGS)'
+    BUILD_CMD:=$(BUILD_EXE) DFLAGS='$(HOST_DFLAGS)'
 endif
 
 .PHONY: all clean test html install \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -63,12 +63,10 @@ build() {
     if [ "$OS_NAME" != "windows" ]; then
         source ~/dlang/*/activate # activate host compiler, incl. setting `DMD`
     fi
-    $DMD compiler/src/build.d -ofgenerated/build
     if [ $unittest -eq 1 ]; then
-        generated/build -j$N MODEL=$MODEL HOST_DMD=$DMD DFLAGS="$CI_DFLAGS" BUILD=debug unittest
+        make -j$N MODEL=$MODEL HOST_DMD=$DMD COMPILER_DFLAGS="$CI_DFLAGS" BUILD=debug dmd-unittest
     fi
-    generated/build -j$N MODEL=$MODEL HOST_DMD=$DMD DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=${ENABLE_RELEASE:-1} dmd
-    make -j$N -C druntime MODEL=$MODEL
+    make -j$N MODEL=$MODEL HOST_DMD=$DMD COMPILER_DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=${ENABLE_RELEASE:-1}
     make -j$N -C ../phobos MODEL=$MODEL
     if [ "$OS_NAME" != "windows" ]; then
         deactivate # deactivate host compiler
@@ -93,7 +91,7 @@ rebuild() {
     cp $build_path/dmd$dotexe _${build_path}/host_dmd$dotexe
     cp $build_path/$conf _${build_path}/
     rm -rf $build_path
-    generated/build -j$N MODEL=$MODEL HOST_DMD=_${build_path}/host_dmd$dotexe DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=${ENABLE_RELEASE:-1} dmd
+    make -j$N MODEL=$MODEL HOST_DMD=_${build_path}/host_dmd$dotexe COMPILER_DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=${ENABLE_RELEASE:-1} dmd
 
     # compare binaries to test reproducible build
     if [ $compare -eq 1 ]; then

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -64,9 +64,9 @@ build() {
         source ~/dlang/*/activate # activate host compiler, incl. setting `DMD`
     fi
     if [ $unittest -eq 1 ]; then
-        make -j$N MODEL=$MODEL HOST_DMD=$DMD COMPILER_DFLAGS="$CI_DFLAGS" BUILD=debug dmd-unittest
+        make -j$N MODEL=$MODEL HOST_DMD=$DMD HOST_DFLAGS="$CI_DFLAGS" BUILD=debug dmd-unittest
     fi
-    make -j$N MODEL=$MODEL HOST_DMD=$DMD COMPILER_DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=${ENABLE_RELEASE:-1}
+    make -j$N MODEL=$MODEL HOST_DMD=$DMD HOST_DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=${ENABLE_RELEASE:-1}
     make -j$N -C ../phobos MODEL=$MODEL
     if [ "$OS_NAME" != "windows" ]; then
         deactivate # deactivate host compiler
@@ -91,7 +91,7 @@ rebuild() {
     cp $build_path/dmd$dotexe _${build_path}/host_dmd$dotexe
     cp $build_path/$conf _${build_path}/
     rm -rf $build_path
-    make -j$N MODEL=$MODEL HOST_DMD=_${build_path}/host_dmd$dotexe COMPILER_DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=${ENABLE_RELEASE:-1} dmd
+    make -j$N MODEL=$MODEL HOST_DMD=_${build_path}/host_dmd$dotexe HOST_DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=${ENABLE_RELEASE:-1} dmd
 
     # compare binaries to test reproducible build
     if [ $compare -eq 1 ]; then

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1203,16 +1203,8 @@ void parseEnvironment()
         env.setDefault("ENABLE_DEBUG", "1");
 
     // detect Model
-    auto model = env.setDefault("MODEL", detectModel);
-    if (env.getDefault("DFLAGS", "").canFind("-mtriple", "-march"))
-    {
-        // Don't pass `-m32|64` flag when explicitly passing triple or arch.
-        env["MODEL_FLAG"] = "";
-    }
-    else
-    {
-        env["MODEL_FLAG"] = "-m" ~ env["MODEL"];
-    }
+    const model = env.setDefault("MODEL", detectModel);
+    env["MODEL_FLAG"] = "-m" ~ model;
 
     // detect PIC
     version(Posix)
@@ -1371,7 +1363,7 @@ void processEnvironment()
     else
         env.setDefault("ZIP", "zip");
 
-    string[] dflags = ["-w", "-de", env["PIC_FLAG"], env["MODEL_FLAG"], "-J"~env["G"], "-I" ~ srcDir];
+    string[] dflags = ["-w", "-de", env["PIC_FLAG"], "-J"~env["G"], "-I" ~ srcDir];
 
     // TODO: add support for dObjc
     auto dObjc = false;
@@ -1438,13 +1430,17 @@ void processEnvironment()
         dflags ~= ["-fsanitize="~sanitizers];
     }
 
+    // Retain user-defined flags
+    const userDflags = flags.get("DFLAGS", []);
+    dflags ~= userDflags;
+
     // Determine the version of FreeBSD that we're building on if the target OS
     // version has not already been set.
     version (FreeBSD)
     {
         import std.ascii : isDigit;
 
-        if (flags.get("DFLAGS", []).find!(a => a.startsWith("-version=TARGET_FREEBSD"))().empty)
+        if (!userDflags.any!(f => f.startsWith("-version=TARGET_FREEBSD")))
         {
             // uname -K gives the kernel version, e.g. 1400097. The first two
             // digits correspond to the major version of the OS.
@@ -1455,8 +1451,11 @@ void processEnvironment()
         }
     }
 
-    // Retain user-defined flags
-    flags["DFLAGS"] = dflags ~= flags.get("DFLAGS", []);
+    // LDC errors when using `-m32|64` along with `-mtriple` or `-march`
+    if (!userDflags.any!(f => f.startsWith("-mtriple") || f.startsWith("-march")))
+        dflags ~= env["MODEL_FLAG"];
+
+    flags["DFLAGS"] = dflags;
 }
 
 /// Setup environment for a C++ compiler

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1475,7 +1475,7 @@ void processEnvironmentCxx()
 
     auto cxxFlags = warnings ~ [
         "-g", "-fno-exceptions", "-fno-rtti", "-fno-common", "-fasynchronous-unwind-tables", "-DMARS=1",
-        env["MODEL_FLAG"], env["PIC_FLAG"],
+        env["PIC_FLAG"],
     ];
 
     if (env.getNumberedBool("ENABLE_COVERAGE"))
@@ -1497,7 +1497,14 @@ void processEnvironmentCxx()
     }
 
     // Retain user-defined flags
-    flags["CXXFLAGS"] = cxxFlags ~= flags.get("CXXFLAGS", []);
+    const userCxxFlags = flags.get("CXXFLAGS", []);
+    cxxFlags ~= userCxxFlags;
+
+    // omit model flag with user-specified `-arch` for clang
+    if (!userCxxFlags.any!(f => f.startsWith("-arch")))
+        cxxFlags ~= env["MODEL_FLAG"];
+
+    flags["CXXFLAGS"] = cxxFlags;
 }
 
 /// Returns: the host C++ compiler, either "g++" or "clang++"


### PR DESCRIPTION
Previously, whenever wanting to specify extra D host-compiler flags for the DMD compiler build, one had to resort to the underlying `build.d` tool. The problem is that `DFLAGS` are very special and consumed by DMD internally, so when setting DFLAGS as env variable (implicit when setting it in the Make command-line), it would apply to all invocations of the *built* DMD (e.g., when building druntime right after the compiler build in the same Make run).

So introduce a ~~`COMPILER_DFLAGS`~~ `HOST_DFLAGS` Make variable for specifying extra flags (for the D host compiler) to be used for the compiler build.

Also add a new `dmd-unittest` convenience target.