### PR TITLE
use abstractions reg_t and REGMAX instead of hardcoding

### DIFF
--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -818,8 +818,8 @@ struct Symbol
         uint Stypidx;           // SCstruct,SCunion,SCclass,SCenum,SCtypedef: debug info type index
         struct
         {
-            ubyte Sreglsw;
-            ubyte Sregmsw;
+            reg_t Sreglsw;
+            reg_t Sregmsw;
           regm_t Sregm;         // mask of registers
         }                       // SCregister,SCregpar,SCpseudo: register number
     }

--- a/compiler/src/dmd/backend/x86/cgreg.d
+++ b/compiler/src/dmd/backend/x86/cgreg.d
@@ -694,7 +694,7 @@ private void cgreg_map(Symbol* s, reg_t regmsw, reg_t reglsw)
             }
         }
     }
-    s.Sreglsw = cast(ubyte)reglsw;
+    s.Sreglsw = reglsw;
     s.Sregm = (1UL << reglsw);
     cgstate.mfuncreg &= ~(1UL << reglsw);
     if (regmsw != NOREG)
@@ -717,8 +717,8 @@ private void cgreg_map(Symbol* s, reg_t regmsw, reg_t reglsw)
     }
     else
     {
-        assert(regmsw < 8);
-        s.Sregmsw = cast(ubyte)regmsw;
+        assert(regmsw < REGMAX);
+        s.Sregmsw = regmsw;
         s.Sregm |= 1UL << regmsw;
         cgstate.mfuncreg &= ~(1UL << regmsw);
         vec_orass(regrange[regmsw],s.Slvreg);


### PR DESCRIPTION
The REGMAX assert tripped because the AArch64 has more than 8 registers.