### PR TITLE
[stable] Fix compilable/zerosize2.d for AArch64

### DIFF
--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -1529,7 +1529,7 @@ struct TargetC
         if (bitFieldStyle == BitFieldStyle.Gcc_Clang)
         {
             // sufficient for DMD's currently supported architectures
-            return !bfd.isAnonymous() || target.isAArch64;
+            return !bfd.isAnonymous() || (target.isAArch64 && target.os != Target.OS.OSX);
         }
         assert(0);
     }

--- a/compiler/test/compilable/zerosize2.d
+++ b/compiler/test/compilable/zerosize2.d
@@ -115,8 +115,14 @@ version (X86_64)
     static assert(C19.sizeof == 0 && C19.alignof == 16);
 }
 
-// Anonymous bitfields *do* contribute to alignment.
 version (AArch64)
+{
+    version (Apple) { /* diverges */ } else
+        version = AAPCS64;
+}
+
+// Anonymous bitfields *do* contribute to alignment.
+version (AAPCS64)
 {
     // Empty
     static assert(D0.sizeof == 1 && D0.alignof == 1);
@@ -135,8 +141,8 @@ version (AArch64)
     // Zero sized arrays
     static assert(D5.sizeof == 1 && D5.alignof == 1);
     static assert(D6.sizeof == 2 && D6.alignof == 2);
-    static assert(D7.sizeof == 3 && D7.alignof == 4);
-    static assert(D8.sizeof == 4 && D8.alignof == 8);
+    static assert(D7.sizeof == 4 && D7.alignof == 4);
+    static assert(D8.sizeof == 8 && D8.alignof == 8);
     static assert(D15.sizeof == 16 && D15.alignof == 16);
     static assert(D16.sizeof == 16 && D16.alignof == 16);
     static assert(D17.sizeof == 16 && D17.alignof == 16);


### PR DESCRIPTION
Firstly, Apple targets diverge and don't have a special case for ARM64 wrt. anonymous bit fields contributing to the aggregate alignment: https://cpp.godbolt.org/z/44GcTKnvY

Secondly, some `extern(D)` sizeofs were wrong (probably typos).