### PR TITLE
Fix #22878 - IFTI fails with named arguments after template variadic

### DIFF
--- a/changelog/dmd.named-args-ifti.dd
+++ b/changelog/dmd.named-args-ifti.dd
@@ -1,0 +1,32 @@
+Implicit Function Template Instantiation (IFTI) handled named arguments better
+
+https://github.com/dlang/dmd/issues/21335
+https://github.com/dlang/dmd/issues/22878
+
+When calling a function template with named arguments, parameters that are
+skipped (because their named argument was not provided) now correctly use
+their template parameter defaults for type deduction.
+
+---
+void f(A = int, B = int)(A a = A.init, B b = B.init) {}
+
+void main()
+{
+    f(b: "hello"); // A = int (template default), B = string (deduced)
+}
+---
+
+Named arguments that appear behind variadic arguments can now be assigned to:
+
+---
+void error(T...)(T args, string file = __FILE__, int line = __LINE__) {}
+
+auto text(T...)(T args, Allocator alloc) {}
+
+void foo(Allocator gc)
+{
+    error("Code: ", code, file: __FILE__, line: __LINE__)
+
+    return text("hello", "world", alloc: gc);
+}
+---

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -4413,7 +4413,11 @@ private MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, TemplateIn
             }
             if (fname && !foundName)
             {
-                argi = DEFAULT_ARGI;
+                // For a variadic tuple parameter, don't mark as DEFAULT_ARGI.
+                // The named arg goes to a post-tuple parameter; the tuple will
+                // be handled below (possibly as an empty tuple T = ()).
+                if (!(fptupindex != IDX_NOTFOUND && parami == fptupindex))
+                    argi = DEFAULT_ARGI;
             }
 
             /* See function parameters which wound up
@@ -4433,20 +4437,26 @@ private MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, TemplateIn
 
                     /* Count function parameters with no defaults following a tuple parameter.
                      * void foo(U, T...)(int y, T, U, double, int bar = 0) {}  // rem == 2 (U, double)
+                     * Parameters provided as named arguments don't count towards rem.
                      */
                     size_t rem = 0;
                     foreach (j; parami + 1 .. nfparams)
                     {
                         Parameter p = fparameters[j];
                         if (p.defaultArg)
-                        {
                             break;
-                        }
-                        foreach(argLabel; fnames)
+                        // If covered by a named argument, no positional arg is needed for it
+                        bool coveredByNamedArg = false;
+                        foreach (argLabel; fnames)
                         {
-                            if (p.ident == argLabel.name)
+                            if (p.ident && p.ident == argLabel.name)
+                            {
+                                coveredByNamedArg = true;
                                 break;
+                            }
                         }
+                        if (coveredByNamedArg)
+                            continue;
                         if (!reliesOnTemplateParameters(p.type, (*td.parameters)[inferStart .. td.parameters.length]))
                         {
                             Type pt = p.type.syntaxCopy().typeSemantic(fd.loc, paramscope);
@@ -4461,12 +4471,26 @@ private MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, TemplateIn
                         }
                     }
 
-                    if (nfargs2 - argi < rem)
-                        return nomatch();
-                    declaredTuple.objects.setDim(nfargs2 - argi - rem);
-                    foreach (i; 0 .. declaredTuple.objects.length)
+                    // Named args are anonymous-tuple boundaries: they always target
+                    // explicitly-named post-tuple parameters. The first named arg
+                    // in the list marks where the tuple ends; any positional args
+                    // after it also go to post-tuple parameters (in order).
+                    size_t tupleEnd = nfargs2;
+                    foreach (i; argi .. nfargs2)
                     {
-                        farg = fargs[argi + i];
+                        if (i < fnames.length && fnames[i].name)
+                        {
+                            tupleEnd = i;
+                            break;
+                        }
+                    }
+
+                    if (tupleEnd - argi < rem)
+                        return nomatch();
+                    declaredTuple.objects.setDim(tupleEnd - argi - rem);
+                    foreach (i; argi .. tupleEnd - rem)
+                    {
+                        farg = fargs[i];
 
                         // Check invalid arguments to detect errors early.
                         if (farg.op == EXP.error || farg.type.ty == Terror)
@@ -4497,7 +4521,7 @@ private MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, TemplateIn
                         {
                             tt = tt.mutableOf();
                         }
-                        declaredTuple.objects[i] = tt;
+                        declaredTuple.objects[i - argi] = tt;
                     }
                     td.declareParameter(paramscope, tp, declaredTuple);
                 }

--- a/compiler/test/compilable/named_arguments_ifti.d
+++ b/compiler/test/compilable/named_arguments_ifti.d
@@ -38,3 +38,21 @@ void testIssue21335()
 {
     f5(b: "hello");
 }
+
+// Variadic tuple with named argument for default parameter (post-tuple)
+// https://github.com/dlang/dmd/issues/22878
+int f6(T...)(T args, string file = __FILE__, int line = __LINE__) { return T.length; }
+static assert(f6(1, 2, file: __FILE__) == 2);
+static assert(f6(file: __FILE__) == 0);
+static assert(f6(1, 2, 3) == 3);
+
+static assert(f6(1, 2, file: __FILE__, 0) == 2);
+static assert(f6(file: __FILE__, 0) == 0);
+static assert(f6(1, 2, line: 0) == 2);
+static assert(f6(1, 2, line: 0, file: __FILE__) == 2);
+
+// Named argument for default parameter before the variadic tuple
+int f7(T...)(int x = 0, T args) { return x + cast(int) T.length; }
+static assert(f7(1, 2, 3) == 1 + 2);    // x=1, args=(2,3)
+static assert(f7(x: 5, 1, 2) == 5 + 2); // x=5 (named), args=(1,2)
+static assert(f7(x: 5) == 5 + 0);       // x=5 (named), args=()


### PR DESCRIPTION
Closes #22878

