### PR TITLE
Fix #21839 - ICE - Crash when using void[N].init 

### DIFF
--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -7550,12 +7550,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
         override void visit(ArrayLiteralExp e)
         {
             // https://issues.dlang.org/show_bug.cgi?id=20092
-            if (e.elements && e.elements.length && e.type.toBasetype().nextOf().ty == Tvoid)
-            {
-                result = deduceEmptyArrayElement();
-                return;
-            }
-            if ((!e.elements || !e.elements.length) && e.type.toBasetype().nextOf().ty == Tvoid && tparam.ty == Tarray)
+            if (e.type.toBasetype().nextOf().ty == Tvoid && tparam.ty == Tarray)
             {
                 // tparam:T[] <- e:[] (void[])
                 result = deduceEmptyArrayElement();

--- a/compiler/test/compilable/test21839.d
+++ b/compiler/test/compilable/test21839.d
@@ -1,0 +1,10 @@
+// https://github.com/dlang/dmd/issues/21839
+// ICE with void[N].init passed to template function
+
+void tf(U)(U) {}
+
+void test()
+{
+    tf(void[16].init);
+    tf(void[8].init);
+}


### PR DESCRIPTION
Closes #21839