### PR TITLE
Fix #22791: [ImportC] Support __builtin_memcpy and related memory functions

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5852,8 +5852,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 arguments.push(makeTemplateItem(Id.InterpolatedExpression, str));
                 Expressions* mix = new Expressions(new StringExp(e.loc, str));
-                // FIXME: i'd rather not use MixinExp but idk how to do it lol
-                arguments.push(new MixinExp(e.loc, mix));
+                auto mixinExp = new MixinExp(e.loc, mix);
+                auto res = mixinExp.expressionSemantic(sc);
+                res = resolveProperties(sc, res);
+                arguments.push(res);
             }
         }
 

--- a/compiler/test/compilable/issue22769.d
+++ b/compiler/test/compilable/issue22769.d
@@ -1,0 +1,19 @@
+// https://issues.dlang.org/show_bug.cgi?id=22769
+
+int foo()() => 0;
+
+void bar()
+{
+    cast(void) i"$(foo)";
+}
+
+struct OutBuffer
+{
+    void opOpAssign(string op, T...)(T args) {}
+}
+
+void qux()
+{
+    OutBuffer buf;
+    buf ~= i"$(foo)";
+}

--- a/compiler/test/compilable/testcbuiltins.c
+++ b/compiler/test/compilable/testcbuiltins.c
@@ -1,0 +1,34 @@
+void* test_memcpy(void* dest, const void* src, unsigned long n)
+{
+    return __builtin_memcpy(dest, src, n);
+}
+
+void* test_memmove(void* dest, const void* src, unsigned long n)
+{
+    return __builtin_memmove(dest, src, n);
+}
+
+void* test_memset(void* s, int c, unsigned long n)
+{
+    return __builtin_memset(s, c, n);
+}
+
+int test_memcmp(const void* s1, const void* s2, unsigned long n)
+{
+    return __builtin_memcmp(s1, s2, n);
+}
+
+int test_strcmp(const char* s1, const char* s2)
+{
+    return __builtin_strcmp(s1, s2);
+}
+
+char* test_strcpy(char* dest, const char* src)
+{
+    return __builtin_strcpy(dest, src);
+}
+
+unsigned long test_strlen(const char* s)
+{
+    return __builtin_strlen(s);
+}

--- a/druntime/src/__importc_builtins.di
+++ b/druntime/src/__importc_builtins.di
@@ -72,6 +72,14 @@ version (DigitalMars)
     alias __builtin_fabsf = imported!"core.stdc.math".fabsf;
     alias __builtin_fabsl = imported!"core.stdc.math".fabsl;
 
+    alias __builtin_memcpy  = imported!"core.stdc.string".memcpy;
+    alias __builtin_memmove = imported!"core.stdc.string".memmove;
+    alias __builtin_memset  = imported!"core.stdc.string".memset;
+    alias __builtin_memcmp  = imported!"core.stdc.string".memcmp;
+    alias __builtin_strcmp  = imported!"core.stdc.string".strcmp;
+    alias __builtin_strcpy  = imported!"core.stdc.string".strcpy;
+    alias __builtin_strlen  = imported!"core.stdc.string".strlen;
+
     ushort __builtin_bswap16()(ushort value)
     {
         return cast(ushort) (((value >> 8) & 0xFF) | ((value << 8) & 0xFF00U));


### PR DESCRIPTION
ImportC was missing these common GCC built-ins, and they are now aliased to the corresponding core.stdc.string functions in __importc_builtins.di. This also adds aliases for __builtin_memset, __builtin_memmove, __builtin_memcmp, __builtin_strcmp, __builtin_strcpy, and __builtin_strlen.