### PR TITLE
Fix #21765 - importC: attribute(aligned)/declspec(align) reduces alig…

### DIFF
--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -480,8 +480,9 @@ extern (C++) struct structalign_t
     ubyte flags;       // Align semantic flags
     enum : ubyte
     {
-        PACK = 0x1,     // use #pragma pack semantics
-        ALIGNAS = 0x2,  // use _Alignas semantics
+        PACK = 0x1,         // use #pragma pack semantics
+        ALIGNAS = 0x2,      // use _Alignas semantics (can shrink below natural alignment)
+        ALIGN_ATTRIB = 0x4, // use __attribute__(align) semantics (only grow alignment)
     }
 
   public:
@@ -496,6 +497,8 @@ extern (C++) struct structalign_t
     void setPack()         { flags |= PACK; }
     bool fromAlignas() const { return !!(flags & ALIGNAS); }
     void setAlignas()      { flags |= ALIGNAS; }
+    bool fromCAlignAttribute() const { return !!(flags & ALIGN_ATTRIB); }
+    void setCAlignAttribute() { flags |= ALIGN_ATTRIB; }
 }
 
 /// Use to return D arrays from C++ functions

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1727,7 +1727,9 @@ final class CParser(AST) : Parser!AST
         {
             auto decls = new AST.Dsymbols(1);
             (*decls)[0] = stags;
-            stags = new AST.AlignDeclaration(stags.loc, tt.alignExps, decls);
+            auto ald = new AST.AlignDeclaration(stags.loc, tt.alignExps, decls);
+            ald.salign.setCAlignAttribute();
+            stags = ald;
         }
         symbols.push(stags);
     }

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -10173,13 +10173,16 @@ private extern(C++) class FinalizeSizeVisitor : Visitor
             }
         }
 
+        // C: __attribute__((aligned(N))) and similar can only increase alignment,
+        // not reduce it below the natural alignment. If N < sd.alignsize, ignore.
+        if (sd.alignment.fromCAlignAttribute() && sd.alignment.get() < sd.alignsize)
+            sd.alignment.setDefault();
+
         // Round struct size up to next alignsize boundary.
         // This will ensure that arrays of structs will get their internals
         // aligned properly.
-        if (sd.alignment.isDefault() || sd.alignment.isPack())
-            sd.structsize = (sd.structsize + sd.alignsize - 1) & ~(sd.alignsize - 1);
-        else
-            sd.structsize = (sd.structsize + sd.alignment.get() - 1) & ~(sd.alignment.get() - 1);
+        const alignTo = (sd.alignment.isDefault() || sd.alignment.isPack()) ? sd.alignsize : sd.alignment.get();
+        sd.structsize = (sd.structsize + alignTo - 1) & ~(alignTo - 1);
 
         sd.sizeok = Sizeok.done;
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6160,6 +6160,7 @@ private:
     {
         PACK = 1u,
         ALIGNAS = 2u,
+        ALIGN_ATTRIB = 4u,
     };
 
 public:
@@ -6173,6 +6174,8 @@ public:
     void setPack();
     bool fromAlignas() const;
     void setAlignas();
+    bool fromCAlignAttribute() const;
+    void setCAlignAttribute();
     structalign_t() :
         value(0u),
         flags()

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -312,6 +312,8 @@ public:
     void setPack();
     bool fromAlignas() const;
     void setAlignas();
+    bool fromCAlignAttribute() const;
+    void setCAlignAttribute();
 };
 
 // magic value means "match whatever the underlying C compiler does"

--- a/compiler/test/compilable/alignas.c
+++ b/compiler/test/compilable/alignas.c
@@ -16,3 +16,16 @@ struct S
 
 struct S s = { 1, 2 };
 _Static_assert(sizeof(struct S) == 8, "in");
+
+// https://github.com/dlang/dmd/issues/21765
+// __attribute__((aligned(N))) can only increase struct alignment
+
+// aligned(2) on struct with int (natural alignment = 4): attribute is ignored, alignment stays 4
+struct __attribute__((aligned(2))) S1 { int x; };
+_Static_assert(sizeof(struct S1) == 4, "sizeof S1");
+_Static_assert(_Alignof(struct S1) == 4, "alignof S1");
+
+// postfix form
+struct S2 { int x; } __attribute__((aligned(1)));
+_Static_assert(sizeof(struct S2) == 4, "sizeof S2");
+_Static_assert(_Alignof(struct S2) == 4, "alignof S2");


### PR DESCRIPTION
…nment

Closes #21765

@ibuclaw 

Claude's fix was to distinguish ImportC based on `ClassKind.c`, but that also applies to `extern(C) struct` in D so I added ALIGN_ATTRIB to structalign_t instead.