### PR TITLE
simplify getTypeInfoIdent()

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -709,33 +709,25 @@ extern (C++) final class SymbolDeclaration : Declaration
 }
 
 /***********************************************************
+ * Generate Identifier for TypeInfo corresponding to `t`
+ * Params:
+ *	t = type to generate TypeInfo identifier for
+ * Returns:
+ *	the identifier
  */
 private Identifier getTypeInfoIdent(Type t)
 {
-    import dmd.mangle;
-    import core.stdc.stdlib;
-    import dmd.root.rmem;
     // _init_10TypeInfo_%s
     OutBuffer buf;
     buf.reserve(32);
+    import dmd.mangle;
     mangleToBuffer(t, buf);
 
-    const slice = buf[];
+    OutBuffer buf2;
+    buf2.reserve(19 + size_t.sizeof * 3 + buf.length + 1);
+    buf2.printf("_D%zuTypeInfo_%.*s6__initZ", 9+buf.length, cast(int)buf.length, buf[].ptr);
 
-    // Allocate buffer on stack, fail over to using malloc()
-    char[128] namebuf;
-    const namelen = 19 + size_t.sizeof * 3 + slice.length + 1;
-    auto name = namelen <= namebuf.length ? namebuf.ptr : cast(char*)Mem.check(malloc(namelen));
-
-    const length = snprintf(name, namelen, "_D%lluTypeInfo_%.*s6__initZ",
-            cast(ulong)(9 + slice.length), cast(int)slice.length, slice.ptr);
-    //printf("%p %s, deco = %s, name = %s\n", this, toChars(), deco, name);
-    assert(0 < length && length < namelen); // don't overflow the buffer
-
-    auto id = Identifier.idPool(name[0 .. length]);
-
-    if (name != namebuf.ptr)
-        free(name);
+    auto id = Identifier.idPool(buf2[]);
     return id;
 }
 


### PR DESCRIPTION
Use of snprintf() is troublesome to make sure it is correctly used.