### PR TITLE
Type.fixTo: Always propagate the naked type to new variants

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -404,6 +404,10 @@ extern (C++) abstract class Type : ASTNode
          * we bank on the idea that usually only one of variants exist.
          * It will also speed up code because these are rarely referenced and
          * so need not be in the cache.
+         *
+         * NOTE: The cache stores the naked type at the "identity" position.
+         * For example, a "shared const T" type will have its naked "T" type
+         * in the field "scto". See also: dmd.typesem.nakedOf(Type).
          */
         Type cto;       // MODFlags.const_
         Type ito;       // MODFlags.immutable_

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -464,57 +464,62 @@ void check(Type _this)
  * For our new type '_this', which is type-constructed from t,
  * fill in the cto, ito, sto, scto, wto shortcuts.
  */
-void fixTo(Type _this, Type t)
+private void fixTo(Type _this, Type t)
 {
+    Type mto = null;            // the naked type of `t`
+    if (_this.mod || t.mod)
+    {
+        _this.getMcache();
+        t.getMcache();
+    }
     // If fixing this: immutable(T*) by t: immutable(T)*,
     // cache t to this.xto won't break transitivity.
-    Type mto = null;
     Type tn = _this.nextOf();
     if (!tn || _this.ty != Tsarray && tn.mod == t.nextOf().mod)
     {
         switch (t.mod)
         {
         case 0:
-            mto = t;
+            mto = t;            // t is naked
             break;
 
         case MODFlags.const_:
-            _this.getMcache();
+            mto = t.mcache.cto; // cto is naked
             _this.mcache.cto = t;
             break;
 
         case MODFlags.wild:
-            _this.getMcache();
+            mto = t.mcache.wto; // wto is naked
             _this.mcache.wto = t;
             break;
 
         case MODFlags.wildconst:
-            _this.getMcache();
+            mto = t.mcache.wcto; // wcto is naked
             _this.mcache.wcto = t;
             break;
 
         case MODFlags.shared_:
-            _this.getMcache();
+            mto = t.mcache.sto;  // sto is naked
             _this.mcache.sto = t;
             break;
 
         case MODFlags.shared_ | MODFlags.const_:
-            _this.getMcache();
+            mto = t.mcache.scto; // scto is naked
             _this.mcache.scto = t;
             break;
 
         case MODFlags.shared_ | MODFlags.wild:
-            _this.getMcache();
+            mto = t.mcache.swto; // swto is naked
             _this.mcache.swto = t;
             break;
 
         case MODFlags.shared_ | MODFlags.wildconst:
-            _this.getMcache();
+            mto = t.mcache.swcto; // swcto is naked
             _this.mcache.swcto = t;
             break;
 
         case MODFlags.immutable_:
-            _this.getMcache();
+            mto = t.mcache.ito;  // ito is naked
             _this.mcache.ito = t;
             break;
 
@@ -524,11 +529,6 @@ void fixTo(Type _this, Type t)
     }
     assert(_this.mod != t.mod);
 
-    if (_this.mod)
-    {
-        _this.getMcache();
-        t.getMcache();
-    }
     switch (_this.mod)
     {
     case 0:
@@ -8529,6 +8529,15 @@ Type immutableOf(Type type)
 
 /********************************
  * Make type mutable.
+ *      0            => 0
+ *      const        => 0
+ *      immutable    => 0
+ *      shared       => shared
+ *      shared const => shared
+ *      wild         => 0
+ *      wild const   => 0
+ *      shared wild  => shared
+ *      shared wild const => shared
  */
 Type mutableOf(Type type)
 {
@@ -8545,15 +8554,12 @@ Type mutableOf(Type type)
         type.getMcache();
         if (type.isShared())
         {
-            if (type.isWild())
-                t = type.mcache.swcto; // shared wild const -> shared
-            else
-                t = type.mcache.sto; // shared const => shared
+            t = type.mcache.sto; // shared (wild) const => shared
         }
         else
         {
             if (type.isWild())
-                t = type.mcache.wcto; // wild const -> naked
+                t = type.mcache.wcto; // wild const => naked
             else
                 t = type.mcache.cto; // const => naked
         }


### PR DESCRIPTION
Previously this was only done when the new type was constructed from the main (naked) variant type[[1]](https://github.com/dlang/dmd/pull/22852/changes#r3022559421).

However this can result in situations where multiple distinct types are created of the same type.

i.e: Given the `mcache` map.
```
T -> sto -> shared(T)
            shared(T) -> sto -> T
            shared(T) -> wsto -> wild-shared(T)
                                 wild-shared(T) -> sto -> shared(T)
```
If you call `shared(T).castMod(0)`, you get the original `T`, as the back reference `shared(T).mcache.sto` exists.

However, if you call `wild-shared(T).castMod(0)`, then there are two different possible outcomes.

1. When calling `wild-shared(T).mutableOf().unSharedOf()`, then we successfully get the original `T` via the back references `wild-shared(T).mcache.sto.mcache.sto`

2. When calling `wild-shared(T).unSharedOf().mutableOf()` (and this is the case in `castMod`[[2]](https://github.com/ibuclaw/dmd/blob/f8c46cedd02e38a7075f9fded3d77c743d42f72b/compiler/src/dmd/typesem.d#L8877-L8891)), then a new variant `wild(T)` type is constructed and fixed to `wild-shared(T)` only.
```
T -> sto -> shared(T)
            shared(T) -> sto -> T
            shared(T) -> wsto -> wild-shared(T)
                                 wild-shared(T) -> sto -> shared(T)
                                 wild-shared(T) -> wto -> wild(T)
                                                          wild(T) -> wsto -> wild-shared(T)
```
Then `wild(T).mutableOf()` creates a new distinct copy of the original `T` because `wild(T).mcache.wto` is null.

It's at this point where `Type.merge`/`merge2` should kick in and discard the second copy. But this only succeeds if `T.deco` was added into the global type table `Type.stringtable` _before_ `castMod` was called !!!

If `lookup(T.deco)` returns null, then we're stuck with a split-brain situation of two T's floating around the AST.

---

What this patch does is to ensure the mcache map _always_ gets populated with the "naked" type (if constructed) when fixing two variant types together, so the mcache map in the above scenario instead ends up looking like:
```
T -> sto -> shared(T)
            shared(T) -> sto -> T
            shared(T) -> wsto -> wild-shared(T)
                                 wild-shared(T) -> sto -> shared(T)
                                 wild-shared(T) -> wsto -> T
                                 wild-shared(T) -> wto -> wild(T)
                                                          wild(T) -> wsto -> wild-shared(T)
                                                          wild(T) -> wto -> T
```
So it doesn't matter which variant we have a reference to, we can always get the original "naked" type without having to rely on `merge`/`merge2`.