### PR TITLE
fix #22406 followup - ambiguous overload for _d_aaIn with `const shared` AA

### DIFF
--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -425,6 +425,21 @@ void testShared()
     cast(void)iprocesses.byKeyValue;
     //iprocesses.remove(3);
     assert(2 in iprocesses);
+
+    const shared int[int] cprocesses = [1: 1, 2:4, 3:9];
+
+    cast(void)cprocesses.sizeof;
+    cast(void)cprocesses.length;
+    cast(void)cprocesses.dup;          // fails in 2.111
+    //cast(void)cprocesses.rehash;
+    //cast(void)cprocesses.clear;
+    //cast(void)cprocesses.keys;       // fails in 2.111
+    //cast(void)cprocesses.values;     // fails in 2.111
+    //cast(void)cprocesses.byKey;      // fails in 2.111
+    //cast(void)cprocesses.byValue;    // fails in 2.111
+    //cast(void)cprocesses.byKeyValue; // fails in 2.111
+    //cprocesses.remove(3);
+    assert(2 in cprocesses);
 }
 
 // https://github.com/dlang/dmd/issues/22556

--- a/druntime/src/core/internal/newaa.d
+++ b/druntime/src/core/internal/newaa.d
@@ -649,12 +649,6 @@ auto _d_aaIn(T : V[K], K, V, K2)(shared T a, auto ref scope K2 key)
     // accept shared for backward compatibility, should be deprecated
     return _d_aaIn(cast(V[K]) a, key);
 }
-/// ditto
-auto _d_aaIn(T : V[K], K, V, K2)(const shared T a, auto ref scope K2 key)
-{
-    // accept shared for backward compatibility, should be deprecated
-    return _d_aaIn(cast(V[K]) a, key);
-}
 
 // fake purity for backward compatibility with runtime hooks
 private extern(C) bool gc_inFinalizer() pure nothrow @safe;


### PR DESCRIPTION
const is already inferred by the shared overload