### PR TITLE
backend: remove C++ fields from param_t

### DIFF
--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -44,8 +44,6 @@ else
 enum IDMAX = 900;              // identifier max (excluding terminating 0)
 enum IDOHD = 4+1+int.sizeof*3; // max amount of overhead to ID added by
 
-struct token_t;
-
 alias Funcsym = Symbol;
 
 alias symlist_t = list_t;
@@ -492,10 +490,6 @@ struct func_t
     elem* Fbaseinit;            // list of member initializers (meminit_t)
                                 // this field has meaning only for
                                 // functions which are constructors
-    token_t* Fbody;             // if deferred parse, this is the list
-                                // of tokens that make up the function
-                                // body
-                                // also used if SCfunctempl, SCftexpspec
     uint Fsequence;             // sequence number at point of definition
     Symbol* Ftempl;         // if Finstance this is the template that generated it
     Funcsym* Falias;            // SCfuncalias: function Symbol referenced
@@ -885,29 +879,11 @@ const(char)* prettyident(const Symbol* s) { return &s.Sident[0]; }
  * Function parameters:
  *      Pident          identifier of parameter
  *      Ptype           type of argument
- *      Pelem           default value for argument
  *      Psym            symbol corresponding to Pident when using the
  *                      parameter list as a symbol table
- * For template-parameter-list:
- *      Pident          identifier of parameter
- *      Ptype           if NULL, this is a type-parameter
- *                      else the type for a parameter-declaration value argument
- *      Pelem           default value for value argument
- *      Pdeftype        default value for type-parameter
- *      Pptpl           template-parameter-list for template-template-parameter
- *      Psym            default value for template-template-parameter
- * For template-arg-list: (actual arguments)
- *      Pident          NULL
- *      Ptype           type-name
- *      Pelem           expression (either Ptype or Pelem is NULL)
- *      Psym            SCtemplate for template-template-argument
  */
 
 alias pflags_t = uint;
-enum
-{
-    PFexplicit = 1,       // this template argument was explicit, i.e. in < >
-}
 
 /************************
  * Params:
@@ -930,33 +906,19 @@ nothrow:
 
     char* Pident;               // identifier
     type* Ptype;                // type of parameter (NULL if not known yet)
-    elem* Pelem;                // default value
-    token_t* PelemToken;        // tokens making up default elem
-    type* Pdeftype;             // Ptype==NULL: default type for type-argument
-    param_t* Pptpl;             // template-parameter-list for template-template-parameter
-    Symbol* Psym;
     param_t* Pnext;             // next in list
-    pflags_t Pflags;
 
-    param_t* createTal(param_t* p) // create template-argument-list blank from
-                                // template-parameter-list
-    { return param_t_createTal(&this, p); }
+    // number of parameters in list
+    uint length() { return param_t_length(&this); }
 
-    param_t* search(char* id) return // look for Pident matching id
-    { return param_t_search(&this, id); }
+    // print this param_t
+    void print() { param_t_print(&this); }
 
-    uint length()               // number of parameters in list
-    { return param_t_length(&this); }
-
-    void print()                // print this param_t
-    { param_t_print(&this); }
-
-    void print_list()           // print this list of param_t's
-    { param_t_print_list(&this); }
+    // print this list of param_t's
+    void print_list() { param_t_print_list(&this); }
 }
 
-import dmd.backend.dtype : param_t_print, param_t_print_list, param_t_length, param_t_createTal,
-    param_t_search, param_t_searchn;
+import dmd.backend.dtype : param_t_print, param_t_print_list, param_t_length;
 
 void param_debug(const param_t* p)
 {

--- a/compiler/src/dmd/backend/dtype.d
+++ b/compiler/src/dmd/backend/dtype.d
@@ -735,7 +735,6 @@ type* type_copy(type* t)
                         {
                             pn.Pident = cast(char*)mem_strdup(p.Pident);
                         }
-                        assert(!p.Pelem);
                     }
                 }
                 else if (tn.Tkey && typtr(tn.Tty))
@@ -861,58 +860,6 @@ type* type_setdependent(type* t)
     return t;
 }
 
-/************************************
- * Determine if type t is a dependent type.
- */
-
-@trusted
-int type_isdependent(type* t)
-{
-    Symbol* stempl;
-
-    //printf("type_isdependent(%p)\n", t);
-    //type_print(t);
-    type* tstart = t;
-    for (; t; t = t.Tnext)
-    {
-        type_debug(t);
-        if (t.Tflags & TF.dependent)
-            goto Lisdependent;
-        if (tyfunc(t.Tty) ||
-            tybasic(t.Tty) == TYtemplate
-           )
-        {
-            for (param_t* p = t.Tparamtypes; p; p = p.Pnext)
-            {
-                if (p.Ptype && type_isdependent(p.Ptype))
-                    goto Lisdependent;
-                if (p.Pelem && el_isdependent(p.Pelem))
-                    goto Lisdependent;
-            }
-        }
-        else if (type_struct(t) &&
-                 (stempl = t.Ttag.Sstruct.Stempsym) != null)
-        {
-            for (param_t* p = t.Ttag.Sstruct.Sarglist; p; p = p.Pnext)
-            {
-                if (p.Ptype && type_isdependent(p.Ptype))
-                    goto Lisdependent;
-                if (p.Pelem && el_isdependent(p.Pelem))
-                    goto Lisdependent;
-            }
-        }
-    }
-    //printf("\tis not dependent\n");
-    return 0;
-
-Lisdependent:
-    //printf("\tis dependent\n");
-    // Dependence on a dependent type makes this type dependent as well
-    tstart.Tflags |= TF.dependent;
-    return 1;
-}
-
-
 /*******************************
  * Recursively check if type u is embedded in type t.
  * Returns:
@@ -1003,14 +950,12 @@ void type_print(const type* t)
                 {   printf("\nTP%d (%p): ",i++,p);
                     fflush(stdout);
 
-                    printf("Pident=%p,Ptype=%p,Pelem=%p,Pnext=%p ",p.Pident,p.Ptype,p.Pelem,p.Pnext);
+                    printf("Pident=%p,Ptype=%p,Pnext=%p ",p.Pident,p.Ptype,p.Pnext);
                     param_debug(p);
                     if (p.Pident)
                         printf("'%s' ", p.Pident);
                     if (p.Ptype)
                         type_print(p.Ptype);
-                    if (p.Pelem)
-                        elem_print(p.Pelem);
                 }
             }
             break;
@@ -1023,7 +968,7 @@ void type_print(const type* t)
                 {   printf("\nP%d (%p): ",i++,p);
                     fflush(stdout);
 
-                    printf("Pident=%p,Ptype=%p,Pelem=%p,Pnext=%p ",p.Pident,p.Ptype,p.Pelem,p.Pnext);
+                    printf("Pident=%p,Ptype=%p,Pnext=%p ",p.Pident,p.Ptype,p.Pnext);
                     param_debug(p);
                     if (p.Pident)
                         printf("'%s' ", p.Pident);
@@ -1043,31 +988,13 @@ void type_print(const type* t)
 @trusted
 void param_t_print(const scope param_t* p)
 {
-    printf("Pident=%p,Ptype=%p,Pelem=%p,Psym=%p,Pnext=%p\n",p.Pident,p.Ptype,p.Pelem,p.Psym,p.Pnext);
+    printf("Pident=%p,Ptype=%p,Pnext=%p\n",p.Pident,p.Ptype,p.Pnext);
     if (p.Pident)
         printf("\tPident = '%s'\n", p.Pident);
     if (p.Ptype)
     {
         printf("\tPtype =\n");
         type_print(p.Ptype);
-    }
-    if (p.Pelem)
-    {
-        printf("\tPelem =\n");
-        elem_print(p.Pelem);
-    }
-    if (p.Pdeftype)
-    {
-        printf("\tPdeftype =\n");
-        type_print(p.Pdeftype);
-    }
-    if (p.Psym)
-    {
-        printf("\tPsym = '%s'\n", p.Psym.Sident.ptr);
-    }
-    if (p.Pptpl)
-    {
-        printf("\tPptpl = %p\n", p.Pptpl);
     }
 }
 
@@ -1150,10 +1077,6 @@ void param_free(param_t** pparamlst)
         pn = p.Pnext;
         type_free(p.Ptype);
         mem_free(p.Pident);
-        el_free(p.Pelem);
-        type_free(p.Pdeftype);
-        if (p.Pptpl)
-            param_free(&p.Pptpl);
 
         debug p.id = 0;
 
@@ -1175,49 +1098,6 @@ uint param_t_length(scope param_t* p)
     return nparams;
 }
 
-/*************************************
- * Create template-argument-list blank from
- * template-parameter-list
- * Input:
- *      ptali   initial template-argument-list
- */
-
-@trusted
-param_t* param_t_createTal(scope param_t* p, param_t* ptali)
-{
-    param_t* ptal = null;
-    param_t** pp = &ptal;
-
-    for (; p; p = p.Pnext)
-    {
-        *pp = param_calloc();
-        if (p.Pident)
-        {
-            // Should find a way to just point rather than dup
-            (*pp).Pident = cast(char*)mem_strdup(p.Pident);
-        }
-        if (ptali)
-        {
-            if (ptali.Ptype)
-            {
-                (*pp).Ptype = ptali.Ptype;
-                (*pp).Ptype.Tcount++;
-            }
-            if (ptali.Pelem)
-            {
-                elem* e = el_copytree(ptali.Pelem);
-                (*pp).Pelem = e;
-            }
-            (*pp).Psym = ptali.Psym;
-            (*pp).Pflags = ptali.Pflags;
-            assert(!ptali.Pptpl);
-            ptali = ptali.Pnext;
-        }
-        pp = &(*pp).Pnext;
-    }
-    return ptal;
-}
-
 /**********************************
  * Look for Pident matching id
  */
@@ -1231,49 +1111,6 @@ param_t* param_t_search(return scope param_t* p, const(char)* id)
             break;
     }
     return p;
-}
-
-/**********************************
- * Look for Pident matching id
- */
-
-@trusted
-int param_t_searchn(param_t* p, char* id)
-{
-    int n = 0;
-    for (; p; p = p.Pnext)
-    {
-        if (p.Pident && strcmp(p.Pident, id) == 0)
-            return n;
-        n++;
-    }
-    return -1;
-}
-
-/*************************************
- * Search for member, create symbol as needed.
- * Used for symbol tables for VLA's such as:
- *      void func(int n, int a[n]);
- */
-
-@trusted
-Symbol* param_search(const(char)* name, param_t** pp)
-{
-    Symbol* s = null;
-    param_t* p = (*pp).search(cast(char*)name);
-    if (p)
-    {
-        s = p.Psym;
-        if (!s)
-        {
-            s = symbol_calloc(p.Pident[0 .. strlen(p.Pident)]);
-            s.Sclass = SC.parameter;
-            s.Stype = p.Ptype;
-            s.Stype.Tcount++;
-            p.Psym = s;
-        }
-    }
-    return s;
 }
 
 // Return TRUE if type lists match.

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -2314,34 +2314,6 @@ targ_real el_toreal(elem* e)
 }
 }
 
-/********************************
- * Is elem type-dependent or value-dependent?
- * Returns: true if so
- */
-
-@trusted
-bool el_isdependent(elem* e)
-{
-    if (type_isdependent(e.ET))
-        return true;
-    while (1)
-    {
-        if (e.PEFflags & PEFdependent)
-            return true;
-        if (OTunary(e.Eoper))
-            e = e.E1;
-        else if (OTbinary(e.Eoper))
-        {
-            if (el_isdependent(e.E2))
-                return true;
-            e = e.E1;
-        }
-        else
-            break;
-    }
-    return false;
-}
-
 /****************************************
  * Returns: alignment size of elem e
  */

--- a/compiler/src/dmd/backend/type.d
+++ b/compiler/src/dmd/backend/type.d
@@ -116,10 +116,10 @@ bool variadic(const type* t) { return (t.Tflags & (TF.prototype | TF.fixed)) == 
 public import dmd.backend.var : chartype;
 
 public import dmd.backend.dtype : type_print, type_free, type_init, type_term, type_copy,
-    type_setdim, type_setdependent, type_isdependent, type_size, type_alignsize, type_zeroSize,
+    type_setdim, type_setdependent, type_size, type_alignsize, type_zeroSize,
     type_parameterSize, type_paramsize, type_alloc, type_allocn, type_fake, type_setty,
     type_settype, type_setmangle, type_setcv, type_embed, type_isvla, param_calloc,
-    param_append_type, param_free_l, param_free, param_search, typematch, type_pointer,
+    param_append_type, param_free_l, param_free, typematch, type_pointer,
     type_dyn_array, type_static_array, type_assoc_array, type_delegate, type_function,
     type_enum, type_struct_class, tstypes, tsptr2types, tslogical, tsclib, tsdlib,
     tspvoid, tspcvoid, tsptrdiff, tssize, tstrace;


### PR DESCRIPTION
Similar to https://github.com/dlang/dmd/pull/23152

Default arguments are done in the frontend, and references to C++ source tokens / templates are obviously dead as well.