### PR TITLE
Fix #18481 - Wrong escaping reference error on returning static array

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -1161,7 +1161,8 @@ private bool checkReturnEscapeImpl(ref Scope sc, Expression e, bool refs, bool g
             return;
         }
 
-        if (v.isTypesafeVariadicArray && p == sc.func)
+        if (v.isTypesafeVariadicArray && p == sc.func &&
+            v.type.toBasetype().isTypeDArray())
         {
             if (!gag)
                 sc.eSink.error(e.loc, "returning `%s` escapes a reference to variadic parameter `%s`", e.toErrMsg(), v.toErrMsg());

--- a/compiler/test/compilable/test18481.d
+++ b/compiler/test/compilable/test18481.d
@@ -1,0 +1,5 @@
+// https://github.com/dlang/dmd/issues/18481
+// Static array variadic parameters are value types, returning by value is safe
+
+int[2] f1(int[2] arr...) { return arr; }
+int*[2] f2(int*[2] arr...) { return arr; }


### PR DESCRIPTION
Closes #18481