### PR TITLE
Revert "small changes to elf.d"

### DIFF
--- a/compiler/src/dmd/lib/elf.d
+++ b/compiler/src/dmd/lib/elf.d
@@ -469,8 +469,8 @@ private:
             h.object_name[0] = '/';
             h.object_name[1] = '/';
             size_t len = snprintf(h.file_size.ptr, ELF_FILE_SIZE_SIZE, "%u", noffset);
-            assert(len < ELF_FILE_SIZE_SIZE);
-            h.file_size[len] = ' '; // overwrite 0 with ' '
+            assert(len < 10);
+            h.file_size[len] = ' ';
             h.trailer[0] = '`';
             h.trailer[1] = '\n';
             libbuf.write((&h)[0 .. 1]);
@@ -566,7 +566,6 @@ void ElfOmToHeader(ElfLibHeader* h, ElfObjModule* om)
         //     name_offset   file_time   u_id gr_id  fmode    fsize   trailer
         len = snprintf(buffer, ElfLibHeader.sizeof, "/%-15d%-12llu%-6u%-6u%-8o%-10u`", om.name_offset, cast(long)om.file_time, om.user_id, om.group_id, om.file_mode, om.length);
     }
-    assert(len + 1 != 0); // some old snprintf's return -1 on error
     assert(ElfLibHeader.sizeof > 0 && len == ElfLibHeader.sizeof - 1);
     // replace trailing \0 with \n
     buffer[len] = '\n';


### PR DESCRIPTION
Reverts dlang/dmd#23089

This appears to be the first PR to be generating the MSCOFF magic number error.

I don't know if this is correct or not, but lets find out.