### PR TITLE
Add a configuration for the GC to try to keep its heap size below a certain size.

### DIFF
--- a/druntime/src/core/gc/config.d
+++ b/druntime/src/core/gc/config.d
@@ -25,6 +25,12 @@ struct Config
     @MemVal size_t minPoolSize = 1  << 20;  // initial and minimum pool size (bytes)
     @MemVal size_t maxPoolSize = 64 << 20;  // maximum pool size (bytes)
     @MemVal size_t incPoolSize = 3  << 20;  // pool size increment (bytes)
+
+    // Limit under which the GC will try to keep its heap (bytes)
+    // The GC does this on a best effort basis, and exceeding this size
+    // might lead to a performance cliff.
+    @MemVal size_t heapSizeLimit = size_t.max;
+
     uint parallel = 99;      // number of additional threads for marking (limited by cpuid.threadsPerCPU-1)
     float heapSizeFactor = 2.0; // heap size to used memory ratio
     string cleanup = "collect"; // select gc cleanup method none|collect|finalize

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -2113,10 +2113,25 @@ struct Gcx
      */
     void updateCollectThresholds() nothrow
     {
-        static float max(float a, float b) nothrow
-        {
-            return a >= b ? a : b;
-        }
+        import core.internal.util.math : min, max;
+
+        // Reserve half of the remaining heap budget to small and large heaps.
+        immutable maxPageUsed = config.heapSizeLimit / PAGESIZE;
+        immutable usedPages = usedSmallPages + usedLargePages;
+        immutable heapBudget = maxPageUsed > usedPages
+            ? maxPageUsed - usedPages
+            : 0;
+
+        immutable smTargetHeap = usedSmallPages + heapBudget / 2;
+        immutable lgTargetHeap = usedLargePages + heapBudget / 2;
+
+        // Compute the target sizes based on the growth factor.
+        immutable smTargetGrowth = usedSmallPages * config.heapSizeFactor;
+        immutable lgTargetGrowth = usedLargePages * config.heapSizeFactor;
+
+        // Collect when either is reached.
+        immutable smTarget = min(smTargetHeap, smTargetGrowth);
+        immutable lgTarget = min(lgTargetHeap, lgTargetGrowth);
 
         // instantly increases, slowly decreases
         static float smoothDecay(float oldVal, float newVal) nothrow
@@ -2128,9 +2143,7 @@ struct Gcx
             return max(newVal, decay);
         }
 
-        immutable smTarget = usedSmallPages * config.heapSizeFactor;
         smallCollectThreshold = smoothDecay(smallCollectThreshold, smTarget);
-        immutable lgTarget = usedLargePages * config.heapSizeFactor;
         largeCollectThreshold = smoothDecay(largeCollectThreshold, lgTarget);
     }
 


### PR DESCRIPTION
As per title. This has been a growing pain in containers that will OOM kill your application if the heap size gets too big.

This is imperfect, because it doesn't account for TLS, malloced memory and more, but all of this is deterministic, while the GC heap size really isn't.