### PR TITLE
Fix #20528 - pragma(printf) gives me the wrong fix

### DIFF
--- a/compiler/src/dmd/chkformat.d
+++ b/compiler/src/dmd/chkformat.d
@@ -18,6 +18,7 @@ import dmd.cond;
 import dmd.errorsink;
 import dmd.expression;
 import dmd.globals;
+import dmd.hdrgen : toErrMsg;
 import dmd.identifier;
 import dmd.location;
 import dmd.mtype;
@@ -142,8 +143,32 @@ bool checkPrintfFormat(Loc loc, scope const char[] format, scope Expression[] ar
 
         void errorMsg(const char* prefix, Expression arg, const char* texpect, Type tactual)
         {
-            eSink.deprecation(arg.loc, "%sargument `%s` for format specification `\"%.*s\"` must be `%s`, not `%s`",
-                  prefix ? prefix : "", arg.toChars(), cast(int)slice.length, slice.ptr, texpect, tactual.toChars());
+            eSink.deprecation(arg.loc, "%sargument `%s` of type `%s` does not match format specification",
+                  prefix ? prefix : "", arg.toErrMsg(), tactual.toErrMsg());
+
+            eSink.deprecationSupplemental(arg.loc, "`\"%.*s\"` requires `%s`", cast(int) slice.length, slice.ptr, texpect);
+
+            if (prefix)
+                return; // width/precision args must be int; no useful format suggestion
+            auto tb = tactual.toBasetype();
+            const(char)* suggestion = integralFormatSpecifier(tb.ty);
+            if (!suggestion)
+            switch (tb.ty)
+            {
+                case Tfloat32:
+                case Tfloat64: suggestion = "%g";  break;
+                case Tfloat80: suggestion = "%Lg"; break;
+                case Tpointer:
+                    auto tn = tb.nextOf();
+                    if (tn && (tn.ty == Tchar || tn.ty == Tint8 || tn.ty == Tuns8))
+                        suggestion = "%s";
+                    else
+                        suggestion = "%p";
+                    break;
+                default: break;
+            }
+            if (suggestion)
+                eSink.deprecationSupplemental(arg.loc, "`%s` may be formatted with `\"%s\"`", tactual.toErrMsg(), suggestion);
         }
 
         if (widthStar)
@@ -412,8 +437,30 @@ bool checkScanfFormat(Loc loc, scope const char[] format, scope Expression[] arg
 
         void errorMsg(const char* prefix, Expression arg, const char* texpect, Type tactual)
         {
-            eSink.deprecation(arg.loc, "%sargument `%s` for format specification `\"%.*s\"` must be `%s`, not `%s`",
-                  prefix ? prefix : "", arg.toChars(), cast(int)slice.length, slice.ptr, texpect, tactual.toChars());
+            eSink.deprecation(arg.loc, "%sargument `%s` of type `%s` does not match format specification",
+                  prefix ? prefix : "", arg.toErrMsg(), tactual.toErrMsg());
+
+            eSink.deprecationSupplemental(arg.loc, "`\"%.*s\"` requires `%s`", cast(int)slice.length, slice.ptr, texpect);
+
+            auto tb = tactual.toBasetype();
+            if (tb.ty != Tpointer)
+                return;
+            auto tnb = tb.nextOf();
+            if (!tnb)
+                return;
+            tnb = tnb.toBasetype();
+            const(char)* suggestion = integralFormatSpecifier(tnb.ty);
+            if (!suggestion)
+                switch (tnb.ty)
+                {
+                    case Tchar:    suggestion = "%s";  break;
+                    case Tfloat32: suggestion = "%g";  break;
+                    case Tfloat64: suggestion = "%lg"; break;
+                    case Tfloat80: suggestion = "%Lg"; break;
+                    default: break;
+                }
+            if (suggestion)
+                eSink.deprecationSupplemental(arg.loc, "`%s` may be formatted with `\"%s\"`", tactual.toChars(), suggestion);
         }
 
         auto e = getNextArg();
@@ -564,6 +611,23 @@ bool checkScanfFormat(Loc loc, scope const char[] format, scope Expression[] arg
 /*****************************************************************************************************/
 
 private:
+
+/// Returns: format specifier string for `ty`, or `null` if not a recognized integer type
+const(char)* integralFormatSpecifier(TY ty) pure nothrow
+{
+    switch (ty)
+    {
+        case Tint8:  return "%hhd";
+        case Tuns8:  return "%hhu";
+        case Tint16: return "%hd";
+        case Tuns16: return "%hu";
+        case Tint32: return "%d";
+        case Tuns32: return "%u";
+        case Tint64: return "%lld";
+        case Tuns64: return "%llu";
+        default:     return null;
+    }
+}
 
 /**************************************
  * Parse the *format specifier* which is of the form:

--- a/compiler/test/compilable/test21177.d
+++ b/compiler/test/compilable/test21177.d
@@ -13,11 +13,17 @@ compilable/test21177.d(153): Deprecation: more format specifiers than 0 argument
 compilable/test21177.d(154): Deprecation: more format specifiers than 0 arguments
 compilable/test21177.d(155): Deprecation: more format specifiers than 0 arguments
 compilable/test21177.d(202): Deprecation: format specifier `"%m"` is invalid
-compilable/test21177.d(203): Deprecation: argument `d` for format specification `"%mc"` must be `char**`, not `int`
-compilable/test21177.d(204): Deprecation: argument `c` for format specification `"%ms"` must be `char**`, not `char*`
+compilable/test21177.d(203): Deprecation: argument `d` of type `int` does not match format specification
+compilable/test21177.d(203):        `"%mc"` requires `char**`
+compilable/test21177.d(204): Deprecation: argument `c` of type `char*` does not match format specification
+compilable/test21177.d(204):        `"%ms"` requires `char**`
+compilable/test21177.d(204):        `char*` may be formatted with `"%s"`
 compilable/test21177.d(205): Deprecation: format specifier `"%ml"` is invalid
-compilable/test21177.d(206): Deprecation: argument `d` for format specification `"%mlc"` must be `wchar_t**`, not `int`
-compilable/test21177.d(207): Deprecation: argument `c` for format specification `"%mls"` must be `wchar_t**`, not `char*`
+compilable/test21177.d(206): Deprecation: argument `d` of type `int` does not match format specification
+compilable/test21177.d(206):        `"%mlc"` requires `wchar_t**`
+compilable/test21177.d(207): Deprecation: argument `c` of type `char*` does not match format specification
+compilable/test21177.d(207):        `"%mls"` requires `wchar_t**`
+compilable/test21177.d(207):        `char*` may be formatted with `"%s"`
 ---
 */
 

--- a/compiler/test/fail_compilation/chkformat.d
+++ b/compiler/test/fail_compilation/chkformat.d
@@ -2,61 +2,126 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/chkformat.d(101): Deprecation: width argument `0L` for format specification `"%*.*d"` must be `int`, not `long`
-fail_compilation/chkformat.d(101): Deprecation: precision argument `1L` for format specification `"%*.*d"` must be `int`, not `long`
-fail_compilation/chkformat.d(101): Deprecation: argument `2L` for format specification `"%*.*d"` must be `int`, not `long`
-fail_compilation/chkformat.d(104): Deprecation: argument `4` for format specification `"%lld"` must be `long`, not `int`
-fail_compilation/chkformat.d(105): Deprecation: argument `5` for format specification `"%jd"` must be `core.stdc.stdint.intmax_t`, not `int`
-fail_compilation/chkformat.d(106): Deprecation: argument `6.0` for format specification `"%zd"` must be `size_t`, not `double`
-fail_compilation/chkformat.d(107): Deprecation: argument `7.0` for format specification `"%td"` must be `ptrdiff_t`, not `double`
-fail_compilation/chkformat.d(108): Deprecation: argument `8.0L` for format specification `"%g"` must be `double`, not `real`
-fail_compilation/chkformat.d(109): Deprecation: argument `9.0` for format specification `"%Lg"` must be `real`, not `double`
-fail_compilation/chkformat.d(110): Deprecation: argument `10` for format specification `"%p"` must be `void*`, not `int`
-fail_compilation/chkformat.d(111): Deprecation: argument `& u` for format specification `"%n"` must be `int*`, not `uint*`
-fail_compilation/chkformat.d(113): Deprecation: argument `& u` for format specification `"%lln"` must be `long*`, not `int*`
-fail_compilation/chkformat.d(114): Deprecation: argument `& u` for format specification `"%hn"` must be `short*`, not `int*`
-fail_compilation/chkformat.d(115): Deprecation: argument `& u` for format specification `"%hhn"` must be `byte*`, not `int*`
-fail_compilation/chkformat.d(116): Deprecation: argument `16L` for format specification `"%c"` must be `char`, not `long`
-fail_compilation/chkformat.d(117): Deprecation: argument `17L` for format specification `"%c"` must be `char`, not `long`
-fail_compilation/chkformat.d(118): Deprecation: argument `& u` for format specification `"%s"` must be `char*`, not `int*`
-fail_compilation/chkformat.d(119): Deprecation: argument `& u` for format specification `"%ls"` must be `wchar_t*`, not `int*`$?:windows=
-fail_compilation/chkformat.d(122): Deprecation: argument `0LU` for format specification `"%lu"` must be `uint`, not `ulong`
-fail_compilation/chkformat.d(122):        C `long` is 4 bytes on your system|32=
-fail_compilation/chkformat.d(122): Deprecation: argument `0LU` for format specification `"%lu"` must be `uint`, not `ulong`
-fail_compilation/chkformat.d(122):        C `long` is 4 bytes on your system$
-fail_compilation/chkformat.d(123): Deprecation: argument `p` for format specification `"%n"` must be `int*`, not `const(int)*`
-fail_compilation/chkformat.d(201): Deprecation: argument `0L` for format specification `"%d"` must be `int*`, not `long`
+fail_compilation/chkformat.d(101): Deprecation: width argument `0L` of type `long` does not match format specification
+fail_compilation/chkformat.d(101):        `"%*.*d"` requires `int`
+fail_compilation/chkformat.d(101): Deprecation: precision argument `1L` of type `long` does not match format specification
+fail_compilation/chkformat.d(101):        `"%*.*d"` requires `int`
+fail_compilation/chkformat.d(101): Deprecation: argument `2L` of type `long` does not match format specification
+fail_compilation/chkformat.d(101):        `"%*.*d"` requires `int`
+fail_compilation/chkformat.d(101):        `long` may be formatted with `"%lld"`
+fail_compilation/chkformat.d(104): Deprecation: argument `4` of type `int` does not match format specification
+fail_compilation/chkformat.d(104):        `"%lld"` requires `long`
+fail_compilation/chkformat.d(104):        `int` may be formatted with `"%d"`
+fail_compilation/chkformat.d(105): Deprecation: argument `5` of type `int` does not match format specification
+fail_compilation/chkformat.d(105):        `"%jd"` requires `core.stdc.stdint.intmax_t`
+fail_compilation/chkformat.d(105):        `int` may be formatted with `"%d"`
+fail_compilation/chkformat.d(106): Deprecation: argument `6.0` of type `double` does not match format specification
+fail_compilation/chkformat.d(106):        `"%zd"` requires `size_t`
+fail_compilation/chkformat.d(106):        `double` may be formatted with `"%g"`
+fail_compilation/chkformat.d(107): Deprecation: argument `7.0` of type `double` does not match format specification
+fail_compilation/chkformat.d(107):        `"%td"` requires `ptrdiff_t`
+fail_compilation/chkformat.d(107):        `double` may be formatted with `"%g"`
+fail_compilation/chkformat.d(108): Deprecation: argument `8.0L` of type `real` does not match format specification
+fail_compilation/chkformat.d(108):        `"%g"` requires `double`
+fail_compilation/chkformat.d(108):        `real` may be formatted with `"%Lg"`
+fail_compilation/chkformat.d(109): Deprecation: argument `9.0` of type `double` does not match format specification
+fail_compilation/chkformat.d(109):        `"%Lg"` requires `real`
+fail_compilation/chkformat.d(109):        `double` may be formatted with `"%g"`
+fail_compilation/chkformat.d(110): Deprecation: argument `10` of type `int` does not match format specification
+fail_compilation/chkformat.d(110):        `"%p"` requires `void*`
+fail_compilation/chkformat.d(110):        `int` may be formatted with `"%d"`
+fail_compilation/chkformat.d(111): Deprecation: argument `& u` of type `uint*` does not match format specification
+fail_compilation/chkformat.d(111):        `"%n"` requires `int*`
+fail_compilation/chkformat.d(111):        `uint*` may be formatted with `"%p"`
+fail_compilation/chkformat.d(113): Deprecation: argument `& u` of type `int*` does not match format specification
+fail_compilation/chkformat.d(113):        `"%lln"` requires `long*`
+fail_compilation/chkformat.d(113):        `int*` may be formatted with `"%p"`
+fail_compilation/chkformat.d(114): Deprecation: argument `& u` of type `int*` does not match format specification
+fail_compilation/chkformat.d(114):        `"%hn"` requires `short*`
+fail_compilation/chkformat.d(114):        `int*` may be formatted with `"%p"`
+fail_compilation/chkformat.d(115): Deprecation: argument `& u` of type `int*` does not match format specification
+fail_compilation/chkformat.d(115):        `"%hhn"` requires `byte*`
+fail_compilation/chkformat.d(115):        `int*` may be formatted with `"%p"`
+fail_compilation/chkformat.d(116): Deprecation: argument `16L` of type `long` does not match format specification
+fail_compilation/chkformat.d(116):        `"%c"` requires `char`
+fail_compilation/chkformat.d(116):        `long` may be formatted with `"%lld"`
+fail_compilation/chkformat.d(117): Deprecation: argument `17L` of type `long` does not match format specification
+fail_compilation/chkformat.d(117):        `"%c"` requires `char`
+fail_compilation/chkformat.d(117):        `long` may be formatted with `"%lld"`
+fail_compilation/chkformat.d(118): Deprecation: argument `& u` of type `int*` does not match format specification
+fail_compilation/chkformat.d(118):        `"%s"` requires `char*`
+fail_compilation/chkformat.d(118):        `int*` may be formatted with `"%p"`
+fail_compilation/chkformat.d(119): Deprecation: argument `& u` of type `int*` does not match format specification
+fail_compilation/chkformat.d(119):        `"%ls"` requires `wchar_t*`
+fail_compilation/chkformat.d(119):        `int*` may be formatted with `"%p"`
+fail_compilation/chkformat.d(122): Deprecation: argument `p` of type `const(int)*` does not match format specification
+fail_compilation/chkformat.d(122):        `"%n"` requires `int*`
+fail_compilation/chkformat.d(122):        `const(int)*` may be formatted with `"%p"`
+fail_compilation/chkformat.d(201): Deprecation: argument `0L` of type `long` does not match format specification
+fail_compilation/chkformat.d(201):        `"%d"` requires `int*`
 fail_compilation/chkformat.d(202): Deprecation: more format specifiers than 1 arguments
-fail_compilation/chkformat.d(203): Deprecation: argument `0L` for format specification `"%d"` must be `int*`, not `long`
-fail_compilation/chkformat.d(204): Deprecation: argument `0L` for format specification `"%3u"` must be `uint*`, not `long`
-fail_compilation/chkformat.d(205): Deprecation: argument `u` for format specification `"%200u"` must be `uint*`, not `uint`
-fail_compilation/chkformat.d(206): Deprecation: argument `3.0` for format specification `"%hhd"` must be `byte*`, not `double`
-fail_compilation/chkformat.d(207): Deprecation: argument `4` for format specification `"%hd"` must be `short*`, not `int`
-fail_compilation/chkformat.d(209): Deprecation: argument `4` for format specification `"%lld"` must be `long*`, not `int`
-fail_compilation/chkformat.d(210): Deprecation: argument `5` for format specification `"%jd"` must be `core.stdc.stdint.intmax_t*`, not `int`
-fail_compilation/chkformat.d(211): Deprecation: argument `6.0` for format specification `"%zd"` must be `size_t*`, not `double`
-fail_compilation/chkformat.d(212): Deprecation: argument `7.0` for format specification `"%td"` must be `ptrdiff_t*`, not `double`
+fail_compilation/chkformat.d(203): Deprecation: argument `0L` of type `long` does not match format specification
+fail_compilation/chkformat.d(203):        `"%d"` requires `int*`
+fail_compilation/chkformat.d(204): Deprecation: argument `0L` of type `long` does not match format specification
+fail_compilation/chkformat.d(204):        `"%3u"` requires `uint*`
+fail_compilation/chkformat.d(205): Deprecation: argument `u` of type `uint` does not match format specification
+fail_compilation/chkformat.d(205):        `"%200u"` requires `uint*`
+fail_compilation/chkformat.d(206): Deprecation: argument `3.0` of type `double` does not match format specification
+fail_compilation/chkformat.d(206):        `"%hhd"` requires `byte*`
+fail_compilation/chkformat.d(207): Deprecation: argument `4` of type `int` does not match format specification
+fail_compilation/chkformat.d(207):        `"%hd"` requires `short*`
+fail_compilation/chkformat.d(209): Deprecation: argument `4` of type `int` does not match format specification
+fail_compilation/chkformat.d(209):        `"%lld"` requires `long*`
+fail_compilation/chkformat.d(210): Deprecation: argument `5` of type `int` does not match format specification
+fail_compilation/chkformat.d(210):        `"%jd"` requires `core.stdc.stdint.intmax_t*`
+fail_compilation/chkformat.d(211): Deprecation: argument `6.0` of type `double` does not match format specification
+fail_compilation/chkformat.d(211):        `"%zd"` requires `size_t*`
+fail_compilation/chkformat.d(212): Deprecation: argument `7.0` of type `double` does not match format specification
+fail_compilation/chkformat.d(212):        `"%td"` requires `ptrdiff_t*`
 fail_compilation/chkformat.d(213): Deprecation: format specifier `"%Ld"` is invalid
-fail_compilation/chkformat.d(214): Deprecation: argument `0` for format specification `"%u"` must be `uint*`, not `int`
-fail_compilation/chkformat.d(215): Deprecation: argument `0` for format specification `"%hhu"` must be `ubyte*`, not `int`
-fail_compilation/chkformat.d(216): Deprecation: argument `0` for format specification `"%hu"` must be `ushort*`, not `int`
-fail_compilation/chkformat.d(218): Deprecation: argument `0` for format specification `"%llu"` must be `ulong*`, not `int`
-fail_compilation/chkformat.d(219): Deprecation: argument `0` for format specification `"%ju"` must be `core.stdc.stdint.uintmax_t*`, not `int`
-fail_compilation/chkformat.d(220): Deprecation: argument `0` for format specification `"%zu"` must be `size_t*`, not `int`
-fail_compilation/chkformat.d(221): Deprecation: argument `0` for format specification `"%tu"` must be `ptrdiff_t*`, not `int`
-fail_compilation/chkformat.d(222): Deprecation: argument `8.0L` for format specification `"%g"` must be `float*`, not `real`
-fail_compilation/chkformat.d(223): Deprecation: argument `8.0L` for format specification `"%lg"` must be `double*`, not `real`
-fail_compilation/chkformat.d(224): Deprecation: argument `9.0` for format specification `"%Lg"` must be `real*`, not `double`
-fail_compilation/chkformat.d(225): Deprecation: argument `& u` for format specification `"%s"` must be `char*`, not `int*`
-fail_compilation/chkformat.d(226): Deprecation: argument `& u` for format specification `"%ls"` must be `wchar_t*`, not `int*`
-fail_compilation/chkformat.d(227): Deprecation: argument `v` for format specification `"%p"` must be `void**`, not `void*`
-fail_compilation/chkformat.d(228): Deprecation: argument `& u` for format specification `"%n"` must be `int*`, not `ushort*`
-fail_compilation/chkformat.d(229): Deprecation: argument `& u` for format specification `"%hhn"` must be `byte*`, not `int*`
+fail_compilation/chkformat.d(214): Deprecation: argument `0` of type `int` does not match format specification
+fail_compilation/chkformat.d(214):        `"%u"` requires `uint*`
+fail_compilation/chkformat.d(215): Deprecation: argument `0` of type `int` does not match format specification
+fail_compilation/chkformat.d(215):        `"%hhu"` requires `ubyte*`
+fail_compilation/chkformat.d(216): Deprecation: argument `0` of type `int` does not match format specification
+fail_compilation/chkformat.d(216):        `"%hu"` requires `ushort*`
+fail_compilation/chkformat.d(218): Deprecation: argument `0` of type `int` does not match format specification
+fail_compilation/chkformat.d(218):        `"%llu"` requires `ulong*`
+fail_compilation/chkformat.d(219): Deprecation: argument `0` of type `int` does not match format specification
+fail_compilation/chkformat.d(219):        `"%ju"` requires `core.stdc.stdint.uintmax_t*`
+fail_compilation/chkformat.d(220): Deprecation: argument `0` of type `int` does not match format specification
+fail_compilation/chkformat.d(220):        `"%zu"` requires `size_t*`
+fail_compilation/chkformat.d(221): Deprecation: argument `0` of type `int` does not match format specification
+fail_compilation/chkformat.d(221):        `"%tu"` requires `ptrdiff_t*`
+fail_compilation/chkformat.d(222): Deprecation: argument `8.0L` of type `real` does not match format specification
+fail_compilation/chkformat.d(222):        `"%g"` requires `float*`
+fail_compilation/chkformat.d(223): Deprecation: argument `8.0L` of type `real` does not match format specification
+fail_compilation/chkformat.d(223):        `"%lg"` requires `double*`
+fail_compilation/chkformat.d(224): Deprecation: argument `9.0` of type `double` does not match format specification
+fail_compilation/chkformat.d(224):        `"%Lg"` requires `real*`
+fail_compilation/chkformat.d(225): Deprecation: argument `& u` of type `int*` does not match format specification
+fail_compilation/chkformat.d(225):        `"%s"` requires `char*`
+fail_compilation/chkformat.d(225):        `int*` may be formatted with `"%d"`
+fail_compilation/chkformat.d(226): Deprecation: argument `& u` of type `int*` does not match format specification
+fail_compilation/chkformat.d(226):        `"%ls"` requires `wchar_t*`
+fail_compilation/chkformat.d(226):        `int*` may be formatted with `"%d"`
+fail_compilation/chkformat.d(227): Deprecation: argument `v` of type `void*` does not match format specification
+fail_compilation/chkformat.d(227):        `"%p"` requires `void**`
+fail_compilation/chkformat.d(228): Deprecation: argument `& u` of type `ushort*` does not match format specification
+fail_compilation/chkformat.d(228):        `"%n"` requires `int*`
+fail_compilation/chkformat.d(228):        `ushort*` may be formatted with `"%hu"`
+fail_compilation/chkformat.d(229): Deprecation: argument `& u` of type `int*` does not match format specification
+fail_compilation/chkformat.d(229):        `"%hhn"` requires `byte*`
+fail_compilation/chkformat.d(229):        `int*` may be formatted with `"%d"`
 fail_compilation/chkformat.d(230): Deprecation: format specifier `"%[n"` is invalid
 fail_compilation/chkformat.d(231): Deprecation: format specifier `"%]"` is invalid
-fail_compilation/chkformat.d(232): Deprecation: argument `& u` for format specification `"%90s"` must be `char*`, not `int*`
-fail_compilation/chkformat.d(233): Deprecation: argument `0L` for format specification `"%d"` must be `int*`, not `long`
-fail_compilation/chkformat.d(234): Deprecation: argument `0L` for format specification `"%d"` must be `int*`, not `long`
+fail_compilation/chkformat.d(232): Deprecation: argument `& u` of type `int*` does not match format specification
+fail_compilation/chkformat.d(232):        `"%90s"` requires `char*`
+fail_compilation/chkformat.d(232):        `int*` may be formatted with `"%d"`
+fail_compilation/chkformat.d(233): Deprecation: argument `0L` of type `long` does not match format specification
+fail_compilation/chkformat.d(233):        `"%d"` requires `int*`
+fail_compilation/chkformat.d(234): Deprecation: argument `0L` of type `long` does not match format specification
+fail_compilation/chkformat.d(234):        `"%d"` requires `int*`
 ---
 */
 
@@ -86,7 +151,6 @@ void test18() { int u; printf("%s\n", &u); }
 void test19() { int u; printf("%ls\n", &u); }
 //void test20() { int u; char[] s; sprintf(&s[0], "%d\n", &u); }
 //void test21() { int u; fprintf(null, "%d\n", &u); }
-void test20() { printf("%lu", ulong.init); }
 void test22() { int i; const(int)* p = &i; printf("%n", p); }
 
 #line 200
@@ -147,18 +211,36 @@ void test302() { va_list vargs; vscanf("%Q", vargs); }
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/chkformat.d(401): Deprecation: argument `p` for format specification `"%u"` must be `uint`, not `char*`
-fail_compilation/chkformat.d(402): Deprecation: argument `p` for format specification `"%d"` must be `int`, not `char*`
-fail_compilation/chkformat.d(403): Deprecation: argument `p` for format specification `"%hhu"` must be `ubyte`, not `char*`
-fail_compilation/chkformat.d(404): Deprecation: argument `p` for format specification `"%hhd"` must be `byte`, not `char*`
-fail_compilation/chkformat.d(405): Deprecation: argument `p` for format specification `"%hu"` must be `ushort`, not `char*`
-fail_compilation/chkformat.d(406): Deprecation: argument `p` for format specification `"%hd"` must be `short`, not `char*`
-fail_compilation/chkformat.d(407): Deprecation: argument `p` for format specification `"%lu"` must be `$?:windows=uint|32=uint|64=ulong$`, not `char*`
-fail_compilation/chkformat.d(408): Deprecation: argument `p` for format specification `"%ld"` must be `$?:windows=int|32=int|64=long$`, not `char*`
-fail_compilation/chkformat.d(409): Deprecation: argument `p` for format specification `"%llu"` must be `ulong`, not `char*`
-fail_compilation/chkformat.d(410): Deprecation: argument `p` for format specification `"%lld"` must be `long`, not `char*`
-fail_compilation/chkformat.d(411): Deprecation: argument `p` for format specification `"%ju"` must be `core.stdc.stdint.uintmax_t`, not `char*`
-fail_compilation/chkformat.d(412): Deprecation: argument `p` for format specification `"%jd"` must be `core.stdc.stdint.intmax_t`, not `char*`
+fail_compilation/chkformat.d(401): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(401):        `"%u"` requires `uint`
+fail_compilation/chkformat.d(401):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(402): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(402):        `"%d"` requires `int`
+fail_compilation/chkformat.d(402):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(403): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(403):        `"%hhu"` requires `ubyte`
+fail_compilation/chkformat.d(403):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(404): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(404):        `"%hhd"` requires `byte`
+fail_compilation/chkformat.d(404):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(405): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(405):        `"%hu"` requires `ushort`
+fail_compilation/chkformat.d(405):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(406): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(406):        `"%hd"` requires `short`
+fail_compilation/chkformat.d(406):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(409): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(409):        `"%llu"` requires `ulong`
+fail_compilation/chkformat.d(409):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(410): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(410):        `"%lld"` requires `long`
+fail_compilation/chkformat.d(410):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(411): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(411):        `"%ju"` requires `core.stdc.stdint.uintmax_t`
+fail_compilation/chkformat.d(411):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(412): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(412):        `"%jd"` requires `core.stdc.stdint.intmax_t`
+fail_compilation/chkformat.d(412):        `char*` may be formatted with `"%s"`
 ---
 */
 
@@ -170,8 +252,8 @@ void test403() { char* p; printf("%hhu", p); }
 void test404() { char* p; printf("%hhd", p); }
 void test405() { char* p; printf("%hu", p); }
 void test406() { char* p; printf("%hd", p); }
-void test407() { char* p; printf("%lu", p); }
-void test408() { char* p; printf("%ld", p); }
+//void test407() { char* p; printf("%lu", p); }  // moved to chkformat_clong.d
+//void test408() { char* p; printf("%ld", p); }  // moved to chkformat_clong.d
 void test409() { char* p; printf("%llu", p); }
 void test410() { char* p; printf("%lld", p); }
 void test411() { char* p; printf("%ju", p); }
@@ -180,11 +262,21 @@ void test412() { char* p; printf("%jd", p); }
 /* https://issues.dlang.org/show_bug.cgi?id=23247
 TEST_OUTPUT:
 ---
-fail_compilation/chkformat.d(501): Deprecation: argument `p` for format specification `"%a"` must be `double`, not `char*`
-fail_compilation/chkformat.d(502): Deprecation: argument `p` for format specification `"%La"` must be `real`, not `char*`
-fail_compilation/chkformat.d(503): Deprecation: argument `p` for format specification `"%a"` must be `float*`, not `char*`
-fail_compilation/chkformat.d(504): Deprecation: argument `p` for format specification `"%la"` must be `double*`, not `char*`
-fail_compilation/chkformat.d(505): Deprecation: argument `p` for format specification `"%La"` must be `real*`, not `char*`
+fail_compilation/chkformat.d(501): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(501):        `"%a"` requires `double`
+fail_compilation/chkformat.d(501):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(502): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(502):        `"%La"` requires `real`
+fail_compilation/chkformat.d(502):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(503): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(503):        `"%a"` requires `float*`
+fail_compilation/chkformat.d(503):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(504): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(504):        `"%la"` requires `double*`
+fail_compilation/chkformat.d(504):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat.d(505): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat.d(505):        `"%La"` requires `real*`
+fail_compilation/chkformat.d(505):        `char*` may be formatted with `"%s"`
 ---
 */
 #line 500

--- a/compiler/test/fail_compilation/chkformat_clong.d
+++ b/compiler/test/fail_compilation/chkformat_clong.d
@@ -1,0 +1,20 @@
+// Test printf format checking for C long size-dependent cases (64-bit: long = 8 bytes)
+/*
+REQUIRED_ARGS: -de
+DISABLED: win32 win64 freebsd32 openbsd32 linux32 osx32
+TEST_OUTPUT:
+---
+fail_compilation/chkformat_clong.d(21): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat_clong.d(21):        `"%lu"` requires `ulong`
+fail_compilation/chkformat_clong.d(21):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat_clong.d(22): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat_clong.d(22):        `"%ld"` requires `long`
+fail_compilation/chkformat_clong.d(22):        `char*` may be formatted with `"%s"`
+---
+*/
+
+import core.stdc.stdio;
+#line 20
+void test_lu_ulong()    { printf("%lu", ulong.init); } // no error: ulong matches %lu on 64-bit
+void test_lu_charstar() { char* p; printf("%lu", p); }
+void test_ld_charstar() { char* p; printf("%ld", p); }

--- a/compiler/test/fail_compilation/chkformat_clong_smalllong.d
+++ b/compiler/test/fail_compilation/chkformat_clong_smalllong.d
@@ -1,0 +1,24 @@
+// Test printf format checking for C long size-dependent cases (32-bit / Windows: long = 4 bytes)
+/*
+REQUIRED_ARGS: -de
+DISABLED: linux64 freebsd64 openbsd64 osx64
+TEST_OUTPUT:
+---
+fail_compilation/chkformat_clong_smalllong.d(20): Deprecation: argument `0LU` of type `ulong` does not match format specification
+fail_compilation/chkformat_clong_smalllong.d(20):        `"%lu"` requires `uint`
+fail_compilation/chkformat_clong_smalllong.d(20):        `ulong` may be formatted with `"%llu"`
+fail_compilation/chkformat_clong_smalllong.d(20):        C `long` is 4 bytes on your system
+fail_compilation/chkformat_clong_smalllong.d(21): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat_clong_smalllong.d(21):        `"%lu"` requires `uint`
+fail_compilation/chkformat_clong_smalllong.d(21):        `char*` may be formatted with `"%s"`
+fail_compilation/chkformat_clong_smalllong.d(22): Deprecation: argument `p` of type `char*` does not match format specification
+fail_compilation/chkformat_clong_smalllong.d(22):        `"%ld"` requires `int`
+fail_compilation/chkformat_clong_smalllong.d(22):        `char*` may be formatted with `"%s"`
+---
+*/
+
+import core.stdc.stdio;
+#line 20
+void test_lu_ulong()    { printf("%lu", ulong.init); }
+void test_lu_charstar() { char* p; printf("%lu", p); }
+void test_ld_charstar() { char* p; printf("%ld", p); }


### PR DESCRIPTION
Closes #20528

Use supplemental errors for either correcting the type, or the format specifier

Also splits off 32/64 bit dependent test cases because having to manually update TEST_OUTPUT with special sequences is a nuisance.