### PR TITLE
Fixes #23072 - Allow compatible anonymous array types across imports

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -5073,6 +5073,24 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return isCCompatible(ats.sym, bts.sym);
         }
 
+        // Treat arrays of anonymous structs/unions as compatible when element types match.
+        static bool isCCompatibleType(Type a, Type b)
+        {
+            if (a.equals(b))
+                return true;
+
+            if (TypeSArray asa = a.isTypeSArray())
+            {
+                if (TypeSArray bsa = b.isTypeSArray())
+                {
+                    if (asa.dim && bsa.dim && asa.dim.toInteger() == bsa.dim.toInteger())
+                        return isCCompatibleType(asa.nextOf(), bsa.nextOf());
+                }
+            }
+
+            return isCCompatibleUnnamedStruct(a, b);
+        }
+
         if (a.fields.length != b.fields.length)
         {
             incompatError();
@@ -5129,7 +5147,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             //   their members such that each pair of corresponding
             //   members are declared with compatible types;
             //
-            if (!a_field.type.equals(b_field.type) && !isCCompatibleUnnamedStruct(a_field.type, b_field.type))
+            if (!isCCompatibleType(a_field.type, b_field.type))
             {
                 // Already errored, just bail
                 incompatError();

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -5081,11 +5081,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (TypeSArray asa = a.isTypeSArray())
             {
-                if (TypeSArray bsa = b.isTypeSArray())
-                {
-                    if (asa.dim && bsa.dim && asa.dim.toInteger() == bsa.dim.toInteger())
-                        return isCCompatibleType(asa.nextOf(), bsa.nextOf());
-                }
+                TypeSArray bsa = b.isTypeSArray();
+                if (bsa && asa.dim && bsa.dim && asa.dim.toInteger() == bsa.dim.toInteger())
+                    return isCCompatibleType(asa.nextOf(), bsa.nextOf());
             }
 
             return isCCompatibleUnnamedStruct(a, b);

--- a/compiler/test/compilable/imports/imp23072.h
+++ b/compiler/test/compilable/imports/imp23072.h
@@ -1,0 +1,8 @@
+typedef struct _SCOPE_TABLE_AMD64 {
+    struct { int x; } ScopeRecord[1];
+} _SCOPE_TABLE_AMD64;
+
+typedef struct _SCOPE_TABLE_UNION {
+    union { int a; float b; } U[2];
+    struct { int y; } Nested[2][3];
+} _SCOPE_TABLE_UNION;

--- a/compiler/test/compilable/imports/imp23072a.c
+++ b/compiler/test/compilable/imports/imp23072a.c
@@ -1,0 +1,1 @@
+#include "imp23072.h"

--- a/compiler/test/compilable/imports/imp23072b.c
+++ b/compiler/test/compilable/imports/imp23072b.c
@@ -1,0 +1,1 @@
+#include "imp23072.h"

--- a/compiler/test/compilable/test23072.d
+++ b/compiler/test/compilable/test23072.d
@@ -1,0 +1,7 @@
+module compiler.test.compilable.test23072;
+
+// https://github.com/dlang/dmd/issues/23072
+// EXTRA_FILES: imports/imp23072a.c imports/imp23072b.c imports/imp23072.h
+
+import imports.imp23072a;
+import imports.imp23072b;


### PR DESCRIPTION
This is related to #23072 

Now anonymous struct/union arrays compare by element compatibility, not by unique anonymous tag names.