### PR TITLE
dmd: file: Add PROT_READ to mmap protections.

### DIFF
--- a/compiler/src/dmd/common/file.d
+++ b/compiler/src/dmd/common/file.d
@@ -121,7 +121,7 @@ struct FileMapping(Datum)
 
             if (size > 0 && size != ulong.max && size <= size_t.max)
             {
-                auto p = mmap(null, cast(size_t) size, is(Datum == const) ? PROT_READ : PROT_WRITE, MAP_SHARED, handle, 0);
+                auto p = mmap(null, cast(size_t) size, is(Datum == const) ? PROT_READ : (PROT_READ | PROT_WRITE), MAP_SHARED, handle, 0);
                 if (p == MAP_FAILED)
                 {
                     fprintf(stderr, "mmap(null, %zu) for \"%s\" failed: %s\n", cast(size_t) size, filename, strerror(errno));
@@ -382,8 +382,8 @@ struct FileMapping(Datum)
                 }
                 if (size > 0)
                 {
-                    auto p = mmap(null, size, PROT_WRITE, MAP_SHARED, handle, 0);
-                    if (cast(ssize_t) p == -1)
+                    auto p = mmap(null, size, PROT_READ | PROT_WRITE, MAP_SHARED, handle, 0);
+                    if (p == MAP_FAILED)
                     {
                         fprintf(stderr, "mmap() failed for \"%s\": %s\n", filename, strerror(errno));
                         exit(1);


### PR DESCRIPTION
On Hurd missing `PROT_READ` causes a segmentation fault with  a later `memcpy` to the mmaped memory

As the file is opened with `O_RDWR`  i dont think this should change anything.

I also changed a check for mmap failure to `MAP_FAILED`

Let me know if I should split that into 2 commit and if the commit message is ok.