### PR TITLE
fix #21638 - AA operations don't honor left-to-right evaluation order

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3685,15 +3685,15 @@ extern (C++) final class InExp : BinExp
 }
 
 /***********************************************************
- * Associative array removal, `aa.remove(arg)`
+ * Associative array removal, `aa.remove(key)`
  *
- * This deletes the key e1 from the associative array e2
+ * This deletes the key ekey from the associative array eaa
  */
 extern (C++) final class RemoveExp : BinExp
 {
-    extern (D) this(Loc loc, Expression e1, Expression e2)
+    extern (D) this(Loc loc, Expression eaa, Expression ekey)
     {
-        super(loc, EXP.remove, e1, e2);
+        super(loc, EXP.remove, eaa, ekey);
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6108,13 +6108,30 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         auto valtype = aaType.nextOf().substWildTo(MODFlags.const_);
         auto tiargs = new Objects(keytype, valtype);
         hookFunc = new DotTemplateInstanceExp(aaExp.loc, hookFunc, hookId, tiargs);
-        auto ale1 = new ArrayLiteralExp(aaExp.loc, keytype.arrayOf(), aaExp.keys);
-        auto ale2 = new ArrayLiteralExp(aaExp.loc, valtype.arrayOf(), aaExp.values);
+        Expression ekv;
+        auto keys = aaExp.keys;
+        auto values = aaExp.values;
+        if (keys && values && values.length > 1)
+        {
+            // ensure lexical order
+            keys = new Expressions(aaExp.keys.length);
+            values = new Expressions(aaExp.values.length);
+            for (size_t i = 0; i < aaExp.values.length; i++)
+            {
+                // use STC.nodtor on temporaries, because the rvalues are moved to a stack
+                // allocated array in lowerArrayLiteral() without an additional postblit call
+                (*keys)[i] = extractSideEffect(sc, "__aalitkey", ekv, (*aaExp.keys)[i], false, STC.exptemp | STC.nodtor);
+                (*values)[i] = extractSideEffect(sc, "__aalitval", ekv, (*aaExp.values)[i], false, STC.exptemp | STC.nodtor);
+            }
+        }
+        auto ale1 = new ArrayLiteralExp(aaExp.loc, keytype.arrayOf(), keys);
+        auto ale2 = new ArrayLiteralExp(aaExp.loc, valtype.arrayOf(), values);
         lowerArrayLiteral(ale1, sc);
         lowerArrayLiteral(ale2, sc);
         auto arguments = new Expressions(ale1, ale2);
 
         Expression loweredExp = new CallExp(aaExp.loc, hookFunc, arguments);
+        loweredExp = Expression.combine(ekv, loweredExp);
         loweredExp = loweredExp.expressionSemantic(sc);
         loweredExp = resolveProperties(sc, loweredExp);
         aaExp.lowering = loweredExp;

--- a/compiler/test/runnable/testaa2.d
+++ b/compiler/test/runnable/testaa2.d
@@ -379,10 +379,7 @@ void testEvaluationOrder()
 	seqaa(1).rehash;
 	seqaa(1).clear;
 
-	version (none)
-		seqaa(1) = [seqi(2, 1) : seqi(3, 1), seqi(4, 2) : seqi(5, 4)]; // aa = [1:1, 2:4]
-	else
-		aa = [1:1, 2:4];
+	seqaa(1) = [seqi(2, 1) : seqi(3, 1), seqi(4, 2) : seqi(5, 4)]; // aa = [1:1, 2:4]
 
 	assert(seqaa(1).remove(seqi(2, 1))); // aa.remove(1)
 


### PR DESCRIPTION
extract side-effects for AA literals in lexical order.

Also fixes the comment for RemoveExp where arguments were reversed.
