### PR TITLE
Fix #17751 - q{} strings don't normalize CRLF to LF

### DIFF
--- a/changelog/dmd.qstring-crlf.dd
+++ b/changelog/dmd.qstring-crlf.dd
@@ -1,0 +1,10 @@
+Token strings now normalize `\r\n` to `\n`
+
+Token strings (`q{...}`) now normalize carriage return + line feed sequences to
+a single line feed, consistent with other string literal types.
+
+```d
+const string s = q{a
+b}; // file saved with CRLF line endings
+static assert(s == "a\nb");
+```

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -1953,9 +1953,16 @@ class Lexer
                 {
                     const length = p - 1 - pstart;
                     if (supportInterpolation)
-                        result.appendInterpolatedPart(pstart[0 .. length]);
+                    {
+                        normalizeCRLF(pstart[0 .. length]);
+                        result.appendInterpolatedPart(stringbuffer[]);
+                    }
                     else
-                        result.setString(pstart[0 .. length]);
+                    {
+                        normalizeCRLF(pstart[0 .. length]);
+                        result.setString(stringbuffer[]);
+                    }
+
                     stringPostfix(result);
                     return;
                 }
@@ -1964,8 +1971,7 @@ class Lexer
                 if (!supportInterpolation)
                     goto default;
 
-                stringbuffer.setsize(0);
-                stringbuffer.write(pstart, p - 1 - pstart);
+                normalizeCRLF(pstart[0 .. p - 1 - pstart]);
                 if (!handleInterpolatedSegment(result, start))
                     goto default;
 
@@ -1981,6 +1987,23 @@ class Lexer
             default:
                 continue;
             }
+        }
+    }
+
+    // Normalize CRLF to LF in raw source bytes and write into stringbuffer
+    private void normalizeCRLF(const(char)[] src)
+    {
+        stringbuffer.setsize(0);
+        foreach (i, char c; src)
+        {
+            if (c == '\r')
+            {
+                if (i + 1 < src.length && src[i + 1] == '\n')
+                    continue;
+                stringbuffer.writeByte('\n');
+            }
+            else
+                stringbuffer.writeByte(c);
         }
     }
 

--- a/compiler/test/unit/compilable/crlf.d
+++ b/compiler/test/unit/compilable/crlf.d
@@ -24,7 +24,6 @@ unittest
 
     import support : compiles, stripDelimited;
 
-    // not using token string due to https://issues.dlang.org/show_bug.cgi?id=19315
     enum crLFCode = `
         #!/usr/bin/env dmd -run
 
@@ -67,7 +66,11 @@ unittest
         `static assert(wstr == "foo\nbar\nbaz\n");`,
 
         format!`enum dstr = q"(%s)";`("\r\nfoo\r\nbar\nbaz\r\n"),
-        `static assert(dstr == "\nfoo\nbar\nbaz\n");`
+        `static assert(dstr == "\nfoo\nbar\nbaz\n");`,
+
+        // https://github.com/dlang/dmd/issues/17751
+        format!`enum tstr = q{%s};`("\r\nfoo\r\nbar\nbaz\r\n"),
+        `static assert(tstr == "\nfoo\nbar\nbaz\n");`,
     ];
 
     enum code = crLFCode ~ "\r\n" ~ codeLines.join('\n') ~ '\n';


### PR DESCRIPTION
Closes #17751

Apparently even single '\r' gets replaced by  '\n' in string literals.

```D
immutable char[] x = mixin("`a\r\b\r\nc\r\rd`");
pragma(msg, cast(ubyte[]) x);
```

