### PR TITLE
Fix #23278 - backend miscompiles nested static array float return

### DIFF
--- a/compiler/src/dmd/backend/x86/cod1.d
+++ b/compiler/src/dmd/backend/x86/cod1.d
@@ -3312,7 +3312,7 @@ void argtypes(type* t, out type* arg1type, out type* arg2type)
         if (I64 && config.exe != EX_WIN64)
         {
             type* tn = t.Tnext;
-            tym_t tyn = tn.Tty;
+            tym_t tyn = tybasic(tn.Tty);
             while (tyn == TYarray)
             {
                 tn = tn.Tnext;

--- a/compiler/test/runnable/test23278.d
+++ b/compiler/test/runnable/test23278.d
@@ -1,0 +1,15 @@
+// https://github.com/dlang/dmd/issues/23278
+
+float[2][2] f()
+{
+    return [[0.25f, 0.5f], [0.75f, 1.00f]];
+}
+
+void main()
+{
+    const float[2][2] c = f();
+    assert(c[0][0] == 0.25f);
+    assert(c[0][1] == 0.50f);
+    assert(c[1][0] == 0.75f);
+    assert(c[1][1] == 1.00f);
+}


### PR DESCRIPTION
Closes #23278