### PR TITLE
Move __monitor as an optional field in Object class

### DIFF
--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -337,7 +337,17 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
      */
     final bool hasMonitor()
     {
-        return classKind == ClassKind.d;
+        if (classKind != ClassKind.d)
+            return false;
+        else if (this.baseClass !is null)
+            return this.baseClass.hasMonitor();
+
+        foreach(field; this.fields)
+        {
+            if (field.ident is Id.__monitor)
+                return true;
+        }
+        return false;
     }
 
     /****************************************

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -9978,8 +9978,6 @@ private extern(C++) class FinalizeSizeVisitor : Visitor
         {
             outerCd.alignsize = target.ptrsize;
             outerCd.structsize = target.ptrsize;      // allow room for __vptr
-            if (outerCd.hasMonitor())
-                outerCd.structsize += target.ptrsize; // allow room for __monitor
         }
 
         //printf("finalizeSize() %s, sizeok = %d\n", toChars(), sizeok);

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -764,7 +764,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
     //printf("+dtb.length: %d\n", dtb.length);
 
     /* Order:
-     *  { base class } or { __vptr, __monitor }
+     *  { base class } or { __vptr }
      *  interfaces
      *  fields
      */
@@ -808,14 +808,9 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
         }
         else
         {
-            // Insert { __vptr, __monitor }
+            // Insert { __vptr }
             dtb.xoff(toVtblSymbol(concreteType), 0);  // __vptr
             offset = target.ptrsize;
-            if (cd.hasMonitor())
-            {
-                dtb.size(0);              // __monitor
-                offset += target.ptrsize;
-            }
         }
 
         // Interface vptr initializations

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -1328,7 +1328,7 @@ Louter:
         foreach (vd; pc.fields)
         {
             //printf("vd = %s %s\n", vd.kind(), vd.toChars());
-            if (vd.hasPointers())
+            if (vd.ident !is Id.__monitor && vd.hasPointers())
             {
                 flags &= ~ClassFlags.noPointers;  // not no-how, not no-way
                 break Louter;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3129,6 +3129,12 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 ss.exp = new CastExp(ss.loc, ss.exp, t);
                 ss.exp = ss.exp.expressionSemantic(sc);
             }
+            if (!cd.hasMonitor())
+            {
+                error(ss.loc, "cannot `synchronize` on a `%s` because `object.Object` has no `__monitor` field",
+                    cd.toChars());
+                return setError();
+            }
             version (all)
             {
                 /* Rewrite as:

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -7182,18 +7182,6 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                 return e;
             }
 
-            if (ident == Id.__monitor && mt.sym.hasMonitor())
-            {
-                /* The handle to the monitor (call it a void*)
-                 * *(cast(void**)e + 1)
-                 */
-                e = e.castTo(sc, mt.tvoidptr.pointerTo());
-                e = new AddExp(e.loc, e, IntegerExp.literal!1);
-                e = new PtrExp(e.loc, e);
-                e = e.expressionSemantic(sc);
-                return e;
-            }
-
             if (ident == Id.outer && mt.sym.vthis)
             {
                 if (mt.sym.vthis.semanticRun == PASS.initial)

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -269,7 +269,7 @@ void test_semantic()
     /* Mini object.d source. Module::parse will add internal members also. */
     const char *buf =
         "module object;\n"
-        "class Object { }\n"
+        "class Object { void* __monitor; }\n"
         "class Throwable { }\n"
         "class Error : Throwable { this(immutable(char)[]); }";
 

--- a/compiler/test/compilable/b18242.d
+++ b/compiler/test/compilable/b18242.d
@@ -7,7 +7,7 @@ class Object { }
 class TypeInfo { }
 class TypeInfo_Class : TypeInfo
 {
-    version(D_LP64) { ubyte[136+16] _x; } else { ubyte[68+16] _x; }
+    version(D_LP64) { ubyte[136+24] _x; } else { ubyte[68+20] _x; }
 }
 
 class Throwable { }

--- a/compiler/test/compilable/dtoh_required_symbols.d
+++ b/compiler/test/compilable/dtoh_required_symbols.d
@@ -47,6 +47,9 @@ struct ExternDStructTemplate final
 
 class Object
 {
+public:
+    void* __monitor_;
+private:
     virtual void __vtable_slot_0();
     virtual void __vtable_slot_1();
     virtual void __vtable_slot_2();

--- a/compiler/test/compilable/extra-files/json.json
+++ b/compiler/test/compilable/extra-files/json.json
@@ -744,7 +744,7 @@
             {
                 "char": 14,
                 "deco": "VALUE_REMOVED_FOR_TEST",
-                "init": "Object()",
+                "init": "Object(null)",
                 "kind": "variable",
                 "line": 120,
                 "name": "c_10011",

--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -151,7 +151,12 @@ imported!()
 }
 RTInfo!(C)
 {
-	enum immutable(void)* RTInfo = null;
+	enum immutable(ulong)* RTInfo = & RTInfoImpl;
+
+}
+RTInfoImpl!([16LU, 2LU])
+{
+	immutable immutable(ulong[2]) RTInfoImpl = [16LU, 2LU];
 
 }
 values!(__c_wchar_t)

--- a/compiler/test/compilable/test13668.d
+++ b/compiler/test/compilable/test13668.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-AliasSeq!("id", "toString", "toHash", "opCmp", "opEquals", "Monitor", "factory")
+AliasSeq!("id", "__monitor", "toString", "toHash", "opCmp", "opEquals", "Monitor", "factory")
 genProps
 ---
 */

--- a/compiler/test/compilable/test17057.d
+++ b/compiler/test/compilable/test17057.d
@@ -7,5 +7,5 @@ class LeClass {
 
 void main()
 {
-    static assert([__traits(allMembers, LeClass)] == ["toString", "toHash", "opCmp", "opEquals", "Monitor", "factory"]);
+    static assert([__traits(allMembers, LeClass)] == ["__monitor", "toString", "toHash", "opCmp", "opEquals", "Monitor", "factory"]);
 }

--- a/compiler/test/fail_compilation/extra-files/no_monitor_synchronized/object.d
+++ b/compiler/test/fail_compilation/extra-files/no_monitor_synchronized/object.d
@@ -1,0 +1,11 @@
+module object;
+
+alias size_t = typeof(int.sizeof);
+
+class Object {
+}
+class TypeInfo {}
+class TypeInfo_Class : TypeInfo
+{
+    version(D_LP64) { ubyte[136+24] _x; } else { ubyte[68+20] _x; }
+}

--- a/compiler/test/fail_compilation/no_monitor_synchronized.d
+++ b/compiler/test/fail_compilation/no_monitor_synchronized.d
@@ -1,0 +1,27 @@
+/*
+DFLAGS:
+REQUIRED_ARGS: -c
+EXTRA_SOURCES: extra-files/no_monitor_synchronized/object.d
+TEST_OUTPUT:
+---
+fail_compilation/no_monitor_synchronized.d(20): Error: cannot `synchronize` on a `Foo` because `object.Object` has no `__monitor` field
+---
+*/
+
+// Test using synchronized(obj) with a custom druntime that has no __monitor field
+
+class Foo
+{
+    int x;
+}
+
+void test(Foo f)
+{
+    synchronized(f) {}
+
+    // Bare synchronized (uses critical section, not monitor) still compiles
+    synchronized {}
+}
+
+// Check that there's only a vtbl before x, no hidden monitor field
+static assert(Foo.x.offsetof == size_t.sizeof);

--- a/compiler/test/fail_compilation/test21008.d
+++ b/compiler/test/fail_compilation/test21008.d
@@ -2,17 +2,17 @@
 TEST_OUTPUT:
 ---
 fail_compilation/test21008.d(110): Error: function `test21008.C.after` circular reference to class `C`
-fail_compilation/test21008.d(117): Error: calling non-static function `toString` requires an instance of type `Object`
-fail_compilation/test21008.d(117): Error: calling non-static function `toHash` requires an instance of type `Object`
-fail_compilation/test21008.d(117): Error: function `opCmp` is not callable using argument types `()`
-fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
+fail_compilation/test21008.d(118): Error: calling non-static function `toString` requires an instance of type `Object`
+fail_compilation/test21008.d(118): Error: calling non-static function `toHash` requires an instance of type `Object`
+fail_compilation/test21008.d(118): Error: function `opCmp` is not callable using argument types `()`
+fail_compilation/test21008.d(118):        too few arguments, expected 1, got 0
 $p:druntime/import/object.d$($n$):        `object.Object.opCmp(Object o)` declared here
-fail_compilation/test21008.d(117): Error: function `opEquals` is not callable using argument types `()`
-fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
+fail_compilation/test21008.d(118): Error: function `opEquals` is not callable using argument types `()`
+fail_compilation/test21008.d(118):        too few arguments, expected 1, got 0
 $p:druntime/import/object.d$($n$):        `object.Object.opEquals(Object o)` declared here
-fail_compilation/test21008.d(117): Error: `Monitor` has no effect
-fail_compilation/test21008.d(117): Error: function `factory` is not callable using argument types `()`
-fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
+fail_compilation/test21008.d(118): Error: `Monitor` has no effect
+fail_compilation/test21008.d(118): Error: function `factory` is not callable using argument types `()`
+fail_compilation/test21008.d(118):        too few arguments, expected 1, got 0
 $p:druntime/import/object.d$($n$):        `object.Object.factory(string classname)` declared here
 fail_compilation/test21008.d(105):        called from here: `handleMiddlewareAnnotation()`
 ---
@@ -38,6 +38,7 @@ string handleMiddlewareAnnotation()
 {
     foreach (member; __traits(allMembers, C))
     {
-        __traits(getMember, C, member);
+        static if (member != "__monitor")
+            __traits(getMember, C, member);
     }
 }

--- a/compiler/test/runnable/traits.d
+++ b/compiler/test/runnable/traits.d
@@ -468,7 +468,7 @@ class C19
 void test19()
 {
     auto a = __traits(allMembers, C19);
-    assert(a.length == 9);
+    assert(a.length == 10);
 
     foreach( m; __traits(allMembers, C19) )
         printf("%.*s\n", cast(int)m.length, m.ptr);
@@ -655,7 +655,7 @@ class Test6674
 static assert([__traits(allMembers,Test6674)] == [
     "i1","i2","i3","i4",
     "func1","func2",
-    "toString","toHash","opCmp","opEquals","Monitor","factory"]);
+    "__monitor", "toString","toHash","opCmp","opEquals","Monitor","factory"]);
 
 /********************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=6073
@@ -1205,7 +1205,7 @@ class C10096X
 }
 static assert(
     [__traits(allMembers, C10096X)] ==
-    ["str", "__ctor", "__dtor", "getStr", "__xdtor", "toString", "toHash", "opCmp", "opEquals", "Monitor", "factory"]);
+    ["str", "__ctor", "__dtor", "getStr", "__xdtor", "__monitor", "toString", "toHash", "opCmp", "opEquals", "Monitor", "factory"]);
 
 // --------
 

--- a/compiler/test/runnable/xtest46.d
+++ b/compiler/test/runnable/xtest46.d
@@ -9,7 +9,7 @@ int
 !! immutable(int)[]
 int(int i, long j = 7L)
 long
-C10390(C10390(C10390(<recursion>)))
+C10390(null, C10390(null, C10390(<recursion>)))
 AliasSeq!(height)
 AliasSeq!(get, get)
 AliasSeq!(clear)
@@ -4772,7 +4772,7 @@ abstract class C2997 : B2997, I2997 {}
 
 void test2997()
 {
-    enum ObjectMembers = ["toString","toHash","opCmp","opEquals","Monitor","factory"];
+    enum ObjectMembers = ["__monitor", "toString","toHash","opCmp","opEquals","Monitor","factory"];
 
     static assert([__traits(allMembers, C2997)] == ["foo"] ~ ObjectMembers ~ ["bar"]);
 }
@@ -5732,7 +5732,7 @@ void test7168()
         void bar(){}
     }
 
-    enum ObjectMembers = ["toString","toHash","opCmp","opEquals","Monitor","factory"];
+    enum ObjectMembers = ["__monitor", "toString","toHash","opCmp","opEquals","Monitor","factory"];
 
     static assert([__traits(allMembers, X)] == ["foo"]~ObjectMembers);          // pass
     static assert([__traits(allMembers, Y)] == ["bar", "foo"]~ObjectMembers);   // fail

--- a/compiler/test/runnable/xtest46_gc.d
+++ b/compiler/test/runnable/xtest46_gc.d
@@ -10,7 +10,7 @@ int
 !! immutable(int)[]
 int(int i, long j = 7L)
 long
-C10390(C10390(<recursion>))
+C10390(null, C10390(<recursion>))
 AliasSeq!(height)
 AliasSeq!(get, get)
 AliasSeq!(clear)

--- a/compiler/test/runnable/xtest47.d
+++ b/compiler/test/runnable/xtest47.d
@@ -2,6 +2,7 @@
 /* TEST_OUTPUT:
 ---
 f
+__monitor
 toString
 toHash
 opCmp

--- a/druntime/src/core/sync/mutex.d
+++ b/druntime/src/core/sync/mutex.d
@@ -102,7 +102,7 @@ class Mutex :
 
         auto self = cast(Mutex) this;
         self.m_proxy.link = self;
-        this.__monitor = cast(void*) &m_proxy;
+        *cast(void**) &this.__monitor = cast(void*) &m_proxy;
     }
 
 
@@ -136,7 +136,7 @@ class Mutex :
     do
     {
         this();
-        obj.__monitor = cast(void*) &m_proxy;
+        *cast(void**) &obj.__monitor = cast(void*) &m_proxy;
     }
 
 

--- a/druntime/src/core/sync/rwmutex.d
+++ b/druntime/src/core/sync/rwmutex.d
@@ -202,7 +202,7 @@ class ReadWriteMutex
             if (is(Q == Reader) || is(Q == shared Reader))
         {
             m_proxy.link = cast(typeof(m_proxy.link)) this;
-            this.__monitor = cast(void*) &m_proxy;
+            *cast(void**) &this.__monitor = cast(void*) &m_proxy;
         }
 
         /**
@@ -373,7 +373,7 @@ class ReadWriteMutex
             if (is(Q == Writer) || is(Q == shared Writer))
         {
             m_proxy.link = cast(typeof(m_proxy.link)) this;
-            this.__monitor = cast(void*) &m_proxy;
+            *cast(void**) &this.__monitor = cast(void*) &m_proxy;
         }
 
 

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -110,6 +110,8 @@ else version (AArch64)
  */
 class Object
 {
+    void* __monitor;
+
     /**
      * Convert Object to a human readable string.
      */

--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -84,7 +84,6 @@ $(H2 $(LNAME2 classes, Classes))
     $(TABLE_3COLS Class Object Layout,
     $(THEAD size, property, contents)
     $(TROW $(I ptrsize), $(D .__vptr), pointer to vtable)
-    $(TROW $(I ptrsize), $(D .__monitor), monitor)
     $(TROW $(I ptrsize)..., $(NBSP), $(ARGS vptrs for any interfaces implemented by this class in left to right, most to least derived, order))
     $(TROW $(D ...), $(D ...), $(ARGS super's non-static fields and super's interface vptrs, from least to most derived))
     $(TROW $(D ...), named fields, non-static fields)

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -232,9 +232,9 @@ void main()
 
 $(H3 $(LNAME2 hidden-fields, Accessing Hidden Fields))
 
-        $(P The properties $(D .__vptr) and $(D .__monitor) give access
-        to the class object's vtbl[] and monitor, respectively, but
-        should not be used in user code.
+        $(P The property $(D .__vptr) gives access to the class object's vtbl[],
+        but should not be used in user code. The $(D .__monitor) field is defined
+        in druntime as the $(D Object) class first field'.
         See $(DDSUBLINK spec/abi, classes, the ABI) for details.
         )
         $(P See also: $(RELATIVE_LINK2 nested-context, Context Pointer).)


### PR DESCRIPTION
Needs spec change.

Rips out the monitor (almost) entirely out of the frontend, and moves it as a typed field in the ``Object`` class.

This work is NOT approved, and needs to go back to the monthly meeting for approval.