### PR TITLE
Fix #23166 Set sc3.minst to root module

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1861,8 +1861,10 @@ void semanticRTInfo(AggregateDeclaration ad)
     Scope* sc3 = ti.tempdecl._scope.startCTFE();
     sc3.tinst = sc.tinst;
     // Use the root module so nested RTInfoImpl instances get codegen'd.
-    // rtInfoScope may come from a non-root ImportC module with null minst,
-    // which would otherwise mark RTInfoImpl as speculative. See issue #23166.
+    // rtInfoScope comes from a non-root ImportC module whose minst is that
+    // module itself (see scopeCreateGlobal), so needsCodegen() would skip
+    // RTInfoImpl even though TypeInfo references it at link time.
+    // See issue #23166.
     sc3.minst = sc._module.importedFrom;
     if (ad.isDeprecated())
         sc3.stc |= STC.deprecated_;

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1861,10 +1861,10 @@ void semanticRTInfo(AggregateDeclaration ad)
     Scope* sc3 = ti.tempdecl._scope.startCTFE();
     sc3.tinst = sc.tinst;
     // Use the root module so nested RTInfoImpl instances get codegen'd.
-    // rtInfoScope comes from a non-root ImportC module whose minst is that
+    // If rtInfoScope comes from a non-root ImportC module whose minst is that
     // module itself (see scopeCreateGlobal), so needsCodegen() would skip
     // RTInfoImpl even though TypeInfo references it at link time.
-    // See issue #23166.
+    // See https://github.com/dlang/dmd/issues/23166.
     sc3.minst = sc._module.importedFrom;
     if (ad.isDeprecated())
         sc3.stc |= STC.deprecated_;

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1860,7 +1860,10 @@ void semanticRTInfo(AggregateDeclaration ad)
     auto sc = ad.rtInfoScope;
     Scope* sc3 = ti.tempdecl._scope.startCTFE();
     sc3.tinst = sc.tinst;
-    sc3.minst = sc.minst;
+    // Use the root module so nested RTInfoImpl instances get codegen'd.
+    // rtInfoScope may come from a non-root ImportC module with null minst,
+    // which would otherwise mark RTInfoImpl as speculative. See issue #23166.
+    sc3.minst = sc._module.importedFrom;
     if (ad.isDeprecated())
         sc3.stc |= STC.deprecated_;
 

--- a/compiler/test/runnable/imports/imp23166.c
+++ b/compiler/test/runnable/imports/imp23166.c
@@ -1,0 +1,13 @@
+// Minified from <aws/s3/s3_client.h>
+
+struct MyFoo {
+};
+
+typedef struct MyFoo *(MyFuncPtr)(struct MyFoo *allocator);
+
+struct BrokenStruct {
+    const struct MyFoo *network_interface_names_array;
+    int num_network_interface_names;
+    MyFuncPtr *buffer_pool_factory_fn;
+    void *buffer_pool_user_data;
+};

--- a/compiler/test/runnable/test23166.d
+++ b/compiler/test/runnable/test23166.d
@@ -1,0 +1,9 @@
+// https://github.com/dlang/dmd/issues/23166
+
+import imports.imp23166;
+
+void main()
+{
+    auto s = new BrokenStruct();
+    assert(s !is null);
+}


### PR DESCRIPTION
This is related to #23166. `RTInfoImpl!([32, 9])` is not emitted when codegen, because it is categerized in c module. 
And reordering the field may change  `RTInfoImpl!([32, 9])` to `RTInfoImpl!([32, 10])`, which accidently is defined in phobos. 