### PR TITLE
Allow section names with mach-o longer than 16 characters by hashing it

### DIFF
--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -34,6 +34,7 @@ import dmd.backend.ty;
 import dmd.backend.type;
 
 import dmd.common.outbuffer;
+import dmd.root.hash;
 
 nothrow:
 @safe:
@@ -1893,10 +1894,14 @@ int MachObj_jmpTableSegment(Symbol* s)
 int MachObj_getsegment(const(char)* sectname, const(char)* segname,
         int p2align, int flags)
 {
-    if (strlen(sectname) > 16)
+    char[16] longSectionNameBuffer;
+    size_t sectionNameLength = strlen(sectname);
+
+    if (sectionNameLength > 16)
     {
-        error(Srcpos.init, "invalid section name, length too long for `%s`", sectname);
-        return 0;
+        uint hash = calcHash(sectname[0 .. sectionNameLength]);
+        snprintf(longSectionNameBuffer.ptr, 16, "_d_sect_%08X", hash);
+        sectname = longSectionNameBuffer.ptr;
     }
 
     if (strlen(segname) > 16)

--- a/compiler/test/runnable/sectiondefs.d
+++ b/compiler/test/runnable/sectiondefs.d
@@ -1,6 +1,7 @@
 /*
 EXTRA_SOURCES: extra-files/sectiondefs.d
 EXTRA_FILES: extra-files/sectiondefs.d
+REQUIRED_ARGS:
 REQUIRED_ARGS(windows): -L/INCREMENTAL:NO
 */
 // Incremental linking must be turned off, or it will add padding.
@@ -118,4 +119,11 @@ void main()
     ] || my8IntsSection.range == [
         [64, 72, 9, 81, 21, 59, 45, 2], [46, 92, 11, 7, 2, 55, 33, 22]
     ]);
+}
+
+version(OSX)
+{
+    // For OSX we need to confirm that the compiler can support section names longer than 16 characters.
+    @section("abcdefghijklmonpqrstuvwxyz")
+    int osxSectLength;
 }


### PR DESCRIPTION
I need to solve this as a dependency for linker lists.

@kinke do you have opinions on how to do this? Currently ldc hasn't got this solved from what I can see and llvm doesn't do it either.

Here is a link to context on the llvm/clang side where something similar was proposed: https://discourse.llvm.org/t/feedback-on-feature-and-status-of-lld-linker-script-support/59342

Initially I am verifying if the assert will be hit, and change the section name approprietely. The test case for section attribute has a new global variable to see if it'll link.