### PR TITLE
implement deh_win64_posix.terminate()

### DIFF
--- a/compiler/src/dmd/backend/arm/instr.d
+++ b/compiler/src/dmd/backend/arm/instr.d
@@ -83,6 +83,7 @@ struct INSTR
     enum mBP = 1 << BP;
 
     enum uint nop = 0xD503201F;
+    enum hlt = 0xD440_0000;          // https://www.scs.stanford.edu/~zyedidia/arm64/hlt.html
 
     alias reg_t = ubyte;
 

--- a/druntime/src/rt/deh_win64_posix.d
+++ b/druntime/src/rt/deh_win64_posix.d
@@ -113,8 +113,11 @@ void terminate()
 {
     version (AArch64)
     {
-        int* p = null;
-        *p = 0;             // TODO AArch64
+        asm
+        {
+            naked;
+            op 0xD440_0000;     // INSTR.hlt https://www.scs.stanford.edu/~zyedidia/arm64/hlt.html
+        }
     }
     else
     asm


### PR DESCRIPTION
Make use of new capability to insert AArch64 code by hex opcode to implement terminate() function.