### PR TITLE
Fix #19346 - Struct members missing from docs when the struct has a d…

### DIFF
--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -1436,8 +1436,12 @@ void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
                 buf.writestring(ddoc_decl_dd_s);
                 {
                     dc.writeSections(sc, &dc.a, *buf);
-                    if (ScopeDsymbol sds = dc.a[0].isScopeDsymbol())
-                        emitMemberComments(sds, *buf, sc);
+                    foreach (sym; dc.a)
+                        if (ScopeDsymbol sds = sym.isScopeDsymbol())
+                        {
+                            emitMemberComments(sds, *buf, sc);
+                            break;
+                        }
                 }
                 buf.writestring(ddoc_decl_dd_e);
                 buf.writeByte(')');

--- a/compiler/test/compilable/ddoc19346.d
+++ b/compiler/test/compilable/ddoc19346.d
@@ -1,0 +1,19 @@
+// https://github.com/dlang/dmd/issues/19346
+// Ddoc: ditto on struct should not prevent member documentation
+
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
+// EXTRA_SOURCES: extra-files/ddoc_minimal.ddoc
+// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+
+module ddoc19346;
+
+/// Docs for foo and Foo
+void foo() {}
+
+/// ditto
+struct Foo
+{
+    /// Docs for bar
+    void bar() {}
+}

--- a/compiler/test/compilable/extra-files/ddoc19346.html
+++ b/compiler/test/compilable/extra-files/ddoc19346.html
@@ -1,0 +1,77 @@
+
+<section class="section ddoc_module_members_section">
+  <div class="ddoc_module_members">
+    <ul class="ddoc_members">
+  <li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#foo" id="foo"><code class="code">foo</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="foo"></span>void <code class="code">foo</code>();
+<br>
+<span class="ddoc_anchor" id="Foo"></span>struct <code class="code">Foo</code>;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    Docs for <code class="code">foo</code> and <code class="code">Foo</code>
+  </p>
+</div>
+
+</section>
+<ul class="ddoc_members">
+  <li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#Foo.bar" id="Foo.bar"><code class="code">bar</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="Foo.bar"></span>void <code class="code">bar</code>();
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    Docs for <code class="code">bar</code>
+  </p>
+</div>
+
+</section>
+
+</div>
+
+</li>
+</ul>
+
+</div>
+
+</li>
+</ul>
+  </div>
+</section>


### PR DESCRIPTION
…amed parameters

> When ditto is used, the struct gets pushed to dc.a but may not be at index 0 - so member comments are never emitted.
> Fix: iterate all items in dc.a to find any ScopeDsymbol.



Closes #19346