### PR TITLE
Fix #21637 - ICE in tuple comparison with conditional expression

### DIFF
--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -2139,6 +2139,7 @@ private elem* elcond(elem* e, Goal goal)
             e.E2 = e1;
             e1.Eoper = OPcond;
             e1.Ety = e.Ety;
+            e1.ET = e.ET;
             return optelem(e, Goal.value);
 
         case OPnot:

--- a/compiler/test/compilable/test21637.d
+++ b/compiler/test/compilable/test21637.d
@@ -1,0 +1,26 @@
+// https://github.com/dlang/dmd/issues/21637
+// ICE in tuple comparison with conditional expression
+
+struct Date {
+    short _year  = 1;
+    ubyte _month;
+    ubyte _day   = 1;
+
+    this(int day) { }
+}
+
+struct Nullable(T){
+    T t;
+    short b;
+}
+
+struct DateRange {
+    Nullable!Date end;
+}
+
+void main()
+{
+    auto thing = DateRange(
+      (Date(1).tupleof == Date(2).tupleof) ? Nullable!Date() : Nullable!Date()
+    );
+}


### PR DESCRIPTION
Closes #21637

The prompt for this was `Fix https://github.com/dlang/dmd/issues/21637`

> In `elcond`, when restructuring `((a,b) ? c : d)` into `(a, (b ? c : d))`, `Ety` was copied to the new inner OPcond but `ET` was not. This left the OPcond with TYstruct Ety but null ET, causing `elstruct` to return early and `exp2_copytotemp` to crash with `assert(ty != TYstruct)`.

