### PR TITLE
Revert "Fix #23332 and add test case."

### DIFF
--- a/compiler/src/dmd/glue/tocsym.d
+++ b/compiler/src/dmd/glue/tocsym.d
@@ -80,12 +80,10 @@ Symbol* toSymbolX(Dsymbol ds, const(char)* prefix, SC sclass, type* t, const(cha
 {
     //printf("Dsymbol::toSymbolX('%s')\n", prefix);
     import dmd.common.outbuffer : OutBuffer;
-    import core.stdc.string : strlen;
-
     OutBuffer buf;
     buf.writestring("_D");
     mangleToBuffer(ds, buf);
-    buf.printf("%d%s%s", cast(int)strlen(prefix), prefix, suffix);
+    buf.printf("%zd%s%s", strlen(prefix), prefix, suffix);
     Symbol* s = symbol_name(buf[], sclass, t);
 
     //printf("-Dsymbol::toSymbolX() %s\n", buf.peekChars());

--- a/compiler/test/compilable/test23332.d
+++ b/compiler/test/compilable/test23332.d
@@ -1,5 +1,0 @@
-// https://github.com/dlang/dmd/issues/23332
-// Segfault generating a struct's static initializer symbol when it has a float member.
-struct S { int a; double b; float c; }
-__gshared S s = { 1, 2, 3 };
-double f(double x) { return x * 2; }


### PR DESCRIPTION
Reverts dlang/dmd#23334

This was a phantom bug caused by `build.d` using an ancient version of the MS CRT DLL on my local machine.

The correct solution is to switch to UCRT for all builds (both of DMD/DRT/Phobos, and user builds using those tools).