### PR TITLE
Fix #22754 - Move Object.__monitor to druntime

### DIFF
--- a/changelog/dmd.monitor-field.dd
+++ b/changelog/dmd.monitor-field.dd
@@ -1,0 +1,10 @@
+The `Object.__monitor` field has been moved to druntime
+
+This field was previously hard coded into the compiler, and is used as a mutex for `synchronized(obj)` blocks.
+By declaring it explicitly in druntime's `Object`, custom druntimes can now omit it entirely, saving 8 bytes per class instance when `synchronized` is not needed.
+
+The field is treated specially by the compiler and remains excluded from:
+
+- `__traits(allMembers, Object)`
+- `Object.tupleof`
+- `__traits(getPointerBitmap, T)` (it is not GC-managed)

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -333,11 +333,17 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     }
 
     /**************
-     * Returns: true if there's a __monitor field
+     * Returns: true if there's a __monitor field, i.e. the druntime `Object` class declares it
      */
     final bool hasMonitor()
     {
-        return classKind == ClassKind.d;
+        if (classKind != ClassKind.d)
+            return false;
+        // Check if Object in druntime actually declares a __monitor field.
+        // Custom druntimes can omit it by not declaring it in Object.
+        if (!object || !object.symtab)
+            return true; // conservative: Object not yet loaded, assume monitor present
+        return object.symtab.lookup(Id.__monitor) !is null;
     }
 
     /****************************************

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -2867,8 +2867,11 @@ public:
             size_t totalFieldCount = 0;
             for (ClassDeclaration c = cd; c; c = c.baseClass)
                 totalFieldCount += c.fields.length;
+
+            totalFieldCount -= cd.hasMonitor(); // skip __monitor field
+
             auto elems = new Expressions(totalFieldCount);
-            size_t fieldsSoFar = totalFieldCount;
+            ptrdiff_t fieldsSoFar = totalFieldCount;
             for (ClassDeclaration c = cd; c; c = c.baseClass)
             {
                 fieldsSoFar -= c.fields.length;
@@ -2880,6 +2883,9 @@ public:
                         result = CTFEExp.cantexp;
                         return;
                     }
+                    if (fieldsSoFar + ptrdiff_t(i) < 0) // field -1 = __monitor which we skip
+                        break;
+
                     Expression m;
                     if (v._init)
                     {

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -9978,8 +9978,6 @@ private extern(C++) class FinalizeSizeVisitor : Visitor
         {
             outerCd.alignsize = target.ptrsize;
             outerCd.structsize = target.ptrsize;      // allow room for __vptr
-            if (outerCd.hasMonitor())
-                outerCd.structsize += target.ptrsize; // allow room for __monitor
         }
 
         //printf("finalizeSize() %s, sizeok = %d\n", toChars(), sizeok);

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -1065,6 +1065,9 @@ public:
 
         if (adparent)
         {
+            if (vd.ident && vd.ident == Id.__monitor)
+                return;
+
             writeProtection(vd.visibility.kind);
             typeToBuffer(type, vd, true);
             buf.writestringln(";");

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9981,7 +9981,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (t1.ty == Tpointer)
                 t1 = t1.nextOf();
 
-            exp.type = exp.type.addMod(t1.mod);
+            // __monitor is always void* regardless of shared - strip shared from the mod
+            auto t1mod = t1.mod;
+            if (exp.var.ident == Id.__monitor)
+                t1mod &= ~MODFlags.shared_;
+            exp.type = exp.type.addMod(t1mod);
 
             // https://issues.dlang.org/show_bug.cgi?id=23109
             // Run semantic on the DotVarExp type

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -37,6 +37,7 @@ import dmd.dsymbol;
 import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
+import dmd.id;
 import dmd.expressionsem : toBool, toInteger;
 import dmd.func;
 import dmd.globals;
@@ -781,6 +782,11 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
             size_t index = 0;
             for (ClassDeclaration c = cdb.baseClass; c; c = c.baseClass)
                 index += c.fields.length;
+            // CTFE elements exclude __monitor (emitted separately).
+            // Subtract it from the index, but only when Object is actually
+            // in the base hierarchy (index > 0 means cdb is not itself Object).
+            if (index > 0)
+                index -= cdb.hasMonitor();
             membersToDt(cdb, dtb, elements, index, concreteType, null);
             offset = cdb.structsize;
         }
@@ -845,9 +851,12 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
         offset = 0;
     // `offset` now is where the fields start
 
+    // __monitor is emitted separately (not from CTFE elements), so exclude it from the count.
+    // This applies to Object itself (the root class with no base class), not to interfaces.
+    const size_t monitorExcluded = (cd && !cd.isInterfaceDeclaration() && !cd.baseClass && cd.hasMonitor()) ? 1 : 0;
     assert(!elements ||
            firstFieldIndex <= elements.length &&
-           firstFieldIndex + ad.fields.length <= elements.length);
+           firstFieldIndex + ad.fields.length - monitorExcluded <= elements.length);
 
     uint bitByteOffset = 0;     // byte offset of bit field
     uint bitOffset = 0;         // starting bit number
@@ -900,6 +909,10 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
 
     foreach (i, field; ad.fields)
     {
+        // __monitor is emitted separately (not from CTFE elements), skip it here
+        if (field.ident == Id.__monitor)
+            continue;
+
         // skip if no element for this field
         if (elements && !(*elements)[firstFieldIndex + i])
             continue;
@@ -1166,6 +1179,9 @@ void ClassReferenceExp_toInstanceDt(ClassReferenceExp ce, ref DtBuilder dtb)
     size_t firstFieldIndex = 0;
     for (ClassDeclaration c = cd.baseClass; c; c = c.baseClass)
         firstFieldIndex += c.fields.length;
+    // CTFE elements exclude __monitor (it is emitted separately by membersToDt),
+    // so adjust the index to match the elements array layout.
+    firstFieldIndex -= cd.hasMonitor();
     membersToDt(cd, dtb, ce.value.elements, firstFieldIndex, cd, null);
 }
 

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -1253,7 +1253,8 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
     }
 
     // m_init[]
-    assert(cd.structsize >= 8 || (cd.classKind == ClassKind.cpp && cd.structsize >= 4));
+    // Class instances always have at least a vtable pointer
+    assert(cd.structsize >= target.ptrsize || (cd.classKind == ClassKind.cpp && cd.structsize >= 4));
     dtb.size(cd.structsize);           // size
     dtb.xoff(sinit, 0, TYnptr);         // initializer
 
@@ -1328,6 +1329,8 @@ Louter:
         foreach (vd; pc.fields)
         {
             //printf("vd = %s %s\n", vd.kind(), vd.toChars());
+            if (vd.ident == Id.__monitor)
+                continue;   // __monitor is not GC-managed
             if (vd.hasPointers())
             {
                 flags &= ~ClassFlags.noPointers;  // not no-how, not no-way

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3129,6 +3129,12 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 ss.exp = new CastExp(ss.loc, ss.exp, t);
                 ss.exp = ss.exp.expressionSemantic(sc);
             }
+            if (!cd.hasMonitor())
+            {
+                error(ss.loc, "cannot `synchronize` on a `%s` because `object.Object` has no `__monitor` field",
+                      cd.toChars());
+                return setError();
+            }
             version (all)
             {
                 /* Rewrite as:

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -267,6 +267,8 @@ ulong getTypePointerBitmap(Loc loc, Type t, ref Array!(ulong) data, ErrorSink eS
                 visitTopLevelClass(t.sym.baseClass.type.isTypeClass());
             foreach (v; t.sym.fields)
             {
+                if (v.ident == Id.__monitor)
+                    continue; // __monitor is not GC-managed
                 offset = classoff + v.offset;
                 visit(v.type);
             }
@@ -1786,6 +1788,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 // Skip over internal members in __traits(allMembers)
                 if ((sm.isCtorDeclaration() && sm.ident != Id.ctor) ||
                     (sm.isDtorDeclaration() && sm.ident != Id.dtor) ||
+                    (sm.ident == Id.__monitor) ||
                     (sm.isPostBlitDeclaration() && sm.ident != Id.postblit) ||
                     sm.isInvariantDeclaration() ||
                     sm.isUnitTestDeclaration())

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -7069,6 +7069,11 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                 // Don't include hidden 'this' pointer
                 if (v.isThisDeclaration())
                     continue;
+
+                // Don't include __monitor field
+                if (v.ident == Id.__monitor)
+                    continue;
+
                 Expression ex;
                 if (ev)
                     ex = new DotVarExp(e.loc, ev, v);
@@ -7182,17 +7187,6 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                 return e;
             }
 
-            if (ident == Id.__monitor && mt.sym.hasMonitor())
-            {
-                /* The handle to the monitor (call it a void*)
-                 * *(cast(void**)e + 1)
-                 */
-                e = e.castTo(sc, mt.tvoidptr.pointerTo());
-                e = new AddExp(e.loc, e, IntegerExp.literal!1);
-                e = new PtrExp(e.loc, e);
-                e = e.expressionSemantic(sc);
-                return e;
-            }
 
             if (ident == Id.outer && mt.sym.vthis)
             {

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -269,7 +269,7 @@ void test_semantic()
     /* Mini object.d source. Module::parse will add internal members also. */
     const char *buf =
         "module object;\n"
-        "class Object { }\n"
+        "class Object { void* __monitor; }\n"
         "class Throwable { }\n"
         "class Error : Throwable { this(immutable(char)[]); }";
 

--- a/compiler/test/compilable/b18242.d
+++ b/compiler/test/compilable/b18242.d
@@ -7,7 +7,7 @@ class Object { }
 class TypeInfo { }
 class TypeInfo_Class : TypeInfo
 {
-    version(D_LP64) { ubyte[136+16] _x; } else { ubyte[68+16] _x; }
+    version(D_LP64) { ubyte[136+24] _x; } else { ubyte[68+20] _x; }
 }
 
 class Throwable { }

--- a/compiler/test/fail_compilation/extra-files/no_monitor_synchronized/object.d
+++ b/compiler/test/fail_compilation/extra-files/no_monitor_synchronized/object.d
@@ -1,0 +1,5 @@
+module object;
+
+alias size_t = typeof(int.sizeof);
+
+class Object {}

--- a/compiler/test/fail_compilation/fail_opover.d
+++ b/compiler/test/fail_compilation/fail_opover.d
@@ -4,7 +4,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail_opover.d(39): Error: no `[]` operator overload for type `object.Object`
-$p:object.d$(111):        perhaps define `auto opIndex() {}` for `object.Object`
+$p:object.d$($n$):        perhaps define `auto opIndex() {}` for `object.Object`
 fail_compilation/fail_opover.d(43): Error: no `[]` operator overload for type `TestS`
 fail_compilation/fail_opover.d(41):        perhaps define `auto opIndex() {}` for `fail_opover.test1.TestS`
 fail_compilation/fail_opover.d(55): Error: no `[]` operator overload for type `S`

--- a/compiler/test/fail_compilation/no_monitor_synchronized.d
+++ b/compiler/test/fail_compilation/no_monitor_synchronized.d
@@ -1,0 +1,27 @@
+/*
+DFLAGS:
+REQUIRED_ARGS: -c
+EXTRA_SOURCES: extra-files/no_monitor_synchronized/object.d
+TEST_OUTPUT:
+---
+fail_compilation/no_monitor_synchronized.d(20): Error: cannot `synchronize` on a `Foo` because `object.Object` has no `__monitor` field
+---
+*/
+
+// Test using synchronized(obj) with a custom druntime that has no __monitor field
+
+class Foo
+{
+    int x;
+}
+
+void test(Foo f)
+{
+    synchronized(f) {}
+
+    // Bare synchronized (uses critical section, not monitor) still compiles
+    synchronized {}
+}
+
+// Check that there's only a vtbl before x, no hidden monitor field
+static assert(Foo.x.offsetof == size_t.sizeof);

--- a/compiler/test/runnable/test42.d
+++ b/compiler/test/runnable/test42.d
@@ -1315,6 +1315,12 @@ void test79()
 //        writeln(c.__monitor);
         assert(c.__monitor !is null);
     }
+
+    // __monitor on a shared object is still void*, not shared(void*)
+    shared C79 sc = new shared C79();
+    void* p = cast(void*) 0x1;
+    sc.__monitor = p;
+    assert(sc.__monitor == p);
 }
 
 /***************************************************/

--- a/druntime/src/core/sync/mutex.d
+++ b/druntime/src/core/sync/mutex.d
@@ -102,7 +102,7 @@ class Mutex :
 
         auto self = cast(Mutex) this;
         self.m_proxy.link = self;
-        this.__monitor = cast(void*) &m_proxy;
+        self.__monitor = cast(void*) &self.m_proxy;
     }
 
 

--- a/druntime/src/core/sync/rwmutex.d
+++ b/druntime/src/core/sync/rwmutex.d
@@ -201,8 +201,9 @@ class ReadWriteMutex
         this(this Q)() @trusted nothrow
             if (is(Q == Reader) || is(Q == shared Reader))
         {
-            m_proxy.link = cast(typeof(m_proxy.link)) this;
-            this.__monitor = cast(void*) &m_proxy;
+            auto self = cast(Reader) this;
+            self.m_proxy.link = cast(typeof(self.m_proxy.link)) this;
+            self.__monitor = cast(void*) &self.m_proxy;
         }
 
         /**
@@ -372,8 +373,9 @@ class ReadWriteMutex
         this(this Q)() @trusted nothrow
             if (is(Q == Writer) || is(Q == shared Writer))
         {
-            m_proxy.link = cast(typeof(m_proxy.link)) this;
-            this.__monitor = cast(void*) &m_proxy;
+            auto self = cast(Writer) this;
+            self.m_proxy.link = cast(typeof(self.m_proxy.link)) this;
+            self.__monitor = cast(void*) &self.m_proxy;
         }
 
 

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -105,11 +105,17 @@ else version (AArch64)
     else version = WithArgTypes;
 }
 
+static assert(Object.__monitor.offsetof == size_t.sizeof);
+
 /**
  * All D class objects inherit from Object.
  */
 class Object
 {
+    // This is an internal field that is omitted from .tupleof, __traits(allMembers), pointer bitmaps etc.
+    // It can be removed in a custom druntime, but if it's there it must remain the first field.
+    void* __monitor;
+
     /**
      * Convert Object to a human readable string.
      */

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -232,9 +232,9 @@ void main()
 
 $(H3 $(LNAME2 hidden-fields, Accessing Hidden Fields))
 
-        $(P The properties $(D .__vptr) and $(D .__monitor) give access
-        to the class object's vtbl[] and monitor, respectively, but
-        should not be used in user code.
+        $(P The property $(D .__vptr) gives access to the class object's vtbl[],
+        but should not be used in user code. The $(D .__monitor) field is defined
+        in druntime, but excluded from `.tupleof` and introspection from traits.
         See $(DDSUBLINK spec/abi, classes, the ABI) for details.
         )
         $(P See also: $(RELATIVE_LINK2 nested-context, Context Pointer).)


### PR DESCRIPTION
Closes #22754

The compiler is hard-coded in various places to assume a specific class layouts from druntime (for example, CTFE assumes Exception.msg is field[0]) so the code has more checks now. It would be a lot nicer if this were refactored in general (TypeInfo generation is especially ugly), but that's a larger task.