### PR TITLE
Fix #20998, #20997 - Alias template parameter with type specialization

### DIFF
--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -2848,7 +2848,13 @@ private MATCH matchArg(TemplateParameter tp, Scope* sc, RootObject oarg, size_t 
             }
             // reject expression arguments that don't match the specialization
             else if (sa != tap.specAlias)
-                return matchArgNoMatch();
+            {
+                // allow expression specialization matched by value (e.g. `alias s : 3` matched by `Bar!3`)
+                Expression ea2 = isExpression(sa);
+                Expression espec = isExpression(tap.specAlias);
+                if (!ea2 || !espec || !ea2.equals(espec))
+                    return matchArgNoMatch();
+            }
         }
         else if (dedtypes[i])
         {

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -2830,8 +2830,8 @@ private MATCH matchArg(TemplateParameter tp, Scope* sc, RootObject oarg, size_t 
                 if (m2 == MATCH.nomatch)
                     return matchArgNoMatch();
             }
-            // check specialization if template arg is a type
-            else if (ta)
+            // check specialization if template arg is a type (and sa doesn't already match specAlias)
+            else if (ta && sa != tap.specAlias)
             {
                 if (Type tspec = isType(tap.specAlias))
                 {
@@ -2846,6 +2846,9 @@ private MATCH matchArg(TemplateParameter tp, Scope* sc, RootObject oarg, size_t 
                     return matchArgNoMatch();
                 }
             }
+            // reject expression arguments that don't match the specialization
+            else if (sa != tap.specAlias)
+                return matchArgNoMatch();
         }
         else if (dedtypes[i])
         {

--- a/compiler/test/fail_compilation/template_alias_param.d
+++ b/compiler/test/fail_compilation/template_alias_param.d
@@ -4,19 +4,25 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/template_alias_param.d(17): Error: template instance `Foo!1` does not match template declaration `Foo(alias s : S)`
-fail_compilation/template_alias_param.d(18): Error: template instance `Foo!(T)` does not match template declaration `Foo(alias s : S)`
+fail_compilation/template_alias_param.d(19): Error: template instance `Foo!1` does not match template declaration `Foo(alias s : S)`
+fail_compilation/template_alias_param.d(20): Error: template instance `Foo!(T)` does not match template declaration `Foo(alias s : S)`
 ---
 */
+
 
 struct S {}
 struct T {}
 template Foo(alias s : S) {}
 
-alias F = Foo!S; // valid: matching type specialization (issue 20997)
-alias G = Foo!1; // invalid: expression should not match type specialization (issue 20998)
-alias H = Foo!T; // invalid: wrong type should not match (issue 20998)
+alias F  = Foo!S; // valid: matching type specialization (issue 20997)
+alias FC = Foo!(const(S));
+alias G  = Foo!1; // invalid: expression should not match type specialization (issue 20998)
+alias H  = Foo!T; // invalid: wrong type should not match (issue 20998)
 
 template Bar(alias s : 3) {}
 alias BG = Bar!3;
 alias BH = Bar!(1 + 2);
+
+template SpecConstS(alias s : const(S)) {}
+alias CS3 = SpecConstS!S;
+alias CS4 = SpecConstS!(const(S));

--- a/compiler/test/fail_compilation/template_alias_param.d
+++ b/compiler/test/fail_compilation/template_alias_param.d
@@ -1,0 +1,18 @@
+// https://github.com/dlang/dmd/issues/20997 - valid alias arg with type specialization
+// https://github.com/dlang/dmd/issues/20998 - mismatched alias arg with type specialization
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/template_alias_param.d(17): Error: template instance `Foo!1` does not match template declaration `Foo(alias s : S)`
+fail_compilation/template_alias_param.d(18): Error: template instance `Foo!(T)` does not match template declaration `Foo(alias s : S)`
+---
+*/
+
+struct S {}
+struct T {}
+template Foo(alias s : S) {}
+
+alias F = Foo!S; // valid: matching type specialization (issue 20997)
+alias G = Foo!1; // invalid: expression should not match type specialization (issue 20998)
+alias H = Foo!T; // invalid: wrong type should not match (issue 20998)

--- a/compiler/test/fail_compilation/template_alias_param.d
+++ b/compiler/test/fail_compilation/template_alias_param.d
@@ -16,3 +16,7 @@ template Foo(alias s : S) {}
 alias F = Foo!S; // valid: matching type specialization (issue 20997)
 alias G = Foo!1; // invalid: expression should not match type specialization (issue 20998)
 alias H = Foo!T; // invalid: wrong type should not match (issue 20998)
+
+template Bar(alias s : 3) {}
+alias BG = Bar!3;
+alias BH = Bar!(1 + 2);

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -825,6 +825,40 @@ $(H4 $(LNAME2 typed_alias_op, Typed Alias Parameters))
 
 $(H4 $(LNAME2 alias_parameter_specialization, Specialization))
 
+    $(P An alias parameter specialization constrains which arguments the parameter
+        will match. The specialization can be either a type or a compile-time expression.)
+
+    $(P $(B Type specialization:) The argument must refer to the same type symbol as
+        the specialization. Type qualifiers such as $(D const) are ignored, so
+        $(D const(S)) and $(D S) are treated as the same specialization.)
+
+    $(SPEC_RUNNABLE_EXAMPLE_COMPILE
+    ---
+    struct S {}
+    struct T {}
+
+    template Foo(alias s : S) {}
+
+    alias f1 = Foo!S;         // ok
+    alias f2 = Foo!(const(S)); // ok: qualifiers ignored
+    //alias f3 = Foo!T;       // error: T is not S
+    //alias f4 = Foo!1;       // error: 1 is not a type symbol
+    ---
+    )
+
+    $(P $(B Expression specialization:) The argument must be a compile-time expression
+        that evaluates to the same value as the specialization.)
+
+    $(SPEC_RUNNABLE_EXAMPLE_COMPILE
+    ---
+    template Bar(alias n : 3) {}
+
+    alias b1 = Bar!3;       // ok
+    alias b2 = Bar!(1 + 2); // ok: evaluates to 3
+    //alias b3 = Bar!4;     // error: 4 != 3
+    ---
+    )
+
     $(P Alias parameters can accept both literals and user-defined type symbols,
         but they are less specialized than the matches to type parameters and
         value parameters:)


### PR DESCRIPTION
Closes #20997
Closes #20998

