### PR TITLE
[dmd/cli.d] HTML fixes

### DIFF
--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -349,7 +349,8 @@ dmd -cov -unittest myprog.d
         ),
         Option("extern-std=<standard>",
             "set C++ name mangling compatibility with <standard>",
-            "Standards supported are:
+            "set C++ name mangling compatibility with <standard>.
+            Standards supported are:
             $(UL
                 $(LI $(I c++98): Use C++98 name mangling,
                     Sets `__traits(getTargetInfo, \"cppStd\")` to `199711`)
@@ -444,7 +445,7 @@ dmd -cov -unittest myprog.d
         ),
         Option("HC[=[?|h|help|silent|verbose]]",
             "write C++ 'header' equivalent to stdout",
-            `write C++ 'header' equivalent to stdout configured with:",
+            `write C++ 'header' equivalent to stdout configured with:
             $(DL
             $(DT ?|h|help)$(DD list available options for C++ 'header' file generation)
             $(DT silent)$(DD only list extern(C[++]) declarations (default))
@@ -453,7 +454,7 @@ dmd -cov -unittest myprog.d
         ),
         Option("HCd=<directory>",
             "write C++ 'header' file to directory",
-            "write C++ 'header' file to directory, ignored if -HCf=<filename> is not present",
+            "write C++ 'header' file to directory, ignored if `-HCf=<filename>` is not present",
         ),
         Option("HCf=<filename>",
             "write C++ 'header' file to filename instead of stdout"

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -208,7 +208,7 @@ struct Usage
         ),
         Option("check=[assert|bounds|in|invariant|out|switch][=[on|off]]",
             "enable or disable specific checks",
-            `Overrides default, -boundscheck, -release and -unittest options to enable or disable specific checks.
+            q"{Overrides default, `-boundscheck`, `-release` and `-unittest` options to enable or disable specific checks.
                 $(UL
                     $(LI $(B assert): assertion checking)
                     $(LI $(B bounds): array bounds)
@@ -220,7 +220,7 @@ struct Usage
                 $(UL
                     $(LI $(B on) or not specified: specified check is enabled.)
                     $(LI $(B off): specified check is disabled.)
-                )`
+                )}"
         ),
         Option("check=[h|help|?]",
             "list information on all available checks"
@@ -397,7 +397,7 @@ dmd -cov -unittest myprog.d
             Set too low, and the profiler overhead will be larger, and the output will be cluttered with tiny events."
         ),
         Option("ftime-trace-file=<filename>",
-            "specify output file for -ftime-trace",
+            "specify output file for `-ftime-trace`",
             "By default, the output name is the same as the first object file name, but with the `.time-trace` extension appended.
             A different filename can be chosen with this option, including a path relative to the current directory or an absolute path."
         ),
@@ -592,7 +592,7 @@ dmd -cov -unittest myprog.d
             $(LINK2 $(ROOT_DIR)spec/expression.html#ImportExpression, $(I ImportExpression))s.
             This switch is required in order to use $(I ImportExpression)s.
             $(I path) is a ; separated
-            list of paths. Multiple $(B -J)'s can be used, and the paths
+            list of paths. Multiple $(TT -J)'s can be used, and the paths
             are searched in the same order.`,
         ),
         Option("L=<linkerflag>",
@@ -624,7 +624,7 @@ dmd -cov -unittest myprog.d
             cast(TargetOS) (TargetOS.all & ~cast(uint)TargetOS.DragonFlyBSD)  // available on all OS'es except DragonFly, which does not support 32-bit binaries
         ),
         Option("m32mscoff",
-            "generate 32 bit code and write MS-COFF object files (deprecated use -m32)",
+            "generate 32 bit code and write MS-COFF object files (deprecated use `-m32`)",
             TargetOS.Windows
         ),
         Option("m64",
@@ -645,7 +645,7 @@ dmd -cov -unittest myprog.d
             `Print dependencies in Makefile compatible format.
             If filename is omitted, it prints to stdout.
             The emitted targets are the compiled artifacts (executable, object files, libraries).
-            The emitted dependencies are imported modules and imported string files (via $(B -J) switch).
+            The emitted dependencies are imported modules and imported string files (via $(SWLINK -J) switch).
             Special characters in a dependency or target filename are escaped in the GNU Make manner.
             `,
         ),
@@ -719,7 +719,7 @@ dmd -cov -unittest myprog.d
             can be omitted if they are the same.`,
         ),
         Option("noboundscheck",
-            "no array bounds checking (deprecated, use -boundscheck=off)",
+            "no array bounds checking (deprecated, use `-boundscheck=off`)",
             `Turns off all array bounds checking, even for safe functions. $(RED Deprecated
             (use $(TT $(SWLINK -boundscheck)=off) instead).)`,
         ),

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -333,8 +333,8 @@ dmd -cov -unittest myprog.d
             With $(I filename), write module dependencies as text to $(I filename)
             (only imports).`,
         ),
-        Option("dllimport=<value>",
-            "Windows only: select symbols to dllimport (none/defaultLibsOnly/externalOnly/all)",
+        Option("dllimport=[none|defaultLibsOnly|externalOnly|all]",
+            "Windows only: select symbols to dllimport",
             `Which symbols to dllimport implicitly if not defined in a module that is being compiled
             $(UL
                 $(LI $(I none): None)

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -311,14 +311,14 @@ dmd -cov -unittest myprog.d
             "compile in debug code identified by ident",
             `Compile in $(LINK2 spec/version.html#debug, debug identifier) $(I ident)`,
         ),
-        Option("debuglib=<name>",
-            "set symbolic debug library to name",
+        Option("debuglib=<libname>",
+            "set symbolic debug library to libname",
             `Link in $(I libname) as the default library when
             compiling for symbolic debugging instead of $(B $(LIB)).
             If $(I libname) is not supplied, then no default library is linked in.`
         ),
-        Option("defaultlib=<name>",
-            "set default library to name",
+        Option("defaultlib=<libname>",
+            "set default library to libname",
             `Link in $(I libname) as the default library when
             not compiling for symbolic debugging instead of $(B $(LIB)).
             If $(I libname) is not supplied, then no default library is linked in.`,
@@ -443,14 +443,16 @@ dmd -cov -unittest myprog.d
         Option("Hf=<filename>",
             "write 'header' file to filename"
         ),
-        Option("HC[=[?|h|help|silent|verbose]]",
+        Option("HC=[silent|verbose]",
             "write C++ 'header' equivalent to stdout",
             `write C++ 'header' equivalent to stdout configured with:
             $(DL
-            $(DT ?|h|help)$(DD list available options for C++ 'header' file generation)
             $(DT silent)$(DD only list extern(C[++]) declarations (default))
             $(DT verbose)$(DD also add comments for ignored declarations (e.g. extern(D)))
             )`,
+        ),
+        Option("HC=[?|h|help]",
+            "list available options for C++ 'header' file generation"
         ),
         Option("HCd=<directory>",
             "write C++ 'header' file to directory",
@@ -555,7 +557,7 @@ dmd -cov -unittest myprog.d
 
              $(P Note that multiple `-i=...` options are allowed, each one adds a pattern.)}"
         ),
-        Option("identifiers=<table>",
+        Option("identifiers=[UAX31|c99|c11|all]",
             "Specify the non-ASCII tables for D identifiers",
             `Set the identifier table to use for the non-ASCII values.
                 $(UL
@@ -565,7 +567,7 @@ dmd -cov -unittest myprog.d
                     $(LI $(I all): All, the least restrictive set, which comes with all others (default))
                 )`
         ),
-        Option("identifiers-importc=<table>",
+        Option("identifiers-importc=[UAX31|c99|c11|all]",
             "Specify the non-ASCII tables for ImportC identifiers",
             `Set the identifier table to use for the non-ASCII values.
                 $(UL
@@ -677,7 +679,6 @@ dmd -cov -unittest myprog.d
             `Set the target architecture for code generation,
             where:
             $(DL
-            $(DT help)$(DD list alternatives)
             $(DT baseline)$(DD the minimum architecture for the target platform (default))
             $(DT avx)$(DD
             generate $(LINK2 https://en.wikipedia.org/wiki/Advanced_Vector_Extensions, AVX)
@@ -791,7 +792,7 @@ dmd -cov -unittest myprog.d
         ),
         Option("preview=<name>",
             "enable an upcoming language change identified by 'name'",
-            `Preview an upcoming language change identified by $(I id)`,
+            `Preview an upcoming language change identified by <name>`,
         ),
         Option("preview=[h|help|?]",
             "list all upcoming language changes"
@@ -843,7 +844,7 @@ dmd -cov -unittest myprog.d
         ),
         Option("revert=<name>",
             "revert language change identified by 'name'",
-            `Revert language change identified by $(I id)`,
+            `Revert language change identified by <name>`,
         ),
         Option("revert=[h|help|?]",
             "list all revertable language changes"
@@ -853,7 +854,7 @@ dmd -cov -unittest myprog.d
             `Compile, link, and run the program $(I srcfile) with the
             rest of the
             command line, $(I args...), as the arguments to the program.
-            No .$(OBJEXT) or executable file is left behind.`
+            No $(TT .$(OBJEXT)) or executable file is left behind.`
         ),
         Option("shared",
             "generate shared library (DLL)",
@@ -878,7 +879,7 @@ dmd -cov -unittest myprog.d
         ),
         Option("transition=<name>",
             "help with language change identified by 'name'",
-            `Show additional info about language change identified by $(I id)`,
+            `Show additional info about language change identified by <name>`,
         ),
         Option("transition=[h|help|?]",
             "list all language changes"
@@ -935,11 +936,11 @@ dmd -cov -unittest myprog.d
         Option("vgc",
             "list all gc allocations including hidden ones"
         ),
-        Option("visibility=<value>",
-            "default visibility of symbols (default/hidden/public)",
+        Option("visibility=[default|hidden|public]",
+            "default visibility of symbols",
             "$(UL
-               $(LI $(I default): Hidden for Windows targets without -shared, otherwise public)
-               $(LI $(I hidden):  Only export symbols marked with 'export')
+               $(LI $(I default): <hidden> for Windows targets without $(SWLINK -shared), otherwise <public>)
+               $(LI $(I hidden):  Only export symbols marked with `export`)
                $(LI $(I public):  Export all symbols)
             )",
         ),


### PR DESCRIPTION
Fix name vs libname conflicts.
Minor formatting tweaks.
Add missing description to long help for `-extern-std`.
List `-HC` help option separately (as other flags do).
~~Opt-in to `-I` directory word italicising - see https://github.com/dlang/dlang.org/issues/4424#issuecomment-4060528747. Will need dlang.org PR also to fix that issue.~~
Avoid italicised *table* words for `-identifiers` by listing targets in flag string.
Fix id vs name conflicts.
Remove help target for `-mcpu=<id>` because it is listed underneath.
Tweak `-visibility` docs.