### PR TITLE
Fix #19974 - Markdown trailing list breaks unittest example

### DIFF
--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -4592,7 +4592,7 @@ void highlightText(Scope* sc, Dsymbols* a, Loc loc, ref OutBuffer buf, size_t of
                 else
                 {
                     i += endRowAndTable(buf, iLineStart, i, inlineDelimiters, columnAlignments);
-                    if (!lineQuoted && quoteLevel)
+                    if (!lineQuoted && (quoteLevel || nestedLists.length))
                     {
                         const delta = endAllListsAndQuotes(buf, iLineStart, nestedLists, quoteLevel, quoteMacroLevel);
                         i += delta;

--- a/compiler/test/compilable/ddoc19974.d
+++ b/compiler/test/compilable/ddoc19974.d
@@ -1,0 +1,18 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
+// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+// EXTRA_SOURCES: extra-files/ddoc_minimal.ddoc
+
+/**
+ * Module docs.
+ */
+module ddoc19974;
+
+/++
+Test markdown list followed by code listing.
+- test
++/
+unittest
+{
+    // test
+}

--- a/compiler/test/compilable/extra-files/ddoc19974.html
+++ b/compiler/test/compilable/extra-files/ddoc19974.html
@@ -1,0 +1,27 @@
+<section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    Module docs.
+  </p>
+</div>
+<div class="ddoc_examples">
+  <h4>Examples</h4>
+  <p class="para">
+    Test markdown list followed by code listing.
+<ul><li>test
+</li>
+</ul>
+<section class="code_listing">
+  <div class="code_sample">
+    <div class="dlang">
+      <ol class="code_lines">
+        <li><pre><code class="code"><span class="comment">// test
+</span></code></pre></li>
+      </ol>
+    </div>
+  </div>
+</section>
+
+  </p>
+</div>
+</section>

--- a/compiler/test/compilable/extra-files/ddoc_markdown_lists.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_lists.html
@@ -15,7 +15,8 @@
 <br><br>
   <em>part of</em> item one
 <br><br>
-
+</li>
+</ul>
 <section class="code_listing">
   <div class="code_sample">
     <div class="dlang">
@@ -26,8 +27,7 @@
     </div>
   </div>
 </section>
-</li>
-</ul>
+<br><br>
  <strong>not</strong> part of item one
 
 <ul><li>three</li>


### PR DESCRIPTION
Closes #19974