### PR TITLE
fix #23335 - some lowerings not shown with -vcg-ast

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2352,11 +2352,19 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
 
     void visitDsymbol(Dsymbol s)
     {
-        // For -vcg-ast, print internal names such as __invariant, __ctor etc.
-        // This condition is a bit kludge, and can be cleaned up if the
-        // mutual dependency `AST.toChars <> hdrgen.d` gets refactored
-        if (hgs.vcg_ast && s.ident && !s.isTemplateInstance() && !s.isTemplateDeclaration())
-            buf.put(s.ident.toChars());
+        if (hgs.vcg_ast)
+        {
+            // For -vcg-ast, print internal names such as __invariant, __ctor etc.
+            // This condition is a bit kludge, and can be cleaned up if the
+            // mutual dependency `AST.toChars <> hdrgen.d` gets refactored
+            auto p = s.toParent();
+            if (s.ident && s.ident.toHChars2() != s.ident.toChars())
+                buf.put(s.ident.toChars());
+            else if (p && (p.isFuncDeclaration() || p.isAggregateDeclaration()))
+                buf.put(s.toChars()); // function local or fields
+            else
+                buf.put(s.toPrettyChars()); // fully qualified name
+        }
         else
             buf.put(s.toChars());
     }
@@ -2710,6 +2718,15 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
         expToBuffer(e.e1, precedence[e.op], buf, hgs);
     }
 
+    void visitBin(BinExp e)
+    {
+        expToBuffer(e.e1, precedence[e.op], buf, hgs);
+        buf.put(' ');
+        buf.put(EXPtoString(e.op));
+        buf.put(' ');
+        expToBuffer(e.e2, cast(PREC)(precedence[e.op] + 1), buf, hgs);
+    }
+
     void visitLoweredAssignExp(LoweredAssignExp e)
     {
         if (hgs.vcg_ast)
@@ -2718,15 +2735,21 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
             return;
         }
 
-        visit(cast(BinExp)e);
+        visitBin(e);
     }
-    void visitBin(BinExp e)
+
+    void visitConstructExp(ConstructExp e)
     {
-        expToBuffer(e.e1, precedence[e.op], buf, hgs);
-        buf.put(' ');
-        buf.put(EXPtoString(e.op));
-        buf.put(' ');
-        expToBuffer(e.e2, cast(PREC)(precedence[e.op] + 1), buf, hgs);
+        if (hgs.vcg_ast && e.lowering)
+            return expressionToBuffer(e.lowering, buf, hgs);
+        visitBin(e);
+    }
+
+    void visitEqualExp(EqualExp e)
+    {
+        if (hgs.vcg_ast && e.lowering)
+            return expressionToBuffer(e.lowering, buf, hgs);
+        visitBin(e);
     }
 
     void visitComma(CommaExp e)
@@ -2910,6 +2933,9 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
 
     void visitCast(CastExp e)
     {
+        if (hgs.vcg_ast && e.lowering)
+            return expressionToBuffer(e.lowering, buf, hgs);
+
         buf.put("cast(");
         if (e.to)
             typeToBuffer(e.to, null, buf, hgs);
@@ -3149,6 +3175,9 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
         case EXP.question:      return visitCond(e.isCondExp());
         case EXP.classReference:        return visitClassReference(e.isClassReferenceExp());
         case EXP.loweredAssignExp:      return visitLoweredAssignExp(e.isLoweredAssignExp());
+        case EXP.construct:     return visitConstructExp(e.isConstructExp());
+        case EXP.equal:
+        case EXP.notEqual:      return visitEqualExp(e.isEqualExp());
     }
 }
 
@@ -4223,7 +4252,7 @@ private void visitFuncIdentWithPrefix(TypeFunction t, const Identifier ident, Te
     else if (hgs.ddoc)
         buf.put("auto ");
     if (ident)
-        buf.put(ident.toHChars2());
+        buf.put(hgs.vcg_ast ? ident.toChars() : ident.toHChars2());
     if (td)
     {
         buf.put('(');

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2357,11 +2357,19 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
 
     void visitDsymbol(Dsymbol s)
     {
-        // For -vcg-ast, print internal names such as __invariant, __ctor etc.
-        // This condition is a bit kludge, and can be cleaned up if the
-        // mutual dependency `AST.toChars <> hdrgen.d` gets refactored
-        if (hgs.vcg_ast && s.ident && !s.isTemplateInstance() && !s.isTemplateDeclaration())
-            buf.put(s.ident.toChars());
+        if (hgs.vcg_ast)
+        {
+            // For -vcg-ast, print internal names such as __invariant, __ctor etc.
+            // This condition is a bit kludge, and can be cleaned up if the
+            // mutual dependency `AST.toChars <> hdrgen.d` gets refactored
+            auto p = s.toParent();
+            if (s.ident && s.ident.toHChars2() != s.ident.toChars())
+                buf.put(s.ident.toChars());
+            else if (p && (p.isFuncDeclaration() || p.isAggregateDeclaration()))
+                buf.put(s.toChars()); // function local or fields
+            else
+                buf.put(s.toPrettyChars()); // fully qualified name
+        }
         else
             buf.put(s.toChars());
     }
@@ -2715,6 +2723,15 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
         expToBuffer(e.e1, precedence[e.op], buf, hgs);
     }
 
+    void visitBin(BinExp e)
+    {
+        expToBuffer(e.e1, precedence[e.op], buf, hgs);
+        buf.put(' ');
+        buf.put(EXPtoString(e.op));
+        buf.put(' ');
+        expToBuffer(e.e2, cast(PREC)(precedence[e.op] + 1), buf, hgs);
+    }
+
     void visitLoweredAssignExp(LoweredAssignExp e)
     {
         if (hgs.vcg_ast)
@@ -2723,15 +2740,21 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
             return;
         }
 
-        visit(cast(BinExp)e);
+        visitBin(e);
     }
-    void visitBin(BinExp e)
+
+    void visitConstructExp(ConstructExp e)
     {
-        expToBuffer(e.e1, precedence[e.op], buf, hgs);
-        buf.put(' ');
-        buf.put(EXPtoString(e.op));
-        buf.put(' ');
-        expToBuffer(e.e2, cast(PREC)(precedence[e.op] + 1), buf, hgs);
+        if (hgs.vcg_ast && e.lowering)
+            return expressionToBuffer(e.lowering, buf, hgs);
+        visitBin(e);
+    }
+
+    void visitEqualExp(EqualExp e)
+    {
+        if (hgs.vcg_ast && e.lowering)
+            return expressionToBuffer(e.lowering, buf, hgs);
+        visitBin(e);
     }
 
     void visitComma(CommaExp e)
@@ -2915,6 +2938,9 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
 
     void visitCast(CastExp e)
     {
+        if (hgs.vcg_ast && e.lowering)
+            return expressionToBuffer(e.lowering, buf, hgs);
+
         buf.put("cast(");
         if (e.to)
             typeToBuffer(e.to, null, buf, hgs);
@@ -3154,6 +3180,9 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
         case EXP.question:      return visitCond(e.isCondExp());
         case EXP.classReference:        return visitClassReference(e.isClassReferenceExp());
         case EXP.loweredAssignExp:      return visitLoweredAssignExp(e.isLoweredAssignExp());
+        case EXP.construct:     return visitConstructExp(e.isConstructExp());
+        case EXP.equal:
+        case EXP.notEqual:      return visitEqualExp(e.isEqualExp());
     }
 }
 
@@ -4237,7 +4266,7 @@ private void visitFuncIdentWithPrefix(TypeFunction t, const Identifier ident, Te
     else if (hgs.ddoc)
         buf.put("auto ");
     if (ident)
-        buf.put(ident.toHChars2());
+        buf.put(hgs.vcg_ast ? ident.toChars() : ident.toHChars2());
     if (td)
     {
         buf.put('(');

--- a/compiler/test/compilable/extra-files/vcg-ast-arraylength-postscript.sh
+++ b/compiler/test/compilable/extra-files/vcg-ast-arraylength-postscript.sh
@@ -3,11 +3,11 @@
 source tools/common_funcs.sh
 
 # Test if there's call to the runtime for .length = 100
-grep "_d_arraysetlengthT(arr, 100.*)" "${TEST_DIR}/${TEST_NAME}.d.cg" &&
+grep "_d_arraysetlengthT!(.*)(arr, 100.*)" "${TEST_DIR}/${TEST_NAME}.d.cg" &&
 # Make sure there's no call to the runtime for .length = 0
-! grep "_d_arraysetlengthT(\(arr\|f\), 0.*)" "${TEST_DIR}/${TEST_NAME}.d.cg" &&
+! grep "_d_arraysetlengthT!(.*)(\(arr\|f\), 0.*)" "${TEST_DIR}/${TEST_NAME}.d.cg" &&
 # Make sure there's no call to the runtime for .length = x
-! grep "_d_arraysetlengthT(f, x.*)" "${TEST_DIR}/${TEST_NAME}.d.cg" &&
+! grep "_d_arraysetlengthT!(.*)(f, x.*)" "${TEST_DIR}/${TEST_NAME}.d.cg" &&
 # Test if a slice expr is applied for the above case
 grep "arr = arr\[0..0\]" "${TEST_DIR}/${TEST_NAME}.d.cg"
 

--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -97,7 +97,7 @@ T[] values(T)()
 }
 void main()
 {
-	values();
+	vcg.values!(__c_wchar_t)();
 	return 0;
 }
 import imports.vcg_ast_import;
@@ -123,7 +123,7 @@ mixin _d_cmain!();
 		extern (C) int _Dmain(char[][] args);
 		extern (C) int main(int argc, char** argv)
 		{
-			return _d_run_main(argc, argv, & _Dmain);
+			return vcg._d_cmain!()._d_run_main(argc, argv, & _Dmain);
 		}
 		version (Solaris)
 		{

--- a/compiler/test/compilable/vcg-ast-lowering.d
+++ b/compiler/test/compilable/vcg-ast-lowering.d
@@ -1,0 +1,185 @@
+/*
+REQUIRED_ARGS: -vcg-ast -o-
+OUTPUT_FILES: compilable/vcg-ast-lowering.d.cg
+TEST_OUTPUT:
+---
+=== compilable/vcg-ast-lowering.d.cg
+module test;
+import object;
+class C : Object
+{
+}
+T func(T)(int x)
+{
+	return 2 * cast(T)x;
+}
+template fun(T)
+{
+	T fun1(int x)
+	{
+		return 2 * cast(T)x;
+	}
+	T fun2(int x)
+	{
+		return 2 * cast(T)x;
+	}
+}
+auto @system void test()
+{
+	long x = test.func!long(3);
+	long x1 = test.fun!long.fun1(3);
+	long x2 = test.fun!long.fun2(3);
+	int[] a = null;
+	short[] b = null;
+	assert(!core.internal.array.equality.__equals!(int, short)(a[], b[]));
+	Object o = core.lifetime._d_newclassT!(C)();
+	C c = core.internal.cast_._d_cast!(C, Object)(o);
+}
+RTInfo!(C)
+{
+	enum immutable(void)* RTInfo = null;
+
+}
+func!long
+{
+	pure nothrow @nogc @safe long func(int x)
+	{
+		return 2L * cast(long)x;
+	}
+
+}
+fun!long
+{
+	long fun1(int x)
+	{
+		return 2L * cast(long)x;
+	}
+	long fun2(int x)
+	{
+		return 2L * cast(long)x;
+	}
+}
+__equals!(int, short)
+{
+	pure nothrow @nogc @trusted bool __equals(scope int[] lhs, scope short[] rhs)
+	{
+		if (lhs.length != rhs.length)
+			return false;
+		if (lhs.length == $?:32=0u|64=0LU$)
+			return true;
+		alias PureType = bool function(scope int[], scope short[], $?:32=uint|64=ulong$) pure nothrow @nogc @safe;
+		return (*& isEqual)(lhs, rhs, lhs.length);
+	}
+
+}
+isEqual!(int, short)
+{
+	pure nothrow @nogc @safe bool isEqual(scope int[] lhs, scope short[] rhs, $?:32=uint|64=ulong$ length)
+	{
+		static ref @trusted at(T)(scope T[] r, size_t i) if (!(is(T == struct) && !is(typeof(T.sizeof))))
+		{
+			static if (is(T == void))
+			{
+				return (cast(ubyte[])r)[i];
+			}
+			else
+			{
+				return r[i];
+			}
+		}
+		{
+			$?:32=uint|64=ulong$ __key3 = $?:32=0u|64=0LU$;
+			$?:32=uint|64=ulong$ __limit4 = length;
+			for (; __key3 < __limit4; __key3 += $?:32=1u|64=1LU$)
+			{
+				const const($?:32=uint|64=ulong$) i = __key3;
+				if (core.internal.array.equality.isEqual!(int, short).at!int(lhs, i) != cast(int)core.internal.array.equality.isEqual!(int, short).at!short(rhs, i))
+					return false;
+			}
+		}
+		return true;
+	}
+
+}
+at!int
+{
+	static pure nothrow @nogc ref @trusted int at(scope int[] r, $?:32=uint|64=ulong$ i)
+	{
+		return r[i];
+	}
+
+}
+at!short
+{
+	static pure nothrow @nogc ref @trusted short at(scope short[] r, $?:32=uint|64=ulong$ i)
+	{
+		return r[i];
+	}
+
+}
+_d_newclassT!(C)
+{
+	pure nothrow @trusted C _d_newclassT()
+	{
+		import core.internal.traits : hasIndirections;
+		import core.exception : onOutOfMemoryError;
+		import core.memory : pureMalloc;
+		import core.memory : GC;
+		alias BlkAttr = BlkAttr;
+		const const(void[]) init = C;
+		void* p = null;
+		BlkAttr attr = BlkAttr.NONE;
+		p = malloc(init.length, attr, typeid(C));
+		p[0..init.length] = init[];
+		return cast(C)p;
+	}
+
+}
+hasIndirections!(C)
+{
+	enum bool hasIndirections = true;
+
+}
+_d_cast!(C, Object)
+{
+	pure nothrow @nogc @trusted void* _d_cast(Object o)
+	{
+		return core.internal.cast_._d_class_cast!(C)(o);
+	}
+
+}
+_d_class_cast!(C)
+{
+	pure nothrow @nogc @safe void* _d_class_cast(return scope const(Object) o)
+	{
+		return core.internal.cast_._d_class_cast_impl(o, typeid(C));
+	}
+
+}
+---
+*/
+// https://github.com/dlang/dmd/issues/23335
+
+module test;
+
+class C {}
+
+T func(T)(int x) { return 2*cast(T)x; }
+
+template fun(T)
+{
+    T fun1(int x) { return 2*cast(T)x; }
+    T fun2(int x) { return 2*cast(T)x; }
+}
+
+auto test()
+{
+    auto x = func!long(3);
+    auto x1 = fun!long.fun1(3);
+    auto x2 = fun!long.fun2(3);
+    int[] a;
+    short[] b;
+    assert(a[] != b[]);
+    Object o = new C;
+    auto c = cast(C)o;
+}

--- a/compiler/test/compilable/vcg-ast-lowering.d
+++ b/compiler/test/compilable/vcg-ast-lowering.d
@@ -1,0 +1,185 @@
+/*
+REQUIRED_ARGS: -vcg-ast -o-
+OUTPUT_FILES: compilable/vcg-ast-lowering.d.cg
+TEST_OUTPUT:
+---
+=== compilable/vcg-ast-lowering.d.cg
+module test;
+import object;
+class C : Object
+{
+}
+T func(T)(int x)
+{
+	return 2 * cast(T)x;
+}
+template fun(T)
+{
+	T fun1(int x)
+	{
+		return 2 * cast(T)x;
+	}
+	T fun2(int x)
+	{
+		return 2 * cast(T)x;
+	}
+}
+auto @system void test()
+{
+	long x = test.func!long(3);
+	long x1 = test.fun!long.fun1(3);
+	long x2 = test.fun!long.fun2(3);
+	int[] a = null;
+	short[] b = null;
+	assert(!core.internal.array.equality.__equals!(int, short)(a[], b[]));
+	Object o = core.lifetime._d_newclassT!(C)();
+	C c = core.internal.cast_._d_cast!(C, Object)(o);
+}
+RTInfo!(C)
+{
+	enum immutable(void)* RTInfo = null;
+
+}
+func!long
+{
+	pure nothrow @nogc @safe long func(int x)
+	{
+		return 2L * cast(long)x;
+	}
+
+}
+fun!long
+{
+	long fun1(int x)
+	{
+		return 2L * cast(long)x;
+	}
+	long fun2(int x)
+	{
+		return 2L * cast(long)x;
+	}
+}
+__equals!(int, short)
+{
+	pure nothrow @nogc @trusted bool __equals(scope int[] lhs, scope short[] rhs)
+	{
+		if (lhs.length != rhs.length)
+			return false;
+		if (lhs.length == $?:32=0u|64=0LU$)
+			return true;
+		alias PureType = bool function(scope int[], scope short[], $?:32=uint|64=ulong$) pure nothrow @nogc @safe;
+		return (*& isEqual)(lhs, rhs, lhs.length);
+	}
+
+}
+isEqual!(int, short)
+{
+	pure nothrow @nogc @safe bool isEqual(scope int[] lhs, scope short[] rhs, $?:32=uint|64=ulong$ length)
+	{
+		static ref @trusted at(T)(scope T[] r, size_t i) if (!(is(T == struct) && !is(typeof(T.sizeof))))
+		{
+			static if (is(T == void))
+			{
+				return (cast(ubyte[])r)[i];
+			}
+			else
+			{
+				return r[i];
+			}
+		}
+		{
+			$?:32=uint|64=ulong$ __key3 = $?:32=0u|64=0LU$;
+			$?:32=uint|64=ulong$ __limit4 = length;
+			for (; __key3 < __limit4; __key3 += $?:32=1u|64=1LU$)
+			{
+				const const($?:32=uint|64=ulong$) i = __key3;
+				if (core.internal.array.equality.isEqual!(int, short).at!int(lhs, i) != cast(int)core.internal.array.equality.isEqual!(int, short).at!short(rhs, i))
+					return false;
+			}
+		}
+		return true;
+	}
+
+}
+at!int
+{
+	static pure nothrow @nogc ref @trusted int at(scope int[] r, $?:32=uint|64=ulong$ i)
+	{
+		return r[i];
+	}
+
+}
+at!short
+{
+	static pure nothrow @nogc ref @trusted short at(scope short[] r, $?:32=uint|64=ulong$ i)
+	{
+		return r[i];
+	}
+
+}
+_d_newclassT!(C)
+{
+	pure nothrow @trusted C _d_newclassT()
+	{
+		import core.internal.traits : hasIndirections;
+		import core.exception : onOutOfMemoryError;
+		import core.memory : pureMalloc;
+		import core.memory : GC;
+		alias BlkAttr = BlkAttr;
+		const const(void[]) init = C;
+		void* p = null;
+		enum uint attr = $?:32=768u|64=1024u$;
+		p = malloc(init.length, $?:32=768u|64=1024u$, typeid(C));
+		p[0..init.length] = init[];
+		return cast(C)p;
+	}
+
+}
+hasIndirections!(C)
+{
+	enum bool hasIndirections = true;
+
+}
+_d_cast!(C, Object)
+{
+	pure nothrow @nogc @trusted void* _d_cast(Object o)
+	{
+		return core.internal.cast_._d_class_cast!(C)(o);
+	}
+
+}
+_d_class_cast!(C)
+{
+	pure nothrow @nogc @safe void* _d_class_cast(return scope const(Object) o)
+	{
+		return core.internal.cast_._d_class_cast_impl(o, typeid(C));
+	}
+
+}
+---
+*/
+// https://github.com/dlang/dmd/issues/23335
+
+module test;
+
+class C {}
+
+T func(T)(int x) { return 2*cast(T)x; }
+
+template fun(T)
+{
+    T fun1(int x) { return 2*cast(T)x; }
+    T fun2(int x) { return 2*cast(T)x; }
+}
+
+auto test()
+{
+    auto x = func!long(3);
+    auto x1 = fun!long.fun1(3);
+    auto x2 = fun!long.fun2(3);
+    int[] a;
+    short[] b;
+    assert(a[] != b[]);
+    Object o = new C;
+    auto c = cast(C)o;
+}

--- a/compiler/test/compilable/vcg_ast_compilable.d
+++ b/compiler/test/compilable/vcg_ast_compilable.d
@@ -17,8 +17,8 @@ void find()(string needle)
 }
 void splitter()
 {
-	find(3);
-	find("");
+	vcg_ast_compilable.find!int(3);
+	vcg_ast_compilable.find!()("");
 }
 binaryFun!int
 {


### PR DESCRIPTION
forward to lowered  AST in CastExp, EqualExp and ConstructExp, add template arguments