### PR TITLE
Fix dmd:frontend inline asm linker references

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,6 +35,7 @@ common_steps_template: &COMMON_STEPS_TEMPLATE
       ./ci/run.sh test_dmd
     fi
 
+  test_frontend_subpackage_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_frontend_subpackage
   test_druntime_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_druntime
   test_phobos_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_phobos
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,6 +159,9 @@ jobs:
           arch: ${{ env.MODEL == '64' && 'x64' || 'x86' }}
       - name: Test dmd
         run: ci/run.sh test_dmd
+      - name: Test frontend subpackage
+        if: '!matrix.coverage && (success() || failure()) && (matrix.host_dmd == ''dmd'' || matrix.host_dmd == ''dmd-latest'')'
+        run: ci/run.sh test_frontend_subpackage
       - name: Test druntime
         if: '!matrix.coverage && (success() || failure())'
         run: ci/run.sh test_druntime
@@ -257,6 +260,12 @@ jobs:
             echo '::group::Test dmd'
             ci/run.sh test_dmd
             echo '::endgroup::'
+
+            if [ "$HOST_DMD" = "dmd" ]; then
+              echo '::group::Test frontend subpackage'
+              ci/run.sh test_frontend_subpackage
+              echo '::endgroup::'
+            fi
 
             echo '::group::Test druntime'
             ci/run.sh test_druntime

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -172,7 +172,7 @@ test_dub_package() {
         echo "Skipping DUB examples on GDC."
     else
         local abs_build_path="$PWD/$build_path"
-        pushd test/dub_package
+        pushd compiler/test/dub_package
         for file in *.d ; do
             dubcmd=""
             # running impvisitor is failing right now
@@ -186,8 +186,21 @@ test_dub_package() {
         done
         popd
         # Test rdmd build
-        "${build_path}/dmd" -version=NoBackend -version=GC -version=NoMain -Jgenerated/dub -Jsrc/dmd/res -Isrc -i -run test/dub_package/frontend.d
+        "${build_path}/dmd" -version=NoBackend -version=GC -version=NoMain -Jgenerated/dub -Jcompiler/src/dmd/res -Icompiler/src -i -run compiler/test/dub_package/frontend.d
     fi
+    if [ "$OS_NAME" != "windows" ]; then
+        deactivate
+    fi
+}
+
+# test that the dmd:frontend subpackage links correctly (no backend symbols pulled in)
+test_frontend_subpackage() {
+    if [ "$OS_NAME" != "windows" ]; then
+        source ~/dlang/*/activate # activate host compiler
+    fi
+    local abs_build_path="$PWD/$build_path"
+    dub --single compiler/test/dub_package/frontend_subpackage.d
+    DFLAGS="-m${MODEL:-64} -de" dub --single --compiler="${abs_build_path}/dmd" compiler/test/dub_package/frontend_subpackage.d
     if [ "$OS_NAME" != "windows" ]; then
         deactivate
     fi
@@ -297,6 +310,7 @@ if [ "$#" -gt 0 ]; then
     test_druntime) test_druntime ;;
     test_phobos) test_phobos ;;
     test_dub_package) test_dub_package ;;
+    test_frontend_subpackage) test_frontend_subpackage ;;
     testsuite) testsuite ;;
     codecov) codecov ;;
     *) echo "Unknown command: $1" >&2; exit 1 ;;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3455,8 +3455,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     {
         if (dsym.semanticRun >= PASS.semanticdone)
             return;
-        import dmd.iasm : asmSemantic;
-        asmSemantic(dsym, sc);
+        version (NoBackend) {}
+        else
+        {
+            import dmd.iasm : asmSemantic;
+            asmSemantic(dsym, sc);
+        }
         dsym.semanticRun = PASS.semanticdone;
     }
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -42,7 +42,6 @@ import dmd.func;
 import dmd.funcsem;
 import dmd.globals;
 import dmd.hdrgen;
-import dmd.iasm;
 import dmd.id;
 import dmd.identifier;
 import dmd.importc;
@@ -3751,7 +3750,13 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
          */
 
         //printf("AsmStatement()::semantic()\n");
-        result = asmSemantic(s, sc);
+        version (NoBackend)
+            result = s;
+        else
+        {
+            import dmd.iasm;
+            result = asmSemantic(s, sc);
+        }
     }
 
     void visitCompoundAsm(CompoundAsmStatement cas)

--- a/compiler/test/dub_package/frontend_file.d
+++ b/compiler/test/dub_package/frontend_file.d
@@ -63,7 +63,7 @@ double average(int[] array)
 }
 }.replace("SIZE_T", size_t.sizeof == 8 ? "ulong" : "uint");
 
-    assert(generated.canFind(expected));
+    assert(generated.canFind(expected), generated);
 }
 
 /**

--- a/compiler/test/dub_package/frontend_subpackage.d
+++ b/compiler/test/dub_package/frontend_subpackage.d
@@ -1,0 +1,14 @@
+#!/usr/bin/env dub
+/+dub.sdl:
+dependency "dmd:frontend" path="../../.."
++/
+
+// Verify that dmd:frontend links without requiring backend symbols.
+// Regression test for https://github.com/dlang/dmd/issues/23119
+
+import dmd.frontend;
+
+void main()
+{
+    initDMD();
+}

--- a/dub.sdl
+++ b/dub.sdl
@@ -34,6 +34,7 @@ subPackage {
   sourcePaths
 
   sourceFiles \
+    "compiler/src/dmd/astenums.d" \
     "compiler/src/dmd/console.d" \
     "compiler/src/dmd/entity.d" \
     "compiler/src/dmd/errors.d" \
@@ -101,6 +102,7 @@ subPackage {
   excludedSourceFiles "compiler/src/dmd/lib/*"
   excludedSourceFiles "compiler/src/dmd/irgen/*"
   excludedSourceFiles "compiler/src/dmd/{\
+    astenums,\
     astbase,\
     console,\
     entity,\


### PR DESCRIPTION
## Summary
- avoid linking dmd:frontend against dmd.iasm backend symbols under version(NoBackend)
- add a dub single-file regression test for dmd:frontend linking

Fixes #23119