### PR TITLE
Fix #21110 - core.sys.linux.sys.timerfd header missing

### DIFF
--- a/druntime/mak/COPY
+++ b/druntime/mak/COPY
@@ -270,6 +270,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\sys\socket.d \
 	$(IMPDIR)\core\sys\linux\sys\syscall.d \
 	$(IMPDIR)\core\sys\linux\sys\sysinfo.d \
+	$(IMPDIR)\core\sys\linux\sys\timerfd.d \
 	$(IMPDIR)\core\sys\linux\sys\xattr.d \
 	$(IMPDIR)\core\sys\linux\sys\time.d \
 	$(IMPDIR)\core\sys\linux\sys\prctl.d \

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -264,6 +264,7 @@ SRCS=\
 	src\core\sys\linux\sys\socket.d \
 	src\core\sys\linux\sys\syscall.d \
 	src\core\sys\linux\sys\sysinfo.d \
+	src\core\sys\linux\sys\timerfd.d \
 	src\core\sys\linux\sys\xattr.d \
 	src\core\sys\linux\sys\time.d \
 	src\core\sys\linux\sys\prctl.d \

--- a/druntime/src/core/sys/linux/sys/timerfd.d
+++ b/druntime/src/core/sys/linux/sys/timerfd.d
@@ -1,0 +1,27 @@
+/**
+ * D header file to interface with the Linux timerfd API.
+ *
+ * $(LINK2 http://man7.org/linux/man-pages/man2/timerfd_create.2.html)
+ *
+ * Available since Linux 2.6
+ *
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ */
+module core.sys.linux.sys.timerfd;
+
+version (linux):
+
+public import core.sys.posix.time;
+
+extern (C):
+@nogc:
+nothrow:
+
+int timerfd_create(int clockid, int flags);
+int timerfd_settime(int fd, int flags, const itimerspec* new_value, itimerspec* old_value);
+int timerfd_gettime(int fd, itimerspec* curr_value);
+
+enum TFD_TIMER_ABSTIME = 1 << 0;
+enum TFD_TIMER_CANCEL_ON_SET = 1 << 1;
+enum TFD_CLOEXEC       = 0x80000;
+enum TFD_NONBLOCK      = 0x800;

--- a/druntime/src/core/sys/linux/timerfd.d
+++ b/druntime/src/core/sys/linux/timerfd.d
@@ -1,24 +1,14 @@
 /**
- * D header file to interface with the Linux timefd API <http://man7.org/linux/man-pages/man2/timerfd_create.2.html>
- * Available since Linux 2.6
+ * Compatibility shim for $(MREF core,sys,linux,sys,timerfd).
  *
- * License : $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Deprecated: Use $(MREF core,sys,linux,sys,timerfd) instead to match the
+ *             C header location `sys/timerfd.h`.
+ *
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  */
+deprecated("use core.sys.linux.sys.timerfd instead to match the C header sys/timerfd.h")
 module core.sys.linux.timerfd;
 
 version (linux):
 
-public import core.sys.posix.time;
-
-extern (C):
-@nogc:
-nothrow:
-
-int timerfd_create(int clockid, int flags);
-int timerfd_settime(int fd, int flags, const itimerspec* new_value, itimerspec* old_value);
-int timerfd_gettime(int fd, itimerspec* curr_value);
-
-enum TFD_TIMER_ABSTIME = 1 << 0;
-enum TFD_TIMER_CANCEL_ON_SET = 1 << 1;
-enum TFD_CLOEXEC       = 0x80000;
-enum TFD_NONBLOCK      = 0x800;
+public import core.sys.linux.sys.timerfd;


### PR DESCRIPTION
Closes #21110

Move the module to the sys/ folder and keep a deprecated shim in the old place publicly importing the new one.