### PR TITLE
Fix #22892 - __declspec(align(N)) reduces alignment

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3405,7 +3405,9 @@ final class CParser(AST) : Parser!AST
                 }
                 else if (token.ident == Id._align)
                 {
-                    // Microsoft spec is very imprecise as to how this actually works
+                    // https://learn.microsoft.com/en-us/cpp/cpp/align-cpp
+                    // __declspec(align(N)) sets the minimum alignment of the type,
+                    // like __attribute__((aligned(N))). It can only increase alignment.
                     nextToken();
                     check(TOK.leftParenthesis);
                     if (token.value == TOK.int32Literal)
@@ -3413,8 +3415,13 @@ final class CParser(AST) : Parser!AST
                         const n = token.unsvalue;
                         if (n < 1 || n & (n - 1) || 8192 < n)
                             error("__decspec(align(%lld)) must be an integer positive power of 2 and be <= 8,192", cast(ulong)n);
-                        specifier.packalign.set(cast(uint)n);
-                        specifier.packalign.setPack();
+                        else
+                        {
+                            auto e = new AST.IntegerExp(token.loc, n, AST.Type.tuns32);
+                            if (!specifier.alignAttrs)
+                                specifier.alignAttrs = new AST.Expressions();
+                            specifier.alignAttrs.push(e);
+                        }
                         nextToken();
                     }
                     else

--- a/compiler/test/compilable/alignas.c
+++ b/compiler/test/compilable/alignas.c
@@ -29,3 +29,49 @@ _Static_assert(_Alignof(struct S1) == 4, "alignof S1");
 struct S2 { int x; } __attribute__((aligned(1)));
 _Static_assert(sizeof(struct S2) == 4, "sizeof S2");
 _Static_assert(_Alignof(struct S2) == 4, "alignof S2");
+
+// __declspec(align(N)) behaves like __attribute__((aligned(N))): only increases alignment
+// N < natural (4): ignored
+struct __declspec(align(2)) S3 { int x; };
+_Static_assert(sizeof(struct S3) == 4, "sizeof S3");
+_Static_assert(_Alignof(struct S3) == 4, "alignof S3");
+
+// N > natural (4): increases to 16
+struct __declspec(align(16)) S4 { int x; };
+_Static_assert(sizeof(struct S4) == 16, "sizeof S4");
+_Static_assert(_Alignof(struct S4) == 16, "alignof S4");
+
+// #pragma pack reduces alignment (unlike aligned), so it must still work
+#pragma pack(2)
+struct S5 { int x; };
+#pragma pack()
+_Static_assert(_Alignof(struct S5) == 2, "alignof S5");
+
+// Combinations of #pragma pack with alignment attributes
+// pack(2) + aligned(8): pack reduces member alignment, aligned(8) still increases struct alignment (matches GCC)
+#pragma pack(2)
+struct S6 { int x; } __attribute__((aligned(8)));
+#pragma pack()
+_Static_assert(sizeof(struct S6) == 8, "sizeof S6");
+_Static_assert(_Alignof(struct S6) == 8, "alignof S6");
+
+// pack(2) + __declspec(align(8)): same result as above
+#pragma pack(2)
+struct __declspec(align(8)) S7 { int x; };
+#pragma pack()
+_Static_assert(sizeof(struct S7) == 8, "sizeof S7");
+_Static_assert(_Alignof(struct S7) == 8, "alignof S7");
+
+// pack(2) + aligned(1) on short: aligned(1) < pack's alignsize(2), so ignored
+#pragma pack(2)
+struct S8 { short x; } __attribute__((aligned(1)));
+#pragma pack()
+_Static_assert(sizeof(struct S8) == 2, "sizeof S8");
+_Static_assert(_Alignof(struct S8) == 2, "alignof S8");
+
+// pack(2) + _Alignas(8) on member: #pragma pack dominates _Alignas (matches GCC)
+#pragma pack(2)
+struct S9 { _Alignas(8) int x; };
+#pragma pack()
+_Static_assert(sizeof(struct S9) == 4, "sizeof S9");
+_Static_assert(_Alignof(struct S9) == 2, "alignof S9");

--- a/compiler/test/compilable/alignas.c
+++ b/compiler/test/compilable/alignas.c
@@ -75,3 +75,17 @@ struct S9 { _Alignas(8) int x; };
 #pragma pack()
 _Static_assert(sizeof(struct S9) == 4, "sizeof S9");
 _Static_assert(_Alignof(struct S9) == 2, "alignof S9");
+
+// pack(2) + aligned(8) on member: #pragma pack dominates __attribute__((aligned)) (matches GCC/clang)
+#pragma pack(2)
+struct S10 { int x __attribute__((aligned(8))); };
+#pragma pack()
+_Static_assert(sizeof(struct S10) == 4, "sizeof S10");
+_Static_assert(_Alignof(struct S10) == 2, "alignof S10");
+
+// pack(2) + __declspec(align(8)) on member: #pragma pack dominates (matches clang -fdeclspec)
+#pragma pack(2)
+struct S11 { __declspec(align(8)) int x; };
+#pragma pack()
+_Static_assert(sizeof(struct S11) == 4, "sizeof S11");
+_Static_assert(_Alignof(struct S11) == 2, "alignof S11");

--- a/compiler/test/compilable/test21150.c
+++ b/compiler/test/compilable/test21150.c
@@ -50,7 +50,6 @@ _Static_assert(_Alignof(struct D)==8, "D");
      unsigned long long b;
  } __attribute__((aligned(4), packed));
 _Static_assert(_Alignof(struct Spacked) == 4, "Spacked");
-_Static_assert(_Alignof(struct Spacked) == 4, "Spacked");
 _Static_assert(offsetof(struct Spacked, a) == 0, "Spacked.a");
 _Static_assert(offsetof(struct Spacked, b) == sizeof(unsigned), "Spacked.b");
 _Static_assert(sizeof(struct Spacked) == sizeof(unsigned) + sizeof(unsigned long long), "sizeof(Spacked)");


### PR DESCRIPTION
Follow up https://github.com/dlang/dmd/pull/22888

__declspec(align(N)) now uses the same mechanism as (like `__attribute__((aligned(N)))`)

@ibuclaw 