### PR TITLE
Android: Add ImportC definitions

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -206,3 +206,19 @@ typedef struct {} __SVFloat64_t;
 #if __APPLE__
 #undef __SIZEOF_INT128__
 #endif
+
+#if __ANDROID__
+#undef __SIZEOF_INT128__
+#define __GNUC_VA_LIST
+#define _VA_LIST
+#define __builtin_va_list va_list
+#define __gnuc_va_list va_list
+#define BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD
+#define __alignof__(x) _Alignof(x)
+#define __builtin_memmove(a,b,c) memmove(a,b,c)
+#define __builtin_memset(a,b,c) memset(a,b,c)
+#define __builtin_ffs(x) ffs(x)
+#define __builtin_ffsl(x) ffsl(x)
+#define __builtin_ffsll(x) ffsll(x)
+#define __sync_synchronize()
+#endif

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -215,8 +215,5 @@ typedef struct {} __SVFloat64_t;
 #define __gnuc_va_list va_list
 #define BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD
 #define __alignof__(x) _Alignof(x)
-#define __builtin_ffs(x) ffs(x)
-#define __builtin_ffsl(x) ffsl(x)
-#define __builtin_ffsll(x) ffsll(x)
 #define __sync_synchronize()
 #endif

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -218,6 +218,5 @@ typedef struct {} __SVFloat64_t;
 // https://android.googlesource.com/platform/bionic/+/master/libc/include/bits/ioctl.h
 #define BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD
 
-#define __alignof__(x) _Alignof(x)
 #define __sync_synchronize()
 #endif

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -213,7 +213,11 @@ typedef struct {} __SVFloat64_t;
 #define _VA_LIST
 #define __builtin_va_list va_list
 #define __gnuc_va_list va_list
+
+// This macro resolves the ambiguity between Bionic and library ioctl.
+// https://android.googlesource.com/platform/bionic/+/master/libc/include/bits/ioctl.h
 #define BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD
+
 #define __alignof__(x) _Alignof(x)
 #define __sync_synchronize()
 #endif

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -215,8 +215,6 @@ typedef struct {} __SVFloat64_t;
 #define __gnuc_va_list va_list
 #define BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD
 #define __alignof__(x) _Alignof(x)
-#define __builtin_memmove(a,b,c) memmove(a,b,c)
-#define __builtin_memset(a,b,c) memset(a,b,c)
 #define __builtin_ffs(x) ffs(x)
 #define __builtin_ffsl(x) ffsl(x)
 #define __builtin_ffsll(x) ffsll(x)


### PR DESCRIPTION
This PR fixes broken ImportC on Android targets. Tested against sqlite3, zlib (with -DZLIB_DEBUG), lwIP.