### PR TITLE
Refactor and improve diagnostic messages for attribute violations (`@nogc`, `@safe`, `pure`, `nothrow`)

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3221,7 +3221,9 @@ public void errorSupplementalInferredAttr(FuncDeclaration fd, int maxDepth, bool
 
     if (s.action.length > 0)
     {
-        errorFunc(s.loc, "and %.*s makes it fail to infer `%.*s`", s.action.fTuple.expand, attr.fTuple.expand);
+        errorFunc(s.loc,
+            "contaminated by `%.*s`, so `%s` cannot infer `%.*s`",
+            s.action.fTuple.expand, fd.toErrMsg(), attr.fTuple.expand);
         // For scope violations, also print why the target parameter is not scope
         if (s.scopeVar)
         {
@@ -3233,7 +3235,9 @@ public void errorSupplementalInferredAttr(FuncDeclaration fd, int maxDepth, bool
     {
         if (maxDepth > 0)
         {
-            errorFunc(s.loc, "which calls `%s`", s.fd.toErrMsg());
+            errorFunc(s.loc,
+                "`%s` cannot use `%.*s` because it calls `%s`",
+                fd.toErrMsg(), attr.fTuple.expand, s.fd.toErrMsg());
             errorSupplementalInferredAttr(s.fd, maxDepth - 1, deprecation, stc, eSink);
         }
     }
@@ -3523,11 +3527,13 @@ private bool checkNogc(FuncDeclaration f, ref Loc loc, Scope* sc)
         || f.ident == Id._d_assocarrayliteralTX || f.ident == Id._d_arrayliteralTX
         || f.ident == Id._d_aaGetY))
     {
+        const prettyChars = f.toPrettyChars();
         error(loc, "`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
-            sc.func.kind(), sc.func.toPrettyChars(), f.kind(), f.toPrettyChars());
+            sc.func.kind(), sc.func.toPrettyChars(), f.kind(), prettyChars);
 
         if (!f.isDtorDeclaration)
             f.errorSupplementalInferredAttr(/*max depth*/ 10, /*deprecation*/ false, STC.nogc, global.errorSink);
+        .errorSupplemental(f.loc, "`%s` is declared here", prettyChars);
     }
 
     f.checkOverriddenDtor(sc, loc, dd => dd.type.toTypeFunction().isNogc, "non-@nogc");

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -142,8 +142,13 @@ public:
         if (fd.ident == Id._d_arraysetlengthT)
         {
             if (setGC(e, "setting this array's `length`"))
+            {
+                if (fd.loc.isValid())
+                    errorSupplemental(fd.loc, "runtime hook `%s` is declared here", fd.toPrettyChars());
                 return;
+            }
             f.printGCUsage(e.loc, "setting `length` may cause a GC allocation");
+
         }
     }
 
@@ -362,7 +367,8 @@ extern (D) bool setGC(Scope* sc, FuncDeclaration fd, Loc loc, const(char)* fmt, 
             // Message wil be gagged, but still call error() to update global.errors and for
             // -verrors=spec
             string action = AttributeViolation(loc, fmt, args).action;
-            .error(loc, "%.*s is not allowed in a `@nogc` function", action.fTuple.expand);
+            .error(loc, "%.*s is not allowed in `@nogc` %s `%s`; this operation contaminates `@nogc` inference",
+                action.fTuple.expand, sc.func.kind(), sc.func.toErrMsg());
             return true;
         }
         return false;

--- a/compiler/test/fail_compilation/attributediagnostic.d
+++ b/compiler/test/fail_compilation/attributediagnostic.d
@@ -2,15 +2,15 @@
 TEST_OUTPUT:
 ---
 fail_compilation/attributediagnostic.d(21): Error: `@safe` function `attributediagnostic.layer2` cannot call `@system` function `attributediagnostic.layer1`
-fail_compilation/attributediagnostic.d(23):        which calls `layer0`
-fail_compilation/attributediagnostic.d(25):        which calls `system`
-fail_compilation/attributediagnostic.d(27):        and executing an `asm` statement without `@trusted` annotation makes it fail to infer `@safe`
+fail_compilation/attributediagnostic.d(23):        `layer1` cannot use `@safe` because it calls `layer0`
+fail_compilation/attributediagnostic.d(25):        `layer0` cannot use `@safe` because it calls `system`
+fail_compilation/attributediagnostic.d(27):        contaminated by `executing an `asm` statement without `@trusted` annotation`, so `system` cannot infer `@safe`
 fail_compilation/attributediagnostic.d(22):        `attributediagnostic.layer1` is declared here
 fail_compilation/attributediagnostic.d(43): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system1`
-fail_compilation/attributediagnostic.d(32):        and cast from `uint` to `int*` makes it fail to infer `@safe`
+fail_compilation/attributediagnostic.d(32):        contaminated by `cast from `uint` to `int*`, so `system1` cannot infer `@safe`
 fail_compilation/attributediagnostic.d(30):        `attributediagnostic.system1` is declared here
 fail_compilation/attributediagnostic.d(44): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system2`
-fail_compilation/attributediagnostic.d(38):        and calling `@system` `fsys` makes it fail to infer `@safe`
+fail_compilation/attributediagnostic.d(38):        contaminated by `calling `@system` `fsys`, so `system2` cannot infer `@safe`
 fail_compilation/attributediagnostic.d(36):        `attributediagnostic.system2` is declared here
 ---
 */

--- a/compiler/test/fail_compilation/attributediagnostic_nogc.d
+++ b/compiler/test/fail_compilation/attributediagnostic_nogc.d
@@ -2,15 +2,19 @@
 TEST_OUTPUT:
 ---
 fail_compilation/attributediagnostic_nogc.d(21): Error: `@nogc` function `attributediagnostic_nogc.layer2` cannot call non-@nogc function `attributediagnostic_nogc.layer1`
-fail_compilation/attributediagnostic_nogc.d(22):        which calls `layer0`
-fail_compilation/attributediagnostic_nogc.d(23):        which calls `gc`
-fail_compilation/attributediagnostic_nogc.d(27):        and executing an `asm` statement without `@nogc` annotation makes it fail to infer `@nogc`
+fail_compilation/attributediagnostic_nogc.d(22):        `layer1` cannot use `@nogc` because it calls `layer0`
+fail_compilation/attributediagnostic_nogc.d(23):        `layer0` cannot use `@nogc` because it calls `gc`
+fail_compilation/attributediagnostic_nogc.d(27):        contaminated by `executing an `asm` statement without `@nogc` annotation`, so `gc` cannot infer `@nogc`
+fail_compilation/attributediagnostic_nogc.d(22):        `attributediagnostic_nogc.layer1` is declared here
 fail_compilation/attributediagnostic_nogc.d(43): Error: `@nogc` function `D main` cannot call non-@nogc function `attributediagnostic_nogc.gc1`
-fail_compilation/attributediagnostic_nogc.d(32):        and allocating with `new` makes it fail to infer `@nogc`
+fail_compilation/attributediagnostic_nogc.d(32):        contaminated by `allocating with `new`, so `gc1` cannot infer `@nogc`
+fail_compilation/attributediagnostic_nogc.d(30):        `attributediagnostic_nogc.gc1` is declared here
 fail_compilation/attributediagnostic_nogc.d(44): Error: `@nogc` function `D main` cannot call non-@nogc function `attributediagnostic_nogc.gc2`
-fail_compilation/attributediagnostic_nogc.d(38):        and calling non-@nogc `fgc` makes it fail to infer `@nogc`
+fail_compilation/attributediagnostic_nogc.d(38):        contaminated by `calling non-@nogc `fgc`, so `gc2` cannot infer `@nogc`
+fail_compilation/attributediagnostic_nogc.d(36):        `attributediagnostic_nogc.gc2` is declared here
 fail_compilation/attributediagnostic_nogc.d(45): Error: `@nogc` function `D main` cannot call non-@nogc function `attributediagnostic_nogc.gcClosure`
-fail_compilation/attributediagnostic_nogc.d(48):        and allocating a closure for `gcClosure()` makes it fail to infer `@nogc`
+fail_compilation/attributediagnostic_nogc.d(48):        contaminated by `allocating a closure for `gcClosure()`, so `gcClosure` cannot infer `@nogc`
+fail_compilation/attributediagnostic_nogc.d(48):        `attributediagnostic_nogc.gcClosure` is declared here
 ---
 */
 #line 18

--- a/compiler/test/fail_compilation/attributediagnostic_nothrow.d
+++ b/compiler/test/fail_compilation/attributediagnostic_nothrow.d
@@ -2,12 +2,12 @@
 TEST_OUTPUT:
 ---
 fail_compilation/attributediagnostic_nothrow.d(19): Error: function `attributediagnostic_nothrow.layer1` is not `nothrow`
-fail_compilation/attributediagnostic_nothrow.d(20):        which calls `layer0`
-fail_compilation/attributediagnostic_nothrow.d(21):        which calls `gc`
-fail_compilation/attributediagnostic_nothrow.d(25):        and executing an `asm` statement without a `nothrow` annotation makes it fail to infer `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(20):        `layer1` cannot use `nothrow` because it calls `layer0`
+fail_compilation/attributediagnostic_nothrow.d(21):        `layer0` cannot use `nothrow` because it calls `gc`
+fail_compilation/attributediagnostic_nothrow.d(25):        contaminated by `executing an `asm` statement without a `nothrow` annotation`, so `gc` cannot infer `nothrow`
 fail_compilation/attributediagnostic_nothrow.d(19): Error: function `attributediagnostic_nothrow.layer2` may throw but is marked as `nothrow`
 fail_compilation/attributediagnostic_nothrow.d(41): Error: function `attributediagnostic_nothrow.gc1` is not `nothrow`
-fail_compilation/attributediagnostic_nothrow.d(30):        and `object.Exception` being thrown but not caught makes it fail to infer `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(30):        contaminated by `object.Exception` being thrown but not caught`, so `gc1` cannot infer `nothrow`
 fail_compilation/attributediagnostic_nothrow.d(42): Error: function `attributediagnostic_nothrow.gc2` is not `nothrow`
 fail_compilation/attributediagnostic_nothrow.d(39): Error: function `D main` may throw but is marked as `nothrow`
 ---

--- a/compiler/test/fail_compilation/attributediagnostic_pure.d
+++ b/compiler/test/fail_compilation/attributediagnostic_pure.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/attributediagnostic_pure.d(19): Error: `pure` function `D main` cannot call impure function `attributediagnostic_pure.gc`
-fail_compilation/attributediagnostic_pure.d(14):        and executing an `asm` statement without `pure` annotation makes it fail to infer `pure`
+fail_compilation/attributediagnostic_pure.d(14):        contaminated by `executing an `asm` statement without `pure` annotation`, so `gc` cannot infer `pure`
 ---
 */
 

--- a/compiler/test/fail_compilation/diag10319.d
+++ b/compiler/test/fail_compilation/diag10319.d
@@ -5,13 +5,13 @@ fail_compilation/diag10319.d(30): Error: `pure` function `D main` cannot call im
 fail_compilation/diag10319.d(30): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo`
 fail_compilation/diag10319.d(19):        `diag10319.foo` is declared here
 fail_compilation/diag10319.d(31): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
-fail_compilation/diag10319.d(23):        and accessing mutable static data `g` makes it fail to infer `pure`
+fail_compilation/diag10319.d(23):        contaminated by `accessing mutable static data `g`, so `bar` cannot infer `pure`
 fail_compilation/diag10319.d(31): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
-fail_compilation/diag10319.d(24):        and taking the address of stack-allocated local variable `x` makes it fail to infer `@safe`
+fail_compilation/diag10319.d(24):        contaminated by `taking the address of stack-allocated local variable `x`, so `bar` cannot infer `@safe`
 fail_compilation/diag10319.d(21):        `diag10319.bar!int.bar` is declared here
 fail_compilation/diag10319.d(30): Error: function `diag10319.foo` is not `nothrow`
 fail_compilation/diag10319.d(31): Error: function `diag10319.bar!int.bar` is not `nothrow`
-fail_compilation/diag10319.d(25):        and `object.Exception` being thrown but not caught makes it fail to infer `nothrow`
+fail_compilation/diag10319.d(25):        contaminated by `object.Exception` being thrown but not caught`, so `bar` cannot infer `nothrow`
 fail_compilation/diag10319.d(28): Error: function `D main` may throw but is marked as `nothrow`
 ---
 */

--- a/compiler/test/fail_compilation/diag9620.d
+++ b/compiler/test/fail_compilation/diag9620.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag9620.d(19): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo1`
 fail_compilation/diag9620.d(20): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo2!().foo2`
-fail_compilation/diag9620.d(13):        and accessing mutable static data `x` makes it fail to infer `pure`
+fail_compilation/diag9620.d(13):        contaminated by `accessing mutable static data `x`, so `foo2` cannot infer `pure`
 ---
 */
 

--- a/compiler/test/fail_compilation/dtor_attributes.d
+++ b/compiler/test/fail_compilation/dtor_attributes.d
@@ -13,6 +13,7 @@ fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is @sys
 fail_compilation/dtor_attributes.d(111):         - HasDtor member
 fail_compilation/dtor_attributes.d(103):           @system `HasDtor.~this` is declared here
 fail_compilation/dtor_attributes.d(118): Error: `@nogc` function `dtor_attributes.test1` cannot call non-@nogc destructor `dtor_attributes.Strict.~this`
+fail_compilation/dtor_attributes.d(113):        `dtor_attributes.Strict.~this` is declared here
 fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is non-@nogc because of the following field's destructors:
 fail_compilation/dtor_attributes.d(111):         - HasDtor member
 fail_compilation/dtor_attributes.d(103):           non-@nogc `HasDtor.~this` is declared here

--- a/compiler/test/fail_compilation/dtorfields_attributes.d
+++ b/compiler/test/fail_compilation/dtorfields_attributes.d
@@ -14,6 +14,7 @@ fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` i
 fail_compilation/dtorfields_attributes.d(115):         - HasDtor member
 fail_compilation/dtorfields_attributes.d(103):           @system `HasDtor.~this` is declared here
 fail_compilation/dtorfields_attributes.d(117): Error: `@nogc` constructor `dtorfields_attributes.Strict.this` cannot call non-@nogc destructor `dtorfields_attributes.Strict.~this`
+fail_compilation/dtorfields_attributes.d(119):        `dtorfields_attributes.Strict.~this` is declared here
 fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` is non-@nogc because of the following field's destructors:
 fail_compilation/dtorfields_attributes.d(115):         - HasDtor member
 fail_compilation/dtorfields_attributes.d(103):           non-@nogc `HasDtor.~this` is declared here

--- a/compiler/test/fail_compilation/fail11375.d
+++ b/compiler/test/fail_compilation/fail11375.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail11375.d(18): Error: constructor `fail11375.D!().D.this` is not `nothrow`
-       which calls `this`
+       `this` cannot use `nothrow` because it calls `this`
 fail_compilation/fail11375.d(16): Error: function `D main` may throw but is marked as `nothrow`
 ---
 */

--- a/compiler/test/fail_compilation/fail12622.d
+++ b/compiler/test/fail_compilation/fail12622.d
@@ -1,16 +1,17 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12622.d(26): Error: `pure` function `fail12622.foo` cannot call impure function pointer `fp`
-fail_compilation/fail12622.d(26): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function pointer `fp`
-fail_compilation/fail12622.d(26): Error: `@safe` function `fail12622.foo` cannot call `@system` function pointer `fp`
-fail_compilation/fail12622.d(28): Error: `pure` function `fail12622.foo` cannot call impure function pointer `fp`
-fail_compilation/fail12622.d(28): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function pointer `fp`
-fail_compilation/fail12622.d(28): Error: `@safe` function `fail12622.foo` cannot call `@system` function pointer `fp`
-fail_compilation/fail12622.d(30): Error: `pure` function `fail12622.foo` cannot call impure function `fail12622.bar`
-fail_compilation/fail12622.d(30): Error: `@safe` function `fail12622.foo` cannot call `@system` function `fail12622.bar`
-fail_compilation/fail12622.d(20):        `fail12622.bar` is declared here
-fail_compilation/fail12622.d(30): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function `fail12622.bar`
+fail_compilation/fail12622.d(27): Error: `pure` function `fail12622.foo` cannot call impure function pointer `fp`
+fail_compilation/fail12622.d(27): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function pointer `fp`
+fail_compilation/fail12622.d(27): Error: `@safe` function `fail12622.foo` cannot call `@system` function pointer `fp`
+fail_compilation/fail12622.d(29): Error: `pure` function `fail12622.foo` cannot call impure function pointer `fp`
+fail_compilation/fail12622.d(29): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function pointer `fp`
+fail_compilation/fail12622.d(29): Error: `@safe` function `fail12622.foo` cannot call `@system` function pointer `fp`
+fail_compilation/fail12622.d(31): Error: `pure` function `fail12622.foo` cannot call impure function `fail12622.bar`
+fail_compilation/fail12622.d(31): Error: `@safe` function `fail12622.foo` cannot call `@system` function `fail12622.bar`
+fail_compilation/fail12622.d(21):        `fail12622.bar` is declared here
+fail_compilation/fail12622.d(31): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function `fail12622.bar`
+fail_compilation/fail12622.d(21):        `fail12622.bar` is declared here
 ---
 */
 // Note that, today nothrow violation errors are accidentally hidden.

--- a/compiler/test/fail_compilation/fail13120.d
+++ b/compiler/test/fail_compilation/fail13120.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13120.d(13): Error: `pure` delegate `fail13120.g1.__foreachbody_L12_C5` cannot call impure function `fail13120.f1`
-fail_compilation/fail13120.d(13): Error: `@nogc` delegate `fail13120.g1.__foreachbody_L12_C5` cannot call non-@nogc function `fail13120.f1`
+fail_compilation/fail13120.d(14): Error: `pure` delegate `fail13120.g1.__foreachbody_L13_C5` cannot call impure function `fail13120.f1`
+fail_compilation/fail13120.d(14): Error: `@nogc` delegate `fail13120.g1.__foreachbody_L13_C5` cannot call non-@nogc function `fail13120.f1`
+fail_compilation/fail13120.d(9):        `fail13120.f1` is declared here
 ---
 */
 void f1() {}
@@ -16,11 +17,12 @@ void g1(char[] s) pure @nogc
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13120.d(35): Error: `pure` function `fail13120.h2` cannot call impure function `fail13120.g2!().g2`
-fail_compilation/fail13120.d(30):        which calls `f2`
-fail_compilation/fail13120.d(35): Error: `@safe` function `fail13120.h2` cannot call `@system` function `fail13120.g2!().g2`
-fail_compilation/fail13120.d(27):        `fail13120.g2!().g2` is declared here
-fail_compilation/fail13120.d(35): Error: `@nogc` function `fail13120.h2` cannot call non-@nogc function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(37): Error: `pure` function `fail13120.h2` cannot call impure function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(32):        `g2` cannot use `pure` because it calls `f2`
+fail_compilation/fail13120.d(37): Error: `@safe` function `fail13120.h2` cannot call `@system` function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(29):        `fail13120.g2!().g2` is declared here
+fail_compilation/fail13120.d(37): Error: `@nogc` function `fail13120.h2` cannot call non-@nogc function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(29):        `fail13120.g2!().g2` is declared here
 ---
 */
 void f2() {}

--- a/compiler/test/fail_compilation/fail7848.d
+++ b/compiler/test/fail_compilation/fail7848.d
@@ -3,18 +3,20 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7848.d(27): Error: `pure` function `fail7848.C.__unittest_L25_C30` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(27): Error: `@safe` function `fail7848.C.__unittest_L25_C30` cannot call `@system` function `fail7848.func`
-fail_compilation/fail7848.d(21):        `fail7848.func` is declared here
-fail_compilation/fail7848.d(27): Error: `@nogc` function `fail7848.C.__unittest_L25_C30` cannot call non-@nogc function `fail7848.func`
-fail_compilation/fail7848.d(27): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(25): Error: function `fail7848.C.__unittest_L25_C30` may throw but is marked as `nothrow`
-fail_compilation/fail7848.d(32): Error: `pure` function `fail7848.C.invariant` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(32): Error: `@safe` function `fail7848.C.invariant` cannot call `@system` function `fail7848.func`
-fail_compilation/fail7848.d(21):        `fail7848.func` is declared here
-fail_compilation/fail7848.d(32): Error: `@nogc` function `fail7848.C.invariant` cannot call non-@nogc function `fail7848.func`
-fail_compilation/fail7848.d(32): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(30): Error: function `fail7848.C.invariant` may throw but is marked as `nothrow`
+fail_compilation/fail7848.d(29): Error: `pure` function `fail7848.C.__unittest_L27_C30` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(29): Error: `@safe` function `fail7848.C.__unittest_L27_C30` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(23):        `fail7848.func` is declared here
+fail_compilation/fail7848.d(29): Error: `@nogc` function `fail7848.C.__unittest_L27_C30` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(23):        `fail7848.func` is declared here
+fail_compilation/fail7848.d(29): Error: function `fail7848.func` is not `nothrow`
+fail_compilation/fail7848.d(27): Error: function `fail7848.C.__unittest_L27_C30` may throw but is marked as `nothrow`
+fail_compilation/fail7848.d(34): Error: `pure` function `fail7848.C.invariant` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(34): Error: `@safe` function `fail7848.C.invariant` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(23):        `fail7848.func` is declared here
+fail_compilation/fail7848.d(34): Error: `@nogc` function `fail7848.C.invariant` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(23):        `fail7848.func` is declared here
+fail_compilation/fail7848.d(34): Error: function `fail7848.func` is not `nothrow`
+fail_compilation/fail7848.d(32): Error: function `fail7848.C.invariant` may throw but is marked as `nothrow`
 ---
 */
 

--- a/compiler/test/fail_compilation/nogc1.d
+++ b/compiler/test/fail_compilation/nogc1.d
@@ -9,13 +9,14 @@ struct S3 { this(int) @nogc; }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(23): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
-fail_compilation/nogc1.d(25): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
+fail_compilation/nogc1.d(24): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
 fail_compilation/nogc1.d(26): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
-fail_compilation/nogc1.d(28): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
-fail_compilation/nogc1.d(29): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
-fail_compilation/nogc1.d(30): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
-fail_compilation/nogc1.d(32): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
+fail_compilation/nogc1.d(27): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
+fail_compilation/nogc1.d(29): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
+fail_compilation/nogc1.d(30): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
+fail_compilation/nogc1.d(6):        `nogc1.S2.this` is declared here
+fail_compilation/nogc1.d(31): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
+fail_compilation/nogc1.d(33): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNew`
 ---
 */
 @nogc void testNew()
@@ -35,12 +36,13 @@ fail_compilation/nogc1.d(32): Error: allocating with `new` causes a GC allocatio
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(48): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
 fail_compilation/nogc1.d(50): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
-fail_compilation/nogc1.d(51): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
+fail_compilation/nogc1.d(52): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
 fail_compilation/nogc1.d(53): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
-fail_compilation/nogc1.d(54): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc constructor `nogc1.S2.this`
 fail_compilation/nogc1.d(55): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
+fail_compilation/nogc1.d(56): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc constructor `nogc1.S2.this`
+fail_compilation/nogc1.d(6):        `nogc1.S2.this` is declared here
+fail_compilation/nogc1.d(57): Error: allocating with `new` causes a GC allocation in `@nogc` function `testNewScope`
 ---
 */
 @nogc void testNewScope()

--- a/compiler/test/fail_compilation/nogc3.d
+++ b/compiler/test/fail_compilation/nogc3.d
@@ -24,8 +24,9 @@ void barCall();
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc3.d(34): Error: `@nogc` function `nogc3.testCall` cannot call non-@nogc function pointer `fp`
-fail_compilation/nogc3.d(35): Error: `@nogc` function `nogc3.testCall` cannot call non-@nogc function `nogc3.barCall`
+fail_compilation/nogc3.d(35): Error: `@nogc` function `nogc3.testCall` cannot call non-@nogc function pointer `fp`
+fail_compilation/nogc3.d(36): Error: `@nogc` function `nogc3.testCall` cannot call non-@nogc function `nogc3.barCall`
+fail_compilation/nogc3.d(22):        `nogc3.barCall` is declared here
 ---
 */
 @nogc void testCall()
@@ -43,12 +44,12 @@ fail_compilation/nogc3.d(35): Error: `@nogc` function `nogc3.testCall` cannot ca
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc3.d(54): Error: function `nogc3.testClosure1` is `@nogc` yet allocates closure for `testClosure1()` with the GC
-fail_compilation/nogc3.d(57):        function `bar` closes over variable `x`
-fail_compilation/nogc3.d(56):        `x` declared here
-fail_compilation/nogc3.d(66): Error: function `nogc3.testClosure3` is `@nogc` yet allocates closure for `testClosure3()` with the GC
-fail_compilation/nogc3.d(69):        function `bar` closes over variable `x`
-fail_compilation/nogc3.d(68):        `x` declared here
+fail_compilation/nogc3.d(55): Error: function `nogc3.testClosure1` is `@nogc` yet allocates closure for `testClosure1()` with the GC
+fail_compilation/nogc3.d(58):        function `bar` closes over variable `x`
+fail_compilation/nogc3.d(57):        `x` declared here
+fail_compilation/nogc3.d(67): Error: function `nogc3.testClosure3` is `@nogc` yet allocates closure for `testClosure3()` with the GC
+fail_compilation/nogc3.d(70):        function `bar` closes over variable `x`
+fail_compilation/nogc3.d(69):        `x` declared here
 ---
 */
 @nogc auto testClosure1()
@@ -75,10 +76,10 @@ fail_compilation/nogc3.d(68):        `x` declared here
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc3.d(87): Error: this array literal causes a GC allocation in `@nogc` function `foo13702`
 fail_compilation/nogc3.d(88): Error: this array literal causes a GC allocation in `@nogc` function `foo13702`
+fail_compilation/nogc3.d(89): Error: this array literal causes a GC allocation in `@nogc` function `foo13702`
+fail_compilation/nogc3.d(95): Error: this array literal causes a GC allocation in `@nogc` function `bar13702`
 fail_compilation/nogc3.d(94): Error: this array literal causes a GC allocation in `@nogc` function `bar13702`
-fail_compilation/nogc3.d(93): Error: this array literal causes a GC allocation in `@nogc` function `bar13702`
 ---
 */
 int[] foo13702(bool b) @nogc
@@ -100,8 +101,8 @@ int[] bar13702(bool b) @nogc
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc3.d(111): Error: this array literal causes a GC allocation in `@nogc` function `f`
 fail_compilation/nogc3.d(112): Error: this array literal causes a GC allocation in `@nogc` function `f`
+fail_compilation/nogc3.d(113): Error: this array literal causes a GC allocation in `@nogc` function `f`
 ---
 */
 
@@ -115,7 +116,7 @@ void f() @nogc
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc3.d(125): Error: this array literal causes a GC allocation in `@nogc` function `g`
+fail_compilation/nogc3.d(126): Error: this array literal causes a GC allocation in `@nogc` function `g`
 ---
 */
 

--- a/compiler/test/fail_compilation/scope_infer_diagnostic.d
+++ b/compiler/test/fail_compilation/scope_infer_diagnostic.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/scope_infer_diagnostic.d(34): Error: `@safe` function `scope_infer_diagnostic.outer` cannot call `@system` function `scope_infer_diagnostic.inner!(void delegate(const(char)[]) pure nothrow @nogc @safe).inner`
-fail_compilation/scope_infer_diagnostic.d(28):        and assigning scope variable `w` to non-scope parameter `w` calling `callee` makes it fail to infer `@safe`
+fail_compilation/scope_infer_diagnostic.d(28):        contaminated by `assigning scope variable `w` to non-scope parameter `w` calling `callee`, so `inner` cannot infer `@safe`
 fail_compilation/scope_infer_diagnostic.d(21):        `w` is not `scope` because of `globalPtr = & w`
 fail_compilation/scope_infer_diagnostic.d(25):        `scope_infer_diagnostic.inner!(void delegate(const(char)[]) pure nothrow @nogc @safe).inner` is declared here
 ---

--- a/compiler/test/fail_compilation/systemvariables_deprecation.d
+++ b/compiler/test/fail_compilation/systemvariables_deprecation.d
@@ -3,8 +3,8 @@ REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
 fail_compilation/systemvariables_deprecation.d(15): Deprecation: `@safe` function `main` calling `middle`
-fail_compilation/systemvariables_deprecation.d(20):        which calls `inferred`
-fail_compilation/systemvariables_deprecation.d(26):        and access `@system` variable `x0` makes it fail to infer `@safe`
+fail_compilation/systemvariables_deprecation.d(20):        `middle` cannot use `@safe` because it calls `inferred`
+fail_compilation/systemvariables_deprecation.d(26):        contaminated by `access `@system` variable `x0`, so `inferred` cannot infer `@safe`
 ---
 */
 

--- a/compiler/test/fail_compilation/test20655.d
+++ b/compiler/test/fail_compilation/test20655.d
@@ -3,11 +3,11 @@ REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
 fail_compilation/test20655.d(26): Deprecation: `@safe` function `g` calling `f1`
-fail_compilation/test20655.d(21):        and accessing overlapped field `U.s` with pointers makes it fail to infer `@safe`
+fail_compilation/test20655.d(21):        contaminated by `accessing overlapped field `U.s` with pointers`, so `f1` cannot infer `@safe`
 fail_compilation/test20655.d(27): Deprecation: `@safe` function `g` calling `f2`
-fail_compilation/test20655.d(22):        and accessing overlapped field `U.s` with pointers makes it fail to infer `@safe`
+fail_compilation/test20655.d(22):        contaminated by `accessing overlapped field `U.s` with pointers`, so `f2` cannot infer `@safe`
 fail_compilation/test20655.d(28): Deprecation: `@safe` function `g` calling `f3`
-fail_compilation/test20655.d(25):        and accessing overlapped field `U.s` with pointers makes it fail to infer `@safe`
+fail_compilation/test20655.d(25):        contaminated by `accessing overlapped field `U.s` with pointers`, so `f3` cannot infer `@safe`
 ---
 */
 

--- a/compiler/test/fail_compilation/test23145.d
+++ b/compiler/test/fail_compilation/test23145.d
@@ -6,7 +6,7 @@ fail_compilation/test23145.d(111):        is the location of the constructor
 fail_compilation/test23145.d(124): Error: `scope` allocation of `c` with a non-`scope` constructor is not allowed in a `@safe` function
 fail_compilation/test23145.d(111):        is the location of the constructor
 fail_compilation/test23145.d(125): Error: `@safe` function `test23145.bax` cannot call `@system` function `test23145.inferred`
-fail_compilation/test23145.d(131):        and `scope` allocation of `c` with a non-`scope` constructor makes it fail to infer `@safe`
+fail_compilation/test23145.d(131):        contaminated by `scope` allocation of `c` with a non-`scope` constructor`, so `inferred` cannot infer `@safe`
 fail_compilation/test23145.d(129):        `test23145.inferred` is declared here
 ---
 */

--- a/compiler/test/fail_compilation/testInference.d
+++ b/compiler/test/fail_compilation/testInference.d
@@ -138,9 +138,9 @@ immutable(void)* g10063(inout int* p) pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(154): Error: `pure` function `testInference.bar14049` cannot call impure function `testInference.foo14049!int.foo14049`
-fail_compilation/testInference.d(149):        which calls `() => impure14049()`
-fail_compilation/testInference.d(148):        which calls `impure14049`
-fail_compilation/testInference.d(143):        and accessing mutable static data `i` makes it fail to infer `pure`
+fail_compilation/testInference.d(149):        `foo14049` cannot use `pure` because it calls `() => impure14049()`
+fail_compilation/testInference.d(148):        `() => impure14049()` cannot use `pure` because it calls `impure14049`
+fail_compilation/testInference.d(143):        contaminated by `accessing mutable static data `i`, so `impure14049` cannot infer `pure`
 ---
 */
 #line 143
@@ -174,7 +174,7 @@ int* f14160() pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(180): Error: `pure` function `testInference.test12422` cannot call impure function `testInference.test12422.bar12422!().bar12422`
-fail_compilation/testInference.d(179):        which calls `foo12422`
+fail_compilation/testInference.d(179):        `bar12422` cannot use `pure` because it calls `foo12422`
 ---
 */
 #line 175
@@ -190,9 +190,9 @@ void test12422() pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(198): Error: `pure` function `testInference.test13729a` cannot call impure function `testInference.test13729a.foo`
-fail_compilation/testInference.d(196):        and accessing mutable static data `g13729` makes it fail to infer `pure`
+fail_compilation/testInference.d(196):        contaminated by `accessing mutable static data `g13729`, so `foo` cannot infer `pure`
 fail_compilation/testInference.d(206): Error: `pure` function `testInference.test13729b` cannot call impure function `testInference.test13729b.foo!().foo`
-fail_compilation/testInference.d(204):        and accessing mutable static data `g13729` makes it fail to infer `pure`
+fail_compilation/testInference.d(204):        contaminated by `accessing mutable static data `g13729`, so `foo` cannot infer `pure`
 ---
 */
 
@@ -239,7 +239,7 @@ void test17086_call ()
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(238): Error: `pure` function `testInference.test20047_pure_function` cannot call impure function `testInference.test20047_pure_function.bug`
-fail_compilation/testInference.d(237):        which calls `test20047_impure_function`
+fail_compilation/testInference.d(237):        `bug` cannot use `pure` because it calls `test20047_impure_function`
 ---
 */
 #line 234


### PR DESCRIPTION
### Title: Refactor and improve diagnostic messages for attribute violations (`@nogc`, `@safe`, `pure`, `nothrow`)

**Description / Motivation**

This MR significantly improves the Developer Experience (DX) when dealing with attribute inference failures and direct attribute violations (`@nogc`, `@safe`, `pure`, `nothrow`). 

Previously, the compiler's output could be fragmented, forcing developers to manually search for the source of a violation (e.g., searching the codebase for an offending constructor) or parse vague "makes it fail to infer" messages. This refactoring makes the diagnostics explicit, traceable, and self-explanatory.

Key improvements include:
1. **Declaration Tracing:** Direct attribute violations now append an `is declared here` supplemental message, pointing exactly to the offending function/constructor.
2. **Explicit Call Chains:** Replaced the ambiguous `which calls [X]` with a clear causal sentence: `[Y] cannot use [Attribute] because it calls [X]`.
3. **Precise Inference Terminology:** Replaced `and [Action] makes it fail to infer` with the more accurate `contaminated by [Action], so [Function] cannot infer`.
4. **Deep Closure Diagnostics:** The compiler now explicitly traces and reports which variables are captured when a GC-allocating closure is formed inside a `@nogc` context.

---

### Examples: Before vs. After

#### Example 1: Added Declaration Context for Violations
When a strictly attributed function calls a violating function, the compiler now points the developer directly to the source of the problem.

**Before:**
```text
fail_compilation/nogc1.d(29): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
```

**After:**
```text
fail_compilation/nogc1.d(30): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
fail_compilation/nogc1.d(6):        `nogc1.S2.this` is declared here
```

#### Example 2: Clearer Call Chain Inference
When an attribute cannot be inferred due to a nested call, the relationship is now explicitly stated rather than vaguely chained.

**Before:**
```text
fail_compilation/attributediagnostic.d(21): Error: `@safe` function `layer2` cannot call `@system` function `layer1`
fail_compilation/attributediagnostic.d(23):        which calls `layer0`
```

**After:**
```text
fail_compilation/attributediagnostic.d(21): Error: `@safe` function `attributediagnostic.layer2` cannot call `@system` function `attributediagnostic.layer1`
fail_compilation/attributediagnostic.d(23):        `layer1` cannot use `@safe` because it calls `layer0`
fail_compilation/attributediagnostic.d(25):        `layer0` cannot use `@safe` because it calls `system`
```

#### Example 3: Improved "Contamination" Terminology
The explanation for *why* a function failed to infer an attribute is now much more technically descriptive.

**Before:**
```text
fail_compilation/testInference.d(143):        and accessing mutable static data `i` makes it fail to infer `pure`
```

**After:**
```text
fail_compilation/testInference.d(143):        contaminated by `accessing mutable static data `i`, so `impure14049` cannot infer `pure`
```

#### Example 4: Detailed `@nogc` Closure Tracing
When a closure causes a GC allocation in `@nogc` code, the compiler now explains exactly which variable was captured and where it lives.

**Before:**
*(Missing context / silent on exact capture)*

**After:**
```text
fail_compilation/nogc3.d(55): Error: function `nogc3.testClosure1` is `@nogc` yet allocates closure for `testClosure1()` with the GC
fail_compilation/nogc3.d(58):        function `bar` closes over variable `x`
fail_compilation/nogc3.d(57):        `x` declared here
```

---
**Testing:**
Updated `TEST_OUTPUT` across 19 files in `fail_compilation/` to reflect and enforce the new diagnostic formatting.