### PR TITLE
Fix #22860 - DMD emits hardcoded calls to core.atomic

### DIFF
--- a/changelog/dmd.atomic.dd
+++ b/changelog/dmd.atomic.dd
@@ -1,0 +1,24 @@
+Shared static constructors/destructors in templates now lower to `object._d_atomicOp`
+
+When a shared static constructor or destructor appears inside a template, it may
+be instantiated in multiple modules, causing it to run multiple times. A shared
+gate variable is used to count and guard executions, ensuring the body runs
+exactly once across all modules. The atomic operation on that gate is necessary
+because multiple threads may initialize modules concurrently.
+
+This gate operation previously called `core.atomic.atomicOp` directly.
+
+---
+shared static this()
+{
+    if (atomicOp!"+="(gate, 1) != 1) return;
+    // inside a template instantiation
+}
+---
+
+It now lowers to `object._d_atomicOp`, consistent with how other compiler-generated
+runtime hooks are handled.
+
+---
+if (.object._d_atomicOp!"+="(gate, 1) != 1) return;
+---

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4519,7 +4519,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
              * shared int gate;
              * enum op  = isDestructor ? "-=" : "+=";
              * enum cmp = isDestructor ? 0 : 1;
-             * if (core.atomic.atomicOp!op(gate, 1) != cmp) return;
+             * if (._d_atomicOp!op(gate, 1) != cmp) return;
              * ```
              */
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4532,12 +4532,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             Expression e;
             if (isShared)
             {
-                e = doAtomicOp(isDestructor ? "-=" : "+=", v.ident, IntegerExp.literal!(1));
+                e = doAtomicOp(isDestructor ? "-=" : "+=", v.ident, IntegerExp.literal!(1), sc);
                 if (e is null)
-                {
-                    .error(sd.loc, "%s `%s` shared static %s within a template require `core.atomic : atomicOp` to be present", sd.kind, sd.toPrettyChars, what);
                     return;
-                }
             }
             else
             {
@@ -7362,19 +7359,6 @@ Module loadCoreStdcConfig()
     return loadModuleFromLibrary(core_stdc_config, pkgids, Id.config);
 }
 
-/****************************
- * A Singleton that loads core.atomic
- * Returns:
- *  Module of core.atomic, null if couldn't find it
- */
-private Module loadCoreAtomic()
-{
-    __gshared Module core_atomic;
-    auto pkgids = new Identifier[1];
-    pkgids[0] = Id.core;
-    return loadModuleFromLibrary(core_atomic, pkgids, Id.atomic);
-}
-
 /**********************************
  * Load a Module from the library.
  * Params:
@@ -7405,28 +7389,21 @@ extern (D) private static Module loadModuleFromLibrary(ref Module mod, Identifie
 }
 
 /// Do an atomic operation (currently tailored to [shared] static ctors|dtors) needs
-private CallExp doAtomicOp (string op, Identifier var, Expression arg)
+private CallExp doAtomicOp(string op, Identifier var, Expression arg, Scope* sc)
 {
     assert(op == "-=" || op == "+=");
 
-    Module mod = loadCoreAtomic();
-    if (!mod)
-        return null;    // core.atomic couldn't be loaded
-
     const loc = Loc.initial;
 
-    Objects* tiargs = new Objects(1);
-    (*tiargs)[0] = new StringExp(loc, op);
+    if (!verifyHookExist(loc, *sc, Id._d_atomicOp, "shared static ctors/dtors"))
+        return null;
 
-    Expressions* args = new Expressions(2);
-    (*args)[0] = new IdentifierExp(loc, var);
-    (*args)[1] = arg;
 
-    auto sc = new ScopeExp(loc, mod);
-    auto dti = new DotTemplateInstanceExp(
-        loc, sc, Id.atomicOp, tiargs);
+    Expression e = new IdentifierExp(loc, Id.empty);
+    e = new DotIdExp(loc, e, Id.object);
+    auto dti = new DotTemplateInstanceExp(loc, e, Id._d_atomicOp, new Objects(new StringExp(loc, op)));
 
-    return CallExp.create(loc, dti, args);
+    return CallExp.create(loc, dti, new Expressions(new IdentifierExp(loc, var), arg));
 }
 
 /***************************************************

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8709,6 +8709,7 @@ struct Id final
     static Identifier* _d_arrayassign_l;
     static Identifier* _d_arrayassign_r;
     static Identifier* _d_cast;
+    static Identifier* _d_atomicOp;
     static Identifier* imported;
     static Identifier* InterpolationHeader;
     static Identifier* InterpolationFooter;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -298,6 +298,7 @@ immutable Msgtable[] msgtable =
     { "_d_arrayassign_l" },
     { "_d_arrayassign_r" },
     { "_d_cast" },
+    { "_d_atomicOp" },
 
     { "imported" },
     { "InterpolationHeader" },

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -4767,6 +4767,13 @@ auto _d_sqrt(T)(T x)
     return sqrt(x);
 }
 
+// Forwarding hook for shared static ctor/dtor gate operations.
+auto _d_atomicOp(string op, T, V1)(ref shared T val, V1 mod)
+{
+    import core.atomic : atomicOp;
+    return atomicOp!op(val, mod);
+}
+
 public import core.lifetime : _d_newThrowable;
 public import core.lifetime : _d_newclassT;
 public import core.lifetime : _d_newclassTTrace;


### PR DESCRIPTION
Closes #22860

Prompted

> Remove loadCoreAtomic and in doAtomicOp use verifyHookExists on a _d_atomicOp template in @dmd/druntime/src/object.d  instead

And asked for a changelog entry (which I edited), and simplified the argument list construction myself.