### PR TITLE
Fix #23332 and add test case.

### DIFF
--- a/compiler/src/dmd/glue/tocsym.d
+++ b/compiler/src/dmd/glue/tocsym.d
@@ -80,10 +80,12 @@ Symbol* toSymbolX(Dsymbol ds, const(char)* prefix, SC sclass, type* t, const(cha
 {
     //printf("Dsymbol::toSymbolX('%s')\n", prefix);
     import dmd.common.outbuffer : OutBuffer;
+    import core.stdc.string : strlen;
+
     OutBuffer buf;
     buf.writestring("_D");
     mangleToBuffer(ds, buf);
-    buf.printf("%zd%s%s", strlen(prefix), prefix, suffix);
+    buf.printf("%d%s%s", cast(int)strlen(prefix), prefix, suffix);
     Symbol* s = symbol_name(buf[], sclass, t);
 
     //printf("-Dsymbol::toSymbolX() %s\n", buf.peekChars());

--- a/compiler/test/compilable/test23332.d
+++ b/compiler/test/compilable/test23332.d
@@ -3,4 +3,3 @@
 struct S { int a; double b; float c; }
 __gshared S s = { 1, 2, 3 };
 double f(double x) { return x * 2; }
-

--- a/compiler/test/compilable/test23332.d
+++ b/compiler/test/compilable/test23332.d
@@ -1,0 +1,6 @@
+// https://github.com/dlang/dmd/issues/23332
+// Segfault generating a struct's static initializer symbol when it has a float member.
+struct S { int a; double b; float c; }
+__gshared S s = { 1, 2, 3 };
+double f(double x) { return x * 2; }
+


### PR DESCRIPTION
Fixed with LLM.

**LLM Model : Opus 4.8
Prompt:**
Instead of reverting the change to tocsym.d, can you fix it to not cause the access violation? Then create a test case using issue number 23332 (https://github.com/dlang/dmd/issues/23332).