### PR TITLE
Allow structs with pointers to be constructed as shared

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -16669,6 +16669,8 @@ bool checkValue(Expression e)
  */
 bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
 {
+    Expression root = e;
+
     if (!sc ||
         !sc.previews.noSharedAccess ||
         sc.intypeof ||
@@ -16846,6 +16848,12 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
             case EXP.star:        return visitPtr(e.isPtrExp());
             case EXP.dotVariable: return visitDotVar(e.isDotVarExp());
             case EXP.index:       return visitIndex(e.isIndexExp());
+            case EXP.structLiteral:
+                // Allow constructing a shared struct literal as a value,
+                // but keep rejecting later accesses through that temporary.
+                if (e is root && e.type && e.type.isShared())
+                    return false;
+                return visit(e);
         }
     }
 

--- a/compiler/test/compilable/test_nosharedaccess_shared_struct_literal.d
+++ b/compiler/test/compilable/test_nosharedaccess_shared_struct_literal.d
@@ -1,0 +1,15 @@
+// REQUIRED_ARGS: -preview=nosharedaccess
+
+import core.atomic;
+
+struct List
+{
+    size_t gen;
+    List* next;
+}
+
+void main()
+{
+    shared(List) head;
+    assert(cas(&head, shared(List)(0, null), shared(List)(1, cast(List*)1)));
+}


### PR DESCRIPTION
I found this limitation while trying to get the druntime unit tests to compile with `-preview=nosharedaccess`.