### PR TITLE
[funcsem.d] refactor `printCandidates`

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -51,6 +51,13 @@ class ErrorSinkCompiler : ErrorSink
     /// print gagged errors anyway
     bool showGaggedErrors;
 
+    /// Returns true if auxillary error reporting functions like `printCandidates`, `getMatchError` or
+    /// `getParamError` should print additional information.
+    final extern(D) bool emitAdditionalContext()
+    {
+        return !global.gag || showGaggedErrors;
+    }
+
   nothrow:
   extern (C++):
 

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2161,7 +2161,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
            fd.kind(), fd.toPrettyChars(), parametersTypeToChars(tf.parameterList),
            tf.modToChars(), fargsBuf.peekChars());
 
-    if (global.gag && !global.errorSink.showGaggedErrors)
+    if (!global.errorSink.emitAdditionalContext())
         return null;
 
     // re-resolve to check for supplemental message
@@ -2271,7 +2271,7 @@ private void checkNamedArgErrorAndReportOverload(Dsymbol od, ArgumentList argume
  */
 private void printCandidates(Decl)(Loc loc, Decl declaration, bool showDeprecated)
 {
-    if (global.gag && !global.errorSink.showGaggedErrors)
+    if (!global.errorSink.emitAdditionalContext())
         return;
     // max num of overloads to print (-v or -verror-supplements overrides this).
     const uint DisplayLimit = global.params.v.errorSupplementCount();

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2058,9 +2058,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
                 checkNamedArgErrorAndReport(td, argumentList, loc);
             }
 
-
-            if (!global.gag || global.errorSink.showGaggedErrors)
-                printCandidates(loc, td, sc.isDeprecated());
+            printCandidates(loc, td, sc.isDeprecated());
             return null;
         }
         /* This case used to happen when several ctors are mixed in an agregate.
@@ -2078,8 +2076,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
             od.ident.toErrMsg(), tiargsBuf.peekChars(), fargsBuf.peekChars());
 
         checkNamedArgErrorAndReportOverload(od, argumentList, loc);
-        if (!global.gag || global.errorSink.showGaggedErrors)
-            printCandidates(loc, od, sc.isDeprecated());
+        printCandidates(loc, od, sc.isDeprecated());
         return null;
     }
 
@@ -2119,8 +2116,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
                 .error(loc, "none of the overloads of `%s` are callable using a %sobject with argument types `(%s)`",
                     fd.toErrMsg(), thisBuf.peekChars(), buf.peekChars());
 
-            if (!global.gag || global.errorSink.showGaggedErrors)
-                printCandidates(loc, fd, sc.isDeprecated());
+            printCandidates(loc, fd, sc.isDeprecated());
             return null;
         }
 
@@ -2157,8 +2153,7 @@ FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
     {
         .error(loc, "none of the overloads of `%s` are callable using argument types `%s`",
                fd.toErrMsg(), fargsBuf.peekChars());
-        if (!global.gag || global.errorSink.showGaggedErrors)
-            printCandidates(loc, fd, sc.isDeprecated());
+        printCandidates(loc, fd, sc.isDeprecated());
         return null;
     }
 
@@ -2276,6 +2271,8 @@ private void checkNamedArgErrorAndReportOverload(Dsymbol od, ArgumentList argume
  */
 private void printCandidates(Decl)(Loc loc, Decl declaration, bool showDeprecated)
 {
+    if (global.gag && !global.errorSink.showGaggedErrors)
+        return;
     // max num of overloads to print (-v or -verror-supplements overrides this).
     const uint DisplayLimit = global.params.v.errorSupplementCount();
     const(char)* constraintsTip;

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -2053,7 +2053,7 @@ private extern(D) ptrdiff_t findParameterIndex(TypeFunction tf, Identifier ident
  */
 private extern(C) void getMatchError(ref OutBuffer buf, const(char)* format, ...)
 {
-    if (global.gag && !global.errorSink.showGaggedErrors)
+    if (!global.errorSink.emitAdditionalContext())
         return;
     va_list ap;
     va_start(ap, format);
@@ -2661,7 +2661,7 @@ private extern(D) MATCH argumentMatchParameter (FuncDeclaration fd, TypeFunction
 // arguments get specially formatted
 private const(char)* getParamError(TypeFunction tf, Expression arg, Parameter par)
 {
-    if (global.gag && !global.errorSink.showGaggedErrors)
+    if (!global.errorSink.emitAdditionalContext())
         return null;
     // show qualification when toChars() is the same but types are different
     // https://issues.dlang.org/show_bug.cgi?id=19948


### PR DESCRIPTION
reduce independent use of `global.errorSink.showGaggedErrors`/`global.gag`