### PR TITLE
Type.unSharedOf: Don't propagate back-end ctype after building variant

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -8655,7 +8655,6 @@ Type unSharedOf(Type type)
     {
         t = type.nullAttributes();
         t.mod = type.mod & ~MODFlags.shared_;
-        t.ctype = type.ctype;
         t = t.merge();
         t.fixTo(type);
     }


### PR DESCRIPTION
Type variants don't share the same ctype.