### PR TITLE
[stable] C++ headers: Remove removed Scope::search() member function and fix signature of dmd::isVirtual()

### DIFF
--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -45,7 +45,7 @@ namespace dmd
     bool equals(const Dsymbol * const ds, const Dsymbol * const s);
     bool hasNestedFrameRefs(FuncDeclaration *fd);
     bool isVirtualMethod(FuncDeclaration *fd);
-    bool isVirtual(const FuncDeclaration *fd);
+    bool isVirtual(const FuncDeclaration * const fd);
 }
 
 //enum STC : ulong from astenums.d:

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -138,6 +138,4 @@ struct Scope final
     AliasDeclaration *aliasAsg; // if set, then aliasAsg is being assigned a new value,
                                 // do not set wasRead for it
     StructDeclaration *argStruct; // elimiate recursion when looking for rvalue construction
-
-    Dsymbol *search(Loc loc, Identifier *ident, Dsymbol *&pscopesym, SearchOptFlags flags = (SearchOptFlags)SearchOpt::all);
 };


### PR DESCRIPTION
That function was converted to a free-standing function in v2.113.