### PR TITLE
Fix regression with deleted catch(Exception) block

### DIFF
--- a/compiler/include/dmd/declaration.h
+++ b/compiler/include/dmd/declaration.h
@@ -675,6 +675,8 @@ public:
     bool hasInlineAsm(bool v);
     bool hasMultipleReturnExp() const;
     bool hasMultipleReturnExp(bool v);
+    bool hasInferredAttributes() const;
+    bool hasInferredAttributes(bool v);
 
     // Data for a function declaration that is needed for the Objective-C
     // integration.

--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -130,7 +130,7 @@ CT canThrow(Expression e, FuncDeclaration func, ErrorSink eSink)
              * then this expression cannot throw.
              * Note that pure functions can throw.
              */
-            if (ce.f && ce.f == func)
+            if (ce.f && ce.f == func && ce.f.hasInferredAttributes) // if recursive and inferred, leave it to inferrence
                 return;
             const tf = ce.calledFunctionType();
             if (tf && tf.isNothrow)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3835,6 +3835,8 @@ public:
     bool hasInlineAsm(bool v);
     bool hasMultipleReturnExp() const;
     bool hasMultipleReturnExp(bool v);
+    bool hasInferredAttributes() const;
+    bool hasInferredAttributes(bool v);
 private:
     uint32_t bitFields;
 public:

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -125,6 +125,8 @@ private struct FUNCFLAG
     bool hasReturnExp;         /// Has return exp; statement
     bool hasInlineAsm;         /// Has asm{} statement
     bool hasMultipleReturnExp; /// Has multiple return exp; statements
+
+    bool hasInferredAttributes; /// If it attempted to infer attributes
 }
 
 /***********************************************************

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1546,6 +1546,8 @@ private void initInferAttributes(FuncDeclaration fd)
 
     // Initialize for inferring STC.scope_
     fd.scopeInprocess = true;
+
+    fd.hasInferredAttributes = true;
 }
 
 /****************************************************

--- a/compiler/test/runnable/test17906.d
+++ b/compiler/test/runnable/test17906.d
@@ -1,0 +1,20 @@
+void foo(bool shouldthrow)
+{
+    if(shouldthrow) {
+        throw new Exception("here");
+    }
+    try {
+        foo(true);
+    }
+    catch(Exception e) {
+        // happy
+    }
+    catch(Throwable t) {
+        assert(0, "should not reach here");
+    }
+}
+
+void main()
+{
+    foo(false);
+}


### PR DESCRIPTION
I think it was introduced in 0be1f3dfa67

when you have a recursive function, it stops trying to see if it throws and thus incorrectly marks it as fallthrough. Then later, in statement semantic you get into this block:

        /* If the try body never throws, we can eliminate any catches
         * of recoverable exceptions. */

and it elides the whole catch block, which leads to bizarre runtime results.

See https://forum.dlang.org/thread/qohwofoqnooswcbgyzja@forum.dlang.org