### PR TITLE
Fix dtoh test after merge error

### DIFF
--- a/compiler/test/compilable/dtoh_StructDeclaration.d
+++ b/compiler/test/compilable/dtoh_StructDeclaration.d
@@ -236,7 +236,7 @@ struct Loc final
 
 struct metas21496 final
 {
-    static const char* const hellos = "worlds";
+    static constexpr const char* hellos = "worlds";
 
     metas21496()
     {


### PR DESCRIPTION
Test introduced by the static foreach PR, modified by the constexpr PR, resulting in a test failure on master after both were merged separately