### PR TITLE
Fix dlang#22639 - opApply triggers GC allocation error with -betterC

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -975,7 +975,20 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                         if (funcdecl.vresult)
                         {
-                            Scope* scret = rs.fesFunc ? rs.fesFunc._scope : sc2;
+                            Scope* scret = sc2;
+
+                            if (rs.fesFunc)
+                            {
+                                // Create a scope with foreach body being `.parent`
+                                // and `funcdecl` as `.func`. So the return value
+                                // is aware of closure access, but picks up
+                                // attributes and instantiates templated copy/move
+                                // ctors in the context of `funcdecl`.
+                                // BUG: remove this fragile hack
+                                scret = rs.fesFunc._scope.push();
+                                scret.parent = rs.fesFunc;
+                                scret.func = funcdecl;
+                            }
 
                             // Create: return (vresult = exp, vresult);
                             exp = new ConstructExp(rs.loc, funcdecl.vresult, exp);

--- a/compiler/test/runnable/issue22639.d
+++ b/compiler/test/runnable/issue22639.d
@@ -1,0 +1,35 @@
+// REQUIRED_ARGS: -betterC
+
+struct Arr(T, int CAPACITY)
+{
+    int count = 0;
+    T[CAPACITY] items;
+    int opApply(scope int delegate(T) dg)
+    {
+        int result;
+        for (int i = 0; i < count; i++)
+            if ((result = dg(items[i])) != 0)
+                break;
+        return result;
+    }
+}
+
+struct Foo {}
+struct Bar {
+    Arr!(Foo*, 32) array;
+    Foo* get()
+    {
+        foreach(Foo* it; array)
+        {
+            return it;
+        }
+        return null;
+    }
+}
+
+Foo* foo;
+Bar bar;
+extern(C) void main()
+{
+    foo = bar.get();
+}


### PR DESCRIPTION
This brings #22642 back.

I'm not sure if this should go to master or stable, but such a regression should not make its way into a release.