### PR TITLE
ftime-trace: break up the template instance span into sub-phases

### DIFF
--- a/changelog/dmd.ftime-trace-sema-subspans.dd
+++ b/changelog/dmd.ftime-trace-sema-subspans.dd
@@ -5,5 +5,5 @@ flat block, making it hard to tell where the time was actually going.
 
 The `Sema1: Template Instance` span now contains sub-spans for each phase:
 `Sema1: Template Arg Semantic`, `Sema1: Overload Resolution`,
-`Sema1: Expand Members`, `Sema2: Template Instance`, and `Sema3: Template Instance`.
+`Sema1: Template Members`, `Sema2: Template Instance`, and `Sema3: Template Instance`.
 These are visible in trace viewers like $(LINK2 https://ui.perfetto.dev/, Perfetto).

--- a/changelog/dmd.ftime-trace-sema-subspans.dd
+++ b/changelog/dmd.ftime-trace-sema-subspans.dd
@@ -1,37 +1,9 @@
-$(CHANGELOG_NAV_INJECT)
+`-ftime-trace`: break up the template instance span into sub-phases
 
-$(VERSION $(CHANGELOG_VERSION_NIGHTLY), =================================================,
+The `-ftime-trace` output previously showed template instantiation as a single
+flat block, making it hard to tell where the time was actually going.
 
-$(BUGSTITLE_TEXT_HEADER Compiler changes,
-
-$(LI $(RELATIVE_LINK2 ftime-trace-sema-subspans,`-ftime-trace`: add sub-spans for template argument semantic and overload resolution))
-
-)
-
-$(BUGSTITLE_TEXT_BODY Compiler changes,
-
-$(LI $(LNAME2 ftime-trace-sema-subspans,`-ftime-trace`: add sub-spans for template argument semantic and overload resolution)
-$(CHANGELOG_SOURCE_FILE dmd, changelog/dmd.ftime-trace-sema-subspans.dd)
-
-The `-ftime-trace` output previously showed `semantic_analysis` as a single
-monolithic block with no sub-breakdown, making it hard to attribute
-compile-time regressions to specific phases (see $(BUGZILLA 22711)).
-
-Two new sub-spans are now emitted inside each `Sema1: Template Instance` event:
-
-$(UL
-    $(LI `Sema1: Template Arg Semantic` — time spent in `semanticTiargs`, which
-         runs semantic analysis on the template arguments)
-    $(LI `Sema1: Overload Resolution` — time spent in `findBestMatch`, which
-         selects the best-matching template overload)
-)
-
-These sub-spans are visible in trace viewers such as
-$(LINK2 https://ui.perfetto.dev/, Perfetto) and make it possible to identify
-whether a compile-time regression is caused by argument evaluation or overload
-resolution.
-
-)
-
-)
-)
+The `Sema1: Template Instance` span now contains sub-spans for each phase:
+`Sema1: Template Arg Semantic`, `Sema1: Overload Resolution`,
+`Sema1: Expand Members`, `Sema2: Template Instance`, and `Sema3: Template Instance`.
+These are visible in trace viewers like $(LINK2 https://ui.perfetto.dev/, Perfetto).

--- a/changelog/dmd.ftime-trace-sema-subspans.dd
+++ b/changelog/dmd.ftime-trace-sema-subspans.dd
@@ -1,0 +1,37 @@
+$(CHANGELOG_NAV_INJECT)
+
+$(VERSION $(CHANGELOG_VERSION_NIGHTLY), =================================================,
+
+$(BUGSTITLE_TEXT_HEADER Compiler changes,
+
+$(LI $(RELATIVE_LINK2 ftime-trace-sema-subspans,`-ftime-trace`: add sub-spans for template argument semantic and overload resolution))
+
+)
+
+$(BUGSTITLE_TEXT_BODY Compiler changes,
+
+$(LI $(LNAME2 ftime-trace-sema-subspans,`-ftime-trace`: add sub-spans for template argument semantic and overload resolution)
+$(CHANGELOG_SOURCE_FILE dmd, changelog/dmd.ftime-trace-sema-subspans.dd)
+
+The `-ftime-trace` output previously showed `semantic_analysis` as a single
+monolithic block with no sub-breakdown, making it hard to attribute
+compile-time regressions to specific phases (see $(BUGZILLA 22711)).
+
+Two new sub-spans are now emitted inside each `Sema1: Template Instance` event:
+
+$(UL
+    $(LI `Sema1: Template Arg Semantic` — time spent in `semanticTiargs`, which
+         runs semantic analysis on the template arguments)
+    $(LI `Sema1: Overload Resolution` — time spent in `findBestMatch`, which
+         selects the best-matching template overload)
+)
+
+These sub-spans are visible in trace viewers such as
+$(LINK2 https://ui.perfetto.dev/, Perfetto) and make it possible to identify
+whether a compile-time regression is caused by argument evaluation or overload
+resolution.
+
+)
+
+)
+)

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -939,7 +939,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
      * last find most specialized template from overload list/set.
      */
     if (!tempinst.findTempDecl(sc, null))
-        goto Lerror;
+        return Lerror();
 
     // Trace template argument semantic analysis as a sub-span of the template instance
     {
@@ -951,7 +951,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
             tiargs_ok = tempinst.semanticTiargs(sc);
         }
         if (!tiargs_ok)
-            goto Lerror;
+            return Lerror();
     }
 
     // Trace overload resolution (findBestMatch) as a sub-span of the template instance
@@ -964,12 +964,11 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
             match_ok = tempinst.findBestMatch(sc, argumentList);
         }
         if (!match_ok)
-            goto Lerror;
+            return Lerror();
     }
 
-    if (false)
+    void Lerror()
     {
-    Lerror:
         if (tempinst.gagged)
         {
             // https://issues.dlang.org/show_bug.cgi?id=13220
@@ -993,12 +992,12 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     if (tempdecl.ismixin)
     {
         .error(tempinst.loc, "%s `%s` mixin templates are not regular templates", tempinst.kind, tempinst.toPrettyChars);
-        goto Lerror;
+        return Lerror();
     }
 
     tempinst.hasNestedArgs(tempinst.tiargs, tempdecl.isstatic);
     if (tempinst.errors)
-        goto Lerror;
+        return Lerror();
 
     // Copy the tempdecl namespace (not the scope one)
     tempinst.cppnamespace = tempdecl.cppnamespace;
@@ -5923,7 +5922,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
                             if (scx == p.sc)
                             {
                                 error(loc, "recursive template expansion while looking for `%s.%s`", ti.toChars(), tdx.toChars());
-                                goto Lerror;
+                                return Lerror();
                             }
                         }
                     }
@@ -5946,7 +5945,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
                 fd = resolveFuncCall(loc, sc, s, null, tthis, argumentList, FuncResolveFlag.quiet);
             }
             else
-                goto Lerror;
+                return Lerror();
 
             if (!fd)
                 return 0;
@@ -6001,7 +6000,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
         for (size_t ovi = 0; f; f = f.overnext0, ovi++)
         {
             if (f.type.ty != Tfunction || f.errors)
-                goto Lerror;
+                return Lerror();
 
             /* This is a 'dummy' instance to evaluate constraint properly.
              */
@@ -6167,7 +6166,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
         tthis_best = m.lastf.needThis() && !m.lastf.isCtorDeclaration() ? tthis : null;
 
         if (m.lastf.type.ty == Terror)
-            goto Lerror;
+            return Lerror();
         auto tf = m.lastf.type.isTypeFunction();
         if (callMatch(m.lastf, tf, tthis_best, argumentList, 0, null, sc) == MATCH.nomatch)
             goto Lnomatch;

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -938,7 +938,36 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
      * then run semantic on each argument (place results in tiargs[]),
      * last find most specialized template from overload list/set.
      */
-    if (!tempinst.findTempDecl(sc, null) || !tempinst.semanticTiargs(sc) || !tempinst.findBestMatch(sc, argumentList))
+    if (!tempinst.findTempDecl(sc, null))
+        goto Lerror;
+
+    // Trace template argument semantic analysis as a sub-span of the template instance
+    {
+        bool tiargs_ok;
+        {
+            timeTraceBeginEvent(TimeTraceEventType.sema1TemplateArgSemantic);
+            scope (exit) timeTraceEndEvent(TimeTraceEventType.sema1TemplateArgSemantic, tempinst,
+                () => tempinst.toPrettyChars().toDString());
+            tiargs_ok = tempinst.semanticTiargs(sc);
+        }
+        if (!tiargs_ok)
+            goto Lerror;
+    }
+
+    // Trace overload resolution (findBestMatch) as a sub-span of the template instance
+    {
+        bool match_ok;
+        {
+            timeTraceBeginEvent(TimeTraceEventType.sema1TemplateOverloadResolution);
+            scope (exit) timeTraceEndEvent(TimeTraceEventType.sema1TemplateOverloadResolution, tempinst,
+                () => tempinst.toPrettyChars().toDString());
+            match_ok = tempinst.findBestMatch(sc, argumentList);
+        }
+        if (!match_ok)
+            goto Lerror;
+    }
+
+    if (false)
     {
     Lerror:
         if (tempinst.gagged)
@@ -1280,7 +1309,12 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     sc2.tinst = tempinst;
     sc2.minst = tempinst.minst;
     sc2.stc &= ~STC.deprecated_;
-    tempinst.tryExpandMembers(sc2);
+    {
+        timeTraceBeginEvent(TimeTraceEventType.sema1TemplateMembers);
+        tempinst.tryExpandMembers(sc2);
+        timeTraceEndEvent(TimeTraceEventType.sema1TemplateMembers, tempinst,
+            () => tempinst.toPrettyChars().toDString());
+    }
 
     tempinst.semanticRun = PASS.semanticdone;
 
@@ -1341,7 +1375,10 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
          * are forward referenced. Find a way to defer semantic()
          * on this template.
          */
+        timeTraceBeginEvent(TimeTraceEventType.sema1TemplateInstanceSema2);
         tempinst.semantic2(sc2);
+        timeTraceEndEvent(TimeTraceEventType.sema1TemplateInstanceSema2, tempinst,
+            () => tempinst.toPrettyChars().toDString());
     }
     if (global.errors != errorsave)
         goto Laftersemantic;
@@ -1368,7 +1405,12 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
         if (sc.isDeprecated() && isDRuntimeHook(tempinst.name))
             global.params.useDeprecated = DiagnosticReporting.off;
 
-        tempinst.trySemantic3(sc2);
+        {
+            timeTraceBeginEvent(TimeTraceEventType.sema1TemplateInstanceSema3);
+            tempinst.trySemantic3(sc2);
+            timeTraceEndEvent(TimeTraceEventType.sema1TemplateInstanceSema3, tempinst,
+                () => tempinst.toPrettyChars().toDString());
+        }
 
         global.params.useDeprecated = saveUseDeprecated;
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -866,6 +866,19 @@ void templateDeclarationSemantic(Scope* sc, TemplateDeclaration tempdecl)
 
 void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList argumentList)
 {
+    void Lerror()
+    {
+        if (tempinst.gagged)
+        {
+            // https://issues.dlang.org/show_bug.cgi?id=13220
+            // Roll back status for later semantic re-running
+            tempinst.semanticRun = PASS.initial;
+        }
+        else
+            tempinst.inst = tempinst;
+        tempinst.errors = true;
+        return;
+    }
     //printf("[%s] TemplateInstance.dsymbolSemantic('%s', this=%p, gag = %d, sc = %p)\n", tempinst.loc.toChars(), tempinst.toChars(), tempinst, global.gag, sc);
     version (none)
     {
@@ -965,20 +978,6 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
         }
         if (!match_ok)
             return Lerror();
-    }
-
-    void Lerror()
-    {
-        if (tempinst.gagged)
-        {
-            // https://issues.dlang.org/show_bug.cgi?id=13220
-            // Roll back status for later semantic re-running
-            tempinst.semanticRun = PASS.initial;
-        }
-        else
-            tempinst.inst = tempinst;
-        tempinst.errors = true;
-        return;
     }
     TemplateDeclaration tempdecl = tempinst.tempdecl.isTemplateDeclaration();
     assert(tempdecl);

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -877,7 +877,6 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
         else
             tempinst.inst = tempinst;
         tempinst.errors = true;
-        return;
     }
     //printf("[%s] TemplateInstance.dsymbolSemantic('%s', this=%p, gag = %d, sc = %p)\n", tempinst.loc.toChars(), tempinst.toChars(), tempinst, global.gag, sc);
     version (none)
@@ -5921,7 +5920,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
                             if (scx == p.sc)
                             {
                                 error(loc, "recursive template expansion while looking for `%s.%s`", ti.toChars(), tdx.toChars());
-                                return Lerror();
+                                goto Lerror;
                             }
                         }
                     }
@@ -5944,7 +5943,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
                 fd = resolveFuncCall(loc, sc, s, null, tthis, argumentList, FuncResolveFlag.quiet);
             }
             else
-                return Lerror();
+                goto Lerror;
 
             if (!fd)
                 return 0;
@@ -5999,7 +5998,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
         for (size_t ovi = 0; f; f = f.overnext0, ovi++)
         {
             if (f.type.ty != Tfunction || f.errors)
-                return Lerror();
+                goto Lerror;
 
             /* This is a 'dummy' instance to evaluate constraint properly.
              */
@@ -6165,7 +6164,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
         tthis_best = m.lastf.needThis() && !m.lastf.isCtorDeclaration() ? tthis : null;
 
         if (m.lastf.type.ty == Terror)
-            return Lerror();
+            goto Lerror;
         auto tf = m.lastf.type.isTypeFunction();
         if (callMatch(m.lastf, tf, tthis_best, argumentList, 0, null, sc) == MATCH.nomatch)
             goto Lnomatch;

--- a/compiler/src/dmd/timetrace.d
+++ b/compiler/src/dmd/timetrace.d
@@ -176,6 +176,11 @@ enum TimeTraceEventType
     sema1Module,
     sema1TemplateDecl,
     sema1TemplateInstance,
+    sema1TemplateArgSemantic,        /// semantic analysis of template arguments (semanticTiargs)
+    sema1TemplateOverloadResolution, /// overload resolution / best-match selection (findBestMatch)
+    sema1TemplateMembers,            /// sema1 pass on template instance members (expandMembers)
+    sema1TemplateInstanceSema2,      /// sema2 pass on template instance members
+    sema1TemplateInstanceSema3,      /// sema3 pass on template instance members
     sema1Function,
     sema2,
     sema3,
@@ -198,6 +203,11 @@ private immutable string[] eventPrefixes = [
     "Sema1: Module ",
     "Sema1: Template Declaration ",
     "Sema1: Template Instance ",
+    "Sema1: Template Arg Semantic: ", /// sema1TemplateArgSemantic
+    "Sema1: Overload Resolution: ",   /// sema1TemplateOverloadResolution
+    "Sema1: Template Members: ",      /// sema1TemplateMembers
+    "Sema2: Template Instance: ",     /// sema1TemplateInstanceSema2
+    "Sema3: Template Instance: ",     /// sema1TemplateInstanceSema3
     "Sema1: Function ",
     "Sema2: ",
     "Sema3: ",

--- a/compiler/test/compilable/ftimetrace.d
+++ b/compiler/test/compilable/ftimetrace.d
@@ -23,12 +23,17 @@ Sema1: Function fun, object.fun
 Sema1: Function id, object.id!int.id
 Sema1: Function uses, object.uses
 Sema1: Module object, object
+Sema1: Overload Resolution: id!int, id!int
+Sema1: Template Arg Semantic: id!int, id!int
 Sema1: Template Declaration id(T)(T t), object.id(T)(T t)
 Sema1: Template Instance id!int, object.id!int
+Sema1: Template Members: id!int, object.id!int
+Sema2: Template Instance: id!int, object.id!int
 Sema2: add, object.add
 Sema2: fun, object.fun
 Sema2: id, object.id!int.id
 Sema2: uses, object.uses
+Sema3: Template Instance: id!int, object.id!int
 Sema3: add, object.add
 Sema3: fun, object.fun
 Sema3: id, object.id!int.id


### PR DESCRIPTION
-ftime-trace output in perfetto and the sema1 template instance block was just one big blob with nothing inside it. makes it really hard to tell if the time is going into arg evaluation, overload resolution, expanding members, sema2 or sema3.

added spans for:
- semanticTiargs (arg semantic)
- findBestMatch (overload resolution)
- expandMembers (sema1 on members)
- semantic2 on the instance
- trySemantic3 on the instance

fixes #22711