### PR TITLE
Fix Issue #22752: Force semantic analysis of fields before is() conversion check

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -9224,6 +9224,9 @@ MATCH implicitConvToWithoutAliasThis(TypeStruct from, Type to)
     /* Check all the fields. If they can all be converted,
      * allow the conversion.
      */
+    import dmd.dsymbolsem : size;
+    if (from.sym.size(Loc.initial) == SIZE_INVALID)
+        return MATCH.nomatch;
     MATCH m = MATCH.constant;
     uint offset = ~0; // must never match a field offset
     foreach (v; from.sym.fields[])

--- a/compiler/test/compilable/test22752.d
+++ b/compiler/test/compilable/test22752.d
@@ -1,0 +1,23 @@
+/*
+REQUIRED_ARGS:
+PERMUTE_ARGS:
+*/
+
+struct S
+{
+    int isnot;
+    int[] arguments;
+}
+
+struct Array(T)
+{
+    static if (is(const(T) : T))
+    {
+        void insert()
+        {
+            static assert (is(const(T) : T));
+        }
+    }
+}
+
+alias A = Array!S;


### PR DESCRIPTION
Fix Issue #22752:
is() expressions should force semantic analysis on forward-referenced structs before conversion checks.

The Problem: Currently, is(const(S) : S) can incorrectly return true if it is evaluated before S's fields have been populated (while the struct is still "opaque" or in a forward-reference state). In this state, the compiler has not yet "seen" any fields, so it assumes the struct is empty and decides that an implicit conversion is valid. This leads to static assert failures later in the compilation when the same condition is re-evaluated after the fields are actually read.

The Fix: I have updated implicitConvToWithoutAliasThis in dmd.typesem to explicitly call from.sym.size(Loc.initial). This forces the compiler to perform field analysis and determine the struct's layout before making a final decision on the implicit conversion.

Verification:

Bug Reproduction: The test case provided in the issue now compiles and passes successfully.
Internal Consistency: All modules passed dmd-unittest, ensuring no regressions in the compiler's core logic.
ABI Safety: High. This change only affects the internal reasoning of the compiler during semantic analysis and does not change the generated mangling or binary layout.