### PR TITLE
Support auto type static array length inference

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2233,6 +2233,20 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         /* If auto type inference, do the inference
          */
         int inferred = 0;
+        Expression autoDollarDim;
+        if (auto tsa = dsym.type ? dsym.type.isTypeSArray() : null)
+        {
+            auto ide = tsa.dim ? tsa.dim.isIdentifierExp() : null;
+            if (ide && ide.ident == Id.dollar)
+            {
+                auto tid = tsa.next.isTypeIdentifier();
+                if (tid && tid.ident == Identifier.idPool(Token.toString(TOK.auto_)))
+                {
+                    autoDollarDim = tsa.dim.syntaxCopy();
+                    dsym.type = null;
+                }
+            }
+        }
         if (!dsym.type)
         {
             dsym.inuse++;
@@ -2248,6 +2262,19 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             //printf("inferring type for %s with init %s\n", dsym.toChars(), dsym._init.toChars());
             dsym._init = dsym._init.inferType(sc);
             dsym.type = dsym._init.initializerToExpression(null, sc.inCfile).type;
+
+            if (autoDollarDim)
+            {
+                Type elem = dsym.type.nextOf();
+                if (!elem)
+                {
+                    .error(dsym.loc, "cannot infer static array element type for `auto[$]`, provide an array initializer");
+                    dsym.type = Type.terror;
+                }
+                else
+                    dsym.type = new TypeSArray(elem, autoDollarDim);
+            }
+
             if (needctfe)
                 sc = sc.endCTFE();
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2230,22 +2230,31 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        /* If auto type inference, do the inference
-         */
         int inferred = 0;
-        Expression autoDollarDim;
-        if (auto tsa = dsym.type ? dsym.type.isTypeSArray() : null)
+        // Collect dimensions of static arrays with `auto` element type and `$` dimension,
+        Expression[] autoDollarDims;
+        if (dsym.type)
         {
-            auto ide = tsa.dim ? tsa.dim.isIdentifierExp() : null;
-            if (ide && ide.ident == Id.dollar)
+            Type t = dsym.type;
+            while (auto tsa = t.isTypeSArray())
             {
-                auto tid = tsa.next.isTypeIdentifier();
-                if (tid && tid.ident == Identifier.idPool(Token.toString(TOK.auto_)))
+                auto ide = tsa.dim ? tsa.dim.isIdentifierExp() : null;
+                if (!(ide && ide.ident == Id.dollar))
                 {
-                    autoDollarDim = tsa.dim.syntaxCopy();
-                    dsym.type = null;
+                    autoDollarDims = null;
+                    break;
                 }
+                autoDollarDims ~= tsa.dim.syntaxCopy();
+                t = tsa.next;
             }
+
+            auto tid = t ? t.isTypeIdentifier() : null;
+            auto autoIdent = Identifier.idPool(Token.toString(TOK.auto_));
+            if (autoDollarDims.length && tid && tid.ident == autoIdent)
+                // Intentionally set type to null to trigger type inference,
+                dsym.type = null;
+            else
+                autoDollarDims = null;
         }
         if (!dsym.type)
         {
@@ -2263,16 +2272,29 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym._init = dsym._init.inferType(sc);
             dsym.type = dsym._init.initializerToExpression(null, sc.inCfile).type;
 
-            if (autoDollarDim)
+            if (autoDollarDims.length)
             {
-                Type elem = dsym.type.nextOf();
-                if (!elem)
+                // dysm.type here is dynamic array type with `auto` element type,
+                // so peels off the array layers and then build static array type with `$` dimensions.
+                Type t = dsym.type;
+                foreach (_; 0 .. autoDollarDims.length)
                 {
-                    .error(dsym.loc, "cannot infer static array element type for `auto[$]`, provide an array initializer");
-                    dsym.type = Type.terror;
+                    auto elem = t.nextOf();
+                    if (!elem)
+                    {
+                        .error(dsym.loc, "cannot infer static array element type for `auto[$]`, provide an array initializer");
+                        t = Type.terror;
+                        break;
+                    }
+                    t = elem;
                 }
-                else
-                    dsym.type = new TypeSArray(elem, autoDollarDim);
+
+                if (t.ty != Terror)
+                {
+                    for (size_t i = autoDollarDims.length; i-- > 0;)
+                        t = new TypeSArray(t, autoDollarDims[i]);
+                }
+                dsym.type = t;
             }
 
             if (needctfe)
@@ -2372,6 +2394,27 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return true;
         }
 
+        static void inferInnerSArrayDimsFromType(TypeSArray dst, Type src, Loc loc)
+        {
+            if (!dst || !src)
+                return;
+
+            auto dstTsa = dst;
+            auto srcTsa = src.toBasetype().isTypeSArray();
+            while (dstTsa && srcTsa)
+            {
+                if (hasDollarDimension(dstTsa))
+                {
+                    auto dim = srcTsa.dim ? srcTsa.dim.isIntegerExp() : null;
+                    if (!dim)
+                        break;
+                    dstTsa.dim = new IntegerExp(loc, dim.value, Type.tsize_t);
+                }
+                dstTsa = dstTsa.next.isTypeSArray();
+                srcTsa = srcTsa.next ? srcTsa.next.toBasetype().isTypeSArray() : null;
+            }
+        }
+
         static bool inferSArrayDim(TypeSArray tsa, Expression ie, Loc loc, Scope* sc)
         {
             if (!tsa || !ie)
@@ -2413,6 +2456,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 return false;
 
             tsa.dim = new IntegerExp(loc, len, Type.tsize_t);
+
+            // For non-literal forms (e.g. concatenation), propagate any known
+            // nested static-array dimensions from the expression element type.
+            if (auto innerTsa = tsa.next.isTypeSArray())
+            {
+                Type elemType = ie.type ? ie.type.toBasetype().nextOf() : null;
+                inferInnerSArrayDimsFromType(innerTsa, elemType, loc);
+            }
+
             return true;
         }
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2236,8 +2236,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dsym.type)
         {
             Type t = dsym.type;
-            while (auto tsa = t.isTypeSArray())
+            while (true)
             {
+                auto tsa = t.isTypeSArray();
+                if (!tsa)
+                    break;
                 auto ide = tsa.dim ? tsa.dim.isIdentifierExp() : null;
                 if (!(ide && ide.ident == Id.dollar))
                 {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -677,6 +677,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 goto Lstc;
 
             case TOK.auto_:
+                if (peekNext() == TOK.leftBracket)
+                    goto Ldeclaration;
                 stc = STC.auto_;
                 if (peekNext() == TOK.ref_)
                     stc |= STC.autoref;
@@ -4613,8 +4615,20 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 }
                 else
                 {
-                    ts = parseBasicType();
-                    ts = parseTypeSuffixes(ts);
+                    if ((storage_class & STC.auto_) &&
+                        token.value == TOK.leftBracket &&
+                        peekNext() == TOK.dollar &&
+                        peekNext2() == TOK.rightBracket)
+                    {
+                        auto autoIdent = Identifier.idPool(Token.toString(TOK.auto_));
+                        ts = new AST.TypeIdentifier(token.loc, autoIdent);
+                        ts = parseTypeSuffixes(ts);
+                    }
+                    else
+                    {
+                        ts = parseBasicType();
+                        ts = parseTypeSuffixes(ts);
+                    }
                 }
             }
         }

--- a/compiler/test/runnable/staticarray.d
+++ b/compiler/test/runnable/staticarray.d
@@ -27,10 +27,41 @@ void main()
 	static assert(autoConcatC.length == 2);
 	static assert(is(typeof(autoConcatC) == int[2]));
 
-	static assert(!__traits(compiles,
-	{
-		auto[$][$] arrAutoNested = [[10], [20, 30]];
-	}));
+	auto[$][$] arrAutoNested = [[10, 11], [20, 21]];
+	assert(arrAutoNested.length == 2);
+	assert(arrAutoNested[0].length == 2);
+	assert(arrAutoNested[1].length == 2);
+	assert(arrAutoNested[0][0] == 10);
+	assert(arrAutoNested[0][1] == 11);
+	assert(arrAutoNested[1][0] == 20);
+	assert(arrAutoNested[1][1] == 21);
+	static assert(arrAutoNested.length == 2);
+	static assert(arrAutoNested[0].length == 2);
+	static assert(arrAutoNested[1].length == 2);
+	static assert(is(typeof(arrAutoNested) == int[2][2]));
+
+	auto[$][$] autoNestedConcatA = [[2]];
+	auto[$][$] autoNestedConcatB = [[2]];
+	auto[$][$] autoNestedConcatC = autoNestedConcatA ~ autoNestedConcatB;
+	assert(autoNestedConcatC.length == 2);
+	assert(autoNestedConcatC[0].length == 1);
+	assert(autoNestedConcatC[1].length == 1);
+	assert(autoNestedConcatC[0][0] == 2);
+	assert(autoNestedConcatC[1][0] == 2);
+	static assert(autoNestedConcatC.length == 2);
+	static assert(autoNestedConcatC[0].length == 1);
+	static assert(autoNestedConcatC[1].length == 1);
+	static assert(is(typeof(autoNestedConcatC) == int[1][2]));
+
+  // Standard array literals should remain dynamic arrays (slices)
+	auto standardArr = [1, 2, 3];
+	static assert(is(typeof(standardArr) == int[]));
+	static assert(!is(typeof(standardArr) == int[3]));
+
+	// String literals should remain immutable(char)[]
+	auto standardStr = "hello";
+	static assert(is(typeof(standardStr) == string));
+	static assert(!is(typeof(standardStr) == char[5]));
 
 	int[$] arr3 = [10] ~ [20];
 	assert(arr3.length == 2);

--- a/compiler/test/runnable/staticarray.d
+++ b/compiler/test/runnable/staticarray.d
@@ -11,6 +11,27 @@ void main()
 	static assert(is(typeof(arr13) == const(int)[3]));
 	assert(arr1 == arr2);
 
+	auto[$] arrAuto = [1, 2];
+	assert(arrAuto.length == 2);
+	assert(arrAuto[0] == 1);
+	assert(arrAuto[1] == 2);
+	static assert(arrAuto.length == 2);
+	static assert(is(typeof(arrAuto) == int[2]));
+
+	auto[$] autoConcatA = [2];
+	auto[$] autoConcatB = [2];
+	auto[$] autoConcatC = autoConcatA ~ autoConcatB;
+	assert(autoConcatC.length == 2);
+	assert(autoConcatC[0] == 2);
+	assert(autoConcatC[1] == 2);
+	static assert(autoConcatC.length == 2);
+	static assert(is(typeof(autoConcatC) == int[2]));
+
+	static assert(!__traits(compiles,
+	{
+		auto[$][$] arrAutoNested = [[10], [20, 30]];
+	}));
+
 	int[$] arr3 = [10] ~ [20];
 	assert(arr3.length == 2);
 	assert(arr3[0] == 10);

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -32,6 +32,10 @@ int[3] s;
         from the initializer.
         )
 
+        $(P If type inference is used (e.g. with $(D auto)), the $(D $) can be used
+        to infer the dimension while the element type is inferred from the initializer.
+        )
+
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---------
 int[$] a = [1, 2, 3];
@@ -39,6 +43,12 @@ static assert(is(typeof(a) == int[3]));
 
 int[$][$] m = [[1, 2, 3], [4, 5, 6]];
 static assert(is(typeof(m) == int[3][2]));
+
+auto[$] b = [1, 2, 3];
+static assert(is(typeof(b) == int[3]));
+
+auto[$][$] c = [[1, 2], [3, 4]];
+static assert(is(typeof(c) == int[2][2]));
 ---------
 )
 


### PR DESCRIPTION
This is an extention to #22745. Now we can write:
```d
auto[$] a = [2];
auto[$] b = [2];
auto[$] c = a ~ b;
```