### PR TITLE
mem.xrealloc: the GC version can also free unused memory

### DIFF
--- a/compiler/src/dmd/root/rmem.d
+++ b/compiler/src/dmd/root/rmem.d
@@ -73,7 +73,13 @@ extern (C++) struct Mem
     static void* xrealloc(void* p, size_t size) pure nothrow
     {
         if (isGCEnabled)
-            return GC.realloc(p, size);
+        {
+            auto q = GC.realloc(p, size);
+            // used with C semantics, so can be free'd
+            if (p && q && p != q)
+                GC.free(p);
+            return q;
+        }
 
         if (!size)
         {
@@ -87,7 +93,13 @@ extern (C++) struct Mem
     static void* xrealloc_noscan(void* p, size_t size) pure nothrow
     {
         if (isGCEnabled)
-            return GC.realloc(p, size, GC.BlkAttr.NO_SCAN);
+        {
+            auto q = GC.realloc(p, size, GC.BlkAttr.NO_SCAN);
+            // used with C semantics, so can be free'd
+            if (p && q && p != q)
+                GC.free(p);
+            return q;
+        }
 
         if (!size)
         {


### PR DESCRIPTION
memory is used with C semantics, so other than the GC, we can assume the old memory is no longer used.

mem.xrealloc isn't used much, but another step in reducing the possibility false pointers.