### PR TITLE
Druntime: Select newer NetBSD time bindings

### DIFF
--- a/druntime/src/core/sys/posix/stdc/time.d
+++ b/druntime/src/core/sys/posix/stdc/time.d
@@ -146,6 +146,7 @@ else version (FreeBSD)
 else version (NetBSD)
 {
     ///
+    pragma(mangle, "__tzset50")
     void tzset();                            // non-standard
     ///
     extern __gshared const(char)*[2] tzname; // non-standard

--- a/druntime/src/core/sys/posix/sys/select.d
+++ b/druntime/src/core/sys/posix/sys/select.d
@@ -268,7 +268,9 @@ else version (NetBSD)
             _p.fds_bits[--_n] = 0;
     }
 
+    pragma(mangle, "__pselect50")
     int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
+    pragma(mangle, "__select50")
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
 else version (OpenBSD)

--- a/druntime/src/core/sys/posix/sys/statvfs.d
+++ b/druntime/src/core/sys/posix/sys/statvfs.d
@@ -180,7 +180,9 @@ else version (NetBSD)
         ST_NOSUID = 2
     }
 
+    pragma(mangle, "__statvfs90")
     int statvfs (const char * file, statvfs_t* buf);
+    pragma(mangle, "__fstatvfs90")
     int fstatvfs (int fildes, statvfs_t *buf) @trusted;
 }
 else version (OpenBSD)

--- a/druntime/src/core/sys/posix/sys/time.d
+++ b/druntime/src/core/sys/posix/sys/time.d
@@ -160,9 +160,13 @@ else version (NetBSD)
         timeval it_value;
     }
 
+    pragma(mangle, "__getitimer50")
     int getitimer(int, itimerval*);
+    pragma(mangle, "__gettimeofday50")
     int gettimeofday(timeval*, void*); // timezone_t* is normally void*
+    pragma(mangle, "__setitimer50")
     int setitimer(int, const scope itimerval*, itimerval*);
+    pragma(mangle, "__utimes50")
     int utimes(const scope char*, ref const(timeval)[2]);
 }
 else version (OpenBSD)

--- a/druntime/src/core/sys/posix/sys/types.d
+++ b/druntime/src/core/sys/posix/sys/types.d
@@ -391,7 +391,7 @@ else version (NetBSD)
     alias clock_t = uint; // unsigned int
     alias id_t = long;
     alias key_t = c_long;
-    alias suseconds_t = c_long;
+    alias suseconds_t = int; // int
     alias useconds_t = uint;
 }
 else version (OpenBSD)

--- a/druntime/src/core/sys/posix/sys/types.d
+++ b/druntime/src/core/sys/posix/sys/types.d
@@ -388,7 +388,7 @@ else version (NetBSD)
 {
     alias fsblkcnt_t = ulong;
     alias fsfilcnt_t = ulong;
-    alias clock_t = c_long;
+    alias clock_t = uint; // unsigned int
     alias id_t = long;
     alias key_t = c_long;
     alias suseconds_t = c_long;

--- a/druntime/src/core/sys/posix/sys/types.d
+++ b/druntime/src/core/sys/posix/sys/types.d
@@ -251,7 +251,7 @@ else version (NetBSD)
     alias pid_t = int;
     //size_t (defined in core.stdc.stddef)
     alias ssize_t = c_long;
-    alias time_t = c_long;
+    alias time_t = long; // _BSD_TIME_T_ mapped to __int64_t
     alias uid_t = uint;
 }
 else version (OpenBSD)

--- a/druntime/src/core/sys/posix/time.d
+++ b/druntime/src/core/sys/posix/time.d
@@ -64,6 +64,7 @@ else version (FreeBSD)
 }
 else version (NetBSD)
 {
+    pragma(mangle, "__timegm50")
     time_t timegm(tm*); // non-standard
 }
 else version (OpenBSD)
@@ -378,14 +379,20 @@ else version (NetBSD)
     alias clockid_t = int; // <sys/_types.h>
     alias timer_t = int;
 
+    pragma(mangle, "__clock_getres50")
     int clock_getres(clockid_t, timespec*);
+    pragma(mangle, "__clock_gettime50")
     int clock_gettime(clockid_t, timespec*);
+    pragma(mangle, "__clock_settime50")
     int clock_settime(clockid_t, const scope timespec*);
+    pragma(mangle, "__nanosleep50")
     int nanosleep(const scope timespec*, timespec*);
     int timer_create(clockid_t, sigevent*, timer_t*);
     int timer_delete(timer_t);
+    pragma(mangle, "__timer_gettime50")
     int timer_gettime(timer_t, itimerspec*);
     int timer_getoverrun(timer_t);
+    pragma(mangle, "__timer_settime50")
     int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 }
 else version (OpenBSD)
@@ -576,8 +583,11 @@ else version (FreeBSD)
 else version (NetBSD)
 {
     char* asctime_r(const scope tm*, char*);
+    pragma(mangle, "__ctime_r50")
     char* ctime_r(const scope time_t*, char*);
+    pragma(mangle, "__gmtime_r50")
     tm*   gmtime_r(const scope time_t*, tm*);
+    pragma(mangle, "__localtime_r50")
     tm*   localtime_r(const scope time_t*, tm*);
 }
 else version (OpenBSD)


### PR DESCRIPTION
When building GDC on NetBSD 10, Druntime has bindings that are using the compatibility symbols, creating linking warnings. NetBSD had an ABI transition at some point regarding time related functions (5.0 to 6.0 made `time_t` 64-bit in 2008), and renamed some of these functions.

This series of small commits add pragma(mangle) to these newer symbols, which also fixes linking errors. Without them, D bindings link against compat stubs.

Tested on NetBSD 10 amd64 using GDC 15.2.

Resources:
- https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/lib/libc/README
- https://mail-index.netbsd.org/tech-userlevel/2008/03/22/msg000231.html
- https://www.netbsd.org/releases/formal-6/NetBSD-6.0.html