### PR TITLE
Fix typo in [spec/property.dd]

### DIFF
--- a/spec/property.dd
+++ b/spec/property.dd
@@ -312,7 +312,7 @@ $(H2 $(LNAME2 tupleof, .tupleof Property))
 $(P $(CODE .tupleof) provides a symbol sequence of all the non-static fields in a struct or class.
 The order of the fields in the tuple matches the order in which the fields are declared.
 
-For classes, hidden fields and fields of the bass class are excluded.
+For classes, hidden fields and fields of the base class are excluded.
 
 A common use case is to iterate over the fields with a $(CODE foreach) loop.)
 


### PR DESCRIPTION
Fixes [dlang.org #4393](https://github.com/dlang/dlang.org/issues/4393)