### PR TITLE
drop symlist_t as CV4 and CVSYM are obsolete

### DIFF
--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -46,7 +46,6 @@ enum IDOHD = 4+1+int.sizeof*3; // max amount of overhead to ID added by
 
 alias Funcsym = Symbol;
 
-alias symlist_t = list_t;
 alias vec_t = size_t*;
 alias enum_TK = ubyte;
 
@@ -439,7 +438,6 @@ enum
 
 struct func_t
 {
-    symlist_t Fsymtree;         // local Symbol table
     block* Fstartblock;         // list of blocks comprising function
     symtab_t Flocsym;           // local Symbol table
     Srcpos Fstartline;          // starting line # of function

--- a/compiler/src/dmd/backend/cgcv.d
+++ b/compiler/src/dmd/backend/cgcv.d
@@ -25,8 +25,6 @@ import dmd.backend.type;
 nothrow:
 @safe:
 
-alias symlist_t = LIST*;
-
 public import dmd.backend.dcgcv : cv_init, cv_typidx, cv_outsym, cv_func, cv_term, cv4_struct,
     cv_stringbytes, cv4_numericbytes, cv4_storenumeric, cv4_signednumericbytes,
     cv4_storesignednumeric, cv_debtyp, cv_namestring, cv4_typidx, cv4_arglist, cv4_callconv,
@@ -51,7 +49,6 @@ struct debtyp_t
 struct Cgcv
 {
     uint signature;
-    symlist_t list;     // deferred list of symbols to output
     idx_t deb_offset;   // offset added to type index
     uint sz_idx;        // size of stored type index
     int LCFDoffset;

--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -1767,7 +1767,6 @@ static if (1)
                 length = 2 + 2 + cgcv.sz_idx;
                 length += cv_namestring(debsym + length,id);
                 TOWORD(debsym,length - 2);
-                list_subtract(&cgcv.list,s);
                 break;
 
             case SC.const_:
@@ -1793,16 +1792,6 @@ Lret:
         free(debsym);
 }
 
-/******************************************
- * Write out any deferred symbols.
- */
-
-@trusted
-private void cv_outlist()
-{
-    while (cgcv.list)
-        cv_outsym(cast(Symbol*) list_pop(&cgcv.list));
-}
 
 /******************************************
  * Write out symbol table for current function.
@@ -2038,8 +2027,6 @@ private void cv4_func(Funcsym* s, ref symtab_t symtab)
 
         objmod.write_bytes(SegData[DEBSYM],endproc[]);
     }
-
-    cv_outlist();
 }
 
 //////////////////////////////////////////////////////////
@@ -2059,8 +2046,8 @@ void cv_term()
     {
         case CV4:
         case CVSYM:
-            cv_outlist();
-            goto case;
+            assert(0);  // obsolete
+
         case CV8:
             objmod.write_bytes(SegData[typeseg],(&cgcv.signature)[0 .. 1]);
             if (debtyp.length != 1 || config.fulltypes == CV8)

--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -2228,15 +2228,6 @@ static if (1)
     }
 
 
-    /******************************************
-     * Write out any deferred symbols.
-     */
-    static if (0)
-    void cv_outlist()
-    {
-    }
-
-
     /* =================== Cached Types in debug_info ================= */
 
     ubyte dwarf_classify_struct(uint sflags)
@@ -3026,7 +3017,6 @@ static if (1)
                 enum_t* se = s.Senum;
                 type* tbase2 = s.Stype.Tnext;
                 uint sz = cast(uint)type_size(tbase2);
-                symlist_t sl;
 
                 if (s.Stypidx)
                     return s.Stypidx;

--- a/compiler/src/dmd/backend/symbol.d
+++ b/compiler/src/dmd/backend/symbol.d
@@ -505,7 +505,6 @@ debug
                 freesymtab(f.Flocsym[].ptr,0,f.Flocsym.length);
 
                 f.Flocsym.dtor();
-                list_free(&f.Fsymtree,cast(list_free_fp)&symbol_free);
                 f.typesTable.dtor();
                 func_free(f);
             }


### PR DESCRIPTION
I'm looking to get rid of all use of dlist.d