### PR TITLE
fix #22671 - Allow GC allocations in if (__ctfe) blocks in @nogc functions

### DIFF
--- a/compiler/include/dmd/statement.h
+++ b/compiler/include/dmd/statement.h
@@ -519,6 +519,7 @@ public:
     Expression *exp;
     size_t caseDim;
     FuncDeclaration *fesFunc;   // nested function for foreach it is in
+    Scope* scope_;
 
     ReturnStatement *syntaxCopy() override;
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3498,7 +3498,7 @@ private bool checkNogc(FuncDeclaration f, ref Loc loc, Scope* sc)
         return false;
     if (sc.intypeof == 1)
         return false;
-    if (sc.ctfe || sc.debug_)
+    if (sc.ctfe || sc.debug_ || sc.ctfeBlock)
         return false;
     if (sc.inDefaultArg || sc.callLoc.isValid)
         return false;

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -114,7 +114,7 @@ public:
      */
     private bool setGC(Expression e, const(char)* msg)
     {
-        if (sc.debug_)
+        if (sc.debug_ || sc.ctfe || sc.ctfeBlock)
             return false;
         if (checkOnly)
         {

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -852,12 +852,13 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     {
                         ReturnStatement rs = (*funcdecl.returns)[i];
                         Expression exp = rs.exp;
+                        Scope* sc3 = rs.scope_;
                         if (exp.op == EXP.error)
                             continue;
                         if (tret.ty == Terror)
                         {
                             // https://issues.dlang.org/show_bug.cgi?id=13702
-                            exp = exp.checkGC(sc2);
+                            exp = exp.checkGC(sc3);
                             continue;
                         }
 
@@ -896,24 +897,24 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                 if (tclass)
                                 {
                                     if ((cast(TypeClass)(exp.type.immutableOf())).implicitConvToWithoutAliasThis(tret))
-                                        exp = exp.castTo(sc2, exp.type.immutableOf());
+                                        exp = exp.castTo(sc3, exp.type.immutableOf());
                                     else if ((cast(TypeClass)(exp.type.wildOf())).implicitConvToWithoutAliasThis(tret))
-                                        exp = exp.castTo(sc2, exp.type.wildOf());
+                                        exp = exp.castTo(sc3, exp.type.wildOf());
                                 }
                                 else
                                 {
                                     if ((cast(TypeStruct)exp.type.immutableOf()).implicitConvToWithoutAliasThis(tret))
-                                        exp = exp.castTo(sc2, exp.type.immutableOf());
+                                        exp = exp.castTo(sc3, exp.type.immutableOf());
                                     else if ((cast(TypeStruct)exp.type.wildOf()).implicitConvToWithoutAliasThis(tret))
-                                        exp = exp.castTo(sc2, exp.type.wildOf());
+                                        exp = exp.castTo(sc3, exp.type.wildOf());
                                 }
                             }
                             else
                             {
                                 if (exp.type.immutableOf().implicitConvTo(tret))
-                                    exp = exp.castTo(sc2, exp.type.immutableOf());
+                                    exp = exp.castTo(sc3, exp.type.immutableOf());
                                 else if (exp.type.wildOf().implicitConvTo(tret))
-                                    exp = exp.castTo(sc2, exp.type.wildOf());
+                                    exp = exp.castTo(sc3, exp.type.wildOf());
                             }
                         }
 
@@ -924,9 +925,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                 error(exp.loc, "expression `%s` of type `%s` is not implicitly convertible to return type `ref %s`",
                                       exp.toErrMsg(), exp.type.toErrMsg(), tret.toErrMsg());
                             else
-                                exp = exp.implicitCastTo(sc2, tret);
+                                exp = exp.implicitCastTo(sc3, tret);
 
-                            exp = exp.toLvalue(sc2, "`ref` return");
+                            exp = exp.toLvalue(sc3, "`ref` return");
                             checkAddressable(exp, sc2, "`ref` return");
                             checkReturnEscapeRef(*sc2, exp, false);
                             exp = exp.optimize(WANTvalue, /*keepLvalue*/ true);
@@ -938,7 +939,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             if (!hasCopyCtor || !exp.isLvalue())
                             {
                                 const errors = global.startGagging();
-                                auto implicitlyCastedExp = exp.implicitCastTo(sc2, tret);
+                                auto implicitlyCastedExp = exp.implicitCastTo(sc3, tret);
                                 global.endGagging(errors);
 
                                 // <https://github.com/dlang/dmd/issues/20888>
@@ -976,17 +977,17 @@ private extern(C++) final class Semantic3Visitor : Visitor
                              * during initialization of __result.
                              */
                             if (!funcdecl.isNRVO && !funcdecl.vresult)
-                                exp = doCopyOrMove(sc2, exp, f.next, true, true);
+                                exp = doCopyOrMove(sc3, exp, f.next, true, true);
 
                             if (tret.hasPointers())
                                 checkReturnEscape(*sc2, exp, false);
                         }
 
-                        exp = exp.checkGC(sc2);
+                        exp = exp.checkGC(sc3);
 
                         if (funcdecl.vresult)
                         {
-                            Scope* scret = sc2;
+                            Scope* scret = sc3;
 
                             if (rs.fesFunc)
                             {
@@ -1011,7 +1012,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         }
                         else if (funcdecl.tintro && !tret.equals(funcdecl.tintro.nextOf()))
                         {
-                            exp = exp.implicitCastTo(sc2, funcdecl.tintro.nextOf());
+                            exp = exp.implicitCastTo(sc3, funcdecl.tintro.nextOf());
                         }
                         rs.exp = exp;
                     }

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -21,6 +21,7 @@ import dmd.astenums;
 import dmd.ast_node;
 import dmd.cond;
 import dmd.declaration;
+import dmd.dscope;
 import dmd.dsymbol;
 import dmd.expression;
 import dmd.func;
@@ -1309,6 +1310,7 @@ extern (C++) final class ReturnStatement : Statement
     Expression exp;
     size_t caseDim;
     FuncDeclaration fesFunc; // nested function for foreach it is in
+    Scope* scope_;
 
     extern (D) this(Loc loc, Expression exp) @safe
     {

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2570,6 +2570,15 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             fd = fd.fes.func; // fd is now function enclosing foreach
         }
 
+        void addToFunctionReturns()
+        {
+            sc.setNoFree();
+            rs.scope_ = sc;
+            if (!fd.returns)
+                fd.returns = new ReturnStatements();
+            fd.returns.push(rs);
+        }
+
         auto tf = fd.type.isTypeFunction();
 
         if (rs.exp && rs.exp.isVarExp() && rs.exp.isVarExp().var == fd.vresult)
@@ -2590,9 +2599,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 return;
             }
 
-            if (!fd.returns)
-                fd.returns = new ReturnStatements();
-            fd.returns.push(rs);
+            addToFunctionReturns();
             result = rs;
             return;
         }
@@ -2980,9 +2987,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         }
         if (rs.exp)
         {
-            if (!fd.returns)
-                fd.returns = new ReturnStatements();
-            fd.returns.push(rs);
+            addToFunctionReturns();
         }
         if (e0)
         {

--- a/compiler/test/compilable/nogc.d
+++ b/compiler/test/compilable/nogc.d
@@ -125,3 +125,47 @@ version (D_SIMD) void f24072() @nogc
     int4 b = cast(int4)[1, 2, 3, 4];
     int4 c = cast(int4)[1, 2];
 }
+
+// https://github.com/dlang/dmd/issues/22671
+
+bool odd22671(int n)
+{
+    auto p = new int[n];
+    return p.length & 1;
+}
+
+char[] test22671(int n) @nogc
+{
+    import core.stdc.stdlib;
+
+    enum odd3 = odd22671(3); // ok to evaluate constant via CTFE, does not change function attributes
+    char[] buf;
+    if (__ctfe)
+    {
+        if (odd22671(n)) // allow calling GC function
+            buf = new char[n + 1]; // ~ new char[1]; // ~ char[int].init.values; // some GC operations
+    }
+    else
+    {
+        if (n & 1)
+            buf = (cast(char*)malloc(n + 1))[0..n];
+    }
+    if (!buf)
+    {
+        if (!__ctfe)
+        {
+            buf = (cast(char*)malloc(n))[0..n];
+        }
+        else
+        {
+            return new char[n];
+        }
+    }
+    debug
+    {
+        buf = new char[0]; // was ok
+        if (!buf)
+            return new char[2]; // used to be bad
+    }
+   return buf;
+}


### PR DESCRIPTION
- ignore ctfe-blocks in checkNogc
- use the scope at the return statement to call checkGC and implicit conversions, not the function scope

This also uncovered that returns from `debug` blocks where also checked at function scope.

Alternative to #22680

Keeping the Scope is likely to use more memory (if the scope isn't kept anyway), but it seems more consistent with other code than to pick partial information (`ctfeBlock` and `debug_`). It also seems more correct to use the scope for implicit conversions of the return expression as the result is written back to the return statement.

There is a small chance that CFTE-blocks have been abused to infer not-`@nogc` for a template function. The alternative is to use if(false) {} blocks instead. Does this warrant a changelog entry for a breaking change?