### PR TITLE
Add -ftime-trace instrumentation for the inliner pass

### DIFF
--- a/changelog/dmd.ftime-trace-inline.dd
+++ b/changelog/dmd.ftime-trace-inline.dd
@@ -1,0 +1,9 @@
+`-ftime-trace`: add instrumentation for the inliner pass
+
+The `-ftime-trace` output previously had no coverage for the inliner pass.
+When compiling with `-inline`, the time spent scanning and inlining functions
+did not appear in the trace at all.
+
+Two new spans are now emitted: `Inlining` covers the entire inliner pass, and
+`Inline: <function>` covers each function scanned individually.
+These are visible in trace viewers like $(LINK2 https://ui.perfetto.dev/, Perfetto).

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -1823,6 +1823,10 @@ public:
         fd.inlineScanned = true;
         fd.semanticRun = pass;
 
+        import dmd.timetrace;
+        timeTraceBeginEvent(TimeTraceEventType.inlineFunction);
+        scope (exit) timeTraceEndEvent(TimeTraceEventType.inlineFunction, fd);
+
         scope InlineScanVisitor v = new InlineScanVisitor(fd, pass, eSink);
 
         do

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -665,6 +665,10 @@ private int tryMain(const(char)[][] argv, out Param params)
     if (global.errors)
         removeHdrFilesAndFail(params, modules);
 
+    {
+    timeTraceBeginEvent(TimeTraceEventType.inlineGeneral);
+    scope (exit) timeTraceEndEvent(TimeTraceEventType.inlineGeneral);
+
     // Scan for modules with always inline functions
     foreach (m; modules)
     {
@@ -685,6 +689,7 @@ private int tryMain(const(char)[][] argv, out Param params)
                 message("scan all inlines in %s", m.toChars());
             inlineScanAllFunctions(m, global.errorSink);
         }
+    }
     }
 
     if (global.warnings)

--- a/compiler/src/dmd/timetrace.d
+++ b/compiler/src/dmd/timetrace.d
@@ -184,6 +184,8 @@ enum TimeTraceEventType
     sema1Function,
     sema2,
     sema3,
+    inlineGeneral,   /// top-level span for the entire inliner pass
+    inlineFunction,  /// per-function span during inlining
     dfa,
     ctfe,
     ctfeCall,
@@ -211,6 +213,8 @@ private immutable string[] eventPrefixes = [
     "Sema1: Function ",
     "Sema2: ",
     "Sema3: ",
+    "Inlining",
+    "Inline: ",
     "DFA: ",
     "Ctfe: ",
     "Ctfe: call ",

--- a/compiler/test/compilable/ftimetrace.d
+++ b/compiler/test/compilable/ftimetrace.d
@@ -16,6 +16,7 @@ DFA: fun, object.fun
 DFA: id, object.id!int.id
 DFA: uses, object.uses
 Import object.object, object.object
+Inlining,
 Parse: Module object, object
 Parsing,
 Sema1: Function add, object.add

--- a/compiler/test/compilable/ftimetrace_inline.d
+++ b/compiler/test/compilable/ftimetrace_inline.d
@@ -1,0 +1,37 @@
+/**
+REQUIRED_ARGS: -ftime-trace -ftime-trace-file=- -ftime-trace-granularity=0 -inline
+TRANSFORM_OUTPUT: sanitize_timetrace
+TEST_OUTPUT:
+---
+Code generation,
+Codegen: function add, object.add
+Codegen: function uses, object.uses
+Codegen: module object, object
+Import object.object, object.object
+Inline: add, object.add
+Inline: uses, object.uses
+Inlining,
+Parse: Module object, object
+Parsing,
+Sema1: Function add, object.add
+Sema1: Function uses, object.uses
+Sema1: Module object, object
+Sema2: add, object.add
+Sema2: uses, object.uses
+Sema3: add, object.add
+Sema3: uses, object.uses
+Semantic analysis,
+---
+*/
+
+module object; // Don't clutter time trace output with object.d
+
+int add(int x, int y)
+{
+    return x + y;
+}
+
+void uses()
+{
+    int a = add(1, 2);
+}

--- a/compiler/test/compilable/ftimetrace_pragma.d
+++ b/compiler/test/compilable/ftimetrace_pragma.d
@@ -1,0 +1,43 @@
+/**
+REQUIRED_ARGS: -ftime-trace -ftime-trace-file=- -ftime-trace-granularity=0
+TRANSFORM_OUTPUT: sanitize_timetrace
+TEST_OUTPUT:
+---
+Code generation,
+Codegen: function cube, object.cube
+Codegen: function square, object.square
+Codegen: function uses, object.uses
+Codegen: module object, object
+Import object.object, object.object
+Inline: cube, object.cube
+Inline: uses, object.uses
+Inlining,
+Parse: Module object, object
+Parsing,
+Sema1: Function cube, object.cube
+Sema1: Function square, object.square
+Sema1: Function uses, object.uses
+Sema1: Module object, object
+Sema2: cube, object.cube
+Sema2: square, object.square
+Sema2: uses, object.uses
+Sema3: cube, object.cube
+Sema3: square, object.square
+Sema3: uses, object.uses
+Semantic analysis,
+---
+*/
+
+module object; // Don't clutter time trace output with object.d
+
+pragma(inline, true)
+int square(int x) { return x * x; }
+
+pragma(inline, true)
+int cube(int x) { return x * square(x); }
+
+void uses()
+{
+    int a = cube(3);
+    int b = square(4);
+}


### PR DESCRIPTION
After PR #22825 I kept looking at traces and noticed the inliner pass just
doesn't show up. When compiling with `-inline -ftime-trace`, the trace shows `Semantic analysis` followed by `Code generation`— nothing in between.

The frontend inliner can contribute to compile-time slowdowns in some codebases, and having visibility into its activity may help when investigating such cases. For example, #20315 highlights a situation where the inliner was suspected to play a role in increased compile times, and there was nothing in the trace to look at when diagnosing it.

This adds two new event types:
- `Inlining` — top-level span covering the entire inliner pass
- `Inline: <function>` — per-function span for each function scanned

The Inlining span covers both the pragma-inline scan and the full -inline scan.
1. `ftimetrace_inline.d` compiled with -inline:
<img width="1627" height="836" alt="Screenshot 2026-04-11 200430" src="https://github.com/user-attachments/assets/fe79dec8-0388-42a1-810e-3f3f9665cca4" />


2. `ftimetrace_pragma.d` compiled without -inline :
<img width="1626" height="830" alt="Screenshot 2026-04-11 200558" src="https://github.com/user-attachments/assets/bca91b2a-cfa6-439d-b293-365194a0de0c" />


3. Recursive template case (reduction from #20315) —
spans showing the inliner working through the divide-and-conquer tree:
<img width="1626" height="884" alt="Screenshot 2026-04-11 200704" src="https://github.com/user-attachments/assets/06784a20-b998-435b-841b-a364339c509e" />


Updated `ftimetrace.d` and added `ftimetrace_inline.d` and `ftimetrace_pragma.d`
to cover all cases.