### PR TITLE
Fix #23270 - print NaN/infinity float literals as valid D expressions

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -3172,6 +3172,17 @@ void floatToBuffer(Type type, const real_t value, ref OutBuffer buf, const bool 
         of 256 (3 characters). The string will be "-M.MMMMe-4932".
         (ie, 8 chars more than mantissa). Plus one for trailing \0.
         Plus one for rounding. */
+    // NaN and infinity have no valid floating point literal syntax, so emit
+    // a property expression (e.g. `float.nan`, `-real.infinity`)
+    if (CTFloat.isNaN(value) || CTFloat.isInfinity(value))
+    {
+        if (CTFloat.isInfinity(value) && value < CTFloat.zero)
+            buf.put('-');
+        buf.put(type.toBaseTypeNonSemantic().toString());
+        buf.put(CTFloat.isNaN(value) ? ".nan" : ".infinity");
+        return;
+    }
+
     const(size_t) BUFFER_LEN = value.sizeof * 3 + 8 + 1 + 1;
     char[BUFFER_LEN] buffer = void;
     CTFloat.sprint(buffer.ptr, BUFFER_LEN, 'g', value);

--- a/compiler/test/compilable/test23270.d
+++ b/compiler/test/compilable/test23270.d
@@ -1,0 +1,10 @@
+// https://github.com/dlang/dmd/issues/23270
+// NaN and infinity should print as valid D expressions
+static assert(float.nan.stringof == "float.nan");
+static assert(double.nan.stringof == "double.nan");
+static assert(real.nan.stringof == "real.nan");
+static assert(float.infinity.stringof == "float.infinity");
+static assert(double.infinity.stringof == "double.infinity");
+static assert(real.infinity.stringof == "real.infinity");
+static assert((-float.infinity).stringof == "-float.infinity");
+static assert((-double.infinity).stringof == "-double.infinity");

--- a/compiler/test/fail_compilation/ice20042.d
+++ b/compiler/test/fail_compilation/ice20042.d
@@ -2,8 +2,8 @@
 DISABLED: freebsd32 openbsd32 linux32 osx32 win32 hurd32
 TEST_OUTPUT:
 ---
-fail_compilation/ice20042.d(18): Error: slice operation `cast(__vector(float[4]))[nanF, nanF, nanF, nanF] = [1.0F, 2.0F, 3.0F, 4.0F][0..4]` cannot be evaluated at compile time
-fail_compilation/ice20042.d(25):        called from here: `Vec4(cast(__vector(float[4]))[nanF, nanF, nanF, nanF]).this([1.0F, 2.0F, 3.0F, 4.0F])`
+fail_compilation/ice20042.d(18): Error: slice operation `cast(__vector(float[4]))[float.nan, float.nan, float.nan,... = [1.0F, 2.0F, 3.0F, 4.0F][0..4]` cannot be evaluated at compile time
+fail_compilation/ice20042.d(25):        called from here: `Vec4(cast(__vector(float[4]))[float.nan, float.nan, float.nan, float.nan]).this([1.0F, 2.0F, 3.0F, 4.0F])`
 ---
 */
 void write(T...)(T t){}


### PR DESCRIPTION
Closes #23270

> floatToBuffer emitted `nanF`/`nanL` and `infF`/`infL` for float/real NaN and infinity, which is not valid D syntax. Emit `float.nan`, `real.infinity` etc. instead so error messages and generated headers round-trip.