### PR TITLE
[cli.d] Improve `-check` docs

### DIFF
--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -206,10 +206,12 @@ struct Usage
         Option("c",
             "compile only, do not link"
         ),
-        Option("check=<option>[=[on|off]]",
-            "enable or disable specific checks for <option>: assert|bounds|in|invariant|nullderef|out|switch.",
+        Option("check=<action>[=[on|off]]",
+            "enable or disable specific checks for <action>: assert|bounds|in|invariant|nullderef|out|switch.",
             q"{Enable or disable specific checks.
-            Overrides default, `-boundscheck`, `-release` and `-unittest` options to enable or disable specific checks. *option* can be:
+            Overrides default, $(SWLINK -boundscheck), $(SWLINK -release) and
+            $(SWLINK -unittest) options to enable or disable specific checks.
+            *action* can be:
                 $(UL
                     $(LI $(B assert): assertion checking)
                     $(LI $(B bounds): array bounds)
@@ -219,12 +221,12 @@ struct Usage
                     $(LI $(B out): out contracts)
                     $(LI $(B switch): $(D final switch) failure checking)
                 )
-                *option* can be set to:
+                Each *action* can be set to:
                 $(UL
                     $(LI $(B on): specified check is enabled.)
                     $(LI $(B off): specified check is disabled.)
                 )
-                If no setting for *option* is given, it will default to `on`,
+                If no setting for *action* is given, it will default to `on`,
                 except `nullderef` defaults to `off`.}"
         ),
         Option("check=[on|off]",

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -206,21 +206,30 @@ struct Usage
         Option("c",
             "compile only, do not link"
         ),
-        Option("check=[assert|bounds|in|invariant|out|switch][=[on|off]]",
-            "enable or disable specific checks",
-            q"{Overrides default, `-boundscheck`, `-release` and `-unittest` options to enable or disable specific checks.
+        Option("check=<option>[=[on|off]]",
+            "enable or disable specific checks for <option>: assert|bounds|in|invariant|nullderef|out|switch.",
+            q"{Enable or disable specific checks.
+            Overrides default, `-boundscheck`, `-release` and `-unittest` options to enable or disable specific checks. *option* can be:
                 $(UL
                     $(LI $(B assert): assertion checking)
                     $(LI $(B bounds): array bounds)
                     $(LI $(B in): in contracts)
                     $(LI $(B invariant): class/struct invariants)
+                    $(LI **nullderef**: null dereference)
                     $(LI $(B out): out contracts)
                     $(LI $(B switch): $(D final switch) failure checking)
                 )
+                *option* can be set to:
                 $(UL
-                    $(LI $(B on) or not specified: specified check is enabled.)
+                    $(LI $(B on): specified check is enabled.)
                     $(LI $(B off): specified check is disabled.)
-                )}"
+                )
+                If no setting for *option* is given, it will default to `on`,
+                except `nullderef` defaults to `off`.}"
+        ),
+        Option("check=[on|off]",
+            "enable or disable all checks above",
+            "Enable or disable all checks above."
         ),
         Option("check=[h|help|?]",
             "list information on all available checks"
@@ -1204,11 +1213,11 @@ struct CLIUsage
   =in[=[on|off]]        Generate In contracts
   =invariant[=[on|off]] Class/struct invariants
   =out[=[on|off]]       Out contracts
-  =switch[=[on|off]]    Final switch failure checking
+  =switch[=[on|off]]    `final switch` failure checking
   =nullderef[=[on|off]] Null dereference error
-  =on                   Enable all assertion checking
-                        (default for non-release builds)
-  =off                  Disable all assertion checking
+  =on                   Enable all checking
+                        (default for non-release builds, except `nullderef`)
+  =off                  Disable all checking
 ";
 
     /// Options supported by -extern-std

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -245,12 +245,12 @@ struct Usage
                     $(LI $(B context): Prints the error context as part of the unrecoverable $(D AssertError).)
                 )`
         ),
+        Option("checkaction=[h|help|?]",
+            "list information on all available check actions"
+        ),
         Option("checkactionfinally=[on|off]",
             "do finally statements that do not have an Exception thrown in try body get emitted?",
             "Default behavior is on. Turning this off means destructors may not run."
-        ),
-        Option("checkaction=[h|help|?]",
-            "list information on all available check actions"
         ),
         Option("color",
             "turn colored console output on"

--- a/compiler/test/compilable/dmdcliflags.sh
+++ b/compiler/test/compilable/dmdcliflags.sh
@@ -13,20 +13,20 @@ function grep() {
 
 for w in "check" "check=" ; do
     output="$(! $DMD "-${w}" 2>&1)"
-    echo "$output" | grep "Enable or disable specific checks:"
-    echo "$output" | grep "=on                   Enable all assertion checking"
+    echo "$output" | grep "Enable or disable specific checks"
+    echo "$output" | grep "=on                   Enable all checking"
     echo "$output" | grep "Error: \`-check=<action>\` requires an action"
 done
 
 for w in "check=?" "check=h" "check=help" ; do
     output="$($DMD "-${w}")"
-    echo "$output" | grep "Enable or disable specific checks:"
+    echo "$output" | grep "Enable or disable specific checks"
 done
 
 output="$(! $DMD -check=foo 2>&1)"
 echo "$output" | grep "Error: switch \`-check=foo\` is invalid"
-echo "$output" | grep "Enable or disable specific checks:"
-echo "$output" | grep "=on                   Enable all assertion checking"
+echo "$output" | grep "Enable or disable specific checks"
+echo "$output" | grep "=on                   Enable all checking"
 
 output="$(! $DMD -checkf 2>&1)"
 echo "$output" | grep "Error: unrecognized switch '-checkf'"


### PR DESCRIPTION
Update for https://github.com/dlang/dmd/pull/22040.

Add missing ddoc description first line.
Add missing `nullderef` option.
Clarify defaults.
List `-check=[on|off]` separately. It's not just for assertions.