### PR TITLE
Fix issue #22819: extern(C++) opBinary error with getOverloads

### DIFF
--- a/compiler/src/dmd/mangle/cpp.d
+++ b/compiler/src/dmd/mangle/cpp.d
@@ -1234,7 +1234,7 @@ private final class CppMangleVisitor : Visitor
         string symName;
 
         // test for special symbols
-        CppOperator whichOp = isCppOperator(ti.name);
+        CppOperator whichOp = isCppOperator(ti.tempdecl.ident);
         final switch (whichOp)
         {
         case CppOperator.Unknown:

--- a/compiler/src/dmd/mangle/cppwin.d
+++ b/compiler/src/dmd/mangle/cppwin.d
@@ -1116,7 +1116,7 @@ string mangleSpecialName(Dsymbol sym)
  */
 bool mangleOperator(ref OutBuffer buf, TemplateInstance ti, ref const(char)[] symName, ref int firstTemplateArg)
 {
-    auto whichOp = isCppOperator(ti.name);
+    auto whichOp = isCppOperator(ti.tempdecl.ident);
     final switch (whichOp)
     {
     case CppOperator.Unknown:

--- a/compiler/test/compilable/issue22819.d
+++ b/compiler/test/compilable/issue22819.d
@@ -1,0 +1,28 @@
+extern(C++) struct S
+{
+    int opBinary(string op)(S rhs) if (op == "+")
+    {
+        return 0;
+    }
+    int opBinary(string op)(int rhs) if (op == "+")
+    {
+        return 0;
+    }
+    int opBinary(string op)(int rhs) if (op == "-")
+    {
+        return 0;
+    }
+}
+size_t test()
+{
+    size_t count;
+    static foreach (overload; __traits(getOverloads, S, "opBinary", true))
+        static foreach(op; ["+", "-"])
+            static if (__traits(compiles, overload!op))
+            {
+                cast(void)&overload!op;
+                count++;
+            }
+    return count;
+}
+static assert(test() == 3);


### PR DESCRIPTION
The name of the foreach variable was used instead of the function itself when checking for operator overloading during mangling of `extern(C++)`.