### PR TITLE
Windows: Improve check for installed MSVC++ VS component

### DIFF
--- a/compiler/src/dmd/vsoptions.d
+++ b/compiler/src/dmd/vsoptions.d
@@ -831,12 +831,15 @@ const(char)* detectVSInstallDirViaCOM()
             continue; // not a newer version, skip
 
         const installDirLength = thisInstallDir.length;
-        const vcInstallDirLength = installDirLength + 4;
-        auto vcInstallDir = (cast(wchar*) mem.xmalloc_noscan(vcInstallDirLength * wchar.sizeof))[0 .. vcInstallDirLength];
-        scope(exit) mem.xfree(vcInstallDir.ptr);
-        vcInstallDir[0 .. installDirLength] = thisInstallDir.ptr[0 .. installDirLength];
-        vcInstallDir[installDirLength .. $] = "\\VC\0"w;
-        if (!exists(vcInstallDir.ptr))
+        // note: the `VC` subdir alone is not sufficient (can exist without having installed the Visual C++ component)
+        const vcToolsSuffix = `\VC\Tools`w;
+        const vcToolsDirLength = installDirLength + vcToolsSuffix.length + 1; // incl. terminating 0
+        auto vcToolsDir = (cast(wchar*) mem.xmalloc_noscan(vcToolsDirLength * wchar.sizeof))[0 .. vcToolsDirLength];
+        scope(exit) mem.xfree(vcToolsDir.ptr);
+        vcToolsDir[0 .. installDirLength] = thisInstallDir.ptr[0 .. installDirLength];
+        vcToolsDir[installDirLength .. $-1] = vcToolsSuffix;
+        vcToolsDir[$-1] = 0;
+        if (!exists(vcToolsDir.ptr))
             continue; // Visual C++ not included, skip
 
         thisVersionString.moveTo(versionString);


### PR DESCRIPTION
A work colleague has a VS 2022 Pro installation without MSVC++ component, and he still has a `C:\Program Files\Microsoft Visual Studio\2022\Professional\VC` subdir, with 2 subdirs (`Auxiliary` and `Redist`, but not `Tools`). This leads to linking errors later on.

I've checked my local VS 2017, 2019 and 2022 installs (all with MSVC++), and all feature the `VC\Tools` subdir.