### PR TITLE
Fix #21458 - Header generation produces .di file with syntax errors

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -1309,7 +1309,9 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         buf.put('{');
         buf.writenl();
         buf.level++;
-        visitAttribDeclaration(s);
+        if (s.decl)
+            foreach (de; *s.decl)
+                toCBuffer(de, buf, hgs);
         buf.level--;
         buf.put('}');
         buf.writenl();

--- a/compiler/test/compilable/header21458.d
+++ b/compiler/test/compilable/header21458.d
@@ -1,0 +1,38 @@
+/*
+REQUIRED_ARGS: -o- -Hf${RESULTS_DIR}/compilable/header21458.di
+OUTPUT_FILES: ${RESULTS_DIR}/compilable/header21458.di
+
+TEST_OUTPUT:
+---
+=== ${RESULTS_DIR}/compilable/header21458.di
+// D import file generated from 'compilable/header21458.d'
+static foreach (x; 0 .. 1)
+{
+	static assert(true);
+	static assert(true);
+}
+static foreach (y; 0 .. 1)
+{
+	static assert(true);
+}
+static foreach (z; 0 .. 1)
+{
+}
+---
+*/
+
+// https://github.com/dlang/dmd/issues/21458
+static foreach (x; 0..1)
+{
+    static assert(true);
+    static assert(true);
+}
+
+static foreach (y; 0..1)
+{
+    static assert(true);
+}
+
+static foreach (z; 0..1)
+{
+}


### PR DESCRIPTION
Closes #21458

Rikki suggested simply removing the static foreach brackets, but the output looks bad that way:

```D
static foreach (x; 0 .. 1)

{
	static assert(true);
	static assert(true);
}

static foreach (y; 0 .. 1)
static assert(true);
```

So instead we just emit the contents in {} braces always without using the AttribDeclaration hdrgen logic.