### PR TITLE
Fix #22902 - Named arguments not cleared after re-ordering

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6798,6 +6798,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.arguments = new Expressions();
                 if (functionParameters(exp.loc, sc, tf, null, exp.type, exp.argumentList, f, exp.type, exp.argprefix))
                     return setError();
+                exp.names = null;
 
                 exp.member = f.isCtorDeclaration();
                 assert(exp.member);
@@ -6911,6 +6912,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.arguments = new Expressions();
                 if (functionParameters(exp.loc, sc, tf, null, exp.type, exp.argumentList, f, exp.type, exp.argprefix))
                     return setError();
+                exp.names = null;
 
                 exp.member = f.isCtorDeclaration();
                 assert(exp.member);
@@ -8515,6 +8517,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.arguments = new Expressions();
         if (functionParameters(exp.loc, sc, cast(TypeFunction)t1, ethis, tthis, exp.argumentList, exp.f, exp.type, argprefix))
             return setError();
+        exp.names = null;
 
         if (!exp.type)
         {

--- a/compiler/test/fail_compilation/named_arguments_error.d
+++ b/compiler/test/fail_compilation/named_arguments_error.d
@@ -18,7 +18,7 @@ fail_compilation/named_arguments_error.d(42):        missing argument for parame
 fail_compilation/named_arguments_error.d(34):        `named_arguments_error.g(int x, int y, int z = 3)` declared here
 fail_compilation/named_arguments_error.d(44): Error: no named argument `element` allowed for array dimension
 fail_compilation/named_arguments_error.d(45): Error: no named argument `number` allowed for scalar
-fail_compilation/named_arguments_error.d(46): Error: cannot implicitly convert expression `g(x: 3, y: 4, z: 5)` of type `int` to `string`
+fail_compilation/named_arguments_error.d(46): Error: cannot implicitly convert expression `g(3, 4, 5)` of type `int` to `string`
 fail_compilation/named_arguments_error.d(47): Error: template `tempfun` is not callable using argument types `!()(int, int)`
 fail_compilation/named_arguments_error.d(47):        argument `1` goes past end of parameter list
 fail_compilation/named_arguments_error.d(50):        Candidate is: `tempfun(T, U)(T t, U u)`
@@ -43,7 +43,7 @@ void main()
 
 	auto g0 = new int[](element: 3);
 	auto g1 = new int(number: 3);
-	string s = g(x: 3, y: 4, z: 5);
+	string s = g(z: 5, x: 3, y: 4);
 	enum x = tempfun(u: 0, 1);
 }
 


### PR DESCRIPTION
Closes #22902

Split off from https://github.com/dlang/dmd/pull/22903

`exp.names = null;` can't be done inside `functionParameters` because the current parameter lists takes an argumentList by value, copying the pointer instead of passing it by ref. I think `functionParameters` should just take the CallExp directly, but I rather do that in a follow up refactoring PR.