### PR TITLE
Fix issue #21500 : [importc] undefined reference `__Float32x4_t`

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -199,6 +199,8 @@ typedef unsigned long long __uint64_t;
 typedef struct {} __SVBool_t;
 typedef struct {} __SVFloat32_t;
 typedef struct {} __SVFloat64_t;
+typedef float  __Float32x4_t __attribute__((vector_size(16)));
+typedef double __Float64x2_t __attribute__((vector_size(16)));
 #endif
 
 #endif // __linux__


### PR DESCRIPTION
TODO: tests

NB, this should fix the undefined identifier. 
This does not address `__attribute__ ((__aarch64_vector_pcs__))` which I presume would need to be a calling convention in LDC.