### PR TITLE
Fix #18754 - dmd should automatically add newline at end of ddoc file

### DIFF
--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -479,6 +479,9 @@ private int tryMain(const(char)[][] argv, out Param params)
                 fatal();
             // BUG: convert file contents to UTF-8 before use
             //printf("file: '%.*s'\n", cast(int)buffer.data.length, buffer.data.ptr);
+            // Separate macro definitions from adjacent files lacking a final \n
+            // https://github.com/dlang/dmd/issues/18754
+            ddocbuf.writeByte('\n');
         }
         ddocbufIsRead = true;
     }


### PR DESCRIPTION
Closes #18754

No test as this requires committing a 'bad' file without trailing newline, which doesn't pass the pre commit style check, and scripting a solution around that is not worth it for an old unimportant bug.