### PR TITLE
Add libclang based C++ header validation

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -229,4 +229,5 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         set -eux
+        python3 -m pip install libclang
         ./dmd/generated/build cpp-layout-test

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -224,3 +224,9 @@ jobs:
           extraFlags=(HOST_DMD=ldmd2 DFLAGS="-mtriple=x86_64-apple-macos14" CXXFLAGS="-arch x86_64")
         fi
         ./dmd/generated/build cxx-unittest "${extraFlags[@]}"
+
+    - name: 'Posix: Run C++ header layout test'
+      if: runner.os == 'Linux'
+      run: |
+        set -eux
+        ./dmd/generated/build cpp-layout-test

--- a/compiler/include/dmd/cond.h
+++ b/compiler/include/dmd/cond.h
@@ -22,7 +22,7 @@ class DebugCondition;
 class ForeachStatement;
 class ForeachRangeStatement;
 
-enum Include
+enum Include : uint8_t
 {
     INCLUDEnotComputed, /// not computed yet
     INCLUDEyes,         /// include the conditional code

--- a/compiler/include/dmd/declaration.h
+++ b/compiler/include/dmd/declaration.h
@@ -481,9 +481,9 @@ public:
 
 enum class ILS : unsigned char
 {
-    ILSuninitialized,   // not computed yet
-    ILSno,              // cannot inline
-    ILSyes              // can inline
+    uninitialized,  // not computed yet
+    no,             // cannot inline
+    yes             // can inline
 };
 
 /**************************************************************/

--- a/compiler/include/dmd/dsymbol.h
+++ b/compiler/include/dmd/dsymbol.h
@@ -113,7 +113,7 @@ namespace dmd
 
 struct Visibility
 {
-    enum Kind
+    enum Kind : uint8_t
     {
         undefined,
         none,           // no access

--- a/compiler/include/dmd/expression.h
+++ b/compiler/include/dmd/expression.h
@@ -286,7 +286,6 @@ public:
     Dsymbol *s;
     d_bool hasOverloads;
 
-    DsymbolExp *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -895,7 +894,6 @@ public:
 class ArrayLengthExp final : public UnaExp
 {
 public:
-    Expression lowering;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/include/dmd/globals.h
+++ b/compiler/include/dmd/globals.h
@@ -151,7 +151,6 @@ struct Verbose
     d_bool field;              // identify non-mutable field variables
     d_bool complex = true;     // identify complex/imaginary type usage
     d_bool vin;                // identify 'in' parameters
-    d_bool showGaggedErrors;   // print gagged errors anyway
     d_bool logo;               // print compiler logo
     d_bool color;              // use ANSI colors in console output
     d_bool cov;                // generate code coverage data
@@ -187,12 +186,10 @@ struct Param
     d_bool trace;         // insert profiling hooks
     d_bool tracegc;       // instrument calls to 'new'
     d_bool vcg_ast;       // write-out codegen-ast
-    Diagnostic useDeprecated;
     d_bool useUnitTests;  // generate unittest code
     d_bool useInline;     // inline expand functions
     d_bool release;       // build release version
     d_bool preservePaths; // true means don't strip path from source file
-    Diagnostic useWarnings;
     d_bool cov;           // generate code coverage data
     unsigned char covPercent;   // 0..100 code coverage percentage required
     d_bool ctfe_cov;      // generate coverage data for ctfe

--- a/compiler/include/dmd/mtype.h
+++ b/compiler/include/dmd/mtype.h
@@ -737,7 +737,7 @@ namespace dmd
     Type *sharedWildOf(Type *type);
     Type *sharedWildConstOf(Type *type);
     Type *unqualify(Type *type, unsigned m);
-    Type *toHeadMutable(Type *type);
+    Type *toHeadMutable(const Type *type);
     Type *aliasthisOf(Type *type);
     Type *castMod(Type *type, MOD mod);
     Type *addMod(Type *type, MOD mod);

--- a/compiler/include/dmd/mtype.h
+++ b/compiler/include/dmd/mtype.h
@@ -220,7 +220,7 @@ public:
 
     static void _init() { return dmd::Type_init(); }
 
-    virtual const char *kind();
+    virtual const char *kind() const;
     Type *copy() const;
     virtual Type *syntaxCopy();
     bool equals(const Type * const t) const;
@@ -289,7 +289,7 @@ public:
 class TypeError final : public Type
 {
 public:
-    const char *kind() override;
+    const char *kind() const override;
     TypeError *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -310,7 +310,7 @@ public:
     const char *dstring;
     unsigned flags;
 
-    const char *kind() override;
+    const char *kind() const override;
     TypeBasic *syntaxCopy() override;
 
     // For eliminating dynamic_cast
@@ -324,7 +324,7 @@ public:
     Type *basetype;
 
     static TypeVector *create(Type *basetype);
-    const char *kind() override;
+    const char *kind() const override;
     TypeVector *syntaxCopy() override;
     TypeBasic *elementType();
 
@@ -343,7 +343,7 @@ class TypeSArray final : public TypeArray
 public:
     Expression *dim;
 
-    const char *kind() override;
+    const char *kind() const override;
     TypeSArray *syntaxCopy() override;
     bool isIncomplete();
 
@@ -354,7 +354,7 @@ public:
 class TypeDArray final : public TypeArray
 {
 public:
-    const char *kind() override;
+    const char *kind() const override;
     TypeDArray *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -367,7 +367,7 @@ public:
     Loc loc;
 
     static TypeAArray *create(Type *t, Type *index);
-    const char *kind() override;
+    const char *kind() const override;
     TypeAArray *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -377,7 +377,7 @@ class TypePointer final : public TypeNext
 {
 public:
     static TypePointer *create(Type *t);
-    const char *kind() override;
+    const char *kind() const override;
     TypePointer *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -386,7 +386,7 @@ public:
 class TypeReference final : public TypeNext
 {
 public:
-    const char *kind() override;
+    const char *kind() const override;
     TypeReference *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -469,7 +469,7 @@ public:
     ArgumentList inferenceArguments; // function arguments
 
     static TypeFunction *create(Parameters *parameters, Type *treturn, VarArg varargs, LINK linkage, StorageClass stc = 0);
-    const char *kind() override;
+    const char *kind() const override;
     TypeFunction *syntaxCopy() override;
     bool hasLazyParameters();
     bool isDstyleVariadic() const;
@@ -516,7 +516,7 @@ public:
     // .next is a TypeFunction
 
     static TypeDelegate *create(TypeFunction *t);
-    const char *kind() override;
+    const char *kind() const override;
     TypeDelegate *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -530,7 +530,7 @@ class TypeTraits final : public Type
     /// Cached type/symbol after semantic analysis.
     RootObject *obj;
 
-    const char *kind() override;
+    const char *kind() const override;
     TypeTraits *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -541,7 +541,7 @@ class TypeMixin final : public Type
     Expressions *exps;
     RootObject *obj;
 
-    const char *kind() override;
+    const char *kind() const override;
     TypeMixin *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -564,7 +564,7 @@ public:
     Identifier *ident;
 
     static TypeIdentifier *create(Loc loc, Identifier *ident);
-    const char *kind() override;
+    const char *kind() const override;
     TypeIdentifier *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -576,7 +576,7 @@ class TypeInstance final : public TypeQualified
 public:
     TemplateInstance *tempinst;
 
-    const char *kind() override;
+    const char *kind() const override;
     TypeInstance *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -587,7 +587,7 @@ public:
     Expression *exp;
     int inuse;
 
-    const char *kind() override;
+    const char *kind() const override;
     TypeTypeof *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -595,7 +595,7 @@ public:
 class TypeReturn final : public TypeQualified
 {
 public:
-    const char *kind() override;
+    const char *kind() const override;
     TypeReturn *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -620,7 +620,7 @@ public:
     d_bool inuse;
 
     static TypeStruct *create(StructDeclaration *sym);
-    const char *kind() override;
+    const char *kind() const override;
     TypeStruct *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -631,7 +631,7 @@ class TypeEnum final : public Type
 public:
     EnumDeclaration *sym;
 
-    const char *kind() override;
+    const char *kind() const override;
     TypeEnum *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -644,7 +644,7 @@ public:
     AliasThisRec att;
     CPPMANGLE cppmangle;
 
-    const char *kind() override;
+    const char *kind() const override;
     TypeClass *syntaxCopy() override;
     ClassDeclaration *isClassHandle() override;
     bool isScopeClass() override;
@@ -664,7 +664,7 @@ public:
     static TypeTuple *create();
     static TypeTuple *create(Type *t1);
     static TypeTuple *create(Type *t1, Type *t2);
-    const char *kind() override;
+    const char *kind() const override;
     TypeTuple *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -675,7 +675,7 @@ public:
     Expression *lwr;
     Expression *upr;
 
-    const char *kind() override;
+    const char *kind() const override;
     TypeSlice *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -683,7 +683,7 @@ public:
 class TypeNull final : public Type
 {
 public:
-    const char *kind() override;
+    const char *kind() const override;
 
     TypeNull *syntaxCopy() override;
 
@@ -693,7 +693,7 @@ public:
 class TypeNoreturn final : public Type
 {
 public:
-    const char *kind() override;
+    const char *kind() const override;
     TypeNoreturn *syntaxCopy() override;
 
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/include/dmd/objc.h
+++ b/compiler/include/dmd/objc.h
@@ -70,12 +70,12 @@ public:
     virtual void validateOptional(FuncDeclaration *fd) const = 0;
     virtual ClassDeclaration* getParent(FuncDeclaration*, ClassDeclaration*) const = 0;
     virtual void addToClassMethodList(FuncDeclaration*, ClassDeclaration*) const = 0;
-    virtual AggregateDeclaration* isThis(FuncDeclaration* fd) = 0;
+    virtual AggregateDeclaration* isThis(FuncDeclaration* fd) const = 0;
     virtual VarDeclaration* createSelectorParameter(FuncDeclaration*, Scope*) const = 0;
 
     virtual void setMetaclass(InterfaceDeclaration* id, Scope*) const = 0;
     virtual void setMetaclass(ClassDeclaration* id, Scope*) const = 0;
-    virtual ClassDeclaration* getRuntimeMetaclass(ClassDeclaration* cd) = 0;
+    virtual ClassDeclaration* getRuntimeMetaclass(ClassDeclaration* cd) const = 0;
 
     virtual void addSymbols(AttribDeclaration*, ClassDeclarations*, ClassDeclarations*) const = 0;
     virtual void addSymbols(ClassDeclaration*, ClassDeclarations*, ClassDeclarations*) const = 0;

--- a/compiler/include/dmd/template.h
+++ b/compiler/include/dmd/template.h
@@ -83,6 +83,10 @@ public:
 
     TemplatePrevious *previous;         // threaded list of previous instantiation attempts on stack
 
+    Expression *lastConstraint;     // the constraint after the last failed evaluation
+    Expressions lastConstraintNegs; // its negative parts
+    Objects *lastConstraintTiargs;  // template instance arguments for lastConstraint
+
     TemplateDeclaration *syntaxCopy(Dsymbol *) override;
     const char *kind() const override;
 

--- a/compiler/src/README.md
+++ b/compiler/src/README.md
@@ -73,3 +73,13 @@ target.
 Note that `dtoh` is currently experimental and may emit invalid code for
 certain declarations, so `frontend.h` is not required to be compilable
 until the remaining issues are resolved.
+
+### cpp-layout-test
+
+Verifies that the manually maintained C++ headers in
+[`compiler/include/dmd/`](../include/dmd/) stay in sync with the D
+`extern(C++)` declarations in the compiler source. Checks enum constant
+values, field offsets and sizes, class instance sizes, vtable indices,
+and C++ mangled names.
+
+Note: Linux/64-bit only (Itanium ABI mangling).

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -48,6 +48,7 @@ immutable rootRules = [
     &buildFrontendHeaders,
     &runCxxHeadersTest,
     &runCxxUnittest,
+    &runCppLayoutTest,
     &detab,
     &tolf,
     &zip,
@@ -778,6 +779,35 @@ alias runCxxUnittest = makeRule!((runCxxBuilder, runCxxRule) {
     else runCxxBuilder
         .deps([cxxUnittestExe])
         .command([cxxUnittestExe.target]);
+});
+
+/// Generates and compiles a D file with static asserts checking that the C++ header
+/// layout (field offsets, enum values, vtable indices, mangled names) matches the
+/// D extern(C++) declarations.
+alias runCppLayoutTest = makeRule!((builder, rule) {
+    const generatedPath = env["G"].buildPath("cpp_layout_asserts.d");
+
+    builder
+        .name("cpp-layout-test")
+        .description("Check that compiler/include/dmd/*.h matches the D extern(C++) declarations")
+        .msg("(TEST) CPP-LAYOUT")
+        .commandFunction(() {
+            const includeDir = compilerDir.buildPath("include", "dmd");
+            const script = compilerDir.buildPath("tools", "gen_cpp_layout_test.py");
+            const result = tryRun(["python3", script, includeDir, generatedPath], runDir);
+            if (result.status != 0)
+                abortBuild("gen_cpp_layout_test.py failed:\n" ~ result.output);
+
+            const compileResult = tryRun(
+                [env["HOST_DMD_RUN"], "-c", "-o-", "-m64",
+                 "-version=IN_LLVM", // skip MARS-only fields
+                 "-I" ~ env["D"] ~ "/..",
+                 "-J" ~ env["RES"],
+                 "-J" ~ env["G"],
+                 generatedPath], runDir);
+            if (compileResult.status != 0)
+                abortBuild("cpp-layout-test failed:\n" ~ compileResult.output);
+        });
 });
 
 /// BuildRule that removes all generated files

--- a/compiler/tools/gen_cpp_layout_test.py
+++ b/compiler/tools/gen_cpp_layout_test.py
@@ -151,8 +151,9 @@ private void checkSize(alias T)(size_t expected)
 
 
 lib = cx.conf.lib
-from clang.cindex import _CXString  # noqa: E402
 
+# clang_getOverriddenCursors / clang_disposeOverriddenCursors are not exposed by
+# the Python bindings, so we wire them up manually via ctypes.
 lib.clang_getOverriddenCursors.restype = None
 lib.clang_getOverriddenCursors.argtypes = [
     cx.Cursor,
@@ -161,8 +162,6 @@ lib.clang_getOverriddenCursors.argtypes = [
 ]
 lib.clang_disposeOverriddenCursors.restype = None
 lib.clang_disposeOverriddenCursors.argtypes = [ctypes.POINTER(cx.Cursor)]
-lib.clang_Cursor_getMangling.restype = _CXString
-lib.clang_Cursor_getMangling.argtypes = [cx.Cursor]
 
 
 def get_overridden_manglings(cursor: cx.Cursor) -> list[str]:
@@ -172,8 +171,7 @@ def get_overridden_manglings(cursor: cx.Cursor) -> list[str]:
     lib.clang_getOverriddenCursors(cursor, ctypes.byref(ptr), ctypes.byref(n))
     result = []
     for i in range(n.value):
-        cxstr = lib.clang_Cursor_getMangling(ptr[i])
-        result.append(_CXString.from_result(cxstr))
+        result.append(ptr[i].mangled_name)
     if n.value:
         lib.clang_disposeOverriddenCursors(ptr)
     return result

--- a/compiler/tools/gen_cpp_layout_test.py
+++ b/compiler/tools/gen_cpp_layout_test.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""
+Generates compiler/src/generated/cpp_layout_asserts.d from compiler/include/dmd/*.h.
+
+Test whether the sizes, offsets, vtable layouts, and enum offsets match between:
+compiler/include/*.h and compiler/src/*.d
+
+Usage: gen_cpp_layout_test.py <include_dir> <output_file>
+
+Parsed with libclang. Output is a D source file of static asserts that verify
+enum values, field offsets/sizes, class instance sizes, vtable indices, and
+C++ mangled names match between the C++ headers and the D extern(C++) declarations.
+"""
+
+import clang.cindex as cx
+import ctypes
+import os
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+# Skip these headers because they are C++ compatibility shims
+_SKIP_HEADERS = frozenset({
+    "root/dcompat.h",
+    "root/dsystem.h",
+})
+
+# Free functions in namespace dmd that are not wrapped in dmd.cxxfrontend on Linux
+# (e.g. Windows/MSVC-only functions).
+_SKIP_FREE_FUNCS = frozenset({
+    "toCppMangleMSVC",
+    "cppTypeInfoMangleMSVC",
+})
+
+# Skip these C++ class/struct names because they are D templates (TODO: instantiate these and check?)
+_SKIP_TYPES = frozenset({
+    "ParseTimeVisitor",   # D: class ParseTimeVisitor(AST) - template, visitor.h
+    "Visitor",            # D: class Visitor : ParseTimeVisitor!ASTCodegen - template
+    "StoppableVisitor",   # D: class StoppableVisitor : Visitor - template chain
+})
+
+# C++ enum member names mapped to a different D name (or None to skip).
+# Default behaviour (no entry): use the C++ name unchanged.
+# The trailing '_' that C++ adds to avoid C++ keyword conflicts usually survives
+# unchanged into D, because most such names are also D keywords.  The exceptions
+# below are names that are C++ keywords but NOT D keywords, so D spells them
+# without the underscore.
+_D_KEYWORD_RENAME: dict[tuple[str, str], str | None] = {
+    ("Baseok", "in"): None,              # D renames to 'start' (unrelated name)
+    # C extension tokens: C++ uses trailing _ or no prefix; D uses __ prefix
+    ("TOK", "pragma"): "__pragma",       # second pragma (C ext); D: __pragma
+    ("TOK", "cdecl_"): "__cdecl",        # Windows calling conv; D: __cdecl
+    ("TOK", "declspec"): "__declspec",   # Windows extension; D: __declspec
+    ("TOK", "stdcall"): "__stdcall",     # Windows calling conv; D: __stdcall
+    ("TOK", "thread"): "__thread",       # GCC thread-local; D: __thread
+    ("TOK", "int128_"): "__int128",      # GCC extension; D: __int128
+    ("TOK", "attribute__"): "__attribute__",  # GCC extension; D: __attribute__
+    # Sentinel / count values not present in D enums
+    ("TOK", "MAX"): None,
+    ("EXP", "MAX"): None,
+    ("TY", "TMAX"): None,
+    # C++ alternative operator tokens: not D keywords, so D drops the trailing _
+    ("TOK", "and_"): "and",
+    ("TOK", "or_"):  "or",
+    ("TOK", "xor_"): "xor",
+    ("TOK", "not_"): "not",
+    ("EXP", "and_"):     "and",
+    ("EXP", "or_"):      "or",
+    ("EXP", "xor_"):     "xor",
+    ("EXP", "not_"):     "not",
+    ("EXP", "_Generic_"):"_Generic",
+    # C99 keywords that are not D keywords
+    ("TOK", "inline_"):   "inline",
+    ("TOK", "register_"): "register",
+    ("TOK", "restrict_"): "restrict",
+    ("TOK", "signed_"):   "signed",
+    ("TOK", "unsigned_"): "unsigned",
+    ("TOK", "volatile_"): "volatile",
+    # C11 _Xxx keywords: trailing _ stripped (leading _ already present)
+    ("TOK", "_Alignas_"):      "_Alignas",
+    ("TOK", "_Alignof_"):      "_Alignof",
+    ("TOK", "_Atomic_"):       "_Atomic",
+    ("TOK", "_Bool_"):         "_Bool",
+    ("TOK", "_Complex_"):      "_Complex",
+    ("TOK", "_Generic_"):      "_Generic",
+    ("TOK", "_Imaginary_"):    "_Imaginary",
+    ("TOK", "_Noreturn_"):     "_Noreturn",
+    ("TOK", "_Static_assert_"):"_Static_assert",
+    ("TOK", "_Thread_local_"): "_Thread_local",
+}
+
+# All D imports needed to check all definitions from include/*.h
+D_IMPORTS = """\
+import dmd.aggregate, dmd.aliasthis, dmd.arraytypes, dmd.ast_node,
+       dmd.attrib, dmd.compiler, dmd.cond, dmd.ctfeexpr, dmd.cxxfrontend, dmd.declaration,
+       dmd.denum, dmd.dimport, dmd.dmodule, dmd.dscope, dmd.dstruct,
+       dmd.dsymbol, dmd.dtemplate, dmd.dversion, dmd.errors,
+       dmd.astenums, dmd.ctorflow, dmd.dclass, dmd.dmacro, dmd.dsymbolsem, dmd.errorsink, dmd.expression, dmd.func,
+       dmd.globals, dmd.hdrgen, dmd.lexer,
+       dmd.id, dmd.identifier, dmd.init, dmd.json, dmd.location,
+       dmd.mangle, dmd.mtype, dmd.nspace, dmd.objc, dmd.rootobject,
+       dmd.statement, dmd.staticassert, dmd.target, dmd.tokens, dmd.typinf,
+       dmd.visitor, dmd.vsoptions,
+       dmd.root.array, dmd.root.bitarray, dmd.root.complex,
+       dmd.root.ctfloat, dmd.root.filename, dmd.root.longdouble,
+       dmd.root.optional, dmd.root.port, dmd.root.rmem,
+       dmd.common.charactertables, dmd.common.outbuffer;"""
+
+# Helper emitted once
+D_HELPER_CODE = """\
+private enum hasMangled(alias T, string method, string mangled) = () {
+    static foreach (alias f; __traits(getOverloads, T, method))
+        static if (f.mangleof == mangled) return true;
+    return false;
+}();
+
+private void checkField(alias T, string field)(size_t expectedOffset, size_t expectedSize)
+{
+    static if (__traits(hasMember, T, field))
+    {
+        static if (is(T == class))
+        {
+            static assert(__traits(getMember, (cast(T) null), field).offsetof == expectedOffset);
+            static assert(__traits(getMember, (cast(T) null), field).sizeof == expectedSize);
+        }
+        else
+        {
+            static assert(__traits(getMember, T.init, field).offsetof == expectedOffset);
+            static assert(__traits(getMember, T.init, field).sizeof == expectedSize);
+        }
+    }
+}
+
+private void checkVtable(alias T, string method)(size_t expected)
+{
+    static assert(__traits(getVirtualIndex, __traits(getMember, T, method)) == expected);
+}
+
+private void checkSize(alias T)(size_t expected)
+{
+    static if (is(T == class))
+    {
+        // D classInstanceSize may omit trailing alignment padding; round up to alignof.
+        enum actual = ((__traits(classInstanceSize, T) + T.alignof - 1) / T.alignof) * T.alignof;
+        static assert(actual == expected);
+    }
+    else
+        static assert(T.sizeof == expected);
+}"""
+
+
+lib = cx.conf.lib
+from clang.cindex import _CXString  # noqa: E402
+
+lib.clang_getOverriddenCursors.restype = None
+lib.clang_getOverriddenCursors.argtypes = [
+    cx.Cursor,
+    ctypes.POINTER(ctypes.POINTER(cx.Cursor)),
+    ctypes.POINTER(ctypes.c_uint),
+]
+lib.clang_disposeOverriddenCursors.restype = None
+lib.clang_disposeOverriddenCursors.argtypes = [ctypes.POINTER(cx.Cursor)]
+lib.clang_Cursor_getMangling.restype = _CXString
+lib.clang_Cursor_getMangling.argtypes = [cx.Cursor]
+
+
+def get_overridden_manglings(cursor: cx.Cursor) -> list[str]:
+    """Return mangled names of methods that *cursor* overrides."""
+    ptr = ctypes.POINTER(cx.Cursor)()
+    n = ctypes.c_uint(0)
+    lib.clang_getOverriddenCursors(cursor, ctypes.byref(ptr), ctypes.byref(n))
+    result = []
+    for i in range(n.value):
+        cxstr = lib.clang_Cursor_getMangling(ptr[i])
+        result.append(_CXString.from_result(cxstr))
+    if n.value:
+        lib.clang_disposeOverriddenCursors(ptr)
+    return result
+
+
+CK = cx.CursorKind
+
+def gen(include_dir: Path, out_path: Path) -> None:
+    include_str = str(include_dir.resolve())
+
+    resource_dir = subprocess.run(
+        ["clang", "-print-resource-dir"], capture_output=True, text=True
+    ).stdout.strip()
+
+    # Build umbrella header.
+    headers: list[str] = []
+    for root, _, files in os.walk(include_dir):
+        for f in sorted(files):
+            if f.endswith(".h"):
+                headers.append(os.path.relpath(os.path.join(root, f), include_dir))
+
+    umbrella_path = out_path.parent / "_umbrella.h"
+    umbrella_path.parent.mkdir(parents=True, exist_ok=True)
+    umbrella_path.write_text("\n".join(f'#include "{h}"' for h in sorted(headers)))
+
+    idx = cx.Index.create()
+    tu = idx.parse(
+        str(umbrella_path),
+        args=[
+            "-x", "c++", "-std=c++17",
+            f"-I{include_str}",
+            f"-I{resource_dir}/include",
+        ],
+    )
+
+    errors = [d for d in tu.diagnostics if d.severity >= cx.Diagnostic.Error]
+    if errors:
+        for e in errors:
+            print(f"clang error: {e.spelling}", file=sys.stderr)
+        sys.exit(1)
+
+    vtable_cache: dict[int, list[tuple[str, str]]] = {}
+
+    def compute_vtable(cls: cx.Cursor) -> list[tuple[str, str]]:
+        key = cls.hash
+        if key in vtable_cache:
+            return vtable_cache[key]
+        # sentinel to break cycles
+        vtable_cache[key] = []
+
+        base_vtable: list[tuple[str, str]] = []
+        for child in cls.get_children():
+            if child.kind == CK.CXX_BASE_SPECIFIER:
+                base = child.referenced
+                if not base.is_definition():
+                    base = base.get_definition()
+                if base and base.is_definition():
+                    base_vtable = compute_vtable(base)
+                break
+
+        vtable = list(base_vtable)
+        for child in cls.get_children():
+            if child.kind != CK.CXX_METHOD or not child.is_virtual_method():
+                continue
+            mangled = child.mangled_name
+            overridden = get_overridden_manglings(child)
+            placed = False
+            if overridden:
+                for i, (slot_m, _) in enumerate(vtable):
+                    if slot_m in overridden:
+                        vtable[i] = (mangled, child.spelling)
+                        placed = True
+                        break
+            if not placed:
+                vtable.append((mangled, child.spelling))
+
+        vtable_cache[key] = vtable
+        return vtable
+
+    def get_vtable_index(method: cx.Cursor, cls: cx.Cursor) -> int:
+        for i, (slot_m, _) in enumerate(compute_vtable(cls)):
+            if slot_m == method.mangled_name:
+                return i
+        return -1
+
+    lines: list[str] = [
+        "// AUTO-GENERATED - do not edit. Regenerated by: ./build.d cpp-layout-test",
+        D_IMPORTS,
+        "",
+        D_HELPER_CODE,
+    ]
+
+    def in_dir(cursor: cx.Cursor) -> bool:
+        loc = cursor.location
+        if not loc.file or not loc.file.name.startswith(include_str):
+            return False
+        rel = os.path.relpath(loc.file.name, include_str)
+        return rel not in _SKIP_HEADERS
+
+    def emit_enum(cursor: cx.Cursor) -> None:
+        # Only check scoped enums (enum class / enum struct): member names match D.
+        # C-style enums rename members (e.g. DYNCAST_OBJECT → object).
+        if not cursor.is_scoped_enum():
+            return
+        name = cursor.spelling
+        if not name or name.startswith("("):
+            return  # anonymous
+
+        members = [
+            (c.spelling, c.enum_value)
+            for c in cursor.get_children()
+            if c.kind == CK.ENUM_CONSTANT_DECL
+        ]
+        if not members:
+            return
+
+        lines.append("")
+        lines.append(f"// enum class {name}")
+        for mname, mval in members:
+            key = (name, mname)
+            if key in _D_KEYWORD_RENAME:
+                d_mname = _D_KEYWORD_RENAME[key]
+                if d_mname is None:
+                    lines.append(f"// skip {name}.{mname} == {mval}")
+                    continue
+                lines.append(f"static assert({name}.{d_mname} == {mval});")
+            else:
+                lines.append(f"static assert({name}.{mname} == {mval});")
+
+    def uses_dstring(cursor: cx.Cursor) -> bool:
+        """Return True if a method/function uses DString (extern(D) mangling)."""
+        if "DString" in cursor.result_type.spelling:
+            return True
+        return any("DString" in a.type.spelling for a in cursor.get_arguments())
+
+    def emit_record(cursor: cx.Cursor) -> None:
+        name = cursor.spelling
+        if not name or name in _SKIP_TYPES:
+            return
+
+        is_class = cursor.kind == CK.CLASS_DECL
+        size = cursor.type.get_size()
+        if size <= 0:
+            return
+
+        # Skip empty structs (sizeof==1, no data fields): C++ uses them as namespaces for enums,
+        # which D represents as plain enums rather than structs.
+        public_fields = [c for c in cursor.get_children()
+                         if c.kind == CK.FIELD_DECL and
+                         c.access_specifier in (cx.AccessSpecifier.PUBLIC, cx.AccessSpecifier.INVALID)]
+        if not is_class and size == 1 and not public_fields:
+            return
+
+        lines.append("")
+        kind_str = "class" if is_class else "struct"
+        lines.append(f"// {kind_str} {name}")
+
+        # Size + field offsets/sizes + vtable indices: all collected into a unittest block.
+        unit_lines: list[str] = []
+        if is_class:
+            # Only check class size when C++ exposes data fields; otherwise it's an API-only
+            # view and D may add internal fields that legitimately increase the size.
+            if public_fields:
+                unit_lines.append(f"    checkSize!({name})({size});")
+        else:
+            unit_lines.append(f"    checkSize!({name})({size});")
+        for child in cursor.get_children():
+            if child.kind != CK.FIELD_DECL:
+                continue
+            if child.access_specifier not in (cx.AccessSpecifier.PUBLIC,
+                                               cx.AccessSpecifier.INVALID):
+                continue  # skip explicitly private/protected C++ fields
+            fname = child.spelling
+            if not fname:
+                continue
+            offset_bytes = child.get_field_offsetof() // 8
+            fsize = child.type.get_size()
+            if fsize <= 0:
+                continue
+            unit_lines.append(f'    checkField!({name}, "{fname}")({offset_bytes}, {fsize});')
+
+        if not is_class:
+            if unit_lines:
+                lines.append("unittest {")
+                lines.extend(unit_lines)
+                lines.append("}")
+            return  # structs have no vtable
+
+        # Virtual methods: vtable index (unittest) + mangled name (static assert).
+        virt_methods = [
+            c for c in cursor.get_children()
+            if c.kind == CK.CXX_METHOD and c.is_virtual_method()
+        ]
+        if not virt_methods:
+            if unit_lines:
+                lines.append("unittest {")
+                lines.extend(unit_lines)
+                lines.append("}")
+            return
+
+        name_count = Counter(m.spelling for m in virt_methods)
+
+        mangled_lines: list[str] = []
+        for method in virt_methods:
+            mname = method.spelling
+            mangled = method.mangled_name
+            overloaded = name_count[mname] > 1
+            d_method = uses_dstring(method)
+
+            idx = get_vtable_index(method, cursor)
+            if not overloaded and idx >= 0:
+                unit_lines.append(f'    checkVtable!({name}, "{mname}")({idx});')
+
+            if d_method:
+                mangled_lines.append(f"// skip {name}.{mname}.mangleof: extern(D) method, mangling differs")
+            elif overloaded:
+                mangled_lines.append(f'static assert(hasMangled!({name}, "{mname}", "{mangled}"));')
+            else:
+                mangled_lines.append(f'static assert({name}.{mname}.mangleof == "{mangled}");')
+
+        if unit_lines:
+            lines.append("unittest {")
+            lines.extend(unit_lines)
+            lines.append("}")
+        lines.extend(mangled_lines)
+
+    # Collected across all namespace dmd {} blocks (may span multiple headers).
+    dmd_free_funcs: list[cx.Cursor] = []
+
+    def collect_dmd_namespace(ns_cursor: cx.Cursor) -> None:
+        """Collect free functions in namespace dmd {} for later emission."""
+        for child in ns_cursor.get_children():
+            if child.kind == CK.FUNCTION_DECL and in_dir(child):
+                dmd_free_funcs.append(child)
+
+    seen: set[int] = set()
+
+    def walk(cursor: cx.Cursor) -> None:
+        for child in cursor.get_children():
+            h = child.hash
+            if h in seen:
+                continue
+            seen.add(h)
+
+            if not in_dir(child):
+                # Recurse into namespaces even from other files (dmd ns spans headers).
+                if child.kind == CK.NAMESPACE:
+                    walk(child)
+                continue
+
+            if child.kind == CK.ENUM_DECL and child.is_definition():
+                emit_enum(child)
+            elif child.kind in (CK.CLASS_DECL, CK.STRUCT_DECL) and child.is_definition():
+                emit_record(child)
+            elif child.kind == CK.NAMESPACE:
+                if child.spelling == "dmd":
+                    collect_dmd_namespace(child)
+                walk(child)
+
+    walk(tu.cursor)
+
+    # Emit mangled name checks for free functions in namespace dmd.
+    # All such functions are re-exported via dmd.cxxfrontend as extern(C++, "dmd").
+    if dmd_free_funcs:
+        name_count = Counter(f.spelling for f in dmd_free_funcs)
+        lines.append("")
+        lines.append("// free functions in namespace dmd (via dmd.cxxfrontend)")
+        for func in dmd_free_funcs:
+            fname = func.spelling
+            mangled = func.mangled_name
+            if fname in _SKIP_FREE_FUNCS:
+                lines.append(f"// skip dmd::{fname}: not in dmd.cxxfrontend on this platform")
+            elif uses_dstring(func):
+                lines.append(f"// skip dmd::{fname}: uses DString")
+            elif name_count[fname] > 1:
+                lines.append(f'static assert(hasMangled!(dmd.cxxfrontend, "{fname}", "{mangled}"));')
+            else:
+                lines.append(f'static assert(dmd.cxxfrontend.{fname}.mangleof == "{mangled}");')
+
+    out_path.write_text("\n".join(lines) + "\n")
+    print(f"Generated {out_path} ({len(lines)} lines)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <include_dir> <output_file>", file=sys.stderr)
+        sys.exit(1)
+
+    gen(Path(sys.argv[1]), Path(sys.argv[2]))


### PR DESCRIPTION
Fix regressions from https://github.com/dlang/dmd/pull/23176, as well as many other mismatches found by a WIP new CI check that I hope to push soon(tm)

Update: adds a new CI check that verifies that the manually maintained C++ headers in
include/dmd/ stay in sync with the D `extern(C++)` declarations in the compiler source.
Checks enum constant values, field offsets and sizes, class instance sizes, vtable indices, and C++ mangled names.

A python script uses clang to walk over all .h files in the include directory, and generate D asserts for enums, fields, and functions with C++ mangling. It currently generates:

https://gist.github.com/dkorpel/f8de8ca519e8dcfc2adcd691af6203e1

Then it runs it with the D compiler and -version=IN_LLVM (to skip fields in version (MARS) blocks). Added to the C++ test targets in build.d so you can run it with: ./build.d cpp-layout-test