### PR TITLE
rename CF.unambig to CF.distinct

### DIFF
--- a/compiler/src/dmd/backend/arm/cod3.d
+++ b/compiler/src/dmd/backend/arm/cod3.d
@@ -1915,14 +1915,14 @@ if ((ins & 0x9F00_0000) == 0x9000_0000)
                         cast(int)cg.EBPtoESP, cast(int)c.IEV1.Voffset, cast(int)sectionOff);
                 }
                 if (s.Sflags & SFLunambig)
-                    c.Iflags |= CF.unambig;
+                    c.Iflags |= CF.distinct;
                 offset = c.IEV1.Voffset + s.Soffset + sectionOff + cg.BPoff;
                 sz = tysize(s.ty());
                 goto L2;
 
             case FL.fltreg:
                 offset = c.IEV1.Vpointer + cg.Foff + cg.BPoff;
-                c.Iflags |= CF.unambig;
+                c.Iflags |= CF.distinct;
                 goto L2;
 
             case FL.allocatmp:
@@ -1946,11 +1946,11 @@ if ((ins & 0x9F00_0000) == 0x9000_0000)
                     break;
                 }
                 offset = CSE.offset(sn) + cg.CSoff + cg.BPoff;
-                c.Iflags |= CF.unambig;
+                c.Iflags |= CF.distinct;
                 goto L2;
 
             case FL.regsave:
-                c.Iflags |= CF.unambig;
+                c.Iflags |= CF.distinct;
                 offset = cg.regsave.off + cg.BPoff;
 
             L2:

--- a/compiler/src/dmd/backend/cgsched.d
+++ b/compiler/src/dmd/backend/cgsched.d
@@ -2083,7 +2083,7 @@ if (c2.IEV1.Vpointer + sz2 <= c1.IEV1.Vpointer) printf("t5\n");
             }
         }
 
-        if ((c1.Iflags | c2.Iflags) & CF.unambig &&
+        if ((c1.Iflags | c2.Iflags) & CF.distinct &&
             (ifl1 != ifl2 ||
              ci1.sibmodrm != ci2.sibmodrm ||
              (c1.IEV1.Vint != c2.IEV1.Vint &&

--- a/compiler/src/dmd/backend/x86/cod3.d
+++ b/compiler/src/dmd/backend/x86/cod3.d
@@ -5904,7 +5904,7 @@ void assignaddrc(ref CGstate cg, code* c)
                 else
                 {   c.IEV1.Vpointer += s.Soffset + soff + cg.BPoff;
                     if (s.Sflags & SFLunambig)
-                        c.Iflags |= CF.unambig;
+                        c.Iflags |= CF.distinct;
             L2:
                     if (!cg.hasframe || (cg.enforcealign && c.IFL1 != FL.para))
                     {   /* Convert to ESP relative address instead of EBP */
@@ -5937,7 +5937,7 @@ void assignaddrc(ref CGstate cg, code* c)
 
             case FL.fltreg:
                 c.IEV1.Vpointer += cg.Foff + cg.BPoff;
-                c.Iflags |= CF.unambig;
+                c.Iflags |= CF.distinct;
                 goto L2;
 
             case FL.allocatmp:
@@ -5960,19 +5960,19 @@ void assignaddrc(ref CGstate cg, code* c)
                     continue;
                 }
                 c.IEV1.Vpointer = CSE.offset(sn) + cg.CSoff + cg.BPoff;
-                c.Iflags |= CF.unambig;
+                c.Iflags |= CF.distinct;
                 goto L2;
 
             case FL.regsave:
                 sn = c.IEV1.Vuns;
                 c.IEV1.Vpointer = sn + cg.regsave.off + cg.BPoff;
-                c.Iflags |= CF.unambig;
+                c.Iflags |= CF.distinct;
                 goto L2;
 
             case FL.ndp:
                 assert(c.IEV1.Vuns < global87.save.length);
                 c.IEV1.Vpointer = c.IEV1.Vuns * tysize(TYreal) + cg.NDPoff + cg.BPoff;
-                c.Iflags |= CF.unambig;
+                c.Iflags |= CF.distinct;
                 goto L2;
 
             case FL.offset:
@@ -8467,7 +8467,7 @@ void CF_print(uint cf)
     print(CF.classinit, "CF.classinit");
     print(CF.volatile, "CF.volatile");
     print(CF.targ2, "CF.targ2");
-    print(CF.unambig, "CF.unambig");
+    print(CF.distinct, "CF.distinct");
     print(CF.selfrel, "CF.selfrel");
     print(CF.wait, "CF.wait");
     print(CF.fs, "CF.fs");

--- a/compiler/src/dmd/backend/x86/code_x86.d
+++ b/compiler/src/dmd/backend/x86/code_x86.d
@@ -278,8 +278,8 @@ enum CF : uint
     gs        =   cs | fs,    // need GS override
     wait      =   0x1000,     // If I32 it indicates when to output a WAIT
     selfrel   =   0x2000,     // if self-relative
-    unambig   =   0x4000,     // indicates cannot be accessed by other addressing
-                                // modes
+    distinct  =   0x4000,     // indicates cannot be accessed by other addressing
+                              // modes
     targ2     =   0x8000,     // like CF.targ, but we can't optimize this away
     volatile  =  0x10000,     // volatile reference, do not schedule
     classinit =  0x20000,     // class init code


### PR DESCRIPTION
Because the 'un' negation makes the code confusing. Trying to reduce negation in the code.