### PR TITLE
Fix #23271 - allow string-literal and literal UDAs on module declarat…

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -2023,8 +2023,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             goto LabelX;
 
         case TOK.vector:
-            ta = parseVector();
-            goto LabelX;
+            return parseVector();
 
         case TOK.void_:
             ta = AST.Type.tvoid;
@@ -8157,7 +8156,21 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     // t is on the next of closing parenthesis
                     continue;
                 }
-                goto Lerror;
+                if (t.value == TOK.vector)
+                {
+                    // @__vector(type)
+                    t = peek(t);
+                    if (!skipParens(t, &t))
+                        goto Lerror;
+                    continue;
+                }
+                // @TemplateSingleArgument, e.g. a basic type or a literal such
+                // as `@"str"`, `@123`, `@int`. These span a single token, except
+                // for adjacent string literals which are concatenated.
+                do
+                    t = peek(t);
+                while (t.value == TOK.string_);
+                continue;
 
             default:
                 goto Ldone;

--- a/compiler/test/compilable/user_defined_attributes.d
+++ b/compiler/test/compilable/user_defined_attributes.d
@@ -1,3 +1,9 @@
+@"hi" @42 @int @null module user_defined_attributes;
+
+// https://github.com/dlang/dmd/issues/23271
+static assert(__traits(getAttributes, user_defined_attributes).length == 4);
+static assert(__traits(getAttributes, user_defined_attributes)[0] == "hi");
+static assert(__traits(getAttributes, user_defined_attributes)[1] == 42);
 
 enum Test;
 
@@ -17,6 +23,11 @@ static assert(   __traits(getAttributes, f)[0] == "test");
 static assert(   __traits(getAttributes, f)[1] == "test2");
 static assert(   __traits(getAttributes, f)[2] == 30);
 static assert(   __traits(getAttributes, f)[3] == 'a');
-static assert(   __traits(getAttributes, f)[4] == 6);
+static assert(   __traits(getAttributes, f)[4] == 12);
 
 static assert(is(__traits(getAttributes, h)[0] == enum));
+
+version (D_SIMD)
+{
+    @__vector(int[4]) int vec;
+}


### PR DESCRIPTION
…ions

Closes #23271

> `skipAttributes` only recognized `@identifier` and `@(...)` UDAs, so the module-attribute detection in `parseModuleAttributes` bailed out for single-token template-argument UDAs like `@"str"`, `@123` or `@int`, making `@"bar" module foo;` fail to parse while `@S() module foo;` worked.

> Teach `skipAttributes` to also skip `@TemplateSingleArgument` (and `@__vector(type)`) UDAs.