### PR TITLE
Fix issue #21296 : Access member function through member in AliasSeq

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9901,20 +9901,43 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 case expression:
                     e = cast(Expression)o;
                     if (auto se = e.isDsymbolExp())
+                    {
                         var = se.s.isDeclaration();
+                        if (auto fd = var ? var.isFuncDeclaration() : null)
+                        {
+                            if (!fd.needThis())
+                                var = null;
+                        }
+                    }
                     else if (auto ve = e.isVarExp())
-                        if (!ve.var.isFuncDeclaration())
+                    {
+                        if (auto fd = ve.var.isFuncDeclaration())
+                        {
+                            // Preserve instance context for member functions.
+                            if (fd.needThis())
+                                var = fd;
+                        }
+                        else
                             // Exempt functions for backwards compatibility reasons.
                             // See: https://issues.dlang.org/show_bug.cgi?id=20470#c1
                             var = ve.var;
+                    }
                     break;
                 case dsymbol:
                     Dsymbol s = cast(Dsymbol) o;
                     Declaration d = s.isDeclaration();
-                    if (!d || d.isFuncDeclaration())
-                        // Exempt functions for backwards compatibility reasons.
-                        // See: https://issues.dlang.org/show_bug.cgi?id=20470#c1
+                    if (!d)
                         e = new DsymbolExp(exp.loc, s);
+                    else if (auto fd = d.isFuncDeclaration())
+                    {
+                        // Preserve instance context for member functions.
+                        if (fd.needThis())
+                            var = d;
+                        else
+                            // Exempt functions for backwards compatibility reasons.
+                            // See: https://issues.dlang.org/show_bug.cgi?id=20470#c1
+                            e = new DsymbolExp(exp.loc, s);
+                    }
                     else
                         var = d;
                     break;

--- a/compiler/test/runnable/test21296.d
+++ b/compiler/test/runnable/test21296.d
@@ -1,0 +1,31 @@
+// https://github.com/dlang/dmd/issues/21296
+
+alias Seq(T...) = T;
+
+struct T1
+{
+    int x;
+    alias y = x;
+    alias expand = Seq!x;
+}
+
+struct T2
+{
+    int _x;
+
+    @property int x() { return _x; }
+
+    alias y = x;
+    alias expand = Seq!x;
+}
+
+void main()
+{
+    auto t1 = T1(1);
+    assert(t1.y == 1);
+    assert(t1.expand[0] == 1);
+
+    auto t2 = T2(2);
+    assert(t2.y == 2);
+    assert(t2.expand[0] == 2);
+}


### PR DESCRIPTION
Fixes #21296: access to member functions/properties through member AliasSeq now preserves instance binding when expanding tuple members.

changes:
- Updated tuple expansion logic in `expressionsem.d`
- When expanding tuple members in semantic analysis, member functions/properties that need an instance now stay tied to that instance