### PR TITLE
Fix Issue #22229 - Fix dip1000 confusing return ref with return scope during inference

### DIFF
--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -1267,7 +1267,7 @@ UnionExp Slice(Type type, Expression e1, Expression lwr, Expression upr)
         {
             auto elements = new Expressions(cast(size_t)(iupr - ilwr));
             memcpy(elements.tdata(), es1.elements.tdata() + ilwr, cast(size_t)(iupr - ilwr) * ((*es1.elements)[0]).sizeof);
-            emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, elements);
+            emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, es1.basis, elements);
         }
     }
     else

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -714,12 +714,14 @@ bool checkAssignEscape(ref Scope sc, Expression e, bool gag, bool byRef)
             inferReturn(fd, v, /*returnScope:*/ true);
         }
 
+        const vHasReturnScope = v.isReference() ? (v.storage_class & STC.returnScope) != 0 : v.isReturn();
+
         if (!(va && va.isScope()) || vaIsRef)
             doNotInferScope(v, e);
 
         if (v.isScope())
         {
-            if (vaIsFirstRef && v.isParameter() && v.isReturn())
+            if (vaIsFirstRef && v.isParameter() && vHasReturnScope)
             {
                 // va=v, where v is `return scope`
                 if (inferScope(va, e))
@@ -759,7 +761,7 @@ bool checkAssignEscape(ref Scope sc, Expression e, bool gag, bool byRef)
             if (inferScope(va, e))
             {
                 // In case of `scope local = returnScopeParam`, do not infer return scope for `x`
-                if (!vaWasScope && v.isReturn() && !va.isReturn())
+                if (!vaWasScope && vHasReturnScope && !va.isReturn())
                 {
                     if (log) printf("infer return for %s\n", va.toChars());
                     va.storage_class |= STC.return_ | STC.returninferred;

--- a/compiler/test/fail_compilation/issue22229.d
+++ b/compiler/test/fail_compilation/issue22229.d
@@ -1,0 +1,25 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/issue22229.d(13): Error: returning scope variable esult is not allowed in a @safe function
+fail_compilation/issue22229.d(12):        esult inferred scope because of esult = s.buf[0..3]
+fail_compilation/issue22229.d(20): Error: returning scope variable esult is not allowed in a @safe function
+fail_compilation/issue22229.d(19):        esult inferred scope because of esult = s.p
+---
+*/
+@safe:
+
+struct S {  char[] buf; char* p; }
+
+char[] def3(scope return ref S s) {
+    auto result = s.buf[0..3];
+    return result; // should produce error
+}
+
+/***********************************/
+
+char* ghi3(scope return ref S s) {
+    auto result = s.p;
+    return result; // should produce error
+}


### PR DESCRIPTION
Fixes #22229

this one had me spinning in circles for a bit... i initially thought the bug was just auto dropping the scope storage class during assignment, or maybe something broken specifically with how slices are tracked. but after debugging escape.d, it turned out the assignment was correctly inferring scope, it was just inferring too much (return scope instead of normal scope).

the root of the issue is in onValue() inside escape.d. When assigning from a return ref parameter to a local variable (e.g., auto result = s.buf[0..3]), the compiler relied on v.isReturn() to decide if the new local should also get return capabilities. For a return ref parameter, v.isReturn() obviously evaluates to true. Because of this it blindly bled the parameter's STC.return_ onto the local non-reference variable as return scope, completely bypassing the safe checks later on

the fix just tightens up that assignment check so we strictly demand the STC.returnScope mask for reference parameters, stopping the generic STC.return_ mask from leaking to places it shouldn't.

added the original cases to fail_compilation