### PR TITLE
Fix an ICE in modifyFieldVar that can be triggered with std.json and std.typecons

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2148,7 +2148,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         version (none)
         {
             printf("VarDeclaration::semantic('%s', parent = '%s') sem = %d\n",
-                   dsym.toChars(), sc.parent ? sc.parent.toChars() : null, dsym.semanticRun);
+                   dsym.toChars(), sc !is null && sc.parent ? sc.parent.toChars() : null, dsym.semanticRun);
             printf(" type = %s\n", dsym.type ? dsym.type.toChars() : "null");
             printf(" stc = x%llx\n", dsym.storage_class);
             printf(" storage_class = x%llx\n", dsym.storage_class);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -18446,7 +18446,13 @@ private bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e
                     if (ad.fields[i] == var)
                         break;
                 }
-                assert(i < dim);
+                if (i == dim)
+                {
+                    // Field not found in ad.fields. This can happen if a prior
+                    // semantic error prevented the field from being added.
+                    // Treat as a non-initializing modification.
+                    return false;
+                }
                 auto fieldInit = &sc.ctorflow.fieldinit[i];
                 const fi = fieldInit.csx;
 


### PR DESCRIPTION
I've been running into an ICE that was created in the last 4 months.

Basically std.json triggers std.typecons Tuple with two tuple members (string, JSONValue), except the JSONValue errors and kills the Tuple.

No test case, I could not minify it.

And no I am super not convinced that this is the right way to fix it, but I've also spent around 5 hours trying to debug this and what the LLM came up with seemed to give the right answer.

New error message:

```
testdfa\json.d(728): Error: Expression reads from an uninitialized variable, it must be written to at least once before reading
        v.orderedObject = null;
        ^
testdfa\json.d(727):        For variable `v`
        JSONValue v = void;
                  ^
P:\ProjectSidero\dmd2\windows\bin\..\..\src\phobos\std\typecons.d(1287): Error: forward reference to type `const(_error_)` of expression `this.__expand_field_1`
                        const k = typeid(T).getHash((() @trusted => cast(const void*) &field[i])());
                                                                                      ^
P:\ProjectSidero\dmd2\windows\bin\..\..\src\phobos\std\typecons.d(675): Error: template instance `std.typecons.Tuple!(string, JSONValue)` error instantiating
            ref inout(Tuple!Types) _Tuple_super() inout @trusted
                      ^
testdfa\json.d(132):        instantiated from here: `Tuple!(string, "key", JSONValue, "value")`
    alias OrderedObjectMember = Tuple!(
```

The stack trace:

```
core.exception.AssertError@src\dmd\expressionsem.d(18449): Assertion failure
----------------
0x00007FF7ACBD88AE in d_createTrace
0x00007FF7ACBC6397 in d_throwc
0x00007FF7ACBBED5C in d_assertp
0x00007FF7AC742E1D in dmd.expressionsem.modifyFieldVar at P:\dmd\compiler\src\dmd\expressionsem.d(18449)
0x00007FF7AC742A6A in dmd.expressionsem.checkModify at P:\dmd\compiler\src\dmd\expressionsem.d(18398)
0x00007FF7AC73F226 in dmd.expressionsem.checkModifiable at P:\dmd\compiler\src\dmd\expressionsem.d(17400)
0x00007FF7AC72519D in dmd.expressionsem.ExpressionSemanticVisitor.visit at P:\dmd\compiler\src\dmd\expressionsem.d(12320)
0x00007FF7AC6E6BE2 in dmd.expression.AssignExp.accept at P:\dmd\compiler\src\dmd\expression.d(3042)
0x00007FF7AC736E46 in dmd.expressionsem.expressionSemantic at P:\dmd\compiler\src\dmd\expressionsem.d(15721)
0x00007FF7AC703A85 in dmd.expressionsem.ExpressionSemanticVisitor.visit at P:\dmd\compiler\src\dmd\expressionsem.d(6017)
0x00007FF7AC6E1EB2 in dmd.expression.TupleExp.accept at P:\dmd\compiler\src\dmd\expression.d(1310)
0x00007FF7AC736E46 in dmd.expressionsem.expressionSemantic at P:\dmd\compiler\src\dmd\expressionsem.d(15721)
0x00007FF7AC724E1E in dmd.expressionsem.ExpressionSemanticVisitor.visit at P:\dmd\compiler\src\dmd\expressionsem.d(12259)
0x00007FF7AC6E6BE2 in dmd.expression.AssignExp.accept at P:\dmd\compiler\src\dmd\expression.d(3042)
0x00007FF7AC736E46 in dmd.expressionsem.expressionSemantic at P:\dmd\compiler\src\dmd\expressionsem.d(15721)
0x00007FF7AC8163B7 in dmd.statementsem.statementSemanticVisit.visitExp at P:\dmd\compiler\src\dmd\statementsem.d(249)
0x00007FF7AC82A294 in dmd.statementsem.statementSemanticVisit.VisitStatement!void.VisitStatement at P:\dmd\compiler\src\dmd\statement.d-mixin-1910(1917)
0x00007FF7AC816268 in dmd.statementsem.statementSemanticVisit at P:\dmd\compiler\src\dmd\statementsem.d(3854)
0x00007FF7AC816221 in dmd.statementsem.statementSemantic at P:\dmd\compiler\src\dmd\statementsem.d(198)
0x00007FF7AC81682F in dmd.statementsem.statementSemanticVisit.visitCompound at P:\dmd\compiler\src\dmd\statementsem.d(318)
0x00007FF7AC82A2C6 in dmd.statementsem.statementSemanticVisit.VisitStatement!void.VisitStatement at P:\dmd\compiler\src\dmd\statement.d-mixin-1911(1918)
0x00007FF7AC816268 in dmd.statementsem.statementSemanticVisit at P:\dmd\compiler\src\dmd\statementsem.d(3854)
0x00007FF7AC816221 in dmd.statementsem.statementSemantic at P:\dmd\compiler\src\dmd\statementsem.d(198)
0x00007FF7AC80758D in dmd.semantic3.Semantic3Visitor.visit at P:\dmd\compiler\src\dmd\semantic3.d(605)
0x00007FF7AC80D118 in dmd.semantic3.Semantic3Visitor.visit at P:\dmd\compiler\src\dmd\semantic3.d(1485)
0x00007FF7AC74FD32 in dmd.func.CtorDeclaration.accept at P:\dmd\compiler\src\dmd\func.d(972)
0x00007FF7AC8055D1 in dmd.semantic3.semantic3 at P:\dmd\compiler\src\dmd\semantic3.d(95)
0x00007FF7AC80D9C1 in dmd.semantic3.Semantic3Visitor.visit at P:\dmd\compiler\src\dmd\semantic3.d(1587)
0x00007FF7AC909FD2 in dmd.visitor.parsetime.ParseTimeVisitor!(dmd.astcodegen.ASTCodegen).ParseTimeVisitor.visit at P:\dmd\compiler\src\dmd\visitor\parsetime.d(80)
0x00007FF7AC90A092 in dmd.visitor.parsetime.ParseTimeVisitor!(dmd.astcodegen.ASTCodegen).ParseTimeVisitor.visit at P:\dmd\compiler\src\dmd\visitor\parsetime.d(86)
0x00007FF7AC5F1B22 in dmd.attrib.StaticIfDeclaration.accept at P:\dmd\compiler\src\dmd\attrib.d(567)
0x00007FF7AC8055D1 in dmd.semantic3.semantic3 at P:\dmd\compiler\src\dmd\semantic3.d(95)
0x00007FF7AC80DB11 in dmd.semantic3.Semantic3Visitor.visit at P:\dmd\compiler\src\dmd\semantic3.d(1612)
0x00007FF7AC90A152 in dmd.visitor.parsetime.ParseTimeVisitor!(dmd.astcodegen.ASTCodegen).ParseTimeVisitor.visit at P:\dmd\compiler\src\dmd\visitor\parsetime.d(89)
0x00007FF7AC689432 in dmd.dstruct.StructDeclaration.accept at P:\dmd\compiler\src\dmd\dstruct.d(127)
0x00007FF7AC8055D1 in dmd.semantic3.semantic3 at P:\dmd\compiler\src\dmd\semantic3.d(95)
0x00007FF7AC8057EA in dmd.semantic3.Semantic3Visitor.visit at P:\dmd\compiler\src\dmd\semantic3.d(144)
0x00007FF7AC6C15D2 in dmd.dtemplate.TemplateInstance.accept at P:\dmd\compiler\src\dmd\dtemplate.d(1039)
0x00007FF7AC8055D1 in dmd.semantic3.semantic3 at P:\dmd\compiler\src\dmd\semantic3.d(95)
0x00007FF7AC6A29EC in dmd.dsymbolsem.DsymbolSemanticVisitor.visit at P:\dmd\compiler\src\dmd\dsymbolsem.d(5021)
0x00007FF7AC689432 in dmd.dstruct.StructDeclaration.accept at P:\dmd\compiler\src\dmd\dstruct.d(127)
0x00007FF7AC68FAF1 in dmd.dsymbolsem.dsymbolSemantic at P:\dmd\compiler\src\dmd\dsymbolsem.d(706)
0x00007FF7AC68FE8B in dmd.dsymbolsem.runDeferredSemantic at P:\dmd\compiler\src\dmd\dsymbolsem.d(795)
0x00007FF7AC69E10E in dmd.dsymbolsem.DsymbolSemanticVisitor.visit.__lambda3(__T17)(s) at P:\dmd\compiler\src\dmd\dsymbolsem.d(3947)
0x00007FF7AC689858 in dmd.dsymbol.foreachDsymbol at P:\dmd\compiler\src\dmd\dsymbol.d(96)
0x00007FF7AC69DFBA in dmd.dsymbolsem.DsymbolSemanticVisitor.visit at P:\dmd\compiler\src\dmd\dsymbolsem.d(3943)
0x00007FF7AC667FC2 in dmd.dmodule.Module.accept at P:\dmd\compiler\src\dmd\dmodule.d(1003)
0x00007FF7AC68FAF1 in dmd.dsymbolsem.dsymbolSemantic at P:\dmd\compiler\src\dmd\dsymbolsem.d(706)
0x00007FF7AC69C3D3 in dmd.dsymbolsem.DsymbolSemanticVisitor.visit at P:\dmd\compiler\src\dmd\dsymbolsem.d(3626)
0x00007FF7AC63E502 in dmd.dimport.Import.accept at P:\dmd\compiler\src\dmd\dimport.d(146)
0x00007FF7AC68FAF1 in dmd.dsymbolsem.dsymbolSemantic at P:\dmd\compiler\src\dmd\dsymbolsem.d(706)
0x00007FF7AC82A04C in dmd.statementsem.statementSemanticVisit.visitImport at P:\dmd\compiler\src\dmd\statementsem.d(3834)
0x00007FF7AC82AA6C in dmd.statementsem.statementSemanticVisit.VisitStatement!void.VisitStatement at P:\dmd\compiler\src\dmd\statement.d-mixin-1951(1958)
0x00007FF7AC816268 in dmd.statementsem.statementSemanticVisit at P:\dmd\compiler\src\dmd\statementsem.d(3854)
0x00007FF7AC816221 in dmd.statementsem.statementSemantic at P:\dmd\compiler\src\dmd\statementsem.d(198)
0x00007FF7AC81682F in dmd.statementsem.statementSemanticVisit.visitCompound at P:\dmd\compiler\src\dmd\statementsem.d(318)
0x00007FF7AC82A2C6 in dmd.statementsem.statementSemanticVisit.VisitStatement!void.VisitStatement at P:\dmd\compiler\src\dmd\statement.d-mixin-1911(1918)
0x00007FF7AC816268 in dmd.statementsem.statementSemanticVisit at P:\dmd\compiler\src\dmd\statementsem.d(3854)
0x00007FF7AC816221 in dmd.statementsem.statementSemantic at P:\dmd\compiler\src\dmd\statementsem.d(198)
0x00007FF7AC80758D in dmd.semantic3.Semantic3Visitor.visit at P:\dmd\compiler\src\dmd\semantic3.d(605)
0x00007FF7AC909BD2 in dmd.visitor.parsetime.ParseTimeVisitor!(dmd.astcodegen.ASTCodegen).ParseTimeVisitor.visit at P:\dmd\compiler\src\dmd\visitor\parsetime.d(62)
0x00007FF7AC750BA2 in dmd.func.UnitTestDeclaration.accept at P:\dmd\compiler\src\dmd\func.d(1216)
0x00007FF7AC8055D1 in dmd.semantic3.semantic3 at P:\dmd\compiler\src\dmd\semantic3.d(95)
0x00007FF7AC805CDB in dmd.semantic3.Semantic3Visitor.visit at P:\dmd\compiler\src\dmd\semantic3.d(215)
0x00007FF7AC667FC2 in dmd.dmodule.Module.accept at P:\dmd\compiler\src\dmd\dmodule.d(1003)
0x00007FF7AC8055D1 in dmd.semantic3.semantic3 at P:\dmd\compiler\src\dmd\semantic3.d(95)
0x00007FF7AC5D5C4D in dmd.main.tryMain at P:\dmd\compiler\src\dmd\main.d(648)
0x00007FF7AC5D3E1B in dmd.main._Dmain at P:\dmd\compiler\src\dmd\main.d(148)
0x00007FF7ACBD8753 in void rt.dmain2._d_run_main2(char[][], ulong, extern (C) int function(char[][])*).runAll().__lambda2()
0x00007FF7ACBD854F in void rt.dmain2._d_run_main2(char[][], ulong, extern (C) int function(char[][])*).tryExec(scope void delegate())
0x00007FF7ACBD866F in void rt.dmain2._d_run_main2(char[][], ulong, extern (C) int function(char[][])*).runAll()
0x00007FF7ACBD854F in void rt.dmain2._d_run_main2(char[][], ulong, extern (C) int function(char[][])*).tryExec(scope void delegate())
0x00007FF7ACBD831A in d_run_main2
0x00007FF7ACBC5B59 in d_run_main
0x00007FF7AC5D3D98 in dmd.main.main at P:\dmd\compiler\src\dmd\main.d(107)
0x00007FF7ACC1F244 in __scrt_common_main_seh at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl(288)
0x00007FFE82AC7374 in BaseThreadInitThunk
0x00007FFE8451CC91 in RtlUserThreadStart
```