### PR TITLE
Fix #21487 - Wrong C++ header generation of `enum string` members

### DIFF
--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -1012,10 +1012,17 @@ public:
                     break;
 
                 case EnumKind.String, EnumKind.Enum:
-                    buf.writestring("static ");
+                    // constexpr allows in-class initialization; only available from C++11
+                    if (global.params.cplusplus >= CppStdRevision.cpp11)
+                        buf.writestring("static constexpr ");
+                    else
+                        buf.writestring("static ");
                     auto target = determineEnumType(type);
                     target.accept(this);
-                    buf.writestring(" const ");
+                    if (global.params.cplusplus < CppStdRevision.cpp11)
+                        buf.writestring(" const ");
+                    else
+                        buf.writestring(" ");
                     writeIdentifier(vd, true);
                     buf.writestring(" = ");
                     auto e = AST.initializerToExpression(vd._init);

--- a/compiler/test/compilable/dtoh_enum.d
+++ b/compiler/test/compilable/dtoh_enum.d
@@ -16,7 +16,7 @@ enum : int32_t { Anon = 10 };
 
 enum : bool { Anon2 = true };
 
-static const char* const Anon3 = "wow";
+static constexpr const char* Anon3 = "wow";
 
 enum class Enum
 {
@@ -89,7 +89,7 @@ enum class STC
     b = 2,
 };
 
-static STC const STC_D = (STC)3;
+static constexpr STC STC_D = (STC)3;
 
 struct Foo final
 {
@@ -109,7 +109,7 @@ namespace MyEnum
     static Foo const B = Foo(84);
 };
 
-static /* MyEnum */ Foo const test = Foo(42);
+static constexpr /* MyEnum */ Foo test = Foo(42);
 
 struct FooCpp final
 {
@@ -129,12 +129,22 @@ namespace MyEnumCpp
     static FooCpp const B = FooCpp(84);
 };
 
-static /* MyEnum */ Foo const testCpp = Foo(42);
+static constexpr /* MyEnum */ Foo testCpp = Foo(42);
 
 extern const bool e_b;
 
 enum class opaque;
 enum class typedOpaque : int64_t;
+struct Hello21487 final
+{
+    static constexpr const char* name = "hello";
+
+    static constexpr STC kind = (STC)1;
+
+    Hello21487()
+    {
+    }
+};
 ---
 +/
 
@@ -242,3 +252,10 @@ enum typedOpaque : long;
 enum arrayOpaque : int[4]; // Cannot be exported to C++
 
 extern(D) enum hidden_d = 42; // Linkage prevents being exported to C++
+
+// https://github.com/dlang/dmd/issues/21487
+extern(C++) struct Hello21487
+{
+    enum string name = "hello";
+    enum STC kind = STC.a;
+}


### PR DESCRIPTION
Closes #21487

inline members is C++ 17, even newer than C++ 11. Holding off a solution for C++ 98 since I don't think inline enums really have a good translation there, so until someone suggests a pragmatic workaround there, I'll just keep the existing behavior intact in that case.