### PR TITLE
Fix arm backend for CI test

### DIFF
--- a/compiler/src/dmd/backend/arm/cod2.d
+++ b/compiler/src/dmd/backend/arm/cod2.d
@@ -2228,7 +2228,7 @@ static if (0)
             goto L4;
 
         case FL.extern_:
-            if (config.exe & EX_posix)
+            if (config.exe & EX_posix && (e.Vsym.ty() & mTYthread))
             {
                 if (log) printf("posix extern threaded\n");
                 regm_t scratch = INSTR.ALLREGS & ~mask(reg);

--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -2329,7 +2329,7 @@ uint codout(int seg, code* c, Barray!ubyte* disasmBuf, ref targ_size_t framehand
                 case SC.inline:
                     ggen.flush();
                     ggen.gen32(op);
-                    objmod.reftoident(ggen.seg,ggen.offset,s,op,flags);
+                    objmod.reftoident(ggen.seg,ggen.offset,s,c.IEV1.Voffset,flags);
                     break;
 
                 default:

--- a/compiler/src/dmd/backend/x86/cgcod.d
+++ b/compiler/src/dmd/backend/x86/cgcod.d
@@ -658,7 +658,7 @@ void prolog(ref CGstate cg, ref CodeBuilder cdb)
         !(config.exe == EX_WIN32) && !(funcsym_p.Sfunc.Fflags3 & Fnothrow) ||
         cg.accessedTLS ||
         sv64 ||
-        (0 && cg.calledafunc && cg.AArch64)
+        (cg.calledafunc && cg.AArch64)
        )
     {
         //printf("0 prolog() needframe %d alwaysframe %d\n", cg.needframe, config.flags & CFGalwaysframe);


### PR DESCRIPTION
Split off from https://github.com/dlang/dmd/pull/23155

Claude made these code changes to make -marm64 work.

- Emit a frame to prevent an endless loop in main.
- Fix wrong passing of s.op instead of addend to relocation.
- Only emit thread local addressing when extern symbol requires it.