### PR TITLE
Fix slicing struct init array field with `ArrayLiteralExpression.basis` set

### DIFF
--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -1267,7 +1267,7 @@ UnionExp Slice(Type type, Expression e1, Expression lwr, Expression upr)
         {
             auto elements = new Expressions(cast(size_t)(iupr - ilwr));
             memcpy(elements.tdata(), es1.elements.tdata() + ilwr, cast(size_t)(iupr - ilwr) * ((*es1.elements)[0]).sizeof);
-            emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, elements);
+            emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, es1.basis, elements);
         }
     }
     else

--- a/compiler/test/compilable/test8717.d
+++ b/compiler/test/compilable/test8717.d
@@ -60,4 +60,6 @@ static if(SPT.init.sii != 1) { static assert(0); }
 static if(SPT.sf() != 1) { static assert(0); }
 static if(SPT.init.f() != 1) { static assert(0); }
 
-void main() { }
+// https://github.com/dlang/dmd/issues/22699
+struct S{ int[8] e; }
+static assert(S().e[0..4] == S.init.e[0..4]);


### PR DESCRIPTION
Fixes #22699.

Thanks to @oCHIKIo for finding the fix.