### PR TITLE
Fix #17906 - recursive call wrongly assumed nothrow elides catch

### DIFF
--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -141,7 +141,7 @@ int blockExit(Statement s, FuncDeclaration func, ErrorSink eSink)
                     if (sl && (!sl.hasCode() || sl.isErrorStatement()))
                     {
                     }
-                    else if (func.getModule().filetype != FileType.c)
+                    else if (func && func.getModule().filetype != FileType.c)
                     {
                         const(char)* gototype = s.isCaseStatement() ? "case" : "default";
                         // https://issues.dlang.org/show_bug.cgi?id=22999

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3508,9 +3508,11 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         }
 
         /* If the try body never throws, we can eliminate any catches
-         * of recoverable exceptions.
+         * of recoverable exceptions. Pass `null` instead of `sc.func`
+         * so that a recursive call to the enclosing function is not assumed to be `nothrow`:
+         * https://github.com/dlang/dmd/issues/17906
          */
-        if (!(tcs._body.blockExit(sc.func, null) & BE.throw_) && ClassDeclaration.exception)
+        if (!(tcs._body.blockExit(null, null) & BE.throw_) && ClassDeclaration.exception)
         {
             foreach_reverse (i; 0 .. tcs.catches.length)
             {

--- a/compiler/test/fail_compilation/switch_fallthrough.d
+++ b/compiler/test/fail_compilation/switch_fallthrough.d
@@ -114,3 +114,25 @@ void test1(int i)
         default: break;
     }
 }
+
+/**
+Part of https://github.com/dlang/dmd/issues/17906
+
+TEST_OUTPUT:
+---
+fail_compilation/switch_fallthrough.d(133): Error: switch case fallthrough - use 'goto case;' if intended
+---
+**/
+void test17906(int i)
+{
+    try
+    {
+        switch (i)
+        {
+            case 1: { int x = 0; }
+            case 2: break;
+            default: break;
+        }
+    }
+    catch (Exception e) {}
+}

--- a/compiler/test/runnable/test17906.d
+++ b/compiler/test/runnable/test17906.d
@@ -1,0 +1,40 @@
+// https://github.com/dlang/dmd/issues/17906
+
+// A recursive call must not be assumed `nothrow` while inferring `nothrow`,
+// otherwise the `catch (Exception)` clause around it gets wrongly elided and
+// the exception is only caught by a more general `catch (Throwable)`.
+
+string caught;
+
+void foo(bool shouldThrow)
+{
+    if (shouldThrow)
+        throw new Exception("here");
+
+    try
+        foo(true);
+    catch (Exception e)
+        caught = "exception";
+    catch (Throwable t)
+        caught = "throwable";
+}
+
+int eval(int c)
+{
+    if (c > 0)
+    {
+        try
+            return eval(c - 1);
+        catch (Exception e)
+            return c;
+    }
+    throw new Exception("boom");
+}
+
+void main()
+{
+    foo(false);
+    assert(caught == "exception");
+
+    assert(eval(1) == 1);
+}


### PR DESCRIPTION
Closes #17906

Alternative to https://github.com/dlang/dmd/pull/23126 / https://github.com/dlang/dmd/pull/23127 which doesn't break nothrow inference or add more flags to FuncDeclaration. @adamdruppe 

nothrow is special because it is computed at the end of a function with `funcdecl.fbody.blockExit(funcdecl, ...)`. But before that, the catch block deletion is performed which also uses `blockExit(func)`. The `func` parameter is used to infer/check `nothrow` for  `func`, which allows recursive calls, which causes the bug: Allowing recursive calls is only sound when checking the entire body, not a subset of it. In the bug report, the `throw` is indeed outside the scope of the try-catch statement. This PR's solution is to not pass `func` to blockExit when used on only the try statement.