### PR TITLE
Fix #22983 - Named argument allowed in int(x: 3)

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7965,6 +7965,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 else if (exp.arguments.length == 1)
                 {
+                    if (exp.names && (*exp.names)[0].name)
+                    {
+                        error(exp.loc, "no named argument `%s` allowed for scalar", (*exp.names)[0].name.toErrMsg());
+                        return setError();
+                    }
                     e = (*exp.arguments)[0];
                     e = e.implicitCastTo(sc, t1);
                     e = new CastExp(exp.loc, e, t1);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7117,7 +7117,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 if (exp.names && (*exp.names)[0].name)
                 {
-                    error(exp.loc, "no named argument `%s` allowed for scalar", (*exp.names)[0].name.toErrMsg());
+                    error(exp.loc, "no named argument `%s` allowed for basic type", (*exp.names)[0].name.toErrMsg());
                     return setError();
                 }
                 Expression e = (*exp.arguments)[0];
@@ -7967,7 +7967,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     if (exp.names && (*exp.names)[0].name)
                     {
-                        error(exp.loc, "no named argument `%s` allowed for scalar", (*exp.names)[0].name.toErrMsg());
+                        error(exp.loc, "no named argument `%s` allowed for basic type", (*exp.names)[0].name.toErrMsg());
                         return setError();
                     }
                     e = (*exp.arguments)[0];

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8492,7 +8492,10 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (token.value == TOK.leftParenthesis)
             {
                 e = new AST.TypeExp(loc, t);
-                e = new AST.CallExp(loc, e, parseArguments());
+                auto args = new AST.Expressions();
+                auto names = new AST.ArgumentLabels();
+                parseNamedArguments(args, names);
+                e = new AST.CallExp(loc, e, args, names);
                 break;
             }
             check(TOK.dot);

--- a/compiler/test/fail_compilation/named_arguments_error.d
+++ b/compiler/test/fail_compilation/named_arguments_error.d
@@ -22,10 +22,10 @@ fail_compilation/named_arguments_error.d(46): Error: cannot implicitly convert e
 fail_compilation/named_arguments_error.d(47): Error: template `tempfun` is not callable using argument types `!()(int, int)`
 fail_compilation/named_arguments_error.d(47):        argument `1` goes past end of parameter list
 fail_compilation/named_arguments_error.d(50):        Candidate is: `tempfun(T, U)(T t, U u)`
+fail_compilation/named_arguments_error.d(59): Error: no named argument `a` allowed for scalar
+fail_compilation/named_arguments_error.d(60): Error: no named argument `bar` allowed for scalar
 ---
 */
-
-
 
 
 
@@ -50,4 +50,12 @@ void main()
 int tempfun(T, U)(T t, U u)
 {
     return 3;
+}
+
+// https://github.com/dlang/dmd/issues/22980
+void test22980()
+{
+    alias T = int;
+    auto x = T(a: 3);
+    auto y = int(bar: 2);
 }

--- a/compiler/test/fail_compilation/named_arguments_error.d
+++ b/compiler/test/fail_compilation/named_arguments_error.d
@@ -17,13 +17,13 @@ fail_compilation/named_arguments_error.d(42): Error: function `g` is not callabl
 fail_compilation/named_arguments_error.d(42):        missing argument for parameter #1: `int x`
 fail_compilation/named_arguments_error.d(34):        `named_arguments_error.g(int x, int y, int z = 3)` declared here
 fail_compilation/named_arguments_error.d(44): Error: no named argument `element` allowed for array dimension
-fail_compilation/named_arguments_error.d(45): Error: no named argument `number` allowed for scalar
+fail_compilation/named_arguments_error.d(45): Error: no named argument `number` allowed for basic type
 fail_compilation/named_arguments_error.d(46): Error: cannot implicitly convert expression `g(3, 4, 5)` of type `int` to `string`
 fail_compilation/named_arguments_error.d(47): Error: template `tempfun` is not callable using argument types `!()(int, int)`
 fail_compilation/named_arguments_error.d(47):        argument `1` goes past end of parameter list
 fail_compilation/named_arguments_error.d(50):        Candidate is: `tempfun(T, U)(T t, U u)`
-fail_compilation/named_arguments_error.d(59): Error: no named argument `a` allowed for scalar
-fail_compilation/named_arguments_error.d(60): Error: no named argument `bar` allowed for scalar
+fail_compilation/named_arguments_error.d(59): Error: no named argument `a` allowed for basic type
+fail_compilation/named_arguments_error.d(60): Error: no named argument `bar` allowed for basic type
 ---
 */
 


### PR DESCRIPTION
Closes #22983

Updates the parser for consistency and to match the grammar