### PR TITLE
Fix #20875 - Error: unknown when calling typeof expression with wrong…

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4158,6 +4158,16 @@ private bool functionParameters(Loc loc, Scope* sc,
             // this can happen when calling `typeof(freefunc)`
             if (buf.length)
                 error(loc, "%s", buf.peekChars());
+            else
+            {
+                // resolveNamedArgs returns null without an error message when there are
+                // too many positional arguments; report the error here
+                // https://github.com/dlang/dmd/issues/20875
+                const nArgs = argumentList.arguments ? argumentList.arguments.length : 0;
+                if (nArgs > nparams && tf.parameterList.varargs == VarArg.none)
+                    error(loc, "expected %llu arguments, not %llu for non-variadic function type `%s`",
+                          cast(ulong)nparams, cast(ulong)nArgs, tf.toErrMsg());
+            }
             return true;
         }
         // note: the argument list should be mutated with named arguments / default arguments,

--- a/compiler/test/fail_compilation/test20875.d
+++ b/compiler/test/fail_compilation/test20875.d
@@ -1,0 +1,20 @@
+// https://github.com/dlang/dmd/issues/20875
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test20875.d(19): Error: expected 0 arguments, not 1 for non-variadic function type `pure nothrow @nogc @safe void()`
+---
+*/
+
+struct S
+{
+    auto front() {}
+}
+
+void test()
+{
+    S res;
+    ulong x;
+    typeof(res.front)(x);
+}


### PR DESCRIPTION
… argument count

When calling a `typeof(expr)` type with too many positional arguments, `resolveNamedArgs` returned null without filling the error buffer because itexpected the caller to do that.