### PR TITLE
remove defensive null check

### DIFF
--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -141,7 +141,7 @@ int blockExit(Statement s, FuncDeclaration func, ErrorSink eSink)
                     if (sl && (!sl.hasCode() || sl.isErrorStatement()))
                     {
                     }
-                    else if (func && func.getModule().filetype != FileType.c)
+                    else if (func.getModule().filetype != FileType.c)
                     {
                         const(char)* gototype = s.isCaseStatement() ? "case" : "default";
                         // https://issues.dlang.org/show_bug.cgi?id=22999


### PR DESCRIPTION
dmd is full of pointers. If we start adding defensive checks, there would be a lot of clutter. It's better to only check if the pointer being null is legitimate. Otherwise, a seg fault and stack trace are needed to find the actual bug rather than paper it over.

For reference: https://github.com/dlang/dmd/pull/23194/changes