### PR TITLE
more Arm64, add AArch64 fixups

### DIFF
--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -916,7 +916,30 @@ void MachObj_term(const(char)[] objfilename)
                     //symbol_print(*s);
                     if (r.flag == 1)  // emit SUBTRACTOR/UNSIGNED pair
                     {
-                        if (I64)
+                        if (AArch64)
+                        {
+                            rel.r_type = ARM64_RELOC_SUBTRACTOR;
+                            rel.r_address = cast(int)r.offset;
+                            rel.r_symbolnum = r.funcsym.Sxtrnnum;
+                            rel.r_pcrel = 0;
+                            rel.r_length = 3;
+                            rel.r_extern = 1;
+                            fobjbuf.write(&rel, rel.sizeof);
+                            foffset += (rel).sizeof;
+                            ++nreloc;
+
+                            rel.r_type = ARM64_RELOC_UNSIGNED;
+                            rel.r_symbolnum = s.Sxtrnnum;
+                            fobjbuf.write(&rel, rel.sizeof);
+                            foffset += rel.sizeof;
+                            ++nreloc;
+
+                            // patch with fdesym.Soffset - offset
+                            long* p = cast(long*)patchAddr64(seg, r.offset);
+                            *p += r.funcsym.Soffset - r.offset;
+                            continue;
+                        }
+                        else if (I64)
                         {
                             rel.r_type = X86_64_RELOC_SUBTRACTOR;
                             rel.r_address = cast(int)r.offset;
@@ -2562,6 +2585,7 @@ size_t MachObj_bytes(int seg, targ_size_t offset, size_t nbytes, const(void)* p)
 void MachObj_addrel(int seg, targ_size_t offset, Symbol* targsym,
         uint targseg, int rtype, int val = 0)
 {
+    //printf("MachObj_addrel()\n");
     Relocation rel = void;
     rel.offset = offset;
     rel.targsym = targsym;
@@ -3066,6 +3090,7 @@ int mach_dwarf_reftoident(int seg, targ_size_t offset, Symbol* s, targ_size_t va
 @trusted
 int dwarf_eh_frame_fixup(int dfseg, targ_size_t offset, Symbol* s, targ_size_t val, Symbol* fdesym)
 {
+    //printf("dwarf_eh_frame_fixup()\n");
     OutBuffer* buf = SegData[dfseg].SDbuf;
     assert(offset == buf.length());
     assert(fdesym.Sseg == dfseg);

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -638,9 +638,9 @@ dmd -cov -unittest myprog.d
             $(LINK2 https://msdn.microsoft.com/en-us/library/dd831853(v=vs.100).aspx, Microsoft Visual Studio 10)
             or later compiler.)`,
         ),
-        Option("maarch64",
-            "generate AArch64 bit code",
-            "Compile an AArch64 bit executable. Only supported for OSX.",
+        Option("marm64",
+            "generate Arm 64 bit code",
+            "Compile an Arm 64 bit executable. Only supported for OSX.",
         ),
         Option("main",
             "add default main() if not present already (e.g. for unittesting)",

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -298,7 +298,7 @@ void getenv_setargv(const(char)* envvalue, Strings* args)
 }
 
 /**
- * Parse command line arguments for the last instance of -m32, -m64, -m32mscoff, -maarch64
+ * Parse command line arguments for the last instance of -m32, -m64, -m32mscoff, -marm64
  * to detect the desired architecture.
  *
  * Params:
@@ -323,8 +323,8 @@ const(char)[] parse_arch_arg(Strings* args, const(char)[] arch)
             case "-m32mscoff":
                 arch = arg[2 .. 4];
                 continue;
-            case "-maarch64":
-                arch = arg[2 .. 9];
+            case "-marm64":
+                arch = arg[2 .. 7];
                 continue;
             case "-run":   // end of args to dmd
                 break;
@@ -1003,7 +1003,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, out Param 
         {
             continue; // skip druntime options, e.g. used to configure the GC
         }
-        else if (arg == "-maarch64") // https://dlang.org/dmd.html#switch-maarch64
+        else if (arg == "-marm64") // https://dlang.org/dmd.html#switch-marm64
         {
             target.isAArch64 = true;
             target.isX86    = false;

--- a/compiler/test/compilable/testhelp.d
+++ b/compiler/test/compilable/testhelp.d
@@ -20,7 +20,7 @@ Where:
   @<cmdfile>       read arguments from cmdfile
 $r:.*$
   -m64              generate 64 bit code
-  -maarch64         generate AArch64 bit code
+  -marm64           generate Arm 64 bit code
   -main             add default main() if not present already (e.g. for unittesting)
 $r:.*$
 ----


### PR DESCRIPTION
At least for the OSX facing code, use Arm64. AArch64 is for the internals.

Chatgpt pointed out I was using the wrong fixups for AArch64, and which ones I should be using.

I'm still working on fixing the eh_frame state machine for AArch64.