### PR TITLE
[stable] test/runnable/ai.d: Don't use `1e-308` double literal, it's an imprecise subnormal

### DIFF
--- a/compiler/test/runnable/ai.d
+++ b/compiler/test/runnable/ai.d
@@ -96,7 +96,7 @@ void arithmetic_expression_selftest()
 
     /* 15) multiplication/division reassociation differs for floats */
     {
-        double a = 1e308, b = 1e-308, c = 1e-308;
+        double a = 1e307, b = 1e-307, c = 1e-307;
         double left  = (a * b) * c;
         double right = a * (b * c);
         /* one side likely underflows differently; we just expect "not always equal" */


### PR DESCRIPTION
Which LDC detects and rejects at parse time:
```
Error: number `1e-308` is not representable as a `double`
```

See https://en.wikipedia.org/wiki/IEEE_754, the smallest positive normal is `2.23e−308`.