### PR TITLE
druntime: hide irrelevant (to docs) sentinel guard on assumeSafeAppend

### DIFF
--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -4064,22 +4064,36 @@ auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr) nothrow @system
     return arr;
 }
 
-///
-@system unittest
+version (D_Ddoc)
 {
-    int[] a = [1, 2, 3, 4];
-
-    // Without assumeSafeAppend. Appending relocates.
-    int[] b = a [0 .. 3];
-    b ~= 5;
-    assert(a.ptr != b.ptr);
-
-    debug(SENTINEL) {} else
+    ///
+    @system unittest
     {
+        int[] a = [1, 2, 3, 4];
+        // Without assumeSafeAppend. Appending relocates.
+        int[] b = a [0 .. 3];
+        b ~= 5;
+        assert(a.ptr != b.ptr);
         // With assumeSafeAppend. Appending overwrites.
         int[] c = a [0 .. 3];
         c.assumeSafeAppend() ~= 5;
         assert(a.ptr == c.ptr);
+    }
+}
+else
+{
+    @system unittest
+    {
+        debug (SENTINEL) {} else
+        {
+            int[] a = [1, 2, 3, 4];
+            int[] b = a [0 .. 3];
+            b ~= 5;
+            assert(a.ptr != b.ptr);
+            int[] c = a [0 .. 3];
+            c.assumeSafeAppend() ~= 5;
+            assert(a.ptr == c.ptr);
+        }
     }
 }
 


### PR DESCRIPTION
Addresses [dlang/dmd#23240](https://github.com/dlang/dmd/issues/23240)

Following @0xEAB suggestion after a clarifying question. 

Image of generated doc without irrelevant guard: 
<img width="388" height="232" alt="image" src="https://github.com/user-attachments/assets/de306830-328e-43f5-99b5-6a297e1df8d3" />

Duplicating the test was pointed out to be a convenient solution barring a feature addition. 