### PR TITLE
Fix Issue #22791 - ImportC: error: undefined identifier __builtin_memcpy

### DIFF
--- a/compiler/test/runnable/test22791.c
+++ b/compiler/test/runnable/test22791.c
@@ -1,0 +1,15 @@
+int printf(const char *, ...);
+
+void test_memcpy() {
+    char dest[20];
+    char src[] = "Hello World";
+    __builtin_memcpy(dest, src, 12);
+    if (__builtin_memcmp(dest, src, 12) != 0) {
+        printf("Error: memcmp failed\n");
+    }
+}
+
+int main() {
+    test_memcpy();
+    return 0;
+}

--- a/druntime/src/__importc_builtins.di
+++ b/druntime/src/__importc_builtins.di
@@ -72,6 +72,11 @@ version (DigitalMars)
     alias __builtin_fabsf = imported!"core.stdc.math".fabsf;
     alias __builtin_fabsl = imported!"core.stdc.math".fabsl;
 
+    alias __builtin_memcmp = imported!"core.stdc.string".memcmp;
+    alias __builtin_memcpy = imported!"core.stdc.string".memcpy;
+    alias __builtin_memmove = imported!"core.stdc.string".memmove;
+    alias __builtin_memset = imported!"core.stdc.string".memset;
+
     ushort __builtin_bswap16()(ushort value)
     {
         return cast(ushort) (((value >> 8) & 0xFF) | ((value << 8) & 0xFF00U));


### PR DESCRIPTION
Fix #22791
ImportC was missing standard memory builtins. I just added aliases for __builtin_memcpy, __builtin_memset, __builtin_memmove, and __builtin_memcmp to _importc_builtins.di so they map correctly to core.stdc.string