### PR TITLE
Fix #21039 - Zero-length static array with scalar initializer causes ICE

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -2547,7 +2547,9 @@ public:
             }
         }
 
-        if (expsx !is e.elements)
+        // Only create new ArrayLiteralExp if needed (don't forget to check basis as well!)
+        // https://github.com/dlang/dmd/issues/21039
+        if (expsx !is e.elements || basis !is e.basis)
         {
             // todo: all tuple expansions should go in semantic phase.
             expandTuples(expsx);

--- a/compiler/test/compilable/test21039.d
+++ b/compiler/test/compilable/test21039.d
@@ -1,0 +1,5 @@
+// https://github.com/dlang/dmd/issues/21039
+// Zero-length static array with scalar initializer caused ICE
+
+struct A { const(char)[0] b = 0; }
+struct B { int[0] x = 5 + 5; }


### PR DESCRIPTION
Closes #21039

CTFE used to check after interpreting if there were any changes, but it neglected the interpretation of the basis element, keeping it around uninterpreted which trips up the compiler down the line.

Honestly it's a pretty sketchy construct to have a length 0 array literal with basis elements, the whole thing should be more encapsulated so that calling code can access array literal elements without prying in internals like the basis element, but that's a big refactor.