### PR TITLE
Only `pragma(printf)` functions marked @safe or @trusted are @safe

### DIFF
--- a/changelog/dmd.saferPrintf.dd
+++ b/changelog/dmd.saferPrintf.dd
@@ -1,15 +1,27 @@
-Allow some forms of printf calls to be treated as @safe
+Allow certain `pragma(printf)` function calls to be treated as `@safe`
 
-`printf` function calls in general are unsafe. Most calls, however, are safe.
-This change examines the format string to `printf` and allows format strings
-that do not include `s` formats to be allowed in @safe code.
+`printf` function calls in general are unsafe. Many calls, however,
+can be automatically checked for safety.
+
+This change allows calling a $(DDSUBLINK spec/pragma, printf,
+`pragma(printf)`) function from @safe code when:
+
+- the callee is marked `@safe` or `@trusted`
+- the format string passed is a literal
+- no zero-terminated string format specifiers are used
+
+Note: `pragma(printf)` already enforces type safety.
 
 For example:
 
 ```d
+extern(C) pragma(printf)
+void printf(const char* format, ...) @trusted;
+
 @safe void func(int i, char* s)
 {
     printf("i is %d\n", i);  // allowed
-    printf("s is %s\n", s);  // unsafe, not allowed
+    printf("s is %s\n", s);  // Error: call is not safe
+    printf(s);               // Error: call is not safe
 }
 ```

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3411,25 +3411,23 @@ private bool checkSafety(FuncDeclaration f, ref Loc loc, Scope* sc, Expressions*
         const isVa_list = tf.parameterList.varargs == VarArg.none;
         const nparams = tf.parameterList.length;
         const nargs = arguments ? arguments.length : 0;
-        if (nparams == 1 && nargs)
+        assert(nparams && nargs); // should have been verified already
+        if (auto se = (*arguments)[nparams - 1 - isVa_list].isStringExp())
         {
-            if (auto se = (*arguments)[nparams - 1 - isVa_list].isStringExp())
+            if (!isFormatSafe(se.peekString()))
             {
-                if (!isFormatSafe(se.peekString()))
-                {
-                    error(loc, "calling `pragma(printf)` %s `%s` with format string `%s` is not `@safe`",
-                        f.kind(), f.toPrettyChars(), se.toChars());
-                    .errorSupplemental(f.loc, "`%s` is declared here", f.toPrettyChars());
-                    return true;
-                }
-            }
-            else
-            {
-                error(loc, "calling `pragma(printf)` %s `%s` with non-literal format string is not `@safe`",
-                    f.kind(), f.toPrettyChars());
+                error(loc, "calling `pragma(printf)` %s `%s` with format string `%s` is not `@safe`",
+                    f.kind(), f.toPrettyChars(), se.toChars());
                 .errorSupplemental(f.loc, "`%s` is declared here", f.toPrettyChars());
                 return true;
             }
+        }
+        else
+        {
+            error(loc, "calling `pragma(printf)` %s `%s` with non-literal format string is not `@safe`",
+                f.kind(), f.toPrettyChars());
+            .errorSupplemental(f.loc, "`%s` is declared here", f.toPrettyChars());
+            return true;
         }
     }
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3404,7 +3404,7 @@ private bool checkSafety(FuncDeclaration f, ref Loc loc, Scope* sc, Expressions*
         return false;
     }
 
-    if (f.printf)
+    if (f.printf && (f.isSafe() || f.isTrusted()))
     {
         TypeFunction tf = f.type.isTypeFunction();
         assert(tf);
@@ -3415,8 +3415,20 @@ private bool checkSafety(FuncDeclaration f, ref Loc loc, Scope* sc, Expressions*
         {
             if (auto se = (*arguments)[nparams - 1 - isVa_list].isStringExp())
             {
-                if (isFormatSafe(se.peekString()))
-                    return false;
+                if (!isFormatSafe(se.peekString()))
+                {
+                    error(loc, "calling `pragma(printf)` %s `%s` with format string `%s` is not `@safe`",
+                        f.kind(), f.toPrettyChars(), se.toChars());
+                    .errorSupplemental(f.loc, "`%s` is declared here", f.toPrettyChars());
+                    return true;
+                }
+            }
+            else
+            {
+                error(loc, "calling `pragma(printf)` %s `%s` with non-literal format string is not `@safe`",
+                    f.kind(), f.toPrettyChars());
+                .errorSupplemental(f.loc, "`%s` is declared here", f.toPrettyChars());
+                return true;
             }
         }
     }

--- a/compiler/test/fail_compilation/safeprintf.d
+++ b/compiler/test/fail_compilation/safeprintf.d
@@ -2,21 +2,24 @@
 DISABLED: win32 win64 freebsd32 openbsd32 linux32 osx32
 TEST_OUTPUT:
 ---
-fail_compilation/safeprintf.d(26): Error: calling `pragma(printf)` function `safeprintf.printf` with format string `"s: %s\n"` is not `@safe`
-fail_compilation/safeprintf.d(19):        `safeprintf.printf` is declared here
-fail_compilation/safeprintf.d(27): Error: calling `pragma(printf)` function `safeprintf.printf` with format string `"s: %S\n"` is not `@safe`
-fail_compilation/safeprintf.d(19):        `safeprintf.printf` is declared here
-fail_compilation/safeprintf.d(28): Error: calling `pragma(printf)` function `safeprintf.printf` with format string `"s: %Z\n"` is not `@safe`
-fail_compilation/safeprintf.d(19):        `safeprintf.printf` is declared here
-fail_compilation/safeprintf.d(28): Deprecation: format specifier `"%Z"` is invalid
-fail_compilation/safeprintf.d(29): Error: calling `pragma(printf)` function `safeprintf.printf` with non-literal format string is not `@safe`
-fail_compilation/safeprintf.d(19):        `safeprintf.printf` is declared here
-fail_compilation/safeprintf.d(30): Error: `@safe` function `safeprintf.func` cannot call `@system` function `safeprintf.sys_printf`
-fail_compilation/safeprintf.d(20):        `safeprintf.sys_printf` is declared here
+fail_compilation/safeprintf.d(29): Error: calling `pragma(printf)` function `safeprintf.printf` with format string `"s: %s\n"` is not `@safe`
+fail_compilation/safeprintf.d(21):        `safeprintf.printf` is declared here
+fail_compilation/safeprintf.d(30): Error: calling `pragma(printf)` function `safeprintf.printf` with format string `"s: %S\n"` is not `@safe`
+fail_compilation/safeprintf.d(21):        `safeprintf.printf` is declared here
+fail_compilation/safeprintf.d(31): Error: calling `pragma(printf)` function `safeprintf.printf` with format string `"s: %Z\n"` is not `@safe`
+fail_compilation/safeprintf.d(21):        `safeprintf.printf` is declared here
+fail_compilation/safeprintf.d(31): Deprecation: format specifier `"%Z"` is invalid
+fail_compilation/safeprintf.d(32): Error: calling `pragma(printf)` function `safeprintf.printf` with non-literal format string is not `@safe`
+fail_compilation/safeprintf.d(21):        `safeprintf.printf` is declared here
+fail_compilation/safeprintf.d(33): Error: calling `pragma(printf)` function `safeprintf.bar` with format string `"%s"` is not `@safe`
+fail_compilation/safeprintf.d(22):        `safeprintf.bar` is declared here
+fail_compilation/safeprintf.d(34): Error: `@safe` function `safeprintf.func` cannot call `@system` function `safeprintf.sys_printf`
+fail_compilation/safeprintf.d(23):        `safeprintf.sys_printf` is declared here
 ---
 */
 
 extern (C) @trusted pragma(printf) int printf(const(char)* format, ...);
+extern(C) pragma(printf) @trusted void bar(int, const char*, ...);
 extern (C) @system pragma(printf) int sys_printf(const(char)* format, ...);
 
 @safe void func(int i, char* s, dchar* d)
@@ -27,5 +30,6 @@ extern (C) @system pragma(printf) int sys_printf(const(char)* format, ...);
     printf("s: %S\n", d);
     printf("s: %Z\n", s);
     printf(s, i); // non-literal
+    bar(1, "%s", s); // preceding args
     sys_printf("d", i);
 }

--- a/compiler/test/fail_compilation/safeprintf.d
+++ b/compiler/test/fail_compilation/safeprintf.d
@@ -2,22 +2,30 @@
 DISABLED: win32 win64 freebsd32 openbsd32 linux32 osx32
 TEST_OUTPUT:
 ---
-fail_compilation/safeprintf.d(20): Error: `@safe` function `safeprintf.func` cannot call `@system` function `safeprintf.printf`
-fail_compilation/safeprintf.d(15):        `safeprintf.printf` is declared here
-fail_compilation/safeprintf.d(21): Error: `@safe` function `safeprintf.func` cannot call `@system` function `safeprintf.printf`
-fail_compilation/safeprintf.d(15):        `safeprintf.printf` is declared here
-fail_compilation/safeprintf.d(22): Error: `@safe` function `safeprintf.func` cannot call `@system` function `safeprintf.printf`
-fail_compilation/safeprintf.d(15):        `safeprintf.printf` is declared here
-fail_compilation/safeprintf.d(22): Deprecation: format specifier `"%Z"` is invalid
+fail_compilation/safeprintf.d(26): Error: calling `pragma(printf)` function `safeprintf.printf` with format string `"s: %s\n"` is not `@safe`
+fail_compilation/safeprintf.d(19):        `safeprintf.printf` is declared here
+fail_compilation/safeprintf.d(27): Error: calling `pragma(printf)` function `safeprintf.printf` with format string `"s: %S\n"` is not `@safe`
+fail_compilation/safeprintf.d(19):        `safeprintf.printf` is declared here
+fail_compilation/safeprintf.d(28): Error: calling `pragma(printf)` function `safeprintf.printf` with format string `"s: %Z\n"` is not `@safe`
+fail_compilation/safeprintf.d(19):        `safeprintf.printf` is declared here
+fail_compilation/safeprintf.d(28): Deprecation: format specifier `"%Z"` is invalid
+fail_compilation/safeprintf.d(29): Error: calling `pragma(printf)` function `safeprintf.printf` with non-literal format string is not `@safe`
+fail_compilation/safeprintf.d(19):        `safeprintf.printf` is declared here
+fail_compilation/safeprintf.d(30): Error: `@safe` function `safeprintf.func` cannot call `@system` function `safeprintf.sys_printf`
+fail_compilation/safeprintf.d(20):        `safeprintf.sys_printf` is declared here
 ---
 */
 
-extern (C) @system pragma(printf) int printf(const(char)* format, ...);
+extern (C) @trusted pragma(printf) int printf(const(char)* format, ...);
+extern (C) @system pragma(printf) int sys_printf(const(char)* format, ...);
 
 @safe void func(int i, char* s, dchar* d)
 {
-    printf("i: %d\n", i);
+    printf("no specs"); // OK
+    printf("i: %d\n", i); // OK
     printf("s: %s\n", s);
     printf("s: %S\n", d);
     printf("s: %Z\n", s);
+    printf(s, i); // non-literal
+    sys_printf("d", i);
 }


### PR DESCRIPTION
Also explain why when not safe to call.
Add test cases for non-literal format string and `@system` function.
Fixes #22768.
Also fixes #22774.

Note: The GitHub 'hide whitespace' setting is useful for this diff.