### PR TITLE
rename WRcodlst to codeListPrint

### DIFF
--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -2346,7 +2346,7 @@ uint codout(int seg, code* c, Barray!ubyte* disasmBuf, ref targ_size_t framehand
  * Debug code to dump code structure.
  */
 
-void WRcodlst(code* c)
+void codeListPrint(code* c)
 {
     for (; c; c = code_next(c))
         code_print(c);

--- a/compiler/src/dmd/backend/cgsched.d
+++ b/compiler/src/dmd/backend/cgsched.d
@@ -163,7 +163,7 @@ public void cgsched_block(block* b)
         scratch &= ~(b.Bregcon.used | b.Bregcon.params | cgstate.mfuncreg);
         scratch &= ~(b.Bregcon.immed.mval | b.Bregcon.cse.mval);
         cgsched_pentium(&b.Bcode,scratch);
-        //printf("after schedule:\n"); WRcodlst(b.Bcode);
+        //printf("after schedule:\n"); code_print_list(b.Bcode);
     }
 }
 

--- a/compiler/src/dmd/backend/x86/cod2.d
+++ b/compiler/src/dmd/backend/x86/cod2.d
@@ -3297,7 +3297,7 @@ void cdind(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
 
      getlvalue(cg,cdb,cs,e,0,RM.load);          // get addressing mode
     //printf("Irex = %02x, Irm = x%02x, Isib = x%02x\n", cs.Irex, cs.Irm, cs.Isib);
-    //fprintf(stderr,"cd2 :\n"); WRcodlst(c);
+    //fprintf(stderr,"cd2 :\n"); codeListPrint(c);
     if (pretregs == 0)
     {
         if (e.Ety & mTYvolatile)               // do the load anyway
@@ -3528,7 +3528,7 @@ void cdind(ref CGstate cg, ref CodeBuilder cdb,elem* e,ref regm_t pretregs)
     L3:
         fixresult(cg,cdb,e,retregs,pretregs);
     }
-    //fprintf(stderr,"cdafter :\n"); WRcodlst(c);
+    //fprintf(stderr,"cdafter :\n"); codeListPrint(c);
 }
 
 

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -8252,7 +8252,7 @@ private void do8bit(ref MiniCodeBuf pbuf, FL fl, ref evc uev)
  * Debug code to dump code structure.
  */
 
-void WRcodlst(code* c)
+void codeListPrint(code* c)
 {
     for (; c; c = code_next(c))
         code_print(c);
@@ -8261,8 +8261,7 @@ void WRcodlst(code* c)
 @trusted
 void code_print(scope code* c)
 {
-    if (cgstate.AArch64)
-        return dmd.backend.arm.cod3.code_print(c);
+    debug assert(!cgstate.AArch64);
 
     ubyte ins;
     ubyte rexb;


### PR DESCRIPTION
Some of the names in the code generator are very old and from a time when compiler memory space was very limited.