### PR TITLE
remove usage of alloca() for AArch64 version

### DIFF
--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -1724,7 +1724,15 @@ void cdfunc(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 
     // Easier to deal with parameters as an array: parameters[0..np]
     int np = OTbinary(e.Eoper) ? el_nparams(e.E2) : 0;
-    Parameter* parameters = cast(Parameter*)alloca(np * Parameter.sizeof);
+    version (AArch64) // TODO AArch64
+    {
+        Parameter* parameters = cast(Parameter*)mem_malloc(np * Parameter.sizeof);
+        scope (exit) mem_free(parameters);
+    }
+    else
+    {
+        Parameter* parameters = cast(Parameter*)alloca(np * Parameter.sizeof);
+    }
     memset(parameters, 0, Parameter.sizeof * np);
 
     if (np)

--- a/compiler/src/dmd/backend/pdata.d
+++ b/compiler/src/dmd/backend/pdata.d
@@ -42,7 +42,10 @@ private bool symbol_iscomdat3(Symbol* s)
         config.flags4 & CFG4allcomdat && s.Sclass == SC.global;
 }
 
-enum ALLOCA_LIMIT = 0x10000;
+version (AArch64)
+    enum ALLOCA_LIMIT = 0;      // TODO AArch64
+else
+    enum ALLOCA_LIMIT = 0x10000;
 
 /**********************************
  * The .pdata section is used on Win64 by the VS debugger and dbghelp to get information
@@ -63,7 +66,7 @@ public void win64_pdata(Symbol* sf, targ_size_t localsize)
 
     // Generate the pdata name, which is $pdata$funcname
     size_t sflen = strlen(sf.Sident.ptr);
-    char* pdata_name = cast(char*)(sflen < ALLOCA_LIMIT ? alloca(7 + sflen + 1) : malloc(7 + sflen + 1));
+    char* pdata_name = cast(char*)(sflen >= ALLOCA_LIMIT ? malloc(7 + sflen + 1) : alloca(7 + sflen + 1));
     assert(pdata_name);
     memcpy(pdata_name, "$pdata$".ptr, 7);
     memcpy(pdata_name + 7, sf.Sident.ptr, sflen + 1);      // include terminating 0
@@ -108,7 +111,7 @@ private Symbol* win64_unwind(Symbol* sf, targ_size_t localsize)
 {
     // Generate the unwind name, which is $unwind$funcname
     size_t sflen = strlen(sf.Sident.ptr);
-    char* unwind_name = cast(char*)(sflen < ALLOCA_LIMIT ? alloca(8 + sflen + 1) : malloc(8 + sflen + 1));
+    char* unwind_name = cast(char*)(sflen >= ALLOCA_LIMIT ? malloc(8 + sflen + 1) : alloca(8 + sflen + 1));
     assert(unwind_name);
     memcpy(unwind_name, "$unwind$".ptr, 8);
     memcpy(unwind_name + 8, sf.Sident.ptr, sflen + 1);     // include terminating 0

--- a/compiler/src/dmd/backend/x86/cod1.d
+++ b/compiler/src/dmd/backend/x86/cod1.d
@@ -3384,7 +3384,15 @@ void cdfunc(ref CGstate cg, ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
 
     // Easier to deal with parameters as an array: parameters[0..np]
     int np = OTbinary(e.Eoper) ? el_nparams(e.E2) : 0;
-    Parameter* parameters = cast(Parameter*)alloca(np * Parameter.sizeof);
+    version (AArch64) // TODO AArch64
+    {
+        Parameter* parameters = cast(Parameter*)mem_malloc(np * Parameter.sizeof);
+        scope (exit) mem_free(parameters);
+    }
+    else
+    {
+        Parameter* parameters = cast(Parameter*)alloca(np * Parameter.sizeof);
+    }
     memset(parameters, 0,Parameter.sizeof * np);
 
     if (np)

--- a/compiler/src/dmd/glue/objc.d
+++ b/compiler/src/dmd/glue/objc.d
@@ -564,7 +564,8 @@ static:
 
         // create data
         auto dtb = DtBuilder(0);
-        dtb.nbytes(str.toStringz()[0 .. str.length + 1]);
+        dtb.nbytes(str);
+        dtb.nzeros(1);  // make it zero terminated
 
         // find segment
         auto seg = Segments[segment];
@@ -1605,44 +1606,4 @@ void xoffOrNull(ref DtBuilder dtb, Symbol* symbol) @safe
         dtb.xoff(symbol, 0);
     else
         dtb.size(0);
-}
-
-/**
- * Converts the given D string to a null terminated C string.
- *
- * Asserts if `str` is longer than `maxLength`, with assertions enabled. With
- * assertions disabled it will truncate the result to `maxLength`.
- *
- * Params:
- *  maxLength = the max length of `str`
- *  str = the string to convert
- *  buf = the buffer where to allocate the result. By default this will be
- *      allocated in the caller scope using `alloca`. If the buffer is created
- *      by the callee it needs to be able to fit at least `str.length + 1` bytes
- *
- * Returns: the given string converted to a C string, a slice of `str` or the
- *  given buffer `buffer`
- */
-const(char)* toStringz(size_t maxLength = 4095)(in const(char)[] str,
-    return scope void[] buffer = alloca(maxLength + 1)[0 .. maxLength + 1]) pure
-in
-{
-    assert(maxLength >= str.length);
-}
-out(result)
-{
-    assert(str.length == result.strlen);
-}
-do
-{
-    if (str.length == 0)
-        return "".ptr;
-
-    const maxLength = buffer.length - 1;
-    const len = str.length > maxLength ? maxLength : str.length;
-    auto buf = cast(char[]) buffer[0 .. len + 1];
-    buf[0 .. len] = str[0 .. len];
-    buf[len] = '\0';
-
-    return cast(const(char)*) buf.ptr;
 }

--- a/compiler/src/dmd/glue/tocsym.d
+++ b/compiler/src/dmd/glue/tocsym.d
@@ -567,7 +567,13 @@ private Symbol* createImport(Symbol* sym, Loc loc)
     const char* n = sym.Sident.ptr;
     import core.stdc.stdlib : alloca;
     const allocLen = 6 + strlen(n) + 1 + type_paramsize(sym.Stype).sizeof*3 + 1;
-    char* id = cast(char *) alloca(allocLen);
+    version (AArch64) // TODO AArch64
+    {
+        char* id = cast(char *) Mem.xmalloc(allocLen);
+        scope (exit) Mem.xfree(id);
+    }
+    else
+        char* id = cast(char *) alloca(allocLen);
     int idlen;
     if (target.os & Target.OS.Posix)
     {

--- a/compiler/src/dmd/glue/tocvdebug.d
+++ b/compiler/src/dmd/glue/tocvdebug.d
@@ -289,7 +289,13 @@ void cv_udt(const char* id, uint typidx)
         return cv8_udt(id, typidx);
 
     const len = strlen(id);
-    ubyte* debsym = cast(ubyte *) alloca(39 + IDOHD + len);
+    version (AArch64) // TODO AArch64
+    {
+        ubyte* debsym = cast(ubyte *) Mem.xmalloc(39 + IDOHD + len);
+        scope (exit) Mem.xfree(debsym);
+    }
+    else
+        ubyte* debsym = cast(ubyte *) alloca(39 + IDOHD + len);
 
     // Output a 'user-defined type' for the tag name
     TOWORD(debsym + 2,S_UDT);


### PR DESCRIPTION
I'm deferring implementing AArch64 alloca() for the moment.