### PR TITLE
Druntime: Select newer pwd and socket symbols for NetBSD

### DIFF
--- a/druntime/src/core/sys/posix/pwd.d
+++ b/druntime/src/core/sys/posix/pwd.d
@@ -201,8 +201,16 @@ else
     static assert(false, "Unsupported platform");
 }
 
-passwd* getpwnam(const scope char*);
-passwd* getpwuid(uid_t);
+version (NetBSD)
+{
+    pragma(mangle, "__getpwnam50") passwd* getpwnam(const scope char*);
+    pragma(mangle, "__getpwuid50") passwd* getpwuid(uid_t);
+}
+else
+{
+    passwd* getpwnam(const scope char*);
+    passwd* getpwuid(uid_t);
+}
 
 //
 // Thread-Safe Functions (TSF)
@@ -301,7 +309,7 @@ else version (FreeBSD)
 else version (NetBSD)
 {
     void    endpwent();
-    passwd* getpwent();
+    pragma(mangle, "__getpwent50") passwd* getpwent();
     void    setpwent();
 }
 else version (OpenBSD)

--- a/druntime/src/core/sys/posix/sys/socket.d
+++ b/druntime/src/core/sys/posix/sys/socket.d
@@ -1704,7 +1704,7 @@ else version (NetBSD)
     ssize_t sendto(int, const scope void*, size_t, int, const scope sockaddr*, socklen_t);
     int     setsockopt(int, int, int, const scope void*, socklen_t);
     int     shutdown(int, int) @safe;
-    int     socket(int, int, int) @safe;
+    pragma(mangle, "__socket30") int     socket(int, int, int) @safe;
     int     sockatmark(int) @safe;
     int     socketpair(int, int, int, ref int[2]) @safe;
 }


### PR DESCRIPTION
When building DUB on NetBSD 10, I noticed additional compat symbols being used in Druntime.

The following are redefined from these symbols.

(NetBSD-src) include/pwd.h:
```c
#ifndef __LIBC12_SOURCE__
struct passwd	*getpwuid(uid_t) __RENAME(__getpwuid50);
struct passwd	*getpwnam(const char *) __RENAME(__getpwnam50);
#endif
...
#ifndef __LIBC12_SOURCE__
struct passwd	*getpwent(void) __RENAME(__getpwent50);
#endif
```

(NetBSD-src) sys/sys/socket.h:
```c
int	socket(int, int, int)
#if !defined(__LIBC12_SOURCE__) && !defined(_STANDALONE)
__RENAME(__socket30)
#endif
```

Interestingly, `__getpwnam_r50` is already properly defined. There isn't any real different using an alias or pragma(mangle), so I'll leave it be.

Tested on NetBSD 10 amd64 using GDC 15.2.

Related: #22720