### PR TITLE
Fix #23021 - getOverloads indexed result .mangleof causes assertion f…

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15776,7 +15776,7 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
                 }
 
                 if (!hasOverloads)
-                    e = StringExp.create(loc, mangleExact(f));
+                    e = StringExp.create(loc, mangleExact(f.toAliasFunc()));
             }
 
             if (!e)

--- a/compiler/test/compilable/getoverloads_mangleof.d
+++ b/compiler/test/compilable/getoverloads_mangleof.d
@@ -1,0 +1,5 @@
+// https://github.com/dlang/dmd/issues/23021
+// getOverloads indexed result .mangleof caused assertion failure
+
+class A { void func() const {} }
+static assert(__traits(getOverloads, A, "func")[0].mangleof.length > 0);


### PR DESCRIPTION
…ailure

Closes #23021

> Root cause: __traits(getOverloads, ...)[n] yields a FuncAliasDeclaration, which inherits FuncDeclaration. The dotMangleof helper called mangleExact(f) directly, but mangleExact asserts !isFuncAliasDeclaration().
