### PR TITLE
Change glue code visibility back to `package(dmd.glue)`

### DIFF
--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -95,7 +95,7 @@ alias Elems = Array!(elem *);
  * Returns:
  *      true if actually implicitly passed by reference
  */
-public
+package(dmd.glue)
 bool ISX64REF(Declaration var)
 {
     if (var.isReference())
@@ -163,7 +163,7 @@ bool ISX64REF(ref IRState irs, Expression exp)
  * Returns:
  *      generated elem
  */
-public
+package(dmd.glue)
 elem* elAssign(elem* e1, elem* e2, Type t, type* tx)
 {
     //printf("e1:\n"); elem_print(e1);
@@ -212,7 +212,7 @@ elem* elAssign(elem* e1, elem* e2, Type t, type* tx)
  * Returns:
  *      Symbol
  */
-public
+package(dmd.glue)
 Symbol* toStringSymbol(const(char)* str, size_t len, size_t sz)
 {
     //printf("toStringSymbol() %s\n", str);
@@ -304,7 +304,7 @@ Symbol* toStringSymbol(const(char)* str, size_t len, size_t sz)
  *      e = elem to modify in place
  *      loc = to get file/line from
  */
-public
+package(dmd.glue)
 void toTraceGC(ref IRState irs, elem* e, Loc loc)
 {
     static immutable RTLSYM[2][5] map =
@@ -348,7 +348,7 @@ void toTraceGC(ref IRState irs, elem* e, Loc loc)
  * Returns:
  *      generated elem tree
  */
-public
+package(dmd.glue)
 elem* toElemDtor(Expression e, ref IRState irs, elem* ehidden = null)
 {
     //printf("Expression.toElemDtor() %s\n", e.toChars());
@@ -403,7 +403,7 @@ elem* toElemDtor(Expression e, ref IRState irs, elem* ehidden = null)
  * Returns:
  *      the equivalent of &e
  */
-public
+package(dmd.glue)
 elem* addressElem(elem* e, Type t, bool alwaysCopy = false)
 {
     //printf("addressElem()\n");
@@ -475,7 +475,7 @@ elem* addressElem(elem* e, Type t, bool alwaysCopy = false)
 /********************************
  * Reset stringTab[] between object files being emitted, because the symbols are local.
  */
-public
+package(dmd.glue)
 void clearStringTab()
 {
     //printf("clearStringTab()\n");
@@ -496,7 +496,7 @@ private __gshared StringTable!(Symbol*) *stringTab;
  * Returns:
  *      true if symbol should be imported from a DLL
  */
-public
+package(dmd.glue)
 bool isDllImported(Dsymbol symbl)
 {
     // Windows is the only platform which dmd supports, that uses the DllImport/DllExport scheme.

--- a/compiler/src/dmd/glue/s2ir.d
+++ b/compiler/src/dmd/glue/s2ir.d
@@ -78,13 +78,13 @@ private:  // detect unmarked symbols that should be public
 
 alias StmtState = dmd.stmtstate.StmtState!block;
 
-public
+package(dmd.glue)
 void elem_setLoc(elem* e, Loc loc) nothrow
 {
     e.Esrcpos = toSrcpos(loc);
 }
 
-public
+package(dmd.glue)
 void Statement_toIR(Statement s, ref IRState irs)
 {
     /* Generate a block for each label
@@ -103,7 +103,7 @@ void Statement_toIR(Statement s, ref IRState irs)
     Statement_toIR(s, irs, &stmtstate);
 }
 
-public
+package(dmd.glue)
 void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
 {
     static import dmd.backend.blockopt;
@@ -1493,7 +1493,7 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
  * Params:
  *      startblock = first block in function
  */
-public
+package(dmd.glue)
 void insertFinallyBlockCalls(block* startblock)
 {
     int flagvalue = 0;          // 0 is forunwind_resume
@@ -1668,7 +1668,7 @@ void insertFinallyBlockCalls(block* startblock)
  * Params:
  *      startblock = first block in function
  */
-public
+package(dmd.glue)
 void insertFinallyBlockGotos(block* startblock)
 {
     enum log = false;
@@ -1722,6 +1722,8 @@ void insertFinallyBlockGotos(block* startblock)
 /*************************************** private *******************************************/
 /*                              No public declarations past this                           */
 /*************************************** private *******************************************/
+
+private:
 
 private void block_setLoc(block* b, Loc loc) nothrow
 {

--- a/compiler/src/dmd/glue/toir.d
+++ b/compiler/src/dmd/glue/toir.d
@@ -70,7 +70,7 @@ private:
 /****************************************
  * Our label symbol
  */
-public
+package(dmd.glue)
 struct Label
 {
     block* lblock;      // The block to which the label is defined.
@@ -79,7 +79,7 @@ struct Label
 /***********************************************************
  * Collect state variables needed by the intermediate representation (IR)
  */
-public
+package(dmd.glue)
 struct IRState
 {
     Module m;                       // module
@@ -163,7 +163,7 @@ struct IRState
  * References:
  * https://dlang.org/dmd-windows.html#switch-cov
  */
-public
+package(dmd.glue)
 extern (D) elem* incUsageElem(ref IRState irs, Loc loc)
 {
     uint linnum = loc.linnum;
@@ -206,7 +206,7 @@ extern (D) elem* incUsageElem(ref IRState irs, Loc loc)
  * 'origSc' is the original scope we inlined from.
  * This routine is critical for implementing nested functions.
  */
-public
+package(dmd.glue)
 elem* getEthis(Loc loc, ref IRState irs, Dsymbol fd, Dsymbol fdp = null, Dsymbol origSc = null)
 {
     elem* ethis;
@@ -424,7 +424,7 @@ elem* getEthis(Loc loc, ref IRState irs, Dsymbol fd, Dsymbol fdp = null, Dsymbol
  * Returns:
  *      *(ethis + offset);
  */
-public
+package(dmd.glue)
 elem* fixEthis2(elem* ethis, FuncDeclaration fd, bool ctxt2 = false)
 {
     if (fd && fd.hasDualContext)
@@ -442,7 +442,7 @@ elem* fixEthis2(elem* ethis, FuncDeclaration fd, bool ctxt2 = false)
  * Returns:
  *      *(ey + (ethis2 ? ad.vthis2 : ad.vthis).offset) = this;
  */
-public
+package(dmd.glue)
 elem* setEthis(Loc loc, ref IRState irs, elem* ey, AggregateDeclaration ad, bool setthis2 = false)
 {
     elem* ethis;
@@ -485,8 +485,8 @@ elem* setEthis(Loc loc, ref IRState irs, elem* ey, AggregateDeclaration ad, bool
     return ey;
 }
 
-public enum NotIntrinsic = -1;
-public enum OPtoPrec = OPMAX + 1; // front end only
+package(dmd.glue) enum NotIntrinsic = -1;
+package(dmd.glue) enum OPtoPrec = OPMAX + 1; // front end only
 
 /*******************************************
  * Convert intrinsic function to operator.
@@ -495,7 +495,7 @@ public enum OPtoPrec = OPMAX + 1; // front end only
  *      NotIntrinsic if not an intrinsic function,
  *      OPtoPrec if frontend-only intrinsic
  */
-public
+package(dmd.glue)
 int intrinsic_op(FuncDeclaration fd)
 {
     int op = NotIntrinsic;
@@ -641,7 +641,7 @@ Lva_start:
  * Returns:
  *      expression that initializes 'length'
  */
-public
+package(dmd.glue)
 elem* resolveLengthVar(VarDeclaration lengthVar, elem **pe, Type t1)
 {
     //printf("resolveLengthVar()\n");
@@ -688,7 +688,7 @@ elem* resolveLengthVar(VarDeclaration lengthVar, elem **pe, Type t1)
  *      sthis = the symbol of the current 'this' derived from fd.vthis
  *      fd = the nested function
  */
-public
+package(dmd.glue)
 type* getParentClosureType(Symbol* sthis, FuncDeclaration fd)
 {
     if (sthis)
@@ -724,7 +724,7 @@ type* getParentClosureType(Symbol* sthis, FuncDeclaration fd)
  * Returns:
  *      overall alignment of the closure
  */
-public
+package(dmd.glue)
 uint setClosureVarOffset(FuncDeclaration fd)
 {
     // Nothing to do
@@ -801,7 +801,7 @@ uint setClosureVarOffset(FuncDeclaration fd)
  * getEthis() and NewExp::toElem need to use sclosure, if set, rather
  * than the current frame pointer.
  */
-public
+package(dmd.glue)
 void buildClosure(FuncDeclaration fd, ref IRState irs)
 {
     //printf("buildClosure(fd = %s)\n", fd.toChars());
@@ -1016,7 +1016,7 @@ void buildClosure(FuncDeclaration fd, ref IRState irs)
  *      https://github.com/dlang/dmd/pull/9143 was an incomplete attempt to solve this problem
  *      that was merged. It should probably be removed.
  */
-public
+package(dmd.glue)
 void buildAlignSection(FuncDeclaration fd, ref IRState irs)
 {
     enum log = false;
@@ -1121,7 +1121,7 @@ void buildAlignSection(FuncDeclaration fd, ref IRState irs)
  * Params:
  *      fd = function
  */
-public
+package(dmd.glue)
 void buildCapture(FuncDeclaration fd)
 {
     if (!driverParams.symdebug)
@@ -1172,7 +1172,7 @@ void buildCapture(FuncDeclaration fd)
  * Returns:
  *   RET.stack if return value from function is on the stack, RET.regs otherwise
  */
-public
+package(dmd.glue)
 RET retStyle(TypeFunction tf, bool needsThis)
 {
     //printf("TypeFunction.retStyle() %s\n", toChars());
@@ -1182,7 +1182,7 @@ RET retStyle(TypeFunction tf, bool needsThis)
 /*********************************** private *********************************/
 /*                           private below the fold                          */
 /*****************************************************************************/
-
+private:
 /**************************************
  * Go through the variables in function fd that are
  * to be allocated in an aligned section, and set the .offset fields


### PR DESCRIPTION
this could still do with some cleanup, e.g. 
```d
package(dmd.glue):
private:  // detect unmarked symbols that should be public
``` 
is redundant.