### PR TITLE
Fix issue 23102 - Allow capacity queries on non-copyable arrays

### DIFF
--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -76,6 +76,18 @@ void _d_arrayshrinkfit(Tarr: T[], T)(Tarr arr, bool isshared) @trusted
     gc_shrinkArrayUsed(arr[0 .. reqlen], curlen * T.sizeof, isshared);
 }
 
+size_t _d_arraygetcapacity(size_t size, void[]* p, bool isshared) pure nothrow @trusted
+in
+{
+    assert(!(*p).length || (*p).ptr);
+}
+do
+{
+    auto datasize = (*p).length * size;
+    auto curCapacity = gc_reserveArrayCapacity((*p).ptr[0 .. datasize], 0, isshared);
+    return curCapacity / size;
+}
+
 /**
 Set the array capacity.
 

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -3912,6 +3912,7 @@ private size_t getArrayHash(const scope TypeInfo element, const scope void* ptr,
 }
 
 
+import core.internal.array.capacity : _d_arraygetcapacity;
 // HACK:  This is a lie.  `_d_arraysetcapacity` is neither `nothrow` nor `pure`, but this lie is
 // necessary for now to prevent breaking code.
 import core.internal.array.capacity : _d_arraysetcapacityPureNothrow;
@@ -3931,9 +3932,7 @@ Note: The _capacity of a slice may be impacted by operations on other slices.
 @property size_t capacity(T)(T[] arr) pure nothrow @trusted
 {
     const isshared = is(T == shared);
-    alias Unqual_T = Unqual!T;
-    // The postblit of T may be impure, so we need to use the `pure nothrow` wrapper
-    return _d_arraysetcapacityPureNothrow!Unqual_T(0, cast(void[]*)&arr, isshared);
+    return _d_arraygetcapacity(T.sizeof, cast(void[]*)&arr, isshared);
 }
 
 ///
@@ -3957,6 +3956,18 @@ Note: The _capacity of a slice may be impacted by operations on other slices.
         assert(a.capacity == b.capacity + 1); //both a and b share the same tail
     }
     assert(c.capacity == 0);              //an append to c must relocate c.
+}
+
+// https://github.com/dlang/dmd/issues/23102
+@safe unittest
+{
+    static struct S
+    {
+        @disable this(this);
+    }
+
+    S[] s;
+    auto c = s.capacity;
 }
 
 /**


### PR DESCRIPTION
Fixes #23102.

Adds a new `_d_arraygetcapacity` plumbing function so that the capacity query path can be instantiated separately from the resizing path.