### PR TITLE
fix: include template argument types in ftime-trace events

### DIFF
--- a/changelog/dmd.ftime-trace-template-args.dd
+++ b/changelog/dmd.ftime-trace-template-args.dd
@@ -1,0 +1,6 @@
+Improve `-ftime-trace` template instance detail
+
+The `-ftime-trace` profiling output now includes template argument types
+in the event name for template instance events, allowing users to
+distinguish between different instantiations of the same template
+(e.g. `isArray!(int)` instead of just `isArray`).

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -914,6 +914,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     timeTraceBeginEvent(TimeTraceEventType.sema1TemplateInstance);
     scope (exit) timeTraceEndEvent(TimeTraceEventType.sema1TemplateInstance, tempinst,
         () => tempinst.toPrettyChars().toDString());
+    // Get the enclosing template instance from the scope tinst
+    tempinst.tinst = sc.tinst;
     // Get the instantiating module from the scope minst
     tempinst.minst = sc.minst;
     // https://issues.dlang.org/show_bug.cgi?id=10920

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -47,6 +47,7 @@ import dmd.mtype;
 import dmd.opover;
 import dmd.optimize;
 import dmd.root.array;
+import dmd.root.string : toDString;
 import dmd.common.outbuffer;
 import dmd.rootobject;
 import dmd.semantic2;
@@ -911,11 +912,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     }
 
     timeTraceBeginEvent(TimeTraceEventType.sema1TemplateInstance);
-    scope (exit) timeTraceEndEvent(TimeTraceEventType.sema1TemplateInstance, tempinst);
-
-    // Get the enclosing template instance from the scope tinst
-    tempinst.tinst = sc.tinst;
-
+    scope (exit) timeTraceEndEvent(TimeTraceEventType.sema1TemplateInstance, tempinst,
+        () => tempinst.toPrettyChars().toDString());
     // Get the instantiating module from the scope minst
     tempinst.minst = sc.minst;
     // https://issues.dlang.org/show_bug.cgi?id=10920


### PR DESCRIPTION
Fixes detail field for sema1TemplateInstance trace events to use 
toPrettyChars() which includes template argument types 
(e.g. isArray!(int) instead of just isArray).

This allows -ftime-trace users to distinguish between different 
instantiations of the same template.

Related to #22711