### PR TITLE
core.sys.posix.sys.dirent: Add dirfd

### DIFF
--- a/druntime/src/core/sys/posix/dirent.d
+++ b/druntime/src/core/sys/posix/dirent.d
@@ -441,6 +441,22 @@ else
     static assert(false, "Unsupported platform");
 }
 
+// Missing druntime declaration
+version (NetBSD)
+{
+    // On NetBSD, this is a macro in dirent.h, not a function.
+    extern (D) int dirfd(DIR* dir) nothrow @nogc
+    {
+        // ABI guarantees dd_fd remains the first field
+        return *(cast(int*) dir);
+    }
+}
+else
+{
+    pragma(mangle, "dirfd")
+    nothrow @nogc int dirfd(DIR* dir);
+}
+
 // Only OS X out of the Darwin family needs special treatment.  Other Darwins
 // (iOS, TVOS, WatchOS) are fine with normal symbol names for these functions
 // in else below.

--- a/druntime/src/core/sys/posix/pwd.d
+++ b/druntime/src/core/sys/posix/pwd.d
@@ -201,8 +201,16 @@ else
     static assert(false, "Unsupported platform");
 }
 
-passwd* getpwnam(const scope char*);
-passwd* getpwuid(uid_t);
+version (NetBSD)
+{
+    pragma(mangle, "__getpwnam50") passwd* getpwnam(const scope char*);
+    pragma(mangle, "__getpwuid50") passwd* getpwuid(uid_t);
+}
+else
+{
+    passwd* getpwnam(const scope char*);
+    passwd* getpwuid(uid_t);
+}
 
 //
 // Thread-Safe Functions (TSF)
@@ -301,7 +309,7 @@ else version (FreeBSD)
 else version (NetBSD)
 {
     void    endpwent();
-    passwd* getpwent();
+    pragma(mangle, "__getpwent50") passwd* getpwent();
     void    setpwent();
 }
 else version (OpenBSD)

--- a/druntime/src/core/sys/posix/sys/socket.d
+++ b/druntime/src/core/sys/posix/sys/socket.d
@@ -1704,7 +1704,7 @@ else version (NetBSD)
     ssize_t sendto(int, const scope void*, size_t, int, const scope sockaddr*, socklen_t);
     int     setsockopt(int, int, int, const scope void*, socklen_t);
     int     shutdown(int, int) @safe;
-    int     socket(int, int, int) @safe;
+    pragma(mangle, "__socket30") int     socket(int, int, int) @safe;
     int     sockatmark(int) @safe;
     int     socketpair(int, int, int, ref int[2]) @safe;
 }


### PR DESCRIPTION
This commit adds the definition of dirfd, a POSIX function.

The pragma is left as-is, as it was (erroneously) defined in Phobos.

`extern (D)` added because the entire module is otherwise affected by `extern (C)`.

