### PR TITLE
Revert "Makefile: Double quote $(MAKE) variable to prevent word split…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ clean:
 	rm -rf $(GENERATED)
 	cd compiler/test && rm -rf test_results *.lst trace.log trace.def
 	$(RM) tags
-	$(QUIET)"$(MAKE)" -C druntime clean
+	$(QUIET)$(MAKE) -C druntime clean
 
 dmd: $(BUILD_EXE)
 	$(BUILD_CMD) $@
@@ -96,10 +96,10 @@ dmd-test: dmd-unittest dmd druntime $(RUN_EXE)
 	$(RUN_EXE) --environment
 
 druntime: dmd
-	$(QUIET)"$(MAKE)" -C druntime
+	$(QUIET)$(MAKE) -C druntime
 
 druntime-test: dmd
-	$(QUIET)"$(MAKE)" -C druntime unittest
+	$(QUIET)$(MAKE) -C druntime unittest
 
 test: dmd-test druntime-test
 
@@ -120,7 +120,7 @@ install: $(BUILD_EXE)
 	$(BUILD_CMD) install INSTALL_DIR='$(if $(findstring $(OS),windows),$(shell cygpath -w '$(INSTALL_DIR)'),$(INSTALL_DIR))'
 	mkdir -p '$(INSTALL_DIR)'/man
 	cp -r $(GENERATED)/docs/man/* '$(INSTALL_DIR)'/man/
-	$(QUIET)"$(MAKE)" -C druntime install INSTALL_DIR='$(INSTALL_DIR)'
+	$(QUIET)$(MAKE) -C druntime install INSTALL_DIR='$(INSTALL_DIR)'
 endif
 
 # Checks that all files have been committed and no temporary, untracked files exist.

--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -379,7 +379,7 @@ $(IMPDIR)/%.h : src/%.h
 ######################## Build DMD if non-existent ##############################
 
 ../generated/$(OS)/$(BUILD)/$(MODEL)/dmd$(DOTEXE):
-	"$(MAKE)" -C .. dmd BUILD=$(BUILD) OS=$(OS) MODEL=$(MODEL) DMD=""
+	$(MAKE) -C .. dmd BUILD=$(BUILD) OS=$(OS) MODEL=$(MODEL) DMD=""
 
 # alias using the absolute path (the Phobos Makefile specifies an absolute path)
 $(abspath ../generated/$(OS)/$(BUILD)/$(MODEL)/dmd$(DOTEXE)): ../generated/$(OS)/$(BUILD)/$(MODEL)/dmd$(DOTEXE)
@@ -447,7 +447,7 @@ unittest : $(UT_MODULES) $(addsuffix /.run,$(ADDITIONAL_TESTS))
 else
 unittest : unittest-debug unittest-release
 unittest-%: target
-	"$(MAKE)" -f $(MAKEFILE) unittest OS=$(OS) MODEL=$(MODEL) DMD=$(DMD) BUILD=$*
+	$(MAKE) -f $(MAKEFILE) unittest OS=$(OS) MODEL=$(MODEL) DMD=$(DMD) BUILD=$*
 endif
 
 ifeq ($(OS),linux)
@@ -509,14 +509,14 @@ ifeq (linux,$(OS))
 endif
 
 test/%/.run: test/%/Makefile $(DMD)
-	$(QUIET)"$(MAKE)" -C test/$* MODEL=$(MODEL) OS=$(OS) DMD=$(abspath $(DMD)) BUILD=$(BUILD) \
+	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) DMD=$(abspath $(DMD)) BUILD=$(BUILD) \
 		DRUNTIME=$(abspath $(DRUNTIME)) DRUNTIMESO=$(abspath $(DRUNTIMESO)) LINKDL=$(LINKDL) \
 		QUIET=$(QUIET) TIMELIMIT='$(TIMELIMIT)' PIC=$(PIC) SHARED=$(SHARED) IS_MUSL=$(IS_MUSL)
 
 test/%/.clean: test/%/Makefile
-	$(QUIET)"$(MAKE)" -C test/$* MODEL=$(MODEL) OS=$(OS) BUILD=$(BUILD) clean
+	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) BUILD=$(BUILD) clean
 ifeq (0,$(BUILD_WAS_SPECIFIED))
-	$(QUIET)"$(MAKE)" -C test/$* MODEL=$(MODEL) OS=$(OS) BUILD=debug clean
+	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) BUILD=debug clean
 endif
 
 #################### benchmark suite ##########################
@@ -597,7 +597,7 @@ test_extractor: $(TESTS_EXTRACTOR)
 ################################################################################
 
 betterc: | $(TESTS_EXTRACTOR) $(BETTERCTESTS_DIR)/.directory
-	"$(MAKE)" $$(find src -type f -name '*.d' | sed 's/[.]d/.betterc/')
+	$(MAKE) $$(find src -type f -name '*.d' | sed 's/[.]d/.betterc/')
 
 %.betterc: %.d | $(TESTS_EXTRACTOR) $(BETTERCTESTS_DIR)/.directory
 	@$(TESTS_EXTRACTOR) --betterC --attributes betterC \

--- a/druntime/posix.mak
+++ b/druntime/posix.mak
@@ -5,7 +5,7 @@ $(warning ============================== )
 # forward everything to Makefile
 
 target:
-	"$(MAKE)" -f Makefile $@
+	$(MAKE) -f Makefile $@
 
 %:
-	"$(MAKE)" -f Makefile $@
+	$(MAKE) -f Makefile $@

--- a/posix.mak
+++ b/posix.mak
@@ -5,7 +5,7 @@ $(warning ============================== )
 # forward everything to Makefile
 
 all:
-	"$(MAKE)" -f Makefile $@
+	$(MAKE) -f Makefile $@
 
 %:
-	"$(MAKE)" -f Makefile $@
+	$(MAKE) -f Makefile $@

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -2,31 +2,31 @@
 
 
 all:
-	$(QUIET)"$(MAKE)" -C .. $@
+	$(QUIET)$(MAKE) -C .. $@
 
 buildkite-test:
-	$(QUIET)"$(MAKE)" -C .. $@
+	$(QUIET)$(MAKE) -C .. $@
 
 toolchain-info:
-	$(QUIET)"$(MAKE)" -C .. $@
+	$(QUIET)$(MAKE) -C .. $@
 
 clean:
-	$(QUIET)"$(MAKE)" -C .. $@
+	$(QUIET)$(MAKE) -C .. $@
 
 test:
-	$(QUIET)"$(MAKE)" -C .. $@
+	$(QUIET)$(MAKE) -C .. $@
 
 html:
-	$(QUIET)"$(MAKE)" -C .. $@
+	$(QUIET)$(MAKE) -C .. $@
 
 tags:
-	$(QUIET)"$(MAKE)" -C .. $@
+	$(QUIET)$(MAKE) -C .. $@
 
 install:
-	$(QUIET)"$(MAKE)" -C .. $@
+	$(QUIET)$(MAKE) -C .. $@
 
 check-clean-git:
-	$(QUIET)"$(MAKE)" -C .. $@
+	$(QUIET)$(MAKE) -C .. $@
 
 style:
-	$(QUIET)"$(MAKE)" -C .. $@
+	$(QUIET)$(MAKE) -C .. $@


### PR DESCRIPTION
…ting (#22678)"

This reverts commit 12995e789ee9e690d59bd51044a6ace40101cd54.

This should fix the Azure CI regressions.