### PR TITLE
fix #19829 - Appending to keys of an empty associative array "cannot …

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6833,7 +6833,7 @@ private Expression interpret_keys(UnionExp* pue, InterState* istate, Expression 
         return earg;
     if (earg.op == EXP.null_)
     {
-        emplaceExp!(NullExp)(pue, earg.loc, earg.type);
+        emplaceExp!(NullExp)(pue, earg.loc, returnType);
         return pue.exp();
     }
     if (earg.op != EXP.assocArrayLiteral && earg.type.toBasetype().ty != Taarray)
@@ -6856,7 +6856,7 @@ private Expression interpret_values(UnionExp* pue, InterState* istate, Expressio
         return earg;
     if (earg.op == EXP.null_)
     {
-        emplaceExp!(NullExp)(pue, earg.loc, earg.type);
+        emplaceExp!(NullExp)(pue, earg.loc, returnType);
         return pue.exp();
     }
     if (earg.op != EXP.assocArrayLiteral && earg.type.toBasetype().ty != Taarray)

--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -515,6 +515,26 @@ void test22567()
     assert(foo["bar"]["baz"] == "boom");
 }
 
+// https://github.com/dlang/dmd/issues/19829
+void test19829()
+{
+    auto foo() {
+        bool[string] p;
+        return p.keys ~ "bar";
+    }
+    enum a = foo;
+    static assert(a == ["bar"]);
+    assert(foo == ["bar"]);
+
+    auto bar() {
+        bool[string] p;
+        return p.values ~ true;
+    }
+    enum b = bar;
+    static assert(b == [true]);
+    assert(bar == [true]);
+}
+
 /***************************************************/
 
 void main()
@@ -546,4 +566,5 @@ void main()
     testShared();
     test22567();
     test22556();
+    test19829();
 }


### PR DESCRIPTION
…be interpreted at compile time"

bad return type for empty keys and values when interpreting. The latter doesn't result in obvious errors because type.nextOf is as expected.