### PR TITLE
Fix #21194 - Modifying global char[] initialized with dup of string l…

### DIFF
--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -430,7 +430,20 @@ void Expression_toDt(Expression e, ref DtBuilder dtb)
                 goto case Tpointer;
 
             case Tpointer:
-                if (e.sz == 1)
+            {
+                // Through CTFE, a mutable char[] might be initialized with a StringExp,
+                // don't use immutable string symbol then
+                const mutableData = t.nextOf().isMutable();
+                if (mutableData)
+                {
+                    auto dtbdata = DtBuilder(0);
+                    dtbdata.nbytes((cast(const ubyte*)p)[0 .. n * e.sz]);
+                    if (auto d = dtbdata.finish())
+                        dtb.dtoff(d, 0);
+                    else
+                        dtb.size(0);
+                }
+                else if (e.sz == 1)
                 {
                     import dmd.glue.e2ir : toStringSymbol;
                     import dmd.glue : totym;
@@ -444,6 +457,7 @@ void Expression_toDt(Expression e, ref DtBuilder dtb)
                     dtb.abytes(0, p[0 .. n * e.sz], cast(uint) e.sz, pow2);
                 }
                 break;
+            }
 
             case Tsarray:
             {

--- a/compiler/test/runnable/testconst.d
+++ b/compiler/test/runnable/testconst.d
@@ -3794,6 +3794,39 @@ static assert((   immutable dstring[1]  ).stringof ==    "immutable(dstring[1])"
 static assert((   immutable dstring[int]).stringof ==    "immutable(dstring[int])" );
 
 /************************************/
+// https://github.com/dlang/dmd/issues/21194
+// Global char[] initialized with dup of string literal must be in writable memory
+
+char[]  ta = "foo".dup;
+wchar[] tb = "bar"w.dup;
+dchar[] tc = "baz"d.dup;
+
+__gshared char[]  ga = "FOO".dup;
+__gshared wchar[] gb = "BAR"w.dup;
+__gshared dchar[] gc = "BAZ"d.dup;
+
+void test21194()
+{
+    ta[0] = 'B';
+    assert(ta == "Boo");
+
+    tb[0] = 'B';
+    assert(tb == "Bar"w);
+
+    tc[0] = 'B';
+    assert(tc == "Baz"d);
+
+    ga[0] = 'b';
+    assert(ga == "bOO");
+
+    gb[0] = 'b';
+    assert(gb == "bAR"w);
+
+    gc[0] = 'b';
+    assert(gc == "bAZ"d);
+}
+
+/************************************/
 
 int main()
 {
@@ -3924,6 +3957,7 @@ int main()
     test11226();
     test11768();
     test13011();
+    test21194();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
…iteral causes segfault

Mirrors logic for ArrayLiteralExp, meaning no 0 byte added either. The ArrayLiteralExp / StringExp duality causes more problems than this (one of which is template parameter mangling), but eliminating it is quite a task.