### PR TITLE
Fix #20078 - Subclasses of C++ classes missing from generated header

### DIFF
--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -2972,6 +2972,11 @@ public:
                 const l = dec.resolvedLinkage();
                 res = (l == LINK.cpp || l == LINK.c);
             }
+            else if (auto ad = sym.isAggregateDeclaration())
+            {
+                import dmd.aggregate : ClassKind;
+                res = ad.classKind == ClassKind.cpp;
+            }
         }
 
         // Remember result for later calls

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7862,6 +7862,12 @@ public:
     virtual void visit(typename AST::CInitializer ) override;
 };
 
+class StatementWalker : public SemanticTimeTransitiveVisitor
+{
+public:
+    void visit(Statement* st) final override;
+};
+
 extern _d_real creall(complex_t x);
 
 extern _d_real cimagl(complex_t x);

--- a/compiler/test/compilable/dtoh_ClassDeclaration.d
+++ b/compiler/test/compilable/dtoh_ClassDeclaration.d
@@ -161,6 +161,16 @@ public:
 class ForwardClass : public BaseClass
 {
 };
+
+class CppBase20078
+{
+public:
+    virtual void vfunc();
+};
+
+class DSubclass20078 : public CppBase20078
+{
+};
 ---
 +/
 
@@ -320,3 +330,7 @@ class BaseClass
 {
     void memberFun(ForwardClass sds);
 }
+
+// https://github.com/dlang/dmd/issues/20078
+extern(C++) class CppBase20078 { void vfunc() {} }
+extern(D) class DSubclass20078 : CppBase20078 {}


### PR DESCRIPTION
Closes #20078