### PR TITLE
Add WASIp1/2/3 as reserved version identifiers

### DIFF
--- a/changelog/dmd.more-wasi-reserved-versions.dd
+++ b/changelog/dmd.more-wasi-reserved-versions.dd
@@ -1,0 +1,5 @@
+`WASIp1`, `WASIp2`, and `WASIp3` are now reserved version identifiers
+
+New version identifiers are reserved for WASI, corresponding to previews 1, 2, and 3 of the WebAssembly System Interface.
+
+The existing `WASI` identifier is retained, meaning ANY version of WASI. i.e. `WASI` is always defined whenever `WASIp{1|2|3}` is.

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -442,6 +442,9 @@ extern (C++) final class VersionCondition : DVCondition
             case "unittest":
             case "VisionOS":
             case "WASI":
+            case "WASIp1":
+            case "WASIp2":
+            case "WASIp3":
             case "WatchOS":
             case "WebAssembly":
             case "Win32":

--- a/compiler/test/fail_compilation/reserved_version.d
+++ b/compiler/test/fail_compilation/reserved_version.d
@@ -111,20 +111,23 @@ fail_compilation/reserved_version.d(212): Error: version identifier `AsmJS` is r
 fail_compilation/reserved_version.d(213): Error: version identifier `Emscripten` is reserved and cannot be set
 fail_compilation/reserved_version.d(214): Error: version identifier `WebAssembly` is reserved and cannot be set
 fail_compilation/reserved_version.d(215): Error: version identifier `WASI` is reserved and cannot be set
-fail_compilation/reserved_version.d(216): Error: version identifier `CppRuntime_LLVM` is reserved and cannot be set
-fail_compilation/reserved_version.d(217): Error: version identifier `CppRuntime_DigitalMars` is reserved and cannot be set
-fail_compilation/reserved_version.d(218): Error: version identifier `CppRuntime_GNU` is reserved and cannot be set
-fail_compilation/reserved_version.d(219): Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
-fail_compilation/reserved_version.d(220): Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
-fail_compilation/reserved_version.d(221): Error: version identifier `D_PIE` is reserved and cannot be set
-fail_compilation/reserved_version.d(222): Error: version identifier `AVR` is reserved and cannot be set
-fail_compilation/reserved_version.d(223): Error: version identifier `D_PreConditions` is reserved and cannot be set
-fail_compilation/reserved_version.d(224): Error: version identifier `D_PostConditions` is reserved and cannot be set
-fail_compilation/reserved_version.d(225): Error: version identifier `D_ProfileGC` is reserved and cannot be set
-fail_compilation/reserved_version.d(226): Error: version identifier `D_Invariants` is reserved and cannot be set
-fail_compilation/reserved_version.d(227): Error: version identifier `D_Optimized` is reserved and cannot be set
-fail_compilation/reserved_version.d(228): Error: version identifier `VisionOS` is reserved and cannot be set
-fail_compilation/reserved_version.d(229): Error: version identifier `D_Profile` is reserved and cannot be set
+fail_compilation/reserved_version.d(216): Error: version identifier `WASIp1` is reserved and cannot be set
+fail_compilation/reserved_version.d(217): Error: version identifier `WASIp2` is reserved and cannot be set
+fail_compilation/reserved_version.d(218): Error: version identifier `WASIp3` is reserved and cannot be set
+fail_compilation/reserved_version.d(219): Error: version identifier `CppRuntime_LLVM` is reserved and cannot be set
+fail_compilation/reserved_version.d(220): Error: version identifier `CppRuntime_DigitalMars` is reserved and cannot be set
+fail_compilation/reserved_version.d(221): Error: version identifier `CppRuntime_GNU` is reserved and cannot be set
+fail_compilation/reserved_version.d(222): Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
+fail_compilation/reserved_version.d(223): Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
+fail_compilation/reserved_version.d(224): Error: version identifier `D_PIE` is reserved and cannot be set
+fail_compilation/reserved_version.d(225): Error: version identifier `AVR` is reserved and cannot be set
+fail_compilation/reserved_version.d(226): Error: version identifier `D_PreConditions` is reserved and cannot be set
+fail_compilation/reserved_version.d(227): Error: version identifier `D_PostConditions` is reserved and cannot be set
+fail_compilation/reserved_version.d(228): Error: version identifier `D_ProfileGC` is reserved and cannot be set
+fail_compilation/reserved_version.d(229): Error: version identifier `D_Invariants` is reserved and cannot be set
+fail_compilation/reserved_version.d(230): Error: version identifier `D_Optimized` is reserved and cannot be set
+fail_compilation/reserved_version.d(231): Error: version identifier `VisionOS` is reserved and cannot be set
+fail_compilation/reserved_version.d(232): Error: version identifier `D_Profile` is reserved and cannot be set
 ---
 */
 
@@ -241,6 +244,9 @@ version = AsmJS;
 version = Emscripten;
 version = WebAssembly;
 version = WASI;
+version = WASIp1;
+version = WASIp2;
+version = WASIp3;
 version = CppRuntime_LLVM;
 version = CppRuntime_DigitalMars;
 version = CppRuntime_GNU;
@@ -323,6 +329,9 @@ debug = HPPA64;
 debug = SH;
 debug = WebAssembly;
 debug = WASI;
+debug = WASIp1;
+debug = WASIp2;
+debug = WASIp3;
 debug = Alpha;
 debug = Alpha_SoftFloat;
 debug = Alpha_HardFloat;

--- a/compiler/test/fail_compilation/reserved_version_switch.d
+++ b/compiler/test/fail_compilation/reserved_version_switch.d
@@ -67,6 +67,9 @@
 // REQUIRED_ARGS: -version=SH
 // REQUIRED_ARGS: -version=WebAssembly
 // REQUIRED_ARGS: -version=WASI
+// REQUIRED_ARGS: -version=WASIp1
+// REQUIRED_ARGS: -version=WASIp2
+// REQUIRED_ARGS: -version=WASIp3
 // REQUIRED_ARGS: -version=Alpha
 // REQUIRED_ARGS: -version=Alpha_SoftFloat
 // REQUIRED_ARGS: -version=Alpha_HardFloat
@@ -178,6 +181,9 @@
 // REQUIRED_ARGS: -debug=SH
 // REQUIRED_ARGS: -debug=WebAssembly
 // REQUIRED_ARGS: -debug=WASI
+// REQUIRED_ARGS: -debug=WASIp1
+// REQUIRED_ARGS: -debug=WASIp2
+// REQUIRED_ARGS: -debug=WASIp3
 // REQUIRED_ARGS: -debug=Alpha
 // REQUIRED_ARGS: -debug=Alpha_SoftFloat
 // REQUIRED_ARGS: -debug=Alpha_HardFloat
@@ -294,6 +300,9 @@ Error: version identifier `HPPA64` is reserved and cannot be set
 Error: version identifier `SH` is reserved and cannot be set
 Error: version identifier `WebAssembly` is reserved and cannot be set
 Error: version identifier `WASI` is reserved and cannot be set
+Error: version identifier `WASIp1` is reserved and cannot be set
+Error: version identifier `WASIp2` is reserved and cannot be set
+Error: version identifier `WASIp3` is reserved and cannot be set
 Error: version identifier `Alpha` is reserved and cannot be set
 Error: version identifier `Alpha_SoftFloat` is reserved and cannot be set
 Error: version identifier `Alpha_HardFloat` is reserved and cannot be set

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -255,6 +255,10 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
         $(TROW $(ARGS $(D Emscripten)) , $(ARGS The Emscripten platform))
         $(TROW $(ARGS $(D PlayStation)) , $(ARGS The PlayStation platform))
         $(TROW $(ARGS $(D PlayStation4)) , $(ARGS The PlayStation 4 platform))
+        $(TROW $(ARGS $(D WASI)) , $(ARGS Any version of the WebAssembly System Interface))
+        $(TROW $(ARGS $(D WASIp1)) , $(ARGS Preview 1 of the WebAssembly System Interface))
+        $(TROW $(ARGS $(D WASIp2)) , $(ARGS Preview 2 of the WebAssembly System Interface))
+        $(TROW $(ARGS $(D WASIp3)) , $(ARGS Preview 3 of the WebAssembly System Interface))
         $(TROW $(ARGS $(D FreeStanding)) , $(ARGS An environment without an operating system (such as Bare-metal targets)))
 
         $(TROW *Target Environment*)
@@ -318,7 +322,6 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
         $(TROW $(ARGS $(D HPPA64)) , $(ARGS The HP PA-RISC architecture, 64-bit))
         $(TROW $(ARGS $(D SH)) , $(ARGS The SuperH architecture, 32-bit))
         $(TROW $(ARGS $(D WebAssembly)) , $(ARGS The WebAssembly virtual ISA $(LPAREN)instruction set architecture$(RPAREN), 32-bit))
-        $(TROW $(ARGS $(D WASI)) , $(ARGS The WebAssembly System Interface))
         $(TROW $(ARGS $(D Xtensa)) , $(ARGS The Xtensa Architecture, 32-bit))
         $(TROW $(ARGS $(D Alpha)) , $(ARGS The Alpha architecture))
         $(TROW $(ARGS $(D Alpha_SoftFloat)) , $(ARGS The Alpha soft float ABI))


### PR DESCRIPTION
Adds new reserved version identifiers to help differentiate between different WASI versions.

Since the `WASI` and `CRuntime_WASI` identifiers were added, there have been two new releases of WASI previews (preview 2 and preview 3). The `wasm32-unknown-wasi` triple (which referred to preview 1) is now considered legacy, and is in the process of being removed from `wasi-libc`, etc., in favor of explicit `wasm32-unknown-wasip{1|2|3}` triples.

The existing `WASI` version is retained to refer to ANY WASI, while new versions are added to differentiate between the versions.

Split from ldc-developers/ldc#5152