### PR TITLE
fix #23065 AA-equality fails compilation with self-referential types

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -69,6 +69,16 @@ private extern (D) struct FlagBitFields
       to prevent perceived false positives for meta-programming heavy code.
     */
     bool knownACompileTimeOnlyContext;
+
+    /**
+    When lowering builtin operations to druntime implementations, some assumptions
+    made by the previous implementations might no longer hold or have to be inferred
+    from the code. With recursive data structures this can easily hit limitations
+    of the semantic analysis. To help with backward compatibility, this flag will
+    cause semantic analysis of function bodies and template instances to be delayed
+    assuming that attribute inference is not necessary.
+    */
+    bool deferSemantic3InCompilerHook;
 }
 
 private extern (D) struct NonFlagBitFields
@@ -259,6 +269,7 @@ extern (C++) struct Scope
         s.previews = this.previews;
         s.lastdc = null;
         s.knownACompileTimeOnlyContext = this.knownACompileTimeOnlyContext;
+        s.deferSemantic3InCompilerHook = this.deferSemantic3InCompilerHook;
         assert(&this != s);
         return s;
     }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -8495,6 +8495,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         assert(t1.ty == Tfunction);
 
+        // semantic on arguments and return type should not be delayed to infer attributes
+        Scope* sc2 = sc;
+        if (sc.deferSemantic3InCompilerHook)
+        {
+            sc = sc.push();
+            sc.deferSemantic3InCompilerHook = false;
+        }
+        scope(exit)
+        {
+            if (sc2 != sc)
+                sc.pop();
+        }
         Expression argprefix;
         if (!exp.arguments)
             exp.arguments = new Expressions();
@@ -14814,14 +14826,20 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         auto arguments = new Expressions(ee.e1, ee.e2);
         auto ce = new CallExp(ee.loc, id, arguments);
+        Expression e = ce;
         if (ee.op == EXP.notEqual)
         {
             auto ne = new NotExp(ee.loc, ce);
             ne.loweredFrom = ee;
-            return ne.expressionSemantic(sc);
+            e = ne;
         }
-        ce.loweredFrom = ee;
-        return ce.expressionSemantic(sc);
+        else
+            ce.loweredFrom = ee;
+        auto sc2 = sc.push();
+        sc2.deferSemantic3InCompilerHook = true;
+        e = e.expressionSemantic(sc2);
+        sc2.pop();
+        return e;
     }
 
     override void visit(EqualExp exp)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7032,6 +7032,8 @@ struct Scope final
     bool ctfeBlock(bool v);
     bool knownACompileTimeOnlyContext() const;
     bool knownACompileTimeOnlyContext(bool v);
+    bool deferSemantic3InCompilerHook() const;
+    bool deferSemantic3InCompilerHook(bool v);
 private:
     uint16_t bitFields;
     uint16_t bitFields2;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1560,6 +1560,15 @@ bool functionSemantic(FuncDeclaration fd)
             return false;
     }
 
+    if (fd.deferred3) // wait until final round of deferred semantic
+        return !fd.errors;
+    if (fd._scope && fd._scope.deferSemantic3InCompilerHook && !fd.errors)
+    {
+        fd._scope.deferSemantic3InCompilerHook = false;
+        addDeferredSemantic3(fd);
+        return !fd.errors;
+    }
+
     // if inferring return type, sematic3 needs to be run
     // - When the function body contains any errors, we cannot assume
     //   the inferred return type is valid.
@@ -1597,7 +1606,7 @@ bool functionSemantic(FuncDeclaration fd)
 public
 bool functionSemantic3(FuncDeclaration fd)
 {
-    if (fd.semanticRun < PASS.semantic3 && fd._scope)
+    if (!fd.deferred3 && fd.semanticRun < PASS.semantic3 && fd._scope)
     {
         /* Forward reference - we need to run semantic3 on this function.
          * If errors are gagged, and it's not part of a template instance,

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -128,6 +128,8 @@ struct Scope final
     bool ctfeBlock(bool v);
     bool knownACompileTimeOnlyContext() const;
     bool knownACompileTimeOnlyContext(bool v);
+    bool deferSemantic3InCompilerHook() const;
+    bool deferSemantic3InCompilerHook(bool v);
 
     UserAttributeDeclaration *userAttribDecl;   // user defined attributes
 

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -74,6 +74,7 @@ import dmd.statement;
 import dmd.target;
 import dmd.targetcompiler;
 import dmd.templateparamsem;
+import dmd.templatesem;
 import dmd.typesem;
 import dmd.visitor;
 
@@ -117,6 +118,12 @@ private extern(C++) final class Semantic3Visitor : Visitor
         if (tempinst.semanticRun >= PASS.semantic3)
             return;
         tempinst.semanticRun = PASS.semantic3;
+        if (tempinst._scope && tempinst._scope.deferSemantic3InCompilerHook)
+        {
+            tempinst._scope.deferSemantic3InCompilerHook = false;
+            templateInstanceSemantic3(tempinst, tempinst._scope, tempinst._scope);
+        }
+
         if (tempinst.errors || !tempinst.members)
             return;
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1210,6 +1210,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
 
     if (sc.isKnownToHaveACompileTimeContext)
         _scope.knownACompileTimeOnlyContext = true;
+    _scope.deferSemantic3InCompilerHook = sc.deferSemantic3InCompilerHook;
 
     // Declare each template parameter as an alias for the argument type
     Scope* paramscope = _scope.push();
@@ -1346,6 +1347,95 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     if (global.errors != errorsave)
         goto Laftersemantic;
 
+    if (sc.deferSemantic3InCompilerHook)
+    {
+        sc2.setNoFree();
+        tempinst._scope = sc2;
+        addDeferredSemantic3(tempinst);
+    }
+    else
+        templateInstanceSemantic3(tempinst, sc, sc2);
+
+    if (tempinst.aliasdecl)
+    {
+        /* https://issues.dlang.org/show_bug.cgi?id=13816
+        * AliasDeclaration tries to resolve forward reference
+        * twice (See inuse check in AliasDeclaration.toAlias()). It's
+        * necessary to resolve mutual references of instantiated symbols, but
+        * it will left a true recursive alias in tuple declaration - an
+        * AliasDeclaration A refers TupleDeclaration B, and B contains A
+        * in its elements.  To correctly make it an error, we strictly need to
+        * resolve the alias of eponymous member.
+        */
+        tempinst.aliasdecl = tempinst.aliasdecl.toAlias2();
+
+        // stop AliasAssign tuple building
+        if (auto td = tempinst.aliasdecl.isTupleDeclaration())
+            td.building = false;
+    }
+
+Laftersemantic:
+    sc2.pop();
+    _scope.pop();
+
+    // Give additional context info if error occurred during instantiation
+    if (global.errors != errorsave)
+    {
+        if (!tempinst.errors)
+        {
+            if (!tempdecl.literal)
+                .error(tempinst.loc, "%s `%s` error instantiating", tempinst.kind, tempinst.toPrettyChars);
+            if (tempinst.tinst)
+                tempinst.tinst.printInstantiationTrace();
+        }
+        tempinst.errors = true;
+        if (tempinst.gagged)
+        {
+            // Errors are gagged, so remove the template instance from the
+            // instance/symbol lists we added it to and reset our state to
+            // finish clean and so we can try to instantiate it again later
+            // (see https://issues.dlang.org/show_bug.cgi?id=4302 and https://issues.dlang.org/show_bug.cgi?id=6602).
+            tempdecl.removeInstance(tempdecl_instance_idx);
+            if (target_symbol_list)
+            {
+                // Because we added 'this' in the last position above, we
+                // should be able to remove it without messing other indices up.
+                assert((*target_symbol_list)[target_symbol_list_idx] == tempinst);
+                target_symbol_list.remove(target_symbol_list_idx);
+                tempinst.memberOf = null;                    // no longer a member
+            }
+            tempinst.semanticRun = PASS.initial;
+            tempinst.inst = null;
+            tempinst.symtab = null;
+        }
+    }
+    else if (errinst)
+    {
+        /* https://issues.dlang.org/show_bug.cgi?id=14541
+        * If the previous gagged instance had failed by
+        * circular references, currrent "error reproduction instantiation"
+        * might succeed, because of the difference of instantiated context.
+        * On such case, the cached error instance needs to be overridden by the
+        * succeeded instance.
+        */
+        //printf("replaceInstance()\n");
+        assert(errinst.errors);
+        auto ti1 = TemplateInstanceBox(errinst);
+        (cast(TemplateInstance[TemplateInstanceBox])tempdecl.instances).remove(ti1);
+
+        auto ti2 = TemplateInstanceBox(tempinst);
+        (*(cast(TemplateInstance[TemplateInstanceBox]*) &tempdecl.instances))[ti2] = tempinst;
+    }
+
+    static if (LOG)
+    {
+        printf("-TemplateInstance.dsymbolSemantic('%s', this=%p)\n", tempinst.toChars(), tempinst);
+    }
+}
+
+void templateInstanceSemantic3(TemplateInstance tempinst, Scope* sc, Scope* sc2)
+{
+    //auto sc = sc2;
     if ((sc.func || sc.fullinst) && !tempinst.tinst)
     {
         /* If a template is instantiated inside function, the whole instantiation
@@ -1458,82 +1548,6 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
                     break;
             }
         }
-    }
-
-    if (tempinst.aliasdecl)
-    {
-        /* https://issues.dlang.org/show_bug.cgi?id=13816
-         * AliasDeclaration tries to resolve forward reference
-         * twice (See inuse check in AliasDeclaration.toAlias()). It's
-         * necessary to resolve mutual references of instantiated symbols, but
-         * it will left a true recursive alias in tuple declaration - an
-         * AliasDeclaration A refers TupleDeclaration B, and B contains A
-         * in its elements.  To correctly make it an error, we strictly need to
-         * resolve the alias of eponymous member.
-         */
-        tempinst.aliasdecl = tempinst.aliasdecl.toAlias2();
-
-        // stop AliasAssign tuple building
-        if (auto td = tempinst.aliasdecl.isTupleDeclaration())
-            td.building = false;
-    }
-
-Laftersemantic:
-    sc2.pop();
-    _scope.pop();
-
-    // Give additional context info if error occurred during instantiation
-    if (global.errors != errorsave)
-    {
-        if (!tempinst.errors)
-        {
-            if (!tempdecl.literal)
-                .error(tempinst.loc, "%s `%s` error instantiating", tempinst.kind, tempinst.toPrettyChars);
-            if (tempinst.tinst)
-                tempinst.tinst.printInstantiationTrace();
-        }
-        tempinst.errors = true;
-        if (tempinst.gagged)
-        {
-            // Errors are gagged, so remove the template instance from the
-            // instance/symbol lists we added it to and reset our state to
-            // finish clean and so we can try to instantiate it again later
-            // (see https://issues.dlang.org/show_bug.cgi?id=4302 and https://issues.dlang.org/show_bug.cgi?id=6602).
-            tempdecl.removeInstance(tempdecl_instance_idx);
-            if (target_symbol_list)
-            {
-                // Because we added 'this' in the last position above, we
-                // should be able to remove it without messing other indices up.
-                assert((*target_symbol_list)[target_symbol_list_idx] == tempinst);
-                target_symbol_list.remove(target_symbol_list_idx);
-                tempinst.memberOf = null;                    // no longer a member
-            }
-            tempinst.semanticRun = PASS.initial;
-            tempinst.inst = null;
-            tempinst.symtab = null;
-        }
-    }
-    else if (errinst)
-    {
-        /* https://issues.dlang.org/show_bug.cgi?id=14541
-         * If the previous gagged instance had failed by
-         * circular references, currrent "error reproduction instantiation"
-         * might succeed, because of the difference of instantiated context.
-         * On such case, the cached error instance needs to be overridden by the
-         * succeeded instance.
-         */
-        //printf("replaceInstance()\n");
-        assert(errinst.errors);
-        auto ti1 = TemplateInstanceBox(errinst);
-        (cast(TemplateInstance[TemplateInstanceBox])tempdecl.instances).remove(ti1);
-
-        auto ti2 = TemplateInstanceBox(tempinst);
-        (*(cast(TemplateInstance[TemplateInstanceBox]*) &tempdecl.instances))[ti2] = tempinst;
-    }
-
-    static if (LOG)
-    {
-        printf("-TemplateInstance.dsymbolSemantic('%s', this=%p)\n", tempinst.toChars(), tempinst);
     }
 }
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1435,7 +1435,6 @@ Laftersemantic:
 
 void templateInstanceSemantic3(TemplateInstance tempinst, Scope* sc, Scope* sc2)
 {
-    //auto sc = sc2;
     if ((sc.func || sc.fullinst) && !tempinst.tinst)
     {
         /* If a template is instantiated inside function, the whole instantiation

--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -458,6 +458,46 @@ void test22556()
     static assert(!__traits(compiles, foo.clear));
 }
 
+// https://github.com/dlang/dmd/issues/23064
+void test23064()
+{
+    static struct A(T)
+    {
+        static assert(is(typeof((T[string]).init == (T[string]).init)),
+                      "is(typeof(...)) is false for " ~ (T[string]).stringof);
+    }
+
+    static struct B { A!B x; }
+}
+
+// https://github.com/dlang/dmd/issues/23065
+void test23065()
+{
+    static struct C(T)
+    {
+        bool opEquals(R)(R rhs)
+            if (is(typeof(T.init == T.init)))
+            {
+                return false;
+            }
+    }
+
+    static struct A(T)
+    {
+        alias _ = C!(T[string]);
+
+        bool opEquals()(A rhs)
+        {
+            T[string] v;
+            return v == v;
+        }
+    }
+
+    static struct B { A!B x; }
+
+    A!B a;
+    a == a;
+}
 /***************************************************/
 
 // https://github.com/dlang/dmd/issues/22567

--- a/druntime/src/core/internal/newaa.d
+++ b/druntime/src/core/internal/newaa.d
@@ -892,12 +892,18 @@ bool _aaEqual(T : AA!(K, V), K, V)(scope T aa1, scope T aa2)
     return true;
 }
 
-/// compares 2 AAs for equality (compiler hook)
-bool _d_aaEqual(K, V)(scope const V[K] a1, scope const V[K] a2)
+private bool impl_aaEqual(K, V)(scope const V[K] a1, scope const V[K] a2) @trusted
 {
     scope aa1 = _toAA!(K, V)(a1);
     scope aa2 = _toAA!(K, V)(a2);
     return _aaEqual(aa1, aa2);
+}
+
+/// compares 2 AAs for equality (compiler hook)
+bool _d_aaEqual(K, V)(scope const V[K] a1, scope const V[K] a2) pure @nogc @safe nothrow
+{
+    enum pure_aaEqual(K, V) = cast(bool function(scope const V[K] a1, scope const V[K] a2) pure @nogc @safe nothrow) &impl_aaEqual!(K, V);
+    return pure_aaEqual!(K, V)(a1, a2);
 }
 
 /// callback from TypeInfo_AssociativeArray.equals (ignore const for now)


### PR DESCRIPTION
fix #23064 .init self-comparison fails for AAs and self-referential struct template

_d_aaEqual breaks the recursive analysis by deferring template and function body analysis.