### PR TITLE
Fix #22980 - "named arguments not allowed here" in const constructor

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8930,7 +8930,10 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                             t.toChars(), token.toChars());
                         return e;
                     }
-                    e = new AST.CallExp(loc, e, parseArguments());
+                    auto args = new AST.Expressions();
+                    auto names = new AST.ArgumentLabels();
+                    parseNamedArguments(args, names);
+                    e = new AST.CallExp(loc, e, args, names);
                 }
                 break;
             }

--- a/compiler/test/compilable/named_arguments.d
+++ b/compiler/test/compilable/named_arguments.d
@@ -84,3 +84,11 @@ struct Concat
 }
 
 static assert(Concat.init("t0", "t1") == "st0t1");
+
+// https://github.com/dlang/dmd/issues/22980
+struct Foo { int bar; }
+
+const fooC1 = const Foo(bar: 2);
+const fooC2 = (const Foo)(bar: 2);
+const fooD1 = immutable Foo(bar: 2);
+const fooD2 = (immutable Foo)(bar: 2);


### PR DESCRIPTION
Grammar allows it, just the parser needs updating

Closes #22980