### PR TITLE
[spec/declaration] Add Statically Allocated Data section

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -745,7 +745,7 @@ $(H2 $(LNAME2 __rvalue, $(D __rvalue) Attribute))
 
 $(H2 $(LNAME2 static, $(D static) Attribute))
 
-        $(P The $(D static) attribute applies to types, functions and data.
+        $(P The $(D static) attribute applies to types, functions and variables.
         $(D static) is ignored when applied to other declarations.)
 
         $(P Inside an aggregate type, a `static`

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -333,10 +333,35 @@ $(H3 $(LNAME2 global_static_init, Global and Static Initializers))
         )
 
         $(IMPLEMENTATION_DEFINED
-        $(OL
-        $(LI Whether some pointers can be initialized with the addresses of other
-        functions or data.)
-        ))
+        Whether some pointers can be initialized with the addresses of other
+        functions or data.
+        )
+
+
+$(H2 $(LNAME2 static, Statically Allocated Data))
+
+    $(P $(GLINK VarDeclarations) outside a function or aggregate type will be statically
+    allocated. By default, they will be thread-local unless marked
+    $(DDSUBLINK spec/const3, shared, `shared`) or
+    $(DDSUBLINK spec/attribute, gshared, `__gshared`).)
+
+    $(P By default, *VarDeclarations* inside a function will be allocated on the stack.
+    The following $(GLINK StorageClasses) will statically allocate data,
+    $(DDSUBLINK spec/function, local-static-variables, even inside a function) or
+    aggregate type:)
+
+    - $(DDSUBLINK spec/attribute, static, `static`) - allocate thread-local data
+    - $(DDSUBLINK spec/const3, shared, `shared`) or
+      $(DDSUBLINK spec/attribute, gshared, `__gshared`) - allocate global data
+
+    $(NOTE When *StorageClasses* includes `enum`, a variable declaration
+    $(DDSUBLINK spec/enum, single_member, will not have) any storage allocated.)
+
+    $(IMPLEMENTATION_DEFINED Static declarations whose initializer is `void` or whose
+    bits are all zero may be listed in the
+    $(LINK2 https://en.wikipedia.org/wiki/.bss, `.bss`) section of the binary to save
+    storage space.
+    Otherwise, static data will be stored in the `.data` section.)
 
 
 $(H2 $(LNAME2 alias, Alias Declarations))

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -364,8 +364,7 @@ $(H2 $(LNAME2 static, Statically Allocated Data))
     $(IMPLEMENTATION_DEFINED Static declarations whose initializer is `void` or whose
     bits are all zero may be listed in the
     $(LINK2 https://en.wikipedia.org/wiki/.bss, `.bss`) section of the binary to save
-    storage space.
-    Otherwise, static data will be stored in the `.data` section.)
+    storage space.)
 
 
 $(H2 $(LNAME2 alias, Alias Declarations))

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -357,8 +357,9 @@ $(H2 $(LNAME2 static, Statically Allocated Data))
     - $(DDSUBLINK spec/const3, shared, `shared`) or
       $(DDSUBLINK spec/attribute, gshared, `__gshared`) - allocate global data
 
-    $(NOTE When *StorageClasses* includes `enum`, a variable declaration
-    $(DDSUBLINK spec/enum, single_member, will not have) any storage allocated.)
+    $(NOTE When *StorageClasses* includes $(DDSUBLINK spec/enum, single_member, `enum`)
+    or $(RELATIVE_LINK2 extern, `extern`), a variable declaration
+    will not have any storage allocated.)
 
     $(IMPLEMENTATION_DEFINED Static declarations whose initializer is `void` or whose
     bits are all zero may be listed in the
@@ -783,16 +784,15 @@ attribute it defaults to $(D extern(D)):)
 ---------------
 // variable allocated and initialized in this module with C linkage
 extern(C) int foo;
+
 // variable allocated outside this module with C linkage
 // (e.g. in a statically linked C library or another module)
 extern extern(C) int bar;
 ---------------
 
         $(BEST_PRACTICE
-        $(OL
-        $(LI The primary usefulness of $(I Extern Declarations) is to
+        The primary usefulness of $(I Extern Declarations) is to
         connect with global variables declarations and functions in C or C++ files.)
-        ))
 
 
 $(H2 $(LNAME2 typequal_vs_storageclass, Type Qualifiers vs. Storage Classes))

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -341,12 +341,15 @@ $(H3 $(LNAME2 global_static_init, Global and Static Initializers))
 $(H2 $(LNAME2 static, Statically Allocated Data))
 
     $(P $(GLINK VarDeclarations) outside a function or aggregate type will be statically
-    allocated. By default, they will be thread-local unless marked
-    $(DDSUBLINK spec/const3, shared, `shared`) or
-    $(DDSUBLINK spec/attribute, gshared, `__gshared`).)
+    allocated. By default, such a variable will be thread-local unless it has one of the
+    following $(GLINK StorageClasses):)
+
+    - $(DDLINK spec/const3, Type Qualifiers, `const`) or `immutable`
+    - $(DDSUBLINK spec/const3, shared, `shared`) or
+      $(DDSUBLINK spec/attribute, gshared, `__gshared`)
 
     $(P By default, *VarDeclarations* inside a function will be allocated on the stack.
-    The following $(GLINK StorageClasses) will statically allocate data,
+    The following *StorageClasses* will instead statically allocate data,
     $(DDSUBLINK spec/function, local-static-variables, even inside a function) or
     aggregate type:)
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -3044,7 +3044,7 @@ $(H2 $(LEGACY_LNAME2 Local Variables, local-variables, Local Variables))
 
 $(H3 $(LEGACY_LNAME2 Local Static Variables, local-static-variables, Local Static Variables))
 
-        $(P Local variables in functions declared as `static`, `shared static`
+        $(P Local variables declared as `static`, `shared static`
         or $(D __gshared) are statically allocated
         rather than being allocated on the stack.
         The lifetime of `__gshared` and `shared static` variables begins


### PR DESCRIPTION
Although this information is maybe present across the spec, it makes sense to collect it all together in the declarations page. This also mentions the `.bss` binary section under *implementation defined*.