### PR TITLE
Fix CircleCI maybe?

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -66,7 +66,7 @@ install_deps() {
 
     download "https://dlang.org/install.sh" "https://nightlies.dlang.org/install.sh" "install.sh"
 
-    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash install.sh dmd-$HOST_DMD_VER --activate)"
+    source "$(CURL_USER_AGENT="$CURL_USER_AGENT" bash install.sh dmd-$HOST_DMD_VER --activate)"
     $DC --version
     env
     deactivate
@@ -109,7 +109,7 @@ setup_repos() {
 coverage()
 {
     # load environment for bootstrap compiler
-    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
+    source "$(CURL_USER_AGENT="$CURL_USER_AGENT" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
 
     local build_path=generated/linux/$BUILD/$MODEL
     local builder=generated/build
@@ -172,7 +172,7 @@ check_d_builder()
 {
     echo "Testing D build"
     # load environment for bootstrap compiler
-    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
+    source "$(CURL_USER_AGENT="$CURL_USER_AGENT" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
     ./compiler/src/build.d clean
     rm -rf generated # just to be sure
     # TODO: add support for 32-bit builds
@@ -186,7 +186,7 @@ check_d_builder()
 test_cxx()
 {
     # load environment for bootstrap compiler
-    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
+    source "$(CURL_USER_AGENT="$CURL_USER_AGENT" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
     echo "Test CXX frontend.h header generation"
     ./compiler/src/build.d
     make -j$N -C druntime MODEL=$MODEL BUILD=$BUILD


### PR DESCRIPTION
I would have never guessed this, I hope Claude's not hallucinating here:

> install.sh DOES use CURL_USER_AGENT, but with a fallback default. The real issue is the quoting bug in the CI script. Look at line 69:
> 
> source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash install.sh ...)"
Inside $(...), \" produces a literal " character, so install.sh receives:
> 
> CURL_USER_AGENT="CirleCI curl 7.68.0 ..."  ← literal " chars in the value
While download() in the CI script uses:
> 
> CURL_USER_AGENT=CirleCI curl 7.68.0 ...    ← correct, no extra quotes
> Cloudflare recently started blocking the malformed user-agent "CirleCI curl..." (starts with ") but not the correct CirleCI curl.... That's why install.sh download itself worked (uses download() with correct UA) but the keyring inside install.sh fails (uses the mangled UA).

> dlang.org recently moved behind Cloudflare. Cloudflare started blocking the malformed user-agent "CirleCI curl..." (with literal " chars caused by \" inside $(...)) but still allows CirleCI curl... (the correct string that download() sends).

Error was:

```
++ CURL_USER_AGENT='"CirleCI curl 7.68.0 (x86_64-pc-linux-gnu) libcurl/7.68.0 OpenSSL/1.1.1f zlib/1.2.11 brotli/1.0.7 libidn2/2.2.0 libpsl/0.21.0 (+libidn2/2.2.0) libssh/0.9.3/openssl/zlib nghttp2/1.40.0 librtmp/2.3"'
++ bash install.sh dmd-2.095.0 --activate
curl: (22) The requested URL returned error: 403 
curl: (22) The requested URL returned error: 403 
curl: (22) The requested URL returned error: 403 
curl: (22) The requested URL returned error: 403 
curl: (22) The requested URL returned error: 403 
curl: (22) The requested URL returned error: 403 
curl: (22) The requested URL returned error: 403 
curl: (22) The requested URL returned error: 403 
curl: (22) The requested URL returned error: 403 
curl: (22) The requested URL returned error: 403 
mv: cannot stat '/home/circleci/dlang/.installer_tmp_xAi017/aOw5Co/d-keyring.gpg': No such file or directory
```

