### PR TITLE
Never do inlining when -cov is passed

### DIFF
--- a/compiler/src/dmd/pragmasem.d
+++ b/compiler/src/dmd/pragmasem.d
@@ -358,6 +358,9 @@ bool pragmaStmtSemantic(PragmaStatement ps, Scope* sc)
  */
 package PINLINE evalPragmaInline(Loc loc, Scope* sc, Expressions* args)
 {
+    if (global.params.cov)
+        return PINLINE.never;
+
     if (!args || args.length == 0)
         return PINLINE.default_;
 


### PR DESCRIPTION
This change makes it possible to measure coverage of functions that are qualified as `pragma(inline, true)`. I can't see how the current opposite behavior can be intentional.

Alternatively, `pragma(inline, true);` could be disabled when `-inline` is _not_ passed. This has been discussed previously.