### PR TITLE
Fix #22813 - Removing __monitor from Object leads to errors

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7335,7 +7335,6 @@ struct Target final
     uint8_t realsize;
     uint8_t realpad;
     uint8_t realalignsize;
-    uint8_t classinfosize;
     uint64_t maxStaticDataSize;
     TargetC c;
     TargetCPP cpp;
@@ -7409,7 +7408,6 @@ public:
         realsize(),
         realpad(),
         realalignsize(),
-        classinfosize(),
         maxStaticDataSize(),
         c(),
         cpp(),
@@ -7430,14 +7428,13 @@ public:
         params()
     {
     }
-    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(), TargetCPP cpp = TargetCPP(), TargetObjC objc = TargetObjC(), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)0u, bool isAArch64 = false, bool isX86_64 = false, bool isX86 = false, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(), Type* tvalist = nullptr, const Param* params = nullptr) :
+    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(), TargetCPP cpp = TargetCPP(), TargetObjC objc = TargetObjC(), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)0u, bool isAArch64 = false, bool isX86_64 = false, bool isX86 = false, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(), Type* tvalist = nullptr, const Param* params = nullptr) :
         os(os),
         osMajor(osMajor),
         ptrsize(ptrsize),
         realsize(realsize),
         realpad(realpad),
         realalignsize(realalignsize),
-        classinfosize(classinfosize),
         maxStaticDataSize(maxStaticDataSize),
         c(c),
         cpp(cpp),

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -1231,6 +1231,9 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
      */
     static void verifyStructSize(ClassDeclaration typeclass, size_t expected)
     {
+        if (!typeclass.hasMonitor)
+            expected -= target.ptrsize;
+
         if (typeclass.structsize != expected)
         {
             debug

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -1084,12 +1084,14 @@ private bool finishVtbl(ClassDeclaration cd)
 }
 
 /// Returns: classInstanceSize of TypeInfo_Class for `cd`
-uint classInfoSize(ClassDeclaration cd)
+uint classInfoSize()
 {
+    auto obj = ClassDeclaration.object;
+    const bool hasMonitor = !obj || !obj.symtab || obj.symtab.lookup(Id.__monitor) !is null;
     if (target.ptrsize == 8)
-        return 0x98 + 8 + (cd.hasMonitor ? 8 : 0); // 168 with monitor
+        return 0x98 + 8 + (hasMonitor ? 8 : 0); // 168 with monitor
     else
-        return 0x4C + 12 + (cd.hasMonitor ? 4 : 0); // 92 with monitor
+        return 0x4C + 12 + (hasMonitor ? 4 : 0); // 92 with monitor
 }
 
 /******************************************
@@ -1100,8 +1102,8 @@ uint classInfoSize(ClassDeclaration cd)
 uint baseVtblOffset(ClassDeclaration cd, BaseClass* bc)
 {
     //printf("ClassDeclaration.baseVtblOffset('%s', bc = %p)\n", cd.toChars(), bc);
-    uint csymoffset = cd.classInfoSize;    // must be ClassInfo.size
-    //printf("cd.classInfoSize: %d\n", csymoffset);
+    uint csymoffset = classInfoSize();    // must be ClassInfo.size
+    //printf("classInfoSize(): %d\n", csymoffset);
     csymoffset += cd.vtblInterfaces.length * (4 * target.ptrsize);
 
     for (size_t i = 0; i < cd.vtblInterfaces.length; i++)
@@ -1161,7 +1163,7 @@ private size_t emitVtbl(ref DtBuilder dtb, BaseClass* b, ref FuncDeclarations bv
     if (id.vtblOffset())
     {
         // First entry is struct Interface reference
-        dtb.xoff(toSymbol(pc), cast(uint)(id.classInfoSize + k * (4 * target.ptrsize)), TYnptr);
+        dtb.xoff(toSymbol(pc), cast(uint)(classInfoSize() + k * (4 * target.ptrsize)), TYnptr);
         jstart = 1;
     }
 
@@ -1195,11 +1197,11 @@ private void genClassInfoForClass(ClassDeclaration cd, Symbol* sinit)
 {
     if (Type.typeinfoclass)
     {
-        if (Type.typeinfoclass.structsize != cd.classInfoSize)
+        if (Type.typeinfoclass.structsize != classInfoSize())
         {
-            debug printf("cd.classInfoSize = x%x, Type.typeinfoclass.structsize = x%x\n", cd.classInfoSize, Type.typeinfoclass.structsize);
+            debug printf("classInfoSize() = x%x, Type.typeinfoclass.structsize = x%x\n", classInfoSize(), Type.typeinfoclass.structsize);
             .error(cd.loc, "%s `%s` mismatch between compiler (%d bytes) and object.d or object.di (%d bytes) found",
-                   cd.kind, cd.toPrettyChars, cast(uint)cd.classInfoSize, cast(uint)Type.typeinfoclass.structsize);
+                   cd.kind, cd.toPrettyChars, cast(uint)classInfoSize(), cast(uint)Type.typeinfoclass.structsize);
             .errorSupplemental(cd.loc, "check installation and import paths with `-v` compiler switch");
             fatal();
         }
@@ -1246,7 +1248,7 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
             uint[4] nameSig;
        }
      */
-    uint offset = cd.classInfoSize;    // must be ClassInfo.size
+    uint offset = classInfoSize();    // must be ClassInfo.size
 
     if (auto tic = Type.typeinfoclass)
     {
@@ -1531,7 +1533,7 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
     dtb.size(0);
 
     // interfaces[]
-    uint offset = id.classInfoSize;
+    uint offset = classInfoSize();
     dtb.size(id.vtblInterfaces.length);
     if (id.vtblInterfaces.length)
     {

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -1083,6 +1083,14 @@ private bool finishVtbl(ClassDeclaration cd)
     return !hasError;
 }
 
+/// Returns: classInstanceSize of TypeInfo_Class for `cd`
+uint classInfoSize(ClassDeclaration cd)
+{
+    if (target.ptrsize == 8)
+        return 0x98 + 8 + (cd.hasMonitor ? 8 : 0); // 168 with monitor
+    else
+        return 0x4C + 12 + (cd.hasMonitor ? 4 : 0); // 92 with monitor
+}
 
 /******************************************
  * Get offset of base class's vtbl[] initializer from start of csym.
@@ -1092,8 +1100,8 @@ private bool finishVtbl(ClassDeclaration cd)
 uint baseVtblOffset(ClassDeclaration cd, BaseClass* bc)
 {
     //printf("ClassDeclaration.baseVtblOffset('%s', bc = %p)\n", cd.toChars(), bc);
-    uint csymoffset = target.classinfosize;    // must be ClassInfo.size
-    //printf("target.classinfosize: %d\n", csymoffset);
+    uint csymoffset = cd.classInfoSize;    // must be ClassInfo.size
+    //printf("cd.classInfoSize: %d\n", csymoffset);
     csymoffset += cd.vtblInterfaces.length * (4 * target.ptrsize);
 
     for (size_t i = 0; i < cd.vtblInterfaces.length; i++)
@@ -1153,7 +1161,7 @@ private size_t emitVtbl(ref DtBuilder dtb, BaseClass* b, ref FuncDeclarations bv
     if (id.vtblOffset())
     {
         // First entry is struct Interface reference
-        dtb.xoff(toSymbol(pc), cast(uint)(target.classinfosize + k * (4 * target.ptrsize)), TYnptr);
+        dtb.xoff(toSymbol(pc), cast(uint)(id.classInfoSize + k * (4 * target.ptrsize)), TYnptr);
         jstart = 1;
     }
 
@@ -1187,11 +1195,11 @@ private void genClassInfoForClass(ClassDeclaration cd, Symbol* sinit)
 {
     if (Type.typeinfoclass)
     {
-        if (Type.typeinfoclass.structsize != target.classinfosize)
+        if (Type.typeinfoclass.structsize != cd.classInfoSize)
         {
-            debug printf("target.classinfosize = x%x, Type.typeinfoclass.structsize = x%x\n", target.classinfosize, Type.typeinfoclass.structsize);
+            debug printf("cd.classInfoSize = x%x, Type.typeinfoclass.structsize = x%x\n", cd.classInfoSize, Type.typeinfoclass.structsize);
             .error(cd.loc, "%s `%s` mismatch between compiler (%d bytes) and object.d or object.di (%d bytes) found",
-                   cd.kind, cd.toPrettyChars, cast(uint)target.classinfosize, cast(uint)Type.typeinfoclass.structsize);
+                   cd.kind, cd.toPrettyChars, cast(uint)cd.classInfoSize, cast(uint)Type.typeinfoclass.structsize);
             .errorSupplemental(cd.loc, "check installation and import paths with `-v` compiler switch");
             fatal();
         }
@@ -1238,7 +1246,7 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
             uint[4] nameSig;
        }
      */
-    uint offset = target.classinfosize;    // must be ClassInfo.size
+    uint offset = cd.classInfoSize;    // must be ClassInfo.size
 
     if (auto tic = Type.typeinfoclass)
     {
@@ -1523,7 +1531,7 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
     dtb.size(0);
 
     // interfaces[]
-    uint offset = target.classinfosize;
+    uint offset = id.classInfoSize;
     dtb.size(id.vtblInterfaces.length);
     if (id.vtblInterfaces.length)
     {

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -356,7 +356,6 @@ extern (C++) struct Target
     ubyte realsize;           /// size a real consumes in memory
     ubyte realpad;            /// padding added to the CPU real size to bring it up to realsize
     ubyte realalignsize;      /// alignment for reals
-    ubyte classinfosize;      /// size of `ClassInfo`
     ulong maxStaticDataSize;  /// maximum size of static data
 
     /// C ABI
@@ -444,7 +443,6 @@ extern (C++) struct Target
         // These have default values for 32 bit code, they get
         // adjusted for 64 bit code.
         ptrsize = 4;
-        classinfosize = 0x4C+16; // 92
 
         /* gcc uses int.max for 32 bit compilations, and long.max for 64 bit ones.
          * Set to int.max for both, because the rest of the compiler cannot handle
@@ -457,9 +455,6 @@ extern (C++) struct Target
         if (isLP64 || isAArch64)
         {
             ptrsize = 8;
-            /* This is affected by version WithArgTypes in object.d
-             */
-            classinfosize = 0x98+16; // 168
         }
 
         if (os & (Target.OS.linux | Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.DragonFlyBSD | Target.OS.Solaris))

--- a/compiler/src/dmd/target.h
+++ b/compiler/src/dmd/target.h
@@ -142,7 +142,6 @@ struct Target
     uint8_t realsize;           // size a real consumes in memory
     uint8_t realpad;            // 'padding' added to the CPU real size to bring it up to realsize
     uint8_t realalignsize;      // alignment for reals
-    uint8_t classinfosize;      // size of 'ClassInfo'
     uint64_t maxStaticDataSize; // maximum size of static data
 
     // C ABI

--- a/compiler/test/compilable/b18242.d
+++ b/compiler/test/compilable/b18242.d
@@ -7,7 +7,7 @@ class Object { }
 class TypeInfo { }
 class TypeInfo_Class : TypeInfo
 {
-    version(D_LP64) { ubyte[136+24] _x; } else { ubyte[68+20] _x; }
+    version(D_LP64) { ubyte[136+16] _x; } else { ubyte[68+16] _x; }
 }
 
 class Throwable { }


### PR DESCRIPTION
Closes #22813 

Need to check whether LDC and GDC use target.classinfosize