### PR TITLE
Remove TLS globals in tools/paths.d

### DIFF
--- a/compiler/test/tools/paths.d
+++ b/compiler/test/tools/paths.d
@@ -40,47 +40,36 @@ alias testPath = path => compilerRootDir.buildPath("test", path);
 
 string build()
 {
-    static string build;
-    return build = build ? build : environment.get("BUILD", "release");
+    return environment.get("BUILD", "release");
 }
 
 string buildOutputPath()
 {
-    static string buildOutputPath;
-    return buildOutputPath ? buildOutputPath : (buildOutputPath = generatedDir.buildPath(os, build, dmdModel));
+    return generatedDir.buildPath(os, build, dmdModel);
 }
 
 // auto-tester might run the test suite with a different $(MODEL) than DMD
 // has been compiled with. Hence we manually check which binary exists.
 string dmdModel()
 {
-    static string dmdModel;
-
-    if (dmdModel)
-        return dmdModel;
-
     const prefix = generatedDir.buildPath(os, build);
-    return dmdModel = environment.get("DMD_MODEL",
+    return environment.get("DMD_MODEL",
         prefix.buildPath("64", dmdFilename).exists ? "64" : "32");
 }
 
 string model()
 {
-    static string model;
-    return model ? model : (model = environment.get("MODEL", dmdModel));
+    return environment.get("MODEL", dmdModel);
 }
 
 string dmdPath()
 {
-    static string dmdPath;
-    return  dmdPath ? dmdPath : (dmdPath = buildOutputPath.buildPath(dmdFilename));
+    return buildOutputPath.buildPath(dmdFilename);
 }
 
 string resultsDir()
 {
-    static string resultsDir;
-    enum def = testPath("test_results");
-    return resultsDir ? resultsDir : (resultsDir = environment.get("RESULTS_DIR", def));
+    return environment.get("RESULTS_DIR", testPath("test_results"));
 }
 
 /// Returns: a path to 'target' relative to `base` using POSIX file separators


### PR DESCRIPTION
Ubuntu x86 CI test log from https://github.com/dlang/dmd/actions/runs/26224573290/job/77168143545
```
 ... dshell/arm_cross.d
==============================
Test 'dshell/arm_cross.d' failed. The logged output:
[COMPILE_TEST] /home/runner/work/dmd/dmd/generated/linux/release/32/dmd '-conf=' '-m32' -od/home/runner/work/dmd/dmd/compiler/test/test_results/dshell/arm_cross -of/home/runner/work/dmd/dmd/compiler/test/test_results/dshell/arm_cross/run '-I=/home/runner/work/dmd/dmd/compiler/test/dshell' '-I=/home/runner/work/dmd/dmd/compiler/test/test_results/dshell/arm_cross' '-I=/home/runner/work/dmd/dmd/compiler/test/tools/dshell_prebuilt' -i '-i=-dshell_prebuilt' /home/runner/work/dmd/dmd/compiler/test/test_results/dshell_prebuilt.o /home/runner/work/dmd/dmd/compiler/test/dshell/arm_cross.d
/usr/bin/ld: /home/runner/work/dmd/dmd/compiler/test/test_results/dshell/arm_cross/run.o: warning: relocation in read-only section `.text._D5tools5paths__T15__lambda_L39_C1TAyaZQwFNaNbNfQnZQq[_D5tools5paths__T15__lambda_L39_C1TAyaZQwFNaNbNfQnZQq]'
/usr/bin/ld: /home/runner/work/dmd/dmd/compiler/test/test_results/dshell/arm_cross/run.o: TLS transition from R_386_TLS_IE to R_386_TLS_LE_32 against `_D5tools5paths5buildFZQiAya' at 0x10 in section `.text._D5tools5paths5buildFZAya[_D5tools5paths5buildFZAya]' failed
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
Error: linker exited with status 1
       cc /home/runner/work/dmd/dmd/compiler/test/test_results/dshell_prebuilt.o /home/runner/work/dmd/dmd/compiler/test/test_results/dshell/arm_cross/run.o -o /home/runner/work/dmd/dmd/compiler/test/test_results/dshell/arm_cross/run -m32 -Xlinker -rpath=/home/runner/work/dmd/dmd/compiler/test/../../../phobos/generated/linux/release/32 -L/home/runner/work/dmd/dmd/compiler/test/../../../phobos/generated/linux/release/32 -lphobos2 -lpthread -lm -lrt -ldl 
==============================
```

Looks like a DMD x86 32-bit TLS codegen bug.