### PR TITLE
Thread class is split into a version(CoreDdoc) and other

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -206,10 +206,6 @@ else
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Thread
-///////////////////////////////////////////////////////////////////////////////
-
 /**
  * This class encapsulates all threading functionality for the D
  * programming language.  As thread manipulation is a required facility
@@ -218,11 +214,219 @@ else
  * A new thread may be created using either derivation or composition, as
  * in the following example.
  */
+version (CoreDdoc)
 class Thread : ThreadBase
 {
+    /**
+     * Initializes a thread object which is associated with a static
+     * D function.
+     *
+     * Params:
+     *  fn = The thread function.
+     *  sz = The stack size for this thread.
+     *
+     * In:
+     *  fn must not be null.
+     */
+    this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
+    {
+    }
+
+
+    /**
+     * Initializes a thread object which is associated with a dynamic
+     * D function.
+     *
+     * Params:
+     *  dg = The thread function.
+     *  sz = The stack size for this thread.
+     *
+     * In:
+     *  dg must not be null.
+     */
+    this( void delegate() dg, size_t sz = 0 ) @safe pure nothrow @nogc
+    {
+    }
+
+    package this( size_t sz = 0 ) @safe pure nothrow @nogc
+    {
+    }
+
+    /**
+     * Cleans up any remaining resources used by this object.
+     */
+    ~this() nothrow @nogc
+    {
+    }
+
     //
-    // Standard thread data
+    // Thread entry point.  Invokes the function or delegate passed on
+    // construction (if any).
     //
+    private final void run()
+    {
+    }
+
+    /**
+     * Provides a reference to the calling thread.
+     *
+     * Returns:
+     *  The thread object representing the calling thread.  The result of
+     *  deleting this object is undefined.  If the current thread is not
+     *  attached to the runtime, a null reference is returned.
+     */
+    static Thread getThis() @safe nothrow @nogc
+    {
+        return null;
+    }
+
+    ///
+    override final void[] savedRegisters() nothrow @nogc
+    {
+        return null;
+    }
+
+    /**
+     * Starts the thread and invokes the function or delegate passed upon
+     * construction.
+     *
+     * In:
+     *  This routine may only be called once per thread instance.
+     *
+     * Throws:
+     *  ThreadException if the thread fails to start.
+     */
+    final Thread start() nothrow
+    {
+        return null;
+    }
+
+    /**
+     * Waits for this thread to complete.  If the thread terminated as the
+     * result of an unhandled exception, this exception will be rethrown.
+     *
+     * Params:
+     *  rethrow = Rethrow any unhandled exception which may have caused this
+     *            thread to terminate.
+     *
+     * Throws:
+     *  ThreadException if the operation fails.
+     *  Any exception not handled by the joined thread.
+     *
+     * Returns:
+     *  Any exception not handled by this thread if rethrow = false, null
+     *  otherwise.
+     */
+    override final Throwable join( bool rethrow = true )
+    {
+        return null;
+    }
+
+    /**
+     * The minimum scheduling priority that may be set for a thread.  On
+     * systems where multiple scheduling policies are defined, this value
+     * represents the minimum valid priority for the scheduling policy of
+     * the process.
+     */
+    @property static int PRIORITY_MIN() @nogc nothrow pure @trusted
+    {
+        return 0;
+    }
+
+    /**
+     * The maximum scheduling priority that may be set for a thread.  On
+     * systems where multiple scheduling policies are defined, this value
+     * represents the maximum valid priority for the scheduling policy of
+     * the process.
+     */
+    @property static const(int) PRIORITY_MAX() @nogc nothrow pure @trusted
+    {
+        return 0;
+    }
+
+    /**
+     * The default scheduling priority that is set for a thread.  On
+     * systems where multiple scheduling policies are defined, this value
+     * represents the default priority for the scheduling policy of
+     * the process.
+     */
+    @property static int PRIORITY_DEFAULT() @nogc nothrow pure @trusted
+    {
+        return 0;
+    }
+
+    /**
+     * Gets the scheduling priority for the associated thread.
+     *
+     * Note: Getting the priority of a thread that already terminated
+     * might return the default priority.
+     *
+     * Returns:
+     *  The scheduling priority of this thread.
+     */
+    final @property int priority()
+    {
+        return 0;
+    }
+
+    /**
+     * Sets the scheduling priority for the associated thread.
+     *
+     * Note: Setting the priority of a thread that already terminated
+     * might have no effect.
+     *
+     * Params:
+     *  val = The new scheduling priority of this thread.
+     */
+    final @property void priority( int val )
+    {
+    }
+
+    /**
+     * Tests whether this thread is running.
+     *
+     * Returns:
+     *  true if the thread is running, false if not.
+     */
+    override final @property bool isRunning() nothrow @nogc
+    {
+        return false;
+    }
+
+    /**
+     * Suspends the calling thread for at least the supplied period.  This may
+     * result in multiple OS calls if period is greater than the maximum sleep
+     * duration supported by the operating system.
+     *
+     * Params:
+     *  val = The minimum duration the calling thread should be suspended.
+     *
+     * In:
+     *  period must be non-negative.
+     *
+     * Example:
+     * ------------------------------------------------------------------------
+     *
+     * Thread.sleep( dur!("msecs")( 50 ) );  // sleep for 50 milliseconds
+     * Thread.sleep( dur!("seconds")( 5 ) ); // sleep for 5 seconds
+     *
+     * ------------------------------------------------------------------------
+     */
+    static void sleep( Duration val ) @nogc nothrow @trusted
+    {
+    }
+
+    /**
+     * Forces a context switch to occur away from the calling thread.
+     */
+    static void yield() @nogc nothrow
+    {
+    }
+}
+
+version (CoreDdoc) {} else
+class Thread : ThreadBase
+{
     version (Windows)
     {
         private HANDLE          m_hndl;
@@ -243,9 +447,6 @@ class Thread : ThreadBase
         private __gshared bool m_isRTClass;
     }
 
-    //
-    // Standard types
-    //
     version (Windows)
     {
         alias TLSKey = uint;
@@ -257,39 +458,11 @@ class Thread : ThreadBase
     else
         static assert(0, "unsupported os");
 
-    ///////////////////////////////////////////////////////////////////////////
-    // Initialization
-    ///////////////////////////////////////////////////////////////////////////
-
-
-    /**
-     * Initializes a thread object which is associated with a static
-     * D function.
-     *
-     * Params:
-     *  fn = The thread function.
-     *  sz = The stack size for this thread.
-     *
-     * In:
-     *  fn must not be null.
-     */
     this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
     {
         super(fn, sz);
     }
 
-
-    /**
-     * Initializes a thread object which is associated with a dynamic
-     * D function.
-     *
-     * Params:
-     *  dg = The thread function.
-     *  sz = The stack size for this thread.
-     *
-     * In:
-     *  dg must not be null.
-     */
     this( void delegate() dg, size_t sz = 0 ) @safe pure nothrow @nogc
     {
         super(dg, sz);
@@ -300,9 +473,6 @@ class Thread : ThreadBase
         super(sz);
     }
 
-    /**
-     * Cleans up any remaining resources used by this object.
-     */
     ~this() nothrow @nogc
     {
         if (super.destructBeforeDtor())
@@ -328,32 +498,15 @@ class Thread : ThreadBase
             static assert(0, "unsupported OS");
     }
 
-    //
-    // Thread entry point.  Invokes the function or delegate passed on
-    // construction (if any).
-    //
     private final void run()
     {
         super.run();
     }
 
-    /**
-     * Provides a reference to the calling thread.
-     *
-     * Returns:
-     *  The thread object representing the calling thread.  The result of
-     *  deleting this object is undefined.  If the current thread is not
-     *  attached to the runtime, a null reference is returned.
-     */
     static Thread getThis() @safe nothrow @nogc
     {
         return ThreadBase.getThis().toThread;
     }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Thread Context and GC Scanning Support
-    ///////////////////////////////////////////////////////////////////////////
-
 
     version (Windows)
     {
@@ -451,21 +604,6 @@ class Thread : ThreadBase
         }
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-    // General Actions
-    ///////////////////////////////////////////////////////////////////////////
-
-
-    /**
-     * Starts the thread and invokes the function or delegate passed upon
-     * construction.
-     *
-     * In:
-     *  This routine may only be called once per thread instance.
-     *
-     * Throws:
-     *  ThreadException if the thread fails to start.
-     */
     final Thread start() nothrow
     in
     {
@@ -568,22 +706,6 @@ class Thread : ThreadBase
         }
     }
 
-    /**
-     * Waits for this thread to complete.  If the thread terminated as the
-     * result of an unhandled exception, this exception will be rethrown.
-     *
-     * Params:
-     *  rethrow = Rethrow any unhandled exception which may have caused this
-     *            thread to terminate.
-     *
-     * Throws:
-     *  ThreadException if the operation fails.
-     *  Any exception not handled by the joined thread.
-     *
-     * Returns:
-     *  Any exception not handled by this thread if rethrow = false, null
-     *  otherwise.
-     */
     override final Throwable join( bool rethrow = true )
     {
         version (Windows)
@@ -618,11 +740,6 @@ class Thread : ThreadBase
         }
         return null;
     }
-
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Thread Priority Actions
-    ///////////////////////////////////////////////////////////////////////////
 
     version (Windows)
     {
@@ -745,36 +862,18 @@ class Thread : ThreadBase
             return result;
         }
 
-        /**
-         * The minimum scheduling priority that may be set for a thread.  On
-         * systems where multiple scheduling policies are defined, this value
-         * represents the minimum valid priority for the scheduling policy of
-         * the process.
-         */
         @property static int PRIORITY_MIN() @nogc nothrow pure @trusted
         {
             return (cast(int function() @nogc nothrow pure @safe)
                 &loadGlobal!"PRIORITY_MIN")();
         }
 
-        /**
-         * The maximum scheduling priority that may be set for a thread.  On
-         * systems where multiple scheduling policies are defined, this value
-         * represents the maximum valid priority for the scheduling policy of
-         * the process.
-         */
         @property static const(int) PRIORITY_MAX() @nogc nothrow pure @trusted
         {
             return (cast(int function() @nogc nothrow pure @safe)
                 &loadGlobal!"PRIORITY_MAX")();
         }
 
-        /**
-         * The default scheduling priority that is set for a thread.  On
-         * systems where multiple scheduling policies are defined, this value
-         * represents the default priority for the scheduling policy of
-         * the process.
-         */
         @property static int PRIORITY_DEFAULT() @nogc nothrow pure @trusted
         {
             return (cast(int function() @nogc nothrow pure @safe)
@@ -792,15 +891,6 @@ class Thread : ThreadBase
         int fakePriority = int.max;
     }
 
-    /**
-     * Gets the scheduling priority for the associated thread.
-     *
-     * Note: Getting the priority of a thread that already terminated
-     * might return the default priority.
-     *
-     * Returns:
-     *  The scheduling priority of this thread.
-     */
     final @property int priority()
     {
         version (Windows)
@@ -828,16 +918,6 @@ class Thread : ThreadBase
             static assert(0, "unsupported os");
     }
 
-
-    /**
-     * Sets the scheduling priority for the associated thread.
-     *
-     * Note: Setting the priority of a thread that already terminated
-     * might have no effect.
-     *
-     * Params:
-     *  val = The new scheduling priority of this thread.
-     */
     final @property void priority( int val )
     in
     {
@@ -947,12 +1027,6 @@ class Thread : ThreadBase
         assert(prio >= PRIORITY_MIN && prio <= PRIORITY_MAX);
     }
 
-    /**
-     * Tests whether this thread is running.
-     *
-     * Returns:
-     *  true if the thread is running, false if not.
-     */
     override final @property bool isRunning() nothrow @nogc
     {
         if (!super.isRunning())
@@ -972,31 +1046,6 @@ class Thread : ThreadBase
             static assert(0, "unsupported os");
     }
 
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Actions on Calling Thread
-    ///////////////////////////////////////////////////////////////////////////
-
-
-    /**
-     * Suspends the calling thread for at least the supplied period.  This may
-     * result in multiple OS calls if period is greater than the maximum sleep
-     * duration supported by the operating system.
-     *
-     * Params:
-     *  val = The minimum duration the calling thread should be suspended.
-     *
-     * In:
-     *  period must be non-negative.
-     *
-     * Example:
-     * ------------------------------------------------------------------------
-     *
-     * Thread.sleep( dur!("msecs")( 50 ) );  // sleep for 50 milliseconds
-     * Thread.sleep( dur!("seconds")( 5 ) ); // sleep for 5 seconds
-     *
-     * ------------------------------------------------------------------------
-     */
     static void sleep( Duration val ) @nogc nothrow @trusted
     in
     {
@@ -1048,10 +1097,6 @@ class Thread : ThreadBase
             static assert(0, "unsupported os");
     }
 
-
-    /**
-     * Forces a context switch to occur away from the calling thread.
-     */
     static void yield() @nogc nothrow
     {
         version (Windows)
@@ -1264,6 +1309,7 @@ version (Posix)
     private __gshared int resumeSignalNumber;
 }
 
+version (CoreDdoc) {} else
 private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow
 {
     Thread thisThread = _thisThread.toThread();
@@ -2268,6 +2314,9 @@ private extern (D) void resume(ThreadBase _t) nothrow @nogc
  * garbage collector on startup and before any other thread routines
  * are called.
  */
+version (CoreDdoc)
+    extern (C) void thread_init() @nogc nothrow {}
+else
 extern (C) void thread_init() @nogc nothrow
 {
     // NOTE: If thread_init itself performs any allocations then the thread
@@ -2521,6 +2570,7 @@ else version (Posix)
         //
         // Entry point for POSIX threads
         //
+        version (CoreDdoc) {} else
         extern (C) void* thread_entryPoint( void* arg ) nothrow
         {
             version (Shared)


### PR DESCRIPTION
* Thread class is split into a version(CoreDdoc) and other
* Removed outdated comments like:
```d
///////////////////////////
/// Like this
//////////////////////////
```
(It was previously discussed that this is obsolete and can be removed.)

The point of this PR is to be able to further separate `Thread` class implementations for Posix, Windows and maybe other OSes