### PR TITLE
Fix dmd:frontend inline asm linker references

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,6 +35,7 @@ common_steps_template: &COMMON_STEPS_TEMPLATE
       ./ci/run.sh test_dmd
     fi
 
+  test_dub_package_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_dub_package
   test_druntime_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_druntime
   test_phobos_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_phobos
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Test dmd
         run: ci/run.sh test_dmd
       - name: Test dub package
-        if: '!matrix.coverage && (success() || failure())'
+        if: '!matrix.coverage && (success() || failure()) && (matrix.host_dmd == ''dmd'' || matrix.host_dmd == ''dmd-latest'')'
         run: ci/run.sh test_dub_package
       - name: Test druntime
         if: '!matrix.coverage && (success() || failure())'
@@ -261,9 +261,11 @@ jobs:
             ci/run.sh test_dmd
             echo '::endgroup::'
 
-            echo '::group::Test dub package'
-            ci/run.sh test_dub_package
-            echo '::endgroup::'
+            if [ "$HOST_DMD" = "dmd" ]; then
+              echo '::group::Test dub package'
+              ci/run.sh test_dub_package
+              echo '::endgroup::'
+            fi
 
             echo '::group::Test druntime'
             ci/run.sh test_druntime

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,6 +159,9 @@ jobs:
           arch: ${{ env.MODEL == '64' && 'x64' || 'x86' }}
       - name: Test dmd
         run: ci/run.sh test_dmd
+      - name: Test dub package
+        if: '!matrix.coverage && (success() || failure())'
+        run: ci/run.sh test_dub_package
       - name: Test druntime
         if: '!matrix.coverage && (success() || failure())'
         run: ci/run.sh test_druntime
@@ -256,6 +259,10 @@ jobs:
 
             echo '::group::Test dmd'
             ci/run.sh test_dmd
+            echo '::endgroup::'
+
+            echo '::group::Test dub package'
+            ci/run.sh test_dub_package
             echo '::endgroup::'
 
             echo '::group::Test druntime'

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -172,7 +172,7 @@ test_dub_package() {
         echo "Skipping DUB examples on GDC."
     else
         local abs_build_path="$PWD/$build_path"
-        pushd test/dub_package
+        pushd compiler/test/dub_package
         for file in *.d ; do
             dubcmd=""
             # running impvisitor is failing right now
@@ -186,7 +186,7 @@ test_dub_package() {
         done
         popd
         # Test rdmd build
-        "${build_path}/dmd" -version=NoBackend -version=GC -version=NoMain -Jgenerated/dub -Jsrc/dmd/res -Isrc -i -run test/dub_package/frontend.d
+        "${build_path}/dmd" -version=NoBackend -version=GC -version=NoMain -Jgenerated/dub -Jcompiler/src/dmd/res -Icompiler/src -i -run compiler/test/dub_package/frontend.d
     fi
     if [ "$OS_NAME" != "windows" ]; then
         deactivate

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3455,8 +3455,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     {
         if (dsym.semanticRun >= PASS.semanticdone)
             return;
-        import dmd.iasm : asmSemantic;
-        asmSemantic(dsym, sc);
+        version (NoBackend) {}
+        else
+        {
+            import dmd.iasm : asmSemantic;
+            asmSemantic(dsym, sc);
+        }
         dsym.semanticRun = PASS.semanticdone;
     }
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -42,7 +42,6 @@ import dmd.func;
 import dmd.funcsem;
 import dmd.globals;
 import dmd.hdrgen;
-import dmd.iasm;
 import dmd.id;
 import dmd.identifier;
 import dmd.importc;
@@ -3751,7 +3750,13 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
          */
 
         //printf("AsmStatement()::semantic()\n");
-        result = asmSemantic(s, sc);
+        version (NoBackend)
+            result = s;
+        else
+        {
+            import dmd.iasm;
+            result = asmSemantic(s, sc);
+        }
     }
 
     void visitCompoundAsm(CompoundAsmStatement cas)

--- a/compiler/test/dub_package/frontend_subpackage.d
+++ b/compiler/test/dub_package/frontend_subpackage.d
@@ -10,6 +10,5 @@ import dmd.frontend;
 
 void main()
 {
-    static assert(false, "temporary: verify CI runs this");
     initDMD();
 }

--- a/compiler/test/dub_package/frontend_subpackage.d
+++ b/compiler/test/dub_package/frontend_subpackage.d
@@ -10,5 +10,6 @@ import dmd.frontend;
 
 void main()
 {
+    static assert(false, "temporary: verify CI runs this");
     initDMD();
 }

--- a/compiler/test/dub_package/frontend_subpackage.d
+++ b/compiler/test/dub_package/frontend_subpackage.d
@@ -1,0 +1,14 @@
+#!/usr/bin/env dub
+/+dub.sdl:
+dependency "dmd:frontend" path="../../.."
++/
+
+// Verify that dmd:frontend links without requiring backend symbols.
+// Regression test for https://github.com/dlang/dmd/issues/23119
+
+import dmd.frontend;
+
+void main()
+{
+    initDMD();
+}


### PR DESCRIPTION
## Summary
- avoid linking dmd:frontend against dmd.iasm backend symbols under version(NoBackend)
- add a dub single-file regression test for dmd:frontend linking

Fixes #23119
