### PR TITLE
fix #23262 - [REG v2.113.0-beta.1] ICE when trying to cast a class instance to a C++ interface

### DIFF
--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -277,7 +277,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         return false;
     }
 
-    enum OFFSET_RUNTIME = 0x76543210;
     enum OFFSET_FWDREF = 0x76543211;
 
     /*******************************************
@@ -426,7 +425,6 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
      * (Actually, if it is an interface supported by cd)
      * Output:
      *      *poffset        offset to start of class
-     *                      OFFSET_RUNTIME  must determine offset at runtime
      * Returns:
      *      false   not a base
      *      true    is a base

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4993,10 +4993,23 @@ private void lowerCastExp(CastExp cex, Scope* sc)
     ClassDeclaration cdto   = tob.isClassHandle();
 
     int offset;
-    if ((cdto.isBaseOf(cdfrom, &offset) && offset != ClassDeclaration.OFFSET_RUNTIME)
-        || cdfrom.classKind == ClassKind.cpp)
-        return;
+    if (cdto.isBaseOf(cdfrom, &offset) && offset != ClassDeclaration.OFFSET_RUNTIME)
+        return; // codegen has to deal with pointer adjustment
 
+    if (cdfrom.classKind != ClassKind.d ||
+        (cdto.classKind != ClassKind.d &&
+         !(cdto.classKind == ClassKind.cpp && cdto.isInterfaceDeclaration())))
+    {
+        if (cdfrom.classKind == cdto.classKind)
+            return; // for non-D classes, generate a reinterpreting cast
+
+        // conversion other than D -> C++ interface result in null
+        Expression lowerNull = new NullExp(cex.loc, cex.to);
+        cex.lowering = lowerNull .expressionSemantic(sc);
+        return;
+    }
+
+    // cast D -> D / C++ interface calls _d_cast
     Identifier hook = Id._d_cast;
     if (!verifyHookExist(cex.loc, *sc, hook, "d_cast", Id.object))
         return;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4994,7 +4994,7 @@ private void lowerCastExp(CastExp cex, Scope* sc)
 
     int offset;
     if ((cdto.isBaseOf(cdfrom, &offset) && offset != ClassDeclaration.OFFSET_RUNTIME)
-        || cdfrom.classKind == ClassKind.cpp || cdto.classKind == ClassKind.cpp)
+        || cdfrom.classKind == ClassKind.cpp)
         return;
 
     Identifier hook = Id._d_cast;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4993,23 +4993,22 @@ private void lowerCastExp(CastExp cex, Scope* sc)
     ClassDeclaration cdto   = tob.isClassHandle();
 
     int offset;
-    if (cdto.isBaseOf(cdfrom, &offset) && offset != ClassDeclaration.OFFSET_RUNTIME)
+    if (cdto.isBaseOf(cdfrom, &offset))
         return; // codegen has to deal with pointer adjustment
 
     if (cdfrom.classKind != ClassKind.d ||
-        (cdto.classKind != ClassKind.d &&
-         !(cdto.classKind == ClassKind.cpp && cdto.isInterfaceDeclaration())))
+        (cdto.classKind != ClassKind.d && !cdto.isInterfaceDeclaration()))
     {
         if (cdfrom.classKind == cdto.classKind)
-            return; // for non-D classes, generate a reinterpreting cast
+            return; // for non-D classes, let the backend take care
 
-        // conversion other than D -> C++ interface result in null
+        // conversions across different linkage result in null
         Expression lowerNull = new NullExp(cex.loc, cex.to);
         cex.lowering = lowerNull .expressionSemantic(sc);
         return;
     }
 
-    // cast D -> D / C++ interface calls _d_cast
+    // cast D -> unrelated D class / any interface calls _d_cast
     Identifier hook = Id._d_cast;
     if (!verifyHookExist(cex.loc, *sc, hook, "d_cast", Id.object))
         return;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6469,8 +6469,6 @@ public:
     static ClassDeclaration* create(Loc loc, Identifier* id, Array<BaseClass* >* baseclasses, Array<Dsymbol* >* members, bool inObject);
     const char* toPrettyChars(bool qualifyTypes = false) override;
     ClassDeclaration* syntaxCopy(Dsymbol* s) override;
-    enum : int32_t { OFFSET_RUNTIME = 1985229328 };
-
     enum : int32_t { OFFSET_FWDREF = 1985229329 };
 
     virtual bool isBaseOf(ClassDeclaration* cd, int32_t* poffset);

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -4644,7 +4644,7 @@ elem* toElemCast(CastExp ce, elem* e, bool isLvalue, ref IRState irs)
         ClassDeclaration cdto   = t.isClassHandle();
 
         int offset;
-        if (cdto.isBaseOf(cdfrom, &offset) && offset != ClassDeclaration.OFFSET_RUNTIME)
+        if (cdto.isBaseOf(cdfrom, &offset))
         {
             /* The offset from cdfrom => cdto is known at compile time.
              * Cases:
@@ -4679,26 +4679,13 @@ elem* toElemCast(CastExp ce, elem* e, bool isLvalue, ref IRState irs)
                 // Casting from derived class to base class is a no-op
             }
         }
-        else if (cdfrom.classKind == ClassKind.cpp)
+        else if (cdfrom.classKind == cdto.classKind)
         {
-            if (cdto.classKind == ClassKind.cpp)
-            {
-                /* Casting from a C++ interface to a C++ interface
-                 * is always a 'paint' operation
-                 */
-                return Lret(ce, e);                  // no-op
-            }
-
-            /* Casting from a C++ interface to a class
-             * always results in null because there is no runtime
-             * information available to do it.
-             *
-             * Casting from a C++ interface to a non-C++ interface
-             * always results in null because there is no way one
-             * can be derived from the other.
+            /* Casting from a non-D linkage class/interface to a unrelated class/interface
+             * is always a 'paint' operation (for dmd, other backends might use RTTI
+             * of other languages)
              */
-            e = el_bin(OPcomma, TYnptr, e, el_long(TYnptr, 0));
-            return Lret(ce, e);
+            return Lret(ce, e);                  // no-op
         }
         else
         {

--- a/compiler/src/dmd/glue/toir.d
+++ b/compiler/src/dmd/glue/toir.d
@@ -273,7 +273,6 @@ elem* getEthis(Loc loc, ref IRState irs, Dsymbol fd, Dsymbol fdp = null, Dsymbol
 
                 int offset;
                 cdp.isBaseOf(cd, &offset);
-                assert(offset != ClassDeclaration.OFFSET_RUNTIME);
                 //printf("%s to %s, offset = %d\n", cd.toChars(), cdp.toChars(), offset);
                 if (offset)
                 {

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -865,13 +865,15 @@ Expression optimize(Expression e, int result, bool keepLvalue = false)
         if (e.type.ty == Tclass && e.e1.type.ty == Tclass)
         {
             import dmd.astenums : Sizeok;
+            import dmd.aggregate : ClassKind;
 
             // See if we can remove an unnecessary cast
             ClassDeclaration cdfrom = e.e1.type.isClassHandle();
             ClassDeclaration cdto = e.type.isClassHandle();
             if (cdfrom.errors || cdto.errors)
                 return errorReturn();
-            if (cdto == ClassDeclaration.object && !cdfrom.isInterfaceDeclaration())
+            if (cdto == ClassDeclaration.object && cdfrom.classKind == ClassKind.d &&
+                !cdfrom.isInterfaceDeclaration())
                 return returnE_e1();    // can always convert a class to Object
             // Need to determine correct offset before optimizing away the cast.
             // https://issues.dlang.org/show_bug.cgi?id=16980

--- a/compiler/test/runnable/casting.d
+++ b/compiler/test/runnable/casting.d
@@ -218,6 +218,11 @@ extern(C++) interface iface23262
     int funCpp();
 }
 
+extern(C++) class cpp23262
+{
+    int funCpp() { return 1; }
+}
+
 class class23262 : Object, iface23262
 {
     extern(C++)	int funCpp() { return 42; }
@@ -226,9 +231,19 @@ class class23262 : Object, iface23262
 void test23262()
 {
     Object obj = new class23262;
-    auto cpp = cast(iface23262) obj;
+    auto cpp = cast(iface23262) obj; // ok for C++ interface
     assert(cpp);
     assert(cpp.funCpp() == 42);
+
+    auto cpp2 = cast(cpp23262) obj;
+    assert(cpp2 is null); // impossible for C++ class
+
+    auto d = cast(class23262) cpp;
+    assert(d is null); // no way back
+
+    auto cppobj = new cpp23262;
+    auto d2 = cast(class23262) cppobj;
+    assert(d2 is null); // classes of different linkage never mix
 }
 
 /***************************************************/

--- a/compiler/test/runnable/casting.d
+++ b/compiler/test/runnable/casting.d
@@ -211,6 +211,27 @@ void test14218()
 }
 
 /***************************************************/
+// https://github.com/dlang/dmd/issues/23262
+
+extern(C++) interface iface23262
+{
+    int funCpp();
+}
+
+class class23262 : Object, iface23262
+{
+    extern(C++)	int funCpp() { return 42; }
+}
+
+void test23262()
+{
+    Object obj = new class23262;
+    auto cpp = cast(iface23262) obj;
+    assert(cpp);
+    assert(cpp.funCpp() == 42);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -223,6 +244,7 @@ int main()
     test10842();
     test11722();
     test14218();
+    test23262();
 
     printf("Success\n");
     return 0;

--- a/compiler/test/runnable/casting.d
+++ b/compiler/test/runnable/casting.d
@@ -213,19 +213,19 @@ void test14218()
 /***************************************************/
 // https://github.com/dlang/dmd/issues/23262
 
-extern(C++) interface iface23262
+extern (C++) interface iface23262
 {
     int funCpp();
 }
 
-extern(C++) class cpp23262
+extern (C++) class cpp23262
 {
     int funCpp() { return 1; }
 }
 
 class class23262 : Object, iface23262
 {
-    extern(C++)	int funCpp() { return 42; }
+    extern (C++) int funCpp() { return 42; }
 }
 
 void test23262()
@@ -240,6 +240,9 @@ void test23262()
 
     auto d = cast(class23262) cpp;
     assert(d is null); // no way back
+
+    auto i = cast(iface23262) cpp2;
+    assert(cast(void*)i is cast(void*)cpp2); // reinterpret cast
 
     auto cppobj = new cpp23262;
     auto d2 = cast(class23262) cppobj;

--- a/compiler/test/runnable/casting.d
+++ b/compiler/test/runnable/casting.d
@@ -241,10 +241,10 @@ void test23262()
     auto d = cast(class23262) cpp;
     assert(d is null); // no way back
 
-    auto i = cast(iface23262) cpp2;
-    assert(cast(void*)i is cast(void*)cpp2); // reinterpret cast
-
     auto cppobj = new cpp23262;
+    auto i = cast(iface23262) cppobj;
+    assert(cast(void*)i is cast(void*)cppobj); // reinterpret cast
+
     auto d2 = cast(class23262) cppobj;
     assert(d2 is null); // classes of different linkage never mix
 }

--- a/compiler/test/runnable/objc_instance_variable.d
+++ b/compiler/test/runnable/objc_instance_variable.d
@@ -29,6 +29,8 @@ class Bar : Foo
     void bar() @selector("bar") {}
 }
 
+extern (Objective-C) extern class NSString {}
+
 // This is implemented in `runnable/extra-files/objc_instance_variable.m` and
 // returns the value of instance variable `c`.
 extern (C) int getInstanceVariableC(Foo);
@@ -49,4 +51,25 @@ void main()
 
     // if non-fragile instance variables didn't work this would be `4`.
     assert(getInstanceVariableC(bar) == 3);
+
+    // static/dynamic casting
+    Foo foo = bar;
+    auto bar2 = cast(Bar) foo;
+    assert(bar is bar2);
+
+    NSObject nsobj = foo;
+    auto foo2 = cast(Foo) nsobj;
+    assert(foo is foo2);
+
+    // for dmd, casting within Objective-C is a reinterpret cast
+    version(DigitalMars)
+        assert(cast(NSString) bar !is null);
+
+    // casting from/to other linkage is always null
+    static extern(C++) class Cpp {}
+    assert(cast(Object) bar is null);
+    assert(cast(Cpp) bar is null);
+
+    auto obj = new Object;
+    assert(cast(Bar) obj is null);
 }


### PR DESCRIPTION


no need to exclude C++ classes/interfaces from runtime cast target