### PR TITLE
pickups to build AArch64 druntime

### DIFF
--- a/compiler/src/dmd/backend/arm/cod1.d
+++ b/compiler/src/dmd/backend/arm/cod1.d
@@ -2688,7 +2688,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
 
         reg = allocreg(cdb, forregs, tym);            // allocate registers
 
-        if (sz == 1)
+        if (0 && sz == 1)
         {   regm_t nregm;
 
             debug

--- a/compiler/src/dmd/lib/scanmach.d
+++ b/compiler/src/dmd/lib/scanmach.d
@@ -79,7 +79,7 @@ void scanMachObjModule(void delegate(const(char)[] name, int pickAny) nothrow pA
         header64 = cast(mach_header_64*)buf;
         if (buflen < mach_header_64.sizeof)
             return corrupt(__LINE__);
-        if (header64.cputype != CPU_TYPE_X86_64)
+        if (header64.cputype != CPU_TYPE_X86_64 && header64.cputype != CPU_TYPE_ARM64)
         {
             eSink.error(Loc.initial, "Mach-O object module `%s` has cputype = %d, should be %d", module_name, header64.cputype, CPU_TYPE_X86_64);
             return;


### PR DESCRIPTION
This gets druntime built targeting AArch64 for OSX.