### PR TITLE
add support for __chkstk_darwin

### DIFF
--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -35,6 +35,7 @@ import dmd.backend.oper;
 import dmd.backend.rtlsym;
 import dmd.backend.ty;
 import dmd.backend.type;
+import dmd.backend.machobj  : MachObj_getChkstkSym;
 import dmd.backend.arm.cod2 : tyToExtend;
 import dmd.backend.arm.cod3 : COND, genBranch, conditionCode, gentstreg;
 import dmd.backend.arm.instr;
@@ -2160,10 +2161,7 @@ private void funccall(ref CodeBuilder cdb, elem* e, uint numpara, uint numalign,
             cgstate.needframe = true;
             cgstate.setSPtoFPonEpilog = true;
 
-            //Symbol* schkstk = getRtlsym(RTLSYM.CHKSTK);
-            //makeitextern(schkstk);
-
-            Symbol* schkstk = s;                // BUG AArch64 should be ___chkstk_darwin
+            Symbol* schkstk = MachObj_getChkstkSym();   // ___chkstk_darwin
             FL fl = schkstk.Sfl;
 
             enum reg_t R9 = 9;                  // argument to __chkstk_darwin

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -94,6 +94,20 @@ void MachObj_refGOTsym()
     assert(0);
 }
 
+/// Returns: a reference to the ___chkstk_darwin pointer to function
+@trusted
+Symbol* MachObj_getChkstkSym()
+{
+    __gshared Symbol* chkstkSym;
+    if (!chkstkSym)
+    {
+        chkstkSym = symbol_name("__chkstk_darwin",SC.global,tspvoid);
+    }
+    return chkstkSym;
+}
+
+
+
 // The object file is built is several separate pieces
 
 // String Table  - String table for all other names
@@ -969,6 +983,11 @@ void MachObj_term(const(char)[] objfilename)
                                     {
                                         rel.r_type = ARM64_RELOC_BRANCHY26;
                                         rel.r_pcrel = 1;
+                                    }
+                                    else if (s.Sfl == FL.unde)   // special case for __chkstk_darwin, need to research what PAGEOFF12 really means
+                                    {
+                                        rel.r_type = r.rtype == RELadd ? ARM64_RELOC_GOT_LOAD_PAGEOFF12 : ARM64_RELOC_GOT_LOAD_PAGE21;
+                                        rel.r_pcrel = r.rtype == RELadd ? 0 : 1;
                                     }
                                     else
                                     {


### PR DESCRIPTION
This pointer-to-function is used by alloca() to check and see if the stack can be grown. It is unique to OSX AArch64 (of course).

There must be a method to the madness of OSX AArch64 fixups, but I haven't figured out the pattern yet to its undocumented scheme. So far, it is implemented as special cases. Ugh.