### PR TITLE
Remove Wasm/WASI changelog entries not relavent to DMD

### DIFF
--- a/changelog/dmd.wasm-c-main-mangle.dd
+++ b/changelog/dmd.wasm-c-main-mangle.dd
@@ -1,7 +1,0 @@
-`extern(C) main` now mangled correctly on WebAssembly
-
-D now matches the mangling behavior of Clang for C `main` on Wasm targets.
-
-`main` is mangled as either `__main_void` or `__main_argc_argv` as appropriate (unless overriden by `pragma(mangle)`)
-
-This change is useful for both WASI and Emscripten targets, which both expect this.

--- a/changelog/druntime.wasi-core-stdc.dd
+++ b/changelog/druntime.wasi-core-stdc.dd
@@ -1,3 +1,0 @@
-`wasi-libc` (`CRuntime_WASI`) support added to `core.stdc`
-
-All the libc declarations in `core.stdc` have been expanded to include support for $(LINK2 https://github.com/WebAssembly/wasi-libc, wasi-libc)


### PR DESCRIPTION
At request of @dkorpel: https://github.com/dlang/dmd/pull/23303#discussion_r3465390723