### PR TITLE
Fix #23185 - ICE on final switch error at CTFE

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -1286,7 +1286,11 @@ Expression interpretStatement(UnionExp* pue, Statement s, InterState* istate)
         if (!scase)
         {
             if (!s.hasDefault)
+            {
                 error(s.loc, "no `default` or `case` for `%s` in `switch` statement", econdition.toErrMsg());
+                result = CTFEExp.cantexp;
+                return;
+            }
             scase = s.sdefault;
         }
 

--- a/compiler/test/fail_compilation/test23185.d
+++ b/compiler/test/fail_compilation/test23185.d
@@ -1,0 +1,15 @@
+// https://github.com/dlang/dmd/issues/23185
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test23185.d(11): Error: no `default` or `case` for `3` in `switch` statement
+fail_compilation/test23185.d(15):        called from here: `(*function () pure nothrow @nogc @safe => 0)()`
+---
+*/
+enum x = () {
+    final switch (3) {
+        case 1: break;
+    }
+    return 0;
+} ();


### PR DESCRIPTION
Closes #23185

The problem was that it tried to interpret `SwitchErrorStatement` which has no visit function for it in `dinterpret.d`