### PR TITLE
fix #23133 - GC.collect() no longer scans in concurrent threads

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -1336,7 +1336,7 @@ class ConservativeGC : GC
         // when collecting.
         static size_t go(Gcx* gcx) nothrow
         {
-            return gcx.fullcollect(false, true); // standard stop the world
+            return gcx.fullcollect(true, false); // standard stop the world
         }
         immutable result = runLocked!go(gcx);
 
@@ -2208,7 +2208,7 @@ struct Gcx
                 if (!newPool(1, false))
                 {
                     // out of memory => try to free some memory
-                    fullcollect(false, true); // stop the world
+                    fullcollect(true, false); // stop the world
                     if (lowMem)
                         minimize();
                     recoverNextPage(bin);
@@ -2216,7 +2216,7 @@ struct Gcx
             }
             else if (usedSmallPages > 0)
             {
-                fullcollect();
+                fullcollect(false, false);
                 if (lowMem)
                     minimize();
                 recoverNextPage(bin);
@@ -2299,13 +2299,13 @@ struct Gcx
                 {
                     // disabled but out of memory => try to free some memory
                     minimizeAfterNextCollection = true;
-                    fullcollect(false, true);
+                    fullcollect(true, false);
                 }
             }
             else if (usedLargePages > 0)
             {
                 minimizeAfterNextCollection = true;
-                fullcollect();
+                fullcollect(false, false);
             }
             // If alloc didn't yet succeed retry now that we collected/minimized
             if (!pool && !tryAlloc() && !tryAllocNewPool())
@@ -3265,7 +3265,7 @@ struct Gcx
      * Return number of full pages free'd.
      * The collection is done concurrently only if block and isFinal are false.
      */
-    size_t fullcollect(bool block = false, bool isFinal = false) nothrow
+    size_t fullcollect(bool block, bool isFinal) nothrow
     {
         // It is possible that `fullcollect` will be called from a thread which
         // is not yet registered in runtime (because allocating `new Thread` is

--- a/druntime/test/gc/Makefile
+++ b/druntime/test/gc/Makefile
@@ -1,6 +1,6 @@
 TESTS:=attributes sentinel printf memstomp invariant logging \
        precise precisegc \
-       recoverfree nocollect
+       recoverfree collect nocollect
 
 ifneq ($(OS),windows)
     # some .d files are for Posix only

--- a/druntime/test/gc/collect.d
+++ b/druntime/test/gc/collect.d
@@ -1,0 +1,17 @@
+module core.thread.collect; // get access to package core.thread
+
+import core.thread.threadbase;
+import core.memory;
+import core.cpuid;
+
+void main()
+{
+    auto threads = threadsPerCPU();
+    if (threads > 1) // no parallel scanning on single-core CPU
+    {
+        assert(ll_nThreads == 0);
+        auto p = new int[10]; // ensure, the proto-gc gets replaced by the conservative GC
+        GC.collect();
+        assert(ll_nThreads > 0);
+    }
+}


### PR DESCRIPTION
calls to gcx.fullcollect have not been updated in #16401 when removing the first argument.

The woes of default arguments. I have removed them and made calls explicit.