### PR TITLE
Remove `import std.stdio;` from fail_compilation/operator_undefined.d

### DIFF
--- a/compiler/test/fail_compilation/operator_undefined.d
+++ b/compiler/test/fail_compilation/operator_undefined.d
@@ -6,7 +6,7 @@ fail_compilation/operator_undefined.d(11):        perhaps overload the operator 
 ---
 */
 
-import std.stdio;
+
 
 struct Json
 {


### PR DESCRIPTION
Test suite should not use Phobos. This import is unused.

Introduced in https://github.com/dlang/dmd/pull/15620