### PR TITLE
Fix Issue #22769: ICE on IFTI call inside interpolated string

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5852,8 +5852,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 arguments.push(makeTemplateItem(Id.InterpolatedExpression, str));
                 Expressions* mix = new Expressions(new StringExp(e.loc, str));
-                // FIXME: i'd rather not use MixinExp but idk how to do it lol
-                arguments.push(new MixinExp(e.loc, mix));
+                auto mixinExp = new MixinExp(e.loc, mix);
+                auto res = mixinExp.expressionSemantic(sc);
+                res = resolveProperties(sc, res);
+                arguments.push(res);
             }
         }
 

--- a/compiler/test/compilable/issue22769.d
+++ b/compiler/test/compilable/issue22769.d
@@ -1,0 +1,19 @@
+// https://github.com/dlang/dmd/issues/22769
+
+int foo()() => 0;
+
+void bar()
+{
+    cast(void) i"$(foo)";
+}
+
+struct OutBuffer
+{
+    void opOpAssign(string op, T...)(T args) {}
+}
+
+void qux()
+{
+    OutBuffer buf;
+    buf ~= i"$(foo)";
+}


### PR DESCRIPTION
When I dug into the ICE crash, I discovered a fascinating blind spot in the compiler. It turns out that when an interpolated string like i"$(foo)" is parsed, it's quietly packaged into a tuple of expressions. Usually, that's fine, but wrapping it in cast(void) told the compiler to ignore the output. The property resolver took that cast(void) instruction at face value, looked at the tuple as a whole, and completely forgot to peek inside! Because of this oversight, the uninstantiated test template foo skipped past the safety checks and plunged straight into the code generator, which panicked and caused the compiler to crash. To fix this, I taught the compiler's property resolver to open up the tuple and recursively resolve every single element hidden inside before moving forward. Once the compiler started checking the elements properly, the crash completely vanished.