### PR TITLE
Add WebAssembly to core.stdc.config

### DIFF
--- a/druntime/src/core/stdc/config.d
+++ b/druntime/src/core/stdc/config.d
@@ -213,6 +213,38 @@ else version (WASI)
         alias cpp_ulonglong = ulong;
     }
 }
+}
+else version (WebAssembly)
+{
+    static if ( (void*).sizeof > int.sizeof )
+    {
+        enum __c_longlong  : long;
+        enum __c_ulonglong : ulong;
+
+        alias c_long = long;
+        alias c_ulong = ulong;
+
+        alias cpp_long = long;
+        alias cpp_ulong = ulong;
+
+        alias cpp_longlong = __c_longlong;
+        alias cpp_ulonglong = __c_ulonglong;
+    }
+    else
+    {
+        enum __c_long  : int;
+        enum __c_ulong : uint;
+
+        alias c_long = int;
+        alias c_ulong = uint;
+
+        alias cpp_long = __c_long;
+        alias cpp_ulong = __c_ulong;
+
+        alias cpp_longlong = long;
+        alias cpp_ulonglong = ulong;
+    }
+}
 
 version (GNU)
     alias c_long_double = real;

--- a/druntime/src/core/stdc/config.d
+++ b/druntime/src/core/stdc/config.d
@@ -213,7 +213,6 @@ else version (WASI)
         alias cpp_ulonglong = ulong;
     }
 }
-}
 else version (WebAssembly)
 {
     static if ( (void*).sizeof > int.sizeof )


### PR DESCRIPTION
Added a version(WebAssembly) block to provide the correct C compatible 
type aliases.

This is a copy of the WASI block.