### PR TITLE
[stable] Comment out prototypes for OSX symbols missing on < 10.12

### DIFF
--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -2030,10 +2030,12 @@ else version (Darwin)
         int stat(const scope char*, stat_t*);
     }
     int   fchmodat(int, const scope char*, mode_t, int);
-    int   futimens(int, ref const(timespec)[2]);
     int   mkdirat(int, const scope char*, mode_t);
-    int   mkfifoat(int, const scope char*, mode_t);
-    int   utimensat(int, const scope char*, ref const(timespec)[2], int);
+    // OSX available starting 10.12
+    //int   futimens(int, ref const(timespec)[2]);
+    //int   utimensat(int, const scope char*, ref const(timespec)[2], int);
+    // OSX available starting 13
+    //int   mkfifoat(int, const scope char*, mode_t);
 }
 else version (FreeBSD)
 {


### PR DESCRIPTION
Phobos uses these (guarded by ie: `static if (is(typeof(&utimensat)))`), which causes a regression in building complete compiler and runtime.

Preferably we should just add a version mechanism like `__traits(getTargetInfo, "macOS_version")` - ditto for freebsd version too.  But to just unbreak the release, just leave these left for now.