### PR TITLE
Refactor globals/ErrorSinkCompiler so sarif / other sinks can extend it cleanly

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1598,7 +1598,7 @@ const(char)* getMessage(DeprecatedDeclaration dd)
 
 bool checkDeprecated(Dsymbol d, Loc loc, Scope* sc)
 {
-    if (global.params.useDeprecated == DiagnosticReporting.off)
+    if (global.errorSink.useDeprecated == DiagnosticReporting.off)
         return false;
     if (!d.isDeprecated())
         return false;
@@ -1929,7 +1929,7 @@ Expression resolveAliasThis(Scope* sc, Expression e, bool gag = false, bool find
  */
 private bool checkDeprecatedAliasThis(AliasThis at, Loc loc, Scope* sc)
 {
-    if (global.params.useDeprecated != DiagnosticReporting.off
+    if (global.errorSink.useDeprecated != DiagnosticReporting.off
         && at.isDeprecated() && !sc.isDeprecated())
     {
         const(char)* message = null;

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -952,8 +952,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             // Set error here as we don't want it to depend on the number of
             // entries that are being printed.
             if (cl == Classification.error ||
-                (cl == Classification.warning && global.params.useWarnings == DiagnosticReporting.error) ||
-                (cl == Classification.deprecation && global.params.useDeprecated == DiagnosticReporting.error))
+                (cl == Classification.warning && global.errorSink.useWarnings == DiagnosticReporting.error) ||
+                (cl == Classification.deprecation && global.errorSink.useDeprecated == DiagnosticReporting.error))
                 cur.errors = true;
 
             // If two instantiations use the same declaration, they are recursive.

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -528,7 +528,7 @@ public:
             }
         }
 
-        if (global.params.useWarnings != DiagnosticReporting.off || canFix)
+        if (global.errorSink.useWarnings != DiagnosticReporting.off || canFix)
         {
             // Warn about identifiers that are keywords in C++.
             if (auto kc = keywordClass(ident, cppStdRevision))

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -38,6 +38,19 @@ nothrow:
  */
 class ErrorSinkCompiler : ErrorSink
 {
+    /// Maximum number of errors/deprecations to display before calling $(D fatal).
+    /// 0 means unlimited.
+    uint errorLimit = 20;
+
+    /// how compiler warnings are handled
+    DiagnosticReporting useWarnings = DiagnosticReporting.off;
+
+    /// how use of deprecated features are handled
+    DiagnosticReporting useDeprecated = DiagnosticReporting.inform;
+
+    /// print gagged errors anyway
+    bool showGaggedErrors;
+
   nothrow:
   extern (C++):
 
@@ -89,15 +102,15 @@ class ErrorSinkCompiler : ErrorSink
         if (!global.gag)
         {
             emit(loc, format, ap, ErrorKind.error, false, false);
-            if (global.params.v.errorLimit && global.errors >= global.params.v.errorLimit)
+            if (errorLimit && global.errors >= errorLimit)
             {
-                fprintf(stderr, "error limit (%d) reached, use `-verrors=0` to show all\n", global.params.v.errorLimit);
+                fprintf(stderr, "error limit (%d) reached, use `-verrors=0` to show all\n", errorLimit);
                 fatal(); // moderate blizzard of cascading messages
             }
         }
         else
         {
-            if (global.params.v.showGaggedErrors)
+            if (showGaggedErrors)
                 emit(loc, format, ap, ErrorKind.error, false, true);
             global.gaggedErrors++;
         }
@@ -105,19 +118,19 @@ class ErrorSinkCompiler : ErrorSink
 
     final void vwarning(const SourceLoc loc, const(char)* format, va_list ap)
     {
-        if (global.params.useWarnings == DiagnosticReporting.off || global.gag)
+        if (useWarnings == DiagnosticReporting.off || global.gag)
             return;
         emit(loc, format, ap, ErrorKind.warning, false, false);
-        if (global.params.useWarnings == DiagnosticReporting.error)
+        if (useWarnings == DiagnosticReporting.error)
             global.warnings++;
     }
 
     final void vdeprecation(const SourceLoc loc, const(char)* format, va_list ap)
     {
-        if (global.params.useDeprecated == DiagnosticReporting.off)
+        if (useDeprecated == DiagnosticReporting.off)
             return;
 
-        if (global.params.useDeprecated == DiagnosticReporting.error)
+        if (useDeprecated == DiagnosticReporting.error)
         {
             // `-de`: gate like an error (count, limit, fatal) but keep the
             // "Deprecation:" header so messages remain distinguishable.
@@ -125,15 +138,15 @@ class ErrorSinkCompiler : ErrorSink
             if (!global.gag)
             {
                 emit(loc, format, ap, ErrorKind.deprecation, false, false);
-                if (global.params.v.errorLimit && global.errors >= global.params.v.errorLimit)
+                if (errorLimit && global.errors >= errorLimit)
                 {
-                    fprintf(stderr, "error limit (%d) reached, use `-verrors=0` to show all\n", global.params.v.errorLimit);
+                    fprintf(stderr, "error limit (%d) reached, use `-verrors=0` to show all\n", errorLimit);
                     fatal();
                 }
             }
             else
             {
-                if (global.params.v.showGaggedErrors)
+                if (showGaggedErrors)
                     emit(loc, format, ap, ErrorKind.deprecation, false, true);
                 global.gaggedErrors++;
             }
@@ -146,7 +159,7 @@ class ErrorSinkCompiler : ErrorSink
             return;
         }
         global.deprecations++;
-        if (global.params.v.errorLimit == 0 || global.deprecations <= global.params.v.errorLimit)
+        if (errorLimit == 0 || global.deprecations <= errorLimit)
             emit(loc, format, ap, ErrorKind.deprecation, false, false);
     }
 
@@ -166,7 +179,7 @@ class ErrorSinkCompiler : ErrorSink
     {
         if (global.gag)
         {
-            if (!global.params.v.showGaggedErrors)
+            if (!showGaggedErrors)
                 return;
             emit(loc, format, ap, ErrorKind.error, true, true);
         }
@@ -176,19 +189,19 @@ class ErrorSinkCompiler : ErrorSink
 
     final void vwarningSupplemental(const SourceLoc loc, const(char)* format, va_list ap)
     {
-        if (global.params.useWarnings != DiagnosticReporting.off && !global.gag)
+        if (useWarnings != DiagnosticReporting.off && !global.gag)
             emit(loc, format, ap, ErrorKind.warning, true, false);
     }
 
     final void vdeprecationSupplemental(const SourceLoc loc, const(char)* format, va_list ap)
     {
-        if (global.params.useDeprecated == DiagnosticReporting.error)
+        if (useDeprecated == DiagnosticReporting.error)
         {
             // Same gating as a primary -de deprecation, but keep the
             // "Deprecation:" header on the supplemental too.
             if (global.gag)
             {
-                if (!global.params.v.showGaggedErrors)
+                if (!showGaggedErrors)
                     return;
                 emit(loc, format, ap, ErrorKind.deprecation, true, true);
             }
@@ -196,9 +209,9 @@ class ErrorSinkCompiler : ErrorSink
                 emit(loc, format, ap, ErrorKind.deprecation, true, false);
             return;
         }
-        if (global.params.useDeprecated == DiagnosticReporting.inform && !global.gag)
+        if (useDeprecated == DiagnosticReporting.inform && !global.gag)
         {
-            if (global.params.v.errorLimit == 0 || global.deprecations <= global.params.v.errorLimit)
+            if (errorLimit == 0 || global.deprecations <= errorLimit)
                 emit(loc, format, ap, ErrorKind.deprecation, true, false);
         }
     }
@@ -627,7 +640,7 @@ private void printDiagnostic(const(char)* format, va_list ap, ref DiagnosticCont
             return;
     }
 
-    if (global.params.v.showGaggedErrors && global.gag)
+    if (global.errorSink.showGaggedErrors && global.gag)
         fprintf(stderr, "(spec:%d) ", global.gag);
     auto con = cast(Console) global.console;
 

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -26,87 +26,231 @@ import dmd.root.string;
 import dmd.console;
 import dmd.console : Color;
 import dmd.root.filename;
-import dmd.sarif;
 
 nothrow:
 
-/// Constants used to discriminate kinds of error messages.
-enum ErrorKind
-{
-    warning,
-    deprecation,
-    error,
-    tip,
-    message,
-}
-
-/********************************
- * Represents a diagnostic message generated during compilation, such as errors,
- * warnings, or other messages.
- */
-struct Diagnostic
-{
-    SourceLoc loc; // The location in the source code where the diagnostic was generated (includes file, line, and column).
-    string message; // The text of the diagnostic message, describing the issue.
-    ErrorKind kind; // The type of diagnostic, indicating whether it is an error, warning, deprecation, etc.
-}
-
-__gshared Diagnostic[] diagnostics = [];
-
 /***************************
  * Error message sink for D compiler.
+ *
+ * Owns the gating logic (gag handling, error limit, warning/deprecation modes)
+ * and delegates the actual output to the virtual $(D emit) method, which
+ * subclasses such as $(D dmd.sarif.ErrorSinkSarif) override to change format.
  */
 class ErrorSinkCompiler : ErrorSink
 {
   nothrow:
   extern (C++):
-  override:
 
-    void verror(Loc loc, const(char)* format, va_list ap)
+    // Overrides of the abstract ErrorSink methods convert Loc to SourceLoc
+    // and dispatch to the SourceLoc-taking overload that holds the gating body.
+
+    override void verror(Loc loc, const(char)* format, va_list ap)
     {
-        vreportDiagnostic(loc, format, ap, ErrorKind.error);
+        verror(loc.SourceLoc, format, ap);
     }
 
-    void verrorSupplemental(Loc loc, const(char)* format, va_list ap)
+    override void verrorSupplemental(Loc loc, const(char)* format, va_list ap)
     {
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.error);
+        verrorSupplemental(loc.SourceLoc, format, ap);
     }
 
-    void vwarning(Loc loc, const(char)* format, va_list ap)
+    override void vwarning(Loc loc, const(char)* format, va_list ap)
     {
-        vreportDiagnostic(loc, format, ap, ErrorKind.warning);
+        vwarning(loc.SourceLoc, format, ap);
     }
 
-    void vwarningSupplemental(Loc loc, const(char)* format, va_list ap)
+    override void vwarningSupplemental(Loc loc, const(char)* format, va_list ap)
     {
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.warning);
+        vwarningSupplemental(loc.SourceLoc, format, ap);
     }
 
-    void vdeprecation(Loc loc, const(char)* format, va_list ap)
+    override void vdeprecation(Loc loc, const(char)* format, va_list ap)
     {
-        vreportDiagnostic(loc, format, ap, ErrorKind.deprecation);
+        vdeprecation(loc.SourceLoc, format, ap);
     }
 
-    void vdeprecationSupplemental(Loc loc, const(char)* format, va_list ap)
+    override void vdeprecationSupplemental(Loc loc, const(char)* format, va_list ap)
     {
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.deprecation);
+        vdeprecationSupplemental(loc.SourceLoc, format, ap);
     }
 
-    void vmessage(Loc loc, const(char)* format, va_list ap)
+    override void vmessage(Loc loc, const(char)* format, va_list ap)
     {
-        vreportDiagnostic(loc, format, ap, ErrorKind.message);
+        vmessage(loc.SourceLoc, format, ap);
     }
 
-    void plugSink()
+    // SourceLoc-taking entry points used directly by `error(filename,linnum,...)`,
+    // `errorBackend`, `tip()` and supplemental sites; also called by the Loc
+    // overloads above.
+
+    final void verror(const SourceLoc loc, const(char)* format, va_list ap)
     {
-        // Exit if there are no collected diagnostics
-        if (!diagnostics.length) return;
+        global.errors++;
+        if (!global.gag)
+        {
+            emit(loc, format, ap, ErrorKind.error, false, false);
+            if (global.params.v.errorLimit && global.errors >= global.params.v.errorLimit)
+            {
+                fprintf(stderr, "error limit (%d) reached, use `-verrors=0` to show all\n", global.params.v.errorLimit);
+                fatal(); // moderate blizzard of cascading messages
+            }
+        }
+        else
+        {
+            if (global.params.v.showGaggedErrors)
+                emit(loc, format, ap, ErrorKind.error, false, true);
+            global.gaggedErrors++;
+        }
+    }
 
-        // Generate the SARIF report with the current diagnostics
-        generateSarifReport(false);
+    final void vwarning(const SourceLoc loc, const(char)* format, va_list ap)
+    {
+        if (global.params.useWarnings == DiagnosticReporting.off || global.gag)
+            return;
+        emit(loc, format, ap, ErrorKind.warning, false, false);
+        if (global.params.useWarnings == DiagnosticReporting.error)
+            global.warnings++;
+    }
 
-        // Clear diagnostics after generating the report
-        diagnostics.length = 0;
+    final void vdeprecation(const SourceLoc loc, const(char)* format, va_list ap)
+    {
+        if (global.params.useDeprecated == DiagnosticReporting.off)
+            return;
+
+        if (global.params.useDeprecated == DiagnosticReporting.error)
+        {
+            // `-de`: gate like an error (count, limit, fatal) but keep the
+            // "Deprecation:" header so messages remain distinguishable.
+            global.errors++;
+            if (!global.gag)
+            {
+                emit(loc, format, ap, ErrorKind.deprecation, false, false);
+                if (global.params.v.errorLimit && global.errors >= global.params.v.errorLimit)
+                {
+                    fprintf(stderr, "error limit (%d) reached, use `-verrors=0` to show all\n", global.params.v.errorLimit);
+                    fatal();
+                }
+            }
+            else
+            {
+                if (global.params.v.showGaggedErrors)
+                    emit(loc, format, ap, ErrorKind.deprecation, false, true);
+                global.gaggedErrors++;
+            }
+            return;
+        }
+
+        if (global.gag)
+        {
+            global.gaggedDeprecations++;
+            return;
+        }
+        global.deprecations++;
+        if (global.params.v.errorLimit == 0 || global.deprecations <= global.params.v.errorLimit)
+            emit(loc, format, ap, ErrorKind.deprecation, false, false);
+    }
+
+    final void vmessage(const SourceLoc loc, const(char)* format, va_list ap)
+    {
+        emit(loc, format, ap, ErrorKind.message, false, false);
+    }
+
+    final void vtip(const(char)* format, va_list ap)
+    {
+        if (global.gag)
+            return;
+        emit(SourceLoc.init, format, ap, ErrorKind.tip, false, false);
+    }
+
+    final void verrorSupplemental(const SourceLoc loc, const(char)* format, va_list ap)
+    {
+        if (global.gag)
+        {
+            if (!global.params.v.showGaggedErrors)
+                return;
+            emit(loc, format, ap, ErrorKind.error, true, true);
+        }
+        else
+            emit(loc, format, ap, ErrorKind.error, true, false);
+    }
+
+    final void vwarningSupplemental(const SourceLoc loc, const(char)* format, va_list ap)
+    {
+        if (global.params.useWarnings != DiagnosticReporting.off && !global.gag)
+            emit(loc, format, ap, ErrorKind.warning, true, false);
+    }
+
+    final void vdeprecationSupplemental(const SourceLoc loc, const(char)* format, va_list ap)
+    {
+        if (global.params.useDeprecated == DiagnosticReporting.error)
+        {
+            // Same gating as a primary -de deprecation, but keep the
+            // "Deprecation:" header on the supplemental too.
+            if (global.gag)
+            {
+                if (!global.params.v.showGaggedErrors)
+                    return;
+                emit(loc, format, ap, ErrorKind.deprecation, true, true);
+            }
+            else
+                emit(loc, format, ap, ErrorKind.deprecation, true, false);
+            return;
+        }
+        if (global.params.useDeprecated == DiagnosticReporting.inform && !global.gag)
+        {
+            if (global.params.v.errorLimit == 0 || global.deprecations <= global.params.v.errorLimit)
+                emit(loc, format, ap, ErrorKind.deprecation, true, false);
+        }
+    }
+
+    /**
+     * Format and write a single diagnostic that has already passed the gating
+     * checks. Default implementation prints coloured text to stderr (or stdout
+     * for plain messages); $(D dmd.sarif.ErrorSinkSarif) overrides this to
+     * write SARIF JSON instead.
+     *
+     * Params:
+     *      loc          = location of the diagnostic
+     *      format       = printf-style format string
+     *      ap           = arguments for `format`
+     *      kind         = error / warning / deprecation / tip / message
+     *      supplemental = follow-on note, not a primary diagnostic
+     *      gagged       = diagnostic occurred under speculative gagging
+     */
+    void emit(const SourceLoc loc, const(char)* format, va_list ap,
+        ErrorKind kind, bool supplemental, bool gagged)
+    {
+        if (kind == ErrorKind.message && !supplemental)
+        {
+            OutBuffer tmp;
+            writeSourceLoc(tmp, loc, Loc.showColumns, Loc.messageStyle);
+            if (tmp.length)
+                fprintf(stdout, "%s: ", tmp.extractChars());
+            tmp.reset();
+            tmp.vprintf(format, ap);
+            fputs(tmp.peekChars(), stdout);
+            fputc('\n', stdout);
+            fflush(stdout); // ensure it gets written out in case of compiler aborts
+            return;
+        }
+
+        DiagnosticContext info = DiagnosticContext(loc, kind, null, null);
+        info.supplemental = supplemental;
+        info.headerColor = gagged ? Classification.gagged : classificationFor(kind);
+        printDiagnostic(format, ap, info);
+    }
+}
+
+/// Map an `ErrorKind` to the color used for its header in stderr output.
+private Classification classificationFor(ErrorKind kind) @safe @nogc pure nothrow
+{
+    final switch (kind)
+    {
+        case ErrorKind.error:       return Classification.error;
+        case ErrorKind.warning:     return Classification.warning;
+        case ErrorKind.deprecation: return Classification.deprecation;
+        case ErrorKind.tip:         return Classification.tip;
+        case ErrorKind.message:     return Classification.error; // unused (handled above)
     }
 }
 
@@ -173,7 +317,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.error);
+        global.errorSink.verror(loc, format, ap);
         va_end(ap);
     }
 else
@@ -181,7 +325,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.error);
+        global.errorSink.verror(loc, format, ap);
         va_end(ap);
     }
 
@@ -200,7 +344,7 @@ static if (__VERSION__ < 2092)
         const loc = SourceLoc(filename.toDString, linnum, charnum);
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.error);
+        global.errorSink.verror(loc, format, ap);
         va_end(ap);
     }
 else
@@ -209,7 +353,7 @@ else
         const loc = SourceLoc(filename.toDString, linnum, charnum);
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.error);
+        global.errorSink.verror(loc, format, ap);
         va_end(ap);
     }
 
@@ -219,7 +363,7 @@ extern(C++) void errorBackend(const(char)* filename, uint linnum, uint charnum, 
     const loc = SourceLoc(filename.toDString, linnum, charnum);
     va_list ap;
     va_start(ap, format);
-    vreportDiagnostic(loc, format, ap, ErrorKind.error);
+    global.errorSink.verror(loc, format, ap);
     va_end(ap);
 }
 
@@ -236,7 +380,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.error);
+        global.errorSink.verrorSupplemental(loc, format, ap);
         va_end(ap);
     }
 else
@@ -244,7 +388,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.error);
+        global.errorSink.verrorSupplemental(loc, format, ap);
         va_end(ap);
     }
 
@@ -260,7 +404,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.warning);
+        global.errorSink.vwarning(loc, format, ap);
         va_end(ap);
     }
 else
@@ -268,7 +412,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.warning);
+        global.errorSink.vwarning(loc, format, ap);
         va_end(ap);
     }
 
@@ -285,7 +429,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.warning);
+        global.errorSink.vwarningSupplemental(loc, format, ap);
         va_end(ap);
     }
 else
@@ -293,7 +437,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.warning);
+        global.errorSink.vwarningSupplemental(loc, format, ap);
         va_end(ap);
     }
 
@@ -310,7 +454,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.deprecation);
+        global.errorSink.vdeprecation(loc, format, ap);
         va_end(ap);
     }
 else
@@ -318,7 +462,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.deprecation);
+        global.errorSink.vdeprecation(loc, format, ap);
         va_end(ap);
     }
 
@@ -335,7 +479,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.deprecation);
+        global.errorSink.vdeprecationSupplemental(loc, format, ap);
         va_end(ap);
     }
 else
@@ -343,7 +487,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vsupplementalDiagnostic(loc, format, ap, ErrorKind.deprecation);
+        global.errorSink.vdeprecationSupplemental(loc, format, ap);
         va_end(ap);
     }
 
@@ -360,7 +504,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.message);
+        global.errorSink.vmessage(loc, format, ap);
         va_end(ap);
     }
 else
@@ -368,7 +512,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(loc, format, ap, ErrorKind.message);
+        global.errorSink.vmessage(loc, format, ap);
         va_end(ap);
     }
 
@@ -383,7 +527,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(Loc.initial, format, ap, ErrorKind.message);
+        global.errorSink.vmessage(Loc.initial, format, ap);
         va_end(ap);
     }
 else
@@ -391,7 +535,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(Loc.initial, format, ap, ErrorKind.message);
+        global.errorSink.vmessage(Loc.initial, format, ap);
         va_end(ap);
     }
 
@@ -420,7 +564,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(Loc.initial, format, ap, ErrorKind.tip);
+        global.errorSink.vtip(format, ap);
         va_end(ap);
     }
 else
@@ -428,7 +572,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vreportDiagnostic(Loc.initial, format, ap, ErrorKind.tip);
+        global.errorSink.vtip(format, ap);
         va_end(ap);
     }
 
@@ -450,197 +594,6 @@ private struct DiagnosticContext
     const(char)* p2;            // additional message prefix
     const ErrorKind kind;       // kind of error being printed
     bool supplemental;          // true if supplemental error
-}
-
-/**
- * Implements $(D error), $(D warning), $(D deprecation), $(D message), and
- * $(D tip). Report a diagnostic error, taking a va_list parameter, and
- * optionally additional message prefixes. Whether the message gets printed
- * depends on runtime values of DiagnosticReporting and global gagging.
- * Params:
- *      loc         = location of error
- *      format      = printf-style format specification
- *      ap          = printf-style variadic arguments
- *      kind        = kind of error being printed
- *      p1          = additional message prefix
- *      p2          = additional message prefix
- */
-private extern(C++) void vreportDiagnostic(Loc loc, const(char)* format, va_list ap, ErrorKind kind, const(char)* p1 = null, const(char)* p2 = null)
-{
-    return vreportDiagnostic(loc.SourceLoc, format, ap, kind, p1, p2);
-}
-
-/// ditto
-private extern(C++) void vreportDiagnostic(const SourceLoc loc, const(char)* format, va_list ap, ErrorKind kind, const(char)* p1 = null, const(char)* p2 = null)
-{
-    auto info = DiagnosticContext(loc, kind, p1, p2);
-
-    final switch (info.kind)
-    {
-    case ErrorKind.error:
-        global.errors++;
-        if (!global.gag)
-        {
-            info.headerColor = Classification.error;
-            if (global.params.v.messageStyle == MessageStyle.sarif)
-            {
-                addSarifDiagnostic(loc, format, ap, kind);
-                return;
-            }
-            printDiagnostic(format, ap, info);
-            if (global.params.v.errorLimit && global.errors >= global.params.v.errorLimit)
-            {
-                fprintf(stderr, "error limit (%d) reached, use `-verrors=0` to show all\n", global.params.v.errorLimit);
-                fatal(); // moderate blizzard of cascading messages
-            }
-        }
-        else
-        {
-            if (global.params.v.showGaggedErrors)
-            {
-                info.headerColor = Classification.gagged;
-                printDiagnostic(format, ap, info);
-            }
-            global.gaggedErrors++;
-        }
-        return;
-
-    case ErrorKind.deprecation:
-        if (global.params.useDeprecated == DiagnosticReporting.error)
-            goto case ErrorKind.error;
-        else if (global.params.useDeprecated == DiagnosticReporting.inform)
-        {
-            if (!global.gag)
-            {
-                global.deprecations++;
-                if (global.params.v.errorLimit == 0 || global.deprecations <= global.params.v.errorLimit)
-                {
-                    info.headerColor = Classification.deprecation;
-                    if (global.params.v.messageStyle == MessageStyle.sarif)
-                    {
-                        addSarifDiagnostic(loc, format, ap, kind);
-                        return;
-                    }
-                    printDiagnostic(format, ap, info);
-                }
-            }
-            else
-            {
-                global.gaggedDeprecations++;
-            }
-        }
-        return;
-
-    case ErrorKind.warning:
-        if (global.params.useWarnings != DiagnosticReporting.off)
-        {
-            if (!global.gag)
-            {
-                info.headerColor = Classification.warning;
-                if (global.params.v.messageStyle == MessageStyle.sarif)
-                {
-                    addSarifDiagnostic(loc, format, ap, kind);
-                    return;
-                }
-                printDiagnostic(format, ap, info);
-                if (global.params.useWarnings == DiagnosticReporting.error)
-                    global.warnings++;
-            }
-        }
-        return;
-
-    case ErrorKind.tip:
-        if (!global.gag)
-        {
-            info.headerColor = Classification.tip;
-            if (global.params.v.messageStyle == MessageStyle.sarif)
-            {
-                addSarifDiagnostic(loc, format, ap, kind);
-                return;
-            }
-            printDiagnostic(format, ap, info);
-        }
-        return;
-
-    case ErrorKind.message:
-        OutBuffer tmp;
-        writeSourceLoc(tmp, info.loc, Loc.showColumns, Loc.messageStyle);
-        if (tmp.length)
-            fprintf(stdout, "%s: ", tmp.extractChars());
-
-        tmp.reset();
-        tmp.vprintf(format, ap);
-        fputs(tmp.peekChars(), stdout);
-        fputc('\n', stdout);
-        fflush(stdout);     // ensure it gets written out in case of compiler aborts
-        if (global.params.v.messageStyle == MessageStyle.sarif)
-        {
-            addSarifDiagnostic(loc, format, ap, kind);
-            return;
-        }
-        return;
-    }
-}
-
-/**
- * Implements $(D errorSupplemental), $(D warningSupplemental), and
- * $(D deprecationSupplemental). Report an addition diagnostic error, taking a
- * va_list parameter. Whether the message gets printed depends on runtime
- * values of DiagnosticReporting and global gagging.
- * Params:
- *      loc         = location of error
- *      format      = printf-style format specification
- *      ap          = printf-style variadic arguments
- *      kind        = kind of error being printed
- */
-private extern(C++) void vsupplementalDiagnostic(Loc loc, const(char)* format, va_list ap, ErrorKind kind)
-{
-    return vsupplementalDiagnostic(loc.SourceLoc, format, ap, kind);
-}
-
-/// ditto
-private extern(C++) void vsupplementalDiagnostic(const SourceLoc loc, const(char)* format, va_list ap, ErrorKind kind)
-{
-    auto info = DiagnosticContext(loc, kind);
-    info.supplemental = true;
-    switch (info.kind)
-    {
-    case ErrorKind.error:
-        if (global.gag)
-        {
-            if (!global.params.v.showGaggedErrors)
-                return;
-            info.headerColor = Classification.gagged;
-        }
-        else
-            info.headerColor = Classification.error;
-        printDiagnostic(format, ap, info);
-        return;
-
-    case ErrorKind.deprecation:
-        if (global.params.useDeprecated == DiagnosticReporting.error)
-            goto case ErrorKind.error;
-        else if (global.params.useDeprecated == DiagnosticReporting.inform && !global.gag)
-        {
-            if (global.params.v.errorLimit == 0 || global.deprecations <= global.params.v.errorLimit)
-            {
-                info.headerColor = Classification.deprecation;
-                printDiagnostic(format, ap, info);
-            }
-        }
-        return;
-
-    case ErrorKind.warning:
-        if (global.params.useWarnings != DiagnosticReporting.off && !global.gag)
-        {
-            info.headerColor = Classification.warning;
-            printDiagnostic(format, ap, info);
-        }
-        return;
-
-    default:
-        assert(false, "internal error: unhandled kind in error report");
-    }
 }
 
 /**

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -15,6 +15,16 @@ import core.stdc.stdarg;
 
 import dmd.location;
 
+/// Constants used to discriminate kinds of error messages.
+enum ErrorKind
+{
+    warning,
+    deprecation,
+    error,
+    tip,
+    message,
+}
+
 /***************************************
  * Where error/warning/deprecation messages go.
  */

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9199,7 +9199,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             // current scope is itself deprecated, or deprecations are not errors
             const bool deprecationAllowed = sc.isDeprecated
-                || global.params.useDeprecated != DiagnosticReporting.error;
+                || global.errorSink.useDeprecated != DiagnosticReporting.error;
             const bool preventAliasThis = e.targ.hasDeprecatedAliasThis && !deprecationAllowed;
 
             if (preventAliasThis && e.targ.ty == Tstruct)

--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -183,7 +183,6 @@ void deinitializeDMD()
     import dmd.mtype : Type;
     import dmd.objc : Objc;
     import dmd.target : target;
-    import dmd.errors : diagnostics;
     import dmd.dfa.fast.structure : DFAAllocator;
 
     diagnosticHandler = null;
@@ -201,8 +200,6 @@ void deinitializeDMD()
     Dsymbol.deinitialize();
     EscapeState.reset();
     DFAAllocator.deinitialize();
-
-    diagnostics.length = 0;
 }
 
 /**

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -328,6 +328,7 @@ class ImportStatement;
 struct Token;
 struct Param;
 class FileManager;
+class ErrorSinkCompiler;
 class Object;
 class TypeInfo_Class;
 class TypeInfo;
@@ -5956,13 +5957,6 @@ enum class ErrorPrintMode : uint8_t
     printErrorContext = 1u,
 };
 
-enum class DiagnosticReporting : uint8_t
-{
-    error = 0u,
-    inform = 1u,
-    off = 2u,
-};
-
 enum class CppStdRevision : uint32_t
 {
     cpp98 = 199711u,
@@ -8058,7 +8052,6 @@ struct Verbose final
     bool field;
     bool complex;
     bool vin;
-    bool showGaggedErrors;
     bool logo;
     bool color;
     bool cov;
@@ -8077,7 +8070,6 @@ struct Verbose final
         field(),
         complex(true),
         vin(),
-        showGaggedErrors(),
         logo(),
         color(),
         cov(),
@@ -8086,7 +8078,7 @@ struct Verbose final
         errorSupplementLimit(6u)
     {
     }
-    Verbose(bool verbose, bool showColumns = false, bool tls = false, bool templates = false, bool templatesListInstances = false, bool gc = false, bool field = false, bool complex = true, bool vin = false, bool showGaggedErrors = false, bool logo = false, bool color = false, bool cov = false, ErrorPrintMode errorPrintMode = (ErrorPrintMode)0u, MessageStyle messageStyle = (MessageStyle)0u, uint32_t errorLimit = 20u, uint32_t errorSupplementLimit = 6u) :
+    Verbose(bool verbose, bool showColumns = false, bool tls = false, bool templates = false, bool templatesListInstances = false, bool gc = false, bool field = false, bool complex = true, bool vin = false, bool logo = false, bool color = false, bool cov = false, ErrorPrintMode errorPrintMode = (ErrorPrintMode)0u, MessageStyle messageStyle = (MessageStyle)0u, uint32_t errorLimit = 20u, uint32_t errorSupplementLimit = 6u) :
         verbose(verbose),
         showColumns(showColumns),
         tls(tls),
@@ -8096,7 +8088,6 @@ struct Verbose final
         field(field),
         complex(complex),
         vin(vin),
-        showGaggedErrors(showGaggedErrors),
         logo(logo),
         color(color),
         cov(cov),
@@ -8130,12 +8121,10 @@ struct Param final
     bool trace;
     bool tracegc;
     bool vcg_ast;
-    DiagnosticReporting useDeprecated;
     bool useUnitTests;
     bool useInline;
     bool release;
     bool preservePaths;
-    DiagnosticReporting useWarnings;
     bool cov;
     uint8_t covPercent;
     bool ctfe_cov;
@@ -8223,12 +8212,10 @@ struct Param final
         trace(),
         tracegc(),
         vcg_ast(),
-        useDeprecated((DiagnosticReporting)1u),
         useUnitTests(),
         useInline(false),
         release(),
         preservePaths(),
-        useWarnings((DiagnosticReporting)2u),
         cov(),
         covPercent(),
         ctfe_cov(false),
@@ -8300,19 +8287,17 @@ struct Param final
         timeTraceFile()
     {
     }
-    Param(bool obj, bool readStdin = false, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting useWarnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = true, bool nothrowOptimizations = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), Edition edition = (Edition)2023u, void* editionFiles = nullptr, FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState safer = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, bool useFastDFA = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useNullCheck = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<ImportPathInfo > imppath = Array<ImportPathInfo >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), bool debugEnabled = false, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool fullyQualifiedObjectFiles = false, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
+    Param(bool obj, bool readStdin = false, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = true, bool nothrowOptimizations = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), Edition edition = (Edition)2023u, void* editionFiles = nullptr, FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState safer = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, bool useFastDFA = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useNullCheck = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<ImportPathInfo > imppath = Array<ImportPathInfo >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), bool debugEnabled = false, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool fullyQualifiedObjectFiles = false, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
         obj(obj),
         readStdin(readStdin),
         multiobj(multiobj),
         trace(trace),
         tracegc(tracegc),
         vcg_ast(vcg_ast),
-        useDeprecated(useDeprecated),
         useUnitTests(useUnitTests),
         useInline(useInline),
         release(release),
         preservePaths(preservePaths),
-        useWarnings(useWarnings),
         cov(cov),
         covPercent(covPercent),
         ctfe_cov(ctfe_cov),
@@ -8420,7 +8405,7 @@ struct Global final
     FileManager* fileManager;
     enum : int32_t { recursionLimit = 500 };
 
-    ErrorSink* errorSink;
+    ErrorSinkCompiler* errorSink;
     ErrorSink* errorSinkNull;
     DArray<uint8_t >(*preprocess)(FileName , Loc , OutBuffer& );
     uint32_t startGagging();
@@ -8456,7 +8441,7 @@ struct Global final
         preprocess()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2026 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<ImportPathInfo > path = Array<ImportPathInfo >(), Array<const char* > importPaths = Array<const char* >(), Array<const char* > filePath = Array<const char* >(), CompileEnv compileEnv = CompileEnv(), Param params = Param(), uint32_t errors = 0u, uint32_t deprecations = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedDeprecations = 0u, void* console = nullptr, Array<Identifier* > versionids = Array<Identifier* >(), Array<Identifier* > debugids = Array<Identifier* >(), bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, ErrorSink* errorSink = nullptr, ErrorSink* errorSinkNull = nullptr, DArray<uint8_t >(*preprocess)(FileName , Loc , OutBuffer& ) = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2026 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<ImportPathInfo > path = Array<ImportPathInfo >(), Array<const char* > importPaths = Array<const char* >(), Array<const char* > filePath = Array<const char* >(), CompileEnv compileEnv = CompileEnv(), Param params = Param(), uint32_t errors = 0u, uint32_t deprecations = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedDeprecations = 0u, void* console = nullptr, Array<Identifier* > versionids = Array<Identifier* >(), Array<Identifier* > debugids = Array<Identifier* >(), bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, ErrorSinkCompiler* errorSink = nullptr, ErrorSink* errorSinkNull = nullptr, DArray<uint8_t >(*preprocess)(FileName , Loc , OutBuffer& ) = nullptr) :
         inifilename(inifilename),
         copyright(copyright),
         written(written),

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2059,7 +2059,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
             }
 
 
-            if (!global.gag || global.params.v.showGaggedErrors)
+            if (!global.gag || global.errorSink.showGaggedErrors)
                 printCandidates(loc, td, sc.isDeprecated());
             return null;
         }
@@ -2078,7 +2078,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
             od.ident.toErrMsg(), tiargsBuf.peekChars(), fargsBuf.peekChars());
 
         checkNamedArgErrorAndReportOverload(od, argumentList, loc);
-        if (!global.gag || global.params.v.showGaggedErrors)
+        if (!global.gag || global.errorSink.showGaggedErrors)
             printCandidates(loc, od, sc.isDeprecated());
         return null;
     }
@@ -2119,7 +2119,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
                 .error(loc, "none of the overloads of `%s` are callable using a %sobject with argument types `(%s)`",
                     fd.toErrMsg(), thisBuf.peekChars(), buf.peekChars());
 
-            if (!global.gag || global.params.v.showGaggedErrors)
+            if (!global.gag || global.errorSink.showGaggedErrors)
                 printCandidates(loc, fd, sc.isDeprecated());
             return null;
         }
@@ -2157,7 +2157,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
     {
         .error(loc, "none of the overloads of `%s` are callable using argument types `%s`",
                fd.toErrMsg(), fargsBuf.peekChars());
-        if (!global.gag || global.params.v.showGaggedErrors)
+        if (!global.gag || global.errorSink.showGaggedErrors)
             printCandidates(loc, fd, sc.isDeprecated());
         return null;
     }
@@ -2166,7 +2166,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
            fd.kind(), fd.toPrettyChars(), parametersTypeToChars(tf.parameterList),
            tf.modToChars(), fargsBuf.peekChars());
 
-    if (global.gag && !global.params.v.showGaggedErrors)
+    if (global.gag && !global.errorSink.showGaggedErrors)
         return null;
 
     // re-resolve to check for supplemental message

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -130,7 +130,6 @@ extern(C++) struct Verbose
     bool field;             // identify non-mutable field variables
     bool complex = true;    // identify complex/imaginary type usage
     bool vin;               // identify 'in' parameters
-    bool showGaggedErrors;  // print gagged errors anyway
     bool logo;              // print compiler logo
     bool color;             // use ANSI colors in console output
     bool cov;               // generate code coverage data
@@ -163,12 +162,10 @@ extern (C++) struct Param
     bool trace;             // insert profiling hooks
     bool tracegc;           // instrument calls to 'new'
     bool vcg_ast;           // write-out codegen-ast
-    DiagnosticReporting useDeprecated = DiagnosticReporting.inform;  // how use of deprecated features are handled
     bool useUnitTests;          // generate unittest code
     bool useInline = false;     // inline expand functions
     bool release;           // build release version
     bool preservePaths;     // true means don't strip path from source file
-    DiagnosticReporting useWarnings = DiagnosticReporting.off;  // how compiler warnings are handled
     bool cov;               // generate code coverage data
     ubyte covPercent;       // 0..100 code coverage percentage required
     bool ctfe_cov = false;  // generate coverage data for ctfe

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -333,8 +333,8 @@ extern (C++) struct Global
 
     enum recursionLimit = 500; /// number of recursive template expansions before abort
 
-    ErrorSink errorSink;       /// where the error messages go
-    ErrorSink errorSinkNull;   /// where the error messages are ignored
+    ErrorSinkCompiler errorSink;  /// where the error messages go
+    ErrorSink errorSinkNull;      /// where the error messages are ignored
 
     extern (C++) DArray!ubyte function(FileName, Loc, ref OutBuffer) preprocess;
 

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -2165,7 +2165,7 @@ private bool canInline(FuncDeclaration fd, bool hasThis, bool statementsToo, PAS
 
 Lno:
     if (fd.inlining == PINLINE.always && pass == PASS.inlinePragma &&
-        global.params.useWarnings == DiagnosticReporting.inform)
+        global.errorSink.useWarnings == DiagnosticReporting.inform)
     {
         eSink.warning(fd.loc, "cannot inline function `%s`", fd.toPrettyChars());
     }

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -192,10 +192,16 @@ private int tryMain(const(char)[][] argv, out Param params)
 
     if (global.params.v.messageStyle == MessageStyle.sarif)
     {
+        // Hand off the settings the CLI wrote into the original sink so the
+        // SARIF sink shares the same gating decisions.
         auto sarif = new ErrorSinkSarif();
+        sarif.useDeprecated = global.errorSink.useDeprecated;
+        sarif.useWarnings = global.errorSink.useWarnings;
+        sarif.showGaggedErrors = global.errorSink.showGaggedErrors;
         global.errorSink = sarif;
         eSink = sarif;
     }
+    global.errorSink.errorLimit = global.params.v.errorLimit;
 
     global.compileEnv.previewIn        = params.previewIn;
     global.compileEnv.transitionIn     = params.v.vin;
@@ -709,7 +715,7 @@ private int tryMain(const(char)[][] argv, out Param params)
     if (global.warnings)
         errorOnWarning();
 
-    if (global.params.useDeprecated == DiagnosticReporting.inform)
+    if (global.errorSink.useDeprecated == DiagnosticReporting.inform)
         mentionOmittedDeprecations();
 
     // Do not attempt to generate output files if errors or warnings occurred

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -183,17 +183,19 @@ private int tryMain(const(char)[][] argv, out Param params)
         // If we are here then compilation has ended
         // gracefully as opposed to with `fatal`
         global.plugErrorSinks();
-
-        if (global.errors == 0 && global.params.v.messageStyle == MessageStyle.sarif)
-        {
-            generateSarifReport(true);
-        }
     }
 
     target.setTargetBuildDefaults();
 
     if (parseCommandlineAndConfig(argv, params, files, eSink))
         return EXIT_FAILURE;
+
+    if (global.params.v.messageStyle == MessageStyle.sarif)
+    {
+        auto sarif = new ErrorSinkSarif();
+        global.errorSink = sarif;
+        eSink = sarif;
+    }
 
     global.compileEnv.previewIn        = params.previewIn;
     global.compileEnv.transitionIn     = params.v.vin;

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -694,11 +694,11 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, out Param 
             }
         }
         else if (arg == "-de")               // https://dlang.org/dmd.html#switch-de
-            params.useDeprecated = DiagnosticReporting.error;
+            global.errorSink.useDeprecated = DiagnosticReporting.error;
         else if (arg == "-d")                // https://dlang.org/dmd.html#switch-d
-            params.useDeprecated = DiagnosticReporting.off;
+            global.errorSink.useDeprecated = DiagnosticReporting.off;
         else if (arg == "-dw")               // https://dlang.org/dmd.html#switch-dw
-            params.useDeprecated = DiagnosticReporting.inform;
+            global.errorSink.useDeprecated = DiagnosticReporting.inform;
         else if (arg == "-c")                // https://dlang.org/dmd.html#switch-c
             driverParams.link = false;
         else if (startsWith(p + 1, "checkaction")) // https://dlang.org/dmd.html#switch-checkaction
@@ -1081,7 +1081,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, out Param 
             }
             if (startsWith(p + 9, "spec"))
             {
-                params.v.showGaggedErrors = true;
+                global.errorSink.showGaggedErrors = true;
             }
             else if (startsWith(p + 9, "simple"))
             {
@@ -1095,6 +1095,10 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, out Param 
             {
                 errorInvalidSwitch(p, "Only a number, `spec`, `simple`, or `context` are allowed for `-verrors`");
                 return true;
+            }
+            else
+            {
+                global.errorSink.errorLimit = params.v.errorLimit;
             }
         }
         else if (startsWith(p + 1, "verror-supplements"))
@@ -1331,9 +1335,9 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, out Param 
             }
         }
         else if (arg == "-w")   // https://dlang.org/dmd.html#switch-w
-            params.useWarnings = DiagnosticReporting.error;
+            global.errorSink.useWarnings = DiagnosticReporting.error;
         else if (arg == "-wi")  // https://dlang.org/dmd.html#switch-wi
-            params.useWarnings = DiagnosticReporting.inform;
+            global.errorSink.useWarnings = DiagnosticReporting.inform;
         else if (arg == "-wo")  // https://dlang.org/dmd.html#switch-wo
         {
             // Obsolete features has been obsoleted until a DIP for "editions"

--- a/compiler/src/dmd/sarif.d
+++ b/compiler/src/dmd/sarif.d
@@ -17,332 +17,156 @@ module dmd.sarif;
 
 import core.stdc.stdarg;
 import core.stdc.stdio;
-import core.stdc.string;
+import core.stdc.string : strchr;
+
+import dmd.errors;
 import dmd.errorsink;
 import dmd.globals;
 import dmd.location;
 import dmd.common.outbuffer;
-import dmd.root.rmem;
-import dmd.console;
-import dmd.errors;
-
-/// Contains information about the tool used for analysis in SARIF reports.
-struct ToolInformation {
-    string name;        /// Name of the tool.
-    string toolVersion; /// Version of the tool.
-
-    /// Converts the tool information to a JSON string.
-    ///
-    /// Returns:
-    /// - A JSON representation of the tool's name and version.
-    string toJson() nothrow {
-        OutBuffer buffer;
-        buffer.writestring(`{"name": "`);
-        buffer.writestring(name);
-        buffer.writestring(`", "version": "`);
-        buffer.writestring(toolVersion);
-        buffer.writestring(`"}`);
-        return cast(string) buffer.extractChars()[0 .. buffer.length()].dup;
-    }
-}
-
-/// Represents a SARIF result containing a rule ID, message, and location.
-struct SarifResult
-{
-    string ruleId;      /// Rule identifier.
-    string message;     /// Error or warning message.
-    string uri;         /// URI of the affected file.
-    int startLine;      /// Line number where the issue occurs.
-    int startColumn;    /// Column number where the issue occurs.
-
-    /// Converts the SARIF result to a JSON string.
-    ///
-    /// Returns:
-    /// - A JSON string representing the SARIF result, including the rule ID, message, and location.
-    string toJson() nothrow
-    {
-        OutBuffer buf;
-        buf.printf(`{"ruleId": "%.*s", "message": "%.*s", "location": {"artifactLocation": {"uri": "%.*s"}, "region": {"startLine": %d, "startColumn": %d}}}`,
-            cast(int)ruleId.length, ruleId.ptr,
-            cast(int)message.length, message.ptr,
-            cast(int)uri.length, uri.ptr,
-            startLine,
-            startColumn);
-        return cast(string) buf[].dup;
-    }
-}
 
 /**
-Adds a SARIF diagnostic entry to the diagnostics list.
-
-Formats a diagnostic message and appends it to the global diagnostics array, allowing errors, warnings, or other diagnostics to be captured in SARIF format.
-
-Params:
-  loc = The location in the source code where the diagnostic was generated (includes file, line, and column).
-  format = The printf-style format string for the diagnostic message.
-  ap = The variadic argument list containing values to format into the diagnostic message.
-  kind = The type of diagnostic, indicating whether it is an error, warning, deprecation, etc.
-*/
-void addSarifDiagnostic(const SourceLoc loc, const(char)* format, va_list ap, ErrorKind kind) nothrow
-{
-    char[1024] buffer = void;
-    int written = vsnprintf(buffer.ptr, buffer.length, format, ap);
-
-    // Handle any truncation
-    string formattedMessage = cast(string) buffer[0 .. (written < 0 || written > buffer.length ? buffer.length : written)].dup;
-
-    // Add the Diagnostic to the global diagnostics array
-    diagnostics ~= Diagnostic(loc, formattedMessage, kind);
-}
-
-/// Represents a SARIF report containing tool information, invocation, and results.
-struct SarifReport
-{
-    ToolInformation tool;  /// Information about the analysis tool.
-    Invocation invocation;  /// Execution information.
-    SarifResult[] results;  /// List of SARIF results (errors, warnings, etc.).
-
-    /// Converts the SARIF report to a JSON string.
-    ///
-    /// Returns:
-    /// - A JSON string representing the SARIF report, including the tool information, invocation, and results.
-    string toJson() nothrow
-    {
-        OutBuffer buffer;
-        buffer.writestring(`{"tool": `);
-        buffer.writestring(tool.toJson());
-        buffer.writestring(`, "invocation": `);
-        buffer.writestring(invocation.toJson());
-        buffer.writestring(`, "results": [`);
-        if (results.length > 0)
-        {
-            buffer.writestring(results[0].toJson());
-            foreach (result; results[1 .. $])
-            {
-                buffer.writestring(`, `);
-                buffer.writestring(result.toJson());
-            }
-        }
-        buffer.writestring(`]}`);
-        return cast(string) buffer.extractChars()[0 .. buffer.length()].dup;
-    }
-}
-
-/// Represents invocation information for the analysis process.
-struct Invocation
-{
-    bool executionSuccessful;  /// Whether the execution was successful.
-
-    /// Converts the invocation information to a JSON string.
-    ///
-    /// Returns:
-    /// - A JSON representation of the invocation status.
-    string toJson() nothrow
-    {
-        OutBuffer buffer;
-        buffer.writestring(`{"executionSuccessful": `);
-        buffer.writestring(executionSuccessful ? "true" : "false");
-        buffer.writestring(`}`);
-        return cast(string) buffer.extractChars()[0 .. buffer.length()].dup;
-    }
-}
-
-/**
-Formats an error message using a format string and a variable argument list.
-
-Params:
-  format = The format string to use.
-  ap = A variable argument list for the format string.
-
-Returns:
-  A formatted error message string.
-*/
-string formatErrorMessage(const(char)* format, va_list ap) nothrow
-{
-    char[2048] buffer;
-    import core.stdc.stdio : vsnprintf;
-    vsnprintf(buffer.ptr, buffer.length, format, ap);
-    return buffer[0 .. buffer.length].dup;
-}
-
-/**
-Converts an `ErrorKind` value to a SARIF-compatible string representation for the severity level.
-
-Params:
-  kind = The `ErrorKind` value to convert (e.g., error, warning, deprecation).
-
-Returns:
-  A SARIF-compatible string representing the `ErrorKind` level, such as "error" or "warning".
-*/
-string errorKindToString(ErrorKind kind) nothrow
+ * Maps an `ErrorKind` value to its SARIF severity-level string.
+ */
+private string errorKindToString(ErrorKind kind) nothrow
 {
     final switch (kind)
     {
-        case ErrorKind.error: return "error";       // Serious problem
-        case ErrorKind.warning: return "warning";   // Problem found
-        case ErrorKind.deprecation: return "note";  // Minor problem, opportunity for improvement
-        case ErrorKind.tip: return "note";          // Minor improvement suggestion
-        case ErrorKind.message: return "none";      // Not applicable for "fail" kind, so use "none"
+        case ErrorKind.error: return "error";
+        case ErrorKind.warning: return "warning";
+        case ErrorKind.deprecation: return "note";
+        case ErrorKind.tip: return "note";
+        case ErrorKind.message: return "none";
     }
 }
 
 /**
-Generates a SARIF (Static Analysis Results Interchange Format) report and prints it to `stdout`.
-
-This function constructs a JSON-formatted SARIF report that includes information about the tool used (such as compiler version and URI), the invocation status (indicating whether the execution was successful), and a detailed array of diagnostics (results) when `executionSuccessful` is set to `false`. Each diagnostic entry in the results array contains the rule identifier (`ruleId`), a text message describing the issue (`message`), the severity level (`level`), and the location of the issue in the source code, including the file path, line number, and column number. The SARIF report adheres to the SARIF 2.1.0 standard.
-
-Params:
-   executionSuccessful = `true` for an empty `results` array; `false` for detailed errors.
-
-Throws:
-  This function is marked as `nothrow` and does not throw exceptions.
-
-See_Also:
-  $(LINK2 https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json, SARIF 2.1.0 schema)
-*/
-void generateSarifReport(bool executionSuccessful) nothrow
+ * Error sink that produces a SARIF 2.1.0 report.
+ *
+ * Inherits all gating logic (gag handling, error limit, warning/deprecation
+ * modes) from $(D ErrorSinkCompiler). The only customisation is the output
+ * format: $(D emit) appends a `results[]` entry to $(D buf), and $(D plugSink)
+ * writes the complete SARIF document to `stdout` at the end of compilation.
+ */
+class ErrorSinkSarif : ErrorSinkCompiler
 {
-    // Create an OutBuffer to store the SARIF report
-    OutBuffer ob;
-    ob.doindent = true;
+    /// Accumulates the `results` array entries (without surrounding `[ ]`).
+    OutBuffer buf;
 
-    // Extract and clean the version string
-    string toolVersion = global.versionString();
-    // Remove 'v' prefix if it exists
-    if (toolVersion.length > 0 && toolVersion[0] == 'v')
-        toolVersion = toolVersion[1 .. $];
+    private int resultCount;
+    private bool plugged;
 
-    // Find the first non-numeric character after the version number
-    size_t length = toolVersion.length;
-    const(char)* nonNumeric = strchr(toolVersion.ptr, '-');
-    if (nonNumeric)
-        length = cast(size_t)(nonNumeric - toolVersion.ptr);
+  nothrow:
 
-    string cleanedVersion = toolVersion[0 .. length];
-
-    // strip trailing newlines
-    while (cleanedVersion.length > 0 && (cleanedVersion[$ - 1] == '\n' || cleanedVersion[$ - 1] == '\r'))
-        cleanedVersion = cleanedVersion[0 .. $ - 1];
-
-
-    // Build SARIF report
-    ob.writestringln("{");
-    ob.level = 1;
-
-    ob.writestringln(`"version": "2.1.0",`);
-    ob.writestringln(`"$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",`);
-    ob.writestringln(`"runs": [{`);
-
-    // Tool Information
-    ob.level += 1;
-    ob.writestringln(`"tool": {`);
-    ob.level += 1;
-    ob.writestringln(`"driver": {`);
-    ob.level += 1;
-
-    // Write "name" field
-    ob.writestring(`"name": "`);
-    ob.writestring(global.compileEnv.vendor.ptr);
-    ob.writestringln(`",`);
-
-    // Write "version" field
-    ob.writestring(`"version": "`);
-    ob.writestring(cleanedVersion);
-    ob.writestringln(`",`);
-
-    // Write "informationUri" field
-    ob.writestringln(`"informationUri": "https://dlang.org/dmd.html"`);
-    ob.level -= 1;
-    ob.writestringln("}");
-    ob.level -= 1;
-    ob.writestringln("},");
-
-    // Invocation Information
-    ob.writestringln(`"invocations": [{`);
-    ob.level += 1;
-    ob.writestring(`"executionSuccessful": `);
-    ob.writestring(executionSuccessful ? "true" : "false");
-    ob.writestringln("");
-    ob.level -= 1;
-    ob.writestringln("}],");
-
-    // Results Array
-    ob.writestringln(`"results": [`);
-    ob.level += 1;
-
-    foreach (idx, diag; diagnostics)
+    extern (C++) override void emit(const SourceLoc loc, const(char)* format, va_list ap,
+        ErrorKind kind, bool supplemental, bool gagged)
     {
-        ob.writestringln("{");
-        ob.level += 1;
+        // Gagged diagnostics are speculative; don't include them in the report.
+        // Supplemental notes are folded into the primary entry by convention.
+        if (gagged || supplemental)
+            return;
 
-        // Rule ID
-        ob.writestring(`"ruleId": "DMD-` ~ errorKindToString(diag.kind) ~ `",`);
-        ob.writestringln("");
+        if (resultCount > 0)
+            buf.writestring(",\n");
+        resultCount++;
 
-        // Message Information
-        ob.writestringln(`"message": {`);
-        ob.level += 1;
-        ob.writestring(`"text": "`);
-        ob.writestring(diag.message);
-        ob.writestringln(`"`);
-        ob.level -= 1;
-        ob.writestringln("},");
+        OutBuffer msg;
+        msg.vprintf(format, ap);
 
-        // Error Severity Level
-        ob.writestring(`"level": "` ~ errorKindToString(diag.kind) ~ `",`);
-        ob.writestringln("");
+        const kindStr = errorKindToString(kind);
+        const(char)[] uri = loc.filename;
 
-        // Location Information
-        ob.writestringln(`"locations": [{`);
-        ob.level += 1;
-        ob.writestringln(`"physicalLocation": {`);
-        ob.level += 1;
-
-        // Artifact Location
-        ob.writestringln(`"artifactLocation": {`);
-        ob.level += 1;
-        ob.writestring(`"uri": "`);
-        ob.writestring(diag.loc.filename);
-        ob.writestringln(`"`);
-        ob.level -= 1;
-        ob.writestringln("},");
-
-        // Region Information
-        ob.writestringln(`"region": {`);
-        ob.level += 1;
-        ob.writestring(`"startLine": `);
-        ob.printf(`%d,`, diag.loc.linnum);
-        ob.writestringln("");
-        ob.writestring(`"startColumn": `);
-        ob.printf(`%d`, diag.loc.charnum);
-        ob.writestringln("");
-        ob.level -= 1;
-        ob.writestringln("}");
-
-        // Close physicalLocation and locations
-        ob.level -= 1;
-        ob.writestringln("}");
-        ob.level -= 1;
-        ob.writestringln("}]");
-
-        // Closing brace for each diagnostic item
-        ob.level -= 1;
-        if (idx < diagnostics.length - 1)
-            ob.writestringln("},");
-        else
-            ob.writestringln("}");
+        buf.printf(
+            "\t\t\t{\n" ~
+            "\t\t\t\t\"ruleId\": \"DMD-%s\",\n" ~
+            "\t\t\t\t\"message\": {\n" ~
+            "\t\t\t\t\t\"text\": \"%s\"\n" ~
+            "\t\t\t\t},\n" ~
+            "\t\t\t\t\"level\": \"%s\",\n" ~
+            "\t\t\t\t\"locations\": [{\n" ~
+            "\t\t\t\t\t\"physicalLocation\": {\n" ~
+            "\t\t\t\t\t\t\"artifactLocation\": {\n" ~
+            "\t\t\t\t\t\t\t\"uri\": \"%.*s\"\n" ~
+            "\t\t\t\t\t\t},\n" ~
+            "\t\t\t\t\t\t\"region\": {\n" ~
+            "\t\t\t\t\t\t\t\"startLine\": %u,\n" ~
+            "\t\t\t\t\t\t\t\"startColumn\": %u\n" ~
+            "\t\t\t\t\t\t}\n" ~
+            "\t\t\t\t\t}\n" ~
+            "\t\t\t\t}]\n" ~
+            "\t\t\t}",
+            kindStr.ptr,
+            msg.peekChars(),
+            kindStr.ptr,
+            cast(int) uri.length, uri.ptr,
+            loc.linnum,
+            loc.charnum);
     }
 
-    // Close the run and SARIF JSON
-    ob.level -= 1;
-    ob.writestringln("]");
-    ob.level -= 1;
-    ob.writestringln("}]");
-    ob.level -= 1;
-    ob.writestringln("}");
+    extern (C++) override void plugSink()
+    {
+        if (plugged)
+            return;
+        plugged = true;
+        writeSarifReport(global.errors == 0);
+    }
 
-    // Extract the final null-terminated string and print it to stdout
-    const(char)* sarifOutput = ob.extractChars();
-    fputs(sarifOutput, stdout);
-    fflush(stdout);
+    /**
+     * Emit the complete SARIF JSON document, wrapping the accumulated
+     * results in $(D buf) with the required prologue and epilogue.
+     */
+    private void writeSarifReport(bool executionSuccessful)
+    {
+        // Clean up the version string: strip leading 'v', strip any suffix
+        // starting at '-', and strip trailing newlines.
+        string toolVersion = global.versionString();
+        if (toolVersion.length > 0 && toolVersion[0] == 'v')
+            toolVersion = toolVersion[1 .. $];
+
+        size_t length = toolVersion.length;
+        const(char)* dash = strchr(toolVersion.ptr, '-');
+        if (dash)
+            length = cast(size_t)(dash - toolVersion.ptr);
+        string cleanedVersion = toolVersion[0 .. length];
+        while (cleanedVersion.length > 0 &&
+               (cleanedVersion[$ - 1] == '\n' || cleanedVersion[$ - 1] == '\r'))
+            cleanedVersion = cleanedVersion[0 .. $ - 1];
+
+        OutBuffer ob;
+        ob.printf(
+            "{\n" ~
+            "\t\"version\": \"2.1.0\",\n" ~
+            "\t\"$schema\": \"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json\",\n" ~
+            "\t\"runs\": [{\n" ~
+            "\t\t\"tool\": {\n" ~
+            "\t\t\t\"driver\": {\n" ~
+            "\t\t\t\t\"name\": \"%s\",\n" ~
+            "\t\t\t\t\"version\": \"%.*s\",\n" ~
+            "\t\t\t\t\"informationUri\": \"https://dlang.org/dmd.html\"\n" ~
+            "\t\t\t}\n" ~
+            "\t\t},\n" ~
+            "\t\t\"invocations\": [{\n" ~
+            "\t\t\t\"executionSuccessful\": %s\n" ~
+            "\t\t}],\n" ~
+            "\t\t\"results\": [",
+            global.compileEnv.vendor.ptr,
+            cast(int) cleanedVersion.length, cleanedVersion.ptr,
+            executionSuccessful ? "true".ptr : "false".ptr);
+
+        if (resultCount > 0)
+        {
+            ob.writeByte('\n');
+            ob.write(buf[]);
+            ob.writeByte('\n');
+        }
+        else
+        {
+            ob.writeByte('\n');
+        }
+
+        ob.writestring("\t\t]\n\t}]\n}\n");
+
+        fputs(ob.extractChars(), stdout);
+        fflush(stdout);
+    }
 }

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1487,9 +1487,9 @@ void templateInstanceSemantic3(TemplateInstance tempinst, Scope* sc, Scope* sc2)
          * types. Deprecations are disabled while analysing hooks to avoid
          * spurious error messages.
          */
-        auto saveUseDeprecated = global.params.useDeprecated;
+        auto saveUseDeprecated = global.errorSink.useDeprecated;
         if (sc.isDeprecated() && isDRuntimeHook(tempinst.name))
-            global.params.useDeprecated = DiagnosticReporting.off;
+            global.errorSink.useDeprecated = DiagnosticReporting.off;
 
         {
             timeTraceBeginEvent(TimeTraceEventType.sema1TemplateInstanceSema3);
@@ -1498,7 +1498,7 @@ void templateInstanceSemantic3(TemplateInstance tempinst, Scope* sc, Scope* sc2)
                 () => tempinst.toPrettyChars().toDString());
         }
 
-        global.params.useDeprecated = saveUseDeprecated;
+        global.errorSink.useDeprecated = saveUseDeprecated;
 
         for (size_t i = 0; i < deferred.length; i++)
         {

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -2053,7 +2053,7 @@ private extern(D) ptrdiff_t findParameterIndex(TypeFunction tf, Identifier ident
  */
 private extern(C) void getMatchError(ref OutBuffer buf, const(char)* format, ...)
 {
-    if (global.gag && !global.params.v.showGaggedErrors)
+    if (global.gag && !global.errorSink.showGaggedErrors)
         return;
     va_list ap;
     va_start(ap, format);
@@ -2661,7 +2661,7 @@ private extern(D) MATCH argumentMatchParameter (FuncDeclaration fd, TypeFunction
 // arguments get specially formatted
 private const(char)* getParamError(TypeFunction tf, Expression arg, Parameter par)
 {
-    if (global.gag && !global.params.v.showGaggedErrors)
+    if (global.gag && !global.errorSink.showGaggedErrors)
         return null;
     // show qualification when toChars() is the same but types are different
     // https://issues.dlang.org/show_bug.cgi?id=19948


### PR DESCRIPTION
SARIF output has been hacked in with global variables and `if (global.params.v.messageStyle == MessageStyle.sarif)` conditions. Meanwhile there's a WIP `ErrorSink` refactor that is supposed to cleanly separate custom presentation from errors.d, so here's a refactor to clean up the tangle.

Put the limiting / gating logic in `ErrorSinkCompiler`,
and make `ErrorSinkSarif` extend from that, separating it from dmd.errors. 
Move `enum ErrorKind` from errors.d to errorsink.d so error sinks can use it without importing errors.d.

- Remove import dmd.console, dmd.errors from dmd.sarif
- Remove reliance on `global.params.v` and errors.d
- Remove redundant `__gshared Diagnostic[]` collection
- Remove redundant `struct SarifReport` indirection

`private extern(C++) void vreportDiagnostic` logic is moved into `ErrorSinkCompiler`. It's private and has no header so I assume it's not used by LDC or GDC. The global gagging/error count, and warning/deprecation as error logic is intact.

This PR is quite big so I can split it up if it's too hard to review or too risky.