### PR TITLE
Fix #23040 - Add -check=nullderef=safeonly

### DIFF
--- a/changelog/dmd.nullderef-safeonly.dd
+++ b/changelog/dmd.nullderef-safeonly.dd
@@ -1,0 +1,22 @@
+`-check=nullderef=safeonly` is now supported
+
+The `-check=nullderef` flag now accepts `safeonly` as a setting, which enables
+null dereference checking only in `@safe` functions. The D spec requires null
+dereferences to be detected in `@safe` code, and this flag allows opting into
+that behavior while the feature matures toward being on by default.
+
+---
+@safe void safeFn()
+{
+    int* p;
+    int x = *p; // null dereference error thrown at runtime
+}
+
+void systemFn()
+{
+    int* p;
+    int x = *p; // no check injected, relies on OS protection
+}
+---
+
+Compile with `-check=nullderef=safeonly` to enable this behavior.

--- a/changelog/dmd.nullderef-safeonly.dd
+++ b/changelog/dmd.nullderef-safeonly.dd
@@ -1,9 +1,6 @@
-`-check=nullderef=safeonly` is now supported
-
-The `-check=nullderef` flag now accepts `safeonly` as a setting, which enables
-null dereference checking only in `@safe` functions. The D spec requires null
-dereferences to be detected in `@safe` code, and this flag allows opting into
-that behavior while the feature matures toward being on by default.
+`-check=nullderef` now supports the `safeonly` setting, which enables null
+dereference checks only in `@safe` functions. Behavior in `@system` code is
+unchanged.
 
 ---
 @safe void safeFn()

--- a/changelog/dmd.nullderef-safeonly.dd
+++ b/changelog/dmd.nullderef-safeonly.dd
@@ -1,6 +1,7 @@
-`-check=nullderef` now supports the `safeonly` setting, which enables null
-dereference checks only in `@safe` functions. Behavior in `@system` code is
-unchanged.
+`-check=nullderef` now supports `=safeonly`
+
+The `-check=nullderef` flag now accepts `safeonly` as a setting, which enables
+the explicit null dereference check only in `@safe` functions.
 
 ---
 @safe void safeFn()
@@ -12,7 +13,7 @@ unchanged.
 void systemFn()
 {
     int* p;
-    int x = *p; // no check injected, relies on OS protection
+    int x = *p; // no explicit check; relies on OS signal/exception
 }
 ---
 

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -206,7 +206,7 @@ struct Usage
         Option("c",
             "compile only, do not link"
         ),
-        Option("check=<action>[=[on|off]]",
+        Option("check=<action>[=[on|off|safeonly]]",
             "enable or disable specific checks for <action>: assert|bounds|in|invariant|nullderef|out|switch.",
             q"{Enable or disable specific checks.
             Overrides default, $(SWLINK -boundscheck), $(SWLINK -release) and
@@ -225,6 +225,7 @@ struct Usage
                 $(UL
                     $(LI $(B on): specified check is enabled.)
                     $(LI $(B off): specified check is disabled.)
+                    $(LI $(B safeonly): check is enabled only in $(D @safe) functions (only for $(B nullderef)).)
                 )
                 If no setting for *action* is given, it will default to `on`,
                 except `nullderef` defaults to `off`.}"

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -225,7 +225,7 @@ struct Usage
                 $(UL
                     $(LI $(B on): specified check is enabled.)
                     $(LI $(B off): specified check is disabled.)
-                    $(LI $(B safeonly): check is enabled only in $(D @safe) functions (only for $(B nullderef)).)
+                    $(LI $(B safeonly): check is enabled only in $(D @safe) functions.)
                 )
                 If no setting for *action* is given, it will default to `on`,
                 except `nullderef` defaults to `off`.}"

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -747,7 +747,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, out Param 
             mixin(checkOptionsMixin("check",
                 "`-check=<action>` requires an action"));
             /* Parse:
-             *    -check=[assert|bounds|in|invariant|out|switch|nullderef][=[on|off]]
+             *    -check=[assert|bounds|in|invariant|out|switch|nullderef][=[on|off|safeonly]]
              */
 
             // Check for legal option string; return true if so
@@ -767,6 +767,11 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, out Param 
                     else if (checkarg == "=off")
                     {
                         ce = CHECKENABLE.off;
+                        return true;
+                    }
+                    else if (checkarg == "=safeonly")
+                    {
+                        ce = CHECKENABLE.safeonly;
                         return true;
                     }
                 }

--- a/compiler/test/runnable/nullderefcheck_safeonly.d
+++ b/compiler/test/runnable/nullderefcheck_safeonly.d
@@ -1,34 +1,26 @@
 // REQUIRED_ARGS: -check=nullderef=safeonly
 // PERMUTE_ARGS:
 
-// Test that -check=nullderef=safeonly enables null checks only in @safe functions
-
 struct Struct
 {
     int field;
 }
 
-// @safe function: null deref check should fire
-@safe void safeDereference()
-{
-    Struct* ptr;
-    int val = ptr.field; // should throw
-}
-
-// @system function: null deref check should NOT fire (would segfault instead)
-// We can't test the @system case at runtime without crashing, so we just
-// verify the @safe case works correctly.
-
 void main()
 {
-    // @safe null deref should be caught
+    wrap!(() @safe { Struct* ptr; int val = ptr.field; })(__LINE__);
+    wrap!(() @safe { int* ptr; int val = *ptr; })(__LINE__);
+}
+
+void wrap(alias test)(int expectedLine)
+{
     try
     {
-        safeDereference();
-        assert(0, "expected null dereference error");
+        test();
+        assert(0);
     }
     catch (Error e)
     {
-        // expected
+        assert(e.line == expectedLine);
     }
 }

--- a/compiler/test/runnable/nullderefcheck_safeonly.d
+++ b/compiler/test/runnable/nullderefcheck_safeonly.d
@@ -1,0 +1,34 @@
+// REQUIRED_ARGS: -check=nullderef=safeonly
+// PERMUTE_ARGS:
+
+// Test that -check=nullderef=safeonly enables null checks only in @safe functions
+
+struct Struct
+{
+    int field;
+}
+
+// @safe function: null deref check should fire
+@safe void safeDereference()
+{
+    Struct* ptr;
+    int val = ptr.field; // should throw
+}
+
+// @system function: null deref check should NOT fire (would segfault instead)
+// We can't test the @system case at runtime without crashing, so we just
+// verify the @safe case works correctly.
+
+void main()
+{
+    // @safe null deref should be caught
+    try
+    {
+        safeDereference();
+        assert(0, "expected null dereference error");
+    }
+    catch (Error e)
+    {
+        // expected
+    }
+}


### PR DESCRIPTION
Fixes #23040

The `safeonly` case was already handled in `funcsem.d` but the CLI parser only accepted `on`/`off` for `nullderef`, so it was never reachable. Wired it up in `mars.d` and updated the docs in `cli.d`.

---

`-check=nullderef=safeonly` — null check fires in `@safe`, caught cleanly:

<img width="1919" height="165" alt="sfeonly" src="https://github.com/user-attachments/assets/a33b4938-14a9-45b4-a6a8-e10cb00dcc11" />

---

`-check=nullderef=off` — no check injected, OS kills it:

<img width="1919" height="165" alt="offonly" src="https://github.com/user-attachments/assets/6ef2905d-92d2-4894-8789-24060ed670df" />