### PR TITLE
core.sys.posix.dirent: Add dirfd

### DIFF
--- a/druntime/src/core/sys/posix/dirent.d
+++ b/druntime/src/core/sys/posix/dirent.d
@@ -453,7 +453,6 @@ version (NetBSD)
 }
 else
 {
-    pragma(mangle, "dirfd")
     nothrow @nogc int dirfd(DIR* dir);
 }
 

--- a/druntime/src/core/sys/posix/dirent.d
+++ b/druntime/src/core/sys/posix/dirent.d
@@ -441,6 +441,22 @@ else
     static assert(false, "Unsupported platform");
 }
 
+// Missing druntime declaration
+version (NetBSD)
+{
+    // On NetBSD, this is a macro in dirent.h, not a function.
+    extern (D) int dirfd(DIR* dir) nothrow @nogc
+    {
+        // ABI guarantees dd_fd remains the first field
+        return *(cast(int*) dir);
+    }
+}
+else
+{
+    pragma(mangle, "dirfd")
+    nothrow @nogc int dirfd(DIR* dir);
+}
+
 // Only OS X out of the Darwin family needs special treatment.  Other Darwins
 // (iOS, TVOS, WatchOS) are fine with normal symbol names for these functions
 // in else below.

--- a/druntime/src/core/sys/posix/dirent.d
+++ b/druntime/src/core/sys/posix/dirent.d
@@ -450,7 +450,7 @@ int dirfd(DIR*);
 version (NetBSD)
 {
     // On NetBSD, this is a macro in dirent.h, not a function.
-    extern (D) int dirfd(DIR* dir) nothrow @nogc
+    extern (D) int dirfd()(DIR* dir) nothrow @nogc
     {
         // ABI guarantees dd_fd remains the first field
         return *(cast(int*) dir);

--- a/druntime/src/core/sys/posix/dirent.d
+++ b/druntime/src/core/sys/posix/dirent.d
@@ -441,7 +441,12 @@ else
     static assert(false, "Unsupported platform");
 }
 
-// Missing druntime declaration
+//
+// POSIX.1-2008
+//
+/*
+int dirfd(DIR*);
+*/
 version (NetBSD)
 {
     // On NetBSD, this is a macro in dirent.h, not a function.


### PR DESCRIPTION
This commit adds the definition of dirfd, a POSIX function.

The pragma is left as-is, as it was (erroneously) defined in Phobos.

extern (D) added because the entire module is otherwise affected by extern (C).

(Take 2, switching branches everywhere gets a little messy, my bad.)