### PR TITLE
Fix #17906 regression with deleted catch(Exception) block

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3501,26 +3501,6 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             return;
         }
 
-        /* If the try body never throws, we can eliminate any catches
-         * of recoverable exceptions.
-         */
-        if (!(tcs._body.blockExit(sc.func, null) & BE.throw_) && ClassDeclaration.exception)
-        {
-            foreach_reverse (i; 0 .. tcs.catches.length)
-            {
-                Catch c = (*tcs.catches)[i];
-
-                /* If catch exception type is derived from Exception
-                 */
-                if (c.type.toBasetype().implicitConvTo(ClassDeclaration.exception.type) &&
-                    (!c.handler || !c.handler.comeFrom()) && !sc.debug_)
-                {
-                    // Remove c from the array of catches
-                    tcs.catches.remove(i);
-                }
-            }
-        }
-
         if (tcs.catches.length == 0)
         {
             result = tcs._body.hasCode() ? tcs._body : null;

--- a/compiler/test/runnable/test17906.d
+++ b/compiler/test/runnable/test17906.d
@@ -1,0 +1,39 @@
+// plain function
+void foo(bool shouldthrow)
+{
+    if(shouldthrow) {
+        throw new Exception("here");
+    }
+    try {
+        foo(true);
+    }
+    catch(Exception e) {
+        // happy
+    }
+    catch(Throwable t) {
+        assert(0, "should not reach here");
+    }
+}
+
+void main()
+{
+    foo(false);
+    foo2(false);
+}
+
+// inferred attrs function template
+void foo2()(bool shouldthrow)
+{
+    if(shouldthrow) {
+        throw new Exception("here");
+    }
+    try {
+        foo2(true);
+    }
+    catch(Exception e) {
+        // happy
+    }
+    catch(Throwable t) {
+        assert(0, "should not reach here");
+    }
+}


### PR DESCRIPTION
when you have a recursive function, it stops trying to see if it throws and thus incorrectly marks it as fallthrough. Then later, in statement semantic you  had into this block:

        /* If the try body never throws, we can eliminate any catches
         * of recoverable exceptions. */

and it elides the whole catch block, which leads to bizarre runtime results. While the nothrow test on the recursive function is not corrected in this commit, it matters less when we no longer use the wrong data to suppress codegen.

I expect the cost of an unnecessary catch block is much smaller than the cost this bug has caused.

See https://forum.dlang.org/thread/qohwofoqnooswcbgyzja@forum.dlang.org