### PR TITLE
Fix Issue 21622: Ambiguous template without parentheses gives 'no effect' error

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -4023,16 +4023,14 @@ private void checkPrintfScanfSignature(FuncDeclaration funcdecl, TypeFunction f,
     const p = (funcdecl.printf ? Id.printf : Id.scanf).toChars();
     if (!(f.linkage == LINK.c || f.linkage == LINK.cpp))
     {
-        .error(funcdecl.loc, "`pragma(%s)` function `%s` must have `extern(C)` or `extern(C++)` linkage,"
-            ~" not `extern(%s)`",
+        .error(funcdecl.loc, "`pragma(%s)` function `%s` must have `extern(C)` or `extern(C++)` linkage, not `extern(%s)`",
             p, funcdecl.toChars(), f.linkage.linkageToChars());
     }
     if (f.parameterList.varargs == VarArg.variadic)
     {
         if (!(nparams >= 1 && isPointerToChar(f.parameterList[nparams - 1])))
         {
-            .error(funcdecl.loc, "`pragma(%s)` function `%s` must have"
-                ~ " signature `%s %s([parameters...], const(char)*, ...)` not `%s`",
+            .error(funcdecl.loc, "`pragma(%s)` function `%s` must have signature `%s %s([parameters...], const(char)*, ...)` not `%s`",
                 p, funcdecl.toChars(), f.next.toChars(), funcdecl.toChars(), funcdecl.type.toChars());
         }
     }
@@ -4040,8 +4038,7 @@ private void checkPrintfScanfSignature(FuncDeclaration funcdecl, TypeFunction f,
     {
         if(!(nparams >= 2 && isPointerToChar(f.parameterList[nparams - 2]) &&
             isVa_list(f.parameterList[nparams - 1])))
-            .error(funcdecl.loc, "`pragma(%s)` function `%s` must have"~
-                " signature `%s %s([parameters...], const(char)*, va_list)`",
+            .error(funcdecl.loc, "`pragma(%s)` function `%s` must have signature `%s %s([parameters...], const(char)*, va_list)`",
                 p, funcdecl.toChars(), f.next.toChars(), funcdecl.toChars());
     }
     else

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -14,6 +14,8 @@ module dmd.sideeffect;
 import dmd.astenums;
 import dmd.declaration;
 import dmd.dscope;
+import dmd.dsymbol;
+import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
 import dmd.expressionsem;
@@ -294,6 +296,25 @@ bool discardValue(Expression e)
     // Assumption that error => no side effect
     case EXP.error:
         return true;
+    case EXP.overloadSet:
+        {
+            OverExp oe = cast(OverExp)e;
+            .error(e.loc, "`%s` matches multiple overloads", oe.vars.ident.toChars());
+            return false;
+        }
+    case EXP.scope_:
+        {
+            ScopeExp se = cast(ScopeExp)e;
+            if (auto ti = se.sds.isTemplateInstance())
+            {
+                if (ti.tempdecl && ti.tempdecl.isOverloadSet())
+                {
+                    .error(e.loc, "`%s` matches multiple overloads", ti.toChars());
+                    return false;
+                }
+            }
+            break;
+        }
     case EXP.variable:
         {
             VarDeclaration v = (cast(VarExp)e).var.isVarDeclaration();

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -28,6 +28,7 @@ import dmd.init;
 import dmd.mtype;
 import dmd.tokens;
 import dmd.typesem;
+import dmd.root.string : toDString;
 import dmd.visitor;
 import dmd.visitor.postorder;
 

--- a/compiler/test/fail_compilation/issue21622.d
+++ b/compiler/test/fail_compilation/issue21622.d
@@ -1,0 +1,15 @@
+/*
+REQUIRED_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/issue21622.d(14): Error: `issue21622.foo!0` matches multiple overloads
+---
+*/
+
+void foo(int i)() {}
+void foo(int i)() {}
+
+void main()
+{
+    foo!0;
+}


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/21622

### Description
When an ambiguous template function is instantiated without parentheses (e.g. \oo!0;\), the compiler previously reported a generic and confusing \has no effect\ error because the expression returned a valid but ambiguous \TemplateInstance\ or \OverExp\ which was then passed to \discardValue()\.

This PR updates \discardValue()\ in \sideeffect.d\ to explicitly check for \EXP.overloadSet\ and \EXP.scope_\ (when it points to an ambiguous \TemplateInstance\/\OverloadSet\) and reports a \matches multiple overloads\ error instead, matching the behavior of parenthesized calls.