### PR TITLE
druntime: DRuntime support for WASI

### DIFF
--- a/druntime/src/core/gc/config.d
+++ b/druntime/src/core/gc/config.d
@@ -19,7 +19,12 @@ struct Config
     bool disable;            // start disabled
     bool fork = false;       // optional concurrent behaviour
     ubyte profile;           // enable profiling with summary when terminating program
-    string gc = "conservative"; // select gc implementation conservative|precise|manual
+
+    // TODO: support full `conservative` GC on Wasm
+    version (WebAssembly)
+        string gc = "manual"; // select gc implementation conservative|precise|manual
+    else
+        string gc = "conservative"; // select gc implementation conservative|precise|manual
 
     @MemVal size_t initReserve;      // initial reserve (bytes)
     @MemVal size_t minPoolSize = 1  << 20;  // initial and minimum pool size (bytes)

--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -223,6 +223,10 @@ private extern (C) void _initialize() @system
         GetSystemInfo(&si);
         (cast() pageSize) = cast(size_t) si.dwPageSize;
     }
+    else version (WebAssembly)
+    {
+        (cast() pageSize) = cast(size_t) 65536;
+    }
     else
         static assert(false, __FUNCTION__ ~ " is not implemented on this platform");
 }

--- a/druntime/src/core/sync/condition.d
+++ b/druntime/src/core/sync/condition.d
@@ -41,6 +41,10 @@ else version (Posix)
         pthread_cond_signal, pthread_cond_t, pthread_cond_timedwait, pthread_cond_wait;
     import core.sys.posix.time : timespec;
 }
+else version (WASI)
+{
+    // Dummy no-ops
+}
 else
 {
     static assert(false, "Platform not supported");
@@ -250,6 +254,10 @@ class Condition
             if ( rc )
                 throw staticError!AssertError("Unable to wait for condition", __FILE__, __LINE__);
         }
+        else version (WASI)
+        {
+            throw staticError!AssertError("Unable to wait for condition", __FILE__, __LINE__);
+        }
     }
 
     /**
@@ -315,6 +323,10 @@ class Condition
                 return false;
             throw staticError!AssertError("Unable to wait for condition", __FILE__, __LINE__);
         }
+        else version (WASI)
+        {
+            throw staticError!AssertError("Unable to wait for condition", __FILE__, __LINE__);
+        }
     }
 
     /**
@@ -363,6 +375,10 @@ class Condition
             if ( rc )
                 throw staticError!AssertError("Unable to notify condition", __FILE__, __LINE__);
         }
+        else version (WASI)
+        {
+            throw staticError!AssertError("Unable to notify condition", __FILE__, __LINE__);
+        }
     }
 
     /**
@@ -410,6 +426,10 @@ class Condition
             } while ( rc == EAGAIN );
             if ( rc )
                 throw staticError!AssertError("Unable to notify condition", __FILE__, __LINE__);
+        }
+        else version (WASI)
+        {
+            throw staticError!AssertError("Unable to notify condition", __FILE__, __LINE__);
         }
     }
 
@@ -615,6 +635,10 @@ private:
     {
         Mutex               m_assocMutex;
         pthread_cond_t      m_hndl;
+    }
+    else version (WASI)
+    {
+        Mutex               m_assocMutex;
     }
 }
 

--- a/druntime/src/core/sync/event.d
+++ b/druntime/src/core/sync/event.d
@@ -26,6 +26,10 @@ else version (Posix)
     import core.sys.posix.sys.types : pthread_cond_t, pthread_mutex_t;
     import core.sys.posix.time : timespec;
 }
+else version (WASI)
+{
+    // Dummy no-op
+}
 else
 {
     static assert(false, "Platform not supported");
@@ -133,6 +137,10 @@ nothrow @nogc:
             m_manualReset = manualReset;
             m_initalized = true;
         }
+        else version (WASI)
+        {
+            abort("Error: Cannot initialize Event on WASI.");
+        }
     }
 
     // copying not allowed, can produce resource leaks
@@ -192,6 +200,10 @@ nothrow @nogc:
                 pthread_mutex_unlock(&m_mutex);
             }
         }
+        else version (WASI)
+        {
+            abort("Error: Cannot deinitialize Event on WASI.");
+        }
     }
 
     /// Reset the event manually
@@ -228,6 +240,11 @@ nothrow @nogc:
         else version (Posix)
         {
             return wait(Duration.max);
+        }
+        else version (WASI)
+        {
+            abort("Error: Cannot wait for Event on WASI.");
+            return false;
         }
     }
 
@@ -289,6 +306,11 @@ nothrow @nogc:
             pthread_mutex_unlock(&m_mutex);
 
             return result == 0;
+        }
+        else version (WASI)
+        {
+            abort("Error: Cannot wait for Event on WASI.");
+            return false;
         }
     }
 

--- a/druntime/src/core/sync/mutex.d
+++ b/druntime/src/core/sync/mutex.d
@@ -31,6 +31,10 @@ else version (Posix)
         pthread_mutexattr_init, pthread_mutexattr_settype;
     import core.sys.posix.sys.types : pthread_mutex_t, pthread_mutexattr_t;
 }
+else version (WASI)
+{
+    // Dummy no-op
+}
 else
 {
     static assert(false, "Platform not supported");
@@ -274,6 +278,10 @@ class Mutex :
         else version (Posix)
         {
             return pthread_mutex_trylock(&self.m_hndl) == 0;
+        }
+        else version (WASI)
+        {
+            return true;
         }
     }
 

--- a/druntime/src/core/sync/semaphore.d
+++ b/druntime/src/core/sync/semaphore.d
@@ -50,6 +50,10 @@ else version (Posix)
     import core.sys.posix.semaphore : sem_destroy, sem_init, sem_post, sem_t, sem_timedwait, sem_trywait, sem_wait;
     import core.sys.posix.time : clock_gettime, CLOCK_REALTIME, timespec;
 }
+else version (WASI)
+{
+    // Dummy no-op
+}
 else
 {
     static assert(false, "Platform not supported");
@@ -106,6 +110,10 @@ class Semaphore
             int rc = sem_init( &m_hndl, 0, count );
             if ( rc )
                 throw new SyncError( "Unable to create semaphore" );
+        }
+        else version (WASI)
+        {
+            m_hndl = count;
         }
     }
 
@@ -171,6 +179,12 @@ class Semaphore
                 if ( errno != EINTR )
                     throw new SyncError( "Unable to wait for semaphore" );
             }
+        }
+        else version (WASI)
+        {
+            if (m_hndl == 0) throw new SyncError( "Unable to wait for semaphore" );
+
+            m_hndl -= 1;
         }
     }
 
@@ -268,6 +282,11 @@ class Semaphore
                     throw new SyncError( "Unable to wait for semaphore" );
             }
         }
+        else version (WASI)
+        {
+            wait();
+            return true;
+        }
     }
 
 
@@ -295,6 +314,13 @@ class Semaphore
         {
             int rc = sem_post( &m_hndl );
             if ( rc )
+                throw new SyncError( "Unable to notify semaphore" );
+        }
+        else version (WASI)
+        {
+            if (m_hndl < typeof(m_hndl).max)
+                m_hndl += 1;
+            else
                 throw new SyncError( "Unable to notify semaphore" );
         }
     }
@@ -340,6 +366,11 @@ class Semaphore
                     throw new SyncError( "Unable to wait for semaphore" );
             }
         }
+        else version (WASI)
+        {
+            wait();
+            return true;
+        }
     }
 
 
@@ -351,6 +382,7 @@ protected:
     else version (Darwin)    alias Handle = semaphore_t;
     /// ditto
     else version (Posix)     alias Handle = sem_t;
+    else version (WASI)      alias Handle = uint;
 
     /// Handle to the system-specific semaphore.
     Handle m_hndl;

--- a/druntime/src/core/thread/fiber/base.d
+++ b/druntime/src/core/thread/fiber/base.d
@@ -11,6 +11,10 @@
 
 module core.thread.fiber.base;
 
+// No Fiber support on WebAssembly (arch issue)
+// TODO: Investigate Wasm `stack-switching` proposal as solution
+version(WebAssembly) {} else:
+
 package:
 
 import core.thread.fiber;

--- a/druntime/src/core/thread/fiber/package.d
+++ b/druntime/src/core/thread/fiber/package.d
@@ -11,6 +11,10 @@
 
 module core.thread.fiber;
 
+// No Fiber support on WebAssembly (arch issue)
+// TODO: Investigate Wasm `stack-switching` proposal as solution
+version(WebAssembly) {} else:
+
 import core.thread.context;
 import core.thread.fiber.base : fiber_entryPoint, FiberBase;
 import core.thread.threadbase;

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -145,10 +145,7 @@ else version (WASI)
 {
     // No real threading support
     // Just manipulations of the main "thread"
-
-    import core.stdc.errno : EINTR, errno;
     import core.stdc.stdlib : free, malloc, realloc;
-    import core.sys.wasi.posix.time : nanosleep, timespec;
 }
 else
     static assert(0, "unsupported operating system");

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -28,6 +28,8 @@ version (Posix)
     public import core.thread.posix_impl;
 else version (Windows)
     public import core.thread.windows_impl;
+else version (WASI)
+    public import core.thread.wasi_impl;
 else
     static assert(false, "Unknown threading implementation.");
 
@@ -138,6 +140,15 @@ else version (Posix)
     {
         // Use POSIX threads for suspend/resume
     }
+}
+else version (WASI)
+{
+    // No real threading support
+    // Just manipulations of the main "thread"
+
+    import core.stdc.errno : EINTR, errno;
+    import core.stdc.stdlib : free, malloc, realloc;
+    import core.sys.wasi.posix.time : nanosleep, timespec;
 }
 else
     static assert(0, "unsupported operating system");
@@ -678,6 +689,12 @@ private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow
 
         atomicStore!(MemoryOrder.raw)(thisThread.toThread.m_isRunning, true);
     }
+    else version (WASI)
+    {
+        thisThread.m_addr  = 1; // assumes this is done only once
+        thisContext.bstack = getStackBottom();
+        thisContext.tstack = thisContext.bstack;
+    }
     else
         static assert(0, "unsupported os");
     thisThread.m_isDaemon = true;
@@ -965,6 +982,11 @@ in (fn)
         }
         assert(0, "implement AArch64 inline assembler for callWithStackShell()"); // TODO AArch64
     }
+    else version (WebAssembly)
+    {
+        // Wasm is special in that this isn't really possible
+        // Spilling has to be done somehow else...
+    }
     else
     {
         static assert(false, "Architecture not supported.");
@@ -989,6 +1011,10 @@ version (Posix)
 else version (Windows)
 {
     alias getpid = imported!"core.sys.windows.winbase".GetCurrentProcessId;
+}
+else version (WASI)
+{
+    int getpid() @nogc nothrow @safe => 1;
 }
 else
     static assert(0, "unsupported os");
@@ -1470,6 +1496,10 @@ private extern (D) bool suspend( Thread t ) nothrow @nogc
             t.m_curr.tstack = getStackTop();
         }
     }
+    else version (WASI)
+    {
+        onThreadError( "Unable to suspend thread" );
+    }
     else
         static assert(0, "unsupported os");
     return true;
@@ -1493,6 +1523,8 @@ extern (C) void thread_preStopTheWorld() nothrow {
  */
 extern (C) void thread_suspendAll() nothrow
 {
+    version (WASI) onThreadError( "Unable to suspend all threads" );
+
     // NOTE: We've got an odd chicken & egg problem here, because while the GC
     //       is required to call thread_init before calling any other thread
     //       routines, thread_init may allocate memory which could in turn
@@ -1559,6 +1591,10 @@ extern (C) void thread_suspendAll() nothrow
         }
         else version (Windows)
         {
+        }
+        else version (WASI)
+        {
+            // bail out handled at start
         }
         else
             static assert(0, "unsupported os");
@@ -1649,6 +1685,10 @@ private extern (D) void resume(ThreadBase _t) nothrow @nogc
         {
             t.m_curr.tstack = t.m_curr.bstack;
         }
+    }
+    else version (WASI)
+    {
+        onThreadError( "Unable to resume thread" );
     }
     else
         static assert(false, "Platform not supported.");
@@ -1776,6 +1816,9 @@ extern (C) void thread_init() @nogc nothrow
 
         status = sem_init( &suspendCount, 0, 0 );
         assert( status == 0 );
+    }
+    else version (WASI)
+    {
     }
     else
         static assert(0, "unsupported os");
@@ -2147,6 +2190,17 @@ else version (Posix)
         }
     }
 }
+else version (WASI)
+{
+    //
+    // Entry point for WASI threads
+    //
+    extern (C) void* thread_entryPoint( void* arg ) nothrow
+    {
+        onThreadError("Cannot enter new WASI threads.");
+        return null;
+    }
+}
 else
 {
     // NOTE: This is the only place threading versions are checked.  If a new
@@ -2489,6 +2543,13 @@ ThreadID createLowLevelThread(void delegate() nothrow dg, uint stacksize = 0,
 
         ll_pThreads[ll_nThreads - 1].tid = tid;
     }
+    else version (WASI)
+    {
+        // no-op for now.
+
+        // falls through to returning `tid`,
+        // which will already be `ThreadID.init` (error)
+    }
     else
         static assert(0, "unsupported os");
     context = null; // free'd in thread
@@ -2530,6 +2591,10 @@ void joinLowLevelThread(ThreadID tid) nothrow @nogc
     {
         if (pthread_join(tid, null) != 0)
             onThreadError("Unable to join thread");
+    }
+    else version (WASI)
+    {
+        onThreadError("Unable to join thread");
     }
     else
         static assert(0, "unsupported os");

--- a/druntime/src/core/thread/types.d
+++ b/druntime/src/core/thread/types.d
@@ -24,6 +24,11 @@ version (Posix)
 
     alias ThreadID = pthread_t;
 }
+else
+version (WASI)
+{
+    alias ThreadID = ubyte; // dummy; always 1
+}
 
 struct ll_ThreadData
 {

--- a/druntime/src/core/thread/wasi_impl.d
+++ b/druntime/src/core/thread/wasi_impl.d
@@ -25,7 +25,6 @@ version (WASI):
 // Just manipulations of the main "thread"
 
 import core.stdc.errno : EINTR, errno;
-import core.stdc.stdlib : free, malloc, realloc;
 import core.sys.wasi.posix.time : nanosleep, timespec;
 
 version (CoreDdoc) {} else

--- a/druntime/src/core/thread/wasi_impl.d
+++ b/druntime/src/core/thread/wasi_impl.d
@@ -1,0 +1,181 @@
+/**
+ * The wasi_impl module provides low-level WASI code
+ * for thread creation and management.
+ *
+ * Copyright: Copyright ???
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   ???
+ * Source:    $(DRUNTIMESRC core/thread/wasi_impl.d)
+ */
+
+module core.thread.wasi_impl;
+
+import core.atomic;
+import core.exception : onOutOfMemoryError;
+import core.internal.traits : externDFunc;
+import core.thread.osthread;
+import core.thread.threadbase;
+import core.time;
+
+version (WASI):
+
+version (all)
+{
+    // No real threading support
+    // Just manipulations of the main "thread"
+
+    import core.stdc.errno : EINTR, errno;
+    import core.stdc.stdlib : free, malloc, realloc;
+    import core.sys.wasi.posix.time : nanosleep, timespec;
+}
+
+version (GNU)
+{
+    import gcc.builtins;
+}
+
+version (CoreDdoc) {} else
+class Thread : ThreadBase
+{
+    package shared bool     m_isRunning;
+
+    alias TLSKey = pthread_key_t;
+
+    this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
+    {
+        super(fn, sz);
+    }
+
+    this( void delegate() dg, size_t sz = 0 ) @safe pure nothrow @nogc
+    {
+        super(dg, sz);
+    }
+
+    package this( size_t sz = 0 ) @safe pure nothrow @nogc
+    {
+        super(sz);
+    }
+
+    ~this() nothrow @nogc
+    {
+        if (super.destructBeforeDtor())
+            return;
+
+        version (all)
+        {
+        }
+    }
+
+    static Thread getThis() @safe nothrow @nogc
+    {
+        return ThreadBase.getThis().toThread;
+    }
+
+    override final void[] savedRegisters() nothrow @nogc
+    {
+        return null;
+    }
+
+    final Thread start() nothrow
+    in
+    {
+        assert( !next && !prev );
+    }
+    do
+    {
+        auto wasThreaded  = multiThreadedFlag;
+        multiThreadedFlag = true;
+        scope( failure )
+        {
+            if ( !wasThreaded )
+                multiThreadedFlag = false;
+        }
+
+        version (all) {
+            onThreadError("cannot start new threads on WASI");
+        }
+    }
+
+    override final Throwable join( bool rethrow = true )
+    {
+        throw new ThreadException( "Unable to join thread" );
+
+        return super.join(rethrow);
+    }
+
+    version (all)
+    {
+        @property static int PRIORITY_MIN() @nogc nothrow pure @safe
+        {
+            return 0;
+        }
+
+        @property static const(int) PRIORITY_MAX() @nogc nothrow pure @safe
+        {
+            return 0;
+        }
+
+        @property static int PRIORITY_DEFAULT() @nogc nothrow pure @safe
+        {
+            return 0;
+        }
+    }
+
+    final @property int priority()
+    {
+        return 0;
+    }
+
+    final @property void priority( int val )
+    in
+    {
+        assert(val >= PRIORITY_MIN);
+        assert(val <= PRIORITY_MAX);
+    }
+    do
+    {
+        // nothing
+    }
+
+    override final @property bool isRunning() nothrow @nogc
+    {
+        if (!super.isRunning())
+            return false;
+
+        // the "main thread" is the only that will pass super.isRunning(), and is always running
+        return true;
+    }
+
+    static void sleep( Duration val ) @nogc nothrow @trusted
+    in
+    {
+        assert( !val.isNegative );
+    }
+    do
+    {
+        version (all)
+        {
+            timespec tin  = void;
+            timespec tout = void;
+
+            val.split!("seconds", "nsecs")(tin.tv_sec, tin.tv_nsec);
+            if ( val.total!"seconds" > tin.tv_sec.max )
+                tin.tv_sec  = tin.tv_sec.max;
+            while ( true )
+            {
+                if ( !nanosleep( &tin, &tout ) )
+                    return;
+                if ( errno != EINTR )
+                    assert(0, "Unable to sleep for the specified duration");
+                tin = tout;
+            }
+        }
+    }
+
+    static void yield() @nogc nothrow
+    {
+        sched_yield();
+    }
+}

--- a/druntime/src/core/thread/wasi_impl.d
+++ b/druntime/src/core/thread/wasi_impl.d
@@ -21,27 +21,17 @@ import core.time;
 
 version (WASI):
 
-version (all)
-{
-    // No real threading support
-    // Just manipulations of the main "thread"
+// No real threading support
+// Just manipulations of the main "thread"
 
-    import core.stdc.errno : EINTR, errno;
-    import core.stdc.stdlib : free, malloc, realloc;
-    import core.sys.wasi.posix.time : nanosleep, timespec;
-}
-
-version (GNU)
-{
-    import gcc.builtins;
-}
+import core.stdc.errno : EINTR, errno;
+import core.stdc.stdlib : free, malloc, realloc;
+import core.sys.wasi.posix.time : nanosleep, timespec;
 
 version (CoreDdoc) {} else
 class Thread : ThreadBase
 {
     package shared bool     m_isRunning;
-
-    alias TLSKey = pthread_key_t;
 
     this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
     {
@@ -62,10 +52,6 @@ class Thread : ThreadBase
     {
         if (super.destructBeforeDtor())
             return;
-
-        version (all)
-        {
-        }
     }
 
     static Thread getThis() @safe nothrow @nogc
@@ -93,9 +79,7 @@ class Thread : ThreadBase
                 multiThreadedFlag = false;
         }
 
-        version (all) {
-            onThreadError("cannot start new threads on WASI");
-        }
+        onThreadError("cannot start new threads on WASI");
     }
 
     override final Throwable join( bool rethrow = true )
@@ -105,22 +89,19 @@ class Thread : ThreadBase
         return super.join(rethrow);
     }
 
-    version (all)
+    @property static int PRIORITY_MIN() @nogc nothrow pure @safe
     {
-        @property static int PRIORITY_MIN() @nogc nothrow pure @safe
-        {
-            return 0;
-        }
+        return 0;
+    }
 
-        @property static const(int) PRIORITY_MAX() @nogc nothrow pure @safe
-        {
-            return 0;
-        }
+    @property static const(int) PRIORITY_MAX() @nogc nothrow pure @safe
+    {
+        return 0;
+    }
 
-        @property static int PRIORITY_DEFAULT() @nogc nothrow pure @safe
-        {
-            return 0;
-        }
+    @property static int PRIORITY_DEFAULT() @nogc nothrow pure @safe
+    {
+        return 0;
     }
 
     final @property int priority()
@@ -155,27 +136,24 @@ class Thread : ThreadBase
     }
     do
     {
-        version (all)
-        {
-            timespec tin  = void;
-            timespec tout = void;
+        timespec tin  = void;
+        timespec tout = void;
 
-            val.split!("seconds", "nsecs")(tin.tv_sec, tin.tv_nsec);
-            if ( val.total!"seconds" > tin.tv_sec.max )
-                tin.tv_sec  = tin.tv_sec.max;
-            while ( true )
-            {
-                if ( !nanosleep( &tin, &tout ) )
-                    return;
-                if ( errno != EINTR )
-                    assert(0, "Unable to sleep for the specified duration");
-                tin = tout;
-            }
+        val.split!("seconds", "nsecs")(tin.tv_sec, tin.tv_nsec);
+        if ( val.total!"seconds" > tin.tv_sec.max )
+            tin.tv_sec  = tin.tv_sec.max;
+        while ( true )
+        {
+            if ( !nanosleep( &tin, &tout ) )
+                return;
+            if ( errno != EINTR )
+                assert(0, "Unable to sleep for the specified duration");
+            tin = tout;
         }
     }
 
     static void yield() @nogc nothrow
     {
-        sched_yield();
+        // do nothing
     }
 }

--- a/druntime/src/core/time.d
+++ b/druntime/src/core/time.d
@@ -92,6 +92,10 @@ else version (Posix)
     import core.sys.posix.sys.time : gettimeofday, timeval;
     import core.sys.posix.time : clock_getres, clock_gettime, CLOCK_MONOTONIC, timespec;
 }
+else version (WASI)
+{
+    import core.sys.wasi.posix.time : clock_getres, clock_gettime, CLOCK_MONOTONIC, timespec;
+}
 
 version (unittest) import core.stdc.stdio : printf;
 
@@ -348,6 +352,13 @@ else version (Hurd) enum ClockType
     // threadCPUTime = 7,
 
 }
+else version (WASI) enum ClockType
+{
+    normal = 0,
+    coarse = 2,
+    precise = 3,
+    second = 6
+}
 else
 {
     // It needs to be decided (and implemented in an appropriate version branch
@@ -468,6 +479,21 @@ version (Posix)
             // mention it if a new platform uses anything that's not supported
             // on all platforms..
             assert(0, "What are the monotonic clock types supported by this system?");
+    }
+}
+else
+version (WASI)
+{
+    private auto _posixClock(ClockType clockType)
+    {
+        import core.sys.wasi.posix.time;
+        with(ClockType) final switch (clockType)
+        {
+            case coarse: return CLOCK_MONOTONIC;
+            case normal: return CLOCK_MONOTONIC;
+            case precise: return CLOCK_MONOTONIC;
+            case second: assert(0);
+        }
     }
 }
 
@@ -2157,6 +2183,10 @@ struct MonoTimeImpl(ClockType clockType)
     {
         enum clockArg = _posixClock(clockType);
     }
+    else version (WASI)
+    {
+        enum clockArg = _posixClock(clockType);
+    }
     else
         static assert(0, "Unsupported platform");
 
@@ -2205,6 +2235,24 @@ struct MonoTimeImpl(ClockType clockType)
         else version (Darwin)
             return MonoTimeImpl(mach_absolute_time());
         else version (Posix)
+        {
+            timespec ts = void;
+            immutable error = clock_gettime(clockArg, &ts);
+            // clockArg is supported and if tv_sec is long or larger
+            // overflow won't happen before 292 billion years A.D.
+            static if (ts.tv_sec.max < long.max)
+            {
+                if (error)
+                {
+                    import core.internal.abort : abort;
+                    abort("Call to clock_gettime failed.");
+                }
+            }
+            return MonoTimeImpl(convClockFreq(ts.tv_sec * 1_000_000_000L + ts.tv_nsec,
+                                              1_000_000_000L,
+                                              ticksPerSecond));
+        }
+        else version (WASI)
         {
             timespec ts = void;
             immutable error = clock_gettime(clockArg, &ts);
@@ -2617,6 +2665,34 @@ extern(C) void _d_initMonoTime() @nogc nothrow
             }
         }
     }
+    else version (WASI)
+    {
+        timespec ts;
+        foreach (i, typeStr; __traits(allMembers, ClockType))
+        {
+            static if (typeStr != "second")
+            {
+                enum clockArg = _posixClock(__traits(getMember, ClockType, typeStr));
+                if (clock_getres(clockArg, &ts) == 0)
+                {
+                    // ensure we are only writing immutable data once
+                    if (tps[i] != 0)
+                        // should only be called once
+                        assert(0);
+
+                    // For some reason, on some systems, clock_getres returns
+                    // a resolution which is clearly wrong:
+                    //  - it's a millisecond or worse, but the time is updated
+                    //    much more frequently than that.
+                    //  - it's negative
+                    //  - it's zero
+                    // In such cases, we'll just use nanosecond resolution.
+                    tps[i] = ts.tv_sec != 0 || ts.tv_nsec <= 0 || ts.tv_nsec >= 1000
+                        ? 1_000_000_000L : 1_000_000_000L / ts.tv_nsec;
+                }
+            }
+        }
+    }
     else
         static assert(0, "Unsupported platform");
 }
@@ -2917,6 +2993,23 @@ deprecated:
             }
             else
                 ticksPerSec = 1_000_000;
+        }
+        else version (WASI)
+        {
+            timespec ts;
+
+            if (clock_getres(CLOCK_MONOTONIC, &ts) != 0)
+                ticksPerSec = 0;
+            else
+            {
+                //For some reason, on some systems, clock_getres returns
+                //a resolution which is clearly wrong (it's a millisecond
+                //or worse, but the time is updated much more frequently
+                //than that). In such cases, we'll just use nanosecond
+                //resolution.
+                ticksPerSec = ts.tv_nsec >= 1000 ? 1_000_000_000
+                                                    : 1_000_000_000 / ts.tv_nsec;
+            }
         }
         else
             static assert(0, "Unsupported platform");
@@ -3486,6 +3579,23 @@ deprecated:
                 return TickDuration(tv.tv_sec * TickDuration.ticksPerSec +
                                     tv.tv_usec * TickDuration.ticksPerSec / 1000 / 1000);
             }
+        }
+        else version (WASI)
+        {
+            timespec ts = void;
+            immutable error = clock_gettime(CLOCK_MONOTONIC, &ts);
+            // CLOCK_MONOTONIC is supported and if tv_sec is long or larger
+            // overflow won't happen before 292 billion years A.D.
+            static if (ts.tv_sec.max < long.max)
+            {
+                if (error)
+                {
+                    import core.internal.abort : abort;
+                    abort("Call to clock_gettime failed.");
+                }
+            }
+            return TickDuration(ts.tv_sec * TickDuration.ticksPerSec +
+                                ts.tv_nsec * TickDuration.ticksPerSec / 1000 / 1000 / 1000);
         }
     }
 

--- a/druntime/src/rt/cover.d
+++ b/druntime/src/rt/cover.d
@@ -11,6 +11,9 @@
 
 module rt.cover;
 
+version (WASI) {}
+else:
+
 import core.internal.utf;
 import core.internal.util.math : max, min;
 import core.stdc.stdio : EOF, fclose, fgetc, FILE, fileno, fprintf, fread, fseek, ftell, printf, SEEK_END, SEEK_SET,

--- a/druntime/src/rt/dmain2.d
+++ b/druntime/src/rt/dmain2.d
@@ -43,6 +43,10 @@ else version (Posix)
 {
     import core.stdc.string : strlen;
 }
+else version (WASI)
+{
+    import core.stdc.string : strlen;
+}
 
 version (DigitalMars) version (AArch64)
     version = UseMalloc;   // cuz alloca() is not implemented yet
@@ -336,6 +340,18 @@ extern (C) int _d_run_main(int argc, char** argv, MainFunc mainFunc)
         }
         else
             char[][] args = (cast(char[]*) alloca(argc * (char[]).sizeof))[0 .. argc];
+
+        size_t totalArgsLength = 0;
+        foreach (i, ref arg; args)
+        {
+            arg = argv[i][0 .. strlen(argv[i])];
+            totalArgsLength += arg.length;
+        }
+    }
+    else version (WASI)
+    {
+        // Allocate args[] on the stack
+        char[][] args = (cast(char[]*) alloca(argc * (char[]).sizeof))[0 .. argc];
 
         size_t totalArgsLength = 0;
         foreach (i, ref arg; args)

--- a/druntime/src/rt/monitor_.d
+++ b/druntime/src/rt/monitor_.d
@@ -24,6 +24,10 @@ else version (Posix)
         pthread_mutexattr_settype;
     import core.sys.posix.sys.types : pthread_mutex_t, pthread_mutexattr_t;
 }
+else version (WASI)
+{
+    // dummy no-op
+}
 else
 {
     static assert(0, "Unsupported platform");
@@ -223,6 +227,26 @@ else version (Posix)
     void unlockMutex(pthread_mutex_t* mtx)
     {
         pthread_mutex_unlock(mtx) && assert(0);
+    }
+}
+else version (WASI) {
+@nogc:
+    alias Mutex = ubyte;
+
+    void initMutex(Mutex* mtx)
+    {
+    }
+
+    void destroyMutex(Mutex* mtx)
+    {
+    }
+
+    void lockMutex(Mutex* mtx)
+    {
+    }
+
+    void unlockMutex(Mutex* mtx)
+    {
     }
 }
 

--- a/druntime/src/rt/profilegc.d
+++ b/druntime/src/rt/profilegc.d
@@ -13,6 +13,12 @@
 
 module rt.profilegc;
 
+// On Wasm, it increases codesize noticably.
+// Meanwhile, ldc (ldmd2) does not support `-profile-gc`, so there's no point
+// keeping it around on Wasm targets
+version (WASI) {}
+else:
+
 private:
 
 import core.stdc.errno : errno;

--- a/druntime/src/rt/sections.d
+++ b/druntime/src/rt/sections.d
@@ -59,6 +59,8 @@ else version (CRuntime_Bionic)
     public import rt.sections_elf_shared;
 else version (CRuntime_UClibc)
     public import rt.sections_elf_shared;
+else version (WebAssembly)
+    public import rt.sections_wasm;
 else
     static assert(0, "unimplemented");
 

--- a/druntime/src/rt/sections_wasm.d
+++ b/druntime/src/rt/sections_wasm.d
@@ -1,0 +1,74 @@
+module rt.sections_wasm;
+
+version (WebAssembly):
+
+import rt.minfo;
+
+struct SectionGroup
+{
+    static int opApply(scope int delegate(ref SectionGroup) dg)
+    {
+        return dg(_sections);
+    }
+
+    static int opApplyReverse(scope int delegate(ref SectionGroup) dg)
+    {
+        return dg(_sections);
+    }
+
+    @property immutable(ModuleInfo*)[] modules() const nothrow @nogc
+    {
+        return _moduleGroup.modules;
+    }
+
+    @property ref inout(ModuleGroup) moduleGroup() inout return nothrow @nogc
+    {
+        return _moduleGroup;
+    }
+
+    @property inout(void[])[] gcRanges() inout return nothrow @nogc
+    {
+        return null;
+    }
+
+private:
+    ModuleGroup _moduleGroup;
+}
+
+void initSections() nothrow @nogc
+{
+    auto mbeg = cast(immutable ModuleInfo**)&__start___minfo;
+    auto mend = cast(immutable ModuleInfo**)&__stop___minfo;
+    _sections.moduleGroup = ModuleGroup(mbeg[0 .. mend - mbeg]);
+}
+
+void finiSections() nothrow @nogc
+{
+}
+
+void[] initTLSRanges() nothrow @nogc
+{
+    return null;
+}
+
+void finiTLSRanges(void[] rng) nothrow @nogc
+{
+}
+
+void scanTLSRanges(void[] rng, scope void delegate(void* pbeg, void* pend) nothrow dg) nothrow
+{
+    dg(rng.ptr, rng.ptr + rng.length);
+}
+
+private:
+
+__gshared SectionGroup _sections;
+
+extern(C)
+{
+    extern __gshared
+    {
+        void* __start___minfo;
+        void* __stop___minfo;
+    }
+}

--- a/druntime/src/rt/trace.d
+++ b/druntime/src/rt/trace.d
@@ -11,6 +11,10 @@
 
 module rt.trace;
 
+// TODO(?): support this on Wasm at some point
+version (WASI) {}
+else:
+
 import core.demangle;
 import core.stdc.ctype : isalpha, isgraph, isspace;
 import core.stdc.stdio : EOF, fclose, fgetc, FILE, fopen, fprintf, stderr, stdout;


### PR DESCRIPTION
Adds WASI support to (most) of DRuntime.

`core.stdc` is handled in #23294
`core.internal` is handled #23301

Split from ldc-developers/ldc#5152