### PR TITLE
Fix #20529 - IFTI fails for variadic static array parameter with narr…

### DIFF
--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -4957,7 +4957,7 @@ private MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, TemplateIn
                                 MATCH m = dim.implicitConvTo(vt);
                                 if (m == MATCH.nomatch)
                                     return nomatch();
-                                (*dedtypes)[i] = dim;
+                                (*dedtypes)[i] = dim.implicitCastTo(sc, vt).ctfeInterpret();
                             }
                         }
                     }

--- a/compiler/test/runnable/ifti.d
+++ b/compiler/test/runnable/ifti.d
@@ -85,6 +85,9 @@ void test24731()
     assert(solve!2(m) == 2);
 }
 
+// https://github.com/dlang/dmd/issues/20529
+int test20529(ubyte n)(int[n] a...) => n;
+static assert(test20529(1, 2, 3) == 3);
 
 void main() {
     Tst!(int) t = new Tst!(int);


### PR DESCRIPTION
…owing conversion on templated length

Closes  #20529

matchArgValue checks that dedtypes "Must match already deduced value" which fails if the IntegerExp type doesn't match (e.g. size_t != ubyte), so cast it to the right type before storing it in dedtypes.

