### PR TITLE
Fix #23182 - Duplicate __aaget declaration for simple expression with associative array

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11825,7 +11825,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             /* If e1 is not trivial, take a reference to it
              */
             Expression de = null;
-            if (exp.e1.op != EXP.variable && exp.e1.op != EXP.arrayLength)
+            if (auto ale = exp.e1.isArrayLengthExp())
+            {
+                // don't evaluate arrExp twice in `arrExp.length++` if non-trivial
+                if (ale.e1.op != EXP.variable)
+                {
+                    // ref v = e1;
+                    auto v = copyToTemp(STC.ref_, "__postref", ale.e1);
+                    de = new DeclarationExp(ale.loc, v);
+                    ale.e1 = new VarExp(ale.e1.loc, v);
+                }
+            }
+            else if (exp.e1.op != EXP.variable)
             {
                 // ref v = e1;
                 auto v = copyToTemp(STC.ref_, "__postref", exp.e1);

--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -498,6 +498,26 @@ void test23065()
     A!B a;
     a == a;
 }
+
+// https://github.com/dlang/dmd/issues/23182
+void test23182()
+{
+    int[][string] aarr;
+    aarr["key"] = [];
+    aarr["key"].length++;
+
+    int calls = 0;
+    int[] a;
+    ref int[] arr()
+    {
+        calls++;
+        return a;
+    }
+    arr().length++;
+    assert(a.length == 1);
+    assert(calls == 1);
+}
+
 /***************************************************/
 
 // https://github.com/dlang/dmd/issues/22567
@@ -567,4 +587,5 @@ void main()
     test22567();
     test22556();
     test19829();
+    test23182();
 }


### PR DESCRIPTION
The underlying issue exists forever: `arrExp` should not be evaluated twice in `arrExp.length++` if non-trivial