### PR TITLE
use OutBuffer instead of stdout for usage/logo

### DIFF
--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -244,13 +244,17 @@ private int tryMain(const(char)[][] argv, out Param params)
 
     if (params.help.usage)
     {
-        usage();
+        OutBuffer buf;
+        usage(buf);
+        fputs(buf.peekChars(), stdout);
         return EXIT_SUCCESS;
     }
 
     if (params.v.logo)
     {
-        logo();
+        OutBuffer buf;
+        logo(buf);
+        fputs(buf.peekChars(), stdout);
         return EXIT_SUCCESS;
     }
 
@@ -367,7 +371,9 @@ private int tryMain(const(char)[][] argv, out Param params)
                 fatal();
             return EXIT_SUCCESS;
         }
-        usage();
+        OutBuffer buf;
+        usage(buf);
+        fputs(buf.peekChars(), stdout);
         return EXIT_FAILURE;
     }
 

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -67,15 +67,17 @@ else
     static assert(0);
 
 /**
- * Print DMD's logo on stdout
+ * Print DMD's logo to `buf`
+ * Params:
+ *   buf = output stream to print the information to
  */
-void logo()
+void logo(ref OutBuffer buf)
 {
     version (AArch64)
         string host = " AArch";
     else
         string host = "";
-    printf("DMD%s%llu D Compiler %.*s\n%.*s %.*s\n",
+    buf.printf("DMD%s%llu D Compiler %.*s\n%.*s %.*s\n",
         host.ptr,
         cast(ulong)size_t.sizeof * 8,
         cast(int) global.versionString().length, global.versionString().ptr,
@@ -106,15 +108,17 @@ void printInternalFailure(ref OutBuffer buf)
 }
 
 /**
- * Print DMD's usage message on stdout
+ * Print DMD's usage message to `buf`
+ * Params:
+ *   buf = output stream to print the information to
  */
-void usage()
+void usage(ref OutBuffer buf)
 {
     import dmd.cli : CLIUsage;
-    logo();
+    logo(buf);
     auto help = CLIUsage.usage;
     const inifileCanon = FileName.canonicalName(global.inifilename);
-    printf("
+    buf.printf("
 Documentation: https://dlang.org/
 Config file: %.*s
 Usage:


### PR DESCRIPTION
Shouldn't be using `printf` in leaf functions. After all, that won't work if compiler has a gui interface.