### PR TITLE
delete pointless overloads of appendInterpolatedPart()

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5142,7 +5142,10 @@ final class CParser(AST) : Parser!AST
                  */
                 defines.writeByte('#');
                 defines.writestring(n.ident.toString());
-                skipToNextLine(defines);
+
+                nothrow void sink(char c) { defines.writeByte(c); }
+
+                skipToNextLine(&sink);          // skip over characters in rest of line
                 defines.writeByte(0);           // each #define line is 0 terminated
                 return true;
             }

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -1643,7 +1643,7 @@ class Lexer
                 if (c == terminator)
                 {
                     if (supportInterpolation)
-                        result.appendInterpolatedPart(stringbuffer);
+                        result.appendInterpolatedPart(stringbuffer[]);
                     else
                         result.setString(stringbuffer[]);
 
@@ -1951,11 +1951,11 @@ class Lexer
             case TOK.rightCurly:
                 if (--nest == 0)
                 {
+                    const length = p - 1 - pstart;
                     if (supportInterpolation)
-                        result.appendInterpolatedPart(pstart, p - 1 - pstart);
+                        result.appendInterpolatedPart(pstart[0 .. length]);
                     else
-                        result.setString(pstart[0 .. p - 1 - pstart]);
-
+                        result.setString(pstart[0 .. length]);
                     stringPostfix(result);
                     return;
                 }
@@ -1994,7 +1994,7 @@ class Lexer
             // expression, at this level we need to scan until the closing ')'
 
             // always put the string part in first
-            token.appendInterpolatedPart(stringbuffer);
+            token.appendInterpolatedPart(stringbuffer[]);
             stringbuffer.setsize(0);
 
             int openParenCount = 1;
@@ -2119,7 +2119,7 @@ class Lexer
                 if (c != tc)
                     goto default;
                 if (supportInterpolation)
-                    t.appendInterpolatedPart(stringbuffer);
+                    t.appendInterpolatedPart(stringbuffer[]);
                 else
                     t.setString(stringbuffer[]);
                 if (!Ccompile)
@@ -3289,9 +3289,9 @@ class Lexer
     /***************************************
      * Scan forward to start of next line.
      * Params:
-     *    defines = send characters to `defines`
+     *    sink = send characters in the line to this delegate
      */
-    final void skipToNextLine(OutBuffer* defines = null)
+    final void skipToNextLine(void delegate(char c) nothrow sink = null)
     {
         while (1)
         {
@@ -3312,8 +3312,8 @@ class Lexer
                 break;
 
             default:
-                if (defines)
-                    defines.writeByte(*p); // don't care about Unicode line endings for C
+                if (sink)
+                    sink(*p); // don't care about Unicode line endings for C
                 else if (*p & 0x80)
                 {
                     const u = decodeUTF();

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -925,27 +925,17 @@ nothrow:
         return 0;
     }
 
-    extern(D) void appendInterpolatedPart(const ref OutBuffer buf)
-    {
-        appendInterpolatedPart(cast(const(char)*)buf[].ptr, buf.length);
-    }
-
     extern(D) void appendInterpolatedPart(const(char)[] str)
-    {
-        appendInterpolatedPart(str.ptr, str.length);
-    }
-
-    extern(D) void appendInterpolatedPart(const(char)* ptr, size_t length)
     {
         assert(value == TOK.interpolated);
         if (interpolatedSet is null)
             interpolatedSet = new InterpolatedSet;
 
-        auto s = cast(char*)mem.xmalloc_noscan(length + 1);
-        memcpy(s, ptr, length);
-        s[length] = 0;
+        auto s = cast(char*)mem.xmalloc_noscan(str.length + 1);
+        memcpy(s, str.ptr, str.length);
+        s[str.length] = 0;
 
-        interpolatedSet.parts ~= cast(string) s[0 .. length];
+        interpolatedSet.parts ~= cast(string) s[0 .. str.length];
     }
 
     /****


### PR DESCRIPTION
also get rid of unnecessary reference to outbuffer.d