### PR TITLE
Fix #23117 - standalone module ctors run multiple times in a cycle

### DIFF
--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -1333,6 +1333,7 @@ private void genObjFile(Module m, bool multiobj, bool doppelganger)
     glue.ectorgates.setDim(0);
     glue.sdtors.setDim(0);
     glue.ssharedctors.setDim(0);
+    glue.sisharedctors.setDim(0);
     glue.esharedctorgates.setDim(0);
     glue.sshareddtors.setDim(0);
     glue.stests.setDim(0);

--- a/compiler/test/runnable/imports/standalone_b.d
+++ b/compiler/test/runnable/imports/standalone_b.d
@@ -5,7 +5,10 @@ import core.attribute : standalone;
 
 immutable int* y;
 
+__gshared int bCount;
+
 @standalone @system shared static this()
 {
     y = new int(2);
+    ++bCount;
 }

--- a/compiler/test/runnable/standalone_modctor.d
+++ b/compiler/test/runnable/standalone_modctor.d
@@ -7,13 +7,21 @@ import core.attribute : standalone;
 
 immutable int* x;
 
+// https://github.com/dlang/dmd/issues/23117
+// a standalone ctor must run exactly once, even when several modules in the
+// same compilation define one and form an import cycle.
+__gshared int aCount;
+
 @standalone @system shared static this()
 {
     x = new int(1);
+    ++aCount;
 }
 
 void main()
 {
     assert(*x == 1);
     assert(*y == 2);
+    assert(aCount == 1);
+    assert(bCount == 1);
 }


### PR DESCRIPTION
Closes #23117

Claude's description:

> glue.sisharedctors was not reset between modules in genObjFile, unlike its sibling arrays. When several modules with @standalone shared static ctors were compiled in one invocation, an earlier module's ctor leaked into a later module's __modsharedictor and ran more than once.