### PR TITLE
avoid false pointers by allocating strings wuth xmalloc_noscan

### DIFF
--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -1247,7 +1247,7 @@ UnionExp Slice(Type type, Expression e1, Expression lwr, Expression upr)
         {
             const len = cast(size_t)(iupr - ilwr);
             const sz = es1.sz;
-            void* s = mem.xmalloc(len * sz);
+            void* s = mem.xmalloc_noscan(len * sz);
             const data1 = es1.peekData();
             memcpy(s, data1.ptr + ilwr * sz, len * sz);
             emplaceExp!(StringExp)(&ue, loc, s[0 .. len * sz], len, sz, es1.postfix);
@@ -1420,7 +1420,7 @@ UnionExp Cat(Loc loc, Type type, Expression e1, Expression e2)
             const sz = cast(ubyte)t.size();
             dinteger_t v = e.toInteger();
             const len = (t.ty == tn.ty) ? 1 : utf_codeLength(sz, cast(dchar)v);
-            void* s = mem.xmalloc(len * sz);
+            void* s = mem.xmalloc_noscan(len * sz);
             if (t.ty == tn.ty)
                 Port.valcpy(s, v, sz);
             else
@@ -1493,7 +1493,7 @@ UnionExp Cat(Loc loc, Type type, Expression e1, Expression e2)
             assert(ue.exp().type);
             return ue;
         }
-        void* s = mem.xmalloc(len * sz);
+        void* s = mem.xmalloc_noscan(len * sz);
         const data1 = es1.peekData();
         const data2 = es2.peekData();
         memcpy(cast(char*)s, data1.ptr, es1.len * sz);
@@ -1550,7 +1550,7 @@ UnionExp Cat(Loc loc, Type type, Expression e1, Expression e2)
         // (char[] ~ char, wchar[]~wchar, or dchar[]~dchar)
         bool homoConcat = (sz == t2.size());
         const len = es1.len + (homoConcat ? 1 : utf_codeLength(sz, cast(dchar)v));
-        void* s = mem.xmalloc(len * sz);
+        void* s = mem.xmalloc_noscan(len * sz);
         const data1 = es1.peekData();
         memcpy(s, data1.ptr, data1.length);
         if (homoConcat)
@@ -1573,7 +1573,7 @@ UnionExp Cat(Loc loc, Type type, Expression e1, Expression e2)
         const len = 1 + es2.len;
         const sz = es2.sz;
         dinteger_t v = e1.toInteger();
-        void* s = mem.xmalloc(len * sz);
+        void* s = mem.xmalloc_noscan(len * sz);
         Port.valcpy(cast(char*)s, v, sz);
         const data2 = es2.peekData();
         memcpy(cast(char*)s + sz, data2.ptr, data2.length);

--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -1380,7 +1380,7 @@ UnionExp ctfeCat(Loc loc, Type type, Expression e1, Expression e2)
         ArrayLiteralExp es2 = e1.isArrayLiteralExp();
         const len = es1.len + es2.elements.length;
         const sz = es1.sz;
-        void* s = mem.xmalloc((len + 1) * sz);
+        void* s = mem.xmalloc_noscan((len + 1) * sz);
         const data1 = es1.peekData();
         memcpy(cast(char*)s + sz * es2.elements.length, data1.ptr, data1.length);
         foreach (size_t i; 0 .. es2.elements.length)
@@ -1410,7 +1410,7 @@ UnionExp ctfeCat(Loc loc, Type type, Expression e1, Expression e2)
         ArrayLiteralExp es2 = e2.isArrayLiteralExp();
         const len = es1.len + es2.elements.length;
         const sz = es1.sz;
-        void* s = mem.xmalloc((len + 1) * sz);
+        void* s = mem.xmalloc_noscan((len + 1) * sz);
         auto slice = es1.peekData();
         memcpy(s, slice.ptr, slice.length);
         foreach (size_t i; 0 .. es2.elements.length)

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -2471,7 +2471,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             const fullSize = (se.len + 1) * se.sz; // incl. terminating 0
             if (fullSize > (e.len + 1) * e.sz)
             {
-                void* s = mem.xmalloc(fullSize);
+                void* s = mem.xmalloc_noscan(fullSize);
                 const srcSize = e.len * e.sz;
                 const data = se.peekData();
                 memcpy(s, data.ptr, srcSize);
@@ -2650,7 +2650,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                 // Copy when changing the string literal
                 const newsz = se.sz;
                 const d = (dim2 < se.len) ? dim2 : se.len;
-                void* s = mem.xmalloc((dim2 + 1) * newsz);
+                void* s = mem.xmalloc_noscan((dim2 + 1) * newsz);
                 memcpy(s, se.peekData().ptr, d * newsz);
                 // Extend with 0, add terminating 0
                 memset(s + d * newsz, 0, (dim2 + 1 - d) * newsz);

--- a/compiler/src/dmd/dmacro.d
+++ b/compiler/src/dmd/dmacro.d
@@ -185,7 +185,7 @@ struct MacroTable
                             // marg = name[ ] ~ "," ~ marg[ ];
                             if (marg.length)
                             {
-                                char* q = cast(char*)mem.xmalloc(namelen + 1 + marg.length);
+                                char* q = cast(char*)mem.xmalloc_noscan(namelen + 1 + marg.length);
                                 assert(q);
                                 memcpy(q, name, namelen);
                                 q[namelen] = ',';
@@ -304,7 +304,7 @@ struct Macro
 char[] memdup(const(char)[] p) nothrow pure @trusted
 {
     size_t len = p.length;
-    return (cast(char*)memcpy(mem.xmalloc(len), p.ptr, len))[0 .. len];
+    return (cast(char*)memcpy(mem.xmalloc_noscan(len), p.ptr, len))[0 .. len];
 }
 
 /**********************************************************

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -398,7 +398,7 @@ struct DocComment
                 p++;
             }
             size_t len = p - start;
-            char* s = cast(char*)memcpy(mem.xmalloc(len + 1), start, len);
+            char* s = cast(char*)memcpy(mem.xmalloc_noscan(len + 1), start, len);
             s[len] = 0;
             escapetable.strings[c] = s[0 .. len];
             //printf("\t%c = '%s'\n", c, s);

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -1172,8 +1172,9 @@ extern (C++) final class StringExp : Expression
      */
     extern (D) const(char)[] toStringz() const
     {
+        assert(sz == 1);
         auto nbytes = len * sz;
-        char* s = cast(char*)mem.xmalloc(nbytes + sz);
+        char* s = cast(char*)mem.xmalloc_noscan(nbytes + sz);
         writeTo(s, true);
         return s[0 .. nbytes];
     }

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -401,7 +401,7 @@ public int runLINK(bool verbose, ErrorSink eSink)
                 }
                 else
                     close(fd);
-                global.params.exefile = name.arraydup;
+                global.params.exefile = name.xarraydup;
                 argv.push(global.params.exefile.xarraydup.ptr);
             }
             else
@@ -573,7 +573,7 @@ public int runLINK(bool verbose, ErrorSink eSink)
             if (!FileName.equalsExt(p, "a"))
             {
                 const plen = strlen(p);
-                char* s = cast(char*)mem.xmalloc(plen + 3);
+                char* s = cast(char*)mem.xmalloc_noscan(plen + 3);
                 s[0] = '-';
                 s[1] = 'l';
                 memcpy(s + 2, p, plen + 1);
@@ -886,7 +886,7 @@ public int runProgram(const char[] exefile, const char*[] runargs, bool verbose,
             if (strchr(arg, ' '))
             {
                 const blen = 3 + strlen(arg);
-                char* b = cast(char*)mem.xmalloc(blen);
+                char* b = cast(char*)mem.xmalloc_noscan(blen);
                 snprintf(b, blen, "\"%s\"", arg);
                 argv.push(b);
                 continue;
@@ -1101,7 +1101,7 @@ public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, c
 
                 // Get current environment variable and rollback
                 auto oldIncludePathLen = GetEnvironmentVariableW("INCLUDE"w.ptr, null, 0);
-                wchar* oldIncludePaths = cast(wchar*)mem.xmalloc(oldIncludePathLen * wchar.sizeof);
+                wchar* oldIncludePaths = cast(wchar*)mem.xmalloc_noscan(oldIncludePathLen * wchar.sizeof);
                 oldIncludePathLen = GetEnvironmentVariableW("INCLUDE"w.ptr, oldIncludePaths, oldIncludePathLen);
                 scope (exit)
                 {

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -2076,7 +2076,7 @@ Module moduleWithEmptyMain()
 {
     auto result = new Module(Loc.initial, "__main.d", Identifier.idPool("__main"), false, false);
     // need 2 trailing nulls for sentinel and 2 for lexer
-    auto data = arraydup("version(D_BetterC)extern(C)int main(){return 0;}else int main(){return 0;}\0\0\0\0");
+    auto data = xarraydup("version(D_BetterC)extern(C)int main(){return 0;}else int main(){return 0;}\0\0\0\0");
     result.src = cast(ubyte[]) data[0 .. $-4];
     result.parse();
     result.importedFrom = result;

--- a/compiler/src/dmd/root/env.d
+++ b/compiler/src/dmd/root/env.d
@@ -57,7 +57,7 @@ Returns:
 string allocNameValue(const(char)[] name, const(char)[] value) nothrow
 {
     const length = name.length + 1 + value.length;
-    auto str = (cast(char*)mem.xmalloc(length + 1))[0 .. length];
+    auto str = (cast(char*)mem.xmalloc_noscan(length + 1))[0 .. length];
     str[0 .. name.length] = name[];
     str[name.length] = '=';
     str[name.length + 1 .. length] = value[];

--- a/compiler/src/dmd/root/filename.d
+++ b/compiler/src/dmd/root/filename.d
@@ -258,7 +258,7 @@ nothrow:
         if (e.length)
         {
             const len = (str.length - e.length) - 1; // -1 for the dot
-            char* n = cast(char*)mem.xmalloc(len + 1);
+            char* n = cast(char*)mem.xmalloc_noscan(len + 1);
             memcpy(n, str.ptr, len);
             n[len] = 0;
             return n[0 .. len];
@@ -360,7 +360,7 @@ nothrow:
                 hasTrailingSlash = true;
         }
         const pathlen = str.length - n.length - (hasTrailingSlash ? 1 : 0);
-        char* path = cast(char*)mem.xmalloc(pathlen + 1);
+        char* path = cast(char*)mem.xmalloc_noscan(pathlen + 1);
         memcpy(path, str.ptr, pathlen);
         path[pathlen] = 0;
         return path[0 .. pathlen];
@@ -594,7 +594,7 @@ nothrow:
     extern(D) static char[] addExt(const char[] name, const char[] ext) pure
     {
         const len = name.length + ext.length + 2;
-        auto s = cast(char*)mem.xmalloc(len);
+        auto s = cast(char*)mem.xmalloc_noscan(len);
         s[0 .. name.length] = name[];
         s[name.length] = '.';
         s[name.length + 1 .. len - 1] = ext[];
@@ -1045,7 +1045,7 @@ nothrow:
                 auto path_max = pathconf("/", _PC_PATH_MAX);
                 if (path_max > 0)
                 {
-                    char *buf = cast(char*)mem.xmalloc(path_max);
+                    char *buf = cast(char*)mem.xmalloc_noscan(path_max);
                     scope(exit) mem.xfree(buf);
                     auto path = name.toCStringThen!((n) => realpath(n.ptr, buf));
                     if (path !is null)

--- a/compiler/src/dmd/root/rmem.d
+++ b/compiler/src/dmd/root/rmem.d
@@ -362,7 +362,7 @@ extern (D) T[] arraydup(T)(const scope T[] s) pure nothrow
         return null;
 
     const dim = s.length;
-    auto p = (cast(T*)mem.xmalloc(T.sizeof * dim))[0 .. dim];
+    auto p = (cast(T*)mem.xmalloc_noscan(T.sizeof * dim))[0 .. dim];
     p[] = s;
     return p;
 }

--- a/compiler/src/dmd/vsoptions.d
+++ b/compiler/src/dmd/vsoptions.d
@@ -158,7 +158,7 @@ extern(C++) struct VSOptions
                 const addpathlen = strlen(addpath);
 
                 const length = addpathlen + 1 + pathlen;
-                char* npath = cast(char*)mem.xmalloc(length);
+                char* npath = cast(char*)mem.xmalloc_noscan(length);
                 memcpy(npath, addpath, addpathlen);
                 npath[addpathlen] = ';';
                 memcpy(npath + addpathlen + 1, path, pathlen);


### PR DESCRIPTION
I stumbled over these while debugging huge GC memory using dmd as a library. The change doesn't achieve much, unfortunately, but is a bit more accurate.