### PR TITLE
[stable] druntime: Add Emscripten support in core.sys.posix.signal

### DIFF
--- a/druntime/src/core/sys/posix/signal.d
+++ b/druntime/src/core/sys/posix/signal.d
@@ -414,6 +414,30 @@ version (linux)
         enum SIGUSR2    = 12;
         enum SIGURG     = 23;
     }
+    else version (Emscripten)
+    {
+        //SIGABRT (defined in core.stdc.signal)
+        enum SIGALRM    = 14;
+        enum SIGBUS     = 7;
+        enum SIGCHLD    = 17;
+        enum SIGCONT    = 18;
+        //SIGFPE (defined in core.stdc.signal)
+        enum SIGHUP     = 1;
+        //SIGILL (defined in core.stdc.signal)
+        //SIGINT (defined in core.stdc.signal)
+        enum SIGKILL    = 9;
+        enum SIGPIPE    = 13;
+        enum SIGQUIT    = 3;
+        //SIGSEGV (defined in core.stdc.signal)
+        enum SIGSTOP    = 19;
+        //SIGTERM (defined in core.stdc.signal)
+        enum SIGTSTP    = 20;
+        enum SIGTTIN    = 21;
+        enum SIGTTOU    = 22;
+        enum SIGUSR1    = 10;
+        enum SIGUSR2    = 12;
+        enum SIGURG     = 23;
+    }
     else
         static assert(0, "unimplemented");
 }
@@ -1784,6 +1808,16 @@ version (linux)
         enum SIGXCPU    = 24;
         enum SIGXFSZ    = 25;
     }
+    else version (Emscripten)
+    {
+        enum SIGPOLL    = 29;
+        enum SIGPROF    = 27;
+        enum SIGSYS     = 31;
+        enum SIGTRAP    = 5;
+        enum SIGVTALRM  = 26;
+        enum SIGXCPU    = 24;
+        enum SIGXFSZ    = 25;
+    }
     else
         static assert(0, "unimplemented");
 
@@ -2764,6 +2798,11 @@ else version (CRuntime_Musl)
         enum SIGSTKSZ    = 16384;
     }
     else version (RISCV64)
+    {
+        enum MINSIGSTKSZ = 2048;
+        enum SIGSTKSZ    = 8192;
+    }
+    else version (Emscripten)
     {
         enum MINSIGSTKSZ = 2048;
         enum SIGSTKSZ    = 8192;


### PR DESCRIPTION
Based on https://github.com/emscripten-core/emscripten/blob/main/system/lib/libc/musl/arch/emscripten/bits/signal.h. This makes `core.stdc.stdio` importable again for Emscripten (tested by LDC), which regressed with v2.113.