### PR TITLE
[root/longdouble.d] make `ld_cmp` use a regular return

### DIFF
--- a/compiler/src/dmd/root/longdouble.d
+++ b/compiler/src/dmd/root/longdouble.d
@@ -560,9 +560,9 @@ int ld_cmp(longdouble_soft x, longdouble_soft y)
             sub     AL, AH;
             movsx   EAX, AL;
             fstp    ST(0);
-            mov     res, EAX;
         }
     }
+    return res;
 }
 
 

--- a/compiler/src/dmd/root/longdouble.d
+++ b/compiler/src/dmd/root/longdouble.d
@@ -560,6 +560,7 @@ int ld_cmp(longdouble_soft x, longdouble_soft y)
             sub     AL, AH;
             movsx   EAX, AL;
             fstp    ST(0);
+            mov     res, EAX;
         }
     }
     return res;


### PR DESCRIPTION
instead of asm