### PR TITLE
add op pseudo-op to inline assembler

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8910,6 +8910,7 @@ struct Id final
     static Identifier* undef;
     static Identifier* ident;
     static Identifier* packed;
+    static Identifier* op;
     static void initialize();
     Id()
     {

--- a/compiler/src/dmd/iasm/dmdaarch64.d
+++ b/compiler/src/dmd/iasm/dmdaarch64.d
@@ -63,13 +63,20 @@ import dmd.backend.iasm;
  */
 public Statement inlineAsmAArch64Semantic(InlineAsmStatement s, Scope* sc)
 {
-    static if (0)
+    static if (1)
     {
         printf("InlineAsmAArch64Statement.semantic()\n");
         for (auto token = s.tokens; token; token = token.next)
         {
-            printf("token: %s\n", token.toChars());
+            printf("TOK.%s %s\n", token.toString(token.value).ptr, token.toChars());
         }
+
+	auto token = s.tokens;
+	if (token.value == TOK.identifier)
+	{
+	    const id = token.ident.toString();
+	    if (strcmp(id.ptr, "naked".ptr) == 0) { printf("found naked\n"); }
+	}
     }
 
     /* For example,

--- a/compiler/src/dmd/iasm/dmdaarch64.d
+++ b/compiler/src/dmd/iasm/dmdaarch64.d
@@ -18,6 +18,7 @@ import core.stdc.stdlib;
 import core.stdc.string;
 
 import dmd.astenums;
+import dmd.astcodegen;
 import dmd.declaration;
 import dmd.denum;
 import dmd.dinterpret;
@@ -34,11 +35,11 @@ import dmd.identifier;
 import dmd.init;
 import dmd.location;
 import dmd.mtype;
-import dmd.optimize;
+import dmd.parse;
 import dmd.statement;
 import dmd.target;
 import dmd.tokens;
-import dmd.typesem : pointerTo, size;
+import dmd.typesem : pointerTo, size, isIntegral;
 
 import dmd.root.ctfloat;
 import dmd.common.outbuffer;
@@ -63,6 +64,15 @@ import dmd.backend.iasm;
  */
 public Statement inlineAsmAArch64Semantic(InlineAsmStatement s, Scope* sc)
 {
+    const bool doUnittests = global.params.parsingUnittestsRequired();
+    scope p = new Parser!ASTCodegen(sc._module, "", false, global.errorSink, &global.compileEnv, doUnittests);
+
+    // Adjust starting line number of the parser.
+    p.token = *s.tokens;
+    p.baseLoc.startLine = s.loc.linnum;
+    p.linnum = s.loc.linnum;
+
+    int errors;
     static if (1)
     {
         printf("InlineAsmAArch64Statement.semantic()\n");
@@ -71,12 +81,45 @@ public Statement inlineAsmAArch64Semantic(InlineAsmStatement s, Scope* sc)
             printf("TOK.%s %s\n", token.toString(token.value).ptr, token.toChars());
         }
 
-	auto token = s.tokens;
-	if (token.value == TOK.identifier)
-	{
-	    const id = token.ident.toString();
-	    if (strcmp(id.ptr, "naked".ptr) == 0) { printf("found naked\n"); }
-	}
+        if (p.token.value == TOK.identifier)
+        {
+            if (p.token.ident == Id.naked)
+            {
+                s.naked = true;
+                sc.func.isNaked = true;
+                p.nextToken();
+            }
+            else if (p.token.ident == Id.op)
+            {
+
+                p.nextToken();
+                Expression exp = p.parseAssignExp();
+                // Must evaluate to a constant, like an enum member does
+                exp = exp.expressionSemantic(sc);
+                exp = resolveProperties(sc, exp);
+                exp = exp.ctfeInterpret();
+                if (exp.op == EXP.error)
+                    return new ErrorStatement();
+
+                //printf("expression: %s\n", exp.toChars());
+                Type t = exp.type;
+                if (!(size(t) == 4 && isIntegral(t)))
+                    error(s.loc, "size of opcode must be 4 of integral type\n");
+                code* pc = code_calloc();
+                pc.Iflags |= CFpsw;            // assume we want to keep the flags
+                pc.Iop = cast(int)exp.toInteger();
+                s.asmcode = pc;
+            }
+
+            if (p.token.value != TOK.endOfFile && !errors)
+            {
+                error(s.loc, "end of instruction expected, not `%s`", p.token.toChars());
+                return new ErrorStatement();
+            }
+            else
+                return s;
+
+        }
     }
 
     /* For example,

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -542,6 +542,9 @@ immutable Msgtable[] msgtable =
     { "undef" },
     { "ident" },
     { "packed" },
+
+    // for inline assembler
+    { "op" },
 ];
 
 


### PR DESCRIPTION
The work on compiling druntime for the AArch64 reveals that the bits of inline assembler are mandatory for it to work. But the inline assembler still needs a fair amount of work.

So I added an "op" pseudo-op to the inline assembler, where the desired opcode can be added with its hex code:
```d
void test()
{
    asm
    {
        naked;
        op      0x1E7F07C0 + 1 - 1;
    }
}
```
Compiling with -vasm gives:
```
_D4testQfFZv:
0000:   1E 7F 07 C0  fccmp     d30,d31,#0x0,eq
```
dhowing that the correct instruction is inserted into the instruction stream.

Note the `+ 1 - 1`. The inline expression capability for X68-64 is a wacky nutburger expression evaluator, to conform to Intel syntax.  For expression evaluation I decided to hijack the D (and C!) expression evaluator, which should save lots of work and be as expressive as D itself.

It will be able to not just evaluate expressions, but compute opcodes using the instr.d instruction builder, so instead of writing instructions in hex (an agonizing process) we can use: `op INSTR.ucvtf_float_int(1,1,0,31)); // ucvtf d31,x0`

But for that to work, dmd/backend/arm/instr.d would need to be incorporated into druntime. I anticipated that long ago as instr.d does not do any imports, it stands alone. I suppose I could just write a scratch program to generate the hex and then copy the hex over to druntime.

I haven't figured out yet how to incorporate symbolic references.