### PR TITLE
Fix missing symbols for template alias arguments during codegen

### DIFF
--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -3282,6 +3282,21 @@ bool needsCodegen(TemplateInstance ti)
         return false;
     }
 
+    if (ti.enclosing)
+    {
+        if (auto fd = ti.enclosing.isFuncDeclaration())
+        {
+            if (auto fld = fd.isFuncLiteralDeclaration())
+            {
+                if (fld.tookAddressOf == 0 && fld.tok != TOK.reserved)
+                {
+                    ti.minst = null; // mark as speculative
+                    return false;
+                }
+            }
+        }
+    }
+
     // This should only be called on the primary instantiation.
     assert(ti is ti.inst);
 

--- a/compiler/test/runnable/issue22848.d
+++ b/compiler/test/runnable/issue22848.d
@@ -1,0 +1,20 @@
+@"
+// Test for Issue 22848
+// Undefined reference to static function in unused mixin lambda
+
+mixin template Main(alias mainFunction) {}
+
+mixin Main!(
+    ()
+    {
+        static bool pred(char c) => false;
+        accept!pred;
+    }
+);
+
+char accept(alias pred)() => pred(0);
+
+void main()
+{
+}
+"@


### PR DESCRIPTION
Fixes #22848

i discovered that the compiler was skipping code generation for symbols (like nested functions) when they were passed only as alias arguments to templates. this resulted in "undefined reference" linker errors because the backend never visited those dependencies.
this PR adds a traversal of template arguments (tiargs) to the toObjFile visitor in toobj.d. this ensures that all symbols required by a non-speculative template instantiation are correctly processed for code generation.