### PR TITLE
refactor and add setTokenList()

### DIFF
--- a/compiler/src/dmd/iasm/dmdaarch64.d
+++ b/compiler/src/dmd/iasm/dmdaarch64.d
@@ -64,15 +64,6 @@ import dmd.backend.iasm;
  */
 public Statement inlineAsmAArch64Semantic(InlineAsmStatement s, Scope* sc)
 {
-    const bool doUnittests = global.params.parsingUnittestsRequired();
-    scope p = new Parser!ASTCodegen(sc._module, "", false, global.errorSink, &global.compileEnv, doUnittests);
-
-    // Adjust starting line number of the parser.
-    p.token = *s.tokens;
-    p.baseLoc.startLine = s.loc.linnum;
-    p.linnum = s.loc.linnum;
-
-    int errors;
     static if (1)
     {
         printf("InlineAsmAArch64Statement.semantic()\n");
@@ -80,7 +71,18 @@ public Statement inlineAsmAArch64Semantic(InlineAsmStatement s, Scope* sc)
         {
             printf("TOK.%s %s\n", token.toString(token.value).ptr, token.toChars());
         }
+    }
 
+    const bool doUnittests = global.params.parsingUnittestsRequired();
+    scope p = new Parser!ASTCodegen(sc._module, "", false, global.errorSink, &global.compileEnv, doUnittests);
+
+    /* Set list of tokens that will be the input to the parser, and starting line number to use.
+     */
+    p.setTokenList(s.tokens, s.loc.linnum);
+
+    int errors;
+    static if (1)
+    {
         if (p.token.value == TOK.identifier)
         {
             if (p.token.ident == Id.naked)

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -79,6 +79,21 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         this.doUnittests = doUnittests;
     }
 
+    /** Instead of parsing text to get tokens, provide a list of tokens ending with null.
+     * Note that the token list will be consumed (added to the tokenFreelist) by the lexer4.
+     * Params:
+     *    pToken = pointer to first token in list, take ownership of list
+     *    linnum = line number to use for the tokens
+     */
+    extern (D)
+    void setTokenList(ref Token* pToken, int linnum)
+    {
+        this.token = *pToken;
+        pToken = null;          // take ownership
+        this.baseLoc.startLine = linnum;
+        this.linnum = linnum;
+    }
+
     /++
      + Parse a module, i.e. the optional `module x.y.z` declaration and all declarations
      + found in the current file.


### PR DESCRIPTION
It's unclear how the parser can be initialized with a token list, so I added setTokenList() to abstract that away. Crucially, the parser takes ownership of the token list, and this change accounts for that by nulling out the callers reference to the list.