### PR TITLE
core.thread.package: Revise unittest

### DIFF
--- a/druntime/src/core/thread/package.d
+++ b/druntime/src/core/thread/package.d
@@ -22,38 +22,36 @@ public import core.thread.context;
 
 // this test is here to avoid a cyclic dependency between
 // core.thread and core.atomic
-unittest
+@system unittest
 {
     import core.atomic;
 
-    // Use heap memory to ensure an optimizing
-    // compiler doesn't put things in registers.
-    uint* x = new uint();
-    bool* f = new bool();
-    uint* r = new uint();
+    shared uint x;
+    shared bool f;
+    shared uint r;
 
     auto thr = new Thread(()
     {
-        while (!*f)
+        while (!atomicLoad(f))
         {
         }
 
-        atomicFence();
+        atomicFence(); // make sure load+store below happens after waiting for f
 
-        *r = *x;
+        cast() r = cast() x;
     });
 
-    thr.start();
+    thr.start(); // new thread will wait until f is set
 
-    *x = 42;
+    cast() x = 42;
 
-    atomicFence();
+    atomicFence(); // make sure x is set before setting f
 
-    *f = true;
+    cast() f = true;
 
     atomicFence();
 
     thr.join();
 
-    assert(*r == 42);
+    assert(cast() r == 42);
 }


### PR DESCRIPTION
I guess this test is about `atomicFence()`, and so rather unorthodox/unsafe.

For optimizing compilers, it's not sufficient to use heap-allocated values (shared by 2 threads). The only concurrent read/write is for the `f` bool, where LDC optimizes the load in the new thread's loop condition to a single load (as the empty loop body definitely won't modify it in this thread).

So switch to an `atomicLoad()` for `f`, which prevents such optimizations, and use normal stack values [well, they end up in a closure], making them proper `shared` and adding the unsafe casts (so that this compiles with `-preview=nosharedaccess`).