### PR TITLE
semantic3.d: Redundant check and possible copy-paste error in TypeStruct conversion

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -893,7 +893,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                 {
                                     if ((cast(TypeStruct)exp.type.immutableOf()).implicitConvToWithoutAliasThis(tret))
                                         exp = exp.castTo(sc2, exp.type.immutableOf());
-                                    else if ((cast(TypeStruct)exp.type.immutableOf()).implicitConvToWithoutAliasThis(tret))
+                                    else if ((cast(TypeStruct)exp.type.wildOf()).implicitConvToWithoutAliasThis(tret))
                                         exp = exp.castTo(sc2, exp.type.wildOf());
                                 }
                             }


### PR DESCRIPTION
### **Description**
In `dmd/semantic3.d`, the logic for implicit conversion seems to contain a copy-paste bug where the `immutable` check is duplicated instead of checking for `wild` (`inout`).

**Location:** https://github.com/dlang/dmd/blob/574850449229f4c8e3ead1dbe49890f2991ca114/compiler/src/dmd/semantic3.d#L894

**Current code:**
```d
if ((cast(TypeStruct)exp.type.immutableOf()).implicitConvToWithoutAliasThis(tret))
    exp = exp.castTo(sc2, exp.type.immutableOf());
else if ((cast(TypeStruct)exp.type.immutableOf()).implicitConvToWithoutAliasThis(tret)) // <---possible copy-paste error 
    exp = exp.castTo(sc2, exp.type.wildOf());
```

**Problem:**
The `else if` condition is identical to the `if` condition, making the second branch unreachable. Based on the context, the second branch should likely check `wildOf()`.

**Suggested fix:**
```d
else if ((cast(TypeStruct)exp.type.wildOf()).implicitConvToWithoutAliasThis(tret))
    exp = exp.castTo(sc2, exp.type.wildOf());
```

---
ISSUE: https://github.com/dlang/dmd/issues/22919