### PR TITLE
issue #17641 - [AA] inserting into associative array invalidates foreach iteration

### DIFF
--- a/druntime/src/core/internal/newaa.d
+++ b/druntime/src/core/internal/newaa.d
@@ -339,7 +339,7 @@ private:
         firstUsed = 0;
         used -= deleted;
         deleted = 0;
-        obuckets.length = 0; // safe to free b/c impossible to reference, but doesn't really free
+        // must not free obuckets, because it might still be iterated over
     }
 
     void clear() pure nothrow

--- a/druntime/test/aa/src/test_aa.d
+++ b/druntime/test/aa/src/test_aa.d
@@ -46,6 +46,7 @@ void main()
     testNew();
     testAliasThis();
     testAliasThis2();
+    test17641();
 }
 
 void testKeysValues1()
@@ -1082,4 +1083,25 @@ void test22510()
 
     auto aa_cti = testDup!(const(T[int]))();
     static assert(is(typeof(aa_cti) == const(T)[int]));
+}
+
+void test17641() @safe
+{
+    alias BinBlob = int[32];
+    BinBlob rv(int i) @safe { BinBlob r = i; return r; }
+
+    int[BinBlob] myMap;
+    foreach (int i; 1 .. 10)
+        myMap[rv(i)] = i;
+
+    int i = 10;
+    BinBlob[] keys_second_pass;
+    foreach (key, value; myMap) // terminates because it iterates over the initial bucket array only
+    {
+        version (BugFree) { /* Not storing the key does not segv */ }
+        else               keys_second_pass ~= key;
+
+        foreach (int j; 0 .. 100_000)
+            myMap[rv(++i)]=i;
+    }
 }


### PR DESCRIPTION

add test case that failed before the change to templated AA implementation, because it no longer frees the old bucket array when resizing