### PR TITLE
fix #22956 - ICE calling function pointer with noreturn parameter

### DIFF
--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -1670,11 +1670,12 @@ elem* toElem(Expression e, ref IRState irs)
             return e;
         }
 
+        tym_t ororty = ae.type && ae.type.toBasetype().ty == Tnoreturn ? TYnoreturn : TYvoid;
         if (irs.params.checkAction == CHECKACTION.C)
         {
             auto econd = toElem(ae.e1, irs);
             auto ea = callCAssert(irs, ae.loc, ae.e1, ae.msg, null);
-            auto eo = el_bin(OPoror, TYvoid, econd, ea);
+            auto eo = el_bin(OPoror, ororty, econd, ea);
             elem_setLoc(eo, ae.loc);
             return eo;
         }
@@ -1686,7 +1687,7 @@ elem* toElem(Expression e, ref IRState irs)
              */
             auto econd = toElem(ae.e1, irs);
             auto ea = genHalt(ae.loc);
-            auto eo = el_bin(OPoror, TYvoid, econd, ea);
+            auto eo = el_bin(OPoror, ororty, econd, ea);
             elem_setLoc(eo, ae.loc);
             return eo;
         }
@@ -1773,11 +1774,11 @@ elem* toElem(Expression e, ref IRState irs)
         {
             // tmp = e, e || assert, e.inv
             elem* eassign = el_bin(OPeq, e.Ety, el_var(ts), e);
-            e = el_combine(eassign, el_bin(OPoror, TYvoid, el_var(ts), ea));
+            e = el_combine(eassign, el_bin(OPoror, ororty, el_var(ts), ea));
             e = el_combine(e, einv);
         }
         else
-            e = el_bin(OPoror,TYvoid,e,ea);
+            e = el_bin(OPoror,ororty,e,ea);
         elem_setLoc(e,ae.loc);
         return e;
     }

--- a/compiler/test/compilable/test23068.d
+++ b/compiler/test/compilable/test23068.d
@@ -5,8 +5,7 @@ TEST_OUTPUT:
 ---
 main:
 0000:   0F 0B                    ud2
-0002:   31 C0                    xor       EAX,EAX
-0004:   C3                       ret
+0002:   C3                       ret
 ---
 */
 

--- a/compiler/test/runnable/noreturn2.d
+++ b/compiler/test/runnable/noreturn2.d
@@ -145,15 +145,20 @@ void testAccess()
         return a;
     });
 
-    // FIXME: assertion failure in the backend in paramsize() - noreturn.sizeof = 0
     // https://github.com/dlang/dmd/issues/20286
-    version (FIXME)
     testAssertFailure(__LINE__ + 4, msg, function noreturn()
     {
         static void foo(noreturn) {}
         noreturn a;
         foo(a);
         assert(false, "Unreachable!"); // Ditto
+    });
+
+    // https://github.com/dlang/dmd/issues/22956
+    testAssertFailure(__LINE__ + 3, "Assertion failure",
+    {
+        void function(noreturn) fun;
+        fun(assert(0));
     });
 
     testAssertFailure(__LINE__ + 5, msg,


### PR DESCRIPTION
do not convert AssertExp of type noreturn to void in the backend

Also fixes #20286.

disclosure: I used this issue as an experiment to see what a local qwen3.6 model can do. It analyzed the issue pretty well, but the proposed fix was slightly off.

