### PR TITLE
Fixes #22884 - segfault in rt_finalize2 during GC sweep when struct arrays are extended.

### DIFF
--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -288,7 +288,10 @@ private size_t _d_arraysetlengthT_(Tarr : T[], T)(return ref scope Tarr arr, siz
     if (!arr.ptr)
     {
         assert(arr.length == 0);
-        void* ptr = GC.malloc(newsize, gcAttrs);
+        version (D_TypeInfo)
+            void* ptr = GC.malloc(newsize, gcAttrs, typeid(T));
+        else
+            void* ptr = GC.malloc(newsize, gcAttrs, null);
         if (!ptr)
         {
             onOutOfMemoryError();
@@ -324,7 +327,10 @@ private size_t _d_arraysetlengthT_(Tarr : T[], T)(return ref scope Tarr arr, siz
 
     if (!gc_expandArrayUsed(newdata[0 .. oldsize], newsize, isShared))
     {
-        newdata = GC.malloc(newsize, gcAttrs);
+        version (D_TypeInfo)
+            newdata = GC.malloc(newsize, gcAttrs, typeid(T));
+        else
+            newdata = GC.malloc(newsize, gcAttrs, null);
         if (!newdata)
         {
             onOutOfMemoryError();


### PR DESCRIPTION
PROBLEM:

In druntime/src/core/internal/array/capacity.d, when extending an array of structs with destructors, the code sets BlkAttr.FINALIZE on the allocated block but never passes typeid(T) to GC.malloc. Without the TypeInfo, the GC's adjustAttrs (gc.d:5551) cannot promote the block to include BlkAttr.STRUCTFINAL. During sweep, the GC then attempts class-style finalization via vtable lookup on memory that contains struct data, resulting in a segfault.
This appears to have been an oversight during the GC metadata refactoring and the templated lowering of array length assignment.

FIX:

Pass typeid(T) to both GC.malloc calls in capacity.d (with version(D_TypeInfo) guard, matching the existing pattern in construction.d and utils.d). This allows adjustAttrs to automatically set STRUCTFINAL so the GC stores and uses the correct TypeInfo for struct finalization.

Credit to @rainers for identifying the root cause in https://github.com/dlang/dmd/pull/22967#issuecomment-4275421974 .

Also thanks to @adamdruppe who participated in that thread.

With this simple change I can run successfully `dub test` in the `ddn` (core) project (https://codeberg.org/ddn/ddn) where I identified the problem originally.