### PR TITLE
rewrite writeCharLiteral() to use sinks

### DIFF
--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -2718,7 +2718,8 @@ public:
 
         foreach (i; 0 .. e.len)
         {
-            writeCharLiteral(*buf, e.getCodeUnit(i));
+            void sink(char c) { buf.writeByte(c); }
+            writeCharLiteral(e.getCodeUnit(i), &sink);
         }
         buf.writeByte('"');
     }

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2401,7 +2401,8 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
         const o = buf.length;
         foreach (i; 0 .. e.len)
         {
-            writeCharLiteral(buf, e.getCodeUnit(i));
+            void sink(char c) { buf.writeByte(c); }
+            writeCharLiteral(e.getCodeUnit(i), &sink);
         }
         if (hgs.ddoc)
             escapeDdocString(buf, o);
@@ -2421,7 +2422,10 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
             if (idx % 2 == 0)
             {
                 foreach(ch; str)
-                    writeCharLiteral(buf, ch);
+                {
+                    void sink(char c) { buf.put(c); }
+                    writeCharLiteral(ch, &sink);
+                }
             }
             else
             {

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -1068,9 +1068,10 @@ nothrow:
             buf.writeByte('"');
             for (size_t i = 0; i < len;)
             {
-                dchar c;
-                utf_decodeChar(ustring[0 .. len], i, c);
-                writeCharLiteral(buf, c);
+                dchar d;
+                utf_decodeChar(ustring[0 .. len], i, d);
+                void sink(char c) { buf.writeByte(c); }
+                writeCharLiteral(d, &sink);
             }
             buf.writeByte('"');
             if (postfix)
@@ -1144,60 +1145,64 @@ nothrow:
  * Useful for printing "" string literals in e.g. error messages, ddoc, or the `.stringof` property
  *
  * Params:
- *   buf = buffer to append character in
- *   c = code point to write
+ *   d = dchar to convert to literal
+ *   sink = sink for generated characters
  */
 nothrow
-void writeCharLiteral(ref OutBuffer buf, dchar c)
+void writeCharLiteral(dchar d, void delegate(char) nothrow sink)
 {
-    switch (c)
+    char c;
+    switch (d)
     {
-        case '\0':
-            buf.writestring("\\0");
+        case '\0': c = '0';  goto Lput;
+        case '\n': c = 'n';  goto Lput;
+        case '\r': c = 'r';  goto Lput;
+        case '\t': c = 't';  goto Lput;
+        case '\b': c = 'b';  goto Lput;
+        case '\f': c = 'f';  goto Lput;
+        Lput:
+            sink('\\');
+            sink(cast(char)c);
             break;
-        case '\n':
-            buf.writestring("\\n");
-            break;
-        case '\r':
-            buf.writestring("\\r");
-            break;
-        case '\t':
-            buf.writestring("\\t");
-            break;
-        case '\b':
-            buf.writestring("\\b");
-            break;
-        case '\f':
-            buf.writestring("\\f");
-            break;
+
         case '"':
         case '\\':
-            buf.writeByte('\\');
+            sink('\\');
             goto default;
         default:
-            if (c <= 0xFF)
+            char[2 + 8 + 1] buf = void;
+            int n = cast(int)buf.length;
+            if (d <= 0xFF)
             {
-                if (isprint(c))
-                    buf.writeByte(cast(char)c);
+                if (isprint(d))
+                {
+                    sink(cast(char)d);
+                    break;
+                }
                 else
-                    buf.printf("\\x%02x", c);
+                    n = snprintf(buf.ptr, n, "\\x%02x", d);
             }
-            else if (c <= 0xFFFF)
-                buf.printf("\\u%04x", c);
+            else if (d <= 0xFFFF)
+                n = snprintf(buf.ptr, n, "\\u%04x", d);
             else
-                buf.printf("\\U%08x", c);
+                n = snprintf(buf.ptr, n, "\\U%08x", d);
+            assert(n < buf.length);
+            foreach (chr; buf[0 .. n])
+                sink(chr);
             break;
     }
 }
 
 unittest
 {
-    OutBuffer buf;
+    char[40] buf = void;   // 40 should be good enough for anybody
+    size_t i;
     foreach(dchar d; "a\n\r\t\b\f\0\x11\u7233\U00017233"d)
     {
-        writeCharLiteral(buf, d);
+        void sink(char c) { buf[i++] = c; }
+        writeCharLiteral(d, &sink);
     }
-    assert(buf[] == `a\n\r\t\b\f\0\x11\u7233\U00017233`);
+    assert(buf[0 .. i] == `a\n\r\t\b\f\0\x11\u7233\U00017233`);
 }
 
 /**
@@ -1219,8 +1224,10 @@ void writeSingleCharLiteral(ref OutBuffer buf, dchar c)
     if (c == '"')
         buf.writeByte('"');
     else
-        writeCharLiteral(buf, c);
-
+    {
+        void sink(char c) { buf.writeByte(c); }
+        writeCharLiteral(c, &sink);
+    }
     buf.writeByte('\'');
 }
 


### PR DESCRIPTION
tokens.d suffers from global variables and memory leaks. This impairs using D as an LSP. This PR starts a bottom_up approach to fixing this by using output sinks.

Lambdas would be cleaner, but I don't think the bootstrap compiler supports the lambda syntax yet.