### PR TITLE
Fix Issue #22790: Allow static array parameters in ImportC

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -2994,10 +2994,6 @@ final class CParser(AST) : Parser!AST
                         {
                             error("variable length arrays are not supported");
                         }
-                        if (isStatic) // C11 6.7.6.3
-                        {
-                            error("static array parameters are not supported");
-                        }
                         if (declarator != DTR.xparameter)
                         {
                             /* C11 6.7.6.2-4: '*' can only be used with function prototype scope.

--- a/compiler/test/fail_compilation/failcstuff1.c
+++ b/compiler/test/fail_compilation/failcstuff1.c
@@ -32,14 +32,12 @@ fail_compilation/failcstuff1.c(260): Error: expected identifier for declarator
 fail_compilation/failcstuff1.c(301): Error: illegal type combination
 fail_compilation/failcstuff1.c(352): Error: found `2` when expecting `:`
 fail_compilation/failcstuff1.c(352): Error: found `:` instead of statement
-fail_compilation/failcstuff1.c(450): Error: static array parameters are not supported
 fail_compilation/failcstuff1.c(450): Error: static or type qualifier used in non-outermost array type derivation
 fail_compilation/failcstuff1.c(451): Error: static or type qualifier used in non-outermost array type derivation
 fail_compilation/failcstuff1.c(451): Error: array type has incomplete element type `int[0]`
 fail_compilation/failcstuff1.c(452): Error: array type has incomplete element type `int[0]`
 fail_compilation/failcstuff1.c(453): Error: array type has incomplete element type `int[0]`
 fail_compilation/failcstuff1.c(454): Error: found `const` when expecting `,`
-fail_compilation/failcstuff1.c(458): Error: static array parameters are not supported
 fail_compilation/failcstuff1.c(458): Error: static or type qualifier used outside of function prototype
 fail_compilation/failcstuff1.c(459): Error: static or type qualifier used outside of function prototype
 fail_compilation/failcstuff1.c(460): Error: variable length arrays are not supported

--- a/compiler/test/runnable/test22790.c
+++ b/compiler/test/runnable/test22790.c
@@ -1,0 +1,12 @@
+﻿// https://issues.dlang.org/show_bug.cgi?id=22790
+
+void test_static(int array[static 4]) {
+    _Static_assert(sizeof(array) == sizeof(int*), "array must decay to pointer");
+}
+
+int main()
+{
+    int a[4];
+    test_static(a);
+    return 0;
+}

--- a/compiler/test/runnable/test22790.c
+++ b/compiler/test/runnable/test22790.c
@@ -1,7 +1,23 @@
-﻿// https://issues.dlang.org/show_bug.cgi?id=22790
+// https://github.com/dlang/dmd/issues/22790
 
 void test_static(int array[static 4]) {
     _Static_assert(sizeof(array) == sizeof(int*), "array must decay to pointer");
+}
+
+void f1 (int[static 1 + 1]);
+// sizeof a fails with undefined identifier 'a' since previous parameters aren't in scope yet.
+// void f2 (int a, int x[static sizeof(a)]);
+
+void f1a (int a[static 2])
+{
+  int **b = &a;
+  int *const *c = &a;
+}
+
+void f3a (int a[static const 2])
+{
+  int **b = &a;
+  int *const *c = &a;
 }
 
 int main()


### PR DESCRIPTION
fixes #22790 
by removing the hardcoded error in cparse.d that explicitly rejected the static keyword inside array parameters. since the compiler's underlying parser already handles the array type structure correctly, simply lifting this restriction allows the C99-compliant behavior to work naturally. I also updated the failcstuff1.c test suite so it no longer expects the compiler to fail when it encounters this syntax.