### PR TITLE
Swap assert to error message for mach-o section name length

### DIFF
--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -1893,8 +1893,18 @@ int MachObj_jmpTableSegment(Symbol* s)
 int MachObj_getsegment(const(char)* sectname, const(char)* segname,
         int p2align, int flags)
 {
-    assert(strlen(sectname) <= 16);
-    assert(strlen(segname)  <= 16);
+    if (strlen(sectname) > 16)
+    {
+        error(Srcpos.init, "invalid section name, length too long for `%s`", sectname);
+        return 0;
+    }
+
+    if (strlen(segname) > 16)
+    {
+        error(Srcpos.init, "invalid segment name, length too long for `%s`", segname);
+        return 0;
+    }
+
     for (int seg = 1; seg < cast(int)SegData.length; seg++)
     {   seg_data* pseg = SegData[seg];
         if (I64)


### PR DESCRIPTION
I discovered this during linker list implementation.

Basically the section name length has a maximum of 16 characters of macos and there is no workaround implemented in the linker.

Having it be an assert means that it can silently error, or even ICE, swapping to the error message at least tells you why it isn't compiling.

No test, only way to trigger this is with section attribute currently which is new.

No changelog, as its more of a bug fix for an ICE.