### PR TITLE
Fix #23202 - mixin templates lose last level of instantiation stack

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4191,6 +4191,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             printf("\tdo semantic() on template instance members '%s'\n", tm.toChars());
         }
         Scope* sc2 = argscope.push(tm);
+        tm.tinst = sc.tinst;
+        sc2.tinst = tm;
         //size_t deferred_dim = Module.deferred.length;
 
         __gshared int nest;

--- a/compiler/test/fail_compilation/fail6334.d
+++ b/compiler/test/fail_compilation/fail6334.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6334.d(13): Error: static assert:  `0` is false
-fail_compilation/fail6334.d(11):        instantiated from here: `mixin T2!();`
+fail_compilation/fail6334.d(14): Error: static assert:  `0` is false
+fail_compilation/fail6334.d(12):        instantiated from here: `mixin T2!();`
+fail_compilation/fail6334.d(19):        instantiated from here: `mixin T1!();`
 ---
 */
 


### PR DESCRIPTION
Closes #23202

Only needed to update the output of the existing mixin test.