### PR TITLE
add sections_darwin_rt.d

### DIFF
--- a/druntime/mak/DOCS
+++ b/druntime/mak/DOCS
@@ -579,7 +579,7 @@ DOCS=\
 	$(DOCDIR)\rt_profilegc.html \
 	$(DOCDIR)\rt_sections_elf_shared.html \
 	$(DOCDIR)\rt_sections_osx_x86.html \
-	$(DOCDIR)\rt_sections_osx_x86_64.html \
+	$(DOCDIR)\rt_sections_osx_64.html \
 	$(DOCDIR)\rt_monitor_.html \
 	$(DOCDIR)\rt_cover.html \
 	\

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -592,7 +592,7 @@ SRCS=\
 	src\rt\sections_darwin_64.d \
 	src\rt\sections_elf_shared.d \
 	src\rt\sections_osx_x86.d \
-	src\rt\sections_osx_x86_64.d \
+	src\rt\sections_osx_64.d \
 	src\rt\sections_solaris.d \
 	src\rt\sections_win64.d \
 	src\rt\tlsgc.d \

--- a/druntime/src/rt/sections.d
+++ b/druntime/src/rt/sections.d
@@ -45,9 +45,11 @@ else version (Solaris)
 else version (Darwin)
 {
     version (X86_64)
-        public import rt.sections_osx_x86_64;
+        public import rt.sections_osx_64;
     else version (X86)
         public import rt.sections_osx_x86;
+    else version (AArch64)
+        public import rt.sections_osx_64;
     else
         static assert(0, "unimplemented");
 }

--- a/druntime/src/rt/sections_osx_64.d
+++ b/druntime/src/rt/sections_osx_64.d
@@ -7,9 +7,9 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors: Walter Bright, Sean Kelly, Martin Nowak, Jacob Carlborg
- * Source: $(DRUNTIMESRC rt/_sections_osx_x86_64.d)
+ * Source: $(DRUNTIMESRC rt/_sections_osx_64.d)
  */
-module rt.sections_osx_x86_64;
+module rt.sections_osx_64;
 
 version (OSX)
     version = Darwin;
@@ -21,7 +21,12 @@ else version (WatchOS)
     version = Darwin;
 
 version (Darwin):
-version (X86_64):
+
+version (X86_64)
+    version = X86_64_or_AArch64;
+else version (AArch64)
+    version = X86_64_or_AArch64;
+version (X86_64_or_AArch64):
 
 // debug = PRINTF;
 


### PR DESCRIPTION
As gdc and ldc compile druntime for OSX AArch64, it is a bit of a mystery why this is not represented in src/rt/sections.d ??

@ibuclaw @kinke please weigh in!