### PR TITLE
Fix issue 22887 - ICE with  ForwardRef*[$] array

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2403,9 +2403,17 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 Expression ie = dsym._init.initializerToExpression(null, sc.inCfile);
                 if (ie && ie.op != EXP.error)
                 {
-                    ie = ie.expressionSemantic(sc);
-                    ie = ie.optimize(WANTvalue);
+                    // Infer from literal syntax first to avoid prematurely
+                    // semantic-analyzing expressions that may depend on
+                    // incomplete types (e.g. recursive initializers).
+                    // https://github.com/dlang/dmd/issues/22887
                     bool dimInferred = inferSArrayDim(tsa, ie, dsym.loc, sc);
+                    if (!dimInferred)
+                    {
+                        ie = ie.expressionSemantic(sc);
+                        ie = ie.optimize(WANTvalue);
+                        dimInferred = inferSArrayDim(tsa, ie, dsym.loc, sc);
+                    }
                     if (!dimInferred)
                     {
                         .error(dsym.loc, "cannot infer static array length from `$`, provide an initializer");

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2389,6 +2389,24 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return true;
         }
 
+        static bool shouldTryDeepSArrayDimInference(Expression ie, Scope* sc)
+        {
+            if (!ie)
+                return false;
+
+            // `new` expressions cannot provide a compile-time static extent
+            // for inferring `$`, and may recurse through incomplete aggregates.
+            if (ie.isNewExp())
+                return false;
+
+            // Field initializers are especially prone to recursive semantic
+            // evaluation against incompletely defined aggregates.
+            if (sc && sc.parent && sc.parent.isAggregateDeclaration())
+                return false;
+
+            return true;
+        }
+
         auto tsa = dsym.type.isTypeSArray();
 
         if (tsa && hasDollarDimension(tsa))
@@ -2397,6 +2415,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 .error(dsym.loc, "cannot infer static array length from `$`, provide an initializer");
                 tsa.dim = new IntegerExp(dsym.loc, 0, Type.tsize_t);
+                dsym._init = new ErrorInitializer();
+                dsym.type = Type.terror;
+                dsym.errors = true;
+                dsym.semanticRun = PASS.semanticdone;
+                return;
             }
             else
             {
@@ -2408,7 +2431,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     // incomplete types (e.g. recursive initializers).
                     // https://github.com/dlang/dmd/issues/22887
                     bool dimInferred = inferSArrayDim(tsa, ie, dsym.loc, sc);
-                    if (!dimInferred)
+                    if (!dimInferred && shouldTryDeepSArrayDimInference(ie, sc))
                     {
                         ie = ie.expressionSemantic(sc);
                         ie = ie.optimize(WANTvalue);
@@ -2418,6 +2441,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     {
                         .error(dsym.loc, "cannot infer static array length from `$`, provide an initializer");
                         tsa.dim = new IntegerExp(dsym.loc, 0, Type.tsize_t);
+                        dsym._init = new ErrorInitializer();
+                        dsym.type = Type.terror;
+                        dsym.errors = true;
+                        dsym.semanticRun = PASS.semanticdone;
+                        return;
                     }
                     if (auto ale = ie.isArrayLiteralExp())
                         dsym._init = new ExpInitializer(dsym.loc, ale);

--- a/compiler/test/fail_compilation/staticarray.d
+++ b/compiler/test/fail_compilation/staticarray.d
@@ -1,17 +1,67 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/staticarray.d(11): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(12): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(13): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(16): Error: variable `staticarray.ForwardRef.arr` recursive initialization of field
+fail_compilation/staticarray.d(24): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(25): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(26): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(29): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(27): Error: struct `staticarray.ForwardRef1` circular or forward reference
+fail_compilation/staticarray.d(38): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(36): Error: struct `staticarray.ForwardRef3` circular or forward reference
+fail_compilation/staticarray.d(43): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(41): Error: struct `staticarray.ForwardRef4` circular or forward reference
+fail_compilation/staticarray.d(50): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(47): Error: struct `staticarray.ForwardRef5` circular or forward reference
+fail_compilation/staticarray.d(55): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(53): Error: struct `staticarray.ForwardRef6` circular or forward reference
+fail_compilation/staticarray.d(60): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(58): Error: struct `staticarray.ForwardRef7` circular or forward reference
+fail_compilation/staticarray.d(66): Error: struct `staticarray.ForwardRef8` cannot have field `arr` with static array of same struct type
+fail_compilation/staticarray.d(33): Error: variable `staticarray.ForwardRef2.arr` recursive initialization of field
 ---
 */
 
 int[$] arr1;
 int[$] arr2 = void;
 int[$][1] arr3 = 1;
-struct ForwardRef
+struct ForwardRef1
 {
-    ForwardRef*[$] arr = [new ForwardRef()];
+    ForwardRef1[$] arr = new ForwardRef1();
+}
+struct ForwardRef2
+{
+    ForwardRef2*[$] arr = [new ForwardRef2()];
+}
+
+struct ForwardRef3
+{
+    ForwardRef3[$] arr = ForwardRef3.init;
+}
+
+struct ForwardRef4
+{
+    ForwardRef4[$] arr = make();
+    static ForwardRef4 make() { return ForwardRef4.init; }
+}
+
+struct ForwardRef5
+{
+    enum bool flag = true;
+    ForwardRef5[$] arr = flag ? ForwardRef5.init : ForwardRef5.init;
+}
+
+struct ForwardRef6
+{
+    ForwardRef6[$] arr = (0, ForwardRef6.init);
+}
+
+struct ForwardRef7
+{
+    ForwardRef7[$] arr = make();
+    static ForwardRef7[] make() { return [ForwardRef7.init]; }
+}
+
+struct ForwardRef8
+{
+    ForwardRef8[$][$] arr = [[ForwardRef8.init]];
 }

--- a/compiler/test/fail_compilation/staticarray.d
+++ b/compiler/test/fail_compilation/staticarray.d
@@ -1,12 +1,17 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/staticarray.d(10): Error: cannot infer static array length from `$`, provide an initializer
 fail_compilation/staticarray.d(11): Error: cannot infer static array length from `$`, provide an initializer
 fail_compilation/staticarray.d(12): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(13): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation/staticarray.d(16): Error: variable `staticarray.ForwardRef.arr` recursive initialization of field
 ---
 */
 
 int[$] arr1;
 int[$] arr2 = void;
 int[$][1] arr3 = 1;
+struct ForwardRef
+{
+    ForwardRef*[$] arr = [new ForwardRef()];
+}


### PR DESCRIPTION
It is related to #22887 

At first, I changed the flow to infer length from raw array/string initializer syntax first, and only run expressionSemantic as fallback for non-literal forms. That avoids the forward-ref assert and align behavior with explicit [1].

Then I realize maybe it's not enough, so I add a new guard to the circular/recursive initializer.