### PR TITLE
Call copy constructor for arguments passed to variadic array

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4302,6 +4302,7 @@ private bool functionParameters(Loc loc, Scope* sc,
                         else
                             a = a.implicitCastTo(sc, tbn);
                         a = a.addDtorHook(sc);
+                        a = doCopyOrMove(sc, a, null, false);
                         (*elements)[u] = a;
                     }
                     // https://issues.dlang.org/show_bug.cgi?id=14395

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1928,7 +1928,7 @@ extern(D) bool arrayExpressionSemantic(
  *
  * Params:
  *   sc = the scope where the expression is encountered
- *   e = the expression the needs to be moved or copied (source)
+ *   e = the expression that needs to be moved or copied (source)
  *   t = if the struct defines a copy constructor, the type of the destination (can be NULL)
  *   nrvo = true if the generated copy can be treated as NRVO
  *   move = true to allow a move constructor to be used, false to prevent infinite recursion

--- a/compiler/test/fail_compilation/fail23452.d
+++ b/compiler/test/fail_compilation/fail23452.d
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=23452
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23452.d(24): Error: struct `fail23452.Foo` is not copyable because it has a disabled postblit
+fail_compilation/fail23452.d(24): Error: struct `fail23452.Foo` is not copyable because it has a disabled postblit
+---
+*/
+import std.stdio;
+
+struct Foo
+{
+    @disable this(this);
+    int x;
+}
+
+void test(Foo[] foos...) {}
+
+void main()
+{
+    Foo f1 = Foo(1);
+    Foo f2 = Foo(2);
+    test(f1, f2);
+}

--- a/compiler/test/fail_compilation/fail23452.d
+++ b/compiler/test/fail_compilation/fail23452.d
@@ -5,9 +5,9 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail23452.d(24): Error: struct `fail23452.Foo` is not copyable because it has a disabled postblit
 fail_compilation/fail23452.d(24): Error: struct `fail23452.Foo` is not copyable because it has a disabled postblit
+fail_compilation/fail23452.d(26): Error: copy constructor `fail23452.NoCopy.this` cannot be used because it is annotated with `@disable`
 ---
 */
-import std.stdio;
 
 struct Foo
 {
@@ -15,11 +15,19 @@ struct Foo
     int x;
 }
 
-void test(Foo[] foos...) {}
+void test(E)(E[] foos...) {}
 
 void main()
 {
     Foo f1 = Foo(1);
     Foo f2 = Foo(2);
     test(f1, f2);
+    NoCopy nc;
+    test(nc);
+}
+
+struct NoCopy
+{
+    @disable this(ref NoCopy);
+    int x;
 }

--- a/compiler/test/runnable/test19393.d
+++ b/compiler/test/runnable/test19393.d
@@ -33,5 +33,5 @@ void bar()
 void main()
 {
     bar();
-    assert(result == "ABB");
+    assert(result == "AABB");
 }

--- a/compiler/test/runnable/test19393.d
+++ b/compiler/test/runnable/test19393.d
@@ -15,17 +15,19 @@ struct S
 
 void foo(const(S)[] ar...)
 {
+    assert(result == "A");
     /* postblit gets called on this initialization,
      * then when the function returns, the destructor
-     * gets called => result = "AB";
+     * gets called, appending "B";
      */
     auto d = ar[0];
+    assert(result == "AA");
 }
 
 void bar()
 {
     /* S(null) needs to be destroyed after the function call,
-     * that means that another `B` is appended => result = "ABB"
+     * that means that another `B` is appended
      */
     foo(S());
 }


### PR DESCRIPTION
Reboot of #14616, addressing @thewilsonator's comments and updating runnable test comments.

Fixes #20176.