### PR TITLE
Fix sectiondefs test so that it runs on all targets

### DIFF
--- a/compiler/test/README.md
+++ b/compiler/test/README.md
@@ -306,6 +306,8 @@ The following is a list of all available settings:
                          default: (none)
                          note: the make variable REQUIRED_ARGS is also added to the $(DMD)
                                command line (see below)
+                         note: if you provide a platform string, it becomes a white list.
+                               add a second without the platform list so that it runs on all targets.
 
     RUN_OUTPUT:         output expected from running the compiled executable which must match
                         the actual output. The comparison adheres to the rules defined for

--- a/compiler/test/runnable/sectiondefs.d
+++ b/compiler/test/runnable/sectiondefs.d
@@ -1,6 +1,7 @@
 /*
 EXTRA_SOURCES: extra-files/sectiondefs.d
 EXTRA_FILES: extra-files/sectiondefs.d
+REQUIRED_ARGS:
 REQUIRED_ARGS(windows): -L/INCREMENTAL:NO
 */
 // Incremental linking must be turned off, or it will add padding.


### PR DESCRIPTION
Found by another PR, that I screwed up the test so it only ran on Windows.
Also updated the CI's README to spell out that it becomes a whitelist.