### PR TITLE
replace no longer existing memory allocation hooks with a proxy GC

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7561,7 +7561,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         scope (exit)
         {
-            if (TypeFunction tf = exp.f ? cast(TypeFunction)exp.f.type : null)
+            if (TypeFunction tf = exp.f && exp.f.type ? exp.f.type.isTypeFunction() : null)
             {
                 if (tf.isRvalue)
                 {

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -99,8 +99,10 @@ extern (C) int main(int argc, char** argv)
     {
         static if(__VERSION__ < 2085)
             __gshared string[] disable_options = [ "gcopt=disable:1" ];
-        else
+        else static if(__VERSION__ < 2096)
             __gshared string[] disable_options = [ "gcopt=disable:1 cleanup:none" ];
+        else
+            __gshared string[] disable_options = [ "gcopt=disable:1 gc:bump cleanup:none" ];
         rt_options = disable_options;
         mem.disableGC();
     }

--- a/compiler/src/dmd/root/rmem.d
+++ b/compiler/src/dmd/root/rmem.d
@@ -200,101 +200,6 @@ extern (D) void* allocmemory(size_t m_size) nothrow
     return allocmemoryNoFree(m_size);
 }
 
-version (DigitalMars)
-{
-    enum OVERRIDE_MEMALLOC = true;
-}
-else version (LDC)
-{
-    // Memory allocation functions gained weak linkage when the @weak attribute was introduced.
-    import ldc.attributes;
-    enum OVERRIDE_MEMALLOC = is(typeof(ldc.attributes.weak));
-}
-else version (GNU)
-{
-    version (IN_GCC)
-        enum OVERRIDE_MEMALLOC = false;
-    else
-        enum OVERRIDE_MEMALLOC = true;
-}
-else
-{
-    enum OVERRIDE_MEMALLOC = false;
-}
-
-static if (OVERRIDE_MEMALLOC)
-{
-    // Override the host druntime allocation functions in order to use the bump-
-    // pointer allocation scheme (`allocmemoryNoFree()` above) if the GC is disabled.
-    // That scheme is faster and comes with less memory overhead than using a
-    // disabled GC alone.
-
-    extern (C) void* _d_allocmemory(size_t m_size) nothrow
-    {
-        return allocmemory(m_size);
-    }
-
-    private void* allocClass(const ClassInfo ci) nothrow pure
-    {
-        alias BlkAttr = GC.BlkAttr;
-
-        assert(!(ci.m_flags & TypeInfo_Class.ClassFlags.isCOMclass));
-
-        BlkAttr attr = BlkAttr.NONE;
-        if (ci.m_flags & TypeInfo_Class.ClassFlags.hasDtor
-            && !(ci.m_flags & TypeInfo_Class.ClassFlags.isCPPclass))
-            attr |= BlkAttr.FINALIZE;
-        if (ci.m_flags & TypeInfo_Class.ClassFlags.noPointers)
-            attr |= BlkAttr.NO_SCAN;
-        return GC.malloc(ci.initializer.length, attr, ci);
-    }
-
-    extern (C) void* _d_newitemU(const TypeInfo ti) nothrow;
-
-    extern (C) Object _d_newclass(const ClassInfo ci) nothrow
-    {
-        const initializer = ci.initializer;
-
-        auto p = mem.isGCEnabled ? allocClass(ci) : allocmemoryNoFree(initializer.length);
-        memcpy(p, initializer.ptr, initializer.length);
-        return cast(Object) p;
-    }
-
-    version (LDC)
-    {
-        extern (C) Object _d_allocclass(const ClassInfo ci) nothrow
-        {
-            if (mem.isGCEnabled)
-                return cast(Object) allocClass(ci);
-
-            return cast(Object) allocmemoryNoFree(ci.initializer.length);
-        }
-    }
-
-    extern (C) void* _d_newitemT(TypeInfo ti) nothrow
-    {
-        auto p = mem.isGCEnabled ? _d_newitemU(ti) : allocmemoryNoFree(ti.tsize);
-        memset(p, 0, ti.tsize);
-        return p;
-    }
-
-    extern (C) void* _d_newitemiT(TypeInfo ti) nothrow
-    {
-        auto p = mem.isGCEnabled ? _d_newitemU(ti) : allocmemoryNoFree(ti.tsize);
-        const initializer = ti.initializer;
-        memcpy(p, initializer.ptr, initializer.length);
-        return p;
-    }
-
-    // TypeInfo.initializer for compilers older than 2.070
-    static if(!__traits(hasMember, TypeInfo, "initializer"))
-    private const(void[]) initializer(T : TypeInfo)(const T t)
-    nothrow pure @safe @nogc
-    {
-        return t.init;
-    }
-}
-
 extern (C) pure @nogc nothrow
 {
     /**
@@ -389,4 +294,257 @@ pure nothrow unittest
     assert(s2 == [4, 1, 2]);
     string sEmpty;
     assert(sEmpty.arraydup is null);
+}
+
+static if(__VERSION__ >= 2_096):
+// access to conservative GC not available before this version, so we cannot proxy it
+
+/////////////////////////////////////
+// BumpPointerGC is a GC that uses the bump-pointer for most allocations, i.e.
+//  it never frees anything, but uses the conservative GC for arrays
+//
+// Retrictions:
+//  realloc and extend don't work on memory allocated without BlkAttr.APPENDABLE
+//
+import core.gc.gcinterface : GCInterface = GC, Root, Range, RootIterator, RangeIterator;
+import core.internal.gc.impl.conservative.gc;
+
+private extern(C) pragma(crt_constructor) void register_bump_gc()
+{
+    import core.gc.registry;
+    registerGCFactory("bump", &BumpPointerGC.initialize);
+}
+
+class BumpPointerGC : GCInterface
+{
+    GCInterface gc;
+    ulong allocated;
+
+    static GCInterface initialize()
+    {
+        __gshared ubyte[__traits(classInstanceSize, BumpPointerGC)] buf;
+
+        auto init = typeid(BumpPointerGC).initializer();
+        assert(init.length == buf.length);
+        auto instance = cast(BumpPointerGC) memcpy(buf.ptr, init.ptr, init.length);
+        instance.__ctor();
+        return instance;
+    }
+
+    this()
+    {
+        // unfortunately, registry cannot be invoked twice, and
+        // initialize for ConservativeGC is private
+        __gshared ubyte[__traits(classInstanceSize, ConservativeGC)] buf;
+
+        auto init = typeid(ConservativeGC).initializer();
+        assert(init.length == __traits(classInstanceSize, ConservativeGC));
+        auto instance = cast(ConservativeGC) memcpy(buf.ptr, init.ptr, init.length);
+        instance.__ctor();
+
+        gc = instance;
+        gc.disable();
+    }
+
+    ~this()
+    {
+        destroy(gc);
+
+        import core.gc.config;
+        if (config.profile)
+            printf("\tAllocated by BumpGC:  %llu MB\n", allocated >> 20);
+    }
+
+    void enable()
+    {
+        // never enable collection in the conservative GC, memory from the
+        // bump-pointer-allocation is not scanned
+    }
+    void disable()
+    {
+        gc.disable();
+    }
+
+    void collect() nothrow
+    {
+        gc.collect();
+    }
+
+    static if(__VERSION__ < 2_109)
+        void collectNoStack() nothrow
+        {
+            gc.collectNoStack();
+        }
+
+    void minimize() nothrow
+    {
+        gc.minimize();
+    }
+    uint getAttr(void* p) nothrow
+    {
+        return gc.getAttr(p);
+    }
+    uint setAttr(void* p, uint mask) nothrow
+    {
+        return gc.setAttr(p, mask);
+    }
+    uint clrAttr(void* p, uint mask) nothrow
+    {
+        return gc.clrAttr(p, mask);
+    }
+
+    void* malloc(size_t size, uint bits, const TypeInfo ti) nothrow
+    {
+        if (bits & GC.BlkAttr.APPENDABLE)
+            return gc.malloc(size, bits, ti);
+        allocated += size;
+        return allocmemoryNoFree(size);
+    }
+
+    GC.BlkInfo qalloc(size_t size, uint bits, scope const TypeInfo ti) nothrow
+    {
+        if (bits & GC.BlkAttr.APPENDABLE)
+            return gc.qalloc(size, bits, ti);
+        allocated += size;
+        GC.BlkInfo bi;
+        bi.base = allocmemoryNoFree(size);
+        bi.size = size;
+        return bi;
+    }
+
+    void* calloc(size_t size, uint bits, const TypeInfo ti) nothrow
+    {
+        if (bits & GC.BlkAttr.APPENDABLE)
+            return gc.calloc(size, bits, ti);
+        allocated += size;
+        void* p = allocmemoryNoFree(size);
+        memset(p, 0, size);
+        return p;
+    }
+
+    void* realloc(void* p, size_t size, uint bits, const TypeInfo ti) nothrow
+    {
+        if (!p || gc.query(p).base)
+            return gc.realloc(p, size, bits, ti);
+        assert(false, "GC.realloc must not be called on non-GC memory");
+    }
+
+    size_t extend(void* p, size_t minsize, size_t maxsize, const TypeInfo ti) nothrow
+    {
+        if (gc.query(p).base)
+            return gc.extend(p, minsize, maxsize, ti);
+        assert(false, "GC.extend must not be called on non-GC memory");
+    }
+
+    size_t reserve(size_t size) nothrow
+    {
+        return gc.reserve(size);
+    }
+
+    void free(void* p) nothrow
+    {
+        gc.free(p);
+    }
+
+    void* addrOf(void* p) nothrow
+    {
+        return gc.addrOf(p);
+    }
+    size_t sizeOf(void* p) nothrow
+    {
+        return gc.sizeOf(p);
+    }
+
+    GC.BlkInfo query(void* p) nothrow
+    {
+        return gc.query(p);
+    }
+
+    GC.Stats stats() nothrow
+    {
+        return gc.stats();
+    }
+    GC.ProfileStats profileStats() nothrow
+    {
+        return gc.profileStats();
+    }
+
+    void addRoot(void* p) nothrow @nogc
+    {
+        gc.addRoot(p);
+    }
+    void removeRoot(void* p) nothrow @nogc
+    {
+        gc.removeRoot(p);
+    }
+    @property RootIterator rootIter() @nogc
+    {
+        return gc.rootIter();
+    }
+
+    void addRange(void* p, size_t sz, const TypeInfo ti) nothrow @nogc
+    {
+        gc.addRange(p, sz, ti);
+    }
+    void removeRange(void* p) nothrow @nogc
+    {
+        gc.removeRange(p);
+    }
+
+    @property RangeIterator rangeIter() @nogc
+    {
+        return gc.rangeIter();
+    }
+
+    static if (__VERSION__ >= 2087)
+        void runFinalizers(scope const void[] segment) nothrow
+        {
+            gc.runFinalizers(segment);
+        }
+    else
+        void runFinalizers(in void[] segment) nothrow
+        {
+            gc.runFinalizers(segment);
+        }
+
+    bool inFinalizer() nothrow
+    {
+        return gc.inFinalizer();
+    }
+    ulong allocatedInCurrentThread() nothrow
+    {
+        return gc.allocatedInCurrentThread();
+    }
+
+    static if(__VERSION__ >= 2_111)
+    {
+        void[] getArrayUsed(void *ptr, bool atomic = false) nothrow
+        {
+            return gc.getArrayUsed(ptr, atomic);
+        }
+        bool expandArrayUsed(void[] slice, size_t newUsed, bool atomic = false) nothrow @safe
+        {
+            return gc.expandArrayUsed(slice, newUsed, atomic);
+        }
+        size_t reserveArrayCapacity(void[] slice, size_t request, bool atomic = false) nothrow @safe
+        {
+            return gc.reserveArrayCapacity(slice, request, atomic);
+        }
+        bool shrinkArrayUsed(void[] slice, size_t existingUsed, bool atomic = false) nothrow
+        {
+            return gc.shrinkArrayUsed(slice, existingUsed, atomic);
+        }
+    }
+    static if(__VERSION__ >= 2_112)
+    {
+        import core.thread.threadbase : ThreadBase;
+        void initThread(ThreadBase thread) nothrow @nogc
+        {
+            gc.initThread(thread);
+        }
+        void cleanupThread(ThreadBase thread) nothrow @nogc
+        {
+            gc.cleanupThread(thread);
+        }
+    }
 }

--- a/compiler/src/dmd/targetcompiler.d
+++ b/compiler/src/dmd/targetcompiler.d
@@ -71,7 +71,11 @@ else
 /**********************************
  * Extra Fields for FuncDeclaration
  */
-version (IN_GCC)
+version (NoBackend)
+{
+    mixin template FuncDeclarationExtra() { }
+}
+else version (IN_GCC)
 {
     mixin template FuncDeclarationExtra() { }
 }
@@ -94,7 +98,11 @@ else
 /**********************************
  * Extra Fields for FuncDeclaration
  */
-version (IN_GCC)
+version (NoBackend)
+{
+    mixin template alignSectionVarsExtra() { void doAlign() { } }
+}
+else version (IN_GCC)
 {
     mixin template alignSectionVarsExtra() { void doAlign() { } }
 }
@@ -131,7 +139,11 @@ else
  */
 mixin template alignSectionVarsContains()
 {
-    version (IN_GCC)
+    version (NoBackend)
+    {
+        bool isAlignSectionVar(VarDeclaration v) { return false; }
+    }
+    else version (IN_GCC)
     {
         bool isAlignSectionVar(VarDeclaration v) { return false; }
     }

--- a/dub.sdl
+++ b/dub.sdl
@@ -97,6 +97,7 @@ subPackage {
     "CallbackAPI"
 
   excludedSourceFiles "compiler/src/dmd/backend/*"
+  excludedSourceFiles "compiler/src/dmd/glue/*"
   excludedSourceFiles "compiler/src/dmd/root/*"
   excludedSourceFiles "compiler/src/dmd/common/*"
   excludedSourceFiles "compiler/src/dmd/lib/*"


### PR DESCRIPTION
While hunting false pointers when using dmd as a library and comparing results with dmd as a compiler, I stumbled over failing allocation hooks in dmd.rmem.

As a test case I use all of phobos built with unittests into a single object file. 
- dmd is built from stable with dmd-2.112.0 with ENABLE_RELEASE=1 (I tried other versions without much differences)
- OS: Win11 64-bit
- AMD Ryzen 7 8845HS, 64 GB RAM
- Timing measurements with an accuracy of 1-2 seconds

Monitoring compilation time, process memory and GC activity, the result on my machine is:
```
Process memory: 20110 MB, GC memory: 9803 MB, Time: 1:00.720 min:sec
```

Note that the GC accounts for about half of the used process memory. This is mostly caused by "recently" added lowerings that bypass the hooks overloaded in dmd.rmem, e.g. `_d_newclass`, but also the increased usage of dynamic D arrays.

As an alternative, why not just let a new type of GC forward all allocations to the existing bump-pointer-allocator? Without keeping allocation information, the GC cannot implement GC.realloc (not needed b dmd, though) and cannot report back size information used for efficient array allocations. Always assuming non-GC memory requiring new allocations results in these values:
```
Process memory: 28639 MB, GC memory: 0 MB, Time: 0:59.250 min:sec
```
That is considerably more memory, so not good enough.

So, here is the refinement: the new GC forwards most allocations to the bump-pointer-allocator, but uses the disabled conservative GC for arrays, so that array appending is still efficient. All other operations can then be forwarded to the conservative GC, too.

The results are:
```
Process memory: 18288 MB, GC memory: 51 MB, Time: 0:53.220 min:sec
```
So the compilation uses about 10% less memory and takes about as much less time. The reduced memory is likely to come from less overhead of the bump-pointer-allocation that uses an alignment of 16 bytes.

When compiling dmd with LDC 1.42 as the host compiler, the results are not that impressive:
```
old:  Process memory: 18769 MB, GC memory: 1867 MB, Time: 0:38.220 min:sec
new:  Process memory: 18182 MB, GC memory:   51 MB, Time: 0:37.980 min:sec
```
Still  memory reduction of about 3%.
IIRC the problem does not yet show up as much with LDC as it does not yet use the templated class allocation, so overloading `_d_newclass` still works. It might be affected in the future, too, though.