### PR TITLE
druntime: add modern SChannel / SSPI / wincrypt bindings (Win10 1809+)

### DIFF
--- a/druntime/src/core/sys/windows/schannel.d
+++ b/druntime/src/core/sys/windows/schannel.d
@@ -10,10 +10,12 @@
 module core.sys.windows.schannel;
 version (Windows):
 
+import core.sys.windows.ntdef;   // UNICODE_STRING
 import core.sys.windows.wincrypt;
 import core.sys.windows.windef;
 
 enum DWORD SCHANNEL_CRED_VERSION = 4;
+enum DWORD SCH_CREDENTIALS_VERSION = 5;
 enum SCHANNEL_SHUTDOWN           = 1;
 /* Comment from MinGW
     ? Do these belong here or in wincrypt.h
@@ -30,12 +32,21 @@ enum DWORD
     SP_PROT_SSL2_CLIENT = 0x08,
     SP_PROT_SSL3_SERVER = 0x10,
     SP_PROT_SSL3_CLIENT = 0x20,
-    SP_PROT_TLS1_SERVER = 0x40,
-    SP_PROT_TLS1_CLIENT = 0x80,
-    SP_PROT_PCT1        = SP_PROT_PCT1_CLIENT | SP_PROT_PCT1_SERVER,
-    SP_PROT_TLS1        = SP_PROT_TLS1_CLIENT | SP_PROT_TLS1_SERVER,
-    SP_PROT_SSL2        = SP_PROT_SSL2_CLIENT | SP_PROT_SSL2_SERVER,
-    SP_PROT_SSL3        = SP_PROT_SSL3_CLIENT | SP_PROT_SSL3_SERVER;
+    SP_PROT_TLS1_SERVER   = 0x40,
+    SP_PROT_TLS1_CLIENT   = 0x80,
+    SP_PROT_TLS1_1_SERVER = 0x100,
+    SP_PROT_TLS1_1_CLIENT = 0x200,
+    SP_PROT_TLS1_2_SERVER = 0x400,
+    SP_PROT_TLS1_2_CLIENT = 0x800,
+    SP_PROT_TLS1_3_SERVER = 0x1000,
+    SP_PROT_TLS1_3_CLIENT = 0x2000,
+    SP_PROT_PCT1          = SP_PROT_PCT1_CLIENT | SP_PROT_PCT1_SERVER,
+    SP_PROT_TLS1          = SP_PROT_TLS1_CLIENT | SP_PROT_TLS1_SERVER,
+    SP_PROT_TLS1_1        = SP_PROT_TLS1_1_CLIENT | SP_PROT_TLS1_1_SERVER,
+    SP_PROT_TLS1_2        = SP_PROT_TLS1_2_CLIENT | SP_PROT_TLS1_2_SERVER,
+    SP_PROT_TLS1_3        = SP_PROT_TLS1_3_CLIENT | SP_PROT_TLS1_3_SERVER,
+    SP_PROT_SSL2          = SP_PROT_SSL2_CLIENT | SP_PROT_SSL2_SERVER,
+    SP_PROT_SSL3          = SP_PROT_SSL3_CLIENT | SP_PROT_SSL3_SERVER;
 
 enum DWORD
     SCH_CRED_NO_SYSTEM_MAPPER                    = 0x0002,
@@ -104,3 +115,50 @@ struct SecPkgContext_ConnectionInfo {
     DWORD  dwExchStrength;
 }
 alias PSecPkgContext_ConnectionInfo = SecPkgContext_ConnectionInfo*;
+
+enum eTlsAlgorithmUsage
+{
+    TlsParametersCngAlgUsageKeyExchange,
+    TlsParametersCngAlgUsageSignature,
+    TlsParametersCngAlgUsageCipher,
+    TlsParametersCngAlgUsageDigest,
+    TlsParametersCngAlgUsageCertSig,
+}
+
+struct CRYPTO_SETTINGS
+{
+    eTlsAlgorithmUsage  eAlgorithmUsage;
+    UNICODE_STRING      strCngAlgId;
+    DWORD               cChainingModes;
+    UNICODE_STRING*     rgstrChainingModes;
+    DWORD               dwMinBitLength;
+    DWORD               dwMaxBitLength;
+}
+alias PCRYPTO_SETTINGS = CRYPTO_SETTINGS*;
+
+struct TLS_PARAMETERS
+{
+    DWORD               cAlpnIds;
+    UNICODE_STRING*     rgstrAlpnIds;
+    DWORD               grbitDisabledProtocols;
+    DWORD               cDisabledCrypto;
+    CRYPTO_SETTINGS*    pDisabledCrypto;
+    DWORD               dwFlags;
+}
+alias PTLS_PARAMETERS = TLS_PARAMETERS*;
+
+struct SCH_CREDENTIALS
+{
+    DWORD               dwVersion;          // SCH_CREDENTIALS_VERSION
+    DWORD               dwCredFormat;
+    DWORD               cCreds;
+    PCCERT_CONTEXT*     paCred;
+    HCERTSTORE          hRootStore;
+    DWORD               cMappers;
+    _HMAPPER**          aphMappers;
+    DWORD               dwSessionLifespan;
+    DWORD               dwFlags;
+    DWORD               cTlsParameters;
+    TLS_PARAMETERS*     pTlsParameters;
+}
+alias PSCH_CREDENTIALS = SCH_CREDENTIALS*;

--- a/druntime/src/core/sys/windows/sspi.d
+++ b/druntime/src/core/sys/windows/sspi.d
@@ -68,6 +68,7 @@ enum :ULONG{
     SECBUFFER_STREAM_HEADER = 7,
     SECBUFFER_PADDING = 9,
     SECBUFFER_STREAM = 10,
+    SECBUFFER_ALERT = 17,
     SECBUFFER_READONLY = 0x80000000,
     SECBUFFER_ATTRMASK = 0xf0000000,
 }
@@ -208,8 +209,7 @@ alias INITIALIZE_SECURITY_CONTEXT_FN_A = SECURITY_STATUS function(PCredHandle,PC
 alias ACCEPT_SECURITY_CONTEXT_FN = SECURITY_STATUS function(PCredHandle,PCtxtHandle,PSecBufferDesc,ULONG,ULONG,PCtxtHandle,PSecBufferDesc,PULONG,PTimeStamp);
 alias COMPLETE_AUTH_TOKEN_FN = SECURITY_STATUS function(PCtxtHandle,PSecBufferDesc);
 alias DELETE_SECURITY_CONTEXT_FN = SECURITY_STATUS function(PCtxtHandle);
-alias APPLY_CONTROL_TOKEN_FN_W = SECURITY_STATUS function(PCtxtHandle,PSecBufferDesc);
-alias APPLY_CONTROL_TOKEN_FN_A = SECURITY_STATUS function(PCtxtHandle,PSecBufferDesc);
+alias APPLY_CONTROL_TOKEN_FN = SECURITY_STATUS function(PCtxtHandle,PSecBufferDesc);
 alias QUERY_CONTEXT_ATTRIBUTES_FN_A = SECURITY_STATUS function(PCtxtHandle,ULONG,PVOID);
 alias QUERY_CONTEXT_ATTRIBUTES_FN_W = SECURITY_STATUS function(PCtxtHandle,ULONG,PVOID);
 alias IMPERSONATE_SECURITY_CONTEXT_FN = SECURITY_STATUS function(PCtxtHandle);
@@ -237,7 +237,7 @@ struct SecurityFunctionTableW{
     ACCEPT_SECURITY_CONTEXT_FN AcceptSecurityContext;
     COMPLETE_AUTH_TOKEN_FN CompleteAuthToken;
     DELETE_SECURITY_CONTEXT_FN DeleteSecurityContext;
-    APPLY_CONTROL_TOKEN_FN_W ApplyControlTokenW;
+    APPLY_CONTROL_TOKEN_FN ApplyControlToken;
     QUERY_CONTEXT_ATTRIBUTES_FN_W QueryContextAttributesW;
     IMPERSONATE_SECURITY_CONTEXT_FN ImpersonateSecurityContext;
     REVERT_SECURITY_CONTEXT_FN RevertSecurityContext;
@@ -267,7 +267,7 @@ struct SecurityFunctionTableA{
     ACCEPT_SECURITY_CONTEXT_FN AcceptSecurityContext;
     COMPLETE_AUTH_TOKEN_FN CompleteAuthToken;
     DELETE_SECURITY_CONTEXT_FN DeleteSecurityContext;
-    APPLY_CONTROL_TOKEN_FN_A ApplyControlTokenA;
+    APPLY_CONTROL_TOKEN_FN ApplyControlToken;
     QUERY_CONTEXT_ATTRIBUTES_FN_A QueryContextAttributesA;
     IMPERSONATE_SECURITY_CONTEXT_FN ImpersonateSecurityContext;
     REVERT_SECURITY_CONTEXT_FN RevertSecurityContext;
@@ -309,8 +309,7 @@ SECURITY_STATUS DecryptMessage(PCtxtHandle,PSecBufferDesc,ULONG,PULONG);
 SECURITY_STATUS EncryptMessage(PCtxtHandle,ULONG,PSecBufferDesc,ULONG);
 SECURITY_STATUS DeleteSecurityContext(PCtxtHandle);
 SECURITY_STATUS CompleteAuthToken(PCtxtHandle,PSecBufferDesc);
-SECURITY_STATUS ApplyControlTokenA(PCtxtHandle,PSecBufferDesc);
-SECURITY_STATUS ApplyControlTokenW(PCtxtHandle,PSecBufferDesc);
+SECURITY_STATUS ApplyControlToken(PCtxtHandle,PSecBufferDesc);
 SECURITY_STATUS ImpersonateSecurityContext(PCtxtHandle);
 SECURITY_STATUS RevertSecurityContext(PCtxtHandle);
 SECURITY_STATUS MakeSignature(PCtxtHandle,ULONG,PSecBufferDesc,ULONG);
@@ -340,12 +339,10 @@ version (Unicode) {
     alias QueryContextAttributes = QueryContextAttributesW;
     alias QueryCredentialsAttributes = QueryCredentialsAttributesW;
     alias QuerySecurityPackageInfo = QuerySecurityPackageInfoW;
-    alias ApplyControlToken = ApplyControlTokenW;
     alias ENUMERATE_SECURITY_PACKAGES_FN = ENUMERATE_SECURITY_PACKAGES_FN_W;
     alias QUERY_CREDENTIALS_ATTRIBUTES_FN = QUERY_CREDENTIALS_ATTRIBUTES_FN_W;
     alias ACQUIRE_CREDENTIALS_HANDLE_FN = ACQUIRE_CREDENTIALS_HANDLE_FN_W;
     alias INITIALIZE_SECURITY_CONTEXT_FN = INITIALIZE_SECURITY_CONTEXT_FN_W;
-    alias APPLY_CONTROL_TOKEN_FN = APPLY_CONTROL_TOKEN_FN_W;
     alias QUERY_CONTEXT_ATTRIBUTES_FN = QUERY_CONTEXT_ATTRIBUTES_FN_W;
     alias QUERY_SECURITY_PACKAGE_INFO_FN = QUERY_SECURITY_PACKAGE_INFO_FN_W;
     alias INIT_SECURITY_INTERFACE = INIT_SECURITY_INTERFACE_W;
@@ -369,12 +366,10 @@ version (Unicode) {
     alias QueryContextAttributes = QueryContextAttributesA;
     alias QueryCredentialsAttributes = QueryCredentialsAttributesA;
     alias QuerySecurityPackageInfo = QuerySecurityPackageInfoA;
-    alias ApplyControlToken = ApplyControlTokenA;
     alias ENUMERATE_SECURITY_PACKAGES_FN = ENUMERATE_SECURITY_PACKAGES_FN_A;
     alias QUERY_CREDENTIALS_ATTRIBUTES_FN = QUERY_CREDENTIALS_ATTRIBUTES_FN_A;
     alias ACQUIRE_CREDENTIALS_HANDLE_FN = ACQUIRE_CREDENTIALS_HANDLE_FN_A;
     alias INITIALIZE_SECURITY_CONTEXT_FN = INITIALIZE_SECURITY_CONTEXT_FN_A;
-    alias APPLY_CONTROL_TOKEN_FN = APPLY_CONTROL_TOKEN_FN_A;
     alias QUERY_CONTEXT_ATTRIBUTES_FN = QUERY_CONTEXT_ATTRIBUTES_FN_A;
     alias QUERY_SECURITY_PACKAGE_INFO_FN = QUERY_SECURITY_PACKAGE_INFO_FN_A;
     alias INIT_SECURITY_INTERFACE = INIT_SECURITY_INTERFACE_A;

--- a/druntime/src/core/sys/windows/wincrypt.d
+++ b/druntime/src/core/sys/windows/wincrypt.d
@@ -148,6 +148,7 @@ enum {
     CRYPT_DELETEKEYSET = 16,
     CRYPT_MACHINE_KEYSET = 32,
     CRYPT_SILENT = 64,
+    CRYPT_USER_KEYSET = 0x00001000,
 }
 
 enum {
@@ -178,6 +179,17 @@ enum {
 
 enum {
     PKCS5_PADDING = 1,
+}
+
+enum {
+    PKCS12_IMPORT_SILENT                    = 0x00000040,
+    PKCS12_INCLUDE_EXTENDED_PROPERTIES      = 0x0010,
+    PKCS12_NO_PERSIST_KEY                   = 0x00008000,
+    PKCS12_ALWAYS_CNG_KSP                   = 0x00000200,
+    PKCS12_ONLY_NOT_ENCRYPTED_CERTIFICATES  = 0x00000800,
+    PKCS12_ONLY_CERTIFICATES                = 0x00000400,
+    PKCS12_PREFER_CNG_KSP                   = 0x00000100,
+    PKCS12_VIRTUAL_ISOLATION_KEY            = 0x00010000,
 }
 
 enum {
@@ -376,6 +388,17 @@ enum {
     CERT_NAME_STR_NO_QUOTING_FLAG = 268435456,
     CERT_NAME_STR_REVERSE_FLAG = 33554432,
     CERT_NAME_STR_ENABLE_T61_UNICODE_FLAG = 131072,
+}
+
+enum {
+    CERT_NAME_EMAIL_TYPE            = 1,
+    CERT_NAME_RDN_TYPE              = 2,
+    CERT_NAME_ATTR_TYPE             = 3,
+    CERT_NAME_SIMPLE_DISPLAY_TYPE   = 4,
+    CERT_NAME_FRIENDLY_DISPLAY_TYPE = 5,
+    CERT_NAME_DNS_TYPE              = 6,
+    CERT_NAME_URL_TYPE              = 7,
+    CERT_NAME_UPN_TYPE              = 8,
 }
 
 enum {
@@ -832,6 +855,11 @@ const(void)*, PCCERT_CONTEXT);
       PCCERT_CONTEXT, PCCERT_CONTEXT, DWORD*);
     PCCERT_CHAIN_CONTEXT CertFindChainInStore(HCERTSTORE, DWORD, DWORD, DWORD,
 const(void)*, PCCERT_CHAIN_CONTEXT);
+    HCERTSTORE     PFXImportCertStore(CRYPT_DATA_BLOB*, LPCWSTR, DWORD);
+    DWORD          CertGetNameStringA(PCCERT_CONTEXT, DWORD, DWORD, void*, LPSTR, DWORD);
+    DWORD          CertGetNameStringW(PCCERT_CONTEXT, DWORD, DWORD, void*, LPWSTR, DWORD);
+    PCCERT_CONTEXT CertCreateCertificateContext(DWORD, const(BYTE)*, DWORD);
+    BOOL           CertAddCertificateContextToStore(HCERTSTORE, PCCERT_CONTEXT, DWORD, PCCERT_CONTEXT*);
 
     BOOL CryptAcquireContextA(HCRYPTPROV*, LPCSTR, LPCSTR, DWORD, DWORD);
     BOOL CryptAcquireContextW(HCRYPTPROV*, LPCWSTR, LPCWSTR, DWORD, DWORD);
@@ -875,6 +903,7 @@ const(void)*, PCCERT_CHAIN_CONTEXT);
 
 version (Unicode) {
     alias CertNameToStr = CertNameToStrW;
+    alias CertGetNameString = CertGetNameStringW;
     alias CryptAcquireContext = CryptAcquireContextW;
     alias CryptSignHash = CryptSignHashW;
     alias CryptVerifySignature = CryptVerifySignatureW;
@@ -884,6 +913,7 @@ version (Unicode) {
     alias CERT_FIND_ISSUER_STR_W CERT_FIND_ISSUER_STR;+/
 } else {
     alias CertNameToStr = CertNameToStrA;
+    alias CertGetNameString = CertGetNameStringA;
     alias CryptAcquireContext = CryptAcquireContextA;
     alias CryptSignHash = CryptSignHashA;
     alias CryptVerifySignature = CryptVerifySignatureA;


### PR DESCRIPTION
Add SCH_CREDENTIALS, TLS_PARAMETERS, CRYPTO_SETTINGS, eTlsAlgorithmUsage, SP_PROT_TLS1_1/2/3, and supporting constants for modern SChannel TLS 1.2 / 1.3 usage. Add PFXImportCertStore, CertGetNameStringA/W, CertCreateCertificateContext, and CertAddCertificateContextToStore to wincrypt. Fill out PKCS12_* and CERT_NAME_*_TYPE constant clusters.

Fix ApplyControlToken: secur32.dll exports a single unsuffixed ApplyControlToken, not the A/W pair druntime previously declared. Replace the wrong A/W exports, function-pointer aliases, and SecurityFunctionTable slots with the correct unsuffixed form.