### PR TITLE
Fix #23239: give the nested tempinst a chance of instantiation

### DIFF
--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1147,45 +1147,6 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
             scope v = new InstMemberWalker(tempinst.inst);
             tempinst.inst.accept(v);
 
-            // If there are speculative nested template instances whose
-            // enclosing chain leads to this now-root instance, update
-            // their minst so they get a chance at codegen.
-            //
-            // We can not use nested.tinst to find the enclosing instance,
-            // because StaticAssert::semantic2() sets sc.tinst = null
-            // before evaluating the condition, which causes nested
-            // instances to lose their tinst relationship.  Instead walk
-            // through nested.tempdecl.parent which reliably points to the
-            // outer TemplateInstance (the tempdecl is a copy placed inside
-            // the outer instance by arraySyntaxCopy).
-            //
-            // https://issues.dlang.org/show_bug.cgi?id=23239
-            if (auto rootModule = tempinst.inst.minst)
-            {
-                foreach (i, ref s; *rootModule.members)
-                {
-                    auto nested = s.isTemplateInstance();
-                    // TemplateMixin also passes isTemplateInstance() but may
-                    // not have tempdecl set yet while semantic analysis is in
-                    // progress.
-                    if (!nested || nested.minst || !nested.tempdecl)
-                        continue;
-
-                    // Only fix instances with static ctors/dtors: if such an
-                    // instance remains speculative, its static ctor/dtor will
-                    // be skipped during codegen and never get a second chance
-                    // to be emitted (unlike regular functions, which can be
-                    // codegen'd when re-instantiated from a root module).
-                    if (!nested.hasStaticCtorOrDtor())
-                        continue;
-                    if (auto enc = nested.tempdecl.isInstantiated())
-                    {
-                        if (enc.inst is tempinst.inst)
-                            nested.minst = rootModule;
-                    }
-                }
-            }
-
             if (!global.params.allInst &&
                 tempinst.minst) // if inst was not speculative...
             {
@@ -3399,6 +3360,21 @@ bool needsCodegen(TemplateInstance ti)
     if (ti.inst && ti.inst.name == Id._d_arrayliteralTX)
     {
         return true;
+    }
+
+    // A speculative instance that contains static ctors/dtors will
+    // lose them if we skip codegen.  Normally tinst propagates minst
+    // from parent to child, but tinst can be null when the instance
+    // was created inside StaticAssert (which clears sc.tinst).
+    // Walk the tempdecl parent chain as a fallback.
+    // https://issues.dlang.org/show_bug.cgi?id=23239
+    if (!ti.minst && ti.hasStaticCtorOrDtor() && ti.tempdecl)
+    {
+        if (auto enc = ti.tempdecl.isInstantiated())
+        {
+            if (enc.inst && enc.inst.needsCodegen())
+                ti.minst = enc.inst.minst;
+        }
     }
 
     if (global.params.allInst)

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1150,6 +1150,15 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
             // If there are speculative nested template instances whose
             // enclosing chain leads to this now-root instance, update
             // their minst so they get a chance at codegen.
+            //
+            // We can not use nested.tinst to find the enclosing instance,
+            // because StaticAssert::semantic2() sets sc.tinst = null
+            // before evaluating the condition, which causes nested
+            // instances to lose their tinst relationship.  Instead walk
+            // through nested.tempdecl.parent which reliably points to the
+            // outer TemplateInstance (the tempdecl is a copy placed inside
+            // the outer instance by arraySyntaxCopy).
+            //
             // https://issues.dlang.org/show_bug.cgi?id=23239
             if (auto rootModule = tempinst.inst.minst)
             {

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1165,7 +1165,10 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
                 foreach (i, ref s; *rootModule.members)
                 {
                     auto nested = s.isTemplateInstance();
-                    if (!nested || nested.minst)
+                    // TemplateMixin also passes isTemplateInstance() but may
+                    // not have tempdecl set yet while semantic analysis is in
+                    // progress.
+                    if (!nested || nested.minst || !nested.tempdecl)
                         continue;
                     if (auto enc = nested.tempdecl.isInstantiated())
                     {

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1170,6 +1170,14 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
                     // progress.
                     if (!nested || nested.minst || !nested.tempdecl)
                         continue;
+
+                    // Only fix instances with static ctors/dtors: if such an
+                    // instance remains speculative, its static ctor/dtor will
+                    // be skipped during codegen and never get a second chance
+                    // to be emitted (unlike regular functions, which can be
+                    // codegen'd when re-instantiated from a root module).
+                    if (!nested.hasStaticCtorOrDtor())
+                        continue;
                     if (auto enc = nested.tempdecl.isInstantiated())
                     {
                         if (enc.inst is tempinst.inst)

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -1147,6 +1147,25 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
             scope v = new InstMemberWalker(tempinst.inst);
             tempinst.inst.accept(v);
 
+            // If there are speculative nested template instances whose
+            // enclosing chain leads to this now-root instance, update
+            // their minst so they get a chance at codegen.
+            // https://issues.dlang.org/show_bug.cgi?id=23239
+            if (auto rootModule = tempinst.inst.minst)
+            {
+                foreach (i, ref s; *rootModule.members)
+                {
+                    auto nested = s.isTemplateInstance();
+                    if (!nested || nested.minst)
+                        continue;
+                    if (auto enc = nested.tempdecl.isInstantiated())
+                    {
+                        if (enc.inst is tempinst.inst)
+                            nested.minst = rootModule;
+                    }
+                }
+            }
+
             if (!global.params.allInst &&
                 tempinst.minst) // if inst was not speculative...
             {

--- a/compiler/test/compilable/test23239.d
+++ b/compiler/test/compilable/test23239.d
@@ -1,0 +1,21 @@
+// https://github.com/dlang/dmd/issues/23239
+// static assert instantiating a template with static this()
+// should not eliminate the static this() as dead code
+// when the template is also used at runtime.
+
+template Tmpl()
+{
+    int data;
+    template touch(T)
+    {
+        static this() { data = T.sizeof; }
+        enum touch = true;
+    }
+}
+
+int main()
+{
+    static assert(Tmpl!().touch!int);   // CTFE instantiation
+    assert(Tmpl!().data == 4);          // runtime use, static this() must have run
+    return 0;
+}


### PR DESCRIPTION
Try to fix #23239:

The instance relationship was not immediately clear to me, so I used an LLM to help draw this graph:
```
module
│
├── template Tmpl                  ← original declaration, parent = module
│   └── template touch             ← original declaration, parent = Tmpl
│
├── Tmpl!()_primary                ← instance (1st, created inside static assert)
│   │   parent = module, inst = self, minst = root (after swap)
│   │
│   ├── int data                   ← copy declaration, parent = Tmpl!()
│   └── template touch             ← copy declaration, parent = Tmpl!()  ← key!
│
├── touch!int                      ← instance (1st, created inside static assert)
│   │   parent = module, inst = self, minst = null  ← BUG！
│   │   tempdecl ──────────────→ template touch (the copy inside Tmpl!())
│   │   tinst = null             (cleared by StaticAssert)
│   │
│   ├── static this()              ← module ctor, parent = touch!int
│   └── enum touch = true          ← eponymous member
│
├── Tmpl!()_secondary              ← instance (2nd, created in main())
│       inst → Tmpl!()_primary, minst = null (after swap)
│       (no members — secondary is just a record, not a copy)
│
└── main()                         ← function declaration
```
The root cause: `touch!int` is only instantiated once, inside `static assert`. StaticAssert::semantic2() sets sc.minst = null before evaluating the condition, so touch!int gets minst = null (speculative).  Later when Tmpl!() is used at runtime and gets swapped to a root instance, the nested touch!int is left behind with minst = null, and needsCodegen() skips it entirely — including its static this().

The fix: after the swap makes Tmpl!() a root instance, scan the root module's members for any speculative TemplateInstances whose enclosing chain resolves to the newly-rooted instance.  There is no direct backlink from TemplateDeclaration to TemplateInstance, so we filter candidates by checking nested.tempdecl.isInstantiated().  Once found, set nested.minst = root.