### PR TITLE
fix #23320 - [reg 2.112] Constness and immutability of AA keys is handled unflexibly

### DIFF
--- a/druntime/src/core/internal/newaa.d
+++ b/druntime/src/core/internal/newaa.d
@@ -115,7 +115,7 @@ private ref compat_key(K, K2)(ref K2 key)
 {
     static if(!(is(K2 == struct) && __traits(isNested, K2)))
         pragma(inline, true);
-    static if (is(K2 == const(char)[]) && is(K == string))
+    static if (is(Unconstify!K2 == const(char)[]) && is(K == string))
         return (ref (ref return K2 k2) @trusted => *cast(string*)&k2)(key);
     else
         return key;

--- a/druntime/test/aa/src/test_aa.d
+++ b/druntime/test/aa/src/test_aa.d
@@ -46,6 +46,7 @@ void main()
     testNew();
     testAliasThis();
     testAliasThis2();
+    testStringKey();
 }
 
 void testKeysValues1()
@@ -1047,6 +1048,21 @@ void testAliasThis2()
     aa[B(5)] = true;
     assert(B(5) in aa);
     assert(A(false, 5) in aa);
+}
+
+void testStringKey()
+{
+    // allow conversion of key of type const(char)[] to string for backward compatibility
+    int[string] properties;
+
+    properties["0"] = 0;
+
+    const(char)[] keyName = "1";
+    properties[keyName] = 1;
+
+    // https://github.com/dlang/dmd/issues/23320
+    const keyName2 = keyName;
+    properties[keyName2] = 2;
 }
 
 void test22510()


### PR DESCRIPTION
for backward compatibility allow implicit conversion of `const(char[])` to `string` for AA keys, too.