### PR TITLE
[HTML docs] Generate missing files for `dmd` and `core`

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -961,7 +961,10 @@ alias html = makeRule!((htmlBuilder, htmlRule) {
         return htmlFilePrefix ~ ".html";
     }
     const stddocs = env.get("STDDOC", "").split();
-    auto docSources = .sources.common ~ .sources.root ~ .sources.lexer ~ .sources.dmd.all ~ env["D"].buildPath("frontend.d");
+    auto docSources = .sources.common ~ .sources.root ~ .sources.lexer ~ .sources.dmd.all
+        ~ env["D"].buildPath("astbase.d")
+        ~ env["D"].buildPath("cxxfrontend.d")
+        ~ env["D"].buildPath("frontend.d");
     htmlBuilder.deps(docSources.chunks(1).map!(sourceArray =>
         methodInit!(BuildRule, (docBuilder, docRule) {
             const source = sourceArray[0];
@@ -1572,9 +1575,9 @@ auto sourceFiles()
         "),
         frontend: fileArray(env["D"], "
             access.d aggregate.d aliasthis.d argtypes_x86.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d
-            arraytypes.d astenums.d ast_node.d astbase.d astcodegen.d asttypename.d attrib.d attribsem.d blockexit.d builtin.d canthrow.d chkformat.d
+            arraytypes.d astenums.d ast_node.d astcodegen.d asttypename.d attrib.d attribsem.d blockexit.d builtin.d canthrow.d chkformat.d
             cli.d clone.d compiler.d cond.d constfold.d  cpreprocess.d ctfeexpr.d
-            ctorflow.d cxxfrontend.d dcast.d dclass.d declaration.d delegatize.d denum.d deps.d dimport.d
+            ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d deps.d dimport.d
             dinterpret.d dmacro.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d dsymbolsem.d
             dtemplate.d dtoh.d dversion.d enumsem.d escape.d expression.d expressionsem.d func.d funcsem.d hdrgen.d
             impcnvtab.d imphint.d importc.d init.d initsem.d inline.d inlinecost.d intrange.d json.d lambdacomp.d

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1591,23 +1591,12 @@ auto sourceFiles()
             dfa/entry.d dfa/utils.d dfa/fast/structure.d dfa/fast/analysis.d dfa/fast/report.d dfa/fast/expression.d dfa/fast/statement.d
         "),
         backendHeaders: fileArray(env["C"], "
-            aarray.d arm/cod1.d arm/cod2.d arm/cod3.d arm/cod4.d arm/disasmarm.d arm/instr.d
-            backconfig.d barray.d bcomplex.d blockopt.d
-            cc.d cdef.d cgcs.d cgcse.d cgcv.d cg.d cgelem.d cgen.d cgsched.d codebuilder.d code.d cv4.d cv8.d
-            dcgcv.d dcode.d debugprint.d divcoeff.d dlist.d dout.d drtlsym.d dt.d dtype.d dvarstats.d dvec.d dwarf2.d dwarf.d dwarfdbginf.d dwarfeh.d
-            ee.d eh.d el.d elem.d elfobj.d elpicpie.d evalu8.d
-            fp.d
-            gdag.d gflow.d global.d glocal.d gloop.d go.d goh.d gother.d gsroa.d
-            iasm.d inliner.d
-            mach.d machobj.d melf.d mem.d mscoff.d mscoffobj.d
-            obj.d oper.d
-            pdata.d ptrntab.d
-            rtlsym.d
-            symbol.d symtab.d
-            ty.d type.d
-            util2.d
-            var.d
-            x86/cg87.d x86/cgcod.d x86/cgreg.d x86/cgxmm.d x86/cod1.d x86/cod2.d x86/cod3.d x86/cod4.d x86/cod5.d x86/code_x86.d x86/disasm86.d x86/nteh.d x86/xmm.d
+            cc.d cdef.d cgcv.d code.d dt.d el.d global.d
+            obj.d oper.d rtlsym.d iasm.d codebuilder.d
+            ty.d type.d dlist.d
+            dwarf.d dwarf2.d cv4.d
+            melf.d mscoff.d mach.d
+            x86/code_x86.d x86/xmm.d
         "),
     };
     foreach (member; __traits(allMembers, DmdSources))
@@ -1642,17 +1631,23 @@ auto sourceFiles()
             optional.h port.h rmem.h
         "),
         backend: fileArray(env["C"], "
-            bcomplex.d evalu8.d divcoeff.d dvec.d go.d gsroa.d glocal.d gdag.d gother.d gflow.d
-            dout.d inliner.d eh.d aarray.d
-            gloop.d cgelem.d cgcs.d ee.d blockopt.d mem.d cg.d
-            dtype.d debugprint.d fp.d symbol.d symtab.d elem.d dcode.d cgsched.d
-            pdata.d util2.d var.d backconfig.d drtlsym.d ptrntab.d
-            dvarstats.d cgen.d goh.d barray.d cgcse.d elpicpie.d
-            dwarfeh.d dwarfdbginf.d cv8.d dcgcv.d
-            machobj.d elfobj.d mscoffobj.d
-            x86/nteh.d x86/cgreg.d x86/cg87.d x86/cgxmm.d x86/disasm86.d
-            x86/cgcod.d x86/cod1.d x86/cod2.d x86/cod3.d x86/cod4.d x86/cod5.d
-            arm/disasmarm.d arm/instr.d arm/cod1.d arm/cod2.d arm/cod3.d arm/cod4.d
+            aarray.d arm/cod1.d arm/cod2.d arm/cod3.d arm/cod4.d arm/disasmarm.d arm/instr.d
+            backconfig.d barray.d bcomplex.d blockopt.d
+            cc.d cdef.d cgcs.d cgcse.d cgcv.d cg.d cgelem.d cgen.d cgsched.d codebuilder.d code.d cv4.d cv8.d
+            dcgcv.d dcode.d debugprint.d divcoeff.d dlist.d dout.d drtlsym.d dt.d dtype.d dvarstats.d dvec.d dwarf2.d dwarf.d dwarfdbginf.d dwarfeh.d
+            ee.d eh.d el.d elem.d elfobj.d elpicpie.d evalu8.d
+            fp.d
+            gdag.d gflow.d global.d glocal.d gloop.d go.d goh.d gother.d gsroa.d
+            iasm.d inliner.d
+            mach.d machobj.d melf.d mem.d mscoff.d mscoffobj.d
+            obj.d oper.d
+            pdata.d ptrntab.d
+            rtlsym.d
+            symbol.d symtab.d
+            ty.d type.d
+            util2.d
+            var.d
+            x86/cg87.d x86/cgcod.d x86/cgreg.d x86/cgxmm.d x86/cod1.d x86/cod2.d x86/cod3.d x86/cod4.d x86/cod5.d x86/code_x86.d x86/disasm86.d x86/nteh.d x86/xmm.d
             "
         ),
     };

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1634,25 +1634,18 @@ auto sourceFiles()
             optional.h port.h rmem.h
         "),
         backend: fileArray(env["C"], "
-            aarray.d arm/cod1.d arm/cod2.d arm/cod3.d arm/cod4.d arm/disasmarm.d arm/instr.d
-            backconfig.d barray.d bcomplex.d blockopt.d
-            cc.d cdef.d cgcs.d cgcse.d cgcv.d cg.d cgelem.d cgen.d cgsched.d codebuilder.d code.d cv4.d cv8.d
-            dcgcv.d dcode.d debugprint.d divcoeff.d dlist.d dout.d drtlsym.d dt.d dtype.d dvarstats.d dvec.d dwarf2.d dwarf.d dwarfdbginf.d dwarfeh.d
-            ee.d eh.d el.d elem.d elfobj.d elpicpie.d evalu8.d
-            fp.d
-            gdag.d gflow.d global.d glocal.d gloop.d go.d goh.d gother.d gsroa.d
-            iasm.d inliner.d
-            mach.d machobj.d melf.d mem.d mscoff.d mscoffobj.d
-            obj.d oper.d
-            pdata.d ptrntab.d
-            rtlsym.d
-            symbol.d symtab.d
-            ty.d type.d
-            util2.d
-            var.d
-            x86/cg87.d x86/cgcod.d x86/cgreg.d x86/cgxmm.d x86/cod1.d x86/cod2.d x86/cod3.d x86/cod4.d x86/cod5.d x86/code_x86.d x86/disasm86.d x86/nteh.d x86/xmm.d
-            "
-        ),
+            bcomplex.d evalu8.d divcoeff.d dvec.d go.d gsroa.d glocal.d gdag.d gother.d gflow.d
+            dout.d inliner.d eh.d aarray.d
+            gloop.d cgelem.d cgcs.d ee.d blockopt.d mem.d cg.d
+            dtype.d debugprint.d fp.d symbol.d symtab.d elem.d dcode.d cgsched.d
+            pdata.d util2.d var.d backconfig.d drtlsym.d ptrntab.d
+            dvarstats.d cgen.d goh.d barray.d cgcse.d elpicpie.d
+            dwarfeh.d dwarfdbginf.d cv8.d dcgcv.d
+            machobj.d elfobj.d mscoffobj.d
+            x86/nteh.d x86/cgreg.d x86/cg87.d x86/cgxmm.d x86/disasm86.d
+            x86/cgcod.d x86/cod1.d x86/cod2.d x86/cod3.d x86/cod4.d x86/cod5.d
+            arm/disasmarm.d arm/instr.d arm/cod1.d arm/cod2.d arm/cod3.d arm/cod4.d
+        "),
     };
 
     return sources;

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1572,9 +1572,9 @@ auto sourceFiles()
         "),
         frontend: fileArray(env["D"], "
             access.d aggregate.d aliasthis.d argtypes_x86.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d
-            arraytypes.d astenums.d ast_node.d astcodegen.d asttypename.d attrib.d attribsem.d blockexit.d builtin.d canthrow.d chkformat.d
+            arraytypes.d astenums.d ast_node.d astbase.d astcodegen.d asttypename.d attrib.d attribsem.d blockexit.d builtin.d canthrow.d chkformat.d
             cli.d clone.d compiler.d cond.d constfold.d  cpreprocess.d ctfeexpr.d
-            ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d deps.d dimport.d
+            ctorflow.d cxxfrontend.d dcast.d dclass.d declaration.d delegatize.d denum.d deps.d dimport.d
             dinterpret.d dmacro.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d dsymbolsem.d
             dtemplate.d dtoh.d dversion.d enumsem.d escape.d expression.d expressionsem.d func.d funcsem.d hdrgen.d
             impcnvtab.d imphint.d importc.d init.d initsem.d inline.d inlinecost.d intrange.d json.d lambdacomp.d
@@ -1591,12 +1591,23 @@ auto sourceFiles()
             dfa/entry.d dfa/utils.d dfa/fast/structure.d dfa/fast/analysis.d dfa/fast/report.d dfa/fast/expression.d dfa/fast/statement.d
         "),
         backendHeaders: fileArray(env["C"], "
-            cc.d cdef.d cgcv.d code.d dt.d el.d global.d
-            obj.d oper.d rtlsym.d iasm.d codebuilder.d
-            ty.d type.d dlist.d
-            dwarf.d dwarf2.d cv4.d
-            melf.d mscoff.d mach.d
-            x86/code_x86.d x86/xmm.d
+            aarray.d arm/cod1.d arm/cod2.d arm/cod3.d arm/cod4.d arm/disasmarm.d arm/instr.d
+            backconfig.d barray.d bcomplex.d blockopt.d
+            cc.d cdef.d cgcs.d cgcse.d cgcv.d cg.d cgelem.d cgen.d cgsched.d codebuilder.d code.d cv4.d cv8.d
+            dcgcv.d dcode.d debugprint.d divcoeff.d dlist.d dout.d drtlsym.d dt.d dtype.d dvarstats.d dvec.d dwarf2.d dwarf.d dwarfdbginf.d dwarfeh.d
+            ee.d eh.d el.d elem.d elfobj.d elpicpie.d evalu8.d
+            fp.d
+            gdag.d gflow.d global.d glocal.d gloop.d go.d goh.d gother.d gsroa.d
+            iasm.d inliner.d
+            mach.d machobj.d melf.d mem.d mscoff.d mscoffobj.d
+            obj.d oper.d
+            pdata.d ptrntab.d
+            README.md rtlsym.d
+            symbol.d symtab.d
+            ty.d type.d
+            util2.d
+            var.d
+            x86/cg87.d x86/cgcod.d x86/cgreg.d x86/cgxmm.d x86/cod1.d x86/cod2.d x86/cod3.d x86/cod4.d x86/cod5.d x86/code_x86.d x86/disasm86.d x86/nteh.d x86/xmm.d
         "),
     };
     foreach (member; __traits(allMembers, DmdSources))

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1602,7 +1602,7 @@ auto sourceFiles()
             mach.d machobj.d melf.d mem.d mscoff.d mscoffobj.d
             obj.d oper.d
             pdata.d ptrntab.d
-            README.md rtlsym.d
+            rtlsym.d
             symbol.d symtab.d
             ty.d type.d
             util2.d

--- a/druntime/mak/DOCS
+++ b/druntime/mak/DOCS
@@ -27,23 +27,23 @@ DOCS=\
 	$(DOCDIR)\core_internal_abort.html \
 	$(DOCDIR)\core_internal_atomic.html \
 	$(DOCDIR)\core_internal_attributes.html \
+	$(DOCDIR)\core_internal_convert.html \
+	$(DOCDIR)\core_internal_dassert.html \
 	$(DOCDIR)\core_internal_destruction.html \
 	$(DOCDIR)\core_internal_entrypoint.html \
 	$(DOCDIR)\core_internal_execinfo.html \
 	$(DOCDIR)\core_internal_hash.html \
+	$(DOCDIR)\core_internal_lifetime.html \
 	$(DOCDIR)\core_internal_moving.html \
 	$(DOCDIR)\core_internal_newaa.html \
 	$(DOCDIR)\core_internal_parseoptions.html \
 	$(DOCDIR)\core_internal_postblit.html \
+	$(DOCDIR)\core_internal_qsort.html \
 	$(DOCDIR)\core_internal_spinlock.html \
 	$(DOCDIR)\core_internal_string.html \
 	$(DOCDIR)\core_internal_switch_.html \
-	$(DOCDIR)\core_internal_utf.html \
-	$(DOCDIR)\core_internal_convert.html \
-	$(DOCDIR)\core_internal_qsort.html \
 	$(DOCDIR)\core_internal_traits.html \
-	$(DOCDIR)\core_internal_lifetime.html \
-	$(DOCDIR)\core_internal_dassert.html \
+	$(DOCDIR)\core_internal_utf.html \
 	\
 	$(DOCDIR)\core_internal_array_capacity.html \
 	$(DOCDIR)\core_internal_array_casting.html \

--- a/druntime/mak/DOCS
+++ b/druntime/mak/DOCS
@@ -45,10 +45,12 @@ DOCS=\
 	$(DOCDIR)\core_internal_traits.html \
 	$(DOCDIR)\core_internal_utf.html \
 	\
+	$(DOCDIR)\core_internal_array_arrayassign.html \
 	$(DOCDIR)\core_internal_array_capacity.html \
 	$(DOCDIR)\core_internal_array_casting.html \
 	$(DOCDIR)\core_internal_array_comparison.html \
 	$(DOCDIR)\core_internal_array_concatenation.html \
+	$(DOCDIR)\core_internal_array_duplication.html \
 	$(DOCDIR)\core_internal_array_equality.html \
 	$(DOCDIR)\core_internal_array_operations.html \
 	$(DOCDIR)\core_internal_array_utils.html \
@@ -59,7 +61,7 @@ DOCS=\
 	$(DOCDIR)\core_internal_elf_io.html \
 	\
 	$(DOCDIR)\core_internal_util_array.html \
-	$(IMPDIR)\core\internal\util\math.d \
+	$(DOCDIR)\core_internal_util_math.html \
 	\
 	$(DOCDIR)\core_internal_vararg_aapcs64.html \
 	$(DOCDIR)\core_internal_vararg_sysv_x64.html \
@@ -86,6 +88,7 @@ DOCS=\
 	$(DOCDIR)\core_stdc_inttypes.html \
 	$(DOCDIR)\core_stdc_locale.html \
 	$(DOCDIR)\core_stdc_signal.html \
+	$(DOCDIR)\core_stdc_stdatomic.html \
 	$(DOCDIR)\core_stdc_stddef.html \
 	$(DOCDIR)\core_stdc_stdio.html \
 	$(DOCDIR)\core_stdc_string.html \
@@ -214,6 +217,7 @@ DOCS=\
 	$(DOCDIR)\core_sys_linux_ifaddrs.html \
 	$(DOCDIR)\core_sys_linux_io_uring.html \
 	$(DOCDIR)\core_sys_linux_link.html \
+	$(DOCDIR)\core_sys_linux_perf_event.html \
 	$(DOCDIR)\core_sys_linux_sched.html \
 	$(DOCDIR)\core_sys_linux_stdio.html \
 	$(DOCDIR)\core_sys_linux_string.html \

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -2396,7 +2396,7 @@ template _d_delstructImpl(T)
         private enum errorMessage = "Cannot delete struct if compiling without support for runtime type information!";
 
         /**
-         * TraceGC wrapper around $(REF _d_delstruct, core,lifetime,_d_delstructImpl).
+         * TraceGC wrapper around $(REF _d_delstruct, core,lifetime).
          *
          * Bugs:
          *   This function template was ported from a much older runtime hook that

--- a/druntime/src/core/thread/context.d
+++ b/druntime/src/core/thread/context.d
@@ -11,6 +11,7 @@
 
 module core.thread.context;
 
+///
 struct StackContext
 {
     void* bstack, tstack;


### PR DESCRIPTION
Also:
- sort list of `core.internal` targets.
- fix wrong REF link
- add a missing doc-comment