### PR TITLE
Add package.d files under core

### DIFF
--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -1,6 +1,7 @@
 SRCS=\
 	src\object.d \
 	\
+	src\core\package.d \
 	src\core\atomic.d \
 	src\core\attribute.d \
 	src\core\bitop.d \
@@ -21,6 +22,7 @@ SRCS=\
 	src\core\vararg.d \
 	src\core\volatile.d \
 	\
+	src\core\gc\package.d \
 	src\core\gc\config.d \
 	src\core\gc\gcinterface.d \
 	src\core\gc\registry.d \
@@ -91,6 +93,7 @@ SRCS=\
 	src\core\internal\vararg\sysv_x64.d \
 	src\core\internal\vararg\gnu.d \
 	\
+	src\core\stdc\package.d \
 	src\core\stdc\assert_.d \
 	src\core\stdc\stdatomic.d \
 	src\core\stdc\complex.d \
@@ -115,6 +118,7 @@ SRCS=\
 	src\core\stdc\wchar_.d \
 	src\core\stdc\wctype.d \
 	\
+	src\core\stdcpp\package.d \
 	src\core\stdcpp\allocator.d \
 	src\core\stdcpp\array.d \
 	src\core\stdcpp\exception.d \

--- a/druntime/src/core/gc/package.d
+++ b/druntime/src/core/gc/package.d
@@ -1,0 +1,5 @@
+module core.gc;
+
+public import core.gc.config;
+public import core.gc.gcinterface;
+public import core.gc.registry;

--- a/druntime/src/core/package.d
+++ b/druntime/src/core/package.d
@@ -1,0 +1,27 @@
+module core;
+
+public import core.atomic;
+public import core.attribute;
+public import core.bitop;
+public import core.builtins;
+public import core.checkedint;
+public import core.cpuid;
+public import core.demangle;
+public import core.exception;
+public import core.factory;
+public import core.gc;
+public import core.int128;
+public import core.interpolation;
+public import core.lifetime;
+public import core.math;
+public import core.memory;
+public import core.runtime;
+public import core.simd;
+public import core.stdc;
+public import core.stdcpp;
+public import core.sync;
+version(none) public import core.sys;
+public import core.thread;
+public import core.time;
+public import core.vararg;
+public import core.volatile;

--- a/druntime/src/core/stdc/package.d
+++ b/druntime/src/core/stdc/package.d
@@ -1,0 +1,25 @@
+module core.stdc;
+
+public import core.stdc.assert_;
+public import core.stdc.complex;
+public import core.stdc.config;
+public import core.stdc.ctype;
+public import core.stdc.errno;
+public import core.stdc.errno;
+public import core.stdc.fenv;
+public import core.stdc.float_;
+public import core.stdc.inttypes;
+public import core.stdc.limits;
+public import core.stdc.locale;
+public import core.stdc.math;
+public import core.stdc.signal;
+public import core.stdc.stdarg;
+public import core.stdc.stddef;
+public import core.stdc.stdint;
+public import core.stdc.stdio;
+public import core.stdc.stdlib;
+public import core.stdc.string;
+public import core.stdc.tgmath;
+public import core.stdc.time;
+public import core.stdc.wchar_;
+public import core.stdc.wctype;

--- a/druntime/src/core/stdcpp/package.d
+++ b/druntime/src/core/stdcpp/package.d
@@ -1,0 +1,14 @@
+module core.stdcpp;
+
+public import core.stdcpp.allocator;
+public import core.stdcpp.array;
+public import core.stdcpp.exception;
+public import core.stdcpp.memory;
+public import core.stdcpp.new_;
+public import core.stdcpp.string;
+public import core.stdcpp.string_view;
+public import core.stdcpp.typeinfo;
+public import core.stdcpp.type_traits;
+public import core.stdcpp.utility;
+public import core.stdcpp.vector;
+public import core.stdcpp.xutility;


### PR DESCRIPTION
For the sake of being able to do, for instance,

`import core.stdc;`

in ImportC.

Shall I go forward with `core.sys` aswell?