### PR TITLE
Fix version identifier for RISC-V architecture in fenv.d

### DIFF
--- a/druntime/src/core/stdc/fenv.d
+++ b/druntime/src/core/stdc/fenv.d
@@ -440,7 +440,7 @@ else version (CRuntime_Musl)
         }
         alias fexcept_t = uint;
     }
-    else version (RICV64)
+    else version (RISCV64)
     {
         alias fenv_t = uint;
         alias fexcept_t = uint;


### PR DESCRIPTION
This affects the ldc2 build for riscv64

### Expected
```console
ldc2-riscv64-linux-musl/bin/ldc2 --version | head -n 6
LDC - the LLVM D compiler (1.42.0):
  based on DMD v2.112.1 and LLVM 21.1.0
  built with 1.42.0
  Default target: riscv64-linux-musl
  Host CPU: generic-rv64
  https://dlang.org - https://wiki.dlang.org/LDC
  ```

cc: @thewilsonator @kinke  