### PR TITLE
Add parse error for `this` or `super` in a basic type

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4977,6 +4977,17 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             addComment(s, comment);
             return a;
         }
+        // alias this Identifier;
+        // accepted in a method, but not in grammar
+        if (token.value == TOK.this_ && peekNext() == TOK.identifier)
+        {
+            auto tokThis = token.ident;
+            nextToken();
+            auto t = new AST.TypeIdentifier(loc, tokThis);
+            auto id = token.ident;
+            check(TOK.identifier);
+            return new AST.Dsymbols(new AST.AliasDeclaration(loc, id, t));
+        }
         /* Look for:
          *  alias this = identifier;
          */
@@ -5085,6 +5096,14 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     }
 
                     v = new AST.AliasDeclaration(loc, ident, s);
+                }
+                else if (token.value == TOK.this_ && peekNext() == TOK.semicolon)
+                {
+                    // `alias id = this;` accepted in a method, but not in grammar
+                    auto tokThis = token.ident;
+                    nextToken();
+                    auto t = new AST.TypeIdentifier(loc, tokThis);
+                    v = new AST.AliasDeclaration(loc, ident, t);
                 }
                 else
                 {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3796,6 +3796,15 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
         case TOK.this_:
         case TOK.super_:
+            // defer `alias a = this.member;` error
+            if (peekNext() == TOK.dot)
+                goto case;
+
+            error("basic type expected, not `%s`, did you mean `typeof(%s)`?",
+                token.toChars(), token.toChars());
+            nextToken();
+            return AST.Type.terror;
+
         case TOK.identifier:
             loc = token.loc;
             id = token.ident;

--- a/compiler/test/fail_compilation/fail18228.d
+++ b/compiler/test/fail_compilation/fail18228.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18228.d(12): Error: undefined identifier `this`, did you mean `typeof(this)`?
-fail_compilation/fail18228.d(13): Error: undefined identifier `this`, did you mean `typeof(this)`?
-fail_compilation/fail18228.d(14): Error: undefined identifier `super`, did you mean `typeof(super)`?
+fail_compilation/fail18228.d(12): Error: basic type expected, not `this`, did you mean `typeof(this)`?
+fail_compilation/fail18228.d(13): Error: basic type expected, not `this`, did you mean `typeof(this)`?
+fail_compilation/fail18228.d(14): Error: basic type expected, not `super`, did you mean `typeof(super)`?
 ---
 */
 

--- a/compiler/test/fail_compilation/fail_typeof.d
+++ b/compiler/test/fail_compilation/fail_typeof.d
@@ -1,28 +1,12 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail_typeof.d(15): Error: undefined identifier `this`
-fail_compilation/fail_typeof.d(20): Error: `this` is not in a class or struct scope
-fail_compilation/fail_typeof.d(25): Error: undefined identifier `super`
-fail_compilation/fail_typeof.d(30): Error: `super` is not in a class scope
-fail_compilation/fail_typeof.d(37): Error: undefined identifier `this`, did you mean `typeof(this)`?
-fail_compilation/fail_typeof.d(47): Error: undefined identifier `super`
-fail_compilation/fail_typeof.d(52): Error: `super` is not in a class scope
-fail_compilation/fail_typeof.d(60): Error: undefined identifier `this`, did you mean `typeof(this)`?
-fail_compilation/fail_typeof.d(70): Error: undefined identifier `super`, did you mean `typeof(super)`?
+fail_compilation/fail_typeof.d(9): Error: `this` is not in a class or struct scope
+fail_compilation/fail_typeof.d(14): Error: `super` is not in a class scope
+fail_compilation/fail_typeof.d(26): Error: `super` is not in a class scope
 ---
 */
 
-enum E1 : this
-{
-    fail,
-}
-
 enum E2 : typeof(this)
-{
-    fail,
-}
-
-enum E3 : super
 {
     fail,
 }
@@ -34,19 +18,9 @@ enum E4 : typeof(super)
 
 struct S1
 {
-    enum E1 : this
-    {
-        fail,
-    }
-
     enum E2 : typeof(this)
     {
         ok = S1(),
-    }
-
-    enum E3 : super
-    {
-        fail,
     }
 
     enum E4 : typeof(super)
@@ -57,19 +31,9 @@ struct S1
 
 class C1
 {
-    enum E1 : this
-    {
-        fail,
-    }
-
     enum E2 : typeof(this)
     {
         ok = new C1,
-    }
-
-    enum E3 : super
-    {
-        fail,
     }
 
     enum E4 : typeof(super)

--- a/compiler/test/fail_compilation/parse14285.d
+++ b/compiler/test/fail_compilation/parse14285.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parse14285.d(10): Error: variable name expected after type `this`, not `;`
+fail_compilation/parse14285.d(10): Error: basic type expected, not `this`, did you mean `typeof(this)`?
 ---
 */
 

--- a/compiler/test/fail_compilation/test12228.d
+++ b/compiler/test/fail_compilation/test12228.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test12228.d(12): Error: undefined identifier `this`, did you mean `typeof(this)`?
-fail_compilation/test12228.d(18): Error: undefined identifier `super`, did you mean `typeof(super)`?
-fail_compilation/test12228.d(19): Error: undefined identifier `super`, did you mean `typeof(super)`?
+fail_compilation/test12228.d(12): Error: basic type expected, not `this`, did you mean `typeof(this)`?
+fail_compilation/test12228.d(18): Error: basic type expected, not `super`, did you mean `typeof(super)`?
+fail_compilation/test12228.d(19): Error: basic type expected, not `super`, did you mean `typeof(super)`?
 ---
 */
 

--- a/compiler/test/fail_compilation/test21317.d
+++ b/compiler/test/fail_compilation/test21317.d
@@ -5,7 +5,7 @@ module dmd.compiler.test.fail_compilation.test21317;
 fail_compilation/test21317.d(16): Error: `writeln` is not defined, perhaps `import std.stdio;` ?
 fail_compilation/test21317.d(21): Error: undefined identifier `Zero`, did you mean variable `zero`?
 fail_compilation/test21317.d(25): Error: undefined identifier `NULL`, did you mean `null`?
-fail_compilation/test21317.d(31): Error: undefined identifier `this`, did you mean `typeof(this)`?
+fail_compilation/test21317.d(31): Error: undefined identifier `This`
 fail_compilation/test21317.d(38): Error: undefined identifier `unknown`
 ---
 */
@@ -28,7 +28,7 @@ int [
 struct S4
 {
     enum E4 :
-    this
+    This // `this` is now a parse error
     {
         fail,
     }

--- a/compiler/test/fail_compilation/this_used_as_type.d
+++ b/compiler/test/fail_compilation/this_used_as_type.d
@@ -1,0 +1,42 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/this_used_as_type.d(15): Error: basic type expected, not `this`, did you mean `typeof(this)`?
+fail_compilation/this_used_as_type.d(19): Error: basic type expected, not `super`, did you mean `typeof(super)`?
+fail_compilation/this_used_as_type.d(27): Error: basic type expected, not `this`, did you mean `typeof(this)`?
+fail_compilation/this_used_as_type.d(29): Error: basic type expected, not `this`, did you mean `typeof(this)`?
+fail_compilation/this_used_as_type.d(30): Error: basic type expected, not `super`, did you mean `typeof(super)`?
+fail_compilation/this_used_as_type.d(35): Error: basic type expected, not `this`, did you mean `typeof(this)`?
+fail_compilation/this_used_as_type.d(41): Error: basic type expected, not `super`, did you mean `typeof(super)`?
+---
+*/
+
+// Note: moved from `fail_typeof.d` as they're now parse errors
+enum E1 : this
+{
+    fail,
+}
+enum E3 : super
+{
+    fail,
+}
+
+struct Test
+{
+    // postblit can't be template
+    this()(this);
+
+    void f()(this);
+    void g()(super);
+
+    void h()
+    {
+        // used to work in a method, but not in spec grammar
+        alias this p;
+    }
+}
+
+class C
+{
+    super* p;
+}

--- a/compiler/test/fail_compilation/this_used_as_type.d
+++ b/compiler/test/fail_compilation/this_used_as_type.d
@@ -1,13 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/this_used_as_type.d(15): Error: basic type expected, not `this`, did you mean `typeof(this)`?
-fail_compilation/this_used_as_type.d(19): Error: basic type expected, not `super`, did you mean `typeof(super)`?
-fail_compilation/this_used_as_type.d(27): Error: basic type expected, not `this`, did you mean `typeof(this)`?
-fail_compilation/this_used_as_type.d(29): Error: basic type expected, not `this`, did you mean `typeof(this)`?
-fail_compilation/this_used_as_type.d(30): Error: basic type expected, not `super`, did you mean `typeof(super)`?
-fail_compilation/this_used_as_type.d(35): Error: basic type expected, not `this`, did you mean `typeof(this)`?
-fail_compilation/this_used_as_type.d(41): Error: basic type expected, not `super`, did you mean `typeof(super)`?
+fail_compilation/this_used_as_type.d(14): Error: basic type expected, not `this`, did you mean `typeof(this)`?
+fail_compilation/this_used_as_type.d(18): Error: basic type expected, not `super`, did you mean `typeof(super)`?
+fail_compilation/this_used_as_type.d(26): Error: basic type expected, not `this`, did you mean `typeof(this)`?
+fail_compilation/this_used_as_type.d(28): Error: basic type expected, not `this`, did you mean `typeof(this)`?
+fail_compilation/this_used_as_type.d(29): Error: basic type expected, not `super`, did you mean `typeof(super)`?
+fail_compilation/this_used_as_type.d(34): Error: basic type expected, not `super`, did you mean `typeof(super)`?
 ---
 */
 
@@ -28,12 +27,6 @@ struct Test
 
     void f()(this);
     void g()(super);
-
-    void h()
-    {
-        // used to work in a method, but not in spec grammar
-        alias this p;
-    }
 }
 
 class C

--- a/compiler/test/runnable/template9.d
+++ b/compiler/test/runnable/template9.d
@@ -1574,7 +1574,7 @@ struct T7694
     //next line causes ice
         match7694!(this)();
     //while this works:
-        alias this p;
+        ref p = this;
         match7694!(p)();
     }
 }
@@ -2086,7 +2086,7 @@ void test9022()
 
 mixin template node9026()
 {
-    static if (is(this == struct))
+    static if (is(typeof(this) == struct))
         alias typeof(this)* E;
     else
         alias typeof(this) E;

--- a/compiler/test/runnable/template9.d
+++ b/compiler/test/runnable/template9.d
@@ -1574,7 +1574,7 @@ struct T7694
     //next line causes ice
         match7694!(this)();
     //while this works:
-        ref p = this;
+        alias this p;
         match7694!(p)();
     }
 }


### PR DESCRIPTION
Fixes #22923.

~~Drop support for `alias this a;` (and `alias a = this;` in the next edition)  which only works inside a method and was tested in `template9.d`, but is not in the [grammar spec](https://dlang.org/spec/declaration.html#alias). Recommend `ref a = this;` instead.~~

Note: this moves 2 semantic error tests from `fail_typeof.d` to new file `this_used_as_type.d` for parse errors.
