### PR TITLE
Inline hasElaborateDestructor!(...) into __(needsDestruction, ...)

### DIFF
--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -173,7 +173,7 @@ _d_arrayliteralTX!(__c_wchar_t)
 		else
 		{
 			import core.memory : GC;
-			import core.internal.traits : hasIndirections, hasElaborateDestructor;
+			import core.internal.traits : hasIndirections;
 			alias BlkAttr = BlkAttr;
 			uint attrs = 8u;
 			attrs |= BlkAttr.NO_SCAN;

--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -34,7 +34,6 @@ Params:
 void _d_arrayshrinkfit(Tarr: T[], T)(Tarr arr, bool isshared) @trusted
 {
     import core.exception : onFinalizeError;
-    import core.internal.traits: hasElaborateDestructor;
 
     debug(PRINTF) printf("_d_arrayshrinkfit, elemsize = %zd, arr.ptr = %p arr.length = %zd\n", T.sizeof, arr.ptr, arr.length);
     auto reqlen = arr.length;
@@ -52,7 +51,7 @@ void _d_arrayshrinkfit(Tarr: T[], T)(Tarr arr, bool isshared) @trusted
         return;
 
     // if the type has a destructor, destroy elements we are about to remove.
-    static if(is(T == struct) && hasElaborateDestructor!T)
+    static if(is(T == struct) && __traits(needsDestruction, T))
     {
         try
         {

--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -659,7 +659,7 @@ void* _d_arrayliteralTX(T)(size_t length) @trusted pure nothrow
     else
     {
         import core.memory : GC;
-        import core.internal.traits : hasIndirections, hasElaborateDestructor;
+        import core.internal.traits : hasIndirections;
         alias BlkAttr = GC.BlkAttr;
 
         /* Same as in core.internal.array.utils.__typeAttrs!T,
@@ -669,7 +669,7 @@ void* _d_arrayliteralTX(T)(size_t length) @trusted pure nothrow
         uint attrs = BlkAttr.APPENDABLE;
         static if (!hasIndirections!T)
             attrs |= BlkAttr.NO_SCAN;
-        static if (is(T == struct) && hasElaborateDestructor!T)
+        static if (is(T == struct) && __traits(needsDestruction, T))
             attrs |= BlkAttr.FINALIZE;
 
         version (D_TypeInfo)

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -235,7 +235,7 @@ size_t newCapacity(size_t newlength, size_t elemsize) pure nothrow
 
 uint __typeAttrs(T)(void *copyAttrsFrom = null)
 {
-    import core.internal.traits : hasIndirections, hasElaborateDestructor;
+    import core.internal.traits : hasIndirections;
     import core.memory : GC;
 
     alias BlkAttr = GC.BlkAttr;
@@ -252,7 +252,7 @@ uint __typeAttrs(T)(void *copyAttrsFrom = null)
     static if (!hasIndirections!T)
         attrs |= BlkAttr.NO_SCAN;
 
-    static if (is(T == struct) && hasElaborateDestructor!T)
+    static if (is(T == struct) && __traits(needsDestruction, T))
         attrs |= BlkAttr.FINALIZE;
 
     return attrs;

--- a/druntime/src/core/internal/destruction.d
+++ b/druntime/src/core/internal/destruction.d
@@ -18,9 +18,7 @@ void __ArrayDtor(T)(scope T[] a)
 
 public void destructRecurse(E, size_t n)(ref E[n] arr)
 {
-    import core.internal.traits : hasElaborateDestructor;
-
-    static if (hasElaborateDestructor!E)
+    static if (__traits(needsDestruction, E))
     {
         foreach_reverse (ref elem; arr)
             destructRecurse(elem);

--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -286,7 +286,7 @@ template hasElaborateMove(S)
 }
 
 // Used by std.traits.hasElaborateDestructor
-// TODO inline this in druntime
+// TODO deprecate
 enum hasElaborateDestructor(S) = __traits(needsDestruction, S);
 
 @safe unittest

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -1908,7 +1908,7 @@ pure nothrow @safe @nogc unittest
         static struct X { int n = 0; ~this(){n = 0;} }
         X x;
     }
-    static assert(hasElaborateDestructor!S3);
+    static assert(__traits(needsDestruction, S3));
     S3 s31, s32;
     s31.x.n = 1;
     move(s31, s32);
@@ -1980,14 +1980,12 @@ pure nothrow @safe @nogc unittest
 
 private void moveImpl(T)(scope ref T target, return scope ref T source)
 {
-    import core.internal.traits : hasElaborateDestructor;
-
     static if (is(T == struct))
     {
         //  Unsafe when compiling without -preview=dip1000
         if ((() @trusted => &source == &target)()) return;
         // Destroy target before overwriting it
-        static if (hasElaborateDestructor!T) target.__xdtor();
+        static if (__traits(needsDestruction, T)) target.__xdtor();
     }
     // move and emplace source into target
     moveEmplaceImpl(target, source);
@@ -2037,7 +2035,7 @@ private T trustedMoveImpl(T)(return scope ref T source) @trusted
         static struct X { int n = 0; ~this(){n = 0;} }
         X x;
     }
-    static assert(hasElaborateDestructor!S3);
+    static assert(__traits(needsDestruction, S3));
     S3 s31;
     s31.x.n = 1;
     S3 s32 = move(s31);
@@ -2217,7 +2215,7 @@ private void moveEmplaceImpl(T)(scope ref T target, return scope ref T source)
 //    }
 
     import core.internal.traits : hasElaborateAssign, isAssignable, hasElaborateMove,
-                                  hasElaborateDestructor, hasElaborateCopyConstructor;
+                                  hasElaborateCopyConstructor;
     static if (is(T == struct))
     {
 
@@ -2237,7 +2235,7 @@ private void moveEmplaceImpl(T)(scope ref T target, return scope ref T source)
 
         // If the source defines a destructor or a postblit hook, we must obliterate the
         // object in order to avoid double freeing and undue aliasing
-        static if (hasElaborateDestructor!T || hasElaborateCopyConstructor!T)
+        static if (__traits(needsDestruction, T) || hasElaborateCopyConstructor!T)
         {
             // If there are members that are nested structs, we must take care
             // not to erase any context pointers, so we might have to recurse
@@ -2251,8 +2249,8 @@ private void moveEmplaceImpl(T)(scope ref T target, return scope ref T source)
     {
         static if (T.length)
         {
-            static if (!hasElaborateMove!T &&
-                       !hasElaborateDestructor!T &&
+            static if (!__traits(needsDestruction, T) &&
+                       !hasElaborateMove!T &&
                        !hasElaborateCopyConstructor!T)
             {
                 // Single blit if no special per-instance handling is required
@@ -3035,8 +3033,4 @@ version (D_ProfileGC)
     }
 }
 
-template TypeInfoSize(T)
-{
-    import core.internal.traits : hasElaborateDestructor;
-    enum TypeInfoSize = (is (T == struct) && hasElaborateDestructor!T) ? size_t.sizeof : 0;
-}
+enum TypeInfoSize(T) = (is (T == struct) && __traits(needsDestruction, T)) ? size_t.sizeof : 0;


### PR DESCRIPTION
For the sake of avoiding template bloat as evaluation of a built trait is magnitudes faster than instantiating any template.

As mentioned in TODO at https://github.com/dlang/dmd/pull/22853/changes#diff-9cf671c1375bf050cf93c1ed0b4b81b30d5ba8822b10b9ef3435fc8f67e85553L289.