### PR TITLE
Disallow safe/trusted `pragma(printf)` function of `va_list` form

### DIFF
--- a/changelog/dmd.saferPrintf.dd
+++ b/changelog/dmd.saferPrintf.dd
@@ -8,9 +8,11 @@ This change allows calling a $(DDSUBLINK spec/pragma, printf,
 
 - the callee is marked `@safe` or `@trusted`
 - the format string passed is a literal
-- no zero-terminated string format specifiers are used
+- no string format specifiers are used
+- the callee has a `...` parameter after the format string
 
-Note: `pragma(printf)` already enforces type safety.
+Note: `pragma(printf)` already enforces type safety for a C-style
+variadic function.
 
 For example:
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3415,11 +3415,12 @@ private bool checkSafety(FuncDeclaration f, ref Loc loc, Scope* sc, Expressions*
     {
         TypeFunction tf = f.type.isTypeFunction();
         assert(tf);
-        const isVa_list = tf.parameterList.varargs == VarArg.none;
+        // safe/trusted va_list pragma(printf) is an error
+        assert(tf.parameterList.varargs != VarArg.none);
         const nparams = tf.parameterList.length;
-        const nargs = arguments ? arguments.length : 0;
-        assert(nparams && nargs); // should have been verified already
-        if (auto se = (*arguments)[nparams - 1 - isVa_list].isStringExp())
+        // verified by pragma(printf) and argument matching already
+        assert(nparams && arguments && arguments.length);
+        if (auto se = (*arguments)[nparams - 1].isStringExp())
         {
             if (!isFormatSafe(se.peekString()))
             {

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -4038,11 +4038,15 @@ private void checkPrintfScanfSignature(FuncDeclaration funcdecl, TypeFunction f,
     }
     else if (f.parameterList.varargs == VarArg.none)
     {
-        if(!(nparams >= 2 && isPointerToChar(f.parameterList[nparams - 2]) &&
+        import dmd.safe;
+        if (!(nparams >= 2 && isPointerToChar(f.parameterList[nparams - 2]) &&
             isVa_list(f.parameterList[nparams - 1])))
             .error(funcdecl.loc, "`pragma(%s)` function `%s` must have"~
                 " signature `%s %s([parameters...], const(char)*, va_list)`",
                 p, funcdecl.toChars(), f.next.toChars(), funcdecl.toChars());
+        else if (funcdecl.isSafe() || funcdecl.isTrusted())
+            .error(funcdecl.loc, "`pragma(%s)` %s `%s` of `va_list` form must be `@system`",
+                p, funcdecl.kind(), funcdecl.toChars());
     }
     else
     {

--- a/compiler/test/fail_compilation/format.d
+++ b/compiler/test/fail_compilation/format.d
@@ -27,8 +27,9 @@ fail_compilation/format.d(204): Error: `pragma(printf)` function `vprintf2` must
 fail_compilation/format.d(205): Error: `pragma(printf)` function `vprintf3` must have signature `int vprintf3([parameters...], const(char)*, va_list)`
 fail_compilation/format.d(206): Error: `pragma(printf)` function `vprintf4` must have signature `int vprintf4([parameters...], const(char)*, va_list)`
 fail_compilation/format.d(207): Error: `pragma(printf)` function `vprintf5` must have C-style variadic `...` or `va_list` parameter
-fail_compilation/format.d(208): Error: `pragma(scanf)` function `vscanf1` must have `extern(C)` or `extern(C++)` linkage, not `extern(Windows)`
-fail_compilation/format.d(208): Error: `pragma(scanf)` function `vscanf1` must have signature `int vscanf1([parameters...], const(char)*, va_list)`
+fail_compilation/format.d(208): Error: `pragma(printf)` function `vprintf8` of `va_list` form must be `@system`
+fail_compilation/format.d(209): Error: `pragma(scanf)` function `vscanf1` must have `extern(C)` or `extern(C++)` linkage, not `extern(Windows)`
+fail_compilation/format.d(209): Error: `pragma(scanf)` function `vscanf1` must have signature `int vscanf1([parameters...], const(char)*, va_list)`
 ---
  */
 
@@ -41,8 +42,10 @@ pragma(printf) extern (C) int vprintf2(const(int )*, va_list);
 pragma(printf) extern (C) int vprintf3(const(char)*);
 pragma(printf) extern (C) int vprintf4(const(char)*, int, va_list);
 pragma(printf) extern (C) int vprintf5(char*, int[] a...);
+pragma(printf) extern (C) int vprintf8(const char*, va_list) @trusted;
 pragma(scanf)  extern (Windows) int vscanf1();
 
-pragma(printf) extern (C) int vprintf5(const(char)*, va_list);
+// OK:
+pragma(printf) extern (C) int vprintf0(const(char)*, va_list);
 pragma(printf) extern (C) int vprintf6(immutable(char)*, va_list);
 pragma(printf) extern (C) int vprintf7(char*, va_list);


### PR DESCRIPTION
Fixes #22786.

Also update changelog item.
In the test I renamed an existing vprintf5 overload for error message clarity.