### PR TITLE
Implement `$` type inference

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -34,6 +34,7 @@ import dmd.globals;
 import dmd.hdrgen;
 import dmd.location;
 import dmd.impcnvtab;
+import dmd.id;
 import dmd.importc;
 import dmd.init;
 import dmd.intrange;
@@ -284,6 +285,33 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
         return result;
     }
 
+    Expression visitIdentifier(IdentifierExp e)
+    {
+        if (e.isDollarExp() && e.type && e.type.ty == Tvoid)
+            return (new TypeExp(e.loc, t)).expressionSemantic(sc);
+        return visit(e);
+    }
+
+    Expression visitCall(CallExp e)
+    {
+        if (e.e1.isDollarExp() && e.e1.type && e.e1.type.ty == Tvoid)
+        {
+            auto n = new CallExp(e.loc, new TypeExp(e.e1.loc, t), e.arguments);
+            return n.expressionSemantic(sc);
+        }
+        return visit(e);
+    }
+
+    Expression visitDotId(DotIdExp e)
+    {
+        if (e.e1.isDollarExp() && e.e1.type && e.e1.type.ty == Tvoid)
+        {
+            auto n = new DotIdExp(e.loc, new TypeExp(e.e1.loc, t), e.ident);
+            return n.expressionSemantic(sc);
+        }
+        return visit(e);
+    }
+
     switch (e.op)
     {
         default              : return visit            (e);
@@ -292,6 +320,10 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
         case EXP.function_   : return visitFunc        (e.isFuncExp());
         case EXP.arrayLiteral: return visitArrayLiteral(e.isArrayLiteralExp());
         case EXP.slice       : return visitSlice       (e.isSliceExp());
+        case EXP.identifier  : return visitIdentifier  (cast(IdentifierExp)e);
+        case EXP.dollar      : return visitIdentifier  (cast(IdentifierExp)e);
+        case EXP.call        : return visitCall        (e.isCallExp());
+        case EXP.dotIdentifier: return visitDotId      (e.isDotIdExp());
     }
 }
 
@@ -325,7 +357,15 @@ MATCH implicitConvTo(Expression e, Type t)
             error(e.loc, "`%s` is not an expression", e.toChars());
             e.type = Type.terror;
         }
-
+        if (e.type.ty == Tvoid)
+        {
+            if (e.isDollarExp() ||
+                (e.op == EXP.call && (cast(CallExp)e).e1.isDollarExp()) ||
+                (e.op == EXP.dotIdentifier && (cast(DotIdExp)e).e1.isDollarExp()))
+            {
+                return MATCH.convert;
+            }
+        }
         Expression ex = e.optimize(WANTvalue);
         if (ex.type.equals(t))
         {
@@ -3280,12 +3320,54 @@ Expression inferType(Expression e, Type t, int flag = 0)
         return ce;
     }
 
+    Expression visitDollar(DollarExp de)
+    {
+        // $ with a known target type becomes a TypeExp
+        // This allows $(args) for construction and $.member for member access
+        if (t)
+            return new TypeExp(de.loc, t);
+        return de;
+    }
+
+    Expression visitDotId(DotIdExp die)
+    {
+        // Handle $.ident - infer $ from the context type
+        // Note: DollarExp extends IdentifierExp, so we check the identifier
+        if (auto ie = die.e1.isIdentifierExp())
+        {
+            if (ie.ident == Id.dollar && t)
+            {
+                die.e1 = inferType(die.e1, t, flag);
+            }
+        }
+        return die;
+    }
+
+    Expression visitCall(CallExp ce)
+    {
+        // Handle $(args) - infer $ from the context type
+        if (auto ie = ce.e1.isIdentifierExp())
+        {
+            if (ie.ident == Id.dollar && t)
+            {
+                ce.e1 = inferType(ce.e1, t, flag);
+            }
+        }
+        return ce;
+    }
+
+    // Handle DollarExp - note: DollarExp has op == EXP.identifier
+    if (auto de = e.isDollarExp())
+        return visitDollar(de);
+
     if (t) switch (e.op)
     {
         case EXP.arrayLiteral:      return visitAle(e.isArrayLiteralExp());
         case EXP.assocArrayLiteral: return visitAar(e.isAssocArrayLiteralExp());
         case EXP.function_:         return visitFun(e.isFuncExp());
         case EXP.question:          return visitTer(e.isCondExp());
+        case EXP.dotIdentifier:     return visitDotId(e.isDotIdExp());
+        case EXP.call:              return visitCall(e.isCallExp());
         default:
     }
     return e;

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -3340,6 +3340,12 @@ Expression inferType(Expression e, Type t, int flag = 0)
                 die.e1 = inferType(die.e1, t, flag);
             }
         }
+        else if (die.e1.op == EXP.call || die.e1.op == EXP.dotIdentifier)
+        {
+            // Handle chained expressions like $.a(10).b(20) or $.a.b.c
+            // Recursively infer type for the left side
+            die.e1 = inferType(die.e1, t, flag);
+        }
         return die;
     }
 
@@ -3352,6 +3358,11 @@ Expression inferType(Expression e, Type t, int flag = 0)
             {
                 ce.e1 = inferType(ce.e1, t, flag);
             }
+        }
+        else if (ce.e1.op == EXP.call || ce.e1.op == EXP.dotIdentifier)
+        {
+            // Handle chained calls like $.a(10)(20) or $.a.b(20)
+            ce.e1 = inferType(ce.e1, t, flag);
         }
         return ce;
     }

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -3318,6 +3318,8 @@ Expression inferType(Expression e, Type t, int flag = 0)
         // Only do this for aggregate types (struct, enum, class), not basic types
         if (t)
         {
+            if (t.ty == Tstruct || t.ty == Tenum || t.ty == Tclass)
+                return new TypeExp(de.loc, t);
             Type tb = t.toBasetype();
             if (tb.ty == Tstruct || tb.ty == Tenum || tb.ty == Tclass)
                 return new TypeExp(de.loc, t);
@@ -3327,14 +3329,13 @@ Expression inferType(Expression e, Type t, int flag = 0)
 
     Expression visitDotId(DotIdExp die)
     {
-        // Handle $.ident - infer $ from the context type
-        // Note: DollarExp extends IdentifierExp, so we check the identifier
-        if (auto ie = die.e1.isIdentifierExp())
+        if (die.e1.isDollarExp() && t)
         {
-            if (ie.ident == Id.dollar && t)
-            {
-                die.e1 = inferType(die.e1, t, flag);
-            }
+            if (t.ty == Tstruct || t.ty == Tenum || t.ty == Tclass)
+                return new DotIdExp(die.loc, new TypeExp(die.e1.loc, t), die.ident);
+            Type tb = t.toBasetype();
+            if (tb.ty == Tstruct || tb.ty == Tenum || tb.ty == Tclass)
+                return new DotIdExp(die.loc, new TypeExp(die.e1.loc, t), die.ident);
         }
         return die;
     }
@@ -3342,12 +3343,13 @@ Expression inferType(Expression e, Type t, int flag = 0)
     Expression visitCall(CallExp ce)
     {
         // Handle $(args) - infer $ from the context type
-        if (auto ie = ce.e1.isIdentifierExp())
+        if (ce.e1.isDollarExp() && t)
         {
-            if (ie.ident == Id.dollar && t)
-            {
-                ce.e1 = inferType(ce.e1, t, flag);
-            }
+            if (t.ty == Tstruct || t.ty == Tenum || t.ty == Tclass)
+                return new CallExp(ce.loc, new TypeExp(ce.e1.loc, t), ce.arguments);
+            Type tb = t.toBasetype();
+            if (tb.ty == Tstruct || tb.ty == Tenum || tb.ty == Tclass)
+                return new CallExp(ce.loc, new TypeExp(ce.e1.loc, t), ce.arguments);
         }
         return ce;
     }

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -3313,9 +3313,7 @@ Expression inferType(Expression e, Type t, int flag = 0)
 
     Expression visitDollar(DollarExp de)
     {
-        // $ with a known target type becomes a TypeExp
-        // This allows $(args) for construction and $.member for member access
-        // Only do this for aggregate types (struct, enum, class), not basic types
+        // Handle $ - infer $ from the context type
         if (t)
         {
             if (t.ty == Tstruct || t.ty == Tenum || t.ty == Tclass)
@@ -3329,13 +3327,19 @@ Expression inferType(Expression e, Type t, int flag = 0)
 
     Expression visitDotId(DotIdExp die)
     {
+        // Handle $.ident - infer $ from the context type
         if (die.e1.isDollarExp() && t)
         {
             if (t.ty == Tstruct || t.ty == Tenum || t.ty == Tclass)
-                return new DotIdExp(die.loc, new TypeExp(die.e1.loc, t), die.ident);
-            Type tb = t.toBasetype();
-            if (tb.ty == Tstruct || tb.ty == Tenum || tb.ty == Tclass)
-                return new DotIdExp(die.loc, new TypeExp(die.e1.loc, t), die.ident);
+            {
+                die.e1 = new TypeExp(die.e1.loc, t);
+            }
+            else
+            {
+                Type tb = t.toBasetype();
+                if (tb.ty == Tstruct || tb.ty == Tenum || tb.ty == Tclass)
+                    die.e1 = new TypeExp(die.e1.loc, t);
+            }
         }
         return die;
     }
@@ -3346,10 +3350,15 @@ Expression inferType(Expression e, Type t, int flag = 0)
         if (ce.e1.isDollarExp() && t)
         {
             if (t.ty == Tstruct || t.ty == Tenum || t.ty == Tclass)
-                return new CallExp(ce.loc, new TypeExp(ce.e1.loc, t), ce.arguments);
-            Type tb = t.toBasetype();
-            if (tb.ty == Tstruct || tb.ty == Tenum || tb.ty == Tclass)
-                return new CallExp(ce.loc, new TypeExp(ce.e1.loc, t), ce.arguments);
+            {
+                ce.e1 = new TypeExp(ce.e1.loc, t);
+            }
+            else
+            {
+                Type tb = t.toBasetype();
+                if (tb.ty == Tstruct || tb.ty == Tenum || tb.ty == Tclass)
+                    ce.e1 = new TypeExp(ce.e1.loc, t);
+            }
         }
         return ce;
     }

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -285,13 +285,6 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
         return result;
     }
 
-    Expression visitIdentifier(IdentifierExp e)
-    {
-        if (e.isDollarExp() && e.type && e.type.ty == Tvoid)
-            return (new TypeExp(e.loc, t)).expressionSemantic(sc);
-        return visit(e);
-    }
-
     Expression visitCall(CallExp e)
     {
         if (e.e1.isDollarExp() && e.e1.type && e.e1.type.ty == Tvoid)
@@ -320,8 +313,6 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
         case EXP.function_   : return visitFunc        (e.isFuncExp());
         case EXP.arrayLiteral: return visitArrayLiteral(e.isArrayLiteralExp());
         case EXP.slice       : return visitSlice       (e.isSliceExp());
-        case EXP.identifier  : return visitIdentifier  (cast(IdentifierExp)e);
-        case EXP.dollar      : return visitIdentifier  (cast(IdentifierExp)e);
         case EXP.call        : return visitCall        (e.isCallExp());
         case EXP.dotIdentifier: return visitDotId      (e.isDotIdExp());
     }
@@ -3324,8 +3315,13 @@ Expression inferType(Expression e, Type t, int flag = 0)
     {
         // $ with a known target type becomes a TypeExp
         // This allows $(args) for construction and $.member for member access
+        // Only do this for aggregate types (struct, enum, class), not basic types
         if (t)
-            return new TypeExp(de.loc, t);
+        {
+            Type tb = t.toBasetype();
+            if (tb.ty == Tstruct || tb.ty == Tenum || tb.ty == Tclass)
+                return new TypeExp(de.loc, t);
+        }
         return de;
     }
 
@@ -3340,12 +3336,6 @@ Expression inferType(Expression e, Type t, int flag = 0)
                 die.e1 = inferType(die.e1, t, flag);
             }
         }
-        else if (die.e1.op == EXP.call || die.e1.op == EXP.dotIdentifier)
-        {
-            // Handle chained expressions like $.a(10).b(20) or $.a.b.c
-            // Recursively infer type for the left side
-            die.e1 = inferType(die.e1, t, flag);
-        }
         return die;
     }
 
@@ -3358,11 +3348,6 @@ Expression inferType(Expression e, Type t, int flag = 0)
             {
                 ce.e1 = inferType(ce.e1, t, flag);
             }
-        }
-        else if (ce.e1.op == EXP.call || ce.e1.op == EXP.dotIdentifier)
-        {
-            // Handle chained calls like $.a(10)(20) or $.a.b(20)
-            ce.e1 = inferType(ce.e1, t, flag);
         }
         return ce;
     }

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2328,8 +2328,28 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (inferred)
             {
+                bool hasDollarInit = false;
+                if (auto ei = dsym._init.isExpInitializer())
+                {
+                    if (ei.exp.isDollarExp() ||
+                        (ei.exp.op == EXP.call && (cast(CallExp)ei.exp).e1.isDollarExp()) ||
+                        (ei.exp.op == EXP.dotIdentifier && (cast(DotIdExp)ei.exp).e1.isDollarExp()))
+                    {
+                        hasDollarInit = true;
+                    }
+                }
+
+                if (hasDollarInit)
+                {
+                    .error(dsym.loc, "%s `%s` - `$` requires a known type context for inference, but type is inferred from initializer `%s`",
+                        dsym.kind, dsym.toPrettyChars, toChars(dsym._init));
+                    .errorSupplemental(dsym.loc, "`auto` does not provide a type context for `$`, consider using an explicit type", dsym.ident.toChars());
+                }
+                else
+                {
                 .error(dsym.loc, "%s `%s` - type `%s` is inferred from initializer `%s`, and variables cannot be of type `void`",
                     dsym.kind, dsym.toPrettyChars, dsym.type.toChars(), toChars(dsym._init));
+                }
             }
             else
                 .error(dsym.loc, "%s `%s` - variables cannot be of type `void`", dsym.kind, dsym.toPrettyChars);

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2347,8 +2347,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 }
                 else
                 {
-                .error(dsym.loc, "%s `%s` - type `%s` is inferred from initializer `%s`, and variables cannot be of type `void`",
-                    dsym.kind, dsym.toPrettyChars, dsym.type.toChars(), toChars(dsym._init));
+                    .error(dsym.loc, "%s `%s` - type `%s` is inferred from initializer `%s`, and variables cannot be of type `void`",
+                        dsym.kind, dsym.toPrettyChars, dsym.type.toChars(), toChars(dsym._init));
                 }
             }
             else

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -770,9 +770,9 @@ extern (C++) class IdentifierExp : Expression
 {
     Identifier ident;
 
-    extern (D) this(Loc loc, Identifier ident) scope @safe
+    extern (D) this(Loc loc, Identifier ident, EXP op = EXP.identifier) scope @safe
     {
-        super(loc, EXP.identifier);
+        super(loc, op);
         this.ident = ident;
     }
 
@@ -796,7 +796,7 @@ extern (C++) final class DollarExp : IdentifierExp
 {
     extern (D) this(Loc loc)
     {
-        super(loc, Id.dollar);
+        super(loc, Id.dollar, EXP.dollar);
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15583,8 +15583,33 @@ Expression binSemantic(BinExp e, Scope* sc)
     {
         printf("BinExp::semantic('%s')\n", e.toChars());
     }
+
+    static bool containsDollarExp(Expression exp)
+    {
+        if (!exp)
+            return false;
+        if (exp.isDollarExp())
+            return true;
+        if (auto ce = exp.isCallExp())
+            return containsDollarExp(ce.e1);
+        if (auto die = exp.isDotIdExp())
+            return containsDollarExp(die.e1);
+        return false;
+    }
+
     Expression e1x = e.e1.expressionSemantic(sc);
+    // If e1 has a type and e2 contains a DollarExp, infer type from e1
+    if (e1x.type && e1x.type.ty != Tvoid && e1x.type.ty != Terror && containsDollarExp(e.e2))
+    {
+        e.e2 = inferType(e.e2, e1x.type);
+    }
     Expression e2x = e.e2.expressionSemantic(sc);
+    // If e2 has a type and e1 is still void (could happen if e1 was DollarExp), infer type from e2
+    if (e2x.type && e2x.type.ty != Tvoid && e2x.type.ty != Terror && e1x.type && e1x.type.ty == Tvoid && containsDollarExp(e.e1))
+    {
+        e.e1 = inferType(e.e1, e2x.type);
+        e.e1 = e.e1.expressionSemantic(sc);
+    }
 
     // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
     if (e1x.op == EXP.type)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5385,6 +5385,27 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         result = e;
     }
 
+    override void visit(DollarExp exp)
+    {
+        static if (LOGSEMANTIC)
+        {
+            printf("DollarExp::semantic('%s')\n", exp.ident.toChars());
+        }
+
+        Dsymbol scopesym;
+        Dsymbol s = sc.search(exp.loc, exp.ident, scopesym);
+        if (s)
+        {
+            // if we found it, it's the expected length of an array slice, etc.
+            visit(cast(IdentifierExp)exp);
+            return;
+        }
+
+        // if not found, it's $ waiting for type inference via implicitCastTo
+        exp.type = Type.tvoid;
+        result = exp;
+    }
+
     override void visit(IdentifierExp exp)
     {
         static if (LOGSEMANTIC)
@@ -7766,6 +7787,17 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp.e1;
             return;
         }
+
+        if (exp.e1.type == Type.tvoid)
+        {
+            if (exp.e1.isDollarExp())
+            {
+                exp.type = Type.tvoid;
+                result = exp;
+                return;
+            }
+        }
+
         if (arrayExpressionSemantic(exp.arguments.peekSlice(), sc) ||
             preFunctionParameters(sc, exp.argumentList, global.errorSink))
             return setError();
@@ -15636,6 +15668,16 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
     if (Expression ex = unaSemantic(exp, sc))
         return ex;
 
+    if (exp.e1.type == Type.tvoid)
+    {
+        if (exp.e1.isDollarExp())
+        {
+            auto n = new DotIdExp(exp.loc, exp.e1, exp.ident);
+            n.type = Type.tvoid;
+            return n;
+        }
+    }
+
     if (!sc.inCfile && exp.ident == Id._mangleof)
     {
         // symbol.mangleof
@@ -16645,6 +16687,16 @@ bool checkValue(Expression e)
 
     if (e.type && e.type.toBasetype().ty == Tvoid)
     {
+        if (e.isDollarExp()) return false;
+        if (auto ce = e.isCallExp())
+        {
+            if (ce.e1.isDollarExp()) return false;
+        }
+        if (auto de = e.isDotIdExp())
+        {
+            if (de.e1.isDollarExp()) return false;
+        }
+
         error(e.loc, "expression `%s` is `void` and has no value", e.toErrMsg());
         //print(); assert(0);
         if (!global.gag)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5401,6 +5401,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
+        if (sc.scopesym && sc.scopesym.isArrayScopeSymbol())
+        {
+            visit(cast(IdentifierExp)exp);
+            return;
+        }
+
         // if not found, it's $ waiting for type inference via implicitCastTo
         exp.type = Type.tvoid;
         result = exp;
@@ -15662,6 +15668,22 @@ private Expression expressionSemanticWithParent(Expression e, Scope* sc, Express
     return v.result;
 }
 
+/******
+ * Check if an expression contains a DollarExp (for chained $ inference)
+ */
+private bool containsDollarExp(Expression e)
+{
+    if (!e)
+        return false;
+    if (e.isDollarExp())
+        return true;
+    if (auto ce = e.isCallExp())
+        return containsDollarExp(ce.e1);
+    if (auto die = e.isDotIdExp())
+        return containsDollarExp(die.e1);
+    return false;
+}
+
 private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
 {
     //printf("dotIdSemanticPropX() %s\n", toChars(exp));
@@ -15670,7 +15692,7 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
 
     if (exp.e1.type == Type.tvoid)
     {
-        if (exp.e1.isDollarExp())
+        if (exp.e1.isDollarExp() || containsDollarExp(exp.e1))
         {
             auto n = new DotIdExp(exp.loc, exp.e1, exp.ident);
             n.type = Type.tvoid;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15668,22 +15668,6 @@ private Expression expressionSemanticWithParent(Expression e, Scope* sc, Express
     return v.result;
 }
 
-/******
- * Check if an expression contains a DollarExp (for chained $ inference)
- */
-private bool containsDollarExp(Expression e)
-{
-    if (!e)
-        return false;
-    if (e.isDollarExp())
-        return true;
-    if (auto ce = e.isCallExp())
-        return containsDollarExp(ce.e1);
-    if (auto die = e.isDotIdExp())
-        return containsDollarExp(die.e1);
-    return false;
-}
-
 private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
 {
     //printf("dotIdSemanticPropX() %s\n", toChars(exp));
@@ -15692,7 +15676,7 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
 
     if (exp.e1.type == Type.tvoid)
     {
-        if (exp.e1.isDollarExp() || containsDollarExp(exp.e1))
+        if (exp.e1.isDollarExp())
         {
             auto n = new DotIdExp(exp.loc, exp.e1, exp.ident);
             n.type = Type.tvoid;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1975,6 +1975,30 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
         const(char)* lastprms = parametersTypeToChars(tf1.parameterList);
         const(char)* nextprms = parametersTypeToChars(tf2.parameterList);
 
+        bool hasDollarArg = false;
+        if (fargs)
+        {
+            foreach (arg; *fargs)
+            {
+                if (arg.isDollarExp() ||
+                    (arg.op == EXP.call && (cast(CallExp)arg).e1.isDollarExp()) ||
+                    (arg.op == EXP.dotIdentifier && (cast(DotIdExp)arg).e1.isDollarExp()))
+                {
+                    hasDollarArg = true;
+                    break;
+                }
+            }
+        }
+
+        if (hasDollarArg)
+        {
+            .error(loc, "`%s.%s` with inferred type from `$` matches multiple overloads:\n%s:     `%s%s%s`\nand:\n%s:     `%s%s%s`\n`$` type inference is ambiguous - consider using an explicit type cast",
+                s.parent.toPrettyChars(), s.ident.toChars(),
+                m.lastf.loc.toChars(), m.lastf.toPrettyChars(), lastprms, tf1.modToChars(),
+                m.nextf.loc.toChars(), m.nextf.toPrettyChars(), nextprms, tf2.modToChars());
+            return null;
+        }
+
         string match = "";
         final switch (m.last)
         {

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -4608,7 +4608,7 @@ string EXPtoString(EXP op)
         EXP.dotVariable : "dotvar",
         EXP.scope_ : "scope",
         EXP.identifier : "identifier",
-        EXP.dollar : "dollar",
+        EXP.dollar : "$",
         EXP.this_ : "this",
         EXP.super_ : "super",
         EXP.int64 : "long",

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -4608,6 +4608,7 @@ string EXPtoString(EXP op)
         EXP.dotVariable : "dotvar",
         EXP.scope_ : "scope",
         EXP.identifier : "identifier",
+        EXP.dollar : "dollar",
         EXP.this_ : "this",
         EXP.super_ : "super",
         EXP.int64 : "long",

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8172,8 +8172,6 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 break;
             }
         case TOK.dollar:
-            if (!inBrackets)
-                error("`$` is valid only inside [] of index or slice");
             e = new AST.DollarExp(loc);
             nextToken();
             break;
@@ -9754,6 +9752,7 @@ immutable PREC[EXP.max + 1] precedence =
     EXP.dotVariable : PREC.primary,
     EXP.scope_ : PREC.primary,
     EXP.identifier : PREC.primary,
+    EXP.dollar : PREC.primary,
     EXP.this_ : PREC.primary,
     EXP.super_ : PREC.primary,
     EXP.int64 : PREC.primary,

--- a/compiler/test/fail_compilation/dollarinfer.d
+++ b/compiler/test/fail_compilation/dollarinfer.d
@@ -1,0 +1,36 @@
+/*
+REQUIRED_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/dollarinfer.d(29): Error: `dollarinfer.ambig` with inferred type from `$` matches multiple overloads:
+fail_compilation/dollarinfer.d(25):     `dollarinfer.ambig(Data d)`
+and:
+fail_compilation/dollarinfer.d(26):     `dollarinfer.ambig(Other o)`
+`$` type inference is ambiguous - consider using an explicit type cast
+fail_compilation/dollarinfer.d(31): Error: variable `dollarinfer.main.unknown` - `$` requires a known type context for inference, but type is inferred from initializer `dollar.VALUE_A`
+fail_compilation/dollarinfer.d(31):        `auto` does not provide a type context for `$` - consider using an explicit type like `unknown = MyType.value`
+fail_compilation/dollarinfer.d(33): Error: no property `VALUE_C` for type `MyEnum`. Did you mean `MyEnum.VALUE_A` ?
+fail_compilation/dollarinfer.d(19):        enum `MyEnum` defined here
+fail_compilation/dollarinfer.d(35): Error: type `int` has no value
+fail_compilation/dollarinfer.d(35):        perhaps use `int.init`
+---
+*/
+
+enum MyEnum { VALUE_A, VALUE_B }
+struct Data { int x, y; }
+struct Other { int x, y; }
+
+void call(MyEnum m) {}
+void call(int i) {}
+void ambig(Data d) {}
+void ambig(Other o) {}
+
+void main() {
+    ambig($(1, 2));
+
+    auto unknown = $.VALUE_A;
+
+    MyEnum m = $.VALUE_C;
+
+    int x = $; 
+}

--- a/compiler/test/fail_compilation/dollarinfer.d
+++ b/compiler/test/fail_compilation/dollarinfer.d
@@ -8,7 +8,7 @@ and:
 fail_compilation/dollarinfer.d(26):     `dollarinfer.ambig(Other o)`
 `$` type inference is ambiguous - consider using an explicit type cast
 fail_compilation/dollarinfer.d(31): Error: variable `dollarinfer.main.unknown` - `$` requires a known type context for inference, but type is inferred from initializer `dollar.VALUE_A`
-fail_compilation/dollarinfer.d(31):        `auto` does not provide a type context for `$` - consider using an explicit type like `unknown = MyType.value`
+fail_compilation/dollarinfer.d(31):        `auto` does not provide a type context for `$`, consider using an explicit type
 fail_compilation/dollarinfer.d(33): Error: no property `VALUE_C` for type `MyEnum`. Did you mean `MyEnum.VALUE_A` ?
 fail_compilation/dollarinfer.d(19):        enum `MyEnum` defined here
 fail_compilation/dollarinfer.d(35): Error: type `int` has no value

--- a/compiler/test/fail_compilation/dollarinfer.d
+++ b/compiler/test/fail_compilation/dollarinfer.d
@@ -32,5 +32,5 @@ void main() {
 
     MyEnum m = $.VALUE_C;
 
-    int x = $; 
+    int x = $;
 }

--- a/compiler/test/fail_compilation/dollarinfer.d
+++ b/compiler/test/fail_compilation/dollarinfer.d
@@ -2,17 +2,16 @@
 REQUIRED_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/dollarinfer.d(29): Error: `dollarinfer.ambig` with inferred type from `$` matches multiple overloads:
-fail_compilation/dollarinfer.d(25):     `dollarinfer.ambig(Data d)`
+fail_compilation/dollarinfer.d(28): Error: `dollarinfer.ambig` with inferred type from `$` matches multiple overloads:
+fail_compilation/dollarinfer.d(24):     `dollarinfer.ambig(Data d)`
 and:
-fail_compilation/dollarinfer.d(26):     `dollarinfer.ambig(Other o)`
+fail_compilation/dollarinfer.d(25):     `dollarinfer.ambig(Other o)`
 `$` type inference is ambiguous - consider using an explicit type cast
-fail_compilation/dollarinfer.d(31): Error: variable `dollarinfer.main.unknown` - `$` requires a known type context for inference, but type is inferred from initializer `dollar.VALUE_A`
-fail_compilation/dollarinfer.d(31):        `auto` does not provide a type context for `$`, consider using an explicit type
-fail_compilation/dollarinfer.d(33): Error: no property `VALUE_C` for type `MyEnum`. Did you mean `MyEnum.VALUE_A` ?
-fail_compilation/dollarinfer.d(19):        enum `MyEnum` defined here
-fail_compilation/dollarinfer.d(35): Error: type `int` has no value
-fail_compilation/dollarinfer.d(35):        perhaps use `int.init`
+fail_compilation/dollarinfer.d(30): Error: variable `dollarinfer.main.unknown` - `$` requires a known type context for inference, but type is inferred from initializer `$.VALUE_A`
+fail_compilation/dollarinfer.d(30):        `auto` does not provide a type context for `$`, consider using an explicit type
+fail_compilation/dollarinfer.d(32): Error: no property `VALUE_C` for type `MyEnum`. Did you mean `MyEnum.VALUE_A` ?
+fail_compilation/dollarinfer.d(18):        enum `MyEnum` defined here
+fail_compilation/dollarinfer.d(34): Error: cannot cast expression `$` of type `void` to `int`
 ---
 */
 

--- a/compiler/test/runnable/dollarinfer.d
+++ b/compiler/test/runnable/dollarinfer.d
@@ -1,3 +1,9 @@
+struct HasSlicing {
+    int[] data;
+    auto opSlice(size_t i, size_t j) { return data[i .. j]; }
+    @property size_t opDollar() { return data.length; }
+}
+
 enum MyEnum { VALUE_A, VALUE_B, VALUE_C }
 
 struct Data {
@@ -46,4 +52,9 @@ void main() {
     assert(slice[0] == 20);
 
     assert(slice[$ - 1] == 50);
+
+    HasSlicing t;
+    t.data = [1, 2, 3, 4, 5];
+    auto x = t[0 .. $];
+    assert(x.length == 5);
 }

--- a/compiler/test/runnable/dollarinfer.d
+++ b/compiler/test/runnable/dollarinfer.d
@@ -1,0 +1,43 @@
+enum MyEnum { VALUE_A, VALUE_B, VALUE_C }
+
+struct Data { 
+    int x, y; 
+}
+
+struct Nested {
+    Data info;
+    MyEnum status;
+}
+
+void checkEnum(MyEnum m) {
+    assert(m == MyEnum.VALUE_B);
+}
+
+void checkStruct(Data d) {
+    assert(d.x == 10 && d.y == 20);
+}
+
+void main() {
+    Data data = $(1, 2);
+    assert(data.x == 1);
+    assert(data.y == 2);
+
+    MyEnum myenum = $.VALUE_A;
+    assert(myenum == MyEnum.VALUE_A);
+
+    checkEnum($.VALUE_B);
+    checkStruct($(10, 20));
+
+    Nested n = $($(100, 200), $.VALUE_C);
+    assert(n.info.x == 100);
+    assert(n.status == MyEnum.VALUE_C);
+
+    int[] pointerBitmap = [10, 20, 30, 40, 50];
+    
+    int[] slice = pointerBitmap[1 .. $]; 
+    assert(slice.length == 4);
+    assert(slice[0] == 20);
+    
+    assert(slice[$ - 1] == 50);
+
+}

--- a/compiler/test/runnable/dollarinfer.d
+++ b/compiler/test/runnable/dollarinfer.d
@@ -30,6 +30,11 @@ void checkStruct(Data d) {
     assert(d.x == 10 && d.y == 20);
 }
 
+MyEnum getB()
+{
+	return $.VALUE_B;
+}
+
 void main() {
     Data data = $(1, 2);
     assert(data.x == 1);
@@ -63,4 +68,6 @@ void main() {
     arr[$-1] = 5;
     int i = arr[idx(cast(uint)$-1)];
     assert(i == 5);
+
+    assert(getB() == $.VALUE_B);
 }

--- a/compiler/test/runnable/dollarinfer.d
+++ b/compiler/test/runnable/dollarinfer.d
@@ -1,7 +1,7 @@
 enum MyEnum { VALUE_A, VALUE_B, VALUE_C }
 
-struct Data { 
-    int x, y; 
+struct Data {
+    int x, y;
 }
 
 struct Nested {
@@ -11,6 +11,13 @@ struct Nested {
 
 void checkEnum(MyEnum m) {
     assert(m == MyEnum.VALUE_B);
+
+    switch (m)
+    {
+        case $.VALUE_A: assert(false); break;
+        case $.VALUE_B: assert(true); break;
+        default: assert(false);
+    }
 }
 
 void checkStruct(Data d) {
@@ -33,11 +40,10 @@ void main() {
     assert(n.status == MyEnum.VALUE_C);
 
     int[] pointerBitmap = [10, 20, 30, 40, 50];
-    
-    int[] slice = pointerBitmap[1 .. $]; 
+
+    int[] slice = pointerBitmap[1 .. $];
     assert(slice.length == 4);
     assert(slice[0] == 20);
-    
-    assert(slice[$ - 1] == 50);
 
+    assert(slice[$ - 1] == 50);
 }

--- a/compiler/test/runnable/dollarinfer.d
+++ b/compiler/test/runnable/dollarinfer.d
@@ -57,4 +57,10 @@ void main() {
     t.data = [1, 2, 3, 4, 5];
     auto x = t[0 .. $];
     assert(x.length == 5);
+
+    int idx(int i) { return i; }
+    int[42] arr;
+    arr[$-1] = 5;
+    int i = arr[idx(cast(uint)$-1)];
+    assert(i == 5);
 }


### PR DESCRIPTION
Following recent forum discussions regarding `.` type inference that sparked my interest, it was noted that the dot syntax conflicts with module scope resolution.

So after some digging, I found that using `$` had been suggested as a viable alternative in past discussions.

I couldn't find the original DIP (if there was any), so I decided to explore the feasibility of a `$` based implementation.

And it turns out the logic is suprisingly straightforward, and this PR demonstrates how it could be integrated.

To keep the scope manageable and code easy to read, the compiler will an error if the context is too ambiguous to resolve.

This was a fun week end project, I'm pretty excited about this feature.

https://forum.dlang.org/post/yegslrvshbtlqcchcufi@forum.dlang.org
