### PR TITLE
[changelog] Tweaks & fixes

### DIFF
--- a/changelog/dmd.exception-rewrite.dd
+++ b/changelog/dmd.exception-rewrite.dd
@@ -1,6 +1,6 @@
-Destructors now run in a nothrow function when an Error unwinds through it
+Destructors now run in a `nothrow` function when an `Error` unwinds through it
 
-Destructors and scope(exit) blocks internally generate try-finally statements.
+Destructors and `scope(exit)` blocks internally generate try-finally statements.
 Since 2018, DMD has optimized `finally` blocks in `nothrow` try bodies by rewriting them into a simple sequence,
 avoiding the overhead of exception unwinding. However, this optimization also skipped `finally` blocks when
 an `Error` was thrown, preventing expected cleanup from running.

--- a/changelog/dmd.nullderefcheck.dd
+++ b/changelog/dmd.nullderefcheck.dd
@@ -2,7 +2,7 @@ An optional check for null dereference is added
 
 A new check has been implemented that injects code to check a pointer for null before it is dereferenced.
 
-It will be typically be used if you need a backtrace generated (when one is not automatically done), or if you want to catch and handle the Error as part of a scheduler.
+It will be typically be used if you need a backtrace generated (when one is not automatically done), or if you want to catch and handle the `Error` as part of a scheduler.
 
 This can be enabled by using ``-check=nullderef=on`` by default it is off.
 What happens may be customized by the ``-checkaction`` switch and by setting a new handler in ``core.exception``.

--- a/changelog/dmd.vgc-closure.dd
+++ b/changelog/dmd.vgc-closure.dd
@@ -1,11 +1,11 @@
--vgc now reports locations of nested functions that create closures
+`-vgc` now reports locations of nested functions that create closures
 
 When a GC-allocated closure was created, the `-vgc` switch would only point to the outer function that a closure was created for.
 For a big function, this still requires you to search where the nested function requiring the closure actually is.
 It now reports the closure function and variable location just like in error messages for `@nogc`.
 
 ```
-auto closure()
+auto foo()
 {
     int x;
     int bar() { return x; }
@@ -13,11 +13,13 @@ auto closure()
 }
 ```
 
-After:
+Before:
 
 $(CONSOLE
 vgc.d(1): vgc: using closure causes GC allocation
 )
+
+After:
 
 $(CONSOLE
 vgc.d(1): vgc: using closure causes GC allocation

--- a/changelog/dmd.with-assign.dd
+++ b/changelog/dmd.with-assign.dd
@@ -1,4 +1,4 @@
-Add support for `with(auto x = expression())`
+Add support for `with (auto x = expression())`
 
-Added support for using `with` statements with an expression initialiser as an `AssignExpression`, like `if`, `while` for` and `switch`.
-For backwards compatibility, `with` still also accepts a qualified expression without assignment to a variable as in `with(immutable expression())`.
+Added support for using `with` statements with an expression initialiser as an `AssignExpression`, like `if`, `while`, `for` and `switch`.
+For backwards compatibility, `with` still also accepts a qualified expression without assignment to a variable, e.g. `with (immutable expression())`.

--- a/changelog/druntime.filterthrown.dd
+++ b/changelog/druntime.filterthrown.dd
@@ -1,6 +1,6 @@
-Gravedigger approach to Throwables escaping a thread entry point is now available
+Gravedigger approach to `Throwable`s escaping a thread entry point is now available
 
-A new method is added to `ThreadBase` enabling filtering of any `Throwable`'s before it is handled by the thread abstraction.
+A new method is added to `ThreadBase` enabling filtering of any `Throwable`s before it is handled by the thread abstraction.
 This may be used per-thread and globally, to log that an `Error` has occured or to exit the process.
 
 A reasonable error handler that may be of use is:

--- a/changelog/druntime.pow.dd
+++ b/changelog/druntime.pow.dd
@@ -1,6 +1,6 @@
-Translate ^^ operator to druntime hook
+Translate `^^` operator to druntime hook
 
-The exponentiation operator (^^) is now lowered to a druntime hook call instead of being expanded inline by the compiler.
+The exponentiation operator (`^^`) is now lowered to a druntime hook call instead of being expanded inline by the compiler.
 This change moves the implementation logic into the runtime library, allowing for easier maintenance and platform-specific optimizations without requiring compiler modifications.
 
 ```d

--- a/changelog/druntime.timerfd.dd
+++ b/changelog/druntime.timerfd.dd
@@ -1,4 +1,4 @@
-core.sys.linux.timerfd moved to core.sys.linux.sys.timerfd
+`core.sys.linux.timerfd` moved to `core.sys.linux.sys.timerfd`
 
 Usually, a linux header that's included in C like `#include <sys/time.h>` gets its translation in `core/sys/linux/sys/time.d`.
 timerfd.d was an exception, not being put in the `sys` package.


### PR DESCRIPTION
Mostly formatting.
Rename `dmd.timerfd.dd` to `druntime.*`.