### PR TITLE
[WIP] Fix #22884 - segfault in rt_finalize2 when conservative GC sweeps stale FINALIZE bits

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -62,7 +62,7 @@ alias currTime = MonoTime.currTime;
 version (linux)
 {
     extern(C) int mincore(void* start, size_t len, ubyte* vec) nothrow @nogc @system;
-    
+
     private bool isReadableAddr(void* p) nothrow @nogc
     {
         ubyte vec;
@@ -5590,6 +5590,7 @@ private void[] setupMetadata(void[] block, uint bits, size_t padding, size_t use
 // Regression test: GC sweep must not crash when encountering a stale
 // FINALIZE bit on memory that has been reused for non-class data.
 // The vtable validation (findPool + isReadableAddr) should skip such blocks.
+// https://github.com/dlang/dmd/issues/22884
 unittest
 {
     version (linux)

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -59,6 +59,29 @@ debug (VALGRIND) import etc.valgrind.valgrind;
 import core.time;
 alias currTime = MonoTime.currTime;
 
+version (linux)
+{
+    extern(C) int mincore(void* start, size_t len, ubyte* vec) nothrow @nogc @system;
+    
+    private bool isReadableAddr(void* p) nothrow @nogc
+    {
+        ubyte vec;
+        auto page = cast(void*)(cast(size_t)p & ~cast(size_t)4095);
+        return mincore(page, 1, &vec) == 0;
+    }
+}
+else
+{
+    private bool isReadableAddr(void* p) nothrow @nogc
+    {
+        auto a = cast(size_t)p;
+        static if (size_t.sizeof == 8)
+            return a >= 0x1000 && a <= 0x7FFFFFFFFFFFUL && (a & 7) == 0;
+        else
+            return a >= 0x1000 && (a & 3) == 0;
+    }
+}
+
 // Track total time spent preparing for GC,
 // marking, sweeping and recovering pages.
 __gshared Duration prepTime;
@@ -2892,8 +2915,15 @@ struct Gcx
                             uint attr = pool.getBits(biti);
                             auto ti = __getBlockFinalizerInfo(q, size, attr);
                             __trimExtents(q, size, attr);
+                            if (ti is null)
+                            {
+                                auto vptr = *cast(void**)q;
+                                if (!vptr || findPool(vptr) !is null || !isReadableAddr(vptr))
+                                    goto LskipFinalizeLarge;
+                            }
                             rt_finalizeFromGC(q, size, attr, ti);
                         }
+                    LskipFinalizeLarge:
 
                         pool.clrBits(biti, ~BlkAttr.NONE ^ BlkAttr.FINALIZE);
 
@@ -3020,8 +3050,20 @@ struct Gcx
                                     uint attr = pool.getBits(biti);
                                     auto ti = __getBlockFinalizerInfo(q, ssize, attr);
                                     __trimExtents(q, ssize, attr);
+                                    // Validate vtable for class finalization (ti == null).
+                                    // A valid ClassInfo lives in the binary's read-only data,
+                                    // never on the GC heap. If the vtable pointer falls
+                                    // inside a GC pool, the block has been reused for
+                                    // non-class data with a stale FINALIZE bit.
+                                    if (ti is null)
+                                    {
+                                        auto vptr = *cast(void**)q;
+                                        if (!vptr || findPool(vptr) !is null || !isReadableAddr(vptr))
+                                            goto LskipFinalize;
+                                    }
                                     rt_finalizeFromGC(q, ssize, attr, ti);
                                 }
+                            LskipFinalize:
 
                                 assert(core.bitop.bt(toFree.ptr, i));
 
@@ -5543,4 +5585,23 @@ private void[] setupMetadata(void[] block, uint bits, size_t padding, size_t use
     }
 
     return block.ptr[0 .. block.length - padding];
+}
+
+// Regression test: GC sweep must not crash when encountering a stale
+// FINALIZE bit on memory that has been reused for non-class data.
+// The vtable validation (findPool + isReadableAddr) should skip such blocks.
+unittest
+{
+    version (linux)
+    {
+        assert(!isReadableAddr(null));
+        assert(!isReadableAddr(cast(void*) 1));
+        assert(!isReadableAddr(cast(void*) 0x100));
+
+        int stackVar;
+        assert(isReadableAddr(&stackVar));
+
+        auto p = new int;
+        assert(isReadableAddr(cast(void*) p));
+    }
 }

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -487,6 +487,24 @@ extern (C) void rt_finalize2(void* p, bool det = true, bool resetMemory = true) 
     if (!p || !*ppv)
         return;
 
+    // Validate that the vtable pointer looks like a valid ClassInfo.
+    // On 64-bit systems, user-space pointers are below 0x0000800000000000
+    // and must be at least pointer-aligned. This guards against the
+    // conservative GC sweeping a block whose FINALIZE bit is stale.
+    auto vptr = *ppv;
+    static if (size_t.sizeof == 8)
+        enum maxUserAddr = 0x7FFFFFFFFFFFUL;
+    else
+        enum maxUserAddr = uint.max;
+    if (vptr < cast(void*)0x1000 ||
+        cast(size_t)vptr > maxUserAddr ||
+        (cast(size_t)vptr & (size_t.sizeof - 1)) != 0)
+    {
+        debug(PRINTF) printf("rt_finalize2: skipping invalid vtable %p at %p\n", vptr, p);
+        *ppv = null;
+        return;
+    }
+
     auto pc = cast(ClassInfo*) *ppv;
     try
     {
@@ -1121,4 +1139,32 @@ unittest
     {
         s.thisptr = &s;
     }
+}
+
+// Regression test: rt_finalize2 must not crash on invalid vtable pointers.
+// This can happen when the conservative GC sweeps a block whose FINALIZE
+// bit is stale because the memory was reused for non-class data.
+unittest
+{
+    import core.memory : GC;
+
+    auto p = GC.malloc(32, GC.BlkAttr.FINALIZE);
+    auto ppv = cast(void**) p;
+
+    *ppv = cast(void*) 1;
+    rt_finalize2(p, false, false);
+
+    static if (size_t.sizeof == 8)
+    {
+        *ppv = cast(void*) 0x6000000000000000UL;
+        rt_finalize2(p, false, false);
+
+        *ppv = cast(void*) 0x10107e8;
+        rt_finalize2(p, false, false);
+    }
+
+    *ppv = null;
+    rt_finalize2(p, false, false);
+
+    GC.free(p);
 }

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -1144,6 +1144,7 @@ unittest
 // Regression test: rt_finalize2 must not crash on invalid vtable pointers.
 // This can happen when the conservative GC sweeps a block whose FINALIZE
 // bit is stale because the memory was reused for non-class data.
+// https://github.com/dlang/dmd/issues/22884
 unittest
 {
     import core.memory : GC;


### PR DESCRIPTION
Fixes the https://github.com/dlang/dmd/issues/22884
**DISCLAIMER: GLM-5.1 LLM was used in fixing the issue.**

For the time being I just want someone who is familiar with the GC and RT modules to have a look at this PR and see if it makes sense. After I build everything with this PR and run dub test (see the #22884)  the problem disappears.

When the conservative GC's mark phase produces false negatives, memory
with a FINALIZE bit can be freed and reused for non-class data. On the
next sweep, the stale FINALIZE bit causes rt_finalize2 to dereference
an invalid vtable pointer.

- Add vtable validation in GC sweep: skip class finalization if the
  vtable pointer is in a GC pool or unmapped memory (mincore on Linux)
- Add user-space address range check in rt_finalize2 as defense in depth
- Applies to both small-object and large-object sweep paths

PS. I do not mind if the PR gets closed and someone writes a better fix as long as it fixes the issue.