### PR TITLE
Fix #18274 - misleading "cannot goto into try block" when skipping va…

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5232,6 +5232,7 @@ public:
     Statement* _body;
     Array<Catch* >* catches;
     Statement* tryBody;
+    TOK loweredFromScopeGuard;
     TryCatchStatement* syntaxCopy() override;
     bool hasBreak() const override;
     void accept(Visitor* v) override;
@@ -5244,6 +5245,8 @@ public:
     Statement* finalbody;
     Statement* tryBody;
     bool bodyFallsThru;
+    TOK loweredFromScopeGuard;
+    VarDeclaration* loweredFrom;
     static TryFinallyStatement* create(Loc loc, Statement* _body, Statement* finalbody);
     TryFinallyStatement* syntaxCopy() override;
     bool hasBreak() const override;

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1460,6 +1460,7 @@ extern (C++) final class TryCatchStatement : Statement
     Catches* catches;
 
     Statement tryBody;   /// set to enclosing TryCatchStatement or TryFinallyStatement if in _body portion
+    TOK loweredFromScopeGuard;  /// set when this was lowered from a scope guard (onScopeFailure, onScopeSuccess)
 
     extern (D) this(Loc loc, Statement _body, Catches* catches) @safe
     {
@@ -1532,6 +1533,8 @@ extern (C++) final class TryFinallyStatement : Statement
 
     Statement tryBody;   /// set to enclosing TryCatchStatement or TryFinallyStatement if in _body portion
     bool bodyFallsThru;  /// true if _body falls through to finally
+    TOK loweredFromScopeGuard;  /// set when this was lowered from a scope guard (onScopeExit, onScopeSuccess)
+    VarDeclaration loweredFrom; /// set when this was lowered from a variable with a destructor
 
     extern (D) this(Loc loc, Statement _body, Statement finalbody) @safe
     {

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -580,6 +580,7 @@ public:
     Catches *catches;
 
     Statement *tryBody;   /// set to enclosing TryCatchStatement or TryFinallyStatement if in _body portion
+    TOK loweredFromScopeGuard;  // set when this was lowered from a scope guard (onScopeFailure, onScopeSuccess)
 
     TryCatchStatement *syntaxCopy() override;
     bool hasBreak() const override;
@@ -614,6 +615,8 @@ public:
 
     Statement *tryBody;   // set to enclosing TryCatchStatement or TryFinallyStatement if in _body portion
     d_bool bodyFallsThru;   // true if _body falls through to finally
+    TOK loweredFromScopeGuard;  // set when this was lowered from a scope guard (onScopeExit, onScopeSuccess)
+    VarDeclaration *loweredFrom; // set when this was lowered from a variable with a destructor
 
     static TryFinallyStatement *create(Loc loc, Statement *body, Statement *finalbody);
     TryFinallyStatement *syntaxCopy() override;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -363,6 +363,10 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             Statement sexception;
             Statement sfinally;
 
+            TOK scopeGuardTok = TOK.init;
+            if (auto sgs = s.isScopeGuardStatement())
+                scopeGuardTok = sgs.tok;
+
             (*cs.statements)[i] = s.scopeCode(sc, sentry, sexception, sfinally);
             if (sentry)
             {
@@ -425,9 +429,17 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     ctch.internalCatch = true;
                     auto catches = new Catches(ctch);
 
-                    Statement st = new TryCatchStatement(Loc.initial, _body, catches);
+                    auto stc = new TryCatchStatement(Loc.initial, _body, catches);
+                    if (scopeGuardTok)
+                        stc.loweredFromScopeGuard = scopeGuardTok;
+                    Statement st = stc;
                     if (sfinally)
-                        st = new TryFinallyStatement(Loc.initial, st, sfinally);
+                    {
+                        auto stf = new TryFinallyStatement(Loc.initial, st, sfinally);
+                        if (scopeGuardTok)
+                            stf.loweredFromScopeGuard = scopeGuardTok;
+                        st = stf;
+                    }
                     st = st.statementSemantic(sc);
 
                     cs.statements.push(st);
@@ -452,9 +464,13 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     cs.statements.setDim(i + 1);
 
                     auto _body = new CompoundStatement(Loc.initial, a);
-                    Statement stf = new TryFinallyStatement(Loc.initial, _body, sfinally);
-                    stf = stf.statementSemantic(sc);
-                    cs.statements.push(stf);
+                    auto stf = new TryFinallyStatement(Loc.initial, _body, sfinally);
+                    if (auto des = sfinally.isDtorExpStatement())
+                        stf.loweredFrom = des.var;
+                    else if (scopeGuardTok)
+                        stf.loweredFromScopeGuard = scopeGuardTok;
+                    Statement stfs = stf.statementSemantic(sc);
+                    cs.statements.push(stfs);
                     break;
                 }
             }
@@ -5193,6 +5209,33 @@ bool checkLabel(GotoStatement gs)
     {
         if (!stb)
         {
+            auto labelTryBody = gs.label.statement.tryBody;
+            TOK loweredFromScopeGuard = TOK.init;
+
+            if (auto stf = labelTryBody.isTryFinallyStatement())
+            {
+                if (stf.loweredFrom)
+                {
+                    error(gs.loc, "`goto` skips declaration of variable `%s`", stf.loweredFrom.toPrettyChars());
+                    errorSupplemental(stf.loweredFrom.loc, "declared here");
+                    return true;
+                }
+                loweredFromScopeGuard = stf.loweredFromScopeGuard;
+            }
+            else if (auto stc = labelTryBody.isTryCatchStatement())
+            {
+                if (stc.loweredFromScopeGuard)
+                {
+                    error(gs.loc, "cannot `goto` past `%s` block", Token.toChars(stc.loweredFromScopeGuard));
+                    return true;
+                }
+                loweredFromScopeGuard = stc.loweredFromScopeGuard;
+            }
+            if (loweredFromScopeGuard)
+            {
+                error(gs.loc, "cannot `goto` past `%s` block", Token.toChars(loweredFromScopeGuard));
+                return true;
+            }
             error(gs.loc, "cannot `goto` into `try` block");
             return true;
         }

--- a/compiler/test/fail_compilation/goto2.d
+++ b/compiler/test/fail_compilation/goto2.d
@@ -141,3 +141,49 @@ L:                                  // line 7
     }
     return false;
 }
+
+/**************************************************
+https://github.com/dlang/dmd/issues/18274
+
+TEST_OUTPUT:
+---
+fail_compilation/goto2.d(1267): Error: `goto` skips declaration of variable `goto2.test_throwing.s`
+fail_compilation/goto2.d(1268):        declared here
+fail_compilation/goto2.d(1274): Error: cannot `goto` past `scope(exit)` block
+fail_compilation/goto2.d(1281): Error: cannot `goto` past `scope(failure)` block
+fail_compilation/goto2.d(1288): Error: cannot `goto` past `scope(success)` block
+---
+*/
+
+struct S
+{
+    ~this() nothrow;
+}
+
+void test_throwing()
+{
+    goto skip;
+    S s;
+skip:
+}
+
+void test_scope_exit(ref int x)
+{
+    goto skip;
+    scope(exit) { x++; }
+skip:
+}
+
+void test_scope_failure(ref int x)
+{
+    goto skip;
+    scope(failure) { x++; }
+skip:
+}
+
+void test_scope_success(ref int x)
+{
+    goto skip;
+    scope(success) { x++; }
+skip:
+}


### PR DESCRIPTION
…riable with destructor

Adds lowering fields for TryCatchStatement and TryFinallyStatement

Closes #18274