### PR TITLE
Mangle C `main` on Wasm

### DIFF
--- a/changelog/dmd.wasm-c-main-mangle.dd
+++ b/changelog/dmd.wasm-c-main-mangle.dd
@@ -1,0 +1,7 @@
+`extern(C) main` now mangled correctly on WebAssembly
+
+D now matches the mangling behavior of Clang for C `main` on Wasm targets.
+
+`main` is mangled as either `__main_void` or `__main_argc_argv` as appropriate (unless overriden by `pragma(mangle)`)
+
+This change is useful for both WASI and Emscripten targets, which both expect this.

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -727,6 +727,23 @@ public:
             buf.writestring(fd.ident.toString());
             return;
         }
+
+        version (IN_LLVM)
+        {
+            import gen.llvmhelpers : isTargetWasm;
+            bool isWasm = isTargetWasm();
+        }
+        else bool isWasm = false;
+
+        if (fd.isCMain() && isWasm)
+        {
+            if (fd.parameters)
+                buf.writestring("__main_argc_argv");
+            else
+                buf.writestring("__main_void");
+            return;
+        }
+
         visit(cast(Declaration)fd);
     }
 


### PR DESCRIPTION
Mangles `extern(C) main` as `__main_void` or `__main_argc_argv` on Wasm targets, as done by Clang, and expected by the `libc`s for Emscripten and WASI.

Split from ldc-developers/ldc#5158
Dependent on remainder of said PR to introduce `gen.llvmhelpers.isTargetWasm`.