### PR TITLE
Fix #19947 - Color syntax highlight doesn't escape backticks in symbo…

### DIFF
--- a/compiler/src/dmd/access.d
+++ b/compiler/src/dmd/access.d
@@ -50,7 +50,7 @@ bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymbol smember)
 
     if (!symbolIsVisible(sc, smember))
     {
-        error(loc, "%s `%s` %s `%s` is not accessible", ad.kind(), ad.toPrettyChars(), smember.kind(), smember.toChars());
+        error(loc, "%s `%s` %s `%s` is not accessible", ad.kind(), ad.toPrettyChars(), smember.kind(), smember.toErrMsg());
         //printf("smember = %s %s, vis = %d, semanticRun = %d\n",
         //        smember.kind(), smember.toPrettyChars(), smember.visible() smember.semanticRun);
         return true;

--- a/compiler/src/dmd/arrayop.d
+++ b/compiler/src/dmd/arrayop.d
@@ -94,7 +94,7 @@ bool checkNonAssignmentArrayOp(Expression e, bool suggestion = false)
         const(char)* s = "";
         if (suggestion)
             s = " (possible missing [])";
-        error(e.loc, "array operation `%s` without destination memory not allowed%s", e.toChars(), s);
+        error(e.loc, "array operation `%s` without destination memory not allowed%s", e.toErrMsg(), s);
         return true;
     }
     return false;
@@ -169,7 +169,7 @@ Expression arrayOp(BinAssignExp e, Scope* sc)
 
     if (tn && (!tn.isMutable() || !tn.isAssignable()))
     {
-        error(e.loc, "slice `%s` is not mutable", e.e1.toChars());
+        error(e.loc, "slice `%s` is not mutable", e.e1.toErrMsg());
         if (e.op == EXP.addAssign)
             checkPossibleAddCatError!(AddAssignExp, CatAssignExp)(e.isAddAssignExp);
         return ErrorExp.get();
@@ -372,7 +372,7 @@ bool isArrayOpOperand(Expression e)
 
 ErrorExp arrayOpInvalidError(Expression e)
 {
-    error(e.loc, "invalid array operation `%s` (possible missing [])", e.toChars());
+    error(e.loc, "invalid array operation `%s` (possible missing [])", e.toErrMsg());
     if (e.op == EXP.add)
         checkPossibleAddCatError!(AddExp, CatExp)(e.isAddExp());
     else if (e.op == EXP.addAssign)

--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -18,6 +18,7 @@ import dmd.astenums;
 import dmd.canthrow;
 import dmd.dclass;
 import dmd.declaration;
+import dmd.errors;
 import dmd.errorsink;
 import dmd.expression;
 import dmd.expressionsem : toBool;
@@ -523,7 +524,7 @@ BE checkThrow(Loc loc, Expression exp, FuncDeclaration func, ErrorSink eSink)
         return BE.errthrow;
     }
     if (eSink)
-        eSink.error(loc, "`%s` is thrown but not caught", exp.type.toChars());
+        eSink.error(loc, "`%s` is thrown but not caught", exp.type.toErrMsg());
     else if (func)
         func.setThrow(loc, "`%s` being thrown but not caught", exp.type);
 

--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -18,6 +18,7 @@ import dmd.astenums;
 import dmd.blockexit : BE, checkThrow;
 import dmd.dsymbol;
 import dmd.dsymbolsem : include, toAlias;
+import dmd.errors;
 import dmd.errorsink;
 import dmd.expression;
 import dmd.expressionsem;
@@ -142,7 +143,7 @@ CT canThrow(Expression e, FuncDeclaration func, ErrorSink eSink)
                 auto e1 = ce.e1;
                 if (auto pe = e1.isPtrExp())   // print 'fp' if e1 is (*fp)
                     e1 = pe.e1;
-                eSink.error(ce.loc, "`%s` is not `nothrow`", e1.toChars());
+                eSink.error(ce.loc, "`%s` is not `nothrow`", e1.toErrMsg());
             }
             result |= CT.exception;
         }

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1732,7 +1732,7 @@ void needCopyOrMoveCtor(StructDeclaration sd, out bool hasCopyCtor, out bool has
 
     if (0 && fieldWithCpCtor && moveCtor)
     {
-        .error(sd.loc, "`struct %s` may not define a rvalue constructor and have fields with copy constructors", sd.toChars());
+        .error(sd.loc, "`struct %s` may not define a rvalue constructor and have fields with copy constructors", sd.toErrMsg());
         errorSupplemental(moveCtor.loc,"rvalue constructor defined here");
         errorSupplemental(fieldWithCpCtor.loc, "field with copy constructor defined here");
         return;

--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -1073,7 +1073,7 @@ UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
         {
             // have to change to internal compiler error
             // all invalid casts should be handled already in Expression::castTo().
-            error(loc, "cannot cast `%s` to `%s`", e1.type.toChars(), type.toChars());
+            error(loc, "cannot cast `%s` to `%s`", e1.type.toErrMsg(), type.toErrMsg());
         }
         emplaceExp!(ErrorExp)(&ue);
     }
@@ -1142,7 +1142,7 @@ UnionExp Index(Type type, Expression e1, Expression e2, bool indexIsInBounds)
         if (i >= length && (e1.op == EXP.arrayLiteral || !indexIsInBounds))
         {
             // C code only checks bounds if an ArrayLiteralExp
-            error(e1.loc, "array index %llu is out of bounds `%s[0 .. %llu]`", i, e1.toChars(), length);
+            error(e1.loc, "array index %llu is out of bounds `%s[0 .. %llu]`", i, e1.toErrMsg(), length);
             emplaceExp!(ErrorExp)(&ue);
         }
         else if (ArrayLiteralExp ale = e1.isArrayLiteralExp())
@@ -1165,7 +1165,7 @@ UnionExp Index(Type type, Expression e1, Expression e2, bool indexIsInBounds)
         {
             if (i >= ale.elements.length)
             {
-                error(e1.loc, "array index %llu is out of bounds `%s[0 .. %llu]`", i, e1.toChars(), cast(ulong) ale.elements.length);
+                error(e1.loc, "array index %llu is out of bounds `%s[0 .. %llu]`", i, e1.toErrMsg(), cast(ulong) ale.elements.length);
                 emplaceExp!(ErrorExp)(&ue);
             }
             else

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -17,6 +17,7 @@ import core.stdc.stdio;
 import core.stdc.string : memcpy;
 
 import dmd.astenums;
+import dmd.errors;
 import dmd.errorsink;
 import dmd.id;
 import dmd.identifier;
@@ -316,7 +317,7 @@ final class CParser(AST) : Parser!AST
             auto exp = cparseExpression();
             if (token.value == TOK.identifier && exp.op == EXP.identifier)
             {
-                error(token.loc, "found `%s` when expecting `;` or `=`, did you mean `%s %s = %s`?", peek(&token).toChars(), exp.toChars(), token.toChars(), peek(peek(&token)).toChars());
+                error(token.loc, "found `%s` when expecting `;` or `=`, did you mean `%s %s = %s`?", peek(&token).toChars(), exp.toErrMsg(), token.toChars(), peek(peek(&token)).toChars());
                 nextToken();
             }
             else
@@ -1794,7 +1795,7 @@ final class CParser(AST) : Parser!AST
             if (auto ti = tspec.isTypeIdentifier())
             {
                 // C11 6.7.2-2
-                error("type-specifier missing for declaration of `%s`", ti.ident.toChars());
+                error("type-specifier missing for declaration of `%s`", ti.ident.toErrMsg());
                 nextToken();
                 return;
             }
@@ -1811,7 +1812,7 @@ final class CParser(AST) : Parser!AST
             if (0 && tt.tok == TOK.enum_)    // C11 proscribes enums with no members, but we allow it
             {
                 if (!tt.members)
-                    error(tt.loc, "`enum %s` has no members", tt.toChars());
+                    error(tt.loc, "`enum %s` has no members", tt.toErrMsg());
             }
             return;
         }
@@ -1851,7 +1852,7 @@ final class CParser(AST) : Parser!AST
             /* C11 6.7.2-2
              * Special check for `const b = 1;` because some compilers allow it
              */
-            error("type-specifier omitted for declaration of `%s`", tspec.isTypeIdentifier().ident.toChars());
+            error("type-specifier omitted for declaration of `%s`", tspec.isTypeIdentifier().ident.toErrMsg());
             return scanPastSemicolon();
         }
 
@@ -2118,7 +2119,7 @@ final class CParser(AST) : Parser!AST
                 case TOK.identifier:
                     if (s)
                     {
-                        error(token.loc, "missing comma or semicolon after declaration of `%s`, found `%s` instead", s.toChars(), token.toChars());
+                        error(token.loc, "missing comma or semicolon after declaration of `%s`, found `%s` instead", s.toErrMsg(), token.toChars());
                         goto Lend;
                     }
                     goto default;
@@ -2226,7 +2227,7 @@ final class CParser(AST) : Parser!AST
                 }
                 if (!p.type)
                 {
-                    error("no declaration for identifier `%s`", p.ident.toChars());
+                    error("no declaration for identifier `%s`", p.ident.toErrMsg());
                     p.type = AST.Type.terror;
                 }
             }
@@ -3021,7 +3022,7 @@ final class CParser(AST) : Parser!AST
                              * function type.
                              */
                             if (ta.isTypeSArray() && ta.isTypeSArray().isIncomplete() && !isVLA)
-                                error("array type has incomplete element type `%s`", ta.toChars());
+                                error("array type has incomplete element type `%s`", ta.toErrMsg());
                         }
 
                         // Apply type qualifiers to the constructed type.
@@ -3253,7 +3254,7 @@ final class CParser(AST) : Parser!AST
             {
                 if ((token.value == TOK.rightParenthesis || token.value == TOK.comma) &&
                     tspec.isTypeIdentifier())
-                    error("type-specifier omitted for parameter `%s`", tspec.isTypeIdentifier().ident.toChars());
+                    error("type-specifier omitted for parameter `%s`", tspec.isTypeIdentifier().ident.toErrMsg());
 
                 tspec = toConst(tspec);
                 specifier.mod = MOD.xnone;      // 'used' it
@@ -3922,7 +3923,7 @@ final class CParser(AST) : Parser!AST
             if (token.value == TOK.rightCurly)  // C11 6.7.2.2-1
             {
                 if (tag)
-                    error("no members for `enum %s`", tag.toChars());
+                    error("no members for `enum %s`", tag.toErrMsg());
                 else
                     error("no members for anonymous enum");
             }
@@ -4146,7 +4147,7 @@ final class CParser(AST) : Parser!AST
             {
                 if (auto ti = tspec.isTypeIdentifier())
                 {
-                    error("type-specifier omitted before declaration of `%s`", ti.ident.toChars());
+                    error("type-specifier omitted before declaration of `%s`", ti.ident.toErrMsg());
                 }
                 return; // legal but meaningless empty declaration
             }
@@ -4193,7 +4194,7 @@ final class CParser(AST) : Parser!AST
             {
                 if (auto ti = tspec.isTypeIdentifier())
                 {
-                    error("type-specifier omitted before bit field declaration of `%s`", ti.ident.toChars());
+                    error("type-specifier omitted before bit field declaration of `%s`", ti.ident.toErrMsg());
                     tspec = AST.Type.tint32;
                 }
 
@@ -5590,7 +5591,7 @@ final class CParser(AST) : Parser!AST
 
         void addSym(AST.Dsymbol s)
         {
-            //printf("addSym() %s\n", s.toChars());
+            //printf("addSym() %s\n", s.toErrMsg());
             if (auto v = s.isVarDeclaration())
                 v.isCmacro = true;       // mark it as coming from a C #define
             if (auto td = s.isTemplateDeclaration())
@@ -5600,7 +5601,7 @@ final class CParser(AST) : Parser!AST
              */
             if (size_t* pd = cast(void*)s.ident in defineTab)
             {
-                //printf("replacing %s\n", s.toChars());
+                //printf("replacing %s\n", s.toErrMsg());
                 newSymbols[*pd] = s;
                 return;
             }
@@ -5610,10 +5611,10 @@ final class CParser(AST) : Parser!AST
 
         void removeSym(Identifier ident)
         {
-            //printf("removeSym() %s\n", ident.toChars());
+            //printf("removeSym() %s\n", ident.toErrMsg());
             if (size_t* pd = cast(void*)ident in defineTab)
             {
-                //printf("removing %s\n", ident.toChars());
+                //printf("removing %s\n", ident.toErrMsg());
                 newSymbols[*pd] = null;
             }
         }
@@ -5823,7 +5824,7 @@ final class CParser(AST) : Parser!AST
                              * Create template function:
                              *    auto id(__MP1, __MP2)(__MP1 a, __MP1 b) { return expression; }
                              */
-                            //printf("functionlike %s\n", id.toChars());
+                            //printf("functionlike %s\n", id.toErrMsg());
 
                             // Capture the parameter list
                             VarArg varargs = VarArg.none;
@@ -5882,7 +5883,7 @@ final class CParser(AST) : Parser!AST
                             eLatch.sawErrors = false;
                             auto exp = cparseExpression();
 
-                            //printf("exp: %s tok: %s\n", exp.toChars(), Token.toChars(token.value));
+                            //printf("exp: %s tok: %s\n", exp.toErrMsg(), Token.toChars(token.value));
                             //printf("parsed: '%.*s'\n", cast(int)(p - pstart), pstart);
                             assert(symbols);
 

--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -122,7 +122,7 @@ void generateUncaughtError(ThrownExceptionExp tee)
     UnionExp ue = void;
     Expression e = resolveSlice((*tee.thrown.value.elements)[0], &ue);
     StringExp se = e.toStringExp();
-    error(tee.thrown.loc, "uncaught CTFE exception `%s(%s)`", tee.thrown.type.toChars(), se ? se.toChars() : e.toChars());
+    error(tee.thrown.loc, "uncaught CTFE exception `%s(%s)`", tee.thrown.type.toErrMsg(), se ? se.toErrMsg() : e.toErrMsg());
     /* Also give the line where the throw statement was. We won't have it
      * in the case where the ThrowStatement is generated internally
      * (eg, in ScopeStatement)
@@ -367,7 +367,7 @@ UnionExp copyLiteral(Expression e)
         emplaceExp!(UnionExp)(&ue, e);
         return ue;
     }
-    error(e.loc, "CTFE internal error: literal `%s`", e.toChars());
+    error(e.loc, "CTFE internal error: literal `%s`", e.toErrMsg());
     assert(0);
 }
 
@@ -438,7 +438,7 @@ private UnionExp paintTypeOntoLiteralCopy(Type type, Expression lit)
         // Can't type paint from struct to struct*; this needs another
         // level of indirection
         if (lit.op == EXP.structLiteral && isPointer(type))
-            error(lit.loc, "CTFE internal error: painting `%s`", type.toChars());
+            error(lit.loc, "CTFE internal error: painting `%s`", type.toErrMsg());
         ue = copyLiteral(lit);
     }
     ue.exp().type = type;
@@ -766,7 +766,7 @@ Expression pointerDifference(UnionExp* pue, Loc loc, Type type, Expression e1, E
     }
     else
     {
-        error(loc, "`%s - %s` cannot be interpreted at compile time: cannot subtract pointers to two different memory blocks", e1.toChars(), e2.toChars());
+        error(loc, "`%s - %s` cannot be interpreted at compile time: cannot subtract pointers to two different memory blocks", e1.toErrMsg(), e2.toErrMsg());
         emplaceExp!(CTFEExp)(pue, EXP.cantExpression);
     }
     return pue.exp();
@@ -843,7 +843,7 @@ Expression pointerArithmetic(UnionExp* pue, Loc loc, EXP op, Type type, Expressi
     }
     if (agg1.op != EXP.arrayLiteral && agg1.op != EXP.string_)
     {
-        error(loc, "CTFE internal error: pointer arithmetic `%s`", agg1.toChars());
+        error(loc, "CTFE internal error: pointer arithmetic `%s`", agg1.toErrMsg());
         return cant();
     }
     if (auto tsa = eptr.type.toBasetype().isTypeSArray())
@@ -1308,7 +1308,7 @@ private int ctfeRawCmp(Loc loc, Expression e1, Expression e2, bool identity = fa
         return e2.isAssocArrayLiteralExp.keys.length != 0;
     }
 
-    error(loc, "CTFE internal error: bad compare of `%s` and `%s`", e1.toChars(), e2.toChars());
+    error(loc, "CTFE internal error: bad compare of `%s` and `%s`", e1.toErrMsg(), e2.toErrMsg());
     assert(0);
 }
 
@@ -1504,7 +1504,7 @@ Expression ctfeIndex(UnionExp* pue, Loc loc, Type type, Expression e1, uinteger_
     {
         if (indx >= ale.elements.length)
         {
-            error(loc, "array index %llu is out of bounds `%s[0 .. %llu]`", indx, e1.toChars(), cast(ulong)ale.elements.length);
+            error(loc, "array index %llu is out of bounds `%s[0 .. %llu]`", indx, e1.toErrMsg(), cast(ulong)ale.elements.length);
             return CTFEExp.cantexp;
         }
         Expression e = (*ale.elements)[cast(size_t)indx];
@@ -1568,7 +1568,7 @@ Expression ctfeCast(UnionExp* pue, Loc loc, Type type, Type to, Expression e, bo
     }
 
     if (CTFEExp.isCantExp(r))
-        error(loc, "cannot cast `%s` to `%s` at compile time", e.toChars(), to.toChars());
+        error(loc, "cannot cast `%s` to `%s` at compile time", e.toErrMsg(), to.toErrMsg());
 
     if (auto ae = e.isArrayLiteralExp())
         ae.ownedByCtfe = OwnedBy.ctfe;
@@ -1861,7 +1861,7 @@ bool isCtfeValueValid(Expression newval)
             return true; // uninitialized value
 
         default:
-            error(newval.loc, "CTFE internal error: illegal CTFE value `%s`", newval.toChars());
+            error(newval.loc, "CTFE internal error: illegal CTFE value `%s`", newval.toErrMsg());
             return false;
     }
 }

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -182,7 +182,7 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
 
         if (!t.deco)
         {
-            error(e.loc, "forward reference to type `%s`", t.toChars());
+            error(e.loc, "forward reference to type `%s`", t.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -211,14 +211,14 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
             // Const -> mutable conversion (disallowed)
             if (fromPointee.isConst() && !toPointee.isConst())
             {
-                error(e.loc, "cannot implicitly convert `%s` to `%s`", e.type.toChars(), t.toChars());
+                error(e.loc, "cannot implicitly convert `%s` to `%s`", e.type.toErrMsg(), t.toErrMsg());
                 errorSupplemental(e.loc, "Note: Converting const to mutable requires an explicit cast (`cast(int*)`).");
                 return ErrorExp.get();
             }
             // Incompatible pointee types (e.g., int* -> float* )
             else if (fromPointee.toBasetype().ty != toPointee.toBasetype().ty)
             {
-                error(e.loc, "cannot implicitly convert `%s` to `%s`", e.type.toChars(), t.toChars());
+                error(e.loc, "cannot implicitly convert `%s` to `%s`", e.type.toErrMsg(), t.toErrMsg());
                 errorSupplemental(e.loc, "Note: Pointer types point to different base types (`%s` vs `%s`)", fromPointee.toChars(), toPointee.toChars());
                 return ErrorExp.get();
             }
@@ -322,7 +322,7 @@ MATCH implicitConvTo(Expression e, Type t)
             return MATCH.nomatch;
         if (!e.type)
         {
-            error(e.loc, "`%s` is not an expression", e.toChars());
+            error(e.loc, "`%s` is not an expression", e.toErrMsg());
             e.type = Type.terror;
         }
 
@@ -2171,7 +2171,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                 if (auto result = tryAliasThisCast())
                     return result;
             }
-            error(e.loc, "cannot cast expression `%s` of type `%s` to `%s`", e.toChars(), e.type.toChars(), t.toChars());
+            error(e.loc, "cannot cast expression `%s` of type `%s` to `%s`", e.toErrMsg(), e.type.toErrMsg(), t.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -2251,7 +2251,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
 
             auto ts = toAutoQualChars(e.type, t);
             error(e.loc, "cannot cast expression `%s` of type `%s` to `%s` because of different sizes",
-                e.toChars(), ts[0], ts[1]);
+                e.toErrMsg(), ts[0], ts[1]);
             return ErrorExp.get();
         }
 
@@ -2280,7 +2280,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                     if (tsize == 0 || (dim * fsize) % tsize != 0)
                     {
                         error(e.loc, "cannot cast expression `%s` of type `%s` to `%s` since sizes don't line up",
-                                e.toChars(), e.type.toChars(), t.toChars());
+                                e.toErrMsg(), e.type.toErrMsg(), t.toErrMsg());
                         return ErrorExp.get();
                     }
                 }
@@ -2322,7 +2322,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                 // void delegate() dg;
                 // cast(U*)dg; // ==> cast(U*)dg.ptr;
                 // Note that it happens even when U is a Tfunction!
-                deprecation(e.loc, "casting from %s to %s is deprecated", e.type.toChars(), t.toChars());
+                deprecation(e.loc, "casting from %s to %s is deprecated", e.type.toErrMsg(), t.toErrMsg());
                 return ok();
             }
             return fail();
@@ -2956,7 +2956,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                     }
                     else if (f.needThis())
                     {
-                        error(e.loc, "no `this` to create delegate for `%s`", f.toChars());
+                        error(e.loc, "no `this` to create delegate for `%s`", f.toErrMsg());
                         return ErrorExp.get();
                     }
                     else if (f.isNested())
@@ -3163,7 +3163,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         }
         auto ts = toAutoQualChars(tsa ? tsa : e.type, t);
         error(e.loc, "cannot cast expression `%s` of type `%s` to `%s`",
-            e.toChars(), ts[0], ts[1]);
+            e.toErrMsg(), ts[0], ts[1]);
         return ErrorExp.get();
     }
 
@@ -4357,7 +4357,7 @@ void fix16997(Scope* sc, UnaExp ue)
         case Twchar:
         case Tdchar:
             deprecation(ue.loc, "integral promotion not done for `%s`, remove '-revert=intpromote' switch or `%scast(int)(%s)`",
-                ue.toChars(), EXPtoString(ue.op).ptr, ue.e1.toChars());
+                ue.toErrMsg(), EXPtoString(ue.op).ptr, ue.e1.toErrMsg());
             return;
 
         default:

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -496,7 +496,7 @@ private Expression interpretFunction(UnionExp* pue, FuncDeclaration fd, InterSta
     {
         // error, no this. Prevent segfault.
         // Here should be unreachable by the strict 'this' check in front-end.
-        error(fd.loc, "%s `%s` need `this` to access member `%s`", fd.kind, fd.toPrettyChars, fd.toChars());
+        error(fd.loc, "%s `%s` need `this` to access member `%s`", fd.kind, fd.toPrettyChars, fd.toErrMsg());
         return CTFEExp.cantexp;
     }
 
@@ -519,7 +519,7 @@ private Expression interpretFunction(UnionExp* pue, FuncDeclaration fd, InterSta
             if (!istate && (fparam.storageClass & STC.out_))
             {
                 // initializing an out parameter involves writing to it.
-                error(earg.loc, "global `%s` cannot be passed as an `out` parameter at compile time", earg.toChars());
+                error(earg.loc, "global `%s` cannot be passed as an `out` parameter at compile time", earg.toErrMsg());
                 return CTFEExp.cantexp;
             }
             // Convert all reference arguments into lvalue references
@@ -613,7 +613,7 @@ private Expression interpretFunction(UnionExp* pue, FuncDeclaration fd, InterSta
             VarDeclaration vx = earg.isVarExp().var.isVarDeclaration();
             if (!vx)
             {
-                error(fd.loc, "%s `%s` cannot interpret `%s` as a `ref` parameter", fd.kind, fd.toPrettyChars, earg.toChars());
+                error(fd.loc, "%s `%s` cannot interpret `%s` as a `ref` parameter", fd.kind, fd.toPrettyChars, earg.toErrMsg());
                 return CTFEExp.cantexp;
             }
 
@@ -685,7 +685,7 @@ private Expression interpretFunction(UnionExp* pue, FuncDeclaration fd, InterSta
 
         if (istatex.start)
         {
-            error(fd.loc, "%s `%s` CTFE internal error: failed to resume at statement `%s`", fd.kind, fd.toPrettyChars, istatex.start.toChars());
+            error(fd.loc, "%s `%s` CTFE internal error: failed to resume at statement `%s`", fd.kind, fd.toPrettyChars, istatex.start.toErrMsg());
             return CTFEExp.cantexp;
         }
 
@@ -823,7 +823,7 @@ Expression interpretStatement(UnionExp* pue, Statement s, InterState* istate)
             istate.start = null;
         }
 
-        error(s.loc, "statement `%s` cannot be interpreted at compile time", s.toChars());
+        error(s.loc, "statement `%s` cannot be interpreted at compile time", s.toErrMsg());
         result = CTFEExp.cantexp;
     }
 
@@ -1286,7 +1286,7 @@ Expression interpretStatement(UnionExp* pue, Statement s, InterState* istate)
         if (!scase)
         {
             if (!s.hasDefault)
-                error(s.loc, "no `default` or `case` for `%s` in `switch` statement", econdition.toChars());
+                error(s.loc, "no `default` or `case` for `%s` in `switch` statement", econdition.toErrMsg());
             scase = s.sdefault;
         }
 
@@ -1720,7 +1720,7 @@ public:
             printf("type = %s\n", e.type.toChars());
             showCtfeExpr(e);
         }
-        error(e.loc, "cannot interpret `%s` at compile time", e.toChars());
+        error(e.loc, "cannot interpret `%s` at compile time", e.toErrMsg());
         result = CTFEExp.cantexp;
     }
 
@@ -1866,14 +1866,14 @@ public:
         if (e.type.ty != Tpointer)
         {
             // Probably impossible
-            error(e.loc, "cannot interpret `%s` at compile time", e.toChars());
+            error(e.loc, "cannot interpret `%s` at compile time", e.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
         Type pointee = (cast(TypePointer)e.type).next;
         if (e.var.isThreadlocal())
         {
-            error(e.loc, "cannot take address of thread-local variable %s at compile time", e.var.toChars());
+            error(e.loc, "cannot take address of thread-local variable %s at compile time", e.var.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -1928,7 +1928,7 @@ public:
                     result = pue.exp();
                     return;
                 }
-                error(e.loc, "reinterpreting cast from `%s` to `%s` is not supported in CTFE", val.type.toChars(), e.type.toChars());
+                error(e.loc, "reinterpreting cast from `%s` to `%s` is not supported in CTFE", val.type.toErrMsg(), e.type.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -1969,7 +1969,7 @@ public:
             return;
         }
 
-        error(e.loc, "cannot convert `&%s` to `%s` at compile time", e.var.type.toChars(), e.type.toChars());
+        error(e.loc, "cannot convert `&%s` to `%s` at compile time", e.var.type.toErrMsg(), e.type.toErrMsg());
         result = CTFEExp.cantexp;
     }
 
@@ -1986,7 +1986,7 @@ public:
             // We cannot take the address of an imported symbol at compile time
             if (decl.isImportedSymbol())
             {
-                error(e.loc, "cannot take address of imported symbol `%s` at compile time", decl.toChars());
+                error(e.loc, "cannot take address of imported symbol `%s` at compile time", decl.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -2144,7 +2144,7 @@ public:
             }
             else if (!(v.isDataseg() || v.storage_class & STC.manifest) && !v.isCTFE() && !istate)
             {
-                error(loc, "variable `%s` cannot be read at compile time", v.toChars());
+                error(loc, "variable `%s` cannot be read at compile time", v.toErrMsg());
                 return CTFEExp.cantexp;
             }
             else
@@ -2157,14 +2157,14 @@ public:
                         e = v.type.defaultInitLiteral(loc);
                     else if (!v.isCTFE() && v.isDataseg())
                     {
-                        error(loc, "static variable `%s` cannot be read at compile time", v.toChars());
+                        error(loc, "static variable `%s` cannot be read at compile time", v.toErrMsg());
                         return CTFEExp.cantexp;
                     }
                     else
                     {
                         assert(!(v._init && v._init.isVoidInitializer()));
                         // CTFE initiated from inside a function
-                        error(loc, "variable `%s` cannot be read at compile time", v.toChars());
+                        error(loc, "variable `%s` cannot be read at compile time", v.toErrMsg());
                         return CTFEExp.cantexp;
                     }
                 }
@@ -2193,7 +2193,7 @@ public:
             // Struct static initializers, for example
             e = s.dsym.type.defaultInitLiteral(loc);
             if (e.op == EXP.error)
-                error(loc, "CTFE failed because of previous errors in `%s.init`", s.toChars());
+                error(loc, "CTFE failed because of previous errors in `%s.init`", s.toErrMsg());
             e = e.expressionSemantic(null);
             if (e.op == EXP.error)
                 e = CTFEExp.cantexp;
@@ -2201,7 +2201,7 @@ public:
                 e = interpret(e, istate, goal);
         }
         else
-            error(loc, "cannot interpret declaration `%s` at compile time", d.toChars());
+            error(loc, "cannot interpret declaration `%s` at compile time", d.toErrMsg());
         return e;
     }
 
@@ -2232,9 +2232,9 @@ public:
                     }
 
                     if (!v.isCTFE() && v.isDataseg())
-                        error(e.loc, "static variable `%s` cannot be read at compile time", v.toChars());
+                        error(e.loc, "static variable `%s` cannot be read at compile time", v.toErrMsg());
                     else // CTFE initiated from inside a function
-                        error(e.loc, "variable `%s` cannot be read at compile time", v.toChars());
+                        error(e.loc, "variable `%s` cannot be read at compile time", v.toErrMsg());
                     result = CTFEExp.cantexp;
                     return;
                 }
@@ -2326,7 +2326,7 @@ public:
                         }
                         else
                         {
-                            error(e.loc, "declaration `%s` is not yet implemented in CTFE", e.toChars());
+                            error(e.loc, "declaration `%s` is not yet implemented in CTFE", e.toErrMsg());
                             result = CTFEExp.cantexp;
                             return 1;
                         }
@@ -2373,7 +2373,7 @@ public:
                         return;
                     }
                 }
-                error(e.loc, "declaration `%s` is not yet implemented in CTFE", e.toChars());
+                error(e.loc, "declaration `%s` is not yet implemented in CTFE", e.toErrMsg());
                 result = CTFEExp.cantexp;
             }
             else if (v.type.size() == 0)
@@ -2383,7 +2383,7 @@ public:
             }
             else
             {
-                error(e.loc, "variable `%s` cannot be modified at compile time", v.toChars());
+                error(e.loc, "variable `%s` cannot be modified at compile time", v.toErrMsg());
                 result = CTFEExp.cantexp;
             }
             return;
@@ -2391,7 +2391,7 @@ public:
         if (s.isTemplateMixin() || s.isTupleDeclaration())
         {
             // These can be made to work, too lazy now
-            error(e.loc, "declaration `%s` is not yet implemented in CTFE", e.toChars());
+            error(e.loc, "declaration `%s` is not yet implemented in CTFE", e.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -2423,7 +2423,7 @@ public:
 
             if (result.op == EXP.null_)
             {
-                error(e.loc, "null pointer dereference evaluating typeid. `%s` is `null`", ex.toChars());
+                error(e.loc, "null pointer dereference evaluating typeid. `%s` is `null`", ex.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -2466,7 +2466,7 @@ public:
                 continue;
             if (ex.op == EXP.voidExpression)
             {
-                error(e.loc, "CTFE internal error: void element `%s` in sequence", exp.toChars());
+                error(e.loc, "CTFE internal error: void element `%s` in sequence", exp.toErrMsg());
                 assert(0);
             }
 
@@ -2803,7 +2803,7 @@ public:
 
         if (e.placement)
         {
-            error(e.placement.loc, "`new ( %s )` PlacementExpression cannot be evaluated at compile time", e.placement.toChars());
+            error(e.placement.loc, "`new ( %s )` PlacementExpression cannot be evaluated at compile time", e.placement.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -2929,7 +2929,7 @@ public:
                     }
                     auto m = e.member;
                     error(m.loc, "%s `%s` `%s` cannot be constructed at compile time, because the constructor has no available source code",
-                        m.kind, m.toPrettyChars, e.newtype.toChars());
+                        m.kind, m.toPrettyChars, e.newtype.toErrMsg());
                     result = CTFEExp.cantexp;
                     return;
                 }
@@ -2971,7 +2971,7 @@ public:
             result = pue.exp();
             return;
         }
-        error(e.loc, "cannot interpret `%s` at compile time", e.toChars());
+        error(e.loc, "cannot interpret `%s` at compile time", e.toErrMsg());
         result = CTFEExp.cantexp;
     }
 
@@ -3075,7 +3075,7 @@ public:
         }
         if (e.e1.type.ty == Tpointer || e.e2.type.ty == Tpointer)
         {
-            error(e.loc, "pointer expression `%s` cannot be interpreted at compile time", e.toChars());
+            error(e.loc, "pointer expression `%s` cannot be interpreted at compile time", e.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -3155,13 +3155,13 @@ public:
             if (e1.isConst() != 1)
             {
                 // The following should really be an assert()
-                error(e1.loc, "CTFE internal error: non-constant value `%s`", e1.toChars());
+                error(e1.loc, "CTFE internal error: non-constant value `%s`", e1.toErrMsg());
                 emplaceExp!CTFEExp(&ue, EXP.cantExpression);
                 return ue;
             }
             if (e2.isConst() != 1)
             {
-                error(e2.loc, "CTFE internal error: non-constant value `%s`", e2.toChars());
+                error(e2.loc, "CTFE internal error: non-constant value `%s`", e2.toErrMsg());
                 emplaceExp!CTFEExp(&ue, EXP.cantExpression);
                 return ue;
             }
@@ -3172,7 +3172,7 @@ public:
         *pue = evaluate(e.loc, e.type, e1, e2);
         result = (*pue).exp();
         if (CTFEExp.isCantExp(result))
-            error(e.loc, "`%s` cannot be interpreted at compile time", e.toChars());
+            error(e.loc, "`%s` cannot be interpreted at compile time", e.toErrMsg());
     }
 
     extern (D) private void interpretCompareCommon(BinExp e, fp2_t fp)
@@ -3219,7 +3219,7 @@ public:
             return;
         if (!isCtfeComparable(e1))
         {
-            error(e.loc, "cannot compare `%s` at compile time", e1.toChars());
+            error(e.loc, "cannot compare `%s` at compile time", e1.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -3228,7 +3228,7 @@ public:
             return;
         if (!isCtfeComparable(e2))
         {
-            error(e.loc, "cannot compare `%s` at compile time", e2.toChars());
+            error(e.loc, "cannot compare `%s` at compile time", e2.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -3355,7 +3355,7 @@ public:
         Expression e1 = e.e1;
         if (!istate)
         {
-            error(e.loc, "value of `%s` is not known at compile time", e1.toChars());
+            error(e.loc, "value of `%s` is not known at compile time", e1.toErrMsg());
             return;
         }
 
@@ -3545,14 +3545,14 @@ public:
             }
             else
             {
-                error(e.loc, "pointer expression `%s` cannot be interpreted at compile time", e.toChars());
+                error(e.loc, "pointer expression `%s` cannot be interpreted at compile time", e.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
             if (exceptionOrCant(newval))
             {
                 if (CTFEExp.isCantExp(newval))
-                    error(e.loc, "cannot interpret `%s` at compile time", e.toChars());
+                    error(e.loc, "cannot interpret `%s` at compile time", e.toErrMsg());
                 return;
             }
         }
@@ -3584,7 +3584,7 @@ public:
             Type t = e1.type.toBasetype();
             if (t.ty != Tarray)
             {
-                error(e.loc, "`%s` is not yet supported at compile time", e.toChars());
+                error(e.loc, "`%s` is not yet supported at compile time", e.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -3726,7 +3726,7 @@ public:
             }
             if (sle.ownedByCtfe != OwnedBy.ctfe)
             {
-                error(e.loc, "cannot modify read-only constant `%s`", sle.toChars());
+                error(e.loc, "cannot modify read-only constant `%s`", sle.toErrMsg());
                 return CTFEExp.cantexp;
             }
 
@@ -3734,7 +3734,7 @@ public:
                        : ex.isClassReferenceExp().findFieldIndexByName(v);
             if (fieldi == -1)
             {
-                error(e.loc, "CTFE internal error: cannot find field `%s` in `%s`", v.toChars(), ex.toChars());
+                error(e.loc, "CTFE internal error: cannot find field `%s` in `%s`", v.toErrMsg(), ex.toErrMsg());
                 return CTFEExp.cantexp;
             }
             assert(0 <= fieldi && fieldi < sle.elements.length);
@@ -3776,7 +3776,7 @@ public:
             {
                 if (existingSE.ownedByCtfe != OwnedBy.ctfe)
                 {
-                    error(e.loc, "cannot modify read-only string literal `%s`", ie.e1.toChars());
+                    error(e.loc, "cannot modify read-only string literal `%s`", ie.e1.toErrMsg());
                     return CTFEExp.cantexp;
                 }
                 existingSE.setCodeUnit(index, cast(dchar)newval.toInteger());
@@ -3784,7 +3784,7 @@ public:
             }
             if (aggregate.op != EXP.arrayLiteral)
             {
-                error(e.loc, "index assignment `%s` is not yet supported in CTFE ", e.toChars());
+                error(e.loc, "index assignment `%s` is not yet supported in CTFE ", e.toErrMsg());
                 return CTFEExp.cantexp;
             }
 
@@ -3792,7 +3792,7 @@ public:
             if (existingAE.ownedByCtfe != OwnedBy.ctfe)
             {
                 Expression literal = existingAE.aaLiteral ? existingAE.aaLiteral : existingAE;
-                error(e.loc, "cannot modify read-only constant `%s`", literal.toChars());
+                error(e.loc, "cannot modify read-only constant `%s`", literal.toErrMsg());
                 return CTFEExp.cantexp;
             }
 
@@ -3801,7 +3801,7 @@ public:
         }
         else
         {
-            error(e.loc, "`%s` cannot be evaluated at compile time", e.toChars());
+            error(e.loc, "`%s` cannot be evaluated at compile time", e.toErrMsg());
             return CTFEExp.cantexp;
         }
 
@@ -3837,7 +3837,7 @@ public:
                 newval = resolveSlice(newval);
                 if (CTFEExp.isCantExp(newval))
                 {
-                    error(e.loc, "CTFE internal error: assignment `%s`", e.toChars());
+                    error(e.loc, "CTFE internal error: assignment `%s`", e.toErrMsg());
                     return CTFEExp.cantexp;
                 }
             }
@@ -3983,7 +3983,7 @@ public:
         {
             if (existingSE.ownedByCtfe != OwnedBy.ctfe)
             {
-                error(e.loc, "cannot modify read-only string literal `%s`", existingSE.toChars());
+                error(e.loc, "cannot modify read-only string literal `%s`", existingSE.toErrMsg());
                 return CTFEExp.cantexp;
             }
 
@@ -4006,7 +4006,7 @@ public:
                     newval = resolveSlice(newval);
                     if (CTFEExp.isCantExp(newval))
                     {
-                        error(e.loc, "CTFE internal error: slice `%s`", orignewval.toChars());
+                        error(e.loc, "CTFE internal error: slice `%s`", orignewval.toErrMsg());
                         return CTFEExp.cantexp;
                     }
                 }
@@ -4044,7 +4044,7 @@ public:
         {
             if (existingAE.ownedByCtfe != OwnedBy.ctfe)
             {
-                error(e.loc, "cannot modify read-only constant `%s`", existingAE.toChars());
+                error(e.loc, "cannot modify read-only constant `%s`", existingAE.toErrMsg());
                 return CTFEExp.cantexp;
             }
 
@@ -4126,7 +4126,7 @@ public:
                     newval = resolveSlice(newval);
                     if (CTFEExp.isCantExp(newval))
                     {
-                        error(e.loc, "CTFE internal error: slice `%s`", orignewval.toChars());
+                        error(e.loc, "CTFE internal error: slice `%s`", orignewval.toErrMsg());
                         return CTFEExp.cantexp;
                     }
                 }
@@ -4247,7 +4247,7 @@ public:
             return interpret(pue, retslice, istate);
         }
 
-        error(e.loc, "slice operation `%s = %s` cannot be evaluated at compile time", e1.toChars(), newval.toChars());
+        error(e.loc, "slice operation `%s = %s` cannot be evaluated at compile time", e1.toErrMsg(), newval.toErrMsg());
         return CTFEExp.cantexp;
     }
 
@@ -4452,7 +4452,7 @@ public:
             }
             if (except)
             {
-                error(e.loc, "comparison `%s` of pointers to unrelated memory blocks remains indeterminate at compile time because exception `%s` was thrown while evaluating `%s`", e.e1.toChars(), except.toChars(), e.e2.toChars());
+                error(e.loc, "comparison `%s` of pointers to unrelated memory blocks remains indeterminate at compile time because exception `%s` was thrown while evaluating `%s`", e.e1.toErrMsg(), except.toErrMsg(), e.e2.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -4475,7 +4475,7 @@ public:
             // comparison is in the same direction as the first, or else
             // more than two memory blocks are involved (either two independent
             // invalid comparisons are present, or else agg3 == agg4).
-            error(e.loc, "comparison `%s` of pointers to unrelated memory blocks is indeterminate at compile time, even when combined with `%s`.", e.e1.toChars(), e.e2.toChars());
+            error(e.loc, "comparison `%s` of pointers to unrelated memory blocks is indeterminate at compile time, even when combined with `%s`.", e.e1.toErrMsg(), e.e2.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -4568,14 +4568,14 @@ public:
                 res = true;
             else
             {
-                error(e.loc, "`%s` does not evaluate to a `bool`", result.toChars());
+                error(e.loc, "`%s` does not evaluate to a `bool`", result.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
         }
         else
         {
-            error(e.loc, "`%s` cannot be interpreted as a `bool`", result.toChars());
+            error(e.loc, "`%s` cannot be interpreted as a `bool`", result.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -4734,13 +4734,13 @@ public:
         {
             // delegate.funcptr()
             // others
-            error(e.loc, "cannot call `%s` at compile time", e.toChars());
+            error(e.loc, "cannot call `%s` at compile time", e.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
         if (!fd)
         {
-            error(e.loc, "CTFE internal error: cannot evaluate `%s` at compile time", e.toChars());
+            error(e.loc, "CTFE internal error: cannot evaluate `%s` at compile time", e.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -4753,7 +4753,7 @@ public:
 
             if (pthis.op == EXP.typeid_)
             {
-                error(pthis.loc, "static variable `%s` cannot be read at compile time", pthis.toChars());
+                error(pthis.loc, "static variable `%s` cannot be read at compile time", pthis.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -4762,7 +4762,7 @@ public:
             if (pthis.op == EXP.null_)
             {
                 assert(pthis.type.toBasetype().ty == Tclass);
-                error(e.loc, "function call through null class reference `%s`", pthis.toChars());
+                error(e.loc, "function call through null class reference `%s`", pthis.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -4784,7 +4784,7 @@ public:
 
         if (fd && fd.semanticRun >= PASS.semantic3done && fd.hasSemantic3Errors)
         {
-            error(e.loc, "CTFE failed because of previous errors in `%s`", fd.toChars());
+            error(e.loc, "CTFE failed because of previous errors in `%s`", fd.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -4796,7 +4796,7 @@ public:
 
         if (!fd.fbody)
         {
-            error(e.loc, "`%s` cannot be interpreted at compile time, because it has no available source code", fd.toChars());
+            error(e.loc, "`%s` cannot be interpreted at compile time, because it has no available source code", fd.toErrMsg());
             result = CTFEExp.showcontext;
             return;
         }
@@ -4936,7 +4936,7 @@ public:
         }
         else
         {
-            error(e.loc, "`%s` does not evaluate to boolean result at compile time", e.econd.toChars());
+            error(e.loc, "`%s` does not evaluate to boolean result at compile time", e.econd.toErrMsg());
             result = CTFEExp.cantexp;
         }
     }
@@ -4954,7 +4954,7 @@ public:
             return;
         if (e1.op != EXP.string_ && e1.op != EXP.arrayLiteral && e1.op != EXP.slice && e1.op != EXP.null_)
         {
-            error(e.loc, "`%s` cannot be evaluated at compile time", e.toChars());
+            error(e.loc, "`%s` cannot be evaluated at compile time", e.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -5007,7 +5007,7 @@ public:
             return;
         if (e1.op != EXP.arrayLiteral && e1.op != EXP.int64 && e1.op != EXP.float64)
         {
-            error(e.loc, "`%s` cannot be evaluated at compile time", e.toChars());
+            error(e.loc, "`%s` cannot be evaluated at compile time", e.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -5037,7 +5037,7 @@ public:
             if (result.op != EXP.vector)
                 return;
         }
-        error(e.loc, "`%s` cannot be evaluated at compile time", e.toChars());
+        error(e.loc, "`%s` cannot be evaluated at compile time", e.toErrMsg());
         result = CTFEExp.cantexp;
     }
 
@@ -5051,7 +5051,7 @@ public:
         assert(e1);
         if (exceptionOrCant(e1))
             return;
-        error(e.loc, "`%s` cannot be evaluated at compile time", e.toChars());
+        error(e.loc, "`%s` cannot be evaluated at compile time", e.toErrMsg());
         result = CTFEExp.cantexp;
     }
 
@@ -5065,7 +5065,7 @@ public:
         assert(e1);
         if (exceptionOrCant(e1))
             return;
-        error(e.loc, "`%s` cannot be evaluated at compile time", e.toChars());
+        error(e.loc, "`%s` cannot be evaluated at compile time", e.toErrMsg());
         result = CTFEExp.cantexp;
     }
 
@@ -5091,7 +5091,7 @@ public:
             // Pointer to a non-array variable
             if (agg.op == EXP.symbolOffset)
             {
-                error(e.loc, "mutable variable `%s` cannot be %s at compile time, even through a pointer", cast(char*)(modify ? "modified" : "read"), agg.isSymOffExp().var.toChars());
+                error(e.loc, "mutable variable `%s` cannot be %s at compile time, even through a pointer", cast(char*)(modify ? "modified" : "read"), agg.isSymOffExp().var.toErrMsg());
                 return false;
             }
 
@@ -5110,9 +5110,9 @@ public:
                 if (ofs + indx != 0)
                 {
                     if (agg.op == EXP.null_)
-                        error(e.loc, "cannot index through null pointer `%s`", e.e1.toChars());
+                        error(e.loc, "cannot index through null pointer `%s`", e.e1.toErrMsg());
                     else if (agg.op == EXP.int64)
-                        error(e.loc, "cannot index through invalid pointer `%s` of value `%s`", e.e1.toChars(), e1.toChars());
+                        error(e.loc, "cannot index through invalid pointer `%s` of value `%s`", e.e1.toErrMsg(), e1.toErrMsg());
                     else
                         error(e.loc, "pointer index `[%lld]` lies outside memory block `[0..1]`", ofs + indx);
                     return false;
@@ -5128,7 +5128,7 @@ public:
             return false;
         if (e1.op == EXP.null_)
         {
-            error(e.loc, "cannot index null array `%s`", e.e1.toChars());
+            error(e.loc, "cannot index null array `%s`", e.e1.toErrMsg());
             return false;
         }
         if (auto ve = e1.isVectorExp())
@@ -5146,7 +5146,7 @@ public:
         {
             if (e1.op != EXP.arrayLiteral && e1.op != EXP.string_ && e1.op != EXP.slice && e1.op != EXP.vector)
             {
-                error(e.loc, "cannot determine length of `%s` at compile time", e.e1.toChars());
+                error(e.loc, "cannot determine length of `%s` at compile time", e.e1.toErrMsg());
                 return false;
             }
             len = resolveArrayLength(e1);
@@ -5165,7 +5165,7 @@ public:
             return false;
         if (e2.op != EXP.int64)
         {
-            error(e.loc, "CTFE internal error: non-integral index `[%s]`", e.e2.toChars());
+            error(e.loc, "CTFE internal error: non-integral index `[%s]`", e.e2.toErrMsg());
             return false;
         }
 
@@ -5264,7 +5264,7 @@ public:
             return;
         if (result.op == EXP.void_)
         {
-            error(e.loc, "`%s` is used before initialized", e.toChars());
+            error(e.loc, "`%s` is used before initialized", e.toErrMsg());
             errorSupplemental(result.loc, "originally uninitialized here");
             result = CTFEExp.cantexp;
             return;
@@ -5287,7 +5287,7 @@ public:
                 return;
             if (e1.op == EXP.int64)
             {
-                error(e.loc, "cannot slice invalid pointer `%s` of value `%s`", e.e1.toChars(), e1.toChars());
+                error(e.loc, "cannot slice invalid pointer `%s` of value `%s`", e.e1.toErrMsg(), e1.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -5315,7 +5315,7 @@ public:
                     result.type = e.type;
                     return;
                 }
-                error(e.loc, "cannot slice null pointer `%s`", e.e1.toChars());
+                error(e.loc, "cannot slice null pointer `%s`", e.e1.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -5327,7 +5327,7 @@ public:
             }
             if (agg.op != EXP.arrayLiteral && agg.op != EXP.string_)
             {
-                error(e.loc, "pointer `%s` cannot be sliced at compile time (it does not point to an array)", e.e1.toChars());
+                error(e.loc, "pointer `%s` cannot be sliced at compile time (it does not point to an array)", e.e1.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -5384,7 +5384,7 @@ public:
         {
             if (e1.op != EXP.arrayLiteral && e1.op != EXP.string_ && e1.op != EXP.null_ && e1.op != EXP.slice && e1.op != EXP.vector)
             {
-                error(e.loc, "cannot determine length of `%s` at compile time", e1.toChars());
+                error(e.loc, "cannot determine length of `%s` at compile time", e1.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -5524,7 +5524,7 @@ public:
 
         if (CTFEExp.isCantExp(result))
         {
-            error(e.loc, "`%s` cannot be interpreted at compile time", e.toChars());
+            error(e.loc, "`%s` cannot be interpreted at compile time", e.toErrMsg());
             return;
         }
         // We know we still own it, because we interpreted both e1 and e2
@@ -5566,7 +5566,7 @@ public:
         case Tclass:
             if (result.op != EXP.classReference)
             {
-                error(e.loc, "`delete` on invalid class reference `%s`", result.toChars());
+                error(e.loc, "`delete` on invalid class reference `%s`", result.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -5657,7 +5657,7 @@ public:
                 }
                 else if (ultimatePointee.ty != Tvoid && ultimateSrc.ty != Tvoid && !isSafePointerCast(elemtype, pointee))
                 {
-                    error(e.loc, "reinterpreting cast from `%s*` to `%s*` is not supported in CTFE", elemtype.toChars(), pointee.toChars());
+                    error(e.loc, "reinterpreting cast from `%s*` to `%s*` is not supported in CTFE", elemtype.toErrMsg(), pointee.toErrMsg());
                     result = CTFEExp.cantexp;
                     return;
                 }
@@ -5716,7 +5716,7 @@ public:
                     }
                     if (!isSafePointerCast(origType, pointee))
                     {
-                        error(e.loc, "using `void*` to reinterpret cast from `%s*` to `%s*` is not supported in CTFE", origType.toChars(), pointee.toChars());
+                        error(e.loc, "using `void*` to reinterpret cast from `%s*` to `%s*` is not supported in CTFE", origType.toErrMsg(), pointee.toErrMsg());
                         result = CTFEExp.cantexp;
                         return;
                     }
@@ -5760,7 +5760,7 @@ public:
                 Type origType = (cast(SymbolExp)e1).var.type;
                 if (castBackFromVoid && !isSafePointerCast(origType, pointee))
                 {
-                    error(e.loc, "using `void*` to reinterpret cast from `%s*` to `%s*` is not supported in CTFE", origType.toChars(), pointee.toChars());
+                    error(e.loc, "using `void*` to reinterpret cast from `%s*` to `%s*` is not supported in CTFE", origType.toErrMsg(), pointee.toErrMsg());
                     result = CTFEExp.cantexp;
                     return;
                 }
@@ -5777,7 +5777,7 @@ public:
             e1 = interpretRegion(e1, istate);
             if (e1.op != EXP.null_)
             {
-                error(e.loc, "pointer cast from `%s` to `%s` is not supported at compile time", e1.type.toChars(), e.to.toChars());
+                error(e.loc, "pointer cast from `%s` to `%s` is not supported at compile time", e1.type.toErrMsg(), e.to.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -5798,7 +5798,7 @@ public:
             SliceExp se = e1.isSliceExp();
             if (!isSafePointerCast(se.e1.type.nextOf(), e.to.nextOf()))
             {
-                error(e.loc, "array cast from `%s` to `%s` is not supported at compile time", se.e1.type.toChars(), e.to.toChars());
+                error(e.loc, "array cast from `%s` to `%s` is not supported at compile time", se.e1.type.toErrMsg(), e.to.toErrMsg());
                 result = CTFEExp.cantexp;
                 return;
             }
@@ -5820,7 +5820,7 @@ public:
                 if ((se.len % sz) != 0)
                 {
                     error(e.loc, "hex string length %d must be a multiple of %d to cast to `%s`",
-                        cast(int) se.len, cast(int) sz, e.to.toChars());
+                        cast(int) se.len, cast(int) sz, e.to.toErrMsg());
                     result = CTFEExp.cantexp;
                     return;
                 }
@@ -5831,7 +5831,7 @@ public:
                 result.type = e.to;
                 return;
             }
-            error(e.loc, "array cast from `%s` to `%s` is not supported at compile time", e1.type.toChars(), e.to.toChars());
+            error(e.loc, "array cast from `%s` to `%s` is not supported at compile time", e1.type.toErrMsg(), e.to.toErrMsg());
             if (se && se.hexString && se.postfix != StringExp.NoPostfix)
                 errorSupplemental(e.loc, "perhaps remove postfix `%.*s` from hex string", 1, &se.postfix);
 
@@ -5884,16 +5884,16 @@ public:
                 if (StringExp se = result.toStringExp())
                     error(e.loc, "%s", se.toStringz().ptr);
                 else
-                    error(e.loc, "%s", result.toChars());
+                    error(e.loc, "%s", result.toErrMsg());
             }
             else
-                error(e.loc, "`%s` failed", e.toChars());
+                error(e.loc, "`%s` failed", e.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
         else
         {
-            error(e.loc, "`%s` is not a compile time boolean expression", e1.toChars());
+            error(e.loc, "`%s` is not a compile time boolean expression", e1.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -5976,7 +5976,7 @@ public:
                 result = getVarExp(e.loc, istate, soe.var, CTFEGoal.RValue);
                 return;
             }
-            error(e.loc, "cannot dereference pointer to static variable `%s` at compile time", soe.var.toChars());
+            error(e.loc, "cannot dereference pointer to static variable `%s` at compile time", soe.var.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -6001,9 +6001,9 @@ public:
         if (result.op != EXP.address)
         {
             if (result.op == EXP.null_)
-                error(e.loc, "dereference of null pointer `%s`", e.e1.toChars());
+                error(e.loc, "dereference of null pointer `%s`", e.e1.toErrMsg());
             else
-                error(e.loc, "dereference of invalid pointer `%s`", result.toChars());
+                error(e.loc, "dereference of invalid pointer `%s`", result.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -6034,7 +6034,7 @@ public:
     {
         void notImplementedYet()
         {
-            error(e.loc, "`%s.%s` is not yet implemented at compile time", e.e1.toChars(), e.var.toChars());
+            error(e.loc, "`%s.%s` is not yet implemented at compile time", e.e1.toErrMsg(), e.var.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -6063,7 +6063,7 @@ public:
         VarDeclaration v = e.var.isVarDeclaration();
         if (!v)
         {
-            error(e.loc, "CTFE internal error: `%s`", e.toChars());
+            error(e.loc, "CTFE internal error: `%s`", e.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -6071,9 +6071,9 @@ public:
         if (ex.op == EXP.null_)
         {
             if (ex.type.toBasetype().ty == Tclass)
-                error(e.loc, "class `%s` is `null` and cannot be dereferenced", e.e1.toChars());
+                error(e.loc, "class `%s` is `null` and cannot be dereferenced", e.e1.toErrMsg());
             else
-                error(e.loc, "CTFE internal error: null this `%s`", e.e1.toChars());
+                error(e.loc, "CTFE internal error: null this `%s`", e.e1.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -6117,7 +6117,7 @@ public:
         }
         if (i == -1)
         {
-            error(e.loc, "couldn't find field `%s` of type `%s` in `%s`", v.toChars(), e.type.toChars(), se.toChars());
+            error(e.loc, "couldn't find field `%s` of type `%s` in `%s`", v.toErrMsg(), e.type.toErrMsg(), se.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -6145,7 +6145,7 @@ public:
         result = (*se.elements)[i];
         if (!result)
         {
-            error(e.loc, "internal compiler error: null field `%s`", v.toChars());
+            error(e.loc, "internal compiler error: null field `%s`", v.toErrMsg());
             result = CTFEExp.cantexp;
             return;
         }
@@ -6217,7 +6217,7 @@ void interpretThrow(ref Expression result, Expression exp, Loc loc, InterState* 
     }
     else
     {
-        error(exp.loc, "to be thrown `%s` must be non-null", exp.toChars());
+        error(exp.loc, "to be thrown `%s` must be non-null", exp.toErrMsg());
         result = ErrorExp.get();
     }
 }
@@ -6542,7 +6542,7 @@ private Expression scrubReturnValue(Loc loc, Expression e)
     }
     else if (auto vie = e.isVoidInitExp())
     {
-        error(loc, "uninitialized variable `%s` cannot be returned from CTFE", vie.var.toChars());
+        error(loc, "uninitialized variable `%s` cannot be returned from CTFE", vie.var.toErrMsg());
         return ErrorExp.get();
     }
 
@@ -6975,7 +6975,7 @@ private Expression interpret_aaIn(UnionExp* pue, InterState* istate, Expression 
         auto aalit = eaa.isAssocArrayLiteralExp();
         if (!aalit)
         {
-            error(aa.loc, "`%s` cannot be interpreted at compile time", aa.toChars());
+            error(aa.loc, "`%s` cannot be interpreted at compile time", aa.toErrMsg());
             return CTFEExp.cantexp;
         }
 
@@ -7003,14 +7003,14 @@ private Expression interpret_aaGetRvalueX(UnionExp* pue, InterState* istate, Exp
     auto aalit = e1.isAssocArrayLiteralExp();
     if (!aalit)
     {
-        error(aa.loc, "cannot index null array `%s`", aa.toChars());
+        error(aa.loc, "cannot index null array `%s`", aa.toErrMsg());
         return CTFEExp.cantexp;
     }
     size_t idx;
     Expression result = findKeyInAA(aa.loc, aalit, e2, &idx);
     if (!result)
     {
-        error(aa.loc, "key `%s` not found in associative array `%s`", key.toChars(), aa.toChars());
+        error(aa.loc, "key `%s` not found in associative array `%s`", key.toErrMsg(), aa.toErrMsg());
         return  CTFEExp.cantexp;
     }
 
@@ -7204,7 +7204,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
 
     if (!se)
     {
-        error(str.loc, "CTFE internal error: cannot foreach `%s`", str.toChars());
+        error(str.loc, "CTFE internal error: cannot foreach `%s`", str.toErrMsg());
         return CTFEExp.cantexp;
     }
     Expressions args = Expressions(numParams);
@@ -7367,7 +7367,7 @@ private Expression evaluateIfBuiltin(UnionExp* pue, InterState* istate, Loc loc,
             e = eval_builtin(loc, fd, &args);
             if (!e)
             {
-                error(loc, "cannot evaluate unimplemented builtin `%s` at compile time", fd.toChars());
+                error(loc, "cannot evaluate unimplemented builtin `%s` at compile time", fd.toErrMsg());
                 e = CTFEExp.cantexp;
             }
         }

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -880,7 +880,7 @@ extern (C++) final class Module : Package
             if (Module mprev = prev.isModule())
             {
                 if (!FileName.equals(srcname, mprev.srcfile.toChars()))
-                    error(loc, "%s `%s` from file %s conflicts with another module %s from file %s", kind, toPrettyChars, srcname, mprev.toChars(), mprev.srcfile.toChars());
+                    error(loc, "%s `%s` from file %s conflicts with another module %s from file %s", kind, toPrettyChars, srcname, mprev.toErrMsg(), mprev.srcfile.toChars());
                 else if (isRoot() && mprev.isRoot())
                     error(loc, "%s `%s` from file %s is specified twice on the command line", kind, toPrettyChars, srcname);
                 else
@@ -895,7 +895,7 @@ extern (C++) final class Module : Package
                 if (isPackageFile)
                     amodules.push(this); // Add to global array of all modules
                 else
-                    error(md ? md.loc : loc, "%s `%s` from file %s conflicts with package name %s", kind, toPrettyChars, srcname, pkg.toChars());
+                    error(md ? md.loc : loc, "%s `%s` from file %s conflicts with package name %s", kind, toPrettyChars, srcname, pkg.toErrMsg());
             }
             else
                 assert(global.errors);

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -1213,7 +1213,7 @@ public:
         }
         if (loc.isValid())
         {
-            .error(loc, "`%s` matches conflicting symbols:", s1.ident.toChars());
+            .error(loc, "`%s` matches conflicting symbols:", s1.ident.toErrMsg());
             errorSupplemental(s1.loc, "%s `%s`", s1.kind(), s1.toPrettyChars());
             errorSupplemental(s2.loc, "%s `%s`", s2.kind(), s2.toPrettyChars());
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -996,7 +996,7 @@ uinteger_t size(Dsymbol _this, Loc loc)
         return aggregateDeclSize(ad, loc);
     else if (auto d = _this.isDeclaration())
         return declSize(d, loc);
-    .error(loc, "%s `%s` symbol `%s` has no size", _this.kind, _this.toPrettyChars, _this.toChars());
+    .error(loc, "%s `%s` symbol `%s` has no size", _this.kind, _this.toPrettyChars, _this.toErrMsg());
     return SIZE_INVALID;
 }
 
@@ -1591,7 +1591,7 @@ const(char)* getMessage(DeprecatedDeclaration dd)
         if (auto se = dd.msg.toStringExp())
             dd.msgstr = se.toStringz().ptr;
         else
-            error(dd.msg.loc, "compile time constant expected, not `%s`", dd.msg.toChars());
+            error(dd.msg.loc, "compile time constant expected, not `%s`", dd.msg.toErrMsg());
     }
     return dd.msgstr;
 }
@@ -1795,7 +1795,7 @@ bool checkHasBothRvalueAndCpCtor(StructDeclaration sd, CtorDeclaration ctor, Tem
      */
     if (sd && sd.hasCopyCtor && isRvalueConstructor(sd, ctor))
     {
-        .error(ctor.loc, "cannot define both an rvalue constructor and a copy constructor for `struct %s`", sd.toChars());
+        .error(ctor.loc, "cannot define both an rvalue constructor and a copy constructor for `struct %s`", sd.toErrMsg());
         .errorSupplemental(ti.loc, "Template instance `%s` creates an rvalue constructor for `struct %s`",
                 ti.toPrettyChars(), sd.toChars());
 
@@ -1941,10 +1941,10 @@ private bool checkDeprecatedAliasThis(AliasThis at, Loc loc, Scope* sc)
         }
         if (message)
             deprecation(loc, "`alias %s this` is deprecated - %s",
-                        at.sym.toChars(), message);
+                        at.sym.toErrMsg(), message);
         else
             deprecation(loc, "`alias %s this` is deprecated",
-                        at.sym.toChars());
+                        at.sym.toErrMsg());
 
         if (auto ti = sc.parent ? sc.parent.isInstantiated() : null)
             ti.printInstantiationTrace(Classification.deprecation);
@@ -2053,7 +2053,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         AggregateDeclaration ad = p.isAggregateDeclaration();
         if (!ad)
         {
-            error(dsym.loc, "alias this can only be a member of aggregate, not %s `%s`", p.kind(), p.toChars());
+            error(dsym.loc, "alias this can only be a member of aggregate, not %s `%s`", p.kind(), p.toErrMsg());
             return;
         }
 
@@ -2064,9 +2064,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             Dsymbol pscopesym;
             s = sc.search(dsym.loc, dsym.ident, pscopesym);
             if (s)
-                error(dsym.loc, "`%s` is not a member of `%s`", s.toChars(), ad.toChars());
+                error(dsym.loc, "`%s` is not a member of `%s`", s.toErrMsg(), ad.toErrMsg());
             else
-                error(dsym.loc, "undefined identifier `%s`", dsym.ident.toChars());
+                error(dsym.loc, "undefined identifier `%s`", dsym.ident.toErrMsg());
             return;
         }
         if (ad.aliasthis && s != ad.aliasthis)
@@ -2099,7 +2099,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             assert(t);
             if (ad.type.implicitConvTo(t) > MATCH.nomatch)
             {
-                error(dsym.loc, "alias this is not reachable as `%s` already converts to `%s`", ad.toChars(), t.toChars());
+                error(dsym.loc, "alias this is not reachable as `%s` already converts to `%s`", ad.toErrMsg(), t.toErrMsg());
             }
         }
 
@@ -2225,7 +2225,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (!(dsym.storage_class & STC.autoref))
             {
-                .error(dsym.loc, "%s `%s` - `auto ref` variable must have `auto` and `ref` adjacent", dsym.kind, dsym.toChars());
+                .error(dsym.loc, "%s `%s` - `auto ref` variable must have `auto` and `ref` adjacent", dsym.kind, dsym.toErrMsg());
                 dsym.storage_class |= STC.autoref;
             }
         }
@@ -2530,7 +2530,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (dsym.alignment.fromAlignas())
                 {
                     error(dsym.loc, "`_Alignas` specifier cannot be less strict than alignment of `%s`",
-                          dsym.toChars());
+                          dsym.toErrMsg());
                 }
                 if (!dsym.alignment.isPack())
                     dsym.alignment.setDefault();
@@ -2557,7 +2557,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (inferred)
             {
                 .error(dsym.loc, "%s `%s` - type `%s` is inferred from initializer `%s`, and variables cannot be of type `void`",
-                    dsym.kind, dsym.toPrettyChars, dsym.type.toChars(), toChars(dsym._init));
+                    dsym.kind, dsym.toPrettyChars, dsym.type.toErrMsg(), toChars(dsym._init));
             }
             else
                 .error(dsym.loc, "%s `%s` - variables cannot be of type `void`", dsym.kind, dsym.toPrettyChars);
@@ -2576,7 +2576,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             // or when the variable is defined externally
             if (!ts.sym.members && !(dsym.storage_class & (STC.ref_ | STC.extern_)))
             {
-                .error(dsym.loc, "%s `%s` - no definition of struct `%s`", dsym.kind, dsym.toPrettyChars, ts.toChars());
+                .error(dsym.loc, "%s `%s` - no definition of struct `%s`", dsym.kind, dsym.toPrettyChars, ts.toErrMsg());
 
                 // Explain why the definition is required when it's part of another type
                 if (!dsym.type.isTypeStruct())
@@ -2795,7 +2795,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
             else if (dsym.isMember())
             {
-                error(dsym.loc, "field `%s` cannot be `scope`", dsym.toChars());
+                error(dsym.loc, "field `%s` cannot be `scope`", dsym.toErrMsg());
             }
             else if (!dsym.type.hasPointers())
             {
@@ -2833,11 +2833,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             InterfaceDeclaration id = parent.isInterfaceDeclaration();
             if (id)
             {
-                error(dsym.loc, "field `%s` not allowed in interface", dsym.toChars());
+                error(dsym.loc, "field `%s` not allowed in interface", dsym.toErrMsg());
             }
             else if (aad && aad.sizeok == Sizeok.done)
             {
-                error(dsym.loc, "cannot declare field `%s` because it will change the determined size of `%s`", dsym.toChars(), aad.toChars());
+                error(dsym.loc, "cannot declare field `%s` because it will change the determined size of `%s`", dsym.toErrMsg(), aad.toErrMsg());
             }
 
             /* Templates cannot add fields to aggregates
@@ -2857,7 +2857,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 AggregateDeclaration ad2 = ti.tempdecl.isMember();
                 if (ad2 && dsym.storage_class != STC.none)
                 {
-                    .error(dsym.loc, "%s `%s` - cannot use template to add field to aggregate `%s`", dsym.kind, dsym.toPrettyChars, ad2.toChars());
+                    .error(dsym.loc, "%s `%s` - cannot use template to add field to aggregate `%s`", dsym.kind, dsym.toPrettyChars, ad2.toErrMsg());
                 }
             }
         }
@@ -2911,7 +2911,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 {
                 }
                 else
-                    .error(dsym.loc, "%s `%s` - default construction is disabled for type `%s`", dsym.kind, dsym.toPrettyChars, dsym.type.toChars());
+                    .error(dsym.loc, "%s `%s` - default construction is disabled for type `%s`", dsym.kind, dsym.toPrettyChars, dsym.type.toErrMsg());
             }
         }
 
@@ -3019,7 +3019,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             //printf("Providing default initializer for '%s'\n", dsym.toChars());
             if (sz == SIZE_INVALID && dsym.type.ty != Terror)
-                .error(dsym.loc, "%s `%s` - size of type `%s` is invalid", dsym.kind, dsym.toPrettyChars, dsym.type.toChars());
+                .error(dsym.loc, "%s `%s` - size of type `%s` is invalid", dsym.kind, dsym.toPrettyChars, dsym.type.toErrMsg());
 
             Type tv = dsym.type;
             while (tv.ty == Tsarray)    // Don't skip Tenum
@@ -3054,7 +3054,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
             if (dsym.type.baseElemOf().ty == Tvoid)
             {
-                .error(dsym.loc, "%s `%s` of type `%s` does not have a default initializer", dsym.kind, dsym.toPrettyChars, dsym.type.toChars());
+                .error(dsym.loc, "%s `%s` of type `%s` does not have a default initializer", dsym.kind, dsym.toPrettyChars, dsym.type.toErrMsg());
             }
             else if (auto e = dsym.type.defaultInit(dsym.loc))
             {
@@ -3204,7 +3204,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                             }
                             else
                             {
-                                .error(dsym.loc, "rvalue `%s` cannot be assigned to `ref %s`", exp.toChars(), dsym.toChars());
+                                .error(dsym.loc, "rvalue `%s` cannot be assigned to `ref %s`", exp.toErrMsg(), dsym.toErrMsg());
                                 exp = ErrorExp.get();
                             }
                         }
@@ -3217,7 +3217,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                             }
                             else
                             {
-                                .error(dsym.loc, "type `%s` cannot be assigned to `ref %s %s`", ta.toChars(), tp.toChars(), dsym.toChars());
+                                .error(dsym.loc, "type `%s` cannot be assigned to `ref %s %s`", ta.toErrMsg(), tp.toErrMsg(), dsym.toErrMsg());
                                 exp = ErrorExp.get();
                             }
                         }
@@ -3230,7 +3230,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                             }
                             else
                             {
-                                .error(dsym.loc, "bitfield `%s` cannot be assigned to `ref %s`", exp.toChars(), dsym.toChars());
+                                .error(dsym.loc, "bitfield `%s` cannot be assigned to `ref %s`", exp.toErrMsg(), dsym.toErrMsg());
                                 exp = ErrorExp.get();
                             }
                         }
@@ -3341,7 +3341,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                             {
                                 // The only allowable initializer is a (non-copy) constructor
                                 if (ei.exp.isLvalue())
-                                    .error(dsym.loc, "%s `%s` of type struct `%s` uses `this(this)`, which is not allowed in static initialization", dsym.kind, dsym.toPrettyChars, tb2.toChars());
+                                    .error(dsym.loc, "%s `%s` of type struct `%s` uses `this(this)`, which is not allowed in static initialization", dsym.kind, dsym.toPrettyChars, tb2.toErrMsg());
                             }
                         }
                     }
@@ -3445,21 +3445,21 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             // C11 6.7.2.1-5
             if (isAnonymous)
-                error(dsym.loc, "anonymous bitfield cannot be of non-integral type `%s`", dsym.type.toChars());
+                error(dsym.loc, "anonymous bitfield cannot be of non-integral type `%s`", dsym.type.toErrMsg());
             else
-                error(dsym.loc, "bitfield `%s` cannot be of non-integral type `%s`", dsym.toChars(), dsym.type.toChars());
+                error(dsym.loc, "bitfield `%s` cannot be of non-integral type `%s`", dsym.toErrMsg(), dsym.type.toErrMsg());
             dsym.errors = true;
             return;
         }
         if (!width.isIntegerExp())
         {
-            error(width.loc, "bitfield width `%s` is not an integer constant", dsym.width.toChars());
+            error(width.loc, "bitfield width `%s` is not an integer constant", dsym.width.toErrMsg());
             dsym.errors = true;
         }
         const uwidth = width.toInteger(); // uwidth is unsigned
         if (uwidth == 0 && !isAnonymous)
         {
-            error(dsym.loc, "bitfield `%s` cannot have zero width", dsym.toChars());
+            error(dsym.loc, "bitfield `%s` cannot have zero width", dsym.toErrMsg());
             dsym.errors = true;
         }
         if (cast(long)uwidth < 0)
@@ -3467,7 +3467,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (isAnonymous)
                 error(width.loc, "anonymous bitfield has negative width `%lld`", cast(long)uwidth);
             else
-                error(width.loc, "bitfield `%s` has negative width `%lld`", dsym.toChars(), cast(long)uwidth);
+                error(width.loc, "bitfield `%s` has negative width `%lld`", dsym.toErrMsg(), cast(long)uwidth);
             dsym.errors = true;
         }
         else
@@ -3479,9 +3479,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (uwidth > max_width)
             {
                 if (isAnonymous)
-                    error(width.loc, "width `%lld` of anonymous bitfield does not fit in type `%s`", cast(long)uwidth, dsym.type.toChars());
+                    error(width.loc, "width `%lld` of anonymous bitfield does not fit in type `%s`", cast(long)uwidth, dsym.type.toErrMsg());
                 else
-                    error(width.loc, "width `%lld` of bitfield `%s` does not fit in type `%s`", cast(long)uwidth, dsym.toChars(), dsym.type.toChars());
+                    error(width.loc, "width `%lld` of bitfield `%s` does not fit in type `%s`", cast(long)uwidth, dsym.toErrMsg(), dsym.type.toErrMsg());
                 dsym.errors = true;
             }
         }
@@ -3593,7 +3593,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (!symbolIsVisible(sc, sym) && !sym.errors)
                 {
                     .error(imp.loc, "%s `%s` member `%s` is not visible from module `%s`", imp.mod.kind, imp.mod.toPrettyChars,
-                        imp.names[i].toChars(), sc._module.toChars());
+                        imp.names[i].toErrMsg(), sc._module.toErrMsg());
                     sym.errors = true;
                 }
                 ad.dsymbolSemantic(sc);
@@ -3607,9 +3607,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 // https://issues.dlang.org/show_bug.cgi?id=23908
                 // Don't suggest symbols from the importer's module
                 if (s && s.parent != importer)
-                    .error(imp.loc, "%s `%s` import `%s` not found, did you mean %s `%s`?", imp.mod.kind, imp.mod.toPrettyChars, imp.names[i].toChars(), s.kind(), s.toPrettyChars());
+                    .error(imp.loc, "%s `%s` import `%s` not found, did you mean %s `%s`?", imp.mod.kind, imp.mod.toPrettyChars, imp.names[i].toErrMsg(), s.kind(), s.toPrettyChars());
                 else
-                    .error(imp.loc, "%s `%s` import `%s` not found", imp.mod.kind, imp.mod.toPrettyChars, imp.names[i].toChars());
+                    .error(imp.loc, "%s `%s` import `%s` not found", imp.mod.kind, imp.mod.toPrettyChars, imp.names[i].toErrMsg());
                 ad.type = Type.terror;
             }
         }
@@ -3661,7 +3661,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         auto ad = p.isAggregateDeclaration();
         if (!ad)
         {
-            error(scd.loc, "%s can only be a part of an aggregate, not %s `%s`", scd.kind(), p.kind(), p.toChars());
+            error(scd.loc, "%s can only be a part of an aggregate, not %s `%s`", scd.kind(), p.kind(), p.toErrMsg());
             scd.errors = true;
             return;
         }
@@ -3800,7 +3800,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 }
                 else
                     error(ns.exp.loc, "`%s`: index %llu is not a string constant, it is a `%s`",
-                                 ns.exp.toChars(), cast(ulong) d, ns.exp.type.toChars());
+                                 ns.exp.toErrMsg(), cast(ulong) d, ns.exp.type.toErrMsg());
             }
         }
         else if (auto se = ns.exp.toStringExp())
@@ -3811,7 +3811,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         else if (!ns.exp.type.isTypeError())
             error(ns.exp.loc, "compile time string constant (or sequence) expected, not `%s`",
-                         ns.exp.toChars());
+                         ns.exp.toErrMsg());
         attribSemantic(ns);
     }
 
@@ -4179,7 +4179,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             TupleExp tup = name ? null : resolved.isTupleExp();
             if (!tup && !name)
             {
-                error(ns.loc, "expected string expression for namespace name, got `%s`", ns.identExp.toChars());
+                error(ns.loc, "expected string expression for namespace name, got `%s`", ns.identExp.toErrMsg());
                 return;
             }
             ns.identExp = resolved; // we don't need to keep the old AST around
@@ -4202,7 +4202,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     name = exp.toStringExp();
                     if (!name)
                     {
-                        error(ns.loc, "expected string expression for namespace name, got `%s`", exp.toChars());
+                        error(ns.loc, "expected string expression for namespace name, got `%s`", exp.toErrMsg());
                         return;
                     }
                     const(char)[] ident = name.toStringz();
@@ -4285,7 +4285,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         AggregateDeclaration ad = p.isAggregateDeclaration();
         if (!ad)
         {
-            error(ctd.loc, "constructor can only be a member of aggregate, not %s `%s`", p.kind(), p.toChars());
+            error(ctd.loc, "constructor can only be a member of aggregate, not %s `%s`", p.kind(), p.toErrMsg());
             ctd.type = Type.terror;
             ctd.errors = true;
             return;
@@ -4393,7 +4393,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         StructDeclaration ad = p.isStructDeclaration();
         if (!ad)
         {
-            error(pbd.loc, "postblit can only be a member of struct, not %s `%s`", p.kind(), p.toChars());
+            error(pbd.loc, "postblit can only be a member of struct, not %s `%s`", p.kind(), p.toErrMsg());
             pbd.type = Type.terror;
             pbd.errors = true;
             return;
@@ -4429,7 +4429,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         AggregateDeclaration ad = p.isAggregateDeclaration();
         if (!ad)
         {
-            error(dd.loc, "destructor can only be a member of aggregate, not %s `%s`", p.kind(), p.toChars());
+            error(dd.loc, "destructor can only be a member of aggregate, not %s `%s`", p.kind(), p.toErrMsg());
             dd.type = Type.terror;
             dd.errors = true;
             return;
@@ -4494,7 +4494,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!p.isScopeDsymbol())
         {
             const(char)* s = isShared ? "shared " : "";
-            error(sd.loc, "`%sstatic` %s can only be member of module/aggregate/template, not %s `%s`", s, what, p.kind(), p.toChars());
+            error(sd.loc, "`%sstatic` %s can only be member of module/aggregate/template, not %s `%s`", s, what, p.kind(), p.toErrMsg());
             sd.type = Type.terror;
             sd.errors = true;
             return;
@@ -4592,11 +4592,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 auto trust = sharedCtor.type.isTypeFunction().trust;
                 if (trust != TRUST.system && trust != TRUST.trusted)
-                    error(e.loc, "a module constructor using `@%s` must be `@system` or `@trusted`", Id.udaStandalone.toChars());
+                    error(e.loc, "a module constructor using `@%s` must be `@system` or `@trusted`", Id.udaStandalone.toErrMsg());
                 sharedCtor.standalone = true;
             }
             else
-                .error(e.loc, "`@%s` can only be used on shared static constructors", Id.udaStandalone.toChars());
+                .error(e.loc, "`@%s` can only be used on shared static constructors", Id.udaStandalone.toErrMsg());
 
             return 1;
         });
@@ -4622,7 +4622,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         AggregateDeclaration ad = p.isAggregateDeclaration();
         if (!ad)
         {
-            error(invd.loc, "`invariant` can only be a member of aggregate, not %s `%s`", p.kind(), p.toChars());
+            error(invd.loc, "`invariant` can only be a member of aggregate, not %s `%s`", p.kind(), p.toErrMsg());
             invd.type = Type.terror;
             invd.errors = true;
             return;
@@ -4665,7 +4665,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         Dsymbol p = utd.parent.pastMixin();
         if (!p.isScopeDsymbol())
         {
-            error(utd.loc, "`unittest` can only be a member of module/aggregate/template, not %s `%s`", p.kind(), p.toChars());
+            error(utd.loc, "`unittest` can only be a member of module/aggregate/template, not %s `%s`", p.kind(), p.toErrMsg());
             utd.type = Type.terror;
             utd.errors = true;
             return;
@@ -5373,7 +5373,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (!tc)
                 {
                     if (b.type != Type.terror)
-                        .error(cldec.loc, "%s `%s` base type must be `class` or `interface`, not `%s`", cldec.kind, cldec.toPrettyChars, b.type.toChars());
+                        .error(cldec.loc, "%s `%s` base type must be `class` or `interface`, not `%s`", cldec.kind, cldec.toPrettyChars, b.type.toErrMsg());
                     cldec.baseclasses.remove(0);
                     goto L7;
                 }
@@ -5460,7 +5460,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     else if (b.type != Type.terror)
                     {
                         error(cldec.loc,"`%s`: base type must be `interface`, not `%s`",
-                              cldec.toPrettyChars(), b.type.toChars());
+                              cldec.toPrettyChars(), b.type.toErrMsg());
                     }
                     cldec.baseclasses.remove(i);
                     continue;
@@ -5472,7 +5472,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     BaseClass* b2 = (*cldec.baseclasses)[j];
                     if (b2.sym == tc.sym)
                     {
-                        .error(cldec.loc, "%s `%s` inherits from duplicate interface `%s`", cldec.kind, cldec.toPrettyChars, b2.sym.toChars());
+                        .error(cldec.loc, "%s `%s` inherits from duplicate interface `%s`", cldec.kind, cldec.toPrettyChars, b2.sym.toErrMsg());
                         cldec.baseclasses.remove(i);
                         continue BCLoop;
                     }
@@ -5539,7 +5539,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (cldec.baseClass)
             {
                 if (cldec.baseClass.storage_class & STC.final_)
-                    .error(cldec.loc, "%s `%s` cannot inherit from class `%s` because it is `final`", cldec.kind, cldec.toPrettyChars, cldec.baseClass.toChars());
+                    .error(cldec.loc, "%s `%s` cannot inherit from class `%s` because it is `final`", cldec.kind, cldec.toPrettyChars, cldec.baseClass.toErrMsg());
 
                 // Inherit properties from base class
                 if (cldec.baseClass.isCOMclass())
@@ -5548,7 +5548,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     cldec.classKind = ClassKind.cpp;
                 if (cldec.classKind != cldec.baseClass.classKind)
                     .error(cldec.loc, "%s `%s` with %s linkage cannot inherit from class `%s` with %s linkage", cldec.kind, cldec.toPrettyChars,
-                        ClassKindToChars(cldec.classKind), cldec.baseClass.toChars(), ClassKindToChars(cldec.baseClass.classKind));
+                        ClassKindToChars(cldec.classKind), cldec.baseClass.toErrMsg(), ClassKindToChars(cldec.baseClass.classKind));
 
                 if (cldec.baseClass.stack)
                     cldec.stack = true;
@@ -5627,7 +5627,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 if (cldec.classKind == ClassKind.cpp && cldec.baseClass.vtbl.length == 0)
                 {
-                    .error(cldec.loc, "%s `%s` C++ base class `%s` needs at least one virtual function", cldec.kind, cldec.toPrettyChars, cldec.baseClass.toChars());
+                    .error(cldec.loc, "%s `%s` C++ base class `%s` needs at least one virtual function", cldec.kind, cldec.toPrettyChars, cldec.baseClass.toErrMsg());
                 }
 
                 // Copy vtbl[] from base class
@@ -5653,7 +5653,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 // Use the base class's 'this' member
                 if (cldec.storage_class & STC.static_)
-                    .error(cldec.loc, "%s `%s` static class cannot inherit from nested class `%s`", cldec.kind, cldec.toPrettyChars, cldec.baseClass.toChars());
+                    .error(cldec.loc, "%s `%s` static class cannot inherit from nested class `%s`", cldec.kind, cldec.toPrettyChars, cldec.baseClass.toErrMsg());
                 if (cldec.toParentLocal() != cldec.baseClass.toParentLocal() &&
                     (!cldec.toParentLocal() ||
                      !cldec.baseClass.toParentLocal().getType() ||
@@ -5662,15 +5662,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     if (cldec.toParentLocal())
                     {
                         .error(cldec.loc, "%s `%s` is nested within `%s`, but super class `%s` is nested within `%s`", cldec.kind, cldec.toPrettyChars,
-                            cldec.toParentLocal().toChars(),
-                            cldec.baseClass.toChars(),
-                            cldec.baseClass.toParentLocal().toChars());
+                            cldec.toParentLocal().toErrMsg(),
+                            cldec.baseClass.toErrMsg(),
+                            cldec.baseClass.toParentLocal().toErrMsg());
                     }
                     else
                     {
                         .error(cldec.loc, "%s `%s` is not nested, but super class `%s` is nested within `%s`", cldec.kind, cldec.toPrettyChars,
-                            cldec.baseClass.toChars(),
-                            cldec.baseClass.toParentLocal().toChars());
+                            cldec.baseClass.toErrMsg(),
+                            cldec.baseClass.toParentLocal().toErrMsg());
                     }
                 }
                 if (cldec.vthis2)
@@ -5683,15 +5683,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         if (cldec.toParent2() && cldec.toParent2() != cldec.toParentLocal())
                         {
                             .error(cldec.loc, "%s `%s` needs the frame pointer of `%s`, but super class `%s` needs the frame pointer of `%s`", cldec.kind, cldec.toPrettyChars,
-                                cldec.toParent2().toChars(),
-                                cldec.baseClass.toChars(),
-                                cldec.baseClass.toParent2().toChars());
+                                cldec.toParent2().toErrMsg(),
+                                cldec.baseClass.toErrMsg(),
+                                cldec.baseClass.toParent2().toErrMsg());
                         }
                         else
                         {
                             .error(cldec.loc, "%s `%s` doesn't need a frame pointer, but super class `%s` needs the frame pointer of `%s`", cldec.kind, cldec.toPrettyChars,
-                                cldec.baseClass.toChars(),
-                                cldec.baseClass.toParent2().toChars());
+                                cldec.baseClass.toErrMsg(),
+                                cldec.baseClass.toParent2().toErrMsg());
                         }
                     }
                 }
@@ -5748,7 +5748,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             foreach (v; cldec.fields)
             {
                 if (v.storage_class & STC.nodefaultctor)
-                    error(v.loc, "field `%s` must be initialized in constructor", v.toChars());
+                    error(v.loc, "field `%s` must be initialized in constructor", v.toErrMsg());
             }
         }
 
@@ -6024,7 +6024,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (!tc || !tc.sym.isInterfaceDeclaration())
                 {
                     if (b.type != Type.terror)
-                        .error(idec.loc, "%s `%s` base type must be `interface`, not `%s`", idec.kind, idec.toPrettyChars, b.type.toChars());
+                        .error(idec.loc, "%s `%s` base type must be `interface`, not `%s`", idec.kind, idec.toPrettyChars, b.type.toErrMsg());
                     idec.baseclasses.remove(i);
                     continue;
                 }
@@ -6035,7 +6035,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     BaseClass* b2 = (*idec.baseclasses)[j];
                     if (b2.sym == tc.sym)
                     {
-                        .error(idec.loc, "%s `%s` inherits from duplicate interface `%s`", idec.kind, idec.toPrettyChars, b2.sym.toChars());
+                        .error(idec.loc, "%s `%s` inherits from duplicate interface `%s`", idec.kind, idec.toPrettyChars, b2.sym.toErrMsg());
                         idec.baseclasses.remove(i);
                         continue BCLoop;
                     }
@@ -6293,7 +6293,7 @@ private extern(C++) class AddMemberVisitor : Visitor
             if (dsym.ident == Id.__sizeof ||
                 !(sc && sc.inCfile) && (dsym.ident == Id.__xalignof || dsym.ident == Id._mangleof))
             {
-                .error(dsym.loc, "%s `%s` `.%s` property cannot be redefined", dsym.kind, dsym.toPrettyChars, dsym.ident.toChars());
+                .error(dsym.loc, "%s `%s` `.%s` property cannot be redefined", dsym.kind, dsym.toPrettyChars, dsym.ident.toErrMsg());
                 dsym.errors = true;
             }
         }
@@ -6785,7 +6785,7 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
                 if (s && s.needThis())
                 {
                     error(ds.loc, "cannot alias %s member `%s` of variable `%s`",
-                        s.kind(), s.toChars(), mt.ident.toChars());
+                        s.kind(), s.toErrMsg(), mt.ident.toErrMsg());
                     errorSupplemental(ds.loc, "Use `typeof(%s)` instead to preserve behaviour",
                         mt.ident.toChars());
                 }
@@ -6797,7 +6797,7 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
             if (tident.ident is ds.ident && !tident.idents.length)
             {
                 error(ds.loc, "`alias %s = %s;` cannot alias itself, use a qualified name to create an overload set",
-                    ds.ident.toChars(), tident.ident.toChars());
+                    ds.ident.toErrMsg(), tident.ident.toErrMsg());
                 ds.type = Type.terror;
             }
         }
@@ -6843,7 +6843,7 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
                 if (!s)
                 {
                     if (e.op != EXP.error)
-                        .error(ds.loc, "%s `%s` cannot alias an expression `%s`", ds.kind, ds.toPrettyChars, e.toChars());
+                        .error(ds.loc, "%s `%s` cannot alias an expression `%s`", ds.kind, ds.toPrettyChars, e.toErrMsg());
                     return errorRet();
                 }
             }
@@ -6899,7 +6899,7 @@ private void aliasAssignSemantic(AliasAssign ds, Scope* sc)
         Dsymbol as = sc.search(ds.loc, ds.ident, scopesym);
         if (!as)
         {
-            .error(ds.loc, "%s `%s` undefined identifier `%s`", ds.kind, ds.toPrettyChars, ds.ident.toChars());
+            .error(ds.loc, "%s `%s` undefined identifier `%s`", ds.kind, ds.toPrettyChars, ds.ident.toErrMsg());
             return null;
         }
         if (as.errors)
@@ -6908,7 +6908,7 @@ private void aliasAssignSemantic(AliasAssign ds, Scope* sc)
         auto ad = as.isAliasDeclaration();
         if (!ad)
         {
-            .error(ds.loc, "%s `%s` identifier `%s` must be an alias declaration", ds.kind, ds.toPrettyChars, as.toChars());
+            .error(ds.loc, "%s `%s` identifier `%s` must be an alias declaration", ds.kind, ds.toPrettyChars, as.toErrMsg());
             return null;
         }
 
@@ -6924,7 +6924,7 @@ private void aliasAssignSemantic(AliasAssign ds, Scope* sc)
         {
             if (!adParent)
                 adParent = ds.toParent();
-            .error(ds.loc, "`%s` must have same parent `%s` as alias `%s`", ds.ident.toChars(), adParent.toChars(), ad.toChars());
+            .error(ds.loc, "`%s` must have same parent `%s` as alias `%s`", ds.ident.toErrMsg(), adParent.toErrMsg(), ad.toErrMsg());
             return null;
         }
         if (!adParent.isTemplateInstance())
@@ -6943,7 +6943,7 @@ private void aliasAssignSemantic(AliasAssign ds, Scope* sc)
     if (aliassym.wasRead)
     {
         if (!aliassym.errors)
-            error(ds.loc, "%s was read, so cannot reassign", aliassym.toChars());
+            error(ds.loc, "%s was read, so cannot reassign", aliassym.toErrMsg());
         aliassym.errors = true;
         return errorRet();
     }
@@ -7043,7 +7043,7 @@ private void aliasAssignSemantic(AliasAssign ds, Scope* sc)
                 if (!s)
                 {
                     if (e.op != EXP.error)
-                        .error(ds.loc, "%s `%s` cannot alias an expression `%s`", ds.kind, ds.toPrettyChars, e.toChars());
+                        .error(ds.loc, "%s `%s` cannot alias an expression `%s`", ds.kind, ds.toPrettyChars, e.toErrMsg());
                     return errorRet();
                 }
             }
@@ -7310,7 +7310,7 @@ bool determineFields(AggregateDeclaration ad)
 
                 const(char)* psz = (v.type.toBasetype().ty == Tsarray) ? "static array of " : "";
                 if (!v.isAnonymous())
-                    .error(v.loc, "%s `%s` cannot have field `%s` with %ssame struct type", ad.kind, ad.toPrettyChars, v.toChars(), psz);
+                    .error(v.loc, "%s `%s` cannot have field `%s` with %ssame struct type", ad.kind, ad.toPrettyChars, v.toErrMsg(), psz);
                 else
                     .error(v.loc, "%s `%s` cannot have anonymous field with %ssame struct type", ad.kind, ad.toPrettyChars, psz);
                 // Don't cache errors from speculative semantic
@@ -7918,7 +7918,7 @@ private extern(C++) class SearchVisitor : Visitor
                     auto ae = exp.isArrayExp();
                     if (ae && ae.arguments.length != 1)
                     {
-                        error(exp.loc, "`%s` only defines opDollar for one dimension", ad.toChars());
+                        error(exp.loc, "`%s` only defines opDollar for one dimension", ad.toErrMsg());
                         return setResult(null);
                     }
                     Declaration d = s.isDeclaration();
@@ -7927,7 +7927,7 @@ private extern(C++) class SearchVisitor : Visitor
                 }
                 e = e.expressionSemantic(ass._scope);
                 if (!e.type)
-                    error(exp.loc, "`%s` has no value", e.toChars());
+                    error(exp.loc, "`%s` has no value", e.toErrMsg());
                 t = e.type.toBasetype();
                 if (t && t.ty == Tfunction)
                     e = new CallExp(e.loc, e);
@@ -7989,7 +7989,7 @@ private extern(C++) class SearchVisitor : Visitor
         if (!ns.members || !ns.symtab) // opaque or semantic() is not yet called
         {
             if (!(flags & SearchOpt.ignoreErrors))
-                .error(loc, "%s `%s` is forward referenced when looking for `%s`", ns.kind, ns.toPrettyChars, ident.toChars());
+                .error(loc, "%s `%s` is forward referenced when looking for `%s`", ns.kind, ns.toPrettyChars, ident.toErrMsg());
             return setResult(null);
         }
 
@@ -8089,7 +8089,7 @@ private extern(C++) class SearchVisitor : Visitor
         {
             // .stringof is always defined (but may be hidden by some other symbol)
             if(ident != Id.stringof && !(flags & SearchOpt.ignoreErrors) && sd.semanticRun < PASS.semanticdone)
-                .error(loc, "%s `%s` is forward referenced when looking for `%s`", sd.kind, sd.toPrettyChars, ident.toChars());
+                .error(loc, "%s `%s` is forward referenced when looking for `%s`", sd.kind, sd.toPrettyChars, ident.toErrMsg());
             return setResult(null);
         }
 
@@ -8466,7 +8466,7 @@ extern (D) bool load(Import imp, Scope* sc)
     {
         if (pkg && pkg.isModule())
         {
-            .error(loc, "can only import from a module, not from a member of module `%s`. Did you mean `import %s : %s`?", pkg.toChars(), pkg.toPrettyChars(), id.toChars());
+            .error(loc, "can only import from a module, not from a member of module `%s`. Did you mean `import %s : %s`?", pkg.toErrMsg(), pkg.toPrettyChars(), id.toErrMsg());
             mod = pkg.isModule(); // Error recovery - treat as import of that module
             return true;
         }
@@ -8480,7 +8480,7 @@ extern (D) bool load(Import imp, Scope* sc)
         {
             if (s.isAliasDeclaration())
             {
-                .error(imp.loc, "%s `%s` conflicts with `%s`", s.kind(), s.toPrettyChars(), imp.id.toChars());
+                .error(imp.loc, "%s `%s` conflicts with `%s`", s.kind(), s.toPrettyChars(), imp.id.toErrMsg());
             }
             else if (Package p = s.isPackage())
             {
@@ -8510,16 +8510,16 @@ extern (D) bool load(Import imp, Scope* sc)
                 }
                 if (!imp.mod)
                 {
-                    .error(imp.loc, "can only import from a module, not from package `%s.%s`", p.toPrettyChars(), imp.id.toChars());
+                    .error(imp.loc, "can only import from a module, not from package `%s.%s`", p.toPrettyChars(), imp.id.toErrMsg());
                 }
             }
             else if (imp.pkg)
             {
-                .error(imp.loc, "can only import from a module, not from package `%s.%s`", imp.pkg.toPrettyChars(), imp.id.toChars());
+                .error(imp.loc, "can only import from a module, not from package `%s.%s`", imp.pkg.toPrettyChars(), imp.id.toErrMsg());
             }
             else
             {
-                .error(imp.loc, "can only import from a module, not from package `%s`", imp.id.toChars());
+                .error(imp.loc, "can only import from a module, not from package `%s`", imp.id.toErrMsg());
             }
         }
     }
@@ -9256,12 +9256,12 @@ void checkGNUABITag(Dsymbol sym, LINK linkage)
             return 0; // continue
         if (sym.isCPPNamespaceDeclaration() || sym.isNspace())
         {
-            .error(exp.loc, "`@%s` cannot be applied to namespaces", Id.udaGNUAbiTag.toChars());
+            .error(exp.loc, "`@%s` cannot be applied to namespaces", Id.udaGNUAbiTag.toErrMsg());
             sym.errors = true;
         }
         else if (linkage != LINK.cpp)
         {
-            .error(exp.loc, "`@%s` can only apply to C++ symbols", Id.udaGNUAbiTag.toChars());
+            .error(exp.loc, "`@%s` can only apply to C++ symbols", Id.udaGNUAbiTag.toErrMsg());
             sym.errors = true;
         }
         // Only one `@gnuAbiTag` is allowed by semantic2
@@ -9381,7 +9381,7 @@ private Expression callScopeDtor(VarDeclaration vd, Scope* sc)
          * could be set.
          */
         //if (cd.isInterfaceDeclaration())
-        //    error("interface `%s` cannot be scope", cd.toChars());
+        //    error("interface `%s` cannot be scope", cd.toErrMsg());
 
         if (!vd.onstack) // if any destructors
             continue;
@@ -9996,13 +9996,13 @@ private bool checkOverlappedFields(AggregateDeclaration ad)
 
             if (vd._init && !vdIsVoidInit && v2._init)
             {
-                .error(ad.loc, "overlapping default initialization for field `%s` and `%s`", v2.toChars(), vd.toChars());
+                .error(ad.loc, "overlapping default initialization for field `%s` and `%s`", v2.toErrMsg(), vd.toErrMsg());
                 errors = true;
             }
             else if (v2._init && i < j)
             {
                 .error(v2.loc, "union field `%s` with default initialization `%s` must be before field `%s`",
-                    v2.toChars(), dmd.hdrgen.toChars(v2._init), vd.toChars());
+                    v2.toErrMsg(), dmd.hdrgen.toChars(v2._init), vd.toErrMsg());
                 errors = true;
             }
         }

--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -92,7 +92,7 @@ void enumSemantic(Scope* sc, EnumDeclaration ed)
     if (ed.semanticRun == PASS.semantic)
     {
         assert(ed.memtype);
-        error(ed.loc, "circular reference to enum base type `%s`", ed.memtype.toChars());
+        error(ed.loc, "circular reference to enum base type `%s`", ed.memtype.toErrMsg());
         ed.errors = true;
         ed.semanticRun = PASS.semanticdone;
         return;
@@ -188,7 +188,7 @@ void enumSemantic(Scope* sc, EnumDeclaration ed)
 
     if (ed.members.length == 0)
     {
-        .error(ed.loc, "%s `%s` enum `%s` must have at least one member", ed.kind, ed.toPrettyChars, ed.toChars());
+        .error(ed.loc, "%s `%s` enum `%s` must have at least one member", ed.kind, ed.toPrettyChars, ed.toErrMsg());
         ed.errors = true;
         ed.semanticRun = PASS.semanticdone;
         return;
@@ -295,7 +295,7 @@ Expression getDefaultValue(EnumDeclaration ed, Loc loc)
         {
             if (em.semanticRun < PASS.semanticdone)
             {
-                error(loc, "%s `%s` forward reference of `%s.init`", ed.kind, ed.toPrettyChars, ed.toChars());
+                error(loc, "%s `%s` forward reference of `%s.init`", ed.kind, ed.toPrettyChars, ed.toErrMsg());
                 return handleErrors();
             }
 
@@ -511,7 +511,7 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
         if (global.endGagging(errors) || terror)
         {
             error(em.loc, "cannot generate 0 value of type `%s` for `%s`",
-                em.ed.memtype.toChars(), em.toChars());
+                em.ed.memtype.toErrMsg(), em.toErrMsg());
         }
         // save origValue for better json output
         em.origValue = e;
@@ -550,7 +550,7 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
             {
                 error(em.loc,
                       "cannot automatically assign value to enum member `%s` because base type `%s` is an enum; provide an explicit value",
-                      em.toPrettyChars(), em.ed.memtype.toChars());
+                      em.toPrettyChars(), em.ed.memtype.toErrMsg());
                 return errorReturn();
             }
         }
@@ -600,7 +600,7 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
             if (!mt)
                 mt = eprev.type;
             .error(em.loc, "%s `%s` initialization with `%s.%s+1` causes overflow for type `%s`", em.kind, em.toPrettyChars,
-                emprev.ed.toChars(), emprev.toChars(), mt.toChars());
+                emprev.ed.toErrMsg(), emprev.toErrMsg(), mt.toErrMsg());
             return errorReturn();
         }
         errors = global.startGagging();

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -13,6 +13,7 @@ module dmd.errors;
 
 public import core.stdc.stdarg;
 public import dmd.root.string: fTuple;
+public import dmd.hdrgen : toErrMsg;
 import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
@@ -23,6 +24,7 @@ import dmd.common.outbuffer;
 import dmd.root.rmem;
 import dmd.root.string;
 import dmd.console;
+import dmd.console : Color;
 import dmd.root.filename;
 import dmd.sarif;
 

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -28,7 +28,6 @@ import dmd.expressionsem;
 import dmd.func;
 import dmd.funcsem;
 import dmd.globals : FeatureState;
-import dmd.hdrgen : toErrMsg;
 import dmd.id;
 import dmd.identifier;
 import dmd.init;
@@ -197,7 +196,7 @@ bool checkMutableArguments(ref Scope sc, FuncDeclaration fd, TypeFunction tf,
                                 : "mutable and const references %s `%s` in arguments to `%s()`";
             sc.eSink.error((*arguments)[i].loc, msg,
                   referenceVerb,
-                  v.toChars(),
+                  v.toErrMsg(),
                   fd ? fd.toPrettyChars() : "indirectly");
         }
         errors = true;
@@ -891,7 +890,7 @@ bool checkAssignEscape(ref Scope sc, Expression e, bool gag, bool byRef)
         {
             if (!gag)
                 sc.eSink.deprecation(ee.loc, "slice of static array temporary returned by `%s` assigned to longer lived variable `%s`",
-                    ee.toChars(), e1.toChars());
+                    ee.toErrMsg(), e1.toErrMsg());
             //result = true;
             return;
         }
@@ -1080,7 +1079,7 @@ bool checkNewEscape(ref Scope sc, Expression e, bool gag)
         if (log) printf("byexp %s\n", ee.toChars());
         if (!gag)
             sc.eSink.error(ee.loc, "escaping reference to stack allocated value returned by `%s` into allocated memory",
-                  ee.toChars());
+                  ee.toErrMsg());
         result = true;
     }
 
@@ -1165,7 +1164,7 @@ private bool checkReturnEscapeImpl(ref Scope sc, Expression e, bool refs, bool g
         if (v.isTypesafeVariadicArray && p == sc.func)
         {
             if (!gag)
-                sc.eSink.error(e.loc, "returning `%s` escapes a reference to variadic parameter `%s`", e.toChars(), v.toChars());
+                sc.eSink.error(e.loc, "returning `%s` escapes a reference to variadic parameter `%s`", e.toErrMsg(), v.toErrMsg());
             result = false;
         }
         else if (v.isScope())
@@ -1376,7 +1375,7 @@ private bool checkReturnEscapeImpl(ref Scope sc, Expression e, bool refs, bool g
         else
         {
             if (!gag)
-                sc.eSink.error(ee.loc, "escaping reference to stack allocated value returned by `%s`", ee.toChars());
+                sc.eSink.error(ee.loc, "escaping reference to stack allocated value returned by `%s`", ee.toErrMsg());
             result = true;
         }
     }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -129,7 +129,7 @@ void merge(Scope* _this, Loc loc, const ref CtorFlow ctorflow)
             fieldInit.loc = fiesCurrent.loc;
         if (!mergeFieldInit(_this.ctorflow.fieldinit[i].csx, fiesCurrent.csx) && mustInit)
         {
-            error(loc, "one path skips field `%s`", v.toChars());
+            error(loc, "one path skips field `%s`", v.toErrMsg());
         }
     }
 }
@@ -143,7 +143,7 @@ real_t toImaginary(Expression _this)
     else if (auto ce = _this.isComplexExp())
         return cimagl(ce.value);
 
-    error(_this.loc, "floating point constant expression expected instead of `%s`", _this.toChars());
+    error(_this.loc, "floating point constant expression expected instead of `%s`", _this.toErrMsg());
     return CTFloat.zero;
 }
 
@@ -167,7 +167,7 @@ real_t toReal(Expression _this)
     {
         return creall(cexp.value);
     }
-    error(_this.loc, "floating point constant expression expected instead of `%s`", _this.toChars());
+    error(_this.loc, "floating point constant expression expected instead of `%s`", _this.toErrMsg());
     return CTFloat.zero;
 }
 
@@ -185,7 +185,7 @@ complex_t toComplex(Expression _this)
     {
         return cexp.value;
     }
-    error(_this.loc, "floating point constant expression expected instead of `%s`", _this.toChars());
+    error(_this.loc, "floating point constant expression expected instead of `%s`", _this.toErrMsg());
     return complex_t(CTFloat.zero);
 }
 
@@ -215,7 +215,7 @@ dinteger_t toInteger(Expression _this)
             if (ide.ident == Id.dollar)
                 return 0;
         }
-        error(_this.loc, "integer constant expression expected instead of `%s`", _this.toChars());
+        error(_this.loc, "integer constant expression expected instead of `%s`", _this.toErrMsg());
     }
     return 0;
 }
@@ -561,7 +561,7 @@ bool hasValidType(Expression e)
 {
     static bool visitTypeExp(TypeExp e)
     {
-        error(e.loc, "type `%s` is not an expression", e.toChars());
+        error(e.loc, "type `%s` is not an expression", e.toErrMsg());
         return false;
     }
 
@@ -569,7 +569,7 @@ bool hasValidType(Expression e)
     {
         if (e.sds.isPackage())
         {
-            error(e.loc, "%s `%s` has no type", e.sds.kind(), e.sds.toChars());
+            error(e.loc, "%s `%s` has no type", e.sds.kind(), e.sds.toErrMsg());
             return false;
         }
         auto ti = e.sds.isTemplateInstance();
@@ -580,7 +580,7 @@ bool hasValidType(Expression e)
             ti.semantictiargsdone &&
             ti.semanticRun == PASS.initial)
         {
-            error(e.loc, "partial %s `%s` has no type", e.sds.kind(), e.toChars());
+            error(e.loc, "partial %s `%s` has no type", e.sds.kind(), e.toErrMsg());
             return false;
         }
         return true;
@@ -588,7 +588,7 @@ bool hasValidType(Expression e)
 
     static bool visitTemplateExp(TemplateExp e)
     {
-        error(e.loc, "%s `%s` has no type", e.td.kind(), e.toChars());
+        error(e.loc, "%s `%s` has no type", e.td.kind(), e.toErrMsg());
         return false;
     }
 
@@ -604,7 +604,7 @@ bool hasValidType(Expression e)
 
     static bool visitDotTemplateExp(DotTemplateExp e)
     {
-        error(e.loc, "%s `%s` has no type", e.td.kind(), e.toChars());
+        error(e.loc, "%s `%s` has no type", e.td.kind(), e.toErrMsg());
         return false;
     }
 
@@ -615,7 +615,7 @@ bool hasValidType(Expression e)
             e.ti.semantictiargsdone &&
             e.ti.semanticRun == PASS.initial)
         {
-            error(e.loc, "partial %s `%s` has no type", e.ti.kind(), e.toChars());
+            error(e.loc, "partial %s `%s` has no type", e.ti.kind(), e.toErrMsg());
             return false;
         }
         return true;
@@ -660,7 +660,7 @@ void fillTupleExpExps(TupleExp _this, TupleDeclaration tup)
         }
         else
         {
-            error(_this.loc, "`%s` is not an expression", o.toChars());
+            error(_this.loc, "`%s` is not an expression", o.toErrMsg());
         }
     }
 }
@@ -1419,7 +1419,7 @@ StringExp semanticString(Scope* sc, Expression exp, const char* s)
     if (auto se = e.toStringExp())
         return se;
     error(exp.loc, "`string` expected for %s, not `(%s)` of type `%s`",
-          s, exp.toChars(), exp.type.toChars());
+          s, exp.toErrMsg(), exp.type.toErrMsg());
     return null;
 }
 
@@ -1456,7 +1456,7 @@ private Expression incompatibleTypes(UnaExp e)
     }
     else
     {
-        error(e.loc, "incompatible type for `%s(%s)`: `%s`", EXPtoString(e.op).ptr, e.e1.toErrMsg(), e.e1.type.toChars());
+        error(e.loc, "incompatible type for `%s(%s)`: `%s`", EXPtoString(e.op).ptr, e.e1.toErrMsg(), e.e1.type.toErrMsg());
     }
     return ErrorExp.get();
 }
@@ -1488,7 +1488,7 @@ extern (D) Expression incompatibleTypes(BinExp e, Scope* sc = null)
     else if (e.e1.type.equals(e.e2.type))
     {
         error(e.loc, "incompatible types for `(%s) %s (%s)`: both operands are of type `%s`",
-            e.e1.toErrMsg(), thisOp, e.e2.toErrMsg(), e.e1.type.toChars());
+            e.e1.toErrMsg(), thisOp, e.e2.toErrMsg(), e.e1.type.toErrMsg());
     }
     else
     {
@@ -1527,7 +1527,7 @@ private Expression checkOpAssignTypes(BinExp binExp, Scope* sc)
     {
         if ((type.isIntegral() && t2.isFloating()))
         {
-            deprecation(loc, "`%s %s %s` is performing truncating conversion", type.toChars(), EXPtoString(op).ptr, t2.toChars());
+            deprecation(loc, "`%s %s %s` is performing truncating conversion", type.toErrMsg(), EXPtoString(op).ptr, t2.toErrMsg());
         }
     }
 
@@ -1539,17 +1539,17 @@ private Expression checkOpAssignTypes(BinExp binExp, Scope* sc)
         const(char)* opstr = EXPtoString(op).ptr;
         if (t1.isReal() && t2.isComplex())
         {
-            error(loc, "`%s %s %s` is undefined. Did you mean `%s %s %s.re`?", t1.toChars(), opstr, t2.toChars(), t1.toChars(), opstr, t2.toChars());
+            error(loc, "`%s %s %s` is undefined. Did you mean `%s %s %s.re`?", t1.toErrMsg(), opstr, t2.toErrMsg(), t1.toErrMsg(), opstr, t2.toErrMsg());
             return ErrorExp.get();
         }
         else if (t1.isImaginary() && t2.isComplex())
         {
-            error(loc, "`%s %s %s` is undefined. Did you mean `%s %s %s.im`?", t1.toChars(), opstr, t2.toChars(), t1.toChars(), opstr, t2.toChars());
+            error(loc, "`%s %s %s` is undefined. Did you mean `%s %s %s.im`?", t1.toErrMsg(), opstr, t2.toErrMsg(), t1.toErrMsg(), opstr, t2.toErrMsg());
             return ErrorExp.get();
         }
         else if ((t1.isReal() || t1.isImaginary()) && t2.isImaginary())
         {
-            error(loc, "`%s %s %s` is an undefined operation", t1.toChars(), opstr, t2.toChars());
+            error(loc, "`%s %s %s` is an undefined operation", t1.toErrMsg(), opstr, t2.toErrMsg());
             return ErrorExp.get();
         }
     }
@@ -1561,7 +1561,7 @@ private Expression checkOpAssignTypes(BinExp binExp, Scope* sc)
         // Thus, r+=i, r+=c, i+=r, i+=c are all forbidden operations.
         if ((t1.isReal() && (t2.isImaginary() || t2.isComplex())) || (t1.isImaginary() && (t2.isReal() || t2.isComplex())))
         {
-            error(loc, "`%s %s %s` is undefined (result is complex)", t1.toChars(), EXPtoString(op).ptr, t2.toChars());
+            error(loc, "`%s %s %s` is undefined (result is complex)", t1.toErrMsg(), EXPtoString(op).ptr, t2.toErrMsg());
             return ErrorExp.get();
         }
         if (type.isReal() || type.isImaginary())
@@ -2356,7 +2356,7 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
                 }
                 if (!eleft.type.isMutable())
                 {
-                    error(ce.loc, "cannot remove key from `%s` associative array `%s`", MODtoChars(t.mod), eleft.toChars());
+                    error(ce.loc, "cannot remove key from `%s` associative array `%s`", MODtoChars(t.mod), eleft.toErrMsg());
                     return ErrorExp.get();
                 }
                 Expression key = (*ce.arguments)[0];
@@ -2824,7 +2824,7 @@ Lagain:
     {
         if (!imp.pkg)
         {
-            .error(loc, "forward reference of import `%s`", imp.toChars());
+            .error(loc, "forward reference of import `%s`", imp.toErrMsg());
             return ErrorExp.get();
         }
         auto ie = new ScopeExp(loc, imp.pkg);
@@ -2891,7 +2891,7 @@ Lagain:
         return e;
     }
 
-    .error(loc, "%s `%s` is not a variable", s.kind(), s.toChars());
+    .error(loc, "%s `%s` is not a variable", s.kind(), s.toErrMsg());
     return ErrorExp.get();
 }
 
@@ -2993,7 +2993,7 @@ L1:
              */
             if (flag)
                 return null;
-            error(e1.loc, "`this` for `%s` needs to be type `%s` not type `%s`", var.toChars(), ad.toChars(), t.toChars());
+            error(e1.loc, "`this` for `%s` needs to be type `%s` not type `%s`", var.toErrMsg(), ad.toErrMsg(), t.toErrMsg());
             return ErrorExp.get();
         }
     }
@@ -3292,7 +3292,7 @@ private bool checkPurity(VarDeclaration v, Loc loc, Scope* sc)
         if (checkImpure(sc, loc, "accessing mutable static data `%s`", v))
         {
             error(loc, "`pure` %s `%s` cannot access mutable static data `%s`",
-                sc.func.kind(), sc.func.toPrettyChars(), v.toChars());
+                sc.func.kind(), sc.func.toPrettyChars(), v.toErrMsg());
             err = true;
         }
     }
@@ -3337,7 +3337,7 @@ private bool checkPurity(VarDeclaration v, Loc loc, Scope* sc)
                 MODMatchToBuffer(&ffbuf, ff.type.mod, v.type.mod);
                 MODMatchToBuffer(&vbuf, v.type.mod, ff.type.mod);
                 error(loc, "%s%s `%s` cannot access %sdata `%s`",
-                    ffbuf.peekChars(), ff.kind(), ff.toPrettyChars(), vbuf.peekChars(), v.toChars());
+                    ffbuf.peekChars(), ff.kind(), ff.toPrettyChars(), vbuf.peekChars(), v.toErrMsg());
                 err = true;
                 break;
             }
@@ -3399,7 +3399,7 @@ private bool checkSafety(FuncDeclaration f, ref Loc loc, Scope* sc, Expressions*
             if (sc.varDecl.storage_class & STC.safe)
             {
                 error(loc, "`@safe` variable `%s` cannot be initialized by calling `@system` function `%s`",
-                    sc.varDecl.toChars(), f.toChars());
+                    sc.varDecl.toErrMsg(), f.toErrMsg());
                 return true;
             }
             else
@@ -3464,7 +3464,7 @@ private bool checkSafety(FuncDeclaration f, ref Loc loc, Scope* sc, Expressions*
         // for dip1000 by default transition, print deprecations for calling functions that will become `@system`
         if (sc.func.isSafeBypassingInference())
         {
-            .deprecation(loc, "`@safe` function `%s` calling `%s`", sc.func.toChars(), f.toChars());
+            .deprecation(loc, "`@safe` function `%s` calling `%s`", sc.func.toErrMsg(), f.toErrMsg());
             errorSupplementalInferredAttr(f, 10, true, STC.safe, global.errorSink);
         }
         else if (!sc.func.safetyViolation)
@@ -3826,7 +3826,7 @@ private bool checkRightThis(Expression e, Scope* sc)
     //        sc.intypeof, sc.getStructClassScope(), func, fdthis);
     auto t = ve.var.isThis();
     assert(t);
-    error(e.loc, "accessing non-static variable `%s` requires an instance of `%s`", ve.var.toChars(), t.toChars());
+    error(e.loc, "accessing non-static variable `%s` requires an instance of `%s`", ve.var.toErrMsg(), t.toErrMsg());
     return true;
 }
 
@@ -4169,7 +4169,7 @@ private bool functionParameters(Loc loc, Scope* sc,
 
     if (nargs > nparams && tf.parameterList.varargs == VarArg.none)
     {
-        error(loc, "expected %llu arguments, not %llu for non-variadic function type `%s`", cast(ulong)nparams, cast(ulong)nargs, tf.toChars());
+        error(loc, "expected %llu arguments, not %llu for non-variadic function type `%s`", cast(ulong)nparams, cast(ulong)nargs, tf.toErrMsg());
         return true;
     }
 
@@ -4500,7 +4500,7 @@ private bool functionParameters(Loc loc, Scope* sc,
                 Type t = arg.type;
                 if (!t.isMutable() || !t.isAssignable()) // check blit assignable
                 {
-                    error(arg.loc, "cannot modify struct `%s` with immutable members", arg.toChars());
+                    error(arg.loc, "cannot modify struct `%s` with immutable members", arg.toErrMsg());
                     err = true;
                 }
                 else
@@ -4959,7 +4959,7 @@ Package resolveIsPackage(Dsymbol sym)
         if (imp.pkg is null)
         {
             .error(sym.loc, "internal compiler error: unable to process forward-referenced import `%s`",
-                    imp.toChars());
+                    imp.toErrMsg());
             assert(0);
         }
         pkg = imp.pkg;
@@ -5341,7 +5341,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         auto t = f.isThis();
         assert(t);
-        .error(loc, "calling non-static function `%s` requires an instance of type `%s`", f.toChars(), t.toChars());
+        .error(loc, "calling non-static function `%s` requires an instance of type `%s`", f.toErrMsg(), t.toErrMsg());
         setError();
     }
 
@@ -5618,24 +5618,24 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (!(sc && sc.inCfile))
         {
             if (const n = importHint(exp.ident.toString()))
-                error(exp.loc, "`%s` is not defined, perhaps `import %.*s;` is needed?", exp.ident.toChars(), cast(int)n.length, n.ptr);
+                error(exp.loc, "`%s` is not defined, perhaps `import %.*s;` is needed?", exp.ident.toErrMsg(), cast(int)n.length, n.ptr);
             else if (auto s2 = sc.search_correct(exp.ident))
-                error(exp.loc, "undefined identifier `%s`, did you mean %s `%s`?", exp.ident.toChars(), s2.kind(), s2.toChars());
+                error(exp.loc, "undefined identifier `%s`, did you mean %s `%s`?", exp.ident.toErrMsg(), s2.kind(), s2.toErrMsg());
             else if (const p = search_correct_C(exp.ident))
-                error(exp.loc, "undefined identifier `%s`, did you mean `%s`?", exp.ident.toChars(), p);
+                error(exp.loc, "undefined identifier `%s`, did you mean `%s`?", exp.ident.toErrMsg(), p);
             else if (exp.ident == Id.dollar)
                 error(exp.loc, "undefined identifier `$`");
             else
-                error(exp.loc, "undefined identifier `%s`", exp.ident.toChars());
+                error(exp.loc, "undefined identifier `%s`", exp.ident.toErrMsg());
         }
         else
         {
             if (const n = cIncludeHint(exp.ident.toString()))
-                error(exp.loc, "`%s` is not defined, perhaps `#include %.*s` is needed?", exp.ident.toChars(), cast(int)n.length, n.ptr);
+                error(exp.loc, "`%s` is not defined, perhaps `#include %.*s` is needed?", exp.ident.toErrMsg(), cast(int)n.length, n.ptr);
             else if (auto s2 = sc.search_correct(exp.ident))
-                error(exp.loc, "undefined identifier `%s`, did you mean %s `%s`?", exp.ident.toChars(), s2.kind(), s2.toChars());
+                error(exp.loc, "undefined identifier `%s`, did you mean %s `%s`?", exp.ident.toErrMsg(), s2.kind(), s2.toErrMsg());
             else
-                error(exp.loc, "undefined identifier `%s`", exp.ident.toChars());
+                error(exp.loc, "undefined identifier `%s`", exp.ident.toErrMsg());
         }
 
         result = ErrorExp.get();
@@ -5687,7 +5687,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         if (!fd)
         {
-            error(e.loc, "`this` is only defined in non-static member functions, not `%s`", sc.parent.toChars());
+            error(e.loc, "`this` is only defined in non-static member functions, not `%s`", sc.parent.toErrMsg());
             return setError();
         }
 
@@ -5742,7 +5742,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 cd = cd.baseClass;
                 if (!cd)
                 {
-                    error(e.loc, "class `%s` has no `super`", s.toChars());
+                    error(e.loc, "class `%s` has no `super`", s.toErrMsg());
                     return setError();
                 }
                 e.type = cd.type;
@@ -5766,7 +5766,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return err();
         if (!cd.baseClass)
         {
-            error(e.loc, "no base class for `%s`", cd.toChars());
+            error(e.loc, "no base class for `%s`", cd.toErrMsg());
             e.type = cd.type.addMod(e.var.type.mod);
         }
         else
@@ -5904,7 +5904,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             if ((e.len % e.sz) != 0)
                 error(e.loc, "hex string with `%s` type needs to be multiple of %d bytes, not %d",
-                    e.type.toChars(), e.sz, cast(int) e.len);
+                    e.type.toErrMsg(), e.sz, cast(int) e.len);
 
             e.setData(arrayCastBigEndian(e.peekData(), e.sz).ptr, e.len / e.sz, e.sz);
         }
@@ -6045,7 +6045,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          */
         if (e.elements.length > 0 && t0.ty == Tvoid)
         {
-            error(e.loc, "`%s` of type `%s` has no value", e.toErrMsg(), e.type.toChars());
+            error(e.loc, "`%s` of type `%s` has no value", e.toErrMsg(), e.type.toErrMsg());
             return setError();
         }
 
@@ -6349,7 +6349,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 if (!v.type)
                 {
-                    error(exp.loc, "forward reference of %s `%s`", v.kind(), v.toChars());
+                    error(exp.loc, "forward reference of %s `%s`", v.kind(), v.toErrMsg());
                     return setError();
                 }
                 if ((v.storage_class & STC.manifest) && v._init)
@@ -6499,7 +6499,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             if (!p.isLvalue())
             {
-                error(p.loc, "PlacementExpression `%s` is an rvalue, but must be an lvalue", p.toChars());
+                error(p.loc, "PlacementExpression `%s` is an rvalue, but must be an lvalue", p.toErrMsg());
                 return setError();
             }
             if (sc.setUnsafe(false, p.loc, "placement `new`", sc.func))
@@ -6508,7 +6508,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             if (!p.type.isNaked)
             {
-                error(p.loc, "PlacementExpression `%s` of type `%s` must be unshared and mutable", p.toChars(), toChars(p.type));
+                error(p.loc, "PlacementExpression `%s` of type `%s` must be unshared and mutable", p.toErrMsg(), toChars(p.type));
                 return setError();
             }
             if (p.type.ty == Tarray)
@@ -6553,7 +6553,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             cdthis = exp.thisexp.type.isClassHandle();
             if (!cdthis)
             {
-                error(exp.loc, "`this` for nested class must be a class type, not `%s`", exp.thisexp.type.toChars());
+                error(exp.loc, "`this` for nested class must be a class type, not `%s`", exp.thisexp.type.toErrMsg());
                 return setError();
             }
 
@@ -6600,7 +6600,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (exp.thisexp && tb.ty != Tclass)
         {
-            error(exp.loc, "`.new` is only for allocating nested classes, not `%s`", tb.toChars());
+            error(exp.loc, "`.new` is only for allocating nested classes, not `%s`", tb.toErrMsg());
             return setError();
         }
 
@@ -6637,19 +6637,19 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 cd.ctor = cd.searchCtor();
             if (cd.noDefaultCtor && !nargs && !cd.defaultCtor)
             {
-                error(exp.loc, "default construction is disabled for type `%s`", cd.type.toChars());
+                error(exp.loc, "default construction is disabled for type `%s`", cd.type.toErrMsg());
                 return setError();
             }
 
             if (cd.isInterfaceDeclaration())
             {
-                error(exp.loc, "cannot create instance of interface `%s`", cd.toChars());
+                error(exp.loc, "cannot create instance of interface `%s`", cd.toErrMsg());
                 return setError();
             }
 
             if (cd.isAbstract())
             {
-                error(exp.loc, "cannot create instance of abstract class `%s`", cd.toChars());
+                error(exp.loc, "cannot create instance of abstract class `%s`", cd.toErrMsg());
                 errorSupplemental(cd.loc, "class `%s` is declared here", cd.toChars());
                 for (size_t i = 0; i < cd.vtbl.length; i++)
                 {
@@ -6682,7 +6682,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                                 error(exp.loc, "cannot construct anonymous nested class because no implicit `this` reference to outer class is available");
                             else
                                 error(exp.loc, "cannot construct nested class `%s` because no implicit `this` reference to outer class `%s` is available",
-                                    cd.toChars(), cdn.toChars());
+                                    cd.toErrMsg(), cdn.toErrMsg());
                             return setError();
                         }
 
@@ -6713,13 +6713,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     {
                         //printf("cdthis = %s\n", cdthis.toChars());
                         error(exp.loc, "`this` for nested class must be of type `%s`, not `%s`",
-                            cdn.toChars(), exp.thisexp.type.toChars());
+                            cdn.toErrMsg(), exp.thisexp.type.toErrMsg());
                         return setError();
                     }
                     if (!MODimplicitConv(exp.thisexp.type.mod, exp.newtype.mod))
                     {
                         error(exp.loc, "nested type `%s` should have the same or weaker constancy as enclosing type `%s`",
-                            exp.newtype.toChars(), exp.thisexp.type.toChars());
+                            exp.newtype.toErrMsg(), exp.thisexp.type.toErrMsg());
                         return setError();
                     }
                 }
@@ -6756,7 +6756,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         te = getRightThis(exp.loc, sc, ad2, te, cd);
                     if (te.op == EXP.error)
                     {
-                        error(exp.loc, "need `this` of type `%s` needed to `new` nested class `%s`", ad2.toChars(), cd.toChars());
+                        error(exp.loc, "need `this` of type `%s` needed to `new` nested class `%s`", ad2.toErrMsg(), cd.toErrMsg());
                         return setError();
                     }
                 }
@@ -6765,7 +6765,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (cd.disableNew && !exp.onstack)
             {
                 error(exp.loc, "cannot allocate `class %s` with `new` because it is annotated with `@disable new()`",
-                          originalNewtype.toChars());
+                          originalNewtype.toErrMsg());
                 return setError();
             }
 
@@ -6796,7 +6796,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 if (nargs)
                 {
-                    error(exp.loc, "no constructor for `%s`", cd.toChars());
+                    error(exp.loc, "no constructor for `%s`", cd.toErrMsg());
                     return setError();
                 }
 
@@ -6871,7 +6871,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 sd.ctor = sd.searchCtor();
             if (sd.noDefaultCtor && !nargs)
             {
-                error(exp.loc, "default construction is disabled for type `%s`", sd.type.toChars());
+                error(exp.loc, "default construction is disabled for type `%s`", sd.type.toErrMsg());
                 return setError();
             }
             // checkDeprecated() is already done in newtype.typeSemantic().
@@ -6879,7 +6879,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (sd.disableNew)
             {
                 error(exp.loc, "cannot allocate `struct %s` with `new` because it is annotated with `@disable new()`",
-                          originalNewtype.toChars());
+                          originalNewtype.toErrMsg());
                 return setError();
             }
 
@@ -6968,7 +6968,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             AggregateDeclaration ad = s ? s.isAggregateDeclaration() : null;
             if (ad && ad.noDefaultCtor)
             {
-                error(exp.loc, "default construction is disabled for type `%s`", tb.nextOf().toChars());
+                error(exp.loc, "default construction is disabled for type `%s`", tb.nextOf().toErrMsg());
                 return setError();
             }
             for (size_t i = 0; i < nargs; i++)
@@ -6982,7 +6982,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression arg = (*exp.arguments)[i];
                 if (exp.names && (*exp.names)[i].name)
                 {
-                    error(exp.loc, "no named argument `%s` allowed for array dimension", (*exp.names)[i].name.toChars());
+                    error(exp.loc, "no named argument `%s` allowed for array dimension", (*exp.names)[i].name.toErrMsg());
                     return setError();
                 }
 
@@ -6994,7 +6994,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (arg.op == EXP.int64 && (target.isLP64 ?
                     cast(sinteger_t)arg.toInteger() : cast(int)arg.toInteger()) < 0)
                 {
-                    error(exp.loc, "negative array dimension `%s`", (*exp.arguments)[i].toChars());
+                    error(exp.loc, "negative array dimension `%s`", (*exp.arguments)[i].toErrMsg());
                     return setError();
                 }
                 (*exp.arguments)[i] = arg;
@@ -7092,7 +7092,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 if (exp.names && (*exp.names)[0].name)
                 {
-                    error(exp.loc, "no named argument `%s` allowed for scalar", (*exp.names)[0].name.toChars());
+                    error(exp.loc, "no named argument `%s` allowed for scalar", (*exp.names)[0].name.toErrMsg());
                     return setError();
                 }
                 Expression e = (*exp.arguments)[0];
@@ -7101,7 +7101,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else
             {
-                error(exp.loc, "more than one argument for construction of `%s`", exp.type.toChars());
+                error(exp.loc, "more than one argument for construction of `%s`", exp.type.toErrMsg());
                 return setError();
             }
 
@@ -7126,7 +7126,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else
         {
-            error(exp.loc, "cannot create a `%s` with `new`", exp.type.toChars());
+            error(exp.loc, "cannot create a `%s` with `new`", exp.type.toErrMsg());
             return setError();
         }
 
@@ -7884,7 +7884,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         exp.e1 = resolveAliasThis(sc, exp.e1);
                         goto Lagain;
                     }
-                    error(exp.loc, "%s `%s` does not overload ()", sd.kind(), sd.toChars());
+                    error(exp.loc, "%s `%s` does not overload ()", sd.kind(), sd.toErrMsg());
                     return setError();
                 }
 
@@ -7946,7 +7946,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 else
                 {
-                    error(exp.loc, "more than one argument for construction of `%s`", t1.toChars());
+                    error(exp.loc, "more than one argument for construction of `%s`", t1.toErrMsg());
                     return setError();
                 }
                 e = e.expressionSemantic(sc);
@@ -7995,10 +7995,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 overloadApply(s, (ds){
                     if (auto fd = ds.isFuncDeclaration())
-                        .errorSupplemental(ds.loc, "%s%s", fd.toChars(),
+                        .errorSupplemental(ds.loc, "%s%s", fd.toErrMsg(),
                             fd.type.toTypeFunction().parameterList.parametersTypeToChars());
                     else
-                        .errorSupplemental(ds.loc, "%s", ds.toChars());
+                        .errorSupplemental(ds.loc, "%s", ds.toErrMsg());
                     return 0;
                 });
             }
@@ -8069,7 +8069,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
              */
             if (sc.func && sc.func.isInvariantDeclaration() && ue.e1.op == EXP.this_ && exp.f.addPostInvariant())
             {
-                error(exp.loc, "cannot call `public`/`export` function `%s` from invariant", exp.f.toChars());
+                error(exp.loc, "cannot call `public`/`export` function `%s` from invariant", exp.f.toErrMsg());
                 return setError();
             }
 
@@ -8086,7 +8086,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             else if (!checkSymbolAccess(sc, exp.f))
             {
                 error(exp.loc, "%s `%s` of type `%s` is not accessible from module `%s`",
-                    exp.f.kind(), exp.f.toPrettyChars(), exp.f.type.toChars(), sc._module.toChars);
+                    exp.f.kind(), exp.f.toPrettyChars(), exp.f.type.toErrMsg(), sc._module.toChars);
                 return setError();
             }
 
@@ -8113,11 +8113,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 version (none)
                 {
-                    printf("ue.e1 = %s\n", ue.e1.toChars());
-                    printf("f = %s\n", exp.f.toChars());
-                    printf("t1 = %s\n", t1.toChars());
-                    printf("e1 = %s\n", exp.e1.toChars());
-                    printf("e1.type = %s\n", exp.e1.type.toChars());
+                    printf("ue.e1 = %s\n", ue.e1.toErrMsg());
+                    printf("f = %s\n", exp.f.toErrMsg());
+                    printf("t1 = %s\n", t1.toErrMsg());
+                    printf("e1 = %s\n", exp.e1.toErrMsg());
+                    printf("e1.type = %s\n", exp.e1.type.toErrMsg());
                 }
 
                 // See if we need to adjust the 'this' pointer
@@ -8168,7 +8168,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 if (!cd.baseClass.ctor)
                 {
-                    error(exp.loc, "no super class constructor for `%s`", cd.baseClass.toChars());
+                    error(exp.loc, "no super class constructor for `%s`", cd.baseClass.toErrMsg());
                     return setError();
                 }
             }
@@ -8332,7 +8332,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else
             {
-                error(exp.loc, "function expected before `()`, not `%s` of type `%s`", exp.e1.toErrMsg(), exp.e1.type.toChars());
+                error(exp.loc, "function expected before `()`, not `%s` of type `%s`", exp.e1.toErrMsg(), exp.e1.type.toErrMsg());
                 return setError();
             }
 
@@ -8423,7 +8423,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     if (exp.isUfcsRewrite)
                     {
                         const arg = (*exp.argumentList.arguments)[0];
-                        .error(exp.loc, "no property `%s` for `%s` of type `%s`", exp.f.ident.toChars(), arg.toChars(), arg.type.toChars());
+                        .error(exp.loc, "no property `%s` for `%s` of type `%s`", exp.f.ident.toErrMsg(), arg.toErrMsg(), arg.type.toErrMsg());
                         .errorSupplemental(exp.loc, "the following error occured while looking for a UFCS match");
                     }
 
@@ -8512,7 +8512,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             if (fd && fd.inferRetType && sc && sc.func == fd)
             {
-                error(exp.loc, "can't infer return type in function `%s`", fd.toChars());
+                error(exp.loc, "can't infer return type in function `%s`", fd.toErrMsg());
             }
             else
             {
@@ -8593,7 +8593,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     te = getRightThis(exp.loc, sc, ad2, te, exp.f);
                 if (te.op == EXP.error)
                 {
-                    error(exp.loc, "need `this` of type `%s` to call function `%s`", ad2.toChars(), exp.f.toChars());
+                    error(exp.loc, "need `this` of type `%s` to call function `%s`", ad2.toErrMsg(), exp.f.toErrMsg());
                     return setError();
                 }
             }
@@ -8608,7 +8608,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("DeclarationExp::semantic() %s\n", e.toChars());
+            printf("DeclarationExp::semantic() %s\n", e.toErrMsg());
         }
 
         const olderrors = global.errors;
@@ -8628,7 +8628,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
         }
 
-        //printf("inserting '%s' %p into sc = %p\n", s.toChars(), s, sc);
+        //printf("inserting '%s' %p into sc = %p\n", s.toErrMsg(), s, sc);
         // Insert into both local scope and function scope.
         // Must be unique in both (except for importC).
         if (s.ident)
@@ -8666,7 +8666,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 auto conflict = sc.search(Loc.initial, s.ident, pscopesym);
                 error(e.loc, "declaration `%s` is already defined", s.toPrettyChars());
                 errorSupplemental(conflict.loc, "`%s` `%s` is defined here",
-                                  conflict.kind(), conflict.toChars());
+                                  conflict.kind(), conflict.toErrMsg());
                 return setError();
             }
 
@@ -8698,7 +8698,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     // 65535 should be enough for anyone
                     if (!s.localNum)
                     {
-                        error(e.loc, "more than 65535 symbols with name `%s` generated", s.ident.toChars());
+                        error(e.loc, "more than 65535 symbols with name `%s` generated", s.ident.toErrMsg());
                         return setError();
                     }
 
@@ -8731,7 +8731,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         auto decl = s2.isDeclaration();
                         if (decl && (decl.storage_class & STC.local))
                             continue;
-                        error(e.loc, "%s `%s` is shadowing %s `%s`", s.kind(), s.ident.toChars(), s2.kind(), s2.toPrettyChars());
+                        error(e.loc, "%s `%s` is shadowing %s `%s`", s.kind(), s.ident.toErrMsg(), s2.kind(), s2.toPrettyChars());
                         errorSupplemental(s2.loc, "declared here");
                         if (!sc.func.fes)
                             return setError();
@@ -8768,7 +8768,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("TypeidExp::semantic() %s\n", exp.toChars());
+            printf("TypeidExp::semantic() %s\n", exp.toErrMsg());
         }
         Type ta = isType(exp.obj);
         Expression ea = isExpression(exp.obj);
@@ -8799,7 +8799,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (!ta)
         {
             //printf("ta %p ea %p sa %p\n", ta, ea, sa);
-            error(exp.loc, "no type for `typeid(%s)`", ea ? ea.toErrMsg() : (sa ? sa.toChars() : ""));
+            error(exp.loc, "no type for `typeid(%s)`", ea ? ea.toErrMsg() : (sa ? sa.toErrMsg() : ""));
             return setError();
         }
 
@@ -8897,7 +8897,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 auto conflict = sc.search(Loc.initial, s.ident, pscopesym);
                 error(e.loc, "declaration `%s` is already defined", s.toPrettyChars());
                 errorSupplemental(conflict.loc, "`%s` `%s` is defined here",
-                                  conflict.kind(), conflict.toChars());
+                                  conflict.kind(), conflict.toErrMsg());
             }
 
             unSpeculative(sc, s);
@@ -8912,7 +8912,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         static if (LOGSEMANTIC)
         {
-            printf("IsExp::semantic(%s)\n", e.toChars());
+            printf("IsExp::semantic(%s)\n", e.toErrMsg());
         }
         if (e.id && !sc.condition)
         {
@@ -9121,8 +9121,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
              * is(targ : tspec)
              */
             e.tspec = e.tspec.typeSemantic(e.loc, sc);
-            //printf("targ  = %s, %s\n", e.targ.toChars(), e.targ.deco);
-            //printf("tspec = %s, %s\n", e.tspec.toChars(), e.tspec.deco);
+            //printf("targ  = %s, %s\n", e.targ.toErrMsg(), e.targ.deco);
+            //printf("tspec = %s, %s\n", e.tspec.toErrMsg(), e.tspec.deco);
 
             if (e.tok != TOK.colon) /* == */
             {
@@ -9201,7 +9201,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     auto conflict = sc.search(Loc.initial, s.ident, pscopesym);
                     error(e.loc, "declaration `%s` is already defined", s.toPrettyChars());
                     errorSupplemental(conflict.loc, "`%s` `%s` is defined here",
-                                        conflict.kind(), conflict.toChars());
+                                        conflict.kind(), conflict.toErrMsg());
                 }
 
                 unSpeculative(sc, s);
@@ -9358,7 +9358,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         static if (LOGSEMANTIC)
         {
-            printf("MixinExp::semantic('%s')\n", exp.toChars());
+            printf("MixinExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         // The expression is not treated as part of a default argument,
@@ -9377,7 +9377,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("ImportExp::semantic('%s')\n", e.toChars());
+            printf("ImportExp::semantic('%s')\n", e.toErrMsg());
         }
 
         auto se = semanticString(sc, e.e1, "file name argument");
@@ -9399,28 +9399,28 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (FileName.absolute(namez))
         {
-            error(e.loc, "absolute path is not allowed in import expression: `%s`", se.toChars());
+            error(e.loc, "absolute path is not allowed in import expression: `%s`", se.toErrMsg());
             return setError();
         }
 
         auto idxReserved = FileName.findReservedChar(namez);
         if (idxReserved != size_t.max)
         {
-            error(e.loc, "`%s` is not a valid filename on this platform", se.toChars());
+            error(e.loc, "`%s` is not a valid filename on this platform", se.toErrMsg());
             errorSupplemental(e.loc, "Character `'%c'` is reserved and cannot be used", namez[idxReserved]);
             return setError();
         }
 
         if (FileName.refersToParentDir(namez))
         {
-            error(e.loc, "path refers to parent (`..`) directory: `%s`", se.toChars());
+            error(e.loc, "path refers to parent (`..`) directory: `%s`", se.toErrMsg());
             return setError();
         }
 
         auto resolvedNamez = FileName.searchPath(global.filePath[], namez, false);
         if (!resolvedNamez)
         {
-            error(e.loc, "file `%s` cannot be found or not in a path specified with `-J`", se.toChars());
+            error(e.loc, "file `%s` cannot be found or not in a path specified with `-J`", se.toErrMsg());
             errorSupplemental(e.loc, "Path(s) searched (as provided by `-J`):");
             foreach (idx, path; global.filePath[])
             {
@@ -9462,7 +9462,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // https://dlang.org/spec/expression.html#assert_expressions
         static if (LOGSEMANTIC)
         {
-            printf("AssertExp::semantic('%s')\n", exp.toChars());
+            printf("AssertExp::semantic('%s')\n", exp.toErrMsg());
         }
         if (auto e = exp.e1.isStringExp())
         {
@@ -9703,7 +9703,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             else
             {
                 OutBuffer buf;
-                buf.printf("`%s` failed", exp.toChars());
+                buf.printf("`%s` failed", exp.toErrMsg());
                 exp.msg = new StringExp(Loc.initial, buf.extractSlice());
                 goto LSkip;
             }
@@ -9797,7 +9797,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("DotIdExp::semantic(this = %p, '%s')\n", exp, exp.toChars());
+            printf("DotIdExp::semantic(this = %p, '%s')\n", exp, exp.toErrMsg());
             printAST(exp);
         }
         scope (exit)
@@ -9864,7 +9864,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("DotVarExp::semantic('%s')\n", exp.toChars());
+            printf("DotVarExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         exp.var = exp.var.toAlias().isDeclaration();
@@ -9937,7 +9937,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     e = new TypeExp(exp.loc, cast(Type)o);
                     break;
                 default:
-                    error(exp.loc, "`%s` is not an expression", o.toChars());
+                    error(exp.loc, "`%s` is not an expression", o.toErrMsg());
                     return setError();
                 }
                 if (var)
@@ -10058,7 +10058,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("DotTemplateInstanceExp::semantic('%s')\n", exp.toChars());
+            printf("DotTemplateInstanceExp::semantic('%s')\n", exp.toErrMsg());
         }
         // Indicate we need to resolve by UFCS.
         Expression e = exp.dotTemplateSemanticProp(sc, DotExpFlag.gag);
@@ -10073,7 +10073,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("DelegateExp::semantic('%s')\n", e.toChars());
+            printf("DelegateExp::semantic('%s')\n", e.toErrMsg());
         }
 
         e.e1 = e.e1.expressionSemantic(sc);
@@ -10118,7 +10118,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     te = getRightThis(e.loc, sc, ad2, te, f);
                 if (te.op == EXP.error)
                 {
-                    error(e.loc, "need `this` of type `%s` to make delegate from function `%s`", ad2.toChars(), f.toChars());
+                    error(e.loc, "need `this` of type `%s` to make delegate from function `%s`", ad2.toErrMsg(), f.toErrMsg());
                     return setError();
                 }
             }
@@ -10134,7 +10134,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("DotTypeExp::semantic('%s')\n", exp.toChars());
+            printf("DotTypeExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         if (auto e = unaSemantic(exp, sc))
@@ -10151,7 +10151,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("AddrExp::semantic('%s')\n", exp.toChars());
+            printf("AddrExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         if (Expression ex = unaSemantic(exp, sc))
@@ -10300,10 +10300,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (auto ve = exp.e1.isVarExp())
                 {
                     Declaration d = ve.var;
-                    error(exp.loc, "forward reference to %s `%s`", d.kind(), d.toChars());
+                    error(exp.loc, "forward reference to %s `%s`", d.kind(), d.toErrMsg());
                 }
                 else
-                    error(exp.loc, "forward reference to type `%s` of expression `%s`", exp.e1.type.toChars(), exp.e1.toErrMsg());
+                    error(exp.loc, "forward reference to type `%s` of expression `%s`", exp.e1.type.toErrMsg(), exp.e1.toErrMsg());
                 return setError();
             }
         }
@@ -10444,7 +10444,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("PtrExp::semantic('%s')\n", exp.toChars());
+            printf("PtrExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         if (Expression e = exp.opOverloadUnary(sc))
@@ -10479,7 +10479,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             break;
 
         default:
-            error(exp.loc, "can only `*` a pointer, not a `%s`", exp.e1.type.toChars());
+            error(exp.loc, "can only `*` a pointer, not a `%s`", exp.e1.type.toErrMsg());
             goto case Terror;
         }
 
@@ -10501,7 +10501,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("NegExp::semantic('%s')\n", exp.toChars());
+            printf("NegExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         if (Expression e = exp.opOverloadUnary(sc))
@@ -10540,7 +10540,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("UAddExp::semantic('%s')\n", exp.toChars());
+            printf("UAddExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         if (Expression e = exp.opOverloadUnary(sc))
@@ -10660,7 +10660,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          * `isRAII` has been set to true for the deletion of a `scope class`.  */
         if (tb.ty != Tclass)
         {
-            error(exp.loc, "cannot delete type `%s`", exp.e1.type.toChars());
+            error(exp.loc, "cannot delete type `%s`", exp.e1.type.toErrMsg());
             return setError();
         }
 
@@ -10669,7 +10669,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             /* Because COM classes are deleted by IUnknown.Release()
              */
-            error(exp.loc, "cannot `delete` instance of COM interface `%s`", cd.toChars());
+            error(exp.loc, "cannot `delete` instance of COM interface `%s`", cd.toErrMsg());
             return setError();
         }
 
@@ -10691,7 +10691,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("CastExp::semantic('%s')\n", exp.toChars());
+            printf("CastExp::semantic('%s')\n", exp.toErrMsg());
         }
         //static int x; assert(++x < 10);
 
@@ -10814,7 +10814,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (exp.to.ty == Ttuple)
         {
-            error(exp.loc, "cannot cast `%s` of type `%s` to type sequence `%s`", exp.e1.toErrMsg(), exp.e1.type.toChars(), exp.to.toChars());
+            error(exp.loc, "cannot cast `%s` of type `%s` to type sequence `%s`", exp.e1.toErrMsg(), exp.e1.type.toErrMsg(), exp.to.toErrMsg());
             return setError();
         }
 
@@ -10979,7 +10979,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("VectorExp::semantic('%s')\n", exp.toChars());
+            printf("VectorExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         exp.e1 = exp.e1.expressionSemantic(sc);
@@ -11025,7 +11025,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("VectorArrayExp::semantic('%s')\n", e.toChars());
+            printf("VectorArrayExp::semantic('%s')\n", e.toErrMsg());
         }
         if (!e.type)
         {
@@ -11047,7 +11047,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("SliceExp::semantic('%s')\n", exp.toChars());
+            printf("SliceExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         // operator overloading should be handled in ArrayExp already.
@@ -11131,7 +11131,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             errorSupplemental(exp.loc,
                                 "pointer `%s` points to an aggregate that defines an `%s`, perhaps you meant `(*%s)[]`",
                                 exp.e1.toErrMsg(),
-                                s.ident.toChars(),
+                                s.ident.toErrMsg(),
                                 exp.e1.toErrMsg()
                             );
                         }
@@ -11173,7 +11173,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else
         {
-            error(exp.loc, "`%s` cannot be sliced with `[]`", t1b.ty == Tvoid ? exp.e1.toErrMsg() : t1b.toChars());
+            error(exp.loc, "`%s` cannot be sliced with `[]`", t1b.ty == Tvoid ? exp.e1.toErrMsg() : t1b.toErrMsg());
             return setError();
         }
 
@@ -11329,7 +11329,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("ArrayLengthExp::semantic('%s')\n", e.toChars());
+            printf("ArrayLengthExp::semantic('%s')\n", e.toErrMsg());
         }
 
         if (Expression ex = unaSemantic(e, sc))
@@ -11347,7 +11347,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("ArrayExp::semantic('%s')\n", exp.toChars());
+            printf("ArrayExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         result = exp.carraySemantic(sc);  // C semantics
@@ -11364,7 +11364,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (exp.arguments.length == 0)
             {
-                error(exp.loc, "no `[]` operator overload for type `%s`", exp.e1.type.toChars());
+                error(exp.loc, "no `[]` operator overload for type `%s`", exp.e1.type.toErrMsg());
                 errorSupplemental(ad.loc, "perhaps define `auto opIndex() {}` for `%s`", ad.toPrettyChars());
             }
             else
@@ -11372,14 +11372,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 const(char)* typeString(Expression exp)
                 {
                     if (auto e = exp.trySemantic(sc))
-                        return e.type.toChars();
+                        return e.type.toErrMsg();
                     else
                         return "__error__";
                 }
 
                 if (auto ie = (*exp.arguments)[0].isIntervalExp())
                 {
-                    error(exp.loc, "no `[%s]` operator overload for type `%s`", ie.toChars(), exp.e1.type.toChars());
+                    error(exp.loc, "no `[%s]` operator overload for type `%s`", ie.toErrMsg(), exp.e1.type.toErrMsg());
                     errorSupplemental(ad.loc, "perhaps define `auto opSlice(%s lower, %s upper) {}` for `%s`",
                         typeString(ie.lwr), typeString(ie.upr), ad.toPrettyChars());
                 }
@@ -11390,18 +11390,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     foreach (e; (*exp.arguments)[1 .. $])
                         buf.printf(", %s", typeString(e));
 
-                    error(exp.loc, "no `[]` operator overload for type `%s`", exp.e1.type.toChars());
+                    error(exp.loc, "no `[]` operator overload for type `%s`", exp.e1.type.toErrMsg());
                     errorSupplemental(ad.loc, "perhaps define `auto opIndex(%s) {}` for `%s`",
                         buf.extractChars, ad.toPrettyChars());
                 }
             }
         }
         else if (exp.e1.op == EXP.type && exp.e1.type.ty != Ttuple)
-            error(exp.loc, "static array of `%s` with multiple lengths not allowed", exp.e1.type.toChars());
+            error(exp.loc, "static array of `%s` with multiple lengths not allowed", exp.e1.type.toErrMsg());
         else if (isIndexableNonAggregate(exp.e1.type))
-            error(exp.loc, "only one index allowed to index `%s`", exp.e1.type.toChars());
+            error(exp.loc, "only one index allowed to index `%s`", exp.e1.type.toErrMsg());
         else
-            error(exp.loc, "cannot use `[]` operator on expression of type `%s`", exp.e1.type.toChars());
+            error(exp.loc, "cannot use `[]` operator on expression of type `%s`", exp.e1.type.toErrMsg());
 
         result = ErrorExp.get();
     }
@@ -11410,9 +11410,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("DotExp::semantic('%s')\n", exp.toChars());
+            printf("DotExp::semantic('%s')\n", exp.toErrMsg());
             if (exp.type)
-                printf("\ttype = %s\n", exp.type.toChars());
+                printf("\ttype = %s\n", exp.type.toErrMsg());
         }
         exp.e1 = exp.e1.expressionSemantic(sc);
         exp.e2 = exp.e2.expressionSemantic(sc);
@@ -11440,7 +11440,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(CommaExp e)
     {
-        //printf("Semantic.CommaExp() %s\n", e.toChars());
+        //printf("Semantic.CommaExp() %s\n", e.toErrMsg());
 
         // Allow `((a,b),(x,y))`
         if (e.allowCommaExp)
@@ -11484,7 +11484,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("IntervalExp::semantic('%s')\n", e.toChars());
+            printf("IntervalExp::semantic('%s')\n", e.toErrMsg());
         }
 
         Expression le = e.lwr;
@@ -11517,7 +11517,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("DelegatePtrExp::semantic('%s')\n", e.toChars());
+            printf("DelegatePtrExp::semantic('%s')\n", e.toErrMsg());
         }
         if (!e.type)
         {
@@ -11538,7 +11538,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("DelegateFuncptrExp::semantic('%s')\n", e.toChars());
+            printf("DelegateFuncptrExp::semantic('%s')\n", e.toErrMsg());
         }
         if (!e.type)
         {
@@ -11558,7 +11558,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("IndexExp::semantic('%s')\n", exp.toChars());
+            printf("IndexExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         // operator overloading should be handled in ArrayExp already.
@@ -11742,7 +11742,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return;
             }
         default:
-            error(exp.loc, "`%s` must be an array or pointer type, not `%s`", exp.e1.toErrMsg(), exp.e1.type.toChars());
+            error(exp.loc, "`%s` must be an array or pointer type, not `%s`", exp.e1.toErrMsg(), exp.e1.type.toErrMsg());
             return setError();
         }
 
@@ -11787,7 +11787,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("PostExp::semantic('%s')\n", exp.toChars());
+            printf("PostExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         if (auto ae = exp.e1.isArrayExp())
@@ -11937,9 +11937,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            if (exp.op == EXP.blit)      printf("BlitExp.semantic('%s')\n", exp.toChars());
-            if (exp.op == EXP.assign)    printf("AssignExp.semantic('%s')\n", exp.toChars());
-            if (exp.op == EXP.construct) printf("ConstructExp.semantic('%s')\n", exp.toChars());
+            if (exp.op == EXP.blit)      printf("BlitExp.semantic('%s')\n", exp.toErrMsg());
+            if (exp.op == EXP.assign)    printf("AssignExp.semantic('%s')\n", exp.toErrMsg());
+            if (exp.op == EXP.construct) printf("ConstructExp.semantic('%s')\n", exp.toErrMsg());
         }
 
         void setResult(Expression e, int line = __LINE__)
@@ -12231,7 +12231,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                 Lnomatch:
                     error(exp.loc, "cannot assign `%s` to expression sequence `%s`",
-                        exp.e2.type.toChars(), exp.e1.type.toChars());
+                        exp.e2.type.toErrMsg(), exp.e1.type.toErrMsg());
                     return setError();
                 }
 
@@ -12249,8 +12249,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                     Parameter arg = Parameter.getNth(tt.arguments, u);
                     //printf("[%d] iexps.length = %d, ", u, iexps.length);
-                    //printf("e = (%s %s, %s), ", Token.toChars[e.op], e.toChars(), e.type.toChars());
-                    //printf("arg = (%s, %s)\n", arg.toChars(), arg.type.toChars());
+                    //printf("e = (%s %s, %s), ", Token.toChars[e.op], e.toErrMsg(), e.type.toErrMsg());
+                    //printf("arg = (%s, %s)\n", arg.toErrMsg(), arg.type.toErrMsg());
 
                     if (!arg || !e.type.implicitConvTo(arg.type))
                     {
@@ -12291,7 +12291,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     {
                         // @@@DEPRECATED_2.121@@@
                         // Deprecated in 2.111, make it an error in 2.121
-                        deprecation(exp.e1.loc, "cannot initialize field `%s` with itself", dve1.var.toChars());
+                        deprecation(exp.e1.loc, "cannot initialize field `%s` with itself", dve1.var.toErrMsg());
                         auto findParameter(const(char)[] s, ref int cost)
                         {
                             foreach (p; *sc.func.parameters)
@@ -12311,7 +12311,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         }
                     }
 
-            //printf("[%s] change to init - %s\n", exp.loc.toChars(), exp.toChars());
+            //printf("[%s] change to init - %s\n", exp.loc.toErrMsg(), exp.toErrMsg());
             auto t = exp.type;
             exp = new ConstructExp(exp.loc, exp.e1, exp.e2);
             exp.type = t;
@@ -12450,7 +12450,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                                 e = new CallExp(exp.loc, e, e2x);
                                 e = new CommaExp(exp.loc, einit, e);
 
-                                //printf("e: %s\n", e.toChars());
+                                //printf("e: %s\n", e.toErrMsg());
 
                                 result = e.expressionSemantic(sc);
                                 return;
@@ -12460,7 +12460,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                                 if (!e2x.type.implicitConvTo(e1x.type))
                                 {
                                     error(exp.loc, "conversion error from `%s` to `%s`",
-                                        e2x.type.toChars(), e1x.type.toChars());
+                                        e2x.type.toErrMsg(), e1x.type.toErrMsg());
                                     return setError();
                                 }
 
@@ -12509,7 +12509,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             e = new CallExp(exp.loc, e, e2x);
                             e = new CommaExp(exp.loc, einit, e);
 
-                            //printf("e: %s\n", e.toChars());
+                            //printf("e: %s\n", e.toErrMsg());
 
                             result = e.expressionSemantic(sc);
                             return;
@@ -12572,7 +12572,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             if (newExp.newtype && newExp.newtype == t1)
                             {
                                 error(exp.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`",
-                                      newExp.toErrMsg(), newExp.type.toChars(), t1.toChars());
+                                      newExp.toErrMsg(), newExp.type.toErrMsg(), t1.toErrMsg());
                                 errorSupplemental(exp.loc, "Perhaps remove the `new` keyword?");
                                 return setError();
                             }
@@ -12743,7 +12743,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         {
                             // dym exceeds maximum array size
                             error(exp.loc, "static array `%s` size overflowed to %llu",
-                                        e1x.type.toChars(), cast(ulong) dim);
+                                        e1x.type.toErrMsg(), cast(ulong) dim);
                             return setError();
                         }
 
@@ -12844,14 +12844,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // https://issues.dlang.org/show_bug.cgi?id=9884
                 (!fun || (fun && !fun.isStaticCtorDeclaration())))
             {
-                error(exp.loc, "slice `%s` is not mutable", se.toChars());
+                error(exp.loc, "slice `%s` is not mutable", se.toErrMsg());
                 return setError();
             }
 
             if (exp.op == EXP.assign && !tn.baseElemOf().isAssignable())
             {
                 error(exp.loc, "slice `%s` is not mutable, struct `%s` has immutable members",
-                    exp.e1.toErrMsg(), tn.baseElemOf().toChars());
+                    exp.e1.toErrMsg(), tn.baseElemOf().toErrMsg());
                 result = ErrorExp.get();
                 return;
             }
@@ -12874,7 +12874,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (tn && !tn.baseElemOf().isAssignable())
                 {
                     error(exp.loc, "array `%s` is not mutable, struct `%s` has immutable members",
-                        exp.e1.toErrMsg(), tn.baseElemOf().toChars());
+                        exp.e1.toErrMsg(), tn.baseElemOf().toErrMsg());
                     result = ErrorExp.get();
                     return;
                 }
@@ -13037,7 +13037,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 // filling not allowed
                 error(exp.loc, "cannot copy `%s` to `%s`",
-                    t2.toChars(), t1.toChars());
+                    t2.toErrMsg(), t1.toErrMsg());
             }
             else if (t2n.implicitConvTo(t1.nextOf()))
             {
@@ -13054,10 +13054,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (sc.previews.fixImmutableConv && !t2.implicitConvTo(t1))
             {
                 error(exp.loc, "cannot copy `%s` to `%s`",
-                    t2.toChars(), t1.toChars());
+                    t2.toErrMsg(), t1.toErrMsg());
                 errorSupplemental(exp.loc,
                     "Source data has incompatible type qualifier(s)");
-                errorSupplemental(exp.loc, "Use `cast(%s)` to force copy", t1.toChars());
+                errorSupplemental(exp.loc, "Use `cast(%s)` to force copy", t1.toErrMsg());
                 return setError();
             }
         }
@@ -13207,7 +13207,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 ae.lowering = lowering;
 
                 if (global.params.v.verbose)
-                    message("lowered   %s =>\n          %s", exp.toChars(), lowering.toChars());
+                    message("lowered   %s =>\n          %s", exp.toErrMsg(), lowering.toErrMsg());
             }
         }
         else if (auto ae = res.isAssignExp())
@@ -13296,7 +13296,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             res = Expression.combine(res, ae.e1).expressionSemantic(sc).checkGC(sc);
 
         if (global.params.v.verbose)
-            message("lowered   %s =>\n          %s", ae.toChars(), res.toChars());
+            message("lowered   %s =>\n          %s", ae.toErrMsg(), res.toErrMsg());
 
         res = new LoweredAssignExp(ae, res);
         res.type = ae.type;
@@ -13381,7 +13381,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(CatAssignExp exp)
     {
-        //printf("CatAssignExp::semantic() %s\n", exp.toChars());
+        //printf("CatAssignExp::semantic() %s\n", exp.toErrMsg());
         if (Expression e = exp.opOverloadBinaryAssign(sc, aliasThisStop))
             return setOpOverloadAssign(e);
 
@@ -13392,7 +13392,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (se.e1.type.toBasetype().ty == Tsarray)
             {
-                error(exp.loc, "cannot append to static array `%s`", se.e1.type.toChars());
+                error(exp.loc, "cannot append to static array `%s`", se.e1.type.toErrMsg());
                 return setError();
             }
         }
@@ -13485,7 +13485,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (result)
                 return;
 
-            error(exp.loc, "cannot append type `%s` to type `%s`", tb2.toChars(), tb1.toChars());
+            error(exp.loc, "cannot append type `%s` to type `%s`", tb2.toErrMsg(), tb1.toErrMsg());
             return setError();
         }
 
@@ -13602,7 +13602,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("AddExp::semantic('%s')\n", exp.toChars());
+            printf("AddExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         if (Expression e = exp.opOverloadBinary(sc, aliasThisStop))
@@ -13701,7 +13701,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("MinExp::semantic('%s')\n", exp.toChars());
+            printf("MinExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         if (Expression e = exp.opOverloadBinary(sc, aliasThisStop))
@@ -13751,7 +13751,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     // See https://github.com/dlang/dmd/pull/7332
                     error(exp.loc, "cannot subtract pointers to different types: `%s` and `%s`.",
-                        t1.toChars(), t2.toChars());
+                        t1.toErrMsg(), t2.toErrMsg());
                     return setError();
                 }
 
@@ -13784,7 +13784,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 e = scaleFactor(exp, sc);
             else
             {
-                error(exp.loc, "can't subtract `%s` from pointer", t2.toChars());
+                error(exp.loc, "can't subtract `%s` from pointer", t2.toErrMsg());
                 e = ErrorExp.get();
             }
             result = e;
@@ -13793,7 +13793,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (t2.ty == Tpointer)
         {
             exp.type = exp.e2.type;
-            error(exp.loc, "can't subtract pointer from `%s`", exp.e1.type.toChars());
+            error(exp.loc, "can't subtract pointer from `%s`", exp.e1.type.toErrMsg());
             return setError();
         }
 
@@ -14096,7 +14096,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else
         {
-            //printf("(%s) ~ (%s)\n", e1.toChars(), e2.toChars());
+            //printf("(%s) ~ (%s)\n", e1.toErrMsg(), e2.toErrMsg());
             result = exp.incompatibleTypes();
             return;
         }
@@ -14142,7 +14142,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         version (none)
         {
-            printf("MulExp::semantic() %s\n", exp.toChars());
+            printf("MulExp::semantic() %s\n", exp.toErrMsg());
         }
 
         if (commonArithBinOpSemantic(exp))
@@ -14492,7 +14492,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("LogicalExp::semantic() %s\n", exp.toChars());
+            printf("LogicalExp::semantic() %s\n", exp.toErrMsg());
         }
 
 
@@ -14574,7 +14574,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("CmpExp::semantic('%s')\n", exp.toChars());
+            printf("CmpExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         exp.setNoderefOperands();
@@ -14621,7 +14621,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Type t2next = t2.nextOf();
             if (t1next.implicitConvTo(t2next) < MATCH.constant && t2next.implicitConvTo(t1next) < MATCH.constant && (t1next.ty != Tvoid && t2next.ty != Tvoid))
             {
-                error(exp.loc, "array comparison type mismatch, `%s` vs `%s`", t1next.toChars(), t2next.toChars());
+                error(exp.loc, "array comparison type mismatch, `%s` vs `%s`", t1next.toErrMsg(), t2next.toErrMsg());
                 return setError();
             }
 
@@ -14648,7 +14648,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else if (t1.isTypeClass() && t2.isTypeClass())
         {
-            error(exp.loc, "need member function `opCmp()` for %s `%s` to compare", t1.toDsymbol(sc).kind(), t1.toChars());
+            error(exp.loc, "need member function `opCmp()` for %s `%s` to compare", t1.toDsymbol(sc).kind(), t1.toErrMsg());
             return setError();
         }
         else if (t1.isComplex() || t2.isComplex())
@@ -14679,7 +14679,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
         }
 
-        //printf("CmpExp: %s, type = %s\n", e.toChars(), e.type.toChars());
+        //printf("CmpExp: %s, type = %s\n", e.toErrMsg(), e.type.toErrMsg());
         if (arrayLowering)
         {
             arrayLowering = arrayLowering.expressionSemantic(sc);
@@ -14846,7 +14846,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(EqualExp exp)
     {
-        //printf("EqualExp::semantic('%s')\n", exp.toChars());
+        //printf("EqualExp::semantic('%s')\n", exp.toErrMsg());
 
         exp.setNoderefOperands();
 
@@ -14897,7 +14897,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             auto t2 = exp.e2.type;
             if (t1.ty == Tenum && t2.ty == Tenum && !t1.equivalent(t2))
                 error(exp.loc, "comparison between different enumeration types `%s` and `%s`; If this behavior is intended consider using `std.conv.asOriginalType`",
-                    t1.toChars(), t2.toChars());
+                    t1.toErrMsg(), t2.toErrMsg());
         }
 
         /* Before checking for operator overloading, check to see if we're
@@ -15034,7 +15034,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // lower some array comparisons to object.__equals(e1, e2)
         if (isArrayComparison && !shouldUseMemcmp(t1, t2, sc))
         {
-            //printf("Lowering to __equals %s %s\n", exp.e1.toChars(), exp.e2.toChars());
+            //printf("Lowering to __equals %s %s\n", exp.e1.toErrMsg(), exp.e2.toErrMsg());
 
             // https://issues.dlang.org/show_bug.cgi?id=22390
             // Equality comparison between array of noreturns simply lowers to length equality comparison
@@ -15101,10 +15101,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (!lowering)
             {
                 if (sc.func)
-                    error(exp.loc, "can't infer return type in function `%s`", sc.func.toChars());
+                    error(exp.loc, "can't infer return type in function `%s`", sc.func.toErrMsg());
                 else
                     error(exp.loc, "incompatible types for array comparison: `%s` and `%s`",
-                  exp.e1.type.toChars(), exp.e2.type.toChars());
+                  exp.e1.type.toErrMsg(), exp.e2.type.toErrMsg());
                 lowering = ErrorExp.get();
             }
             exp.lowering = lowering;
@@ -15225,7 +15225,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("CondExp::semantic('%s')\n", exp.toChars());
+            printf("CondExp::semantic('%s')\n", exp.toErrMsg());
         }
 
         if (auto die = exp.econd.isDotIdExp())
@@ -15370,9 +15370,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.type = exp.type.merge2();
         version (none)
         {
-            printf("res: %s\n", exp.type.toChars());
-            printf("e1 : %s\n", exp.e1.type.toChars());
-            printf("e2 : %s\n", exp.e2.type.toChars());
+            printf("res: %s\n", exp.type.toErrMsg());
+            printf("e1 : %s\n", exp.e1.type.toErrMsg());
+            printf("e2 : %s\n", exp.e2.type.toErrMsg());
         }
 
         /* https://issues.dlang.org/show_bug.cgi?id=14696
@@ -15395,7 +15395,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         static if (LOGSEMANTIC)
         {
-            printf("GenericExp::semantic('%s')\n", exp.toChars());
+            printf("GenericExp::semantic('%s')\n", exp.toErrMsg());
         }
         // C11 6.5.1.1 Generic Selection
 
@@ -15432,7 +15432,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 if (t2 && t2.equals(t))
                 {
-                    error(ec.loc, "generic association type `%s` can only appear once", t.toChars());
+                    error(ec.loc, "generic association type `%s` can only appear once", t.toErrMsg());
                     errors = true;
                     break;
                 }
@@ -15475,7 +15475,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             imatch = idefault;
         if (imatch == None)
         {
-            error(exp.loc, "no compatible generic association type for controlling expression type `%s`", tc.toChars());
+            error(exp.loc, "no compatible generic association type for controlling expression type `%s`", tc.toErrMsg());
             return setError();
         }
 
@@ -15523,14 +15523,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
  */
 Expression trySemantic(Expression exp, Scope* sc)
 {
-    //printf("+trySemantic(%s)\n", exp.toChars());
+    //printf("+trySemantic(%s)\n", exp.toErrMsg());
     const errors = global.startGagging();
     Expression e = expressionSemantic(exp, sc);
     if (global.endGagging(errors))
     {
         e = null;
     }
-    //printf("-trySemantic(%s)\n", exp.toChars());
+    //printf("-trySemantic(%s)\n", exp.toErrMsg());
     return e;
 }
 
@@ -15568,7 +15568,7 @@ Expression unaSemantic(UnaExp e, Scope* sc)
 {
     static if (LOGSEMANTIC)
     {
-        printf("UnaExp::semantic('%s')\n", e.toChars());
+        printf("UnaExp::semantic('%s')\n", e.toErrMsg());
     }
     Expression e1x = e.e1.expressionSemantic(sc);
     if (e1x.op == EXP.error)
@@ -15585,7 +15585,7 @@ Expression binSemantic(BinExp e, Scope* sc)
 {
     static if (LOGSEMANTIC)
     {
-        printf("BinExp::semantic('%s')\n", e.toChars());
+        printf("BinExp::semantic('%s')\n", e.toErrMsg());
     }
     Expression e1x = e.e1.expressionSemantic(sc);
     Expression e2x = e.e2.expressionSemantic(sc);
@@ -15779,12 +15779,12 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
     // Template has no built-in properties except for 'stringof'.
     if ((exp.e1.isDotTemplateExp() || exp.e1.isTemplateExp()) && exp.ident != Id.stringof)
     {
-        error(exp.loc, "template `%s` does not have property `%s`", exp.e1.toErrMsg(), exp.ident.toChars());
+        error(exp.loc, "template `%s` does not have property `%s`", exp.e1.toErrMsg(), exp.ident.toErrMsg());
         return ErrorExp.get();
     }
     if (!exp.e1.type)
     {
-        error(exp.loc, "expression `%s` does not have property `%s`", exp.e1.toErrMsg(), exp.ident.toChars());
+        error(exp.loc, "expression `%s` does not have property `%s`", exp.e1.toErrMsg(), exp.ident.toErrMsg());
         return ErrorExp.get();
     }
 
@@ -15802,7 +15802,7 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
  */
 Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
 {
-    //printf("dotIdSemanticProp('%s')\n", exp.toChars());
+    //printf("dotIdSemanticProp('%s')\n", exp.toErrMsg());
 
     //{ static int z; fflush(stdout); if (++z == 10) *(char*)0=0; }
 
@@ -15894,7 +15894,7 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
             }
             if (auto v = s.isVarDeclaration())
             {
-                //printf("DotIdExp:: Identifier '%s' is a variable, type '%s'\n", toChars(), v.type.toChars());
+                //printf("DotIdExp:: Identifier '%s' is a variable, type '%s'\n", toChars(), v.type.toErrMsg());
                 if (!v.type ||
                     !v.type.deco && v.inuse)
                 {
@@ -15992,7 +15992,7 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
             }
             if (auto o = s.isOverloadSet())
             {
-                //printf("'%s' is an overload set\n", o.toChars());
+                //printf("'%s' is an overload set\n", o.toErrMsg());
                 return new OverExp(exp.loc, o);
             }
 
@@ -16017,7 +16017,7 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
 
             if (auto sds = s.isScopeDsymbol())
             {
-                //printf("it's a ScopeDsymbol %s\n", ident.toChars());
+                //printf("it's a ScopeDsymbol %s\n", ident.toErrMsg());
                 Expression e = new ScopeExp(exp.loc, sds);
                 e = e.expressionSemantic(sc);
                 if (eleft)
@@ -16043,7 +16043,7 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
             // BUG: handle other cases like in IdentifierExp::semantic()
             debug
             {
-                printf("s = %p '%s', kind = '%s'\n", s, s.toChars(), s.kind());
+                printf("s = %p '%s', kind = '%s'\n", s, s.toErrMsg(), s.kind());
             }
             assert(0);
         }
@@ -16063,15 +16063,15 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
         if (s && symbolIsVisible(sc, s))
         {
             if (s.isPackage())
-                error(exp.loc, "undefined identifier `%s` in %s `%s`, perhaps add `static import %s;`", exp.ident.toChars(), ie.sds.kind(), ie.sds.toPrettyChars(), s.toPrettyChars());
+                error(exp.loc, "undefined identifier `%s` in %s `%s`, perhaps add `static import %s;`", exp.ident.toErrMsg(), ie.sds.kind(), ie.sds.toPrettyChars(), s.toPrettyChars());
             else
             {
-                error(exp.loc, "undefined identifier `%s` in %s `%s`, did you mean %s `%s`?", exp.ident.toChars(), ie.sds.kind(), ie.sds.toPrettyChars(), s.kind(), s.toChars());
+                error(exp.loc, "undefined identifier `%s` in %s `%s`, did you mean %s `%s`?", exp.ident.toErrMsg(), ie.sds.kind(), ie.sds.toPrettyChars(), s.kind(), s.toErrMsg());
                 errorSupplemental(s.loc, "`%s` located here", s.toPrettyChars(true));
             }
         }
         else
-            error(exp.loc, "undefined identifier `%s` in %s `%s`", exp.ident.toChars(), ie.sds.kind(), ie.sds.toPrettyChars());
+            error(exp.loc, "undefined identifier `%s` in %s `%s`", exp.ident.toErrMsg(), ie.sds.kind(), ie.sds.toPrettyChars());
         return ErrorExp.get();
     }
     else if (t1b.ty == Tpointer && exp.e1.type.ty != Tenum &&
@@ -16156,7 +16156,7 @@ Expression dotTemplateSemanticProp(DotTemplateInstanceExp exp, Scope* sc, bool g
 {
     static if (LOGSEMANTIC)
     {
-        printf("DotTemplateInstanceExpY::semantic('%s')\n", exp.toChars());
+        printf("DotTemplateInstanceExpY::semantic('%s')\n", exp.toErrMsg());
     }
 
     static Expression errorExp()
@@ -16339,11 +16339,11 @@ MATCH matchType(FuncExp funcExp, Type to, Scope* sc, FuncExp* presult, ErrorSink
 
     MATCH cannotInfer()
     {
-        eSink.error(loc, "cannot infer parameter types from `%s`", to.toChars());
+        eSink.error(loc, "cannot infer parameter types from `%s`", to.toErrMsg());
         return MATCH.nomatch;
     }
 
-    //printf("FuncExp::matchType('%s'), to=%s\n", type ? type.toChars() : "null", to.toChars());
+    //printf("FuncExp::matchType('%s'), to=%s\n", type ? type.toErrMsg() : "null", to.toErrMsg());
     if (presult)
         *presult = null;
 
@@ -16352,7 +16352,7 @@ MATCH matchType(FuncExp funcExp, Type to, Scope* sc, FuncExp* presult, ErrorSink
     {
         if (tok == TOK.function_)
         {
-            eSink.error(loc, "cannot match function literal to delegate type `%s`", to.toChars());
+            eSink.error(loc, "cannot match function literal to delegate type `%s`", to.toErrMsg());
             return MATCH.nomatch;
         }
         tof = cast(TypeFunction)to.nextOf();
@@ -16361,7 +16361,7 @@ MATCH matchType(FuncExp funcExp, Type to, Scope* sc, FuncExp* presult, ErrorSink
     {
         if (tok == TOK.delegate_)
         {
-            eSink.error(loc, "cannot match delegate literal to function pointer type `%s`", to.toChars());
+            eSink.error(loc, "cannot match delegate literal to function pointer type `%s`", to.toErrMsg());
             return MATCH.nomatch;
         }
     }
@@ -16376,8 +16376,8 @@ MATCH matchType(FuncExp funcExp, Type to, Scope* sc, FuncExp* presult, ErrorSink
         // Parameter types inference from 'tof'
         assert(td._scope);
         TypeFunction tf = fd.type.isTypeFunction();
-        //printf("\ttof = %s\n", tof.toChars());
-        //printf("\ttf  = %s\n", tf.toChars());
+        //printf("\ttof = %s\n", tof.toErrMsg());
+        //printf("\ttf  = %s\n", tf.toErrMsg());
         const dim = tf.parameterList.length;
 
         if (tof.parameterList.length != dim || tof.parameterList.varargs != tf.parameterList.varargs)
@@ -16473,7 +16473,7 @@ MATCH matchType(FuncExp funcExp, Type to, Scope* sc, FuncExp* presult, ErrorSink
         assert(tok == TOK.function_ || tok == TOK.reserved && type.ty == Tpointer || fd.errors);
         tx = tfx.pointerTo();
     }
-    //printf("\ttx = %s, to = %s\n", tx.toChars(), to.toChars());
+    //printf("\ttx = %s, to = %s\n", tx.toErrMsg(), to.toErrMsg());
 
     MATCH m = tx.implicitConvTo(to);
     if (m > MATCH.nomatch)
@@ -16510,7 +16510,7 @@ private bool checkScalar(Expression e)
         return true;
     if (!e.type.isScalar())
     {
-        error(e.loc, "`%s` is not a scalar, it is a `%s`", e.toErrMsg(), e.type.toChars());
+        error(e.loc, "`%s` is not a scalar, it is a `%s`", e.toErrMsg(), e.type.toErrMsg());
         return true;
     }
     return e.checkValue();
@@ -16538,7 +16538,7 @@ private bool checkIntegral(Expression e)
         return true;
     if (!e.type.isIntegral())
     {
-        error(e.loc, "`%s` is not of integral type, it is a `%s`", e.toErrMsg(), e.type.toChars());
+        error(e.loc, "`%s` is not of integral type, it is a `%s`", e.toErrMsg(), e.type.toErrMsg());
         return true;
     }
     return e.checkValue();
@@ -16556,7 +16556,7 @@ private bool checkArithmetic(Expression e, EXP op)
         const char* msg = e.type.isAggregate() ?
             "operator `%s` is not defined for `%s` of type `%s`" :
             "illegal operator `%s` for `%s` of type `%s`";
-        error(e.loc, msg, EXPtoString(op).ptr, e.toErrMsg(), e.type.toChars());
+        error(e.loc, msg, EXPtoString(op).ptr, e.toErrMsg(), e.type.toErrMsg());
         return true;
     }
 
@@ -16581,7 +16581,7 @@ private bool checkArithmetic(Expression e, EXP op)
  */
 private bool checkReadModifyWrite(Expression e, EXP rmwOp, Expression ex = null)
 {
-    //printf("Expression::checkReadModifyWrite() %s %s", toChars(), ex ? ex.toChars() : "");
+    //printf("Expression::checkReadModifyWrite() %s %s", toChars(), ex ? ex.toErrMsg() : "");
     if (!e.type || !e.type.isShared() || e.type.isTypeStruct() || e.type.isTypeClass())
         return false;
 
@@ -16602,7 +16602,7 @@ private bool checkReadModifyWrite(Expression e, EXP rmwOp, Expression ex = null)
 
     error(e.loc, "read-modify-write operations are not allowed for `shared` variables");
     errorSupplemental(e.loc, "Use `core.atomic.atomicOp!\"%s\"(%s, %s)` instead",
-                        EXPtoString(rmwOp).ptr, e.toChars(), ex ? ex.toChars() : "1");
+                        EXPtoString(rmwOp).ptr, e.toErrMsg(), ex ? ex.toErrMsg() : "1");
     return true;
 }
 
@@ -16641,7 +16641,7 @@ bool checkValue(Expression e)
     {
         error(e.loc, "type `%s` has no value", e.toErrMsg());
         if (!e.type.isOpaqueType)
-            errorSupplemental(e.loc, "perhaps use `%s.init`", e.toChars());
+            errorSupplemental(e.loc, "perhaps use `%s.init`", e.toErrMsg());
         return true;
     }
 
@@ -16653,19 +16653,19 @@ bool checkValue(Expression e)
 
             error(e.loc, "partial %s `%s` has no value", dtie.ti.kind(), e.toErrMsg());
         else
-            error(e.loc, "%s `%s` has no value", dtie.ti.kind(), dtie.ti.toChars());
+            error(e.loc, "%s `%s` has no value", dtie.ti.kind(), dtie.ti.toErrMsg());
         return true;
     }
 
     if (auto se = e.isScopeExp())
     {
-        error(e.loc, "%s `%s` has no value", se.sds.kind(), se.sds.toChars());
+        error(e.loc, "%s `%s` has no value", se.sds.kind(), se.sds.toErrMsg());
         return true;
     }
 
     if (auto te = e.isTemplateExp())
     {
-        error(e.loc, "%s `%s` has no value", te.td.kind(), te.toChars());
+        error(e.loc, "%s `%s` has no value", te.td.kind(), te.toErrMsg());
         return true;
     }
 
@@ -16742,7 +16742,7 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
         }
     }
 
-    //printf("checkSharedAccess() `%s` returnRef: %d\n", e.toChars(), returnRef);
+    //printf("checkSharedAccess() `%s` returnRef: %d\n", e.toErrMsg(), returnRef);
 
     bool check(Expression e, bool allowRef)
     {
@@ -16819,7 +16819,7 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
 
         bool visitDotVar(DotVarExp e)
         {
-            //printf("dotvarexp = %s\n", e.toChars());
+            //printf("dotvarexp = %s\n", e.toErrMsg());
             if (e.type.isShared())
             {
                 if (e.e1.isThisExp())
@@ -17073,12 +17073,12 @@ Expression resolveLoc(Expression exp, Loc loc, Scope* sc)
 
     Expression visitFileInit(FileInitExp exp)
     {
-        //printf("FileInitExp::resolve() %s\n", exp.toChars());
+        //printf("FileInitExp::resolve() %s\n", exp.toErrMsg());
         const(char)* s;
         if (exp.op == EXP.fileFullPath)
             s = FileName.toAbsolute(loc.isValid() ? loc.filename : sc._module.srcfile.toChars());
         else
-            s = loc.isValid() ? loc.filename : sc._module.ident.toChars();
+            s = loc.isValid() ? loc.filename : sc._module.ident.toErrMsg();
 
         Expression e = new StringExp(loc, s.toDString());
         return e.expressionSemantic(sc);
@@ -17272,7 +17272,7 @@ Expression addDtorHook(Expression e, Scope* sc)
 */
 Expression toLvalue(Expression _this, Scope* sc, const(char)* action, Expression eorig = null)
 {
-    //printf("toLvalue() %s\n", _this.toChars());
+    //printf("toLvalue() %s\n", _this.toErrMsg());
     if (!eorig)
         eorig = _this;
     if (!action)
@@ -17290,7 +17290,7 @@ Expression toLvalue(Expression _this, Scope* sc, const(char)* action, Expression
             _this.loc = eorig.loc;
 
         if (eorig.op == EXP.type)
-            error(_this.loc, "cannot %s type `%s`", action, eorig.type.toChars());
+            error(_this.loc, "cannot %s type `%s`", action, eorig.type.toErrMsg());
         else if (eorig.op == EXP.template_)
             error(_this.loc, "cannot %s template `%s`, perhaps instantiate it first", action, eorig.toErrMsg());
         else
@@ -17320,7 +17320,7 @@ Expression toLvalue(Expression _this, Scope* sc, const(char)* action, Expression
 
     Expression visitString(StringExp _this)
     {
-        //printf("StringExp::toLvalue(%s) type = %s\n", _this.toChars(), _this.type ? _this.type.toChars() : NULL);
+        //printf("StringExp::toLvalue(%s) type = %s\n", _this.toErrMsg(), _this.type ? _this.type.toErrMsg() : NULL);
         return (_this.type && _this.type.toBasetype().ty == Tsarray) ? _this : visit(_this);
     }
 
@@ -17347,12 +17347,12 @@ Expression toLvalue(Expression _this, Scope* sc, const(char)* action, Expression
         auto var = _this.var;
         if (var.storage_class & STC.manifest)
         {
-            error(_this.loc, "cannot %s manifest constant `%s`", action, var.toChars());
+            error(_this.loc, "cannot %s manifest constant `%s`", action, var.toErrMsg());
             return ErrorExp.get();
         }
         if (var.storage_class & STC.lazy_ && !_this.delegateWasExtracted)
         {
-            error(_this.loc, "cannot %s lazy variable `%s`", action, var.toChars());
+            error(_this.loc, "cannot %s lazy variable `%s`", action, var.toErrMsg());
             return ErrorExp.get();
         }
         if (var.ident == Id.ctfe)
@@ -17372,7 +17372,7 @@ Expression toLvalue(Expression _this, Scope* sc, const(char)* action, Expression
     {
         auto e1 = _this.e1;
         auto var = _this.var;
-        //printf("DotVarExp::toLvalue(%s)\n", _this.toChars());
+        //printf("DotVarExp::toLvalue(%s)\n", _this.toErrMsg());
         if (sc && sc.inCfile)
         {
             /* C11 6.5.2.3-3: A postfix expression followed by the '.' or '->' operator
@@ -17447,7 +17447,7 @@ Expression toLvalue(Expression _this, Scope* sc, const(char)* action, Expression
 
     Expression visitSlice(SliceExp _this)
     {
-        //printf("SliceExp::toLvalue(%s) _this.type = %s\n", _this.toChars(), _this.type ? _this.type.toChars() : NULL);
+        //printf("SliceExp::toLvalue(%s) _this.type = %s\n", _this.toErrMsg(), _this.type ? _this.type.toErrMsg() : NULL);
         return (_this.type && _this.type.toBasetype().ty == Tsarray) ? _this : visit(_this);
     }
 
@@ -17566,14 +17566,14 @@ Modifiable checkModifiable(Expression exp, Scope* sc, ModifyFlags flag = ModifyF
         case EXP.variable:
             auto varExp = cast(VarExp)exp;
 
-            //printf("VarExp::checkModifiable %s", varExp.toChars());
+            //printf("VarExp::checkModifiable %s", varExp.toErrMsg());
             assert(varExp.type);
             return varExp.var.checkModify(varExp.loc, sc, null, flag);
 
         case EXP.dotVariable:
             auto dotVarExp = cast(DotVarExp)exp;
 
-            //printf("DotVarExp::checkModifiable %s %s\n", dotVarExp.toChars(), dotVarExp.type.toChars());
+            //printf("DotVarExp::checkModifiable %s %s\n", dotVarExp.toErrMsg(), dotVarExp.type.toErrMsg());
             if (dotVarExp.e1.op == EXP.this_)
                 return dotVarExp.var.checkModify(dotVarExp.loc, sc, dotVarExp.e1, flag);
 
@@ -17645,7 +17645,7 @@ Modifiable checkModifiable(Expression exp, Scope* sc, ModifyFlags flag = ModifyF
                 }
             }
 
-            //printf("\te1 = %s\n", e1.toChars());
+            //printf("\te1 = %s\n", e1.toErrMsg());
             return dotVarExp.e1.checkModifiable(sc, flag);
 
         case EXP.star:
@@ -17663,7 +17663,7 @@ Modifiable checkModifiable(Expression exp, Scope* sc, ModifyFlags flag = ModifyF
         case EXP.slice:
             auto sliceExp = cast(SliceExp)exp;
 
-            //printf("SliceExp::checkModifiable %s\n", sliceExp.toChars());
+            //printf("SliceExp::checkModifiable %s\n", sliceExp.toErrMsg());
             auto e1 = sliceExp.e1;
             if (e1.type.ty == Tsarray || (e1.op == EXP.index && e1.type.ty != Tarray) || e1.op == EXP.slice)
             {
@@ -17713,7 +17713,7 @@ Expression modifiableLvalue(Expression _this, Scope* sc, Expression eorig = null
 
     Expression visit(Expression exp)
     {
-        //printf("Expression::modifiableLvalue() %s, type = %s\n", exp.toChars(), exp.type.toChars());
+        //printf("Expression::modifiableLvalue() %s, type = %s\n", exp.toErrMsg(), exp.type.toErrMsg());
         // See if this expression is a modifiable lvalue (i.e. not const)
         if (exp.isBinAssignExp())
             return exp.toLvalue(sc, "modify");
@@ -17745,7 +17745,7 @@ Expression modifiableLvalue(Expression _this, Scope* sc, Expression eorig = null
             else if (!type.isAssignable())
             {
                 error(exp.loc, "cannot modify struct instance `%s` of type `%s` because it contains `const` or `immutable` members",
-                    exp.toChars(), type.toChars());
+                    exp.toErrMsg(), type.toErrMsg());
                 return ErrorExp.get();
             }
         }
@@ -17760,7 +17760,7 @@ Expression modifiableLvalue(Expression _this, Scope* sc, Expression eorig = null
 
     Expression visitVar(VarExp exp)
     {
-        //printf("VarExp::modifiableLvalue('%s')\n", exp.var.toChars());
+        //printf("VarExp::modifiableLvalue('%s')\n", exp.var.toErrMsg());
         if (exp.var.storage_class & STC.manifest)
         {
             error(exp.loc, "cannot modify manifest constant `%s`", exp.toErrMsg());
@@ -17772,7 +17772,7 @@ Expression modifiableLvalue(Expression _this, Scope* sc, Expression eorig = null
 
     Expression visitPtr(PtrExp exp)
     {
-        //printf("PtrExp::modifiableLvalue() %s, type %s\n", exp.toChars(), exp.type.toChars());
+        //printf("PtrExp::modifiableLvalue() %s, type %s\n", exp.toErrMsg(), exp.type.toErrMsg());
         Declaration var;
         auto e1 = exp.e1;
         if (auto se = e1.isSymOffExp())
@@ -17782,9 +17782,9 @@ Expression modifiableLvalue(Expression _this, Scope* sc, Expression eorig = null
         if (var && var.type.isFunction_Delegate_PtrToFunction())
         {
             if (var.type.isTypeFunction())
-                error(exp.loc, "function `%s` is not an lvalue and cannot be modified", var.toChars());
+                error(exp.loc, "function `%s` is not an lvalue and cannot be modified", var.toErrMsg());
             else
-                error(exp.loc, "function pointed to by `%s` is not an lvalue and cannot be modified", var.toChars());
+                error(exp.loc, "function pointed to by `%s` is not an lvalue and cannot be modified", var.toErrMsg());
             return ErrorExp.get();
         }
         return visit(exp);
@@ -17858,7 +17858,7 @@ Expression modifiableLvalue(Expression _this, Scope* sc, Expression eorig = null
  */
 private bool checkAddressVar(Scope* sc, Expression exp, VarDeclaration v)
 {
-    //printf("checkAddressVar(exp: %s, v: %s)\n", exp.toChars(), v.toChars());
+    //printf("checkAddressVar(exp: %s, v: %s)\n", exp.toErrMsg(), v.toErrMsg());
     if (v is null)
         return true;
 
@@ -17894,7 +17894,7 @@ private bool checkAddressVar(Scope* sc, Expression exp, VarDeclaration v)
  */
 bool checkAddressable(Expression e, Scope* sc, const(char)* action)
 {
-    //printf("checkAddressable() %s\n", e.toChars());
+    //printf("checkAddressable() %s\n", e.toErrMsg());
     Expression ex = e;
     while (true)
     {
@@ -18008,7 +18008,7 @@ Expression getThisSkipNestedFuncs(Loc loc, Scope* sc, Dsymbol s, AggregateDeclar
         {
             if (flag)
                 return null;
-            error(e1.loc, "need `this` of type `%s` to access member `%s` from static function `%s`", ad.toChars(), var.toChars(), f.toChars());
+            error(e1.loc, "need `this` of type `%s` to access member `%s` from static function `%s`", ad.toErrMsg(), var.toErrMsg(), f.toErrMsg());
             e1 = ErrorExp.get();
             return e1;
         }
@@ -18076,7 +18076,7 @@ bool verifyHookExist(Loc loc, ref Scope sc, Identifier id, string description, I
     if (auto moduleSymbol = rootSymbol.search(loc, module_))
         if (moduleSymbol.search(loc, id))
           return true;
-    error(loc, "`%s.%s` not found. The current runtime does not support %.*s, or the runtime is corrupt.", module_.toChars(), id.toChars(), cast(int)description.length, description.ptr);
+    error(loc, "`%s.%s` not found. The current runtime does not support %.*s, or the runtime is corrupt.", module_.toErrMsg(), id.toErrMsg(), cast(int)description.length, description.ptr);
     return false;
 }
 
@@ -18114,7 +18114,7 @@ private bool fit(StructDeclaration sd, Loc loc, Scope* sc, Expressions* elements
                 // CTFE sometimes creates null as hidden pointer; we'll allow this.
                 continue;
             }
-                .error(loc, "more initializers than fields (%llu) of `%s`", cast(ulong)nfields, sd.toChars());
+                .error(loc, "more initializers than fields (%llu) of `%s`", cast(ulong)nfields, sd.toErrMsg());
             return false;
         }
         VarDeclaration v = sd.fields[i];
@@ -18126,7 +18126,7 @@ private bool fit(StructDeclaration sd, Loc loc, Scope* sc, Expressions* elements
 
         if (vbitoffset < bitoffset)
         {
-            .error(loc, "overlapping initialization for `%s`", v.toChars());
+            .error(loc, "overlapping initialization for `%s`", v.toErrMsg());
             if (!sd.isUnionDeclaration())
             {
                 enum errorMsg = "`struct` initializers that contain anonymous unions" ~
@@ -18351,7 +18351,7 @@ Expression toBoolean(Expression exp, Scope* sc)
                 if (tb != Type.terror)
                 {
                     error(exp.loc, "expression `%s` of type `%s` does not have a boolean value",
-                              exp.toChars(), t.toChars());
+                              exp.toErrMsg(), t.toErrMsg());
                     if (auto ts = tb.isTypeStruct())
                         errorSupplemental(ts.sym.loc, "perhaps add Cast Operator Overloading with `bool opCast(T : bool)() => ...`");
                 }
@@ -18470,9 +18470,9 @@ bool checkFrameAccess(Loc loc, Scope* sc, AggregateDeclaration ad, size_t iStart
     Dsymbol s = sc.func;
     if (ad.isNested() && s)
     {
-        //printf("ad = %p %s [%s], parent:%p\n", ad, ad.toChars(), ad.loc.toChars(), ad.parent);
-        //printf("sparent = %p %s [%s], parent: %s\n", sparent, sparent.toChars(), sparent.loc.toChars(), sparent.parent,toChars());
-        //printf("sparent2 = %p %s [%s], parent: %s\n", sparent2, sparent2.toChars(), sparent2.loc.toChars(), sparent2.parent,toChars());
+        //printf("ad = %p %s [%s], parent:%p\n", ad, ad.toErrMsg(), ad.loc.toErrMsg(), ad.parent);
+        //printf("sparent = %p %s [%s], parent: %s\n", sparent, sparent.toErrMsg(), sparent.loc.toErrMsg(), sparent.parent,toChars());
+        //printf("sparent2 = %p %s [%s], parent: %s\n", sparent2, sparent2.toErrMsg(), sparent2.loc.toErrMsg(), sparent2.parent,toChars());
         if (!ensureStaticLinkTo(s, sparent) || sparent != sparent2 && !ensureStaticLinkTo(s, sparent2))
         {
             error(loc, "cannot access frame pointer of `%s`", ad.toPrettyChars());
@@ -18533,7 +18533,7 @@ enum ModifyFlags
  */
 private Modifiable checkModify(Declaration d, Loc loc, Scope* sc, Expression e1, ModifyFlags flag)
 {
-    //printf("checkModify() d: %s, e1: %s\n", d.toChars(), e1.toChars());
+    //printf("checkModify() d: %s, e1: %s\n", d.toErrMsg(), e1.toErrMsg());
     VarDeclaration v = d.isVarDeclaration();
     if (v && v.canassign)
         return Modifiable.initialization;
@@ -18546,7 +18546,7 @@ private Modifiable checkModify(Declaration d, Loc loc, Scope* sc, Expression e1,
             {
                 const(char)* s = d.isParameter() && d.parent.ident != Id.ensure ? "parameter" : "result";
                 if (!(flag & ModifyFlags.noError))
-                    error(loc, "%s `%s` cannot modify %s `%s` in contract", d.kind, d.toPrettyChars, s, d.toChars());
+                    error(loc, "%s `%s` cannot modify %s `%s` in contract", d.kind, d.toPrettyChars, s, d.toErrMsg());
                 return Modifiable.initialization; // do not report type related errors
             }
         }
@@ -18591,7 +18591,7 @@ private Modifiable checkModify(Declaration d, Loc loc, Scope* sc, Expression e1,
  */
 private bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
 {
-    //printf("modifyFieldVar(var: %s, e1: %s)\n", var.toChars(), e1.toChars());
+    //printf("modifyFieldVar(var: %s, e1: %s)\n", var.toErrMsg(), e1.toErrMsg());
     Dsymbol s = sc.func;
     while (1)
     {
@@ -18607,7 +18607,7 @@ private bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e
             bool result = true;
 
             var.ctorinit = true;
-            //printf("setting ctorinit for %s\n", var.toChars());
+            //printf("setting ctorinit for %s\n", var.toErrMsg());
 
             if (var.isField() && sc.ctorflow.fieldinit.length && !sc.intypeof)
             {
@@ -18635,7 +18635,7 @@ private bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e
                     else
                     {
                         const(char)* modStr = !var.type.isMutable() ? MODtoChars(var.type.mod) : MODtoChars(e1.type.mod);
-                        .error(loc, "%s field `%s` initialized multiple times", modStr, var.toChars());
+                        .error(loc, "%s field `%s` initialized multiple times", modStr, var.toErrMsg());
                         .errorSupplemental(fieldInit.loc, "Previous initialization is here.");
                     }
                 }
@@ -18646,7 +18646,7 @@ private bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e
                     else
                     {
                         const(char)* modStr = !var.type.isMutable() ? MODtoChars(var.type.mod) : MODtoChars(e1.type.mod);
-                        .error(loc, "%s field `%s` initialization is not allowed in loops or after labels", modStr, var.toChars());
+                        .error(loc, "%s field `%s` initialization is not allowed in loops or after labels", modStr, var.toErrMsg());
                     }
                 }
 
@@ -18671,20 +18671,20 @@ private bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e
                 {
                     const(char)* p = var.isField() ? "field" : var.kind();
                     .error(loc, "%s %s `%s` initialization is not allowed in foreach loop",
-                        MODtoChars(var.type.mod), p, var.toChars());
+                        MODtoChars(var.type.mod), p, var.toErrMsg());
                 }
                 else
                 {
                     const(char)* p = var.isField() ? "field" : var.kind();
                     .error(loc, "%s %s `%s` initialization is not allowed in nested function `%s`",
-                        MODtoChars(var.type.mod), p, var.toChars(), sc.func.toChars());
+                        MODtoChars(var.type.mod), p, var.toErrMsg(), sc.func.toErrMsg());
                 }
             }
             else if (fd.isStaticCtorDeclaration() && !fd.isSharedStaticCtorDeclaration() &&
                      var.type.isImmutable())
             {
                 .error(loc, "%s %s `%s` initialization is not allowed in `static this`",
-                    MODtoChars(var.type.mod), var.kind(), var.toChars());
+                    MODtoChars(var.type.mod), var.kind(), var.toErrMsg());
                 errorSupplemental(loc, "Use `shared static this` instead.");
             }
             else if (fd.isStaticCtorDeclaration() && !fd.isSharedStaticCtorDeclaration() &&
@@ -18693,7 +18693,7 @@ private bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e
                 // @@@DEPRECATED_2.116@@@
                 // Turn this into an error, merging with the branch above
                 .deprecation(loc, "%s %s `%s` initialization is not allowed in `static this`",
-                    MODtoChars(var.type.mod), var.kind(), var.toChars());
+                    MODtoChars(var.type.mod), var.kind(), var.toErrMsg());
                 deprecationSupplemental(loc, "Use `shared static this` instead.");
             }
             return result;
@@ -18746,7 +18746,7 @@ void semanticTypeInfo(Scope* sc, Type t)
 
     void visitStruct(TypeStruct t)
     {
-        //printf("semanticTypeInfo.visit(TypeStruct = %s)\n", t.toChars());
+        //printf("semanticTypeInfo.visit(TypeStruct = %s)\n", t.toErrMsg());
         StructDeclaration sd = t.sym;
 
         /* Step 1: create TypeInfoDeclaration
@@ -18802,7 +18802,7 @@ void semanticTypeInfo(Scope* sc, Type t)
         {
             if (sd.inNonRoot())
             {
-                //printf("deferred sem3 for TypeInfo - sd = %s, inNonRoot = %d\n", sd.toChars(), sd.inNonRoot());
+                //printf("deferred sem3 for TypeInfo - sd = %s, inNonRoot = %d\n", sd.toErrMsg(), sd.inNonRoot());
                 addDeferredSemantic3(sd);
             }
         }
@@ -18888,7 +18888,7 @@ bool checkDisabled(Declaration d, Loc loc, Scope* sc, bool isAliasedDeclaration 
                         continue;
                     if (sdv.postblit.isDisabled())
                     {
-                        .error(loc, "%s `%s` is not copyable because field `%s` is not copyable", p.kind, p.toPrettyChars, structField.toChars());
+                        .error(loc, "%s `%s` is not copyable because field `%s` is not copyable", p.kind, p.toPrettyChars, structField.toErrMsg());
                         return true;
                     }
                 }
@@ -18989,7 +18989,7 @@ private Expression expandInitializer(VarDeclaration vd, Loc loc)
     auto e = vd.getConstInitializer();
     if (!e)
     {
-        .error(loc, "cannot make expression out of initializer for `%s`", vd.toChars());
+        .error(loc, "cannot make expression out of initializer for `%s`", vd.toErrMsg());
         return ErrorExp.get();
     }
 
@@ -19100,7 +19100,7 @@ private bool needsTypeInference(TemplateInstance ti, Scope* sc, int flag = 0)
                     if (td.semanticRun == PASS.initial)
                     {
                         .error(ti.loc, "%s `%s` `%s` forward references template declaration `%s`",
-                               ti.kind, ti.toPrettyChars, ti.toChars(), td.toChars());
+                               ti.kind, ti.toPrettyChars, ti.toErrMsg(), td.toErrMsg());
                         return 1;
                     }
                 }
@@ -19122,7 +19122,7 @@ private bool needsTypeInference(TemplateInstance ti, Scope* sc, int flag = 0)
     {
         if (!global.gag)
         {
-            errorSupplemental(ti.loc, "while looking for match for `%s`", ti.toChars());
+            errorSupplemental(ti.loc, "while looking for match for `%s`", ti.toErrMsg());
             ti.semanticRun = PASS.semanticdone;
             ti.inst = ti;
         }
@@ -19197,7 +19197,7 @@ bool fill(StructDeclaration sd, Loc loc, ref Expressions elements, bool ctorinit
                 }
                 else if (v2._init)
                 {
-                    .error(loc, "overlapping initialization for field `%s` and `%s`", v2.toChars(), vd.toChars());
+                    .error(loc, "overlapping initialization for field `%s` and `%s`", v2.toErrMsg(), vd.toErrMsg());
                     errors = true;
                 }
             }
@@ -19221,7 +19221,7 @@ bool fill(StructDeclaration sd, Loc loc, ref Expressions elements, bool ctorinit
                 else if (vx._init && v2._init)
                 {
                     .error(loc, "overlapping default initialization for field `%s` and `%s`",
-                        v2.toChars(), vd.toChars());
+                        v2.toErrMsg(), vd.toErrMsg());
                     errors = true;
                 }
                 else
@@ -19252,7 +19252,7 @@ bool fill(StructDeclaration sd, Loc loc, ref Expressions elements, bool ctorinit
             if ((vx.storage_class & STC.nodefaultctor) && !ctorinit)
             {
                 .error(loc, "field `%s.%s` must be initialized because it has no default constructor",
-                    sd.type.toChars(), vx.toChars());
+                    sd.type.toErrMsg(), vx.toErrMsg());
                 errors = true;
             }
             /* https://issues.dlang.org/show_bug.cgi?id=12509
@@ -19625,7 +19625,7 @@ private extern(C++) class IncludeVisitor : Visitor {
     override void visit(VersionCondition vc)
     {
         //printf("VersionCondition::include() level = %d, versionlevel = %d\n", level, global.params.versionlevel);
-        //if (ident) printf("\tident = '%s'\n", ident.toChars());
+        //if (ident) printf("\tident = '%s'\n", ident.toErrMsg());
         if (vc.inc != Include.notComputed)
         {
             result = vc.inc == Include.yes;
@@ -19913,7 +19913,7 @@ private Expression rewriteAAIndexAssign(BinExp exp, Scope* sc, ref Type[2] alias
         Type tidx = ekey.type.toBasetype();
         if (tidx.ty == Tarray && tidx.nextOf().isMutable() && !ekey.isArrayLiteralExp())
         {
-            error(loc, "associative arrays can only be assigned values with immutable keys, not `%s`", tidx.toChars());
+            error(loc, "associative arrays can only be assigned values with immutable keys, not `%s`", tidx.toErrMsg());
             return ErrorExp.get();
         }
     }

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -771,7 +771,7 @@ void funcDeclarationSemantic(Scope* sc, FuncDeclaration funcdecl)
         if (sc.scopesym && sc.scopesym.isAggregateDeclaration())
             .error(funcdecl.loc, "%s `%s` `static` member has no `this` to which `return` can apply", funcdecl.kind, funcdecl.toPrettyChars);
         else
-            error(funcdecl.loc, "top-level function `%s` has no `this` to which `return` can apply", funcdecl.toChars());
+            error(funcdecl.loc, "top-level function `%s` has no `this` to which `return` can apply", funcdecl.toErrMsg());
     }
 
     if (funcdecl.isAbstract() && !funcdecl.isVirtual())
@@ -807,15 +807,15 @@ void funcDeclarationSemantic(Scope* sc, FuncDeclaration funcdecl)
     {
         funcdecl.storage_class |= STC.abstract_;
         if (funcdecl.isCtorDeclaration() || funcdecl.isPostBlitDeclaration() || funcdecl.isDtorDeclaration() || funcdecl.isInvariantDeclaration() || funcdecl.isNewDeclaration() || funcdecl.isDelete())
-            .error(funcdecl.loc, "%s `%s` constructors, destructors, postblits, invariants, new and delete functions are not allowed in interface `%s`", funcdecl.kind, funcdecl.toPrettyChars, id.toChars());
+            .error(funcdecl.loc, "%s `%s` constructors, destructors, postblits, invariants, new and delete functions are not allowed in interface `%s`", funcdecl.kind, funcdecl.toPrettyChars, id.toErrMsg());
         if (funcdecl.fbody && funcdecl.isVirtual())
-            .error(funcdecl.loc, "%s `%s` function body only allowed in `final` functions in interface `%s`", funcdecl.kind, funcdecl.toPrettyChars, id.toChars());
+            .error(funcdecl.loc, "%s `%s` function body only allowed in `final` functions in interface `%s`", funcdecl.kind, funcdecl.toPrettyChars, id.toErrMsg());
     }
 
     if (UnionDeclaration ud = parent.isUnionDeclaration())
     {
         if (funcdecl.isPostBlitDeclaration() || funcdecl.isDtorDeclaration() || funcdecl.isInvariantDeclaration())
-            .error(funcdecl.loc, "%s `%s` destructors, postblits and invariants are not allowed in union `%s`", funcdecl.kind, funcdecl.toPrettyChars, ud.toChars());
+            .error(funcdecl.loc, "%s `%s` destructors, postblits and invariants are not allowed in union `%s`", funcdecl.kind, funcdecl.toPrettyChars, ud.toErrMsg());
     }
 
     if (StructDeclaration sd = parent.isStructDeclaration())
@@ -873,7 +873,7 @@ Ldone:
             // If it's a member template
             if (ClassDeclaration cd = ti.tempdecl.isClassMember())
             {
-                .error(funcdecl.loc, "%s `%s` cannot use template to add virtual function to class `%s`", funcdecl.kind, funcdecl.toPrettyChars, cd.toChars());
+                .error(funcdecl.loc, "%s `%s` cannot use template to add virtual function to class `%s`", funcdecl.kind, funcdecl.toPrettyChars, cd.toErrMsg());
             }
         }
     }
@@ -1113,7 +1113,7 @@ private int classFuncSemantic(ClassDeclaration cd, FuncDeclaration funcdecl,
                 /* the derived class cd doesn't have its vtbl[] allocated yet.
                  * https://issues.dlang.org/show_bug.cgi?id=21008
                  */
-                .error(funcdecl.loc, "%s `%s` circular reference to class `%s`", funcdecl.kind, funcdecl.toPrettyChars, cd.toChars());
+                .error(funcdecl.loc, "%s `%s` circular reference to class `%s`", funcdecl.kind, funcdecl.toPrettyChars, cd.toErrMsg());
                 funcdecl.errors = true;
                 return 2;
             }
@@ -1307,7 +1307,7 @@ Linterfaces:
                         {
                             if (!funcdecl.tintro.nextOf().equals(ti.nextOf()) && !funcdecl.tintro.nextOf().isBaseOf(ti.nextOf(), null) && !ti.nextOf().isBaseOf(funcdecl.tintro.nextOf(), null))
                             {
-                                .error(funcdecl.loc, "%s `%s` incompatible covariant types `%s` and `%s`", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.tintro.toChars(), ti.toChars());
+                                .error(funcdecl.loc, "%s `%s` incompatible covariant types `%s` and `%s`", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.tintro.toErrMsg(), ti.toErrMsg());
                             }
                         }
                         else
@@ -1359,7 +1359,7 @@ Linterfaces:
                 if (fd.errors)
                 {
                     error(funcdecl.loc, "function `%s` does not override any function, did you mean to override `%s`?",
-                        funcdecl.toChars(), fd.toPrettyChars());
+                        funcdecl.toErrMsg(), fd.toPrettyChars());
                     errorSupplemental(fd.loc, "Function `%s` contains errors in its declaration, therefore it cannot be correctly overridden",
                         fd.toPrettyChars());
                 }
@@ -1470,7 +1470,7 @@ L2:
                 {
                     f2 = f2.overloadExactMatch(funcdecl.type);
                     if (f2 && f2.isFinalFunc() && f2.visible().kind != Visibility.Kind.private_)
-                        .error(funcdecl.loc, "%s `%s` cannot override `final` function `%s.%s`", funcdecl.kind, funcdecl.toPrettyChars, b.sym.toChars(), f2.toPrettyChars());
+                        .error(funcdecl.loc, "%s `%s` cannot override `final` function `%s.%s`", funcdecl.kind, funcdecl.toPrettyChars, b.sym.toErrMsg(), f2.toPrettyChars());
                 }
             }
         }
@@ -1498,7 +1498,7 @@ private TypeFunction getFunctionType(FuncDeclaration fd)
 
     if (!fd.type.isTypeError())
     {
-        .error(fd.loc, "%s `%s` `%s` must be a function instead of `%s`", fd.kind, fd.toPrettyChars, fd.toChars(), fd.type.toChars());
+        .error(fd.loc, "%s `%s` `%s` must be a function instead of `%s`", fd.kind, fd.toPrettyChars, fd.toErrMsg(), fd.type.toErrMsg());
         fd.type = Type.terror;
     }
     fd.errors = true;
@@ -1706,7 +1706,7 @@ extern (D) bool checkForwardRef(FuncDeclaration fd, Loc loc)
         bool inSemantic3 = (fd.inferRetType && fd.semanticRun >= PASS.semantic3);
         .error(loc, "forward reference to %s`%s`",
             (inSemantic3 ? "inferred return type of function " : "").ptr,
-            fd.toChars());
+            fd.toErrMsg());
         return true;
     }
     return false;
@@ -1992,7 +1992,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
         }
 
         .error(loc, "`%s.%s` called with argument types `%s` matches multiple overloads %.*s:\n%s:     `%s%s%s`\nand:\n%s:     `%s%s%s`",
-            s.parent.toPrettyChars(), s.ident.toChars(),
+            s.parent.toPrettyChars(), s.ident.toErrMsg(),
             fargsBuf.peekChars(),
             match.fTuple.expand,
             m.lastf.loc.toChars(), m.lastf.toPrettyChars(), lastprms, tf1.modToChars(),
@@ -2004,7 +2004,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
     if (flags & FuncResolveFlag.ufcs)
     {
         auto arg = (*fargs)[0];
-        .error(loc, "no property `%s` for `%s` of type `%s`", s.ident.toChars(), arg.toChars(), arg.type.toChars());
+        .error(loc, "no property `%s` for `%s` of type `%s`", s.ident.toErrMsg(), arg.toErrMsg(), arg.type.toErrMsg());
         .errorSupplemental(loc, "the following error occured while looking for a UFCS match");
     }
 
@@ -2016,14 +2016,14 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
             if (!od && !td.overnext)
             {
                 .error(loc, "%s `%s` is not callable using argument types `!(%s)%s`",
-                    td.kind(), td.ident.toChars(), tiargsBuf.peekChars(), fargsBuf.peekChars());
+                    td.kind(), td.ident.toErrMsg(), tiargsBuf.peekChars(), fargsBuf.peekChars());
 
                 checkNamedArgErrorAndReport(td, argumentList, loc);
             }
             else
             {
                 .error(loc, "none of the overloads of %s `%s.%s` are callable using argument types `!(%s)%s`",
-                    td.kind(), td.parent.toPrettyChars(), td.ident.toChars(),
+                    td.kind(), td.parent.toPrettyChars(), td.ident.toErrMsg(),
                     tiargsBuf.peekChars(), fargsBuf.peekChars());
 
                 checkNamedArgErrorAndReport(td, argumentList, loc);
@@ -2046,7 +2046,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
     if (od)
     {
         .error(loc, "none of the overloads of `%s` are callable using argument types `!(%s)%s`",
-            od.ident.toChars(), tiargsBuf.peekChars(), fargsBuf.peekChars());
+            od.ident.toErrMsg(), tiargsBuf.peekChars(), fargsBuf.peekChars());
 
         checkNamedArgErrorAndReportOverload(od, argumentList, loc);
         if (!global.gag || global.params.v.showGaggedErrors)
@@ -2081,14 +2081,14 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
             {
                 if (tthis.mod & MODFlags.immutable_)
                     .error(loc, "none of the overloads of `%s` can construct an immutable object with argument types `(%s)`. Expected `immutable(%s)`",
-                        fd.toChars(), buf.peekChars(), buf.peekChars());
+                        fd.toErrMsg(), buf.peekChars(), buf.peekChars());
                 else
                     .error(loc, "none of the overloads of `%s` can construct a %sobject with argument types `(%s)`",
-                        fd.toChars(), thisBuf.peekChars(), buf.peekChars());
+                        fd.toErrMsg(), thisBuf.peekChars(), buf.peekChars());
             }
             else
                 .error(loc, "none of the overloads of `%s` are callable using a %sobject with argument types `(%s)`",
-                    fd.toChars(), thisBuf.peekChars(), buf.peekChars());
+                    fd.toErrMsg(), thisBuf.peekChars(), buf.peekChars());
 
             if (!global.gag || global.params.v.showGaggedErrors)
                 printCandidates(loc, fd, sc.isDeprecated());
@@ -2127,7 +2127,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
     if (hasOverloads)
     {
         .error(loc, "none of the overloads of `%s` are callable using argument types `%s`",
-               fd.toChars(), fargsBuf.peekChars());
+               fd.toErrMsg(), fargsBuf.peekChars());
         if (!global.gag || global.params.v.showGaggedErrors)
             printCandidates(loc, fd, sc.isDeprecated());
         return null;
@@ -2696,7 +2696,7 @@ int getLevelAndCheck(FuncDeclaration fd, Loc loc, Scope* sc, FuncDeclaration tar
         const(char)* xstatic = fd.isStatic() ? "`static` " : "";
         // better diagnostics for static functions
         .error(loc, "%s%s `%s` cannot access %s `%s` in frame of function `%s`",
-               xstatic, fd.kind(), fd.toPrettyChars(), decl.kind(), decl.toChars(),
+               xstatic, fd.kind(), fd.toPrettyChars(), decl.kind(), decl.toErrMsg(),
                target.toPrettyChars());
             .errorSupplemental(decl.loc, "`%s` declared here", decl.toChars());
         return LevelError;
@@ -2787,7 +2787,7 @@ void buildResultVar(FuncDeclaration fd, Scope* sc, Type tret)
         fd.vresult.type = tret;
         fd.vresult.dsymbolSemantic(sc);
         if (!sc.insert(fd.vresult))
-            .error(fd.loc, "%s `%s` out result %s is already defined", fd.kind, fd.toPrettyChars, fd.vresult.toChars());
+            .error(fd.loc, "%s `%s` out result %s is already defined", fd.kind, fd.toPrettyChars, fd.vresult.toErrMsg());
         assert(fd.vresult.parent == fd);
     }
 }
@@ -3325,7 +3325,7 @@ extern (D) void checkMain(FuncDeclaration fd)
     retType = retType.toBasetype();
 
     if (retType.ty != Tint32 && retType.ty != Tvoid && retType.ty != Tnoreturn)
-        .error(fd.loc, "%s `%s` must return `int`, `void` or `noreturn`, not `%s`", fd.kind, fd.toPrettyChars, tf.nextOf().toChars());
+        .error(fd.loc, "%s `%s` must return `int`, `void` or `noreturn`, not `%s`", fd.kind, fd.toPrettyChars, tf.nextOf().toErrMsg());
 }
 
 enum LevelError = -2;
@@ -4025,7 +4025,7 @@ private void checkPrintfScanfSignature(FuncDeclaration funcdecl, TypeFunction f,
     {
         .error(funcdecl.loc, "`pragma(%s)` function `%s` must have `extern(C)` or `extern(C++)` linkage,"
             ~" not `extern(%s)`",
-            p, funcdecl.toChars(), f.linkage.linkageToChars());
+            p, funcdecl.toErrMsg(), f.linkage.linkageToChars());
     }
     if (f.parameterList.varargs == VarArg.variadic)
     {
@@ -4033,7 +4033,7 @@ private void checkPrintfScanfSignature(FuncDeclaration funcdecl, TypeFunction f,
         {
             .error(funcdecl.loc, "`pragma(%s)` function `%s` must have"
                 ~ " signature `%s %s([parameters...], const(char)*, ...)` not `%s`",
-                p, funcdecl.toChars(), f.next.toChars(), funcdecl.toChars(), funcdecl.type.toChars());
+                p, funcdecl.toErrMsg(), f.next.toErrMsg(), funcdecl.toErrMsg(), funcdecl.type.toErrMsg());
         }
     }
     else if (f.parameterList.varargs == VarArg.none)
@@ -4043,15 +4043,15 @@ private void checkPrintfScanfSignature(FuncDeclaration funcdecl, TypeFunction f,
             isVa_list(f.parameterList[nparams - 1])))
             .error(funcdecl.loc, "`pragma(%s)` function `%s` must have"~
                 " signature `%s %s([parameters...], const(char)*, va_list)`",
-                p, funcdecl.toChars(), f.next.toChars(), funcdecl.toChars());
+                p, funcdecl.toErrMsg(), f.next.toErrMsg(), funcdecl.toErrMsg());
         else if (funcdecl.isSafe() || funcdecl.isTrusted())
             .error(funcdecl.loc, "`pragma(%s)` %s `%s` of `va_list` form must be `@system`",
-                p, funcdecl.kind(), funcdecl.toChars());
+                p, funcdecl.kind(), funcdecl.toErrMsg());
     }
     else
     {
         .error(funcdecl.loc, "`pragma(%s)` function `%s` must have C-style variadic `...` or `va_list` parameter",
-            p, funcdecl.toChars());
+            p, funcdecl.toErrMsg());
     }
 }
 

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -692,7 +692,7 @@ elem* toElem(Expression e, ref IRState irs)
         //printf("\tparent = '%s'\n", se.var.parent ? se.var.parent.toChars() : "null");
         if (se.op == EXP.variable && se.var.needThis())
         {
-            irs.eSink.error(se.loc, "need `this` to access member `%s`", se.toChars());
+            irs.eSink.error(se.loc, "need `this` to access member `%s`", se.toErrMsg());
             return el_long(TYsize_t, 0);
         }
 
@@ -1340,7 +1340,7 @@ elem* toElem(Expression e, ref IRState irs)
 
                 if (!cd.vthis)
                 {
-                    irs.eSink.error(ne.loc, "forward reference to `%s`", cd.toChars());
+                    irs.eSink.error(ne.loc, "forward reference to `%s`", cd.toErrMsg());
                 }
                 else
                 {
@@ -1515,7 +1515,7 @@ elem* toElem(Expression e, ref IRState irs)
         }
         else
         {
-            irs.eSink.error(ne.loc, "internal compiler error: cannot new type `%s`\n", t.toChars());
+            irs.eSink.error(ne.loc, "internal compiler error: cannot new type `%s`\n", t.toErrMsg());
             assert(0);
         }
 
@@ -1939,7 +1939,7 @@ elem* toElem(Expression e, ref IRState irs)
          */
         if (!irs.params.useGC)
         {
-            irs.eSink.error(ce.loc, "array concatenation of expression `%s` requires the GC which is not available with -betterC", ce.toChars());
+            irs.eSink.error(ce.loc, "array concatenation of expression `%s` requires the GC which is not available with -betterC", ce.toErrMsg());
             return el_long(TYint, 0);
         }
 
@@ -3074,7 +3074,7 @@ elem* toElem(Expression e, ref IRState irs)
                 {
                     irs.eSink.error(ce.loc,
                         "appending to array in `%s` requires the GC which is not available with -betterC",
-                        ce.toChars());
+                        ce.toErrMsg());
                     return el_long(TYint, 0);
                 }
 
@@ -3329,13 +3329,13 @@ elem* toElem(Expression e, ref IRState irs)
     elem* visitType(TypeExp e)
     {
         //printf("TypeExp.toElem()\n");
-        irs.eSink.error(e.loc, "type `%s` is not an expression", e.toChars());
+        irs.eSink.error(e.loc, "type `%s` is not an expression", e.toErrMsg());
         return el_long(TYint, 0);
     }
 
     elem* visitScope(ScopeExp e)
     {
-        irs.eSink.error(e.loc, "`%s` is not an expression", e.sds.toChars());
+        irs.eSink.error(e.loc, "`%s` is not an expression", e.sds.toErrMsg());
         return el_long(TYint, 0);
     }
 
@@ -3348,7 +3348,7 @@ elem* toElem(Expression e, ref IRState irs)
         VarDeclaration v = dve.var.isVarDeclaration();
         if (!v)
         {
-            irs.eSink.error(dve.loc, "`%s` is not a field, but a %s", dve.var.toChars(), dve.var.kind());
+            irs.eSink.error(dve.loc, "`%s` is not a field, but a %s", dve.var.toErrMsg(), dve.var.kind());
             return el_long(TYint, 0);
         }
 
@@ -5379,7 +5379,7 @@ elem* toElemCast(CastExp ce, elem* e, bool isLvalue, ref IRState irs)
                 //dump(0);
                 //printf("fty = %d, tty = %d, %d\n", fty, tty, t.ty);
                 // This error should really be pushed to the front end
-                irs.eSink.error(ce.loc, "e2ir: cannot cast `%s` of type `%s` to type `%s`", ce.e1.toChars(), ce.e1.type.toChars(), t.toChars());
+                irs.eSink.error(ce.loc, "e2ir: cannot cast `%s` of type `%s` to type `%s`", ce.e1.toErrMsg(), ce.e1.type.toErrMsg(), t.toErrMsg());
                 e = el_long(TYint, 0);
                 return e;
 
@@ -5521,7 +5521,7 @@ elem* callfunc(Loc loc,
         {
             Expression arg = (*arguments)[0];
             if (arg.op != EXP.int64)
-                irs.eSink.error(arg.loc, "simd operator must be an integer constant, not `%s`", arg.toChars());
+                irs.eSink.error(arg.loc, "simd operator must be an integer constant, not `%s`", arg.toErrMsg());
         }
 
         /* Convert arguments[] to elems[] in left-to-right order

--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -310,7 +310,7 @@ tym_t totym(Type tx)
         case Ttypeof:
         case Tmixin:
             //printf("ty = %d, '%s'\n", tx.ty, tx.toChars());
-            error(Loc.initial, "forward reference of `%s`", tx.toChars());
+            error(Loc.initial, "forward reference of `%s`", tx.toErrMsg());
             t = TYint;
             break;
 

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -241,7 +241,7 @@ void Expression_toDt(Expression e, ref DtBuilder dtb)
         {
             printf("Expression.toDt() op = %d e = %s \n", e.op, e.toChars());
         }
-        error(e.loc, "non-constant expression `%s`", e.toChars());
+        error(e.loc, "non-constant expression `%s`", e.toErrMsg());
         dtb.nzeros(1);
     }
 
@@ -545,7 +545,7 @@ void Expression_toDt(Expression e, ref DtBuilder dtb)
             if ((v.isConst() || v.isImmutable()) &&
                 e.type.toBasetype().ty != Tsarray && v._init)
             {
-                error(e.loc, "recursive reference `%s`", e.toChars());
+                error(e.loc, "recursive reference `%s`", e.toErrMsg());
                 return;
             }
             v.inuse++;
@@ -1225,7 +1225,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
                     typeclass.toChars(), cast(uint)typeclass.structsize);
             }
             error(typeclass.loc, "`%s`: mismatch between compiler (%d bytes) and object.d or object.di (%d bytes) found",
-                typeclass.toChars(), cast(uint)expected, cast(uint)typeclass.structsize);
+                typeclass.toErrMsg(), cast(uint)expected, cast(uint)typeclass.structsize);
             errorSupplemental(typeclass.loc, "check installation and import paths with `-v` compiler switch");
             fatal();
         }

--- a/compiler/src/dmd/glue/toir.d
+++ b/compiler/src/dmd/glue/toir.d
@@ -50,6 +50,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem : followInstantiationContext, toParentP;
 import dmd.expressionsem : toInteger;
 import dmd.dtemplate;
+import dmd.errors;
 import dmd.errorsink;
 import dmd.func;
 import dmd.funcsem;
@@ -337,7 +338,7 @@ elem* getEthis(Loc loc, ref IRState irs, Dsymbol fd, Dsymbol fdp = null, Dsymbol
     {
         if (!irs.sthis)                // if no frame pointer for this function
         {
-            irs.eSink.error(loc, "`%s` is a nested function and cannot be accessed from `%s`", fd.toChars(), irs.getFunc().toPrettyChars());
+            irs.eSink.error(loc, "`%s` is a nested function and cannot be accessed from `%s`", fd.toErrMsg(), irs.getFunc().toPrettyChars());
             return el_long(TYnptr, 0); // error recovery
         }
 

--- a/compiler/src/dmd/iasm/dmdx86.d
+++ b/compiler/src/dmd/iasm/dmdx86.d
@@ -707,7 +707,7 @@ PTRNTAB asm_classify(OP* pop, OPND[] opnds, out int outNumops)
 
             if (i == 0 && bRetry && opnd.s && !opnd.s.isLabel())
             {
-                error(asmstate.loc, "label expected", opnd.s.toChars());
+                error(asmstate.loc, "label expected", opnd.s.toErrMsg());
                 return;
             }
             opnd.usFlags |= CONSTRUCT_FLAGS(0, 0, 0, _fanysize);
@@ -2228,7 +2228,7 @@ void asm_merge_opnds(ref OPND o1, ref OPND o2)
                 break;
             default:
             }
-            error(asmstate.loc, "invalid asm operand `%s`", o1.s.toChars());
+            error(asmstate.loc, "invalid asm operand `%s`", o1.s.toErrMsg());
         }
     }
 
@@ -2365,12 +2365,12 @@ void asm_merge_symbol(ref OPND o1, Dsymbol s)
 
         if (v.isThreadlocal())
         {
-            error(asmstate.loc, "cannot directly load TLS variable `%s`", v.toChars());
+            error(asmstate.loc, "cannot directly load TLS variable `%s`", v.toErrMsg());
             return;
         }
         else if (v.isDataseg() && driverParams.pic != PIC.fixed)
         {
-            error(asmstate.loc, "cannot directly load global variable `%s` with PIC or PIE code", v.toChars());
+            error(asmstate.loc, "cannot directly load global variable `%s` with PIC or PIE code", v.toErrMsg());
             return;
         }
     }
@@ -2385,10 +2385,10 @@ L2:
     Declaration d = s.isDeclaration();
     if (!d)
     {
-        error(asmstate.loc, "%s `%s` is not a declaration", s.kind(), s.toChars());
+        error(asmstate.loc, "%s `%s` is not a declaration", s.kind(), s.toErrMsg());
     }
     else if (d.getType())
-        error(asmstate.loc, "cannot use type `%s` as an operand", d.getType().toChars());
+        error(asmstate.loc, "cannot use type `%s` as an operand", d.getType().toErrMsg());
     else if (d.isTupleDeclaration())
     {
     }
@@ -3494,7 +3494,7 @@ code* asm_da_parse(OP* pop)
             LabelDsymbol label = asmstate.sc.func.searchLabel(asmstate.tok.ident, asmstate.loc);
             if (!label)
             {
-                error(asmstate.loc, "label `%s` not found", asmstate.tok.ident.toChars());
+                error(asmstate.loc, "label `%s` not found", asmstate.tok.ident.toErrMsg());
                 break;
             }
             else
@@ -4163,7 +4163,7 @@ void asm_una_exp(ref OPND o1)
             }
             else
             {
-                error(asmstate.loc, "property of basic type `%s` expected", ptype.toChars());
+                error(asmstate.loc, "property of basic type `%s` expected", ptype.toErrMsg());
             }
             asm_token();
             return;
@@ -4566,7 +4566,7 @@ TOK tryExpressionToOperand(Expression e, out OPND o1, out Dsymbol s)
             return TOK.const_;
         }
     }
-    error(asmstate.loc, "bad type/size of operands `%s`", e.toChars());
+    error(asmstate.loc, "bad type/size of operands `%s`", e.toErrMsg());
     return TOK.error;
 }
 

--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -139,7 +139,7 @@ Expression fieldLookup(Expression e, Scope* sc, Identifier id, bool arrow)
         t = t.isTypePointer().next;
         auto pe = e.toChars();
         if (!arrow)
-            error(e.loc, "since `%s` is a pointer, use `%s->%s` instead of `%s.%s`", pe, pe, id.toChars(), pe, id.toChars());
+            error(e.loc, "since `%s` is a pointer, use `%s->%s` instead of `%s.%s`", pe, pe, id.toErrMsg(), pe, id.toErrMsg());
         e = new PtrExp(e.loc, e);
     }
     Dsymbol s;
@@ -147,7 +147,7 @@ Expression fieldLookup(Expression e, Scope* sc, Identifier id, bool arrow)
         s = ts.sym.search(e.loc, id, 0);
     if (!s)
     {
-        error(e.loc, "`%s` is not a member of `%s`", id.toChars(), t.toChars());
+        error(e.loc, "`%s` is not a member of `%s`", id.toErrMsg(), t.toErrMsg());
         return ErrorExp.get();
     }
     Expression ef = new DotVarExp(e.loc, e, s.isDeclaration());
@@ -538,7 +538,7 @@ Dsymbol handleSymbolRedeclarations(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsy
         if (!cTypeEquivalence(vd.type, vd2.type))
         {
             .error(vd.loc, "redefinition of `%s` with different type: `%s` vs `%s`",
-                vd2.ident.toChars(), vd2.type.toChars(), vd.type.toChars());
+                vd2.ident.toErrMsg(), vd2.type.toErrMsg(), vd.type.toErrMsg());
         }
         return vd2;
     }
@@ -666,13 +666,13 @@ void cEnumSemantic(Scope* sc, EnumDeclaration ed)
             if (!ie)
             {
                 // C11 6.7.2.2-2
-                .error(em.loc, "%s `%s` enum member must be an integral constant expression, not `%s` of type `%s`", em.kind, em.toPrettyChars, e.toChars(), e.type.toChars());
+                .error(em.loc, "%s `%s` enum member must be an integral constant expression, not `%s` of type `%s`", em.kind, em.toPrettyChars, e.toErrMsg(), e.type.toErrMsg());
                 return errorReturn(em);
             }
             if (ed.memtype && !ir.contains(getIntRange(ie)))
             {
                 // C11 6.7.2.2-2
-                .error(em.loc, "%s `%s` enum member value `%s` does not fit in `%s`", em.kind, em.toPrettyChars, e.toChars(), commonType.toChars());
+                .error(em.loc, "%s `%s` enum member value `%s` does not fit in `%s`", em.kind, em.toPrettyChars, e.toErrMsg(), commonType.toErrMsg());
                 return errorReturn(em);
             }
             nextValue = ie.toInteger();
@@ -689,7 +689,7 @@ void cEnumSemantic(Scope* sc, EnumDeclaration ed)
                 Expression max = getProperty(commonType, null, em.loc, Id.max, 0);
                 if (nextValue == max.toInteger())
                 {
-                    .error(em.loc, "%s `%s` initialization with `%s+1` causes overflow for type `%s`", em.kind, em.toPrettyChars, max.toChars(), commonType.toChars());
+                    .error(em.loc, "%s `%s` initialization with `%s+1` causes overflow for type `%s`", em.kind, em.toPrettyChars, max.toErrMsg(), commonType.toErrMsg());
                     return errorReturn(em);
                 }
                 nextValue += 1;

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -152,7 +152,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             if (sd.hasRegularCtor(true))
             {
                 error(i.loc, "Cannot use %s initializer syntax for %s `%s` because it has a constructor",
-                    sd.kind(), sd.kind(), sd.toChars());
+                    sd.kind(), sd.kind(), sd.toErrMsg());
                 errorSupplemental(i.loc, "Use `%s( arguments )` instead of `{ initializers }`",
                     sd.toChars());
                 return err();
@@ -199,7 +199,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             return ie.initializerSemantic(sc, t, needInterpret);
         }
         if (t.ty != Terror)
-            error(i.loc, "a struct is not a valid initializer for a `%s`", t.toChars());
+            error(i.loc, "a struct is not a valid initializer for a `%s`", t.toErrMsg());
         return err();
     }
 
@@ -230,7 +230,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                 // Bugzilla 13987
                 if (!e)
                 {
-                    error(i.loc, "cannot use array to initialize `%s`", t.toChars());
+                    error(i.loc, "cannot use array to initialize `%s`", t.toErrMsg());
                     return err();
                 }
                 auto ei = new ExpInitializer(e.loc, e);
@@ -246,7 +246,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             return err();
 
         default:
-            error(i.loc, "cannot use array to initialize `%s`", t.toChars());
+            error(i.loc, "cannot use array to initialize `%s`", t.toErrMsg());
             return err();
         }
         i.type = t;
@@ -421,7 +421,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
         }
         if (i.exp.op == EXP.type)
         {
-            error(i.exp.loc, "initializer must be an expression, not `%s`", i.exp.toChars());
+            error(i.exp.loc, "initializer must be an expression, not `%s`", i.exp.toErrMsg());
             // If the error location differs from the initializer location, show where it was used
             if (i.exp.loc != i.loc)
                 errorSupplemental(i.loc, "used in initialization here");
@@ -447,7 +447,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
         // Make sure all pointers are constants
         if (needInterpret && hasNonConstPointers(i.exp))
         {
-            error(i.exp.loc, "cannot use non-constant CTFE pointer in an initializer `%s`", currExp.toChars());
+            error(i.exp.loc, "cannot use non-constant CTFE pointer in an initializer `%s`", currExp.toErrMsg());
             return err();
         }
         Type ti = i.exp.type.toBasetype();
@@ -619,7 +619,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             const errors = global.startGagging();
             i.exp = i.exp.implicitCastTo(sc, t);
             if (global.endGagging(errors))
-                error(currExp.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`", currExp.toErrMsg(), et.toChars(), t.toChars());
+                error(currExp.loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`", currExp.toErrMsg(), et.toErrMsg(), t.toErrMsg());
         }
         }
     L1:
@@ -890,7 +890,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                             }
                             if (!found)
                             {
-                                error(ci.loc, "`.%s` is not a field of `%s`\n", id.toChars(), nstsd.toChars());
+                                error(ci.loc, "`.%s` is not a field of `%s`\n", id.toErrMsg(), nstsd.toErrMsg());
                                 return err();
                             }
 
@@ -966,7 +966,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                             continue Loop1;
                         }
                     }
-                    error(ci.loc, "`.%s` is not a field of `%s`\n", id.toChars(), sd.toChars());
+                    error(ci.loc, "`.%s` is not a field of `%s`\n", id.toErrMsg(), sd.toErrMsg());
                     return err();
                 }
 
@@ -1184,7 +1184,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             /* just convert _Complex = { a, b} to _Complex =. a + b*i */
             if (ci.initializerList[].length != 2)
             {
-                error(ci.loc, "only two initializers required for complex type `%s`", t.toChars());
+                error(ci.loc, "only two initializers required for complex type `%s`", t.toErrMsg());
                 return err();
             }
             auto rexp = ci.initializerList[0].initializer.initializerToExpression();
@@ -1199,7 +1199,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
         }
         else
         {
-            error(ci.loc, "unrecognized C initializer `%s` for type `%s`", toChars(ci), t.toChars());
+            error(ci.loc, "unrecognized C initializer `%s` for type `%s`", toChars(ci), t.toErrMsg());
             return err();
         }
     }
@@ -1307,9 +1307,9 @@ Initializer inferType(Initializer init, Scope* sc)
         {
             TemplateInstance ti = se.sds.isTemplateInstance();
             if (ti && ti.semanticRun == PASS.semantic && !ti.aliasdecl)
-                error(se.loc, "cannot infer type from %s `%s`, possible circular dependency", se.sds.kind(), se.toChars());
+                error(se.loc, "cannot infer type from %s `%s`, possible circular dependency", se.sds.kind(), se.toErrMsg());
             else
-                error(se.loc, "cannot infer type from %s `%s`", se.sds.kind(), se.toChars());
+                error(se.loc, "cannot infer type from %s `%s`", se.sds.kind(), se.toErrMsg());
             return new ErrorInitializer();
         }
 
@@ -1323,7 +1323,7 @@ Initializer inferType(Initializer init, Scope* sc)
             }
             if (hasOverloads && !f.isUnique())
             {
-                error(init.exp.loc, "cannot infer type from overloaded function symbol `%s`", init.exp.toChars());
+                error(init.exp.loc, "cannot infer type from overloaded function symbol `%s`", init.exp.toErrMsg());
                 return new ErrorInitializer();
             }
         }
@@ -1331,7 +1331,7 @@ Initializer inferType(Initializer init, Scope* sc)
         {
             if (ae.e1.op == EXP.overloadSet)
             {
-                error(init.exp.loc, "cannot infer type from overloaded function symbol `%s`", init.exp.toChars());
+                error(init.exp.loc, "cannot infer type from overloaded function symbol `%s`", init.exp.toErrMsg());
                 return new ErrorInitializer();
             }
         }
@@ -1716,9 +1716,9 @@ Expressions* resolveStructLiteralNamedArgs(StructDeclaration sd, Type t, Scope* 
             {
                 s = sd.search_correct(id);
                 if (s)
-                    error(nameLoc, "`%s` is not a member of `%s`, did you mean %s `%s`?", id.toChars(), sd.toChars(), s.kind(), s.toChars());
+                    error(nameLoc, "`%s` is not a member of `%s`, did you mean %s `%s`?", id.toErrMsg(), sd.toErrMsg(), s.kind(), s.toErrMsg());
                 else
-                    error(nameLoc, "`%s` is not a member of `%s`", id.toChars(), sd.toChars());
+                    error(nameLoc, "`%s` is not a member of `%s`", id.toErrMsg(), sd.toErrMsg());
                 return null;
             }
             s.checkDeprecated(iloc, sc);
@@ -1729,7 +1729,7 @@ Expressions* resolveStructLiteralNamedArgs(StructDeclaration sd, Type t, Scope* 
             {
                 if (fieldi >= nfields)
                 {
-                    error(iloc, "`%s.%s` is not a per-instance initializable field", sd.toChars(), s.toChars());
+                    error(iloc, "`%s.%s` is not a per-instance initializable field", sd.toErrMsg(), s.toErrMsg());
                     return null;
                 }
                 if (s == sd.fields[fieldi])
@@ -1738,25 +1738,25 @@ Expressions* resolveStructLiteralNamedArgs(StructDeclaration sd, Type t, Scope* 
         }
         if (nfields == 0)
         {
-            error(argLoc, "initializer provided for struct `%s` with no fields", sd.toChars());
+            error(argLoc, "initializer provided for struct `%s` with no fields", sd.toErrMsg());
             return null;
         }
         if (j >= nfields)
         {
-            error(argLoc, "too many initializers for `%s` with %d field%s", sd.toChars(),
+            error(argLoc, "too many initializers for `%s` with %d field%s", sd.toErrMsg(),
                 cast(int) nfields, nfields != 1 ? "s".ptr : "".ptr);
             return null;
         }
         if (fieldi >= nfields)
         {
-            error(argLoc, "trying to initialize past the last field `%s` of `%s`", sd.fields[nfields - 1].toChars(), sd.toChars());
+            error(argLoc, "trying to initialize past the last field `%s` of `%s`", sd.fields[nfields - 1].toErrMsg(), sd.toErrMsg());
             return null;
         }
 
         VarDeclaration vd = sd.fields[fieldi];
         if (elems[fieldi])
         {
-            error(argLoc, "duplicate initializer for field `%s`", vd.toChars());
+            error(argLoc, "duplicate initializer for field `%s`", vd.toErrMsg());
             errors = true;
             elems[fieldi] = ErrorExp.get(); // for better diagnostics on multiple errors
             ++fieldi;
@@ -1785,7 +1785,7 @@ Expressions* resolveStructLiteralNamedArgs(StructDeclaration sd, Type t, Scope* 
         {
             if (vd.isOverlappedWith(v2) && elems[k])
             {
-                error(elems[k].loc, "overlapping initialization for field `%s` and `%s`", v2.toChars(), vd.toChars());
+                error(elems[k].loc, "overlapping initialization for field `%s` and `%s`", v2.toErrMsg(), vd.toErrMsg());
                 enum errorMsg = "`struct` initializers that contain anonymous unions" ~
                     " must initialize only the first member of a `union`. All subsequent" ~
                     " non-overlapping fields are default initialized";

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -30,7 +30,7 @@ import dmd.dsymbolsem;
 import dmd.dtemplate;
 import dmd.expression;
 import dmd.expressionsem : canElideCopy, semanticTypeInfo;
-import dmd.errors : message;
+import dmd.errors;
 import dmd.errorsink;
 import dmd.func;
 import dmd.funcsem;
@@ -108,7 +108,7 @@ public Expression inlineCopy(Expression e, Scope* sc)
     const cost = inlineCostExpression(e);
     if (cost >= COST_MAX)
     {
-        sc.eSink.error(e.loc, "cannot inline default argument `%s`", e.toChars());
+        sc.eSink.error(e.loc, "cannot inline default argument `%s`", e.toErrMsg());
         return ErrorExp.get();
     }
     scope ids = new InlineDoState(sc.parent, null);
@@ -682,7 +682,7 @@ public:
         override void visit(ThisExp e)
         {
             //if (!ids.vthis)
-            //    e.error("no `this` when inlining `%s`", ids.parent.toChars());
+            //    e.error("no `this` when inlining `%s`", ids.parent.toErrMsg());
             if (!ids.vthis)
             {
                 result = e;

--- a/compiler/src/dmd/mangle/cpp.d
+++ b/compiler/src/dmd/mangle/cpp.d
@@ -500,7 +500,7 @@ private final class CppMangleVisitor : Visitor
             }
             else
             {
-                .error(ti.loc, "%s `%s` internal compiler error: C++ `%s` template value parameter is not supported", ti.kind, ti.toPrettyChars, tv.valType.toChars());
+                .error(ti.loc, "%s `%s` internal compiler error: C++ `%s` template value parameter is not supported", ti.kind, ti.toPrettyChars, tv.valType.toErrMsg());
                 errors = true;
                 return;
             }
@@ -540,13 +540,13 @@ private final class CppMangleVisitor : Visitor
             }
             else
             {
-                .error(ti.loc, "%s `%s` internal compiler error: C++ `%s` template alias parameter is not supported", ti.kind, ti.toPrettyChars, o.toChars());
+                .error(ti.loc, "%s `%s` internal compiler error: C++ `%s` template alias parameter is not supported", ti.kind, ti.toPrettyChars, o.toErrMsg());
                 errors = true;
             }
         }
         else if (tp.isTemplateThisParameter())
         {
-            .error(ti.loc, "%s `%s` internal compiler error: C++ `%s` template this parameter is not supported", ti.kind, ti.toPrettyChars, o.toChars());
+            .error(ti.loc, "%s `%s` internal compiler error: C++ `%s` template this parameter is not supported", ti.kind, ti.toPrettyChars, o.toErrMsg());
             errors = true;
         }
         else
@@ -595,7 +595,7 @@ private final class CppMangleVisitor : Visitor
                     Type t = isType((*ti.tiargs)[j]);
                     if (t is null)
                     {
-                        .error(ti.loc, "%s `%s` internal compiler error: C++ `%s` template value parameter is not supported", ti.kind, ti.toPrettyChars, (*ti.tiargs)[j].toChars());
+                        .error(ti.loc, "%s `%s` internal compiler error: C++ `%s` template value parameter is not supported", ti.kind, ti.toPrettyChars, (*ti.tiargs)[j].toErrMsg());
                         errors = true;
                         return false;
                     }
@@ -1369,7 +1369,7 @@ private final class CppMangleVisitor : Visitor
             {
                 // Static arrays in D are passed by value; no counterpart in C++
                 .error(loc, "internal compiler error: unable to pass static array `%s` to extern(C++) function, use pointer instead",
-                    t.toChars());
+                    t.toErrMsg());
                 errors = true;
                 return;
             }
@@ -1408,7 +1408,7 @@ private final class CppMangleVisitor : Visitor
             p = "`shared` ";
         else
             p = "";
-        .error(loc, "internal compiler error: %stype `%s` cannot be mapped to C++\n", p, t.toChars());
+        .error(loc, "internal compiler error: %stype `%s` cannot be mapped to C++\n", p, t.toErrMsg());
         errors = true; //Fatal, because this error should be handled in frontend
     }
 

--- a/compiler/src/dmd/mangle/cppwin.d
+++ b/compiler/src/dmd/mangle/cppwin.d
@@ -98,7 +98,7 @@ public:
         if (checkImmutableShared(type, loc))
             return;
 
-        eSink.error(loc, "internal compiler error: type `%s` cannot be mapped to C++\n", type.toChars());
+        eSink.error(loc, "internal compiler error: type `%s` cannot be mapped to C++\n", type.toErrMsg());
         errors = true;
     }
 
@@ -550,7 +550,7 @@ extern(D):
     {
         if (!tv.valType.isIntegral())
         {
-            eSink.error(sym.loc, "%s `%s` internal compiler error: C++ %s template value parameter is not supported", sym.kind, sym.toPrettyChars, tv.valType.toChars());
+            eSink.error(sym.loc, "%s `%s` internal compiler error: C++ %s template value parameter is not supported", sym.kind, sym.toPrettyChars, tv.valType.toErrMsg());
             errors = true;
             return;
         }
@@ -626,7 +626,7 @@ extern(D):
         }
         else
         {
-            eSink.error(sym.loc, "%s `%s` internal compiler error: `%s` is unsupported parameter for C++ template", sym.kind, sym.toPrettyChars, o.toChars());
+            eSink.error(sym.loc, "%s `%s` internal compiler error: `%s` is unsupported parameter for C++ template", sym.kind, sym.toPrettyChars, o.toErrMsg());
             errors = true;
         }
     }
@@ -765,7 +765,7 @@ extern(D):
                 if (t is null)
                 {
                     eSink.error(actualti.loc, "%s `%s` internal compiler error: C++ `%s` template value parameter is not supported",
-                        actualti.kind, actualti.toPrettyChars, o.toChars());
+                        actualti.kind, actualti.toPrettyChars, o.toErrMsg());
                     errors = true;
                     return;
                 }
@@ -823,7 +823,7 @@ extern(D):
     {
         if (type.isImmutable() || type.isShared())
         {
-            eSink.error(loc, "internal compiler error: `shared` or `immutable` types cannot be mapped to C++ (%s)", type.toChars());
+            eSink.error(loc, "internal compiler error: `shared` or `immutable` types cannot be mapped to C++ (%s)", type.toErrMsg());
             errors = true;
             return true;
         }

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -874,7 +874,7 @@ public:
                     }
                     if (!d.type || !d.type.deco)
                     {
-                        error(ti.loc, "%s `%s` forward reference of %s `%s`", ti.kind, ti.toPrettyChars, d.kind(), d.toChars());
+                        error(ti.loc, "%s `%s` forward reference of %s `%s`", ti.kind, ti.toPrettyChars, d.kind(), d.toErrMsg());
                         continue;
                     }
                 }
@@ -931,7 +931,7 @@ public:
     override void visit(Expression e)
     {
         if (!e.type.isTypeError())
-            error(e.loc, "expression `%s` is not a valid template value argument", e.toChars());
+            error(e.loc, "expression `%s` is not a valid template value argument", e.toErrMsg());
     }
 
     override void visit(IntegerExp e)

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -123,7 +123,7 @@ public:
         }
         if (sc.setGC(f, e.loc, msg))
         {
-            error(e.loc, "%s causes a GC allocation in `@nogc` %s `%s`", msg, f.kind(), f.toChars());
+            error(e.loc, "%s causes a GC allocation in `@nogc` %s `%s`", msg, f.kind(), f.toErrMsg());
             err = true;
             return true;
         }

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -2052,12 +2052,12 @@ void checkObErrors(ref ObState obstate)
 
                     if (pvsr.state == Undefined)
                     {
-                        .error(e.loc, "%s `%s` is reading from `%s` which is Undefined", v.kind, v.toPrettyChars, r.toChars());
+                        .error(e.loc, "%s `%s` is reading from `%s` which is Undefined", v.kind, v.toPrettyChars, r.toErrMsg());
                     }
                     else if (isBorrowedPtr(v))  // v is going to borrow from r
                     {
                         if (pvsr.state == Readonly)
-                            .error(e.loc, "%s `%s` is borrowing from `%s` which is Readonly", v.kind, v.toPrettyChars, r.toChars());
+                            .error(e.loc, "%s `%s` is borrowing from `%s` which is Readonly", v.kind, v.toPrettyChars, r.toErrMsg());
 
                         pvs.state = Borrowed;
                     }

--- a/compiler/src/dmd/objc.d
+++ b/compiler/src/dmd/objc.d
@@ -838,8 +838,8 @@ extern(C++) private final class Supported : Objc
         enum supplementalMessage = "`offsetof` is not available for members " ~
             "of Objective-C classes. Please use the Objective-C runtime instead";
 
-        error(expression.loc, errorMessage, expression.toChars(),
-            expression.type.toChars());
+        error(expression.loc, errorMessage, expression.toErrMsg(),
+            expression.type.toErrMsg());
         errorSupplemental(expression.loc, supplementalMessage);
     }
 
@@ -848,7 +848,7 @@ extern(C++) private final class Supported : Objc
         if (type.sym.classKind != ClassKind.objc)
             return;
 
-        error(expression.loc, "no property `tupleof` for type `%s`", type.toChars());
+        error(expression.loc, "no property `tupleof` for type `%s`", type.toErrMsg());
         errorSupplemental(expression.loc, "`tupleof` is not available for members " ~
             "of Objective-C classes. Please use the Objective-C runtime instead");
     }

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -292,7 +292,7 @@ Expression opOverloadUnary(UnaExp e, Scope* sc)
         // For ++ and --, rewrites to += and -= are also tried, so don't error yet
         if (!e.isPreExp())
         {
-            error(e.loc, "operator `%s` is not defined for `%s`", EXPtoString(e.op).ptr, ad.toChars());
+            error(e.loc, "operator `%s` is not defined for `%s`", EXPtoString(e.op).ptr, ad.toErrMsg());
             errorSupplemental(ad.loc, "perhaps overload the operator with `auto opUnary(string op : \"%s\")() {}`",
                 EXPtoString(e.op).ptr);
             return ErrorExp.get();
@@ -509,7 +509,7 @@ Expression binAliasThis(BinExp e, Scope* sc, Type[2] aliasThisStop)
     if (rewrittenLhs)
     {
         error(e.loc, "cannot use `alias this` to partially initialize variable `%s` of type `%s`. Use `%s`",
-                e.e1.toChars(), ad1.toChars(), rewrittenLhs.toChars());
+                e.e1.toErrMsg(), ad1.toErrMsg(), rewrittenLhs.toErrMsg());
         return ErrorExp.get();
     }
     return null;
@@ -555,14 +555,14 @@ Expression opOverloadBinary(BinExp e, Scope* sc, Type[2] aliasThisStop)
 
     if (s && !(s.isTemplateDeclaration() || s.isOverloadSet))
     {
-        error(e.e1.loc, "`%s.opBinary` isn't a template", e.e1.toChars());
+        error(e.e1.loc, "`%s.opBinary` isn't a template", e.e1.toErrMsg());
         return ErrorExp.get();
     }
 
     Dsymbol s_r = search_function(ad2, Id.opBinaryRight);
     if (s_r && !(s_r.isTemplateDeclaration() || s_r.isOverloadSet()))
     {
-        error(e.e2.loc, "`%s.opBinaryRight` isn't a template", e.e2.toChars());
+        error(e.e2.loc, "`%s.opBinaryRight` isn't a template", e.e2.toErrMsg());
         return ErrorExp.get();
     }
     if (s_r && s_r == s) // https://issues.dlang.org/show_bug.cgi?id=12778
@@ -634,7 +634,7 @@ bool suggestOpOpAssign(BinAssignExp exp, Scope* sc, Expression parent)
 
     if (parent && (parent.isPreExp() || parent.isPostExp()))
     {
-        error(exp.loc, "operator `%s` not supported for `%s` of type `%s`", EXPtoString(parent.op).ptr, exp.e1.toChars(), ad.toChars());
+        error(exp.loc, "operator `%s` not supported for `%s` of type `%s`", EXPtoString(parent.op).ptr, exp.e1.toErrMsg(), ad.toErrMsg());
         errorSupplemental(ad.loc,
             "perhaps implement `auto opUnary(string op : \"%s\")() {}`"~
             " or `auto opOpAssign(string op : \"%s\")(int) {}`",
@@ -651,7 +651,7 @@ bool suggestOpOpAssign(BinAssignExp exp, Scope* sc, Expression parent)
     }
     else
     {
-        error(exp.loc, "operator `%s` not supported for `%s` of type `%s`", EXPtoString(exp.op).ptr, exp.e1.toChars(), ad.toChars());
+        error(exp.loc, "operator `%s` not supported for `%s` of type `%s`", EXPtoString(exp.op).ptr, exp.e1.toErrMsg(), ad.toErrMsg());
         errorSupplemental(ad.loc, "perhaps implement `auto opOpAssign(string op : \"%s\")(%s) {}`",
             EXPtoString(stripAssignOp(exp.op)).ptr, exp.e2.type.toChars());
     }
@@ -1008,7 +1008,7 @@ Expression opOverloadBinaryAssign(BinAssignExp e, Scope* sc, Type[2] aliasThisSt
     Dsymbol s = search_function(ad1, Id.opOpAssign);
     if (s && !(s.isTemplateDeclaration() || s.isOverloadSet()))
     {
-        error(e.loc, "`%s.opOpAssign` isn't a template", e.e1.toChars());
+        error(e.loc, "`%s.opOpAssign` isn't a template", e.e1.toErrMsg());
         return ErrorExp.get();
     }
 
@@ -1080,7 +1080,7 @@ private Expression pickBestBinaryOverload(Scope* sc, Objects* tiargs, Dsymbol s,
         if (!(m.lastf == lastf && m.count == 2 && count == 1))
         {
             // Error, ambiguous
-            error(e.loc, "overloads `%s` and `%s` both match argument list for `%s`", m.lastf.type.toChars(), m.nextf.type.toChars(), m.lastf.toChars());
+            error(e.loc, "overloads `%s` and `%s` both match argument list for `%s`", m.lastf.type.toErrMsg(), m.nextf.type.toErrMsg(), m.lastf.toErrMsg());
         }
     }
     else if (m.last == MATCH.nomatch)
@@ -1527,7 +1527,7 @@ private FuncDeclaration findBestOpApplyMatch(Expression ethis, FuncDeclaration f
     if (fd_ambig)
     {
         .error(ethis.loc, "`%s.%s` matches more than one declaration:",
-            ethis.toChars(), fstart.ident.toChars());
+            ethis.toErrMsg(), fstart.ident.toErrMsg());
         .errorSupplemental(fd_best.loc, "`%s`\nand:", fd_best.type.toChars());
         .errorSupplemental(fd_ambig.loc, "`%s`", fd_ambig.type.toChars());
         return null;

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -466,7 +466,7 @@ Expression optimize(Expression e, int result, bool keepLvalue = false)
                     {
                         auto t = v.isThis();
                         assert(t);
-                        .error(e.loc, "taking the address of non-static variable `%s` requires an instance of `%s`", v.toChars(), t.toChars());
+                        .error(e.loc, "taking the address of non-static variable `%s` requires an instance of `%s`", v.toErrMsg(), t.toErrMsg());
                         ret = ErrorExp.get();
                         return;
                     }
@@ -1085,7 +1085,7 @@ Expression optimize(Expression e, int result, bool keepLvalue = false)
         // All negative integral powers are illegal.
         if (e.e1.type.isIntegral() && (e.e2.op == EXP.int64) && cast(sinteger_t)e.e2.toInteger() < 0)
         {
-            error(e.loc, "cannot raise `%s` to a negative integer power.", e.e1.type.toBasetype().toChars());
+            error(e.loc, "cannot raise `%s` to a negative integer power.", e.e1.type.toBasetype().toErrMsg());
             errorSupplemental(e.loc, "did you mean `(cast(real)%s)^^%s` ?", e.e1.toChars(), e.e2.toChars());
             return errorReturn();
         }

--- a/compiler/src/dmd/pragmasem.d
+++ b/compiler/src/dmd/pragmasem.d
@@ -208,7 +208,7 @@ void pragmaDeclSemantic(PragmaDeclaration pd, Scope* sc)
     }
     else if (!global.params.ignoreUnsupportedPragmas)
     {
-        error(pd.loc, "unrecognized `pragma(%s)`", pd.ident.toChars());
+        error(pd.loc, "unrecognized `pragma(%s)`", pd.ident.toErrMsg());
         return declarations();
     }
 
@@ -331,7 +331,7 @@ bool pragmaStmtSemantic(PragmaStatement ps, Scope* sc)
     }
     else if (!global.params.ignoreUnsupportedPragmas)
     {
-        error(ps.loc, "unrecognized `pragma(%s)`", ps.ident.toChars());
+        error(ps.loc, "unrecognized `pragma(%s)`", ps.ident.toErrMsg());
         return false;
     }
 
@@ -339,7 +339,7 @@ bool pragmaStmtSemantic(PragmaStatement ps, Scope* sc)
     {
         if (ps.ident == Id.msg || ps.ident == Id.startaddress)
         {
-            error(ps.loc, "`pragma(%s)` is missing a terminating `;`", ps.ident.toChars());
+            error(ps.loc, "`pragma(%s)` is missing a terminating `;`", ps.ident.toErrMsg());
             return false;
         }
         ps._body = ps._body.statementSemantic(sc);
@@ -378,7 +378,7 @@ package PINLINE evalPragmaInline(Loc loc, Scope* sc, Expressions* args)
         e = e.ctfeInterpret();
         e = e.toBoolean(sc);
         if (e.isErrorExp())
-            .error(loc, "pragma(`inline`, `true` or `false`) expected, not `%s`", (*args)[0].toChars());
+            .error(loc, "pragma(`inline`, `true` or `false`) expected, not `%s`", (*args)[0].toErrMsg());
         (*args)[0] = e;
     }
 
@@ -475,7 +475,7 @@ private bool pragmaStartAddressSemantic(Loc loc, Scope* sc, Expressions* args)
         Dsymbol sa = getDsymbol(e);
         if (!sa || !sa.isFuncDeclaration())
         {
-            .error(loc, "function name expected for start address, not `%s`", e.toChars());
+            .error(loc, "function name expected for start address, not `%s`", e.toErrMsg());
             return false;
         }
     }
@@ -571,14 +571,14 @@ private bool pragmaMangleSemantic(Loc loc, Scope* sc, Expressions* args, Dsymbol
                     bool expectedString()
                     {
                         error(e.loc, "`string` expected for pragma mangle argument, not `%s` of type `%s`",
-                              e.toChars(), e.type.toChars());
+                              e.toErrMsg(), e.type.toErrMsg());
                         return false;
                     }
 
                     bool expectedType()
                     {
                         error(e.loc, "`class` or `struct` type expected for pragma mangle argument, not `%s` of type `%s`",
-                              e.toChars(), e.type.toChars());
+                              e.toErrMsg(), e.type.toErrMsg());
                         return false;
                     }
 

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -488,7 +488,7 @@ bool setUnsafe(Scope* sc, bool gag, Loc loc, VarDeclaration scopeVar,
             if (sc.varDecl.storage_class & STC.safe)
             {
                 string action = AttributeViolation(loc, format, args).action;
-                .error(loc, "%.*s can't initialize `@safe` variable `%s`", action.fTuple.expand, sc.varDecl.toChars());
+                .error(loc, "%.*s can't initialize `@safe` variable `%s`", action.fTuple.expand, sc.varDecl.toErrMsg());
                 return true;
             }
             else if (!(sc.varDecl.storage_class & STC.trusted))

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -352,7 +352,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         {
             const uwidth = bfd.fieldWidth;
             error(ei.loc, "default initializer `%s` is not representable as bitfield type `%s:%lld`",
-                  ei.exp.toChars(), bfd.type.toBasetype().toChars(), cast(long)uwidth);
+                  ei.exp.toErrMsg(), bfd.type.toBasetype().toErrMsg(), cast(long)uwidth);
             if (isUnsigned)
                 errorSupplemental(bfd.loc, "bitfield `%s` default initializer must be a value between `%llu..%llu`",
                                   bfd.toChars(), bounds.imin.value, bounds.imax.value);
@@ -773,7 +773,7 @@ private void doGNUABITagSemantic(ref Expression e, ref Expression* lastTag)
     // When `@gnuAbiTag` is used, the type will be the UDA, not the struct literal
     if (e.op == EXP.type)
     {
-        error(e.loc, "`@%s` at least one argument expected", Id.udaGNUAbiTag.toChars());
+        error(e.loc, "`@%s` at least one argument expected", Id.udaGNUAbiTag.toErrMsg());
         return;
     }
 
@@ -791,7 +791,7 @@ private void doGNUABITagSemantic(ref Expression e, ref Expression* lastTag)
     auto ale = (*sle.elements)[0].isArrayLiteralExp();
     if (ale is null)
     {
-        error(e.loc, "`@%s` at least one argument expected", Id.udaGNUAbiTag.toChars());
+        error(e.loc, "`@%s` at least one argument expected", Id.udaGNUAbiTag.toErrMsg());
         return;
     }
 
@@ -800,7 +800,7 @@ private void doGNUABITagSemantic(ref Expression e, ref Expression* lastTag)
     {
         const str1 = (*lastTag.isStructLiteralExp().elements)[0].toString();
         const str2 = ale.toString();
-        error(e.loc, "only one `@%s` allowed per symbol", Id.udaGNUAbiTag.toChars());
+        error(e.loc, "only one `@%s` allowed per symbol", Id.udaGNUAbiTag.toErrMsg());
         errorSupplemental(e.loc, "instead of `@%s @%s`, use `@%s(%.*s, %.*s)`",
             lastTag.toChars(), e.toChars(), Id.udaGNUAbiTag.toChars(),
             // Avoid [ ... ]
@@ -818,7 +818,7 @@ private void doGNUABITagSemantic(ref Expression e, ref Expression* lastTag)
         if (!str.length)
         {
             error(e.loc, "argument `%d` to `@%s` cannot be %s", cast(int)(idx + 1),
-                    Id.udaGNUAbiTag.toChars(),
+                    Id.udaGNUAbiTag.toErrMsg(),
                     elem.isNullExp() ? "`null`".ptr : "empty".ptr);
             continue;
         }
@@ -828,7 +828,7 @@ private void doGNUABITagSemantic(ref Expression e, ref Expression* lastTag)
             if (!c.isValidMangling())
             {
                 error(e.loc, "`@%s` char `0x%02x` not allowed in mangling",
-                        Id.udaGNUAbiTag.toChars(), c);
+                        Id.udaGNUAbiTag.toErrMsg(), c);
                 break;
             }
         }
@@ -1075,7 +1075,7 @@ void staticAssertFail(StaticAssert sa, Scope* sc)
         error(sa.loc, "static assert:  %s", msgbuf.extractChars());
     }
     else
-        error(sa.loc, "static assert:  `%s` is false", sa.exp.toChars());
+        error(sa.loc, "static assert:  `%s` is false", sa.exp.toErrMsg());
     if (sc.tinst)
         sc.tinst.printInstantiationTrace();
     if (!global.gag)

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -492,7 +492,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     v.dsymbolSemantic(sc2);
                     if (!sc2.insert(v))
                     {
-                        .error(funcdecl.loc, "%s `%s` parameter `%s.%s` is already defined", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toChars(), v.toChars());
+                        .error(funcdecl.loc, "%s `%s` parameter `%s.%s` is already defined", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toErrMsg(), v.toErrMsg());
                         funcdecl.errors = true;
                     }
                     else
@@ -532,7 +532,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 //printf("declaring tuple %s\n", v.toChars());
                 v.isexp = true;
                 if (!sc2.insert(v))
-                    .error(funcdecl.loc, "%s `%s` parameter `%s.%s` is already defined", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toChars(), v.toChars());
+                    .error(funcdecl.loc, "%s `%s` parameter `%s.%s` is already defined", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toErrMsg(), v.toErrMsg());
                 funcdecl.localsymtab.insert(v);
                 v.parent = funcdecl;
             }
@@ -694,18 +694,18 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                  *    as delegating calls to other constructors
                                  */
                                 if (v.isCtorinit() && !v.type.isMutable() && cd)
-                                    .error(funcdecl.loc, "%s `%s` missing initializer for %s field `%s`", funcdecl.kind, funcdecl.toPrettyChars, MODtoChars(v.type.mod), v.toChars());
+                                    .error(funcdecl.loc, "%s `%s` missing initializer for %s field `%s`", funcdecl.kind, funcdecl.toPrettyChars, MODtoChars(v.type.mod), v.toErrMsg());
                                 else if (v.storage_class & STC.nodefaultctor)
-                                    error(funcdecl.loc, "field `%s` must be initialized in constructor", v.toChars());
+                                    error(funcdecl.loc, "field `%s` must be initialized in constructor", v.toErrMsg());
                                 else if (v.type.needsNested())
-                                    error(funcdecl.loc, "field `%s` must be initialized in constructor, because it is nested struct", v.toChars());
+                                    error(funcdecl.loc, "field `%s` must be initialized in constructor, because it is nested struct", v.toErrMsg());
                             }
                             else
                             {
                                 bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
                                 if (mustInit && !(sc2.ctorflow.fieldinit[i].csx & CSX.this_ctor))
                                 {
-                                    .error(funcdecl.loc, "%s `%s` field `%s` must be initialized but skipped", funcdecl.kind, funcdecl.toPrettyChars, v.toChars());
+                                    .error(funcdecl.loc, "%s `%s` field `%s` must be initialized but skipped", funcdecl.kind, funcdecl.toPrettyChars, v.toErrMsg());
                                 }
                             }
                         }
@@ -811,7 +811,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     // Fallthrough despite being declared as noreturn? return is already rejected when evaluating the ReturnStatement
                     if (blockexit & BE.fallthru)
                     {
-                        .error(funcdecl.loc, "%s `%s` is typed as `%s` but does return", funcdecl.kind, funcdecl.toPrettyChars, f.next.toChars());
+                        .error(funcdecl.loc, "%s `%s` is typed as `%s` but does return", funcdecl.kind, funcdecl.toPrettyChars, f.next.toErrMsg());
                         funcdecl.loc.errorSupplemental("`noreturn` functions must either throw, abort or loop indefinitely");
                     }
                 }
@@ -820,7 +820,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if ((blockexit & BE.fallthru) && f.next.ty != Tvoid && !funcdecl.hasInlineAsm && !sc.inCfile)
                     {
                         if (!funcdecl.hasReturnExp)
-                            .error(funcdecl.loc, "%s `%s` has no `return` statement, but is expected to return a value of type `%s`", funcdecl.kind, funcdecl.toPrettyChars, f.next.toChars());
+                            .error(funcdecl.loc, "%s `%s` has no `return` statement, but is expected to return a value of type `%s`", funcdecl.kind, funcdecl.toPrettyChars, f.next.toErrMsg());
                         else
                             .error(funcdecl.loc, "%s `%s` no `return exp;` or `assert(0);` at end of function", funcdecl.kind, funcdecl.toPrettyChars);
                     }
@@ -911,7 +911,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         {
                             if (!MODimplicitConv(exp.type.mod, tret.mod) && !tret.isTypeSArray())
                                 error(exp.loc, "expression `%s` of type `%s` is not implicitly convertible to return type `ref %s`",
-                                      exp.toChars(), exp.type.toChars(), tret.toChars());
+                                      exp.toErrMsg(), exp.type.toErrMsg(), tret.toErrMsg());
                             else
                                 exp = exp.implicitCastTo(sc2, tret);
 
@@ -1269,7 +1269,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                     else
                     {
-                        .error(funcdecl.loc, "%s `%s` synchronized function `%s` must be a member of a class", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toChars());
+                        .error(funcdecl.loc, "%s `%s` synchronized function `%s` must be a member of a class", funcdecl.kind, funcdecl.toPrettyChars, funcdecl.toErrMsg());
                     }
                 }
 
@@ -1286,7 +1286,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     LabelDsymbol label = cast(LabelDsymbol)keyValue.value;
                     if (!label.statement && (!label.deleted || label.iasm))
                     {
-                        .error(label.loc, "%s `%s` label `%s` is undefined", funcdecl.kind, funcdecl.toPrettyChars, label.toChars());
+                        .error(label.loc, "%s `%s` label `%s` is undefined", funcdecl.kind, funcdecl.toPrettyChars, label.toErrMsg());
                     }
                 }
 
@@ -1406,7 +1406,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             }
             if (isCppNonMappableType(f.next.toBasetype()) && !funcdecl.skipCodegen)
             {
-                .error(funcdecl.loc, "%s `%s` cannot return type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toErrMsg(), f.next.toChars());
+                .error(funcdecl.loc, "%s `%s` cannot return type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toErrMsg(), f.next.toErrMsg());
                 if (f.next.isTypeDArray())
                     errorSupplemental(funcdecl.loc, "slices are specific to D and do not have a counterpart representation in C++", f.next.toChars());
                 funcdecl.errors = true;
@@ -1415,7 +1415,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             {
                 if (isCppNonMappableType(param.type.toBasetype(), param))
                 {
-                    .error(funcdecl.loc, "%s `%s` cannot have parameter of type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toErrMsg(), param.type.toChars());
+                    .error(funcdecl.loc, "%s `%s` cannot have parameter of type `%s` because its linkage is `extern(C++)`", funcdecl.kind, funcdecl.toErrMsg(), param.type.toErrMsg());
                     if (param.type.toBasetype().isTypeSArray())
                         errorSupplemental(funcdecl.loc, "perhaps use a `%s*` type instead",
                                           param.type.nextOf().mutableOf().unSharedOf().toChars());
@@ -1640,7 +1640,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         void notTemplateFunction(Loc loc, Identifier id)
         {
-            error(loc, "`%s` isn't a template function", id.toChars());
+            error(loc, "`%s` isn't a template function", id.toErrMsg());
         }
 
         // generate ti.entry
@@ -1876,13 +1876,13 @@ extern (D) bool checkClosure(FuncDeclaration fd)
 
     if (setGC(null, fd, fd.loc, "allocating a closure for `%s()`", fd))
     {
-        .error(fd.loc, "%s `%s` is `@nogc` yet allocates closure for `%s()` with the GC", fd.kind, fd.toPrettyChars(), fd.toChars());
+        .error(fd.loc, "%s `%s` is `@nogc` yet allocates closure for `%s()` with the GC", fd.kind, fd.toPrettyChars(), fd.toErrMsg());
         if (global.gag)     // need not report supplemental errors
             return true;
     }
     else if (!global.params.useGC)
     {
-        .error(fd.loc, "%s `%s` is `-betterC` yet allocates closure for `%s()` with the GC", fd.kind, fd.toPrettyChars(), fd.toChars());
+        .error(fd.loc, "%s `%s` is `-betterC` yet allocates closure for `%s()` with the GC", fd.kind, fd.toPrettyChars(), fd.toErrMsg());
         if (global.gag)     // need not report supplemental errors
             return true;
     }

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -754,7 +754,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             {
                 if (!p.type)
                 {
-                    error(fs.loc, "cannot infer type for `foreach` variable `%s`, perhaps set it explicitly", p.ident.toChars());
+                    error(fs.loc, "cannot infer type for `foreach` variable `%s`, perhaps set it explicitly", p.ident.toErrMsg());
                     p.type = Type.terror;
                     result = true;
                 }
@@ -804,7 +804,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             assert(oaggr.type);
 
             error(fs.loc, "invalid `%s` aggregate `%s` of type `%s`",
-                Token.toChars(fs.op), oaggr.toChars(), oaggr.type.toPrettyChars());
+                Token.toChars(fs.op), oaggr.toErrMsg(), oaggr.type.toPrettyChars());
 
             if (auto ad = isAggregate(fs.aggr.type))
             {
@@ -860,7 +860,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                                 error(fs.aggr.loc, "%s method `%s` is not callable using a `%s` foreach aggregate",
                                     !fd.type.mod ? "mutable" : fd.type.modToChars(),
                                     fd.toPrettyChars(),
-                                    fs.aggr.type.toChars());
+                                    fs.aggr.type.toErrMsg());
                                 errorSupplemental(fd.loc, "Consider adding a method type qualifier here");
                                 return setError();
                             }
@@ -1036,7 +1036,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     Type tindex = (*fs.parameters)[0].type;
                     if (!tindex.isIntegral())
                     {
-                        error(fs.loc, "foreach: index cannot be of non-integral type `%s`", tindex.toChars());
+                        error(fs.loc, "foreach: index cannot be of non-integral type `%s`", tindex.toErrMsg());
                         return retError();
                     }
                     /* What cases to deprecate implicit conversions for:
@@ -1060,7 +1060,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                         }
                         if (err)
                             deprecation(fs.loc, "foreach: loop index implicitly converted from `size_t` to `%s`",
-                                       tindex.toChars());
+                                       tindex.toErrMsg());
                     }
                 }
 
@@ -1106,7 +1106,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                         if (fs.key.type.constConv(p.type) == MATCH.nomatch)
                         {
                             error(fs.loc, "key type mismatch, `%s` to `ref %s`",
-                                     fs.key.type.toChars(), p.type.toChars());
+                                     fs.key.type.toErrMsg(), p.type.toErrMsg());
                             return retError();
                         }
                     }
@@ -1118,7 +1118,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                         if (!intRangeFromType(fs.key.type).contains(dimrange))
                         {
                             error(fs.loc, "index type `%s` cannot cover index range 0..%llu",
-                                     p.type.toChars(), ta.dim.toInteger());
+                                     p.type.toErrMsg(), ta.dim.toInteger());
                             return retError();
                         }
                         fs.key.range = new IntRange(SignExtendedNumber(0), dimrange.imax);
@@ -1141,7 +1141,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                         if (t.constConv(p.type) == MATCH.nomatch)
                         {
                             error(fs.loc, "argument type mismatch, `%s` to `ref %s`",
-                                     t.toChars(), p.type.toChars());
+                                     t.toErrMsg(), p.type.toErrMsg());
                             return retError();
                         }
                     }
@@ -1377,7 +1377,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 }
                 if (tfront.ty == Tvoid)
                 {
-                    error(fs.loc, "`%s.front` is `void` and has no value", oaggr.toChars());
+                    error(fs.loc, "`%s.front` is `void` and has no value", oaggr.toErrMsg());
                     return retError();
                 }
 
@@ -1440,7 +1440,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                         if (!exp.implicitConvTo(p.type))
                         {
                             error(fs.loc, "cannot implicitly convert tuple element of type `%s` to variable `%s` of type `%s`",
-                                exp.type.toChars(), p.toChars(), p.type.toChars());
+                                exp.type.toErrMsg(), p.toChars(), p.type.toErrMsg());
                             return retError();
                         }
 
@@ -1472,7 +1472,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         case Terror:
             return retError();
         default:
-            error(fs.loc, "`foreach`: `%s` is not an aggregate type", fs.aggr.type.toChars());
+            error(fs.loc, "`foreach`: `%s` is not an aggregate type", fs.aggr.type.toErrMsg());
             return retError();
         }
     }
@@ -1499,7 +1499,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         fs.lwr = fs.lwr.optimize(WANTvalue);
         if (!fs.lwr.type)
         {
-            error(fs.loc, "invalid range lower bound `%s`", fs.lwr.toChars());
+            error(fs.loc, "invalid range lower bound `%s`", fs.lwr.toErrMsg());
             return setError();
         }
 
@@ -1508,7 +1508,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         fs.upr = fs.upr.optimize(WANTvalue);
         if (!fs.upr.type)
         {
-            error(fs.loc, "invalid range upper bound `%s`", fs.upr.toChars());
+            error(fs.loc, "invalid range upper bound `%s`", fs.upr.toErrMsg());
             return setError();
         }
 
@@ -1662,7 +1662,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         {
             if (fs.key.type.constConv(fs.param.type) == MATCH.nomatch)
             {
-                error(fs.loc, "argument type mismatch, `%s` to `ref %s`", fs.key.type.toChars(), fs.param.type.toChars());
+                error(fs.loc, "argument type mismatch, `%s` to `ref %s`", fs.key.type.toErrMsg(), fs.param.type.toErrMsg());
                 return setError();
             }
         }
@@ -1922,7 +1922,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             if (!ss.condition.isErrorExp())
             {
                 error(ss.loc, "`%s` must be of integral or string type, it is a `%s`",
-                    ss.condition.toChars(), ss.condition.type.toChars());
+                    ss.condition.toErrMsg(), ss.condition.type.toErrMsg());
                 conditionError = true;
                 break;
             }
@@ -1991,7 +1991,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     }
                 }
             }
-            error(gcs.loc, "`case %s` not found", gcs.exp.toChars());
+            error(gcs.loc, "`case %s` not found", gcs.exp.toErrMsg());
             sc.pop();
             return setError();
         }
@@ -2010,7 +2010,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             // Check if enum semantic analysis is not yet complete
             if (ed && ed.semanticRun < PASS.semantic2done)
             {
-                error(ss.loc, "cannot use `final switch` on enum `%s` while it is being defined", ed.toChars());
+                error(ss.loc, "cannot use `final switch` on enum `%s` while it is being defined", ed.toErrMsg());
                 sc.pop();
                 return setError();
             }
@@ -2269,7 +2269,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                         if (!scx.search(cs.exp.loc, v.ident, pscopesym))
                         {
                             error(cs.loc, "`case` variable `%s` declared at %s cannot be declared in `switch` body",
-                                v.toChars(), v.loc.toChars());
+                                v.toErrMsg(), v.loc.toChars());
                             errors = true;
                         }
                         break;
@@ -2284,7 +2284,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 cs.exp = se;
             else if (!cs.exp.isIntegerExp() && !cs.exp.isErrorExp())
             {
-                error(cs.loc, "`case` expression must be a compile-time `string` or an integral constant, not `%s`", cs.exp.toChars());
+                error(cs.loc, "`case` expression must be a compile-time `string` or an integral constant, not `%s`", cs.exp.toErrMsg());
                 errors = true;
             }
 
@@ -2297,7 +2297,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 auto box = CaseExpressionBox(cs.exp);
                 if (box in seen)
                 {
-                    error(cs.loc, "duplicate `case %s` in `switch` statement", initialExp.toChars());
+                    error(cs.loc, "duplicate `case %s` in `switch` statement", initialExp.toErrMsg());
                     errors = true;
                 }
                 else
@@ -2392,7 +2392,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         uinteger_t lval = crs.last.toInteger();
         if ((crs.first.type.isUnsigned() && fval > lval) || (!crs.first.type.isUnsigned() && cast(sinteger_t)fval > cast(sinteger_t)lval))
         {
-            error(crs.loc, "first `case %s` is greater than last `case %s`", crs.first.toChars(), crs.last.toChars());
+            error(crs.loc, "first `case %s` is greater than last `case %s`", crs.first.toErrMsg(), crs.last.toErrMsg());
             errors = true;
             lval = fval;
         }
@@ -2753,8 +2753,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     else if (!rs.exp.isErrorExp())
                     {
                         error(rs.loc, "expected return type of `%s`, not `%s`:",
-                                 tret.toChars(),
-                                 rs.exp.type.toChars());
+                                 tret.toErrMsg(),
+                                 rs.exp.type.toErrMsg());
                         errorSupplemental((fd.returns) ? (*fd.returns)[0].loc : fd.loc,
                                           "Return type of `%s` inferred here.",
                                           tret.toChars());
@@ -2841,7 +2841,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 {
                     if (!tf.next.isTypeError())
                     {
-                        error(rs.loc, "mismatched function return type inference of `void` and `%s`", tf.next.toChars());
+                        error(rs.loc, "mismatched function return type inference of `void` and `%s`", tf.next.toErrMsg());
                     }
                     errors = true;
                     tf.next = Type.terror;
@@ -2860,7 +2860,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 if (!tbret.isTypeError())
                 {
                     if (e0)
-                        error(rs.loc, "expected return type of `%s`, not `%s`", tret.toChars(), resType.toChars());
+                        error(rs.loc, "expected return type of `%s`, not `%s`", tret.toErrMsg(), resType.toErrMsg());
                     else if (tbret.isTypeNoreturn())
                     {
                         error(rs.loc, "cannot return from `noreturn` function");
@@ -2895,7 +2895,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
                 if (mustInit && !(sc.ctorflow.fieldinit[i].csx & CSX.this_ctor))
                 {
-                    error(rs.loc, "an earlier `return` statement skips field `%s` initialization", v.toChars());
+                    error(rs.loc, "an earlier `return` statement skips field `%s` initialization", v.toErrMsg());
                     errors = true;
                 }
             }
@@ -3009,7 +3009,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 {
                     Statement s = ls.statement;
                     if (!s || !s.hasBreak())
-                        error(bs.loc, "label `%s` has no `break`", bs.ident.toChars());
+                        error(bs.loc, "label `%s` has no `break`", bs.ident.toErrMsg());
                     else if (ls.tf != sc.tryFinally)
                         error(bs.loc, "cannot break out of `finally` block");
                     else
@@ -3021,7 +3021,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     return setError();
                 }
             }
-            error(bs.loc, "enclosing label `%s` for `break` not found", bs.ident.toChars());
+            error(bs.loc, "enclosing label `%s` for `break` not found", bs.ident.toErrMsg());
             return setError();
         }
         else if (!sc.sbreak)
@@ -3097,7 +3097,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 {
                     Statement s = ls.statement;
                     if (!s || !s.hasContinue())
-                        error(cs.loc, "label `%s` has no `continue`", cs.ident.toChars());
+                        error(cs.loc, "label `%s` has no `continue`", cs.ident.toErrMsg());
                     else if (ls.tf != sc.tryFinally)
                         error(cs.loc, "cannot continue out of `finally` block");
                     else
@@ -3108,7 +3108,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     return setError();
                 }
             }
-            error(cs.loc, "enclosing label `%s` for `continue` not found", cs.ident.toChars());
+            error(cs.loc, "enclosing label `%s` for `continue` not found", cs.ident.toErrMsg());
             return setError();
         }
         else if (!sc.scontinue)
@@ -3155,7 +3155,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             ClassDeclaration cd = ss.exp.type.isClassHandle();
             if (!cd)
             {
-                error(ss.loc, "can only `synchronize` on class objects, not `%s`", ss.exp.type.toChars());
+                error(ss.loc, "can only `synchronize` on class objects, not `%s`", ss.exp.type.toErrMsg());
                 return setError();
             }
             else if (cd.isInterfaceDeclaration())
@@ -3179,7 +3179,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             if (!cd.hasMonitor())
             {
                 error(ss.loc, "cannot `synchronize` on a `%s` because `object.Object` has no `__monitor` field",
-                      cd.toChars());
+                      cd.toErrMsg());
                 return setError();
             }
             version (all)
@@ -3283,7 +3283,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             Dsymbol s = et.type.toDsymbol(sc);
             if (!s || !s.isScopeDsymbol())
             {
-                error(ws.loc, "`with` type `%s` has no members", ws.exp.toChars());
+                error(ws.loc, "`with` type `%s` has no members", ws.exp.toErrMsg());
                 return setError();
             }
             sym = new WithScopeSymbol(ws);
@@ -3384,7 +3384,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             }
             else
             {
-                error(ws.loc, "`with` expression types must be enums or aggregates or pointers to them, not `%s`", olde.type.toChars());
+                error(ws.loc, "`with` expression types must be enums or aggregates or pointers to them, not `%s`", olde.type.toErrMsg());
                 return setError();
             }
         }
@@ -3692,12 +3692,12 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             if (ls.loc == ls2.loc)
             {
                 ls2.duplicated = true;
-                error(ls.loc, "label `%s` is duplicated", ls2.toChars());
+                error(ls.loc, "label `%s` is duplicated", ls2.toErrMsg());
                 .errorSupplemental(ls2.loc, "labels cannot be used in a static foreach with more than 1 iteration");
             }
             else
             {
-                error(ls.loc, "label `%s` is already defined", ls2.toChars());
+                error(ls.loc, "label `%s` is already defined", ls2.toErrMsg());
                 .errorSupplemental(ls2.loc, "first definition is here");
             }
             return setError();
@@ -3862,7 +3862,7 @@ public bool throwSemantic(Loc loc, ref Expression exp, Scope* sc)
     {
         // @@@DEPRECATED_2.112@@@
         // Deprecated in 2.102, change into an error & return false in 2.112
-        exp.loc.deprecation("cannot throw object of qualified type `%s`", exp.type.toChars());
+        exp.loc.deprecation("cannot throw object of qualified type `%s`", exp.type.toErrMsg());
         //return false;
     }
     checkThrowEscape(*sc, exp, false);
@@ -3870,7 +3870,7 @@ public bool throwSemantic(Loc loc, ref Expression exp, Scope* sc)
     ClassDeclaration cd = exp.type.toBasetype().isClassHandle();
     if (!cd || ((cd != ClassDeclaration.throwable) && !ClassDeclaration.throwable.isBaseOf(cd, null)))
     {
-        loc.error("can only throw class objects derived from `Throwable`, not type `%s`", exp.type.toChars());
+        loc.error("can only throw class objects derived from `Throwable`, not type `%s`", exp.type.toErrMsg());
         return false;
     }
     return true;
@@ -3905,7 +3905,7 @@ private extern(D) Expression applyOpApply(ForeachStatement fs, Expression flde,
         return null;
     if (ec.type != Type.tint32)
     {
-        error(fs.loc, "`opApply()` function for `%s` must return an `int`", tab.toChars());
+        error(fs.loc, "`opApply()` function for `%s` must return an `int`", tab.toErrMsg());
         return null;
     }
     return ec;
@@ -3931,7 +3931,7 @@ private extern(D) Expression applyDelegate(ForeachStatement fs, Expression flde,
         return null;
     if (ec.type != Type.tint32)
     {
-        error(fs.loc, "`opApply()` function for `%s` must return an `int`", tab.toChars());
+        error(fs.loc, "`opApply()` function for `%s` must return an `int`", tab.toErrMsg());
         return null;
     }
     return ec;
@@ -4016,7 +4016,7 @@ private extern(D) Expression applyAssocArray(ForeachStatement fs, Expression fld
         if (isRef ? !ti.constConv(ta) : !ti.implicitConvTo(ta))
         {
             error(fs.loc, "`foreach`: index parameter `%s%s` must be type `%s`, not `%s`",
-                 isRef ? "ref ".ptr : "".ptr, p.toChars(), ti.toChars(), ta.toChars());
+                 isRef ? "ref ".ptr : "".ptr, p.toChars(), ti.toErrMsg(), ta.toErrMsg());
             return null;
         }
         p = (*fs.parameters)[1];
@@ -4027,7 +4027,7 @@ private extern(D) Expression applyAssocArray(ForeachStatement fs, Expression fld
     if (isRef ? !taav.constConv(ta) : !taav.implicitConvTo(ta))
     {
         error(fs.loc, "`foreach`: value parameter `%s%s` must be type `%s`, not `%s`",
-            isRef ? "ref ".ptr : "".ptr, p.toChars(), taav.toChars(), ta.toChars());
+            isRef ? "ref ".ptr : "".ptr, p.toChars(), taav.toErrMsg(), ta.toErrMsg());
         return null;
     }
 
@@ -4113,7 +4113,7 @@ private FuncExp foreachBodyToFunction(Scope* sc, ForeachStatement fs, TypeFuncti
             {
                 if (!(param.storageClass & STC.ref_))
                 {
-                    error(fs.loc, "`foreach`: cannot make `%s` `ref`", p.ident.toChars());
+                    error(fs.loc, "`foreach`: cannot make `%s` `ref`", p.ident.toErrMsg());
                     return null;
                 }
                 goto LcopyArg;
@@ -4215,7 +4215,7 @@ void catchSemantic(Catch c, Scope* sc)
     {
         // @@@DEPRECATED_2.115@@@
         // Deprecated in 2.105, change into an error & uncomment assign in 2.115
-        deprecation(c.loc, "can only catch mutable or const qualified types, not `%s`", c.type.toChars());
+        deprecation(c.loc, "can only catch mutable or const qualified types, not `%s`", c.type.toErrMsg());
         //c.errors = true;
     }
     c.type = c.type.typeSemantic(c.loc, sc);
@@ -4230,7 +4230,7 @@ void catchSemantic(Catch c, Scope* sc)
     auto cd = c.type.toBasetype().isClassHandle();
     if (!cd)
     {
-        error(c.loc, "can only catch class objects, not `%s`", c.type.toChars());
+        error(c.loc, "can only catch class objects, not `%s`", c.type.toErrMsg());
         c.errors = true;
     }
     else if (cd.isCPPclass())
@@ -4248,7 +4248,7 @@ void catchSemantic(Catch c, Scope* sc)
     }
     else if (cd != ClassDeclaration.throwable && !ClassDeclaration.throwable.isBaseOf(cd, null))
     {
-        error(c.loc, "can only catch class objects derived from `Throwable`, not `%s`", c.type.toChars());
+        error(c.loc, "can only catch class objects derived from `Throwable`, not `%s`", c.type.toErrMsg());
         c.errors = true;
     }
     else if (!c.internalCatch && ClassDeclaration.exception &&
@@ -4523,7 +4523,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
             if (p.isReference() || p.isLazy())
             {
                 error(fs.loc, "invalid storage class `%s` for index `%s`",
-                    stcToString(p.storageClass).ptr, p.ident.toChars());
+                    stcToString(p.storageClass).ptr, p.ident.toErrMsg());
                 return returnEarly();
             }
 
@@ -4539,7 +4539,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
             if (!p.type.isIntegral())
             {
                 error(fs.loc, "foreach: index cannot be of non-integral type `%s`",
-                         p.type.toChars());
+                         p.type.toErrMsg());
                 return returnEarly();
             }
 
@@ -4550,7 +4550,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
             if (!intRangeFromType(p.type).contains(dimrange))
             {
                 error(fs.loc, "index type `%s` cannot cover index range 0..%llu",
-                         p.type.toChars(), cast(ulong)length);
+                         p.type.toErrMsg(), cast(ulong)length);
                 return returnEarly();
             }
             Initializer ie = new ExpInitializer(Loc.initial, new IntegerExp(k));
@@ -4584,7 +4584,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
                 storageClass & STC.ref_ && !te)
             {
                 error(fs.loc, "invalid storage class `%s` for element `%s`",
-                    stcToString(p.storageClass).ptr, ident.toChars());
+                    stcToString(p.storageClass).ptr, ident.toErrMsg());
                 return false;
             }
             Declaration var;
@@ -4621,12 +4621,12 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
                     var = new AliasDeclaration(loc, ident, ds);
                     if (storageClass & STC.ref_)
                     {
-                        error(fs.loc, "symbol `%s` cannot be `ref`", ds.toChars());
+                        error(fs.loc, "symbol `%s` cannot be `ref`", ds.toErrMsg());
                         return false;
                     }
                     if (paramtype)
                     {
-                        error(fs.loc, "cannot specify element type for symbol `%s`", ds.toChars());
+                        error(fs.loc, "cannot specify element type for symbol `%s`", ds.toErrMsg());
                         return false;
                     }
                 }
@@ -4635,7 +4635,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
                     var = new AliasDeclaration(loc, ident, e.type);
                     if (paramtype)
                     {
-                        error(fs.loc, "cannot specify element type for type `%s`", e.type.toChars());
+                        error(fs.loc, "cannot specify element type for type `%s`", e.type.toErrMsg());
                         return false;
                     }
                 }
@@ -4666,7 +4666,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
                                 }
                                 else
                                 {
-                                    error(fs.loc, "constant value `%s` cannot be `ref`", ident.toChars());
+                                    error(fs.loc, "constant value `%s` cannot be `ref`", ident.toErrMsg());
                                 }
                             }
                             return false;
@@ -4682,13 +4682,13 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
                 var = new AliasDeclaration(loc, ident, t);
                 if (paramtype)
                 {
-                    error(fs.loc, "cannot specify element type for symbol `%s`", ident.toChars());
+                    error(fs.loc, "cannot specify element type for symbol `%s`", ident.toErrMsg());
                     return false;
                 }
                 if (storageClass & STC.manifest)
                 {
                     error(fs.loc, "invalid storage class `enum` for element `%s`",
-                        ident.toChars());
+                        ident.toErrMsg());
                     return false;
                 }
             }
@@ -5049,7 +5049,7 @@ private Statement toStatement(Dsymbol s)
     }
     else
     {
-        .error(Loc.initial, "internal compiler error: cannot mixin %s `%s`\n", s.kind(), s.toChars());
+        .error(Loc.initial, "internal compiler error: cannot mixin %s `%s`\n", s.kind(), s.toErrMsg());
         result = new ErrorStatement();
     }
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -804,7 +804,7 @@ void templateDeclarationSemantic(Scope* sc, TemplateDeclaration tempdecl)
         TemplateParameter tp = (*tempdecl.parameters)[i];
         if (!tp.declareParameter(paramscope))
         {
-            error(tp.loc, "parameter `%s` multiply defined", tp.ident.toChars());
+            error(tp.loc, "parameter `%s` multiply defined", tp.ident.toErrMsg());
             tempdecl.errors = true;
         }
         if (!tp.tpsemantic(paramscope, tempdecl.parameters))
@@ -1219,7 +1219,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     if (tempdecl.semanticRun == PASS.initial)
     {
         .error(tempinst.loc, "%s `%s` template instantiation `%s` forward references template declaration `%s`",
-           tempinst.kind, tempinst.toPrettyChars, tempinst.toChars(), tempdecl.toChars());
+           tempinst.kind, tempinst.toPrettyChars, tempinst.toErrMsg(), tempdecl.toErrMsg());
         return;
     }
 
@@ -1648,8 +1648,8 @@ private bool hasNestedArgs(TemplateInstance _this, Objects* args, bool isstatic)
         if (search(dparent, _this.enclosing))
         {
             .error(_this.loc, "%s `%s` `%s` is nested in both `%s` and `%s`",
-                   _this.kind, _this.toPrettyChars(), _this.toChars(),
-                   _this.enclosing.toChars(), dparent.toChars());
+                   _this.kind, _this.toPrettyChars(), _this.toErrMsg(),
+                   _this.enclosing.toErrMsg(), dparent.toErrMsg());
             _this.errors = true;
         }
         //printf("\tnested inside %s as it references %s\n", enclosing.toChars(), sa.toChars());
@@ -1718,7 +1718,7 @@ private bool hasNestedArgs(TemplateInstance _this, Objects* args, bool isstatic)
         if (ea.op != EXP.int64 && ea.op != EXP.float64 && ea.op != EXP.complex80 && ea.op != EXP.null_ && ea.op != EXP.string_ && ea.op != EXP.arrayLiteral && ea.op != EXP.assocArrayLiteral && ea.op != EXP.structLiteral)
         {
             if (!ea.type.isTypeError())
-                .error(ea.loc, "%s `%s` expression `%s` is not a valid template value argument", _this.kind, _this.toPrettyChars, ea.toChars());
+                .error(ea.loc, "%s `%s` expression `%s` is not a valid template value argument", _this.kind, _this.toPrettyChars, ea.toErrMsg());
             _this.errors = true;
         }
     }
@@ -2057,9 +2057,9 @@ bool findTempDecl(TemplateInstance ti, Scope* sc, WithScopeSymbol* pwithsym)
         {
             s = sc.search_correct(id);
             if (s)
-                .error(ti.loc, "%s `%s` template `%s` is not defined, did you mean %s?", ti.kind, ti.toPrettyChars(), id.toChars(), s.toChars());
+                .error(ti.loc, "%s `%s` template `%s` is not defined, did you mean %s?", ti.kind, ti.toPrettyChars(), id.toErrMsg(), s.toErrMsg());
             else
-                .error(ti.loc, "%s `%s` template `%s` is not defined", ti.kind, ti.toPrettyChars(), id.toChars());
+                .error(ti.loc, "%s `%s` template `%s` is not defined", ti.kind, ti.toPrettyChars(), id.toErrMsg());
             return false;
         }
         static if (LOG)
@@ -2128,7 +2128,7 @@ bool findTempDecl(TemplateInstance ti, Scope* sc, WithScopeSymbol* pwithsym)
                 if (td.semanticRun == PASS.initial)
                 {
                     .error(ti.loc, "%s `%s` `%s` forward references template declaration `%s`",
-                           ti.kind, ti.toPrettyChars(), ti.toChars(), td.toChars());
+                           ti.kind, ti.toPrettyChars(), ti.toErrMsg(), td.toErrMsg());
                     return 1;
                 }
             }
@@ -2180,7 +2180,7 @@ bool findMixinTempDecl(TemplateMixin tm, Scope* sc)
         if (!tm.tempdecl)
         {
             .error(tm.loc, "%s `%s` - `%s` is a %s, not a template", tm.kind,
-                   tm.toPrettyChars, s.toChars(), s.kind());
+                   tm.toPrettyChars, s.toErrMsg(), s.kind());
             return false;
         }
     }
@@ -2842,7 +2842,7 @@ private MATCH matchArg(TemplateParameter tp, Scope* sc, RootObject oarg, size_t 
                 else
                 {
                     error(tap.loc, "template parameter specialization for a type must be a type and not `%s`",
-                        tap.specAlias.toChars());
+                        tap.specAlias.toErrMsg());
                     return matchArgNoMatch();
                 }
             }
@@ -2957,7 +2957,7 @@ bool updateTempDecl(TemplateInstance ti, Scope* sc, Dsymbol s)
         }
         if (!s)
         {
-            .error(ti.loc, "%s `%s` template `%s` is not defined", ti.kind, ti.toPrettyChars, id.toChars());
+            .error(ti.loc, "%s `%s` template `%s` is not defined", ti.kind, ti.toPrettyChars, id.toErrMsg());
             return false;
         }
     }
@@ -2988,7 +2988,7 @@ bool updateTempDecl(TemplateInstance ti, Scope* sc, Dsymbol s)
         Dsymbol s2 = dmd.dsymbolsem.getType(s).toDsymbol(sc);
         if (!s2)
         {
-            .error(ti.loc, "`%s` is not a valid template instance, because `%s` is not a template declaration but a type (`%s == %s`)", ti.toChars(), id.toChars(), id.toChars(), dmd.dsymbolsem.getType(s).kind());
+            .error(ti.loc, "`%s` is not a valid template instance, because `%s` is not a template declaration but a type (`%s == %s`)", ti.toErrMsg(), id.toErrMsg(), id.toErrMsg(), dmd.dsymbolsem.getType(s).kind());
             return false;
         }
         // because s can be the alias created for a TemplateParameter
@@ -3029,7 +3029,7 @@ bool updateTempDecl(TemplateInstance ti, Scope* sc, Dsymbol s)
     else
     {
         .error(ti.loc, "%s `%s` `%s` is not a template declaration, it is a %s",
-               ti.kind, ti.toPrettyChars, id.toChars(), s.kind());
+               ti.kind, ti.toPrettyChars, id.toErrMsg(), s.kind());
         return false;
     }
 }
@@ -3549,7 +3549,7 @@ private bool evaluateConstraint(TemplateDeclaration td, TemplateInstance ti, Sco
             if (!ti.symtab)
                 ti.symtab = new DsymbolTable();
             if (!scx.insert(v))
-                .error(td.loc, "%s `%s` parameter `%s.%s` is already defined", td.kind, td.toPrettyChars, td.toChars(), v.toChars());
+                .error(td.loc, "%s `%s` parameter `%s.%s` is already defined", td.kind, td.toPrettyChars, td.toErrMsg(), v.toErrMsg());
             else
                 v.parent = fd;
         }
@@ -3751,7 +3751,7 @@ bool findBestMatch(TemplateInstance ti, Scope* sc, ArgumentList argumentList)
         if (td_ambig)
         {
             .error(ti.loc, "%s `%s.%s` matches more than one template declaration:",
-                td_best.kind(), td_best.parent.toPrettyChars(), td_best.ident.toChars());
+                td_best.kind(), td_best.parent.toPrettyChars(), td_best.ident.toErrMsg());
             .errorSupplemental(td_best.loc, "`%s`\nand:", td_best.toChars());
             .errorSupplemental(td_ambig.loc, "`%s`", td_ambig.toChars());
             return false;
@@ -4614,7 +4614,7 @@ private MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, TemplateIn
                                     matchTiargs = m2; // pick worst match
                                 if (!rootObjectsEqual((*dedtypes)[i], oded))
                                     .error(td.loc, "%s `%s` specialization not allowed for deduced parameter `%s`",
-                                        td.kind, td.toPrettyChars, td.kind, td.toPrettyChars, tparam.ident.toChars());
+                                        td.kind, td.toPrettyChars, td.kind, td.toPrettyChars, tparam.ident.toErrMsg());
                             }
                             else
                             {
@@ -5016,7 +5016,7 @@ Lmatch:
                 if (m2 < matchTiargs)
                     matchTiargs = m2; // pick worst match
                 if (!rootObjectsEqual((*dedtypes)[i],oded))
-                    .error(td.loc, "%s `%s` specialization not allowed for deduced parameter `%s`", td.kind, td.toPrettyChars, tparam.ident.toChars());
+                    .error(td.loc, "%s `%s` specialization not allowed for deduced parameter `%s`", td.kind, td.toPrettyChars, tparam.ident.toErrMsg());
             }
             else
             {
@@ -5063,7 +5063,7 @@ Lmatch:
                 if (m2 < matchTiargs)
                     matchTiargs = m2; // pick worst match
                 if (!rootObjectsEqual((*dedtypes)[i], oded))
-                    .error(td.loc, "%s `%s` specialization not allowed for deduced parameter `%s`", td.kind, td.toPrettyChars, tparam.ident.toChars());
+                    .error(td.loc, "%s `%s` specialization not allowed for deduced parameter `%s`", td.kind, td.toPrettyChars, tparam.ident.toErrMsg());
             }
         }
         oded = td.declareParameter(paramscope, tparam, oded);
@@ -5320,7 +5320,7 @@ private RootObject declareParameter(TemplateDeclaration td, Scope* sc, TemplateP
     }
 
     if (!sc.insert(d))
-        .error(td.loc, "%s `%s` declaration `%s` is already defined", td.kind, td.toPrettyChars, tp.ident.toChars());
+        .error(td.loc, "%s `%s` declaration `%s` is already defined", td.kind, td.toPrettyChars, tp.ident.toErrMsg());
     d.dsymbolSemantic(sc);
     /* So the caller's o gets updated with the result of semantic() being run on o
      */
@@ -5699,7 +5699,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
         }
         if (fd.semanticRun < PASS.semanticdone)
         {
-            .error(loc, "forward reference to template `%s`", fd.toChars());
+            .error(loc, "forward reference to template `%s`", fd.toErrMsg());
             return 1;
         }
         //printf("fd = %s %s, fargs = %s\n", fd.toChars(), fd.type.toChars(), fargs.toChars());
@@ -5872,7 +5872,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
         }
         if (td.semanticRun == PASS.initial)
         {
-            .error(loc, "forward reference to template `%s`", td.toChars());
+            .error(loc, "forward reference to template `%s`", td.toErrMsg());
         Lerror:
             m.lastf = null;
             m.count = 0;
@@ -5918,7 +5918,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
                         {
                             if (scx == p.sc)
                             {
-                                error(loc, "recursive template expansion while looking for `%s.%s`", ti.toChars(), tdx.toChars());
+                                error(loc, "recursive template expansion while looking for `%s.%s`", ti.toErrMsg(), tdx.toErrMsg());
                                 goto Lerror;
                             }
                         }

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -115,7 +115,7 @@ ulong getTypePointerBitmap(Loc loc, Type t, ref Array!(ulong) data, ErrorSink eS
     assert(sz_size_t <= ulong.sizeof);
     if (sz > sz.max - sz_size_t)
     {
-        eSink.error(loc, "size overflow for type `%s`", t.toChars());
+        eSink.error(loc, "size overflow for type `%s`", t.toErrMsg());
         return ulong.max;
     }
 
@@ -303,7 +303,7 @@ private Expression pointerBitmap(TraitsExp e, ErrorSink eSink)
     Type t = getType((*e.args)[0]);
     if (!t)
     {
-        eSink.error(e.loc, "`%s` is not a type", (*e.args)[0].toChars());
+        eSink.error(e.loc, "`%s` is not a type", (*e.args)[0].toErrMsg());
         return ErrorExp.get();
     }
 
@@ -352,7 +352,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
     Expression dimError(int expected)
     {
-        error(e.loc, "expected %d arguments for `%s` but had %d", expected, e.ident.toChars(), cast(int)dim);
+        error(e.loc, "expected %d arguments for `%s` but had %d", expected, e.ident.toErrMsg(), cast(int)dim);
         return ErrorExp.get();
     }
 
@@ -554,7 +554,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!t)
         {
             error(e.loc, "type expected as second argument of __traits `%s` instead of `%s`",
-                e.ident.toChars(), o.toChars());
+                e.ident.toErrMsg(), o.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -578,7 +578,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!t)
         {
             error(e.loc, "type expected as second argument of __traits `%s` instead of `%s`",
-                e.ident.toChars(), o.toChars());
+                e.ident.toErrMsg(), o.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -607,7 +607,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!t)
         {
             error(e.loc, "type expected as second argument of __traits `%s` instead of `%s`",
-                    e.ident.toChars(), o.toChars());
+                    e.ident.toErrMsg(), o.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -631,7 +631,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!t)
         {
             error(e.loc, "type expected as second argument of __traits `%s` instead of `%s`",
-                    e.ident.toChars(), o.toChars());
+                    e.ident.toErrMsg(), o.toErrMsg());
             return ErrorExp.get();
         }
         // FIXME should just check t.needsDestruction() but that doesn't run dsymbolSemantic
@@ -671,7 +671,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return fd.isNested() ? True() : False();
         }
 
-        error(e.loc, "aggregate or function expected instead of `%s`", o.toChars());
+        error(e.loc, "aggregate or function expected instead of `%s`", o.toErrMsg());
         return ErrorExp.get();
     }
     if (e.ident == Id.isDisabled)
@@ -773,7 +773,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
         if (!s || ((agg = s.isAggregateDeclaration()) is null))
         {
-            error(e.loc, "argument to `__traits(isCOMClass, %s)` is not a declaration", o.toChars());
+            error(e.loc, "argument to `__traits(isCOMClass, %s)` is not a declaration", o.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -799,7 +799,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             if (!po.ident)
             {
-                error(e.loc, "argument `%s` has no identifier", po.type.toChars());
+                error(e.loc, "argument `%s` has no identifier", po.type.toErrMsg());
                 return ErrorExp.get();
             }
             id = po.ident;
@@ -809,7 +809,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             Dsymbol s = getDsymbolWithoutExpCtx(o);
             if (!s || !s.ident)
             {
-                error(e.loc, "argument `%s` has no identifier", o.toChars());
+                error(e.loc, "argument `%s` has no identifier", o.toErrMsg());
                 return ErrorExp.get();
             }
             id = s.ident;
@@ -848,7 +848,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         else
         {
             if (!isError(o))
-                error(e.loc, "argument `%s` has no identifier", o.toChars());
+                error(e.loc, "argument `%s` has no identifier", o.toErrMsg());
             return ErrorExp.get();
         }
         assert(fqn);
@@ -865,7 +865,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto s = getDsymbolWithoutExpCtx(o);
         if (!s)
         {
-            error(e.loc, "bitfield symbol expected not `%s`", o.toChars());
+            error(e.loc, "bitfield symbol expected not `%s`", o.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -912,7 +912,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!s)
         {
             if (!isError(o))
-                error(e.loc, "argument `%s` has no visibility", o.toChars());
+                error(e.loc, "argument `%s` has no visibility", o.toErrMsg());
             return ErrorExp.get();
         }
         if (s.semanticRun == PASS.initial)
@@ -963,7 +963,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         if (!s || s.isImport())
         {
-            error(e.loc, "argument `%s` has no parent", o.toChars());
+            error(e.loc, "argument `%s` has no parent", o.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -999,7 +999,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             ex = exp;
         else
         {
-            error(e.loc, "symbol or expression expected as first argument of __traits `child` instead of `%s`", op.toChars());
+            error(e.loc, "symbol or expression expected as first argument of __traits `child` instead of `%s`", op.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -1008,7 +1008,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto symc = getDsymbol(oc);
         if (!symc)
         {
-            error(e.loc, "symbol expected as second argument of __traits `child` instead of `%s`", oc.toChars());
+            error(e.loc, "symbol expected as second argument of __traits `child` instead of `%s`", oc.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -1032,7 +1032,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto ex = isExpression((*e.args)[0]);
         if (!ex)
         {
-            error(e.loc, "expression expected as second argument of __traits `%s`", e.ident.toChars());
+            error(e.loc, "expression expected as second argument of __traits `%s`", e.ident.toErrMsg());
             return ErrorExp.get();
         }
         ex = ex.ctfeInterpret();
@@ -1045,7 +1045,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         Type t = decoToType(se.toUTF8(sc).peekString());
         if (!t)
         {
-            error(e.loc, "cannot determine `%s`", e.toChars());
+            error(e.loc, "cannot determine `%s`", e.toErrMsg());
             return ErrorExp.get();
         }
         return (new TypeExp(e.loc, t)).expressionSemantic(sc);
@@ -1063,7 +1063,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto ex = isExpression((*e.args)[1]);
         if (!ex)
         {
-            error(e.loc, "expression expected as second argument of __traits `%s`", e.ident.toChars());
+            error(e.loc, "expression expected as second argument of __traits `%s`", e.ident.toErrMsg());
             return ErrorExp.get();
         }
         ex = ex.ctfeInterpret();
@@ -1075,7 +1075,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             b = b.ctfeInterpret();
             if (!b.type.equals(Type.tbool))
             {
-                error(e.loc, "`bool` expected as third argument of `__traits(getOverloads)`, not `%s` of type `%s`", b.toChars(), b.type.toChars());
+                error(e.loc, "`bool` expected as third argument of `__traits(getOverloads)`, not `%s` of type `%s`", b.toErrMsg(), b.type.toErrMsg());
                 return ErrorExp.get();
             }
             includeTemplates = b.toBool().get();
@@ -1084,7 +1084,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         StringExp se = ex.toStringExp();
         if (!se || se.len == 0)
         {
-            error(e.loc, "string expected as second argument of __traits `%s` instead of `%s`", e.ident.toChars(), ex.toChars());
+            error(e.loc, "string expected as second argument of __traits `%s` instead of `%s`", e.ident.toErrMsg(), ex.toErrMsg());
             return ErrorExp.get();
         }
         se = se.toUTF8(sc);
@@ -1171,7 +1171,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             Expression eorig = ex;
             ex = ex.expressionSemantic(scx);
             if (errors < global.errors)
-                error(e.loc, "`%s` cannot be resolved", eorig.toChars());
+                error(e.loc, "`%s` cannot be resolved", eorig.toErrMsg());
 
             if (e.ident == Id.getVirtualFunctions)
             {
@@ -1340,7 +1340,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         if (cd.sizeok != Sizeok.done)
         {
-            error(e.loc, "%s `%s` is forward referenced", cd.kind(), cd.toChars());
+            error(e.loc, "%s `%s` is forward referenced", cd.kind(), cd.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -1390,7 +1390,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             {
                 if (fd.overnext)
                 {
-                    deprecation(e.loc, "`__traits(getAttributes)` may only be used for individual functions, not the overload set `%s`", fd.toChars());
+                    deprecation(e.loc, "`__traits(getAttributes)` may only be used for individual functions, not the overload set `%s`", fd.toErrMsg());
                     deprecationSupplemental(e.loc, "the result of `__traits(getOverloads)` may be used to select the desired function to extract attributes from");
                 }
             }
@@ -1400,7 +1400,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             {
                 if (td.overnext)
                 {
-                    deprecation(e.loc, "`__traits(getAttributes)` may only be used for individual functions, not the overload set `%s`", td.ident.toChars());
+                    deprecation(e.loc, "`__traits(getAttributes)` may only be used for individual functions, not the overload set `%s`", td.ident.toErrMsg());
                     deprecationSupplemental(e.loc, "the result of `__traits(getOverloads)` may be used to select the desired function to extract attributes from");
                 }
             }
@@ -1490,7 +1490,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
         if (!tf)
         {
-            error(e.loc, "argument to `__traits(isReturnOnStack, %s)` is not a function", o.toChars());
+            error(e.loc, "argument to `__traits(isReturnOnStack, %s)` is not a function", o.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -1526,7 +1526,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             if (!fd)
             {
-                error(e.loc, "argument to `__traits(getFunctionVariadicStyle, %s)` is not a function", o.toChars());
+                error(e.loc, "argument to `__traits(getFunctionVariadicStyle, %s)` is not a function", o.toErrMsg());
                 return ErrorExp.get();
             }
             link = fd._linkage;
@@ -1578,7 +1578,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             else
             {
                 error(e.loc, "first argument to `__traits(getParameterStorageClasses, %s, %s)` is not a function or a function call",
-                    o.toChars(), o1.toChars());
+                    o.toErrMsg(), o1.toErrMsg());
                 return ErrorExp.get();
             }
         }
@@ -1594,14 +1594,14 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!ex)
         {
             error(e.loc, "expression expected as second argument of `__traits(getParameterStorageClasses, %s, %s)`",
-                o.toChars(), o1.toChars());
+                o.toErrMsg(), o1.toErrMsg());
             return ErrorExp.get();
         }
         ex = ex.ctfeInterpret();
         auto ii = ex.toUInteger();
         if (ii >= fparams.length)
         {
-            error(e.loc, "parameter index must be in range 0..%u not %s", cast(uint)fparams.length, ex.toChars());
+            error(e.loc, "parameter index must be in range 0..%u not %s", cast(uint)fparams.length, ex.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -1673,7 +1673,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             AggregateDeclaration agg;
             if (!s || ((d = s.isDeclaration()) is null && (agg = s.isAggregateDeclaration()) is null))
             {
-                error(e.loc, "argument to `__traits(getLinkage, %s)` is not a declaration", o.toChars());
+                error(e.loc, "argument to `__traits(getLinkage, %s)` is not a declaration", o.toErrMsg());
                 return ErrorExp.get();
             }
 
@@ -1687,7 +1687,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                     agg.size(e.loc);
                     if (agg.sizeok != Sizeok.done)
                     {
-                        error(e.loc, "%s `%s` is forward referenced", agg.kind(), agg.toChars());
+                        error(e.loc, "%s `%s` is forward referenced", agg.kind(), agg.toErrMsg());
                         return ErrorExp.get();
                     }
                 }
@@ -1723,7 +1723,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto s = getDsymbol(o);
         if (!s)
         {
-            error(e.loc, "in expression `%s` `%s` can't have members", e.toChars(), o.toChars());
+            error(e.loc, "in expression `%s` `%s` can't have members", e.toErrMsg(), o.toErrMsg());
             errorSupplemental(e.loc, "`%s` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation", o.toChars());
 
             return ErrorExp.get();
@@ -1746,7 +1746,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto sds = s.isScopeDsymbol();
         if (!sds || sds.isTemplateDeclaration())
         {
-            error(e.loc, "in expression `%s` %s `%s` has no members", e.toChars(), s.kind(), s.toChars());
+            error(e.loc, "in expression `%s` %s `%s` has no members", e.toErrMsg(), s.kind(), s.toErrMsg());
             errorSupplemental(e.loc, "`%s` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation", s.toChars());
             return ErrorExp.get();
         }
@@ -1969,7 +1969,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!s)
         {
             error(e.loc, "argument `%s` to __traits(getUnitTests) must be a module or aggregate",
-                o.toChars());
+                o.toErrMsg());
             return ErrorExp.get();
         }
         if (auto imp = s.isImport()) // https://issues.dlang.org/show_bug.cgi?id=10990
@@ -1979,7 +1979,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!sds || sds.isTemplateDeclaration())
         {
             error(e.loc, "argument `%s` to __traits(getUnitTests) must be a module or aggregate, not a %s",
-                s.toChars(), s.kind());
+                s.toErrMsg(), s.kind());
             return ErrorExp.get();
         }
 
@@ -2049,7 +2049,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
         ErrorExp badArgument()
         {
-            error(e.loc, "struct / class type expected as argument to __traits(initSymbol) instead of `%s`", o.toChars());
+            error(e.loc, "struct / class type expected as argument to __traits(initSymbol) instead of `%s`", o.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -2079,7 +2079,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!t)
         {
             error(e.loc, "type expected as second argument of __traits `%s` instead of `%s`",
-                e.ident.toChars(), o.toChars());
+                e.ident.toErrMsg(), o.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -2100,7 +2100,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         StringExp se = ex ? ex.ctfeInterpret().toStringExp() : null;
         if (!ex || !se || se.len == 0)
         {
-            error(e.loc, "string expected as argument of __traits `%s` instead of `%s`", e.ident.toChars(), (*e.args)[0].toChars());
+            error(e.loc, "string expected as argument of __traits `%s` instead of `%s`", e.ident.toErrMsg(), (*e.args)[0].toErrMsg());
             return ErrorExp.get();
         }
         se = se.toUTF8(sc);
@@ -2123,7 +2123,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         Dsymbol s = getDsymbolWithoutExpCtx(arg0);
         if (!s || !s.loc.isValid() || s.isModule())
         {
-            error(e.loc, "can only get the location of a symbol, not `%s`", s ? s.toPrettyChars() : arg0.toChars());
+            error(e.loc, "can only get the location of a symbol, not `%s`", s ? s.toPrettyChars() : arg0.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -2135,7 +2135,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             error(e.loc, "cannot get location of an overload set, " ~
                     "use `__traits(getOverloads, ..., \"%s\"%s)[N]` " ~
                     "to get the Nth overload",
-                    arg0.toChars(), /*td ? ", true".ptr :*/ "".ptr);
+                    arg0.toErrMsg(), /*td ? ", true".ptr :*/ "".ptr);
             return ErrorExp.get();
         }
 
@@ -2497,7 +2497,7 @@ private void traitNotFound(TraitsExp e)
     }
 
     if (auto sub = speller!trait_search_fp(e.ident.toString()))
-        error(e.loc, "unrecognized trait `%s`, did you mean `%.*s`?", e.ident.toChars(), cast(int) sub.length, sub.ptr);
+        error(e.loc, "unrecognized trait `%s`, did you mean `%.*s`?", e.ident.toErrMsg(), cast(int) sub.length, sub.ptr);
     else
-        error(e.loc, "unrecognized trait `%s`", e.ident.toChars());
+        error(e.loc, "unrecognized trait `%s`", e.ident.toErrMsg());
 }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1453,7 +1453,7 @@ private void resolveTupleIndex(Loc loc, Scope* sc, Dsymbol s, out Expression pe,
         eindex = symbolToExp(sindex, loc, sc, false);
     if (!eindex)
     {
-        .error(loc, "index `%s` is not an expression", oindex.toChars());
+        .error(loc, "index `%s` is not an expression", oindex.toErrMsg());
         pt = Type.terror;
         return;
     }
@@ -1516,7 +1516,7 @@ private void resolveHelper(TypeQualified mt, Loc loc, Scope* sc, Dsymbol s, Dsym
             if (const n = importHint(id.toString()))
                 error(loc, "`%s` is not defined, perhaps `import %.*s;` ?", p, cast(int)n.length, n.ptr);
             else if (auto s2 = sc.search_correct(id))
-                error(mt.loc, "undefined identifier `%s`, did you mean %s `%s`?", p, s2.kind(), s2.toChars());
+                error(mt.loc, "undefined identifier `%s`, did you mean %s `%s`?", p, s2.kind(), s2.toErrMsg());
             else if (const q = search_correct_C(id))
                 error(mt.loc, "undefined identifier `%s`, did you mean `%s`?", p, q);
             else if ((id == Id.This   && sc.getStructClassScope()) ||
@@ -1529,7 +1529,7 @@ private void resolveHelper(TypeQualified mt, Loc loc, Scope* sc, Dsymbol s, Dsym
             if (const n = cIncludeHint(id.toString()))
                 error(loc, "`%s` is not defined, perhaps `#include %.*s` ?", p, cast(int)n.length, n.ptr);
             else if (auto s2 = sc.search_correct(id))
-                error(mt.loc, "undefined identifier `%s`, did you mean %s `%s`?", p, s2.kind(), s2.toChars());
+                error(mt.loc, "undefined identifier `%s`, did you mean %s `%s`?", p, s2.kind(), s2.toErrMsg());
             else
                 error(mt.loc, "undefined identifier `%s`", p);
         }
@@ -1591,7 +1591,7 @@ private void resolveHelper(TypeQualified mt, Loc loc, Scope* sc, Dsymbol s, Dsym
         {
             if (!sc.ignoresymbolvisibility && !symbolIsVisible(sc, sm))
             {
-                .error(loc, "`%s` is not visible from module `%s`", sm.toPrettyChars(), sc._module.toChars());
+                .error(loc, "`%s` is not visible from module `%s`", sm.toPrettyChars(), sc._module.toErrMsg());
                 sm = null;
             }
             // Same check as in dotIdSemanticProp(DotIdExp)
@@ -1717,7 +1717,7 @@ private void resolveHelper(TypeQualified mt, Loc loc, Scope* sc, Dsymbol s, Dsym
         if (ti != mt && !ti.deco)
         {
             if (!ti.tempinst.errors)
-                error(loc, "forward reference to `%s`", ti.toChars());
+                error(loc, "forward reference to `%s`", ti.toErrMsg());
             pt = Type.terror;
             return;
         }
@@ -2014,13 +2014,13 @@ extern (D) bool checkComplexTransition(Type type, Loc loc, Scope* sc)
         if (t.isComplex())
         {
             deprecation(loc, "use of complex type `%s` is deprecated, use `std.complex.Complex!(%s)` instead",
-                type.toChars(), rt.toChars());
+                type.toErrMsg(), rt.toErrMsg());
             return true;
         }
         else
         {
             deprecation(loc, "use of imaginary type `%s` is deprecated, use `%s` instead",
-                type.toChars(), rt.toChars());
+                type.toErrMsg(), rt.toErrMsg());
             return true;
         }
     }
@@ -2903,7 +2903,7 @@ uinteger_t size(Type t, Loc loc)
 
     uinteger_t visitType(Type t)
     {
-        error(loc, "no size for type `%s`", t.toChars());
+        error(loc, "no size for type `%s`", t.toErrMsg());
         return SIZE_INVALID;
     }
 
@@ -2995,7 +2995,7 @@ uinteger_t size(Type t, Loc loc)
         if (overflow || sz >= uint.max)
         {
             if (elemsize != SIZE_INVALID && n != uint.max)
-                error(loc, "static array `%s` size overflowed to %lld", t.toChars(), cast(long)sz);
+                error(loc, "static array `%s` size overflowed to %lld", t.toErrMsg(), cast(long)sz);
             return SIZE_INVALID;
         }
         return sz;
@@ -3011,7 +3011,7 @@ uinteger_t size(Type t, Loc loc)
                 return type.size(loc);
         }
 
-        error(t.loc, "size of type `%s` is not known", t.toChars());
+        error(t.loc, "size of type `%s` is not known", t.toErrMsg());
         return SIZE_INVALID;
     }
 
@@ -3246,7 +3246,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         mtype.basetype = mtype.basetype.toBasetype().mutableOf();
         if (mtype.basetype.ty != Tsarray)
         {
-            .error(loc, "T in __vector(T) must be a static array, not `%s`", mtype.basetype.toChars());
+            .error(loc, "T in __vector(T) must be a static array, not `%s`", mtype.basetype.toErrMsg());
             return error();
         }
         TypeSArray t = mtype.basetype.isTypeSArray();
@@ -3264,12 +3264,12 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
 
         case 2:
             // invalid base type
-            .error(loc, "vector type `%s` is not supported on this platform", mtype.toChars());
+            .error(loc, "vector type `%s` is not supported on this platform", mtype.toErrMsg());
             return error();
 
         case 3:
             // invalid size
-            .error(loc, "%d byte vector type `%s` is not supported on this platform", sz, mtype.toChars());
+            .error(loc, "%d byte vector type `%s` is not supported on this platform", sz, mtype.toErrMsg());
             return error();
         }
         return merge(mtype);
@@ -3300,7 +3300,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             RootObject o = (*tup.objects)[cast(size_t)d];
             if (auto tt = o.isType())
                 return tt.addMod(mtype.mod);
-            .error(loc, "`%s` is not a type", mtype.toChars());
+            .error(loc, "`%s` is not a type", mtype.toErrMsg());
             return error();
         }
 
@@ -3355,7 +3355,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             Type overflowError()
             {
                 .error(loc, "`%s` size %llu * %llu exceeds 0x%llx size limit for static array",
-                        mtype.toChars(), cast(ulong)tbn.size(loc), cast(ulong)d1, target.maxStaticDataSize);
+                        mtype.toErrMsg(), cast(ulong)tbn.size(loc), cast(ulong)d1, target.maxStaticDataSize);
                 return error();
             }
 
@@ -3405,7 +3405,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
 
         case Tfunction:
         case Tnone:
-            .error(loc, "cannot have array of `%s`", tbn.toChars());
+            .error(loc, "cannot have array of `%s`", tbn.toErrMsg());
             return error();
 
         default:
@@ -3413,7 +3413,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         }
         if (tbn.isScopeClass())
         {
-            .error(loc, "cannot have array of scope `%s`", tbn.toChars());
+            .error(loc, "cannot have array of scope `%s`", tbn.toErrMsg());
             return error();
         }
 
@@ -3436,7 +3436,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
 
         case Tfunction:
         case Tnone:
-            .error(loc, "cannot have array of `%s`", tbn.toChars());
+            .error(loc, "cannot have array of `%s`", tbn.toErrMsg());
             return error();
 
         case Terror:
@@ -3447,7 +3447,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         }
         if (tn.isScopeClass())
         {
-            .error(loc, "cannot have array of scope `%s`", tn.toChars());
+            .error(loc, "cannot have array of scope `%s`", tn.toErrMsg());
             return error();
         }
         mtype.next = tn;
@@ -3534,7 +3534,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         case Tvoid:
         case Tnone:
         case Ttuple:
-            .error(loc, "cannot have associative array key of `%s`", mtype.index.toBasetype().toChars());
+            .error(loc, "cannot have associative array key of `%s`", mtype.index.toBasetype().toErrMsg());
             goto case Terror;
         case Terror:
             return error();
@@ -3579,11 +3579,11 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             {
                 if (search_function(sd, Id.opEquals))
                 {
-                    .error(loc, "%sAA key type `%s` does not have `bool opEquals(ref const %s) const`", s, sd.toChars(), sd.toChars());
+                    .error(loc, "%sAA key type `%s` does not have `bool opEquals(ref const %s) const`", s, sd.toErrMsg(), sd.toErrMsg());
                 }
                 else
                 {
-                    .error(loc, "%sAA key type `%s` does not support const equality", s, sd.toChars());
+                    .error(loc, "%sAA key type `%s` does not support const equality", s, sd.toErrMsg());
                 }
                 return error();
             }
@@ -3591,11 +3591,11 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             {
                 if (search_function(sd, Id.opEquals))
                 {
-                    .error(loc, "%sAA key type `%s` should have `extern (D) size_t toHash() const nothrow @safe` if `opEquals` defined", s, sd.toChars());
+                    .error(loc, "%sAA key type `%s` should have `extern (D) size_t toHash() const nothrow @safe` if `opEquals` defined", s, sd.toErrMsg());
                 }
                 else
                 {
-                    .error(loc, "%sAA key type `%s` supports const equality but doesn't support const hashing", s, sd.toChars());
+                    .error(loc, "%sAA key type `%s` supports const equality but doesn't support const hashing", s, sd.toErrMsg());
                 }
                 return error();
             }
@@ -3641,7 +3641,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                     if (fcmp.vtblIndex < cd.vtbl.length && cd.vtbl[fcmp.vtblIndex] != fcmp)
                     {
                         const(char)* s = (mtype.index.toBasetype().ty != Tclass) ? "bottom of " : "";
-                        .error(loc, "%sAA key type `%s` now requires equality rather than comparison", s, cd.toChars());
+                        .error(loc, "%sAA key type `%s` now requires equality rather than comparison", s, cd.toErrMsg());
                         errorSupplemental(loc, "Please override `Object.opEquals` and `Object.toHash`.");
                     }
                 }
@@ -3656,7 +3656,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         case Tvoid:
         case Tnone:
         case Ttuple:
-            .error(loc, "cannot have associative array of `%s`", mtype.next.toChars());
+            .error(loc, "cannot have associative array of `%s`", mtype.next.toErrMsg());
             goto case Terror;
         case Terror:
             return error();
@@ -3665,7 +3665,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         }
         if (mtype.next.isScopeClass())
         {
-            .error(loc, "cannot have array of scope `%s`", mtype.next.toChars());
+            .error(loc, "cannot have array of scope `%s`", mtype.next.toErrMsg());
             return error();
         }
         return merge(mtype);
@@ -3682,7 +3682,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         switch (n.toBasetype().ty)
         {
         case Ttuple:
-            .error(loc, "cannot have pointer to `%s`", n.toChars());
+            .error(loc, "cannot have pointer to `%s`", n.toErrMsg());
             goto case Terror;
         case Terror:
             return error();
@@ -3831,7 +3831,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             errors |= tf.checkRetType(loc);
             if (tf.next.isScopeClass() && !tf.isCtor)
             {
-                .error(loc, "functions cannot return `scope %s`", tf.next.toChars());
+                .error(loc, "functions cannot return `scope %s`", tf.next.toErrMsg());
                 errors = true;
             }
             if (tf.next.hasWild())
@@ -3881,7 +3881,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             {
                 const(char)* errTxt = fparam.storageClass & STC.ref_ ? "ref" : "out";
                 .error(e.loc, "expression `%s` of type `%s` is not implicitly convertible to type `%s %s` of parameter `%s`",
-                      e.toErrMsg(), e.type.toChars(), errTxt, fparam.type.toChars(), fparam.toChars());
+                      e.toErrMsg(), e.type.toErrMsg(), errTxt, fparam.type.toErrMsg(), fparam.toChars());
             }
             e = e.implicitCastTo(sc, fparam.type);
 
@@ -4018,7 +4018,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
 
                 if (t.ty == Tfunction)
                 {
-                    .error(loc, "cannot have parameter of function type `%s`", fparam.type.toChars());
+                    .error(loc, "cannot have parameter of function type `%s`", fparam.type.toErrMsg());
                     errors = true;
                 }
                 else if (!fparam.isReference() &&
@@ -4031,17 +4031,17 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                         if (fparam.storageClass & STC.constscoperef)
                         {
                             .error(loc, "cannot infer `ref` for `in` parameter `%s` of opaque type `%s`",
-                                   fparam.toChars(), fparam.type.toChars());
+                                   fparam.toChars(), fparam.type.toErrMsg());
                         }
                         else
                             .error(loc, "cannot have parameter of opaque type `%s` by value",
-                                   fparam.type.toChars());
+                                   fparam.type.toErrMsg());
                         errors = true;
                     }
                 }
                 else if (!fparam.isLazy() && t.ty == Tvoid)
                 {
-                    .error(loc, "cannot have parameter of type `%s`", fparam.type.toChars());
+                    .error(loc, "cannot have parameter of type `%s`", fparam.type.toErrMsg());
                     errors = true;
                 }
 
@@ -4052,7 +4052,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                 {
                     // Deprecated in 2.111, kept as a legacy feature for compatibility (currently no plan to turn it into an error)
                     .deprecation(loc, "typesafe variadic parameters with a `class` type (`%s %s...`) are deprecated",
-                        t.isTypeClass().sym.ident.toChars(), fparam.toChars());
+                        t.isTypeClass().sym.ident.toErrMsg(), fparam.toChars());
                 }
 
                 if (isStackAllocatedVariadic)
@@ -4083,7 +4083,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                          * https://dlang.org/spec/function.html#typesafe_variadic_functions
                          */
                         .error(loc, "typesafe variadic function parameter `%s` of type `%s` cannot be marked `return`",
-                            fparam.ident ? fparam.ident.toChars() : "", t.toChars());
+                            fparam.ident ? fparam.ident.toErrMsg() : "", t.toErrMsg());
                         errors = true;
                     }
                 }
@@ -4092,7 +4092,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                 {
                     if (ubyte m = fparam.type.mod & (MODFlags.immutable_ | MODFlags.const_ | MODFlags.wild))
                     {
-                        .error(loc, "cannot have `%s out` parameter of type `%s`", MODtoChars(m), t.toChars());
+                        .error(loc, "cannot have `%s out` parameter of type `%s`", MODtoChars(m), t.toErrMsg());
                         errors = true;
                     }
                     else
@@ -4100,7 +4100,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                         Type tv = t.baseElemOf();
                         if (tv.ty == Tstruct && tv.isTypeStruct().sym.noDefaultCtor)
                         {
-                            .error(loc, "cannot have `out` parameter of type `%s` because the default construction is disabled", fparam.type.toChars());
+                            .error(loc, "cannot have `out` parameter of type `%s` because the default construction is disabled", fparam.type.toErrMsg());
                             errors = true;
                         }
                     }
@@ -4220,7 +4220,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
 
         if (wildreturn && !wildparams)
         {
-            .error(loc, "`inout` on `return` means `inout` must be on a parameter as well for `%s`", mtype.toChars());
+            .error(loc, "`inout` on `return` means `inout` must be on a parameter as well for `%s`", mtype.toErrMsg());
             errors = true;
         }
         tf.isInOutParam = (wildparams & 1) != 0;
@@ -4326,7 +4326,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             Dsymbol varDecl = mtype.toDsymbol(sc);
             Module varDeclModule = varDecl.getModule(); //This can be null
 
-            .error(loc, "variable `%s` is used as a type", mtype.toChars());
+            .error(loc, "variable `%s` is used as a type", mtype.toErrMsg());
             //Check for null to avoid https://issues.dlang.org/show_bug.cgi?id=22574
             if ((varDeclModule !is null) && varDeclModule != sc._module) // variable is imported
             {
@@ -4341,7 +4341,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             .errorSupplemental(varDecl.loc, "variable `%s` is declared here", varDecl.toChars);
         }
         else
-            .error(loc, "`%s` is used as a type", mtype.toChars());
+            .error(loc, "`%s` is used as a type", mtype.toErrMsg());
         return error();
     }
 
@@ -4366,10 +4366,10 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             {
                 // if there was an error evaluating the symbol, it might actually
                 // be a type. Avoid misleading error messages.
-                .error(loc, "`%s` had previous errors", mtype.toChars());
+                .error(loc, "`%s` had previous errors", mtype.toErrMsg());
             }
             else
-                .error(loc, "`%s` is used as a type", mtype.toChars());
+                .error(loc, "`%s` is used as a type", mtype.toErrMsg());
             return error();
         }
         return t;
@@ -4386,7 +4386,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             t = t.addMod(mtype.mod);
         if (!t)
         {
-            .error(loc, "`%s` is used as a type", mtype.toChars());
+            .error(loc, "`%s` is used as a type", mtype.toErrMsg());
             return error();
         }
         return t;
@@ -4419,7 +4419,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             t = t.addMod(mtype.mod);
         if (!t)
         {
-            .error(loc, "`%s` is used as a type", mtype.toChars());
+            .error(loc, "`%s` is used as a type", mtype.toErrMsg());
             return error();
         }
         return t;
@@ -4489,7 +4489,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         Type tbn = tn.toBasetype();
         if (tbn.ty != Ttuple)
         {
-            .error(loc, "can only slice type sequences, not `%s`", tbn.toChars());
+            .error(loc, "can only slice type sequences, not `%s`", tbn.toErrMsg());
             return error();
         }
         TypeTuple tt = cast(TypeTuple)tbn;
@@ -4641,7 +4641,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
         {
             // no pre-existing declaration, so declare it
             if (mtype.tok == TOK.enum_ && !mtype.members)
-                .error(mtype.loc, "`enum %s` is incomplete without members", mtype.id.toChars()); // C11 6.7.2.3-3
+                .error(mtype.loc, "`enum %s` is incomplete without members", mtype.id.toErrMsg()); // C11 6.7.2.3-3
             declareTag();
             return returnType(mtype);
         }
@@ -4657,7 +4657,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             {
                 auto ed = s.isEnumDeclaration();
                 if (mtype.members && ed.members)
-                    .error(mtype.loc, "`%s` already has members", mtype.id.toChars());
+                    .error(mtype.loc, "`%s` already has members", mtype.id.toErrMsg());
                 else if (!ed.members)
                 {
                     ed.members = mtype.members;
@@ -4677,7 +4677,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                     /* struct S { int b; };
                      * struct S { int a; } *s;
                      */
-                    .error(mtype.loc, "`%s` already has members", mtype.id.toChars());
+                    .error(mtype.loc, "`%s` already has members", mtype.id.toErrMsg());
                 }
                 else if (!sd.members)
                 {
@@ -4708,7 +4708,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                 /* int S;
                  * struct S { int a; } *s;
                  */
-                .error(mtype.loc, "redeclaration of `%s`", mtype.id.toChars());
+                .error(mtype.loc, "redeclaration of `%s`", mtype.id.toErrMsg());
                 mtype.resolved = error();
             }
         }
@@ -4739,7 +4739,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                  * { struct S* s; }
                  */
                 .error(mtype.loc, "redeclaring `%s %s` as `%s %s`",
-                    s.kind(), s.toChars(), Token.toChars(mtype.tok), mtype.id.toChars());
+                    s.kind(), s.toErrMsg(), Token.toChars(mtype.tok), mtype.id.toErrMsg());
                 declareTag();
             }
         }
@@ -5064,7 +5064,7 @@ Expression getProperty(Type t, Scope* scope_, Loc loc, Identifier ident, int fla
         {
             if (!mt.deco)
             {
-                error(loc, "forward reference of type `%s.mangleof`", mt.toChars());
+                error(loc, "forward reference of type `%s.mangleof`", mt.toErrMsg());
                 return ErrorExp.get();
             }
             else
@@ -5460,7 +5460,7 @@ Expression getProperty(Type t, Scope* scope_, Loc loc, Identifier ident, int fla
         }
         else
         {
-            error(loc, "no property `%s` for sequence `%s`", ident.toChars(), mt.toChars());
+            error(loc, "no property `%s` for sequence `%s`", ident.toErrMsg(), mt.toErrMsg());
             e = ErrorExp.get();
         }
         return e;
@@ -5862,12 +5862,12 @@ void resolve(Type mt, Loc loc, Scope* sc, out Expression pe, out Type pt, out Ds
         Type t = mt.exp.type;
         if (!t)
         {
-            error(loc, "expression `%s` has no type", mt.exp.toChars());
+            error(loc, "expression `%s` has no type", mt.exp.toErrMsg());
             goto Lerr;
         }
         if (t.ty == Ttypeof)
         {
-            error(loc, "forward reference to `%s`", mt.toChars());
+            error(loc, "forward reference to `%s`", mt.toErrMsg());
             goto Lerr;
         }
         if (mt.idents.length == 0)
@@ -5906,7 +5906,7 @@ void resolve(Type mt, Loc loc, Scope* sc, out Expression pe, out Type pt, out Ds
             t = func.type.nextOf();
             if (!t)
             {
-                error(loc, "cannot use `typeof(return)` inside function `%s` with inferred return type", sc.func.toChars());
+                error(loc, "cannot use `typeof(return)` inside function `%s` with inferred return type", sc.func.toErrMsg());
                 return returnError();
             }
         }
@@ -6212,7 +6212,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                             value = ident == Id.bitoffsetof ? bf.bitOffset : bf.fieldWidth;
                         }
                         else
-                            error(v.loc, "`%s` is not a bitfield, cannot apply `%s`", v.toChars(), ident.toChars());
+                            error(v.loc, "`%s` is not a bitfield, cannot apply `%s`", v.toErrMsg(), ident.toErrMsg());
                     }
                     return new IntegerExp(e.loc, value, Type.tsize_t);
                 }
@@ -6610,7 +6610,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
 
         if (++nest > global.recursionLimit)
         {
-            .error(e.loc, "cannot resolve identifier `%s`", ident.toChars());
+            .error(e.loc, "cannot resolve identifier `%s`", ident.toErrMsg());
             return returnExp(gagError ? null : ErrorExp.get());
         }
 
@@ -6739,7 +6739,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
 
             if (!mt.sym.determineFields())
             {
-                error(e.loc, "unable to determine fields of `%s` because of forward references", mt.toChars());
+                error(e.loc, "unable to determine fields of `%s` because of forward references", mt.toErrMsg());
             }
 
             Expression e0;
@@ -6920,7 +6920,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
         Declaration d = s.isDeclaration();
         if (!d)
         {
-            error(e.loc, "`%s.%s` is not a declaration", e.toErrMsg(), ident.toChars());
+            error(e.loc, "`%s.%s` is not a declaration", e.toErrMsg(), ident.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -7010,11 +7010,11 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
             if (!(flag & 1) && !res)
             {
                 if (auto ns = mt.sym.search_correct(ident))
-                    error(e.loc, "no property `%s` for type `%s`. Did you mean `%s.%s` ?", ident.toChars(), mt.toChars(), mt.toChars(),
-                        ns.toChars());
+                    error(e.loc, "no property `%s` for type `%s`. Did you mean `%s.%s` ?", ident.toErrMsg(), mt.toErrMsg(), mt.toErrMsg(),
+                        ns.toErrMsg());
                 else
-                    error(e.loc, "no property `%s` for type `%s`", ident.toChars(),
-                        mt.toChars());
+                    error(e.loc, "no property `%s` for type `%s`", ident.toErrMsg(),
+                        mt.toErrMsg());
 
                 errorSupplemental(mt.sym.loc, "%s `%s` defined here",
                     mt.sym.kind, mt.toChars());
@@ -7351,7 +7351,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
         Declaration d = s.isDeclaration();
         if (!d)
         {
-            error(e.loc, "`%s.%s` is not a declaration", e.toErrMsg(), ident.toChars());
+            error(e.loc, "`%s.%s` is not a declaration", e.toErrMsg(), ident.toErrMsg());
             return ErrorExp.get();
         }
 
@@ -8001,7 +8001,7 @@ Type getComplexLibraryType(Loc loc, Scope* sc, TY ty)
     Dsymbol s = mConfig.searchX(Loc.initial, sc, id, SearchOpt.ignorePrivateImports);
     if (!s)
     {
-        error(loc, "`%s` not found in core.stdc.config", id.toChars());
+        error(loc, "`%s` not found in core.stdc.config", id.toErrMsg());
         return *pt;
     }
     s = s.toAlias();
@@ -8019,7 +8019,7 @@ Type getComplexLibraryType(Loc loc, Scope* sc, TY ty)
         return sd.type;
     }
 
-    error(loc, "`%s` must be an alias for a complex struct", s.toChars());
+    error(loc, "`%s` must be an alias for a complex struct", s.toErrMsg());
     return *pt;
 }
 
@@ -9325,7 +9325,7 @@ uint numberOfElems(Type t, Loc loc)
         n = mulu(n, (cast(TypeSArray)tb).dim.toUInteger(), overflow);
         if (overflow || n >= uint.max)
         {
-            error(loc, "static array `%s` size overflowed to %llu", t.toChars(), cast(ulong)n);
+            error(loc, "static array `%s` size overflowed to %llu", t.toErrMsg(), cast(ulong)n);
             return uint.max;
         }
         tb = (cast(TypeSArray)tb).next;
@@ -9352,7 +9352,7 @@ bool checkRetType(TypeFunction tf, Loc loc)
         {
             if (!ts.sym.members)
             {
-                error(loc, "functions cannot return opaque type `%s` by value", tb.toChars());
+                error(loc, "functions cannot return opaque type `%s` by value", tb.toErrMsg());
                 tf.next = Type.terror;
             }
         }
@@ -9550,7 +9550,7 @@ Expression getMaxMinValue(EnumDeclaration ed, Loc loc, Identifier id)
 
     if (ed.inuse)
     {
-        .error(loc, "%s `%s` recursive definition of `.%s` property", ed.kind, ed.toPrettyChars, id.toChars());
+        .error(loc, "%s `%s` recursive definition of `.%s` property", ed.kind, ed.toPrettyChars, id.toErrMsg());
         return errorReturn();
     }
     if (*pval)
@@ -9562,13 +9562,13 @@ Expression getMaxMinValue(EnumDeclaration ed, Loc loc, Identifier id)
         return errorReturn();
     if (!ed.members)
     {
-        .error(loc, "%s `%s` is opaque and has no `.%s`", ed.kind, ed.toPrettyChars, id.toChars(), id.toChars());
+        .error(loc, "%s `%s` is opaque and has no `.%s`", ed.kind, ed.toPrettyChars, id.toErrMsg(), id.toErrMsg());
         return errorReturn();
     }
     if (!(ed.memtype && ed.memtype.isIntegral()))
     {
-        .error(loc, "%s `%s` has no `.%s` property because base type `%s` is not an integral type", ed.kind, ed.toPrettyChars, id.toChars(),
-              id.toChars(), ed.memtype ? ed.memtype.toChars() : "");
+        .error(loc, "%s `%s` has no `.%s` property because base type `%s` is not an integral type", ed.kind, ed.toPrettyChars, id.toErrMsg(),
+              id.toErrMsg(), ed.memtype ? ed.memtype.toErrMsg() : "");
         return errorReturn();
     }
 
@@ -9586,7 +9586,7 @@ Expression getMaxMinValue(EnumDeclaration ed, Loc loc, Identifier id)
 
         if (em.semanticRun < PASS.semanticdone)
         {
-            .error(em.loc, "%s `%s` is forward referenced looking for `.%s`", em.kind, em.toPrettyChars, id.toChars());
+            .error(em.loc, "%s `%s` is forward referenced looking for `.%s`", em.kind, em.toPrettyChars, id.toErrMsg());
             ed.errors = true;
             continue;
         }
@@ -9663,7 +9663,7 @@ RootObject compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
     if (p.token.value != TOK.endOfFile)
     {
         .error(loc, "unexpected token `%s` after type `%s`",
-            p.token.toChars(), o.toChars());
+            p.token.toChars(), o.toErrMsg());
         .errorSupplemental(loc, "while parsing string mixin type `%s`",
             str.ptr);
         return null;

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -51,7 +51,7 @@ bool genTypeInfo(Expression e, Loc loc, Type torig, Scope* sc)
         {
             global.gag = 0;
             if (e)
-                .error(loc, "expression `%s` uses the GC and cannot be used with switch `-betterC`", e.toChars());
+                .error(loc, "expression `%s` uses the GC and cannot be used with switch `-betterC`", e.toErrMsg());
             else
                 .error(loc, "`TypeInfo` cannot be used with `-betterC`");
 

--- a/compiler/test/fail_compilation/fail12236.d
+++ b/compiler/test/fail_compilation/fail12236.d
@@ -6,7 +6,7 @@ fail_compilation/fail12236.d(16):        while evaluating `pragma(msg, f1.mangle
 fail_compilation/fail12236.d(21): Error: forward reference to inferred return type of function `f2`
 fail_compilation/fail12236.d(21):        while evaluating `pragma(msg, f2(T)(T).mangleof)`
 fail_compilation/fail12236.d(27): Error: template instance `fail12236.f2!int` error instantiating
-fail_compilation/fail12236.d(31): Error: forward reference to inferred return type of function `__lambda_L29_C5`
+fail_compilation/fail12236.d(31): Error: forward reference to inferred return type of function `(int a) { int x = 0; pragma (msg, __lambda_L29_C5(__T1)(a).mangleof); }`
 fail_compilation/fail12236.d(31):        while evaluating `pragma(msg, __lambda_L29_C5(__T1)(a).mangleof)`
 ---
 */

--- a/compiler/test/fail_compilation/ice12235.d
+++ b/compiler/test/fail_compilation/ice12235.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12235.d(14): Error: forward reference to inferred return type of function `__lambda_L12_C5`
-fail_compilation/ice12235.d(15): Error: forward reference to inferred return type of function `__lambda_L12_C5`
+fail_compilation/ice12235.d(14): Error: forward reference to inferred return type of function `() { int x = 0; enum s = __lambda_L12_C5.mangleof; pragma (msg, __traits(pare...`
+fail_compilation/ice12235.d(15): Error: forward reference to inferred return type of function `() { int x = 0; enum _error_ s = __error__; pragma (msg, __lambda_L12_C5.mang...`
 fail_compilation/ice12235.d(15):        while evaluating `pragma(msg, __lambda_L12_C5.mangleof)`
 ---
 */

--- a/compiler/test/fail_compilation/ice12673.d
+++ b/compiler/test/fail_compilation/ice12673.d
@@ -1,11 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12673.d(13): Error: static assert:  `__traits(compiles, () pure nothrow @nogc @safe
-{
-__error__
-}
-)` is false
+fail_compilation/ice12673.d(9): Error: static assert:  `__traits(compiles, () { __error__ } )` is false
 ---
 */
 void main()

--- a/compiler/test/fail_compilation/test23170.d
+++ b/compiler/test/fail_compilation/test23170.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test23170.d(10): Error: this array literal causes a GC allocation in `@nogc` delegate `__lambda_L10_C15`
+fail_compilation/test23170.d(10): Error: this array literal causes a GC allocation in `@nogc` delegate `() => (*(int[] array) => id(array))([1, 2, 3])`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=23170


### PR DESCRIPTION
…l names

Yeah, very tedious stuff. Still have to convince Walter that an error() interface taking RootObject arguments instead of `char*` strings is better.