### PR TITLE
remove use of printf format %z[d|u] from dmd source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ untracked_files/
 .DS_Store
 /compiler/src/vcbuild/*.filters
 /compiler/src/vcbuild/*.sources
+
+/compiler/backend/old/*
+/compiler/backend/new/*

--- a/compiler/src/dmd/backend/debugprint.d
+++ b/compiler/src/dmd/backend/debugprint.d
@@ -300,7 +300,7 @@ void WRdefnod(ref GlobalOptimizer go)
 {
     foreach (i; 0 .. go.defnod.length)
     {
-        printf("defnod[%d] in B%zu = (", go.defnod[i].DNblock.Bdfoidx, i);
+        printf("defnod[%d] in B%u = (", go.defnod[i].DNblock.Bdfoidx, cast(uint)i);
         WReqn(go.defnod[i].DNelem);
         printf(");\n");
     }

--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -132,7 +132,7 @@ void outdata(Symbol* s)
                 break;
 
             case DT.nbytes:
-                //printf("DT.nbytes %zd\n", dt.DTpbytes.length);
+                //printf("DT.nbytes %d\n", cast(int)dt.DTpbytes.length);
                 datasize += dt.DTpbytes.length;
                 break;
 

--- a/compiler/src/dmd/backend/type.d
+++ b/compiler/src/dmd/backend/type.d
@@ -1049,7 +1049,7 @@ void type_print(const type* t)
                     auto a = *t.Tparamtypes;
                     foreach (i, ref p; a)
                     {
-                        printf("\nP%zd: ",i);
+                        printf("\nP%d: ",cast(int)i);
                         fflush(stdout);
 
                         printf("Pident=%p,Ptype=%p ",p.Pident,p.Ptype);

--- a/compiler/src/dmd/common/file.d
+++ b/compiler/src/dmd/common/file.d
@@ -124,7 +124,7 @@ struct FileMapping(Datum)
                 auto p = mmap(null, cast(size_t) size, is(Datum == const) ? PROT_READ : (PROT_READ | PROT_WRITE), MAP_SHARED, handle, 0);
                 if (p == MAP_FAILED)
                 {
-                    fprintf(stderr, "mmap(null, %zu) for \"%s\" failed: %s\n", cast(size_t) size, filename, strerror(errno));
+                    fprintf(stderr, "mmap(null, %llu) for \"%s\" failed: %s\n", cast(ulong) size, filename, strerror(errno));
                     exit(1);
                 }
                 // The cast below will always work because it's gated by the `size <= size_t.max` condition.

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -725,7 +725,7 @@ private Identifier getTypeInfoIdent(Type t)
 
     OutBuffer buf2;
     buf2.reserve(19 + size_t.sizeof * 3 + buf.length + 1);
-    buf2.printf("_D%zuTypeInfo_%.*s6__initZ", 9+buf.length, cast(int)buf.length, buf[].ptr);
+    buf2.printf("_D%uTypeInfo_%.*s6__initZ", cast(uint)(9+buf.length), cast(int)buf.length, buf[].ptr);
 
     auto id = Identifier.idPool(buf2[]);
     return id;

--- a/compiler/src/dmd/dfa/fast/expression.d
+++ b/compiler/src/dmd/dfa/fast/expression.d
@@ -2533,12 +2533,12 @@ struct ExpressionWalker
                     ob.writestring("Calling function parameter info\n");
 
                     prefix("    ");
-                    ob.printf("count=%zd, calledFunctionInfo=%p:%zd\n", arguments.length, calledFunctionInfo,
-                        calledFunctionInfo !is null ? calledFunctionInfo.parameters.length : 0);
+                    ob.printf("count=%d, calledFunctionInfo=%p:%d\n", cast(int)arguments.length, calledFunctionInfo,
+                        calledFunctionInfo !is null ? cast(int)calledFunctionInfo.parameters.length : 0);
 
                     prefix("    ");
-                    ob.printf("allParameters=%zd, allParameterVars=%zd\n",
-                        allParameters.length, allParameterVars.length);
+                    ob.printf("allParameters=%d, allParameterVars=%d\n",
+                        cast(int)allParameters.length, cast(int)allParameterVars.length);
                 });
 
                 foreach (i, arg; *arguments)
@@ -2551,7 +2551,7 @@ struct ExpressionWalker
                     ParameterDFAInfo* info = i < allInfos.length ? &allInfos.ptr[i] : null;
 
                     dfaCommon.printState((ref OutBuffer ob, scope PrintPrefixType prefix) {
-                        ob.printf("Argument %zd, stc=%lld", i, storageClass);
+                        ob.printf("Argument %d, stc=%lld", cast(int)i, storageClass);
                         ob.writestring("\n");
 
                         if (info !is null)

--- a/compiler/src/dmd/dfa/fast/statement.d
+++ b/compiler/src/dmd/dfa/fast/statement.d
@@ -430,8 +430,8 @@ final:
                     scv = dfaCommon.acquireScopeVar(var);
 
                     dfaCommon.printStructure((ref OutBuffer ob,
-                            scope PrintPrefixType prefix) => ob.printf("param (%zd) is `%s` %p scv %p stc %lld\n",
-                            i, param.ident !is null ? param.ident.toChars : null,
+                            scope PrintPrefixType prefix) => ob.printf("param (%d) is `%s` %p scv %p stc %lld\n",
+                            cast(int)i, param.ident !is null ? param.ident.toChars : null,
                             var, scv, param.storage_class));
                     assert(scv.var is var);
 
@@ -559,7 +559,7 @@ final:
 
                 foreach (i, param; fd.parametersDFAInfo.parameters)
                 {
-                    ob.printf("%zd: %d:%d", i, param.notNullIn, param.notNullOut);
+                    ob.printf("%d: %d:%d", cast(int)i, param.notNullIn, param.notNullOut);
                     ob.writestring("\n");
                 }
             });

--- a/compiler/src/dmd/dfa/fast/structure.d
+++ b/compiler/src/dmd/dfa/fast/structure.d
@@ -882,7 +882,7 @@ struct DFACommon
 
             foreach (i; 0 .. sc.buckets.length)
             {
-                printf("    - bucket %zd:\n", i);
+                printf("    - bucket %d:\n", cast(int)i);
 
                 DFAScopeVar* bucket = sc.buckets[i];
                 while (bucket !is null)

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -603,7 +603,7 @@ private Expression interpretFunction(UnionExp* pue, FuncDeclaration fd, InterSta
         VarDeclaration v = (*fd.parameters)[i];
         debug (LOG)
         {
-            printf("arg[%zu] = %s\n", i, earg.toChars());
+            printf("arg[%u] = %s\n", cast(uint)i, earg.toChars());
         }
         ctfeGlobals.stack.push(v);
 
@@ -647,12 +647,12 @@ private Expression interpretFunction(UnionExp* pue, FuncDeclaration fd, InterSta
         }
         debug (LOG)
         {
-            printf("interpreted arg[%zu] = %s\n", i, earg.toChars());
+            printf("interpreted arg[%u] = %s\n", cast(uint)i, earg.toChars());
             showCtfeExpr(earg);
         }
         debug (LOGASSIGN)
         {
-            printf("interpreted arg[%zu] = %s\n", i, earg.toChars());
+            printf("interpreted arg[%u] = %s\n", cast(uint)i, earg.toChars());
             showCtfeExpr(earg);
         }
     }

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -5206,8 +5206,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (a.fields.length != b.fields.length)
         {
             incompatError();
-            errorSupplemental(a.loc, "`%s` has %zu field(s) while `%s` has %zu field(s)",
-                    a.toPrettyChars(), a.fields.length, b.toPrettyChars(), b.fields.length);
+            errorSupplemental(a.loc, "`%s` has %u field(s) while `%s` has %u field(s)",
+                    a.toPrettyChars(), cast(uint)a.fields.length, b.toPrettyChars(), cast(uint)b.fields.length);
             return false;
         }
         // both are structs or both are unions
@@ -5266,7 +5266,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (a_field.type.isTypeError()) return false;
                 if (b_field.type.isTypeError()) return false;
 
-                errorSupplemental(a_field.loc, "Field %zu differs in type", i);
+                errorSupplemental(a_field.loc, "Field %u differs in type", cast(uint)i);
                 errorSupplemental(a_field.loc, "typeof(%s): %s",
                         a_field.toChars(), typeName(a_field.type));
                 errorSupplemental(b_field.loc, "typeof(%s): %s",
@@ -5281,7 +5281,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (a_field.alignment != b_field.alignment)
             {
                 incompatError();
-                errorSupplemental(a_field.loc, "Field %zu differs in alignment or packing", i);
+                errorSupplemental(a_field.loc, "Field %u differs in alignment or packing", cast(uint)i);
                 if (a_field.alignment.isDefault() && ! b_field.alignment.isDefault())
                 {
                     errorSupplemental(a_field.loc, "`%s.%s` alignment: default",
@@ -5325,7 +5325,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (!b_field.ident.isAnonymous())
                 {
                     incompatError();
-                    errorSupplemental(a_field.loc, "Field %zu differs in name", i);
+                    errorSupplemental(a_field.loc, "Field %u differs in name", cast(uint)i);
                     errorSupplemental(a_field.loc, "(anonymous)", a_field.ident.toChars());
                     errorSupplemental(b_field.loc, "%s", b_field.ident.toChars());
                     return false;
@@ -5334,7 +5334,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             else if (b_field.ident.isAnonymous())
             {
                 incompatError();
-                errorSupplemental(a_field.loc, "Field %zu differs in name", i);
+                errorSupplemental(a_field.loc, "Field %u differs in name", cast(uint)i);
                 errorSupplemental(a_field.loc, "%s", a_field.ident.toChars());
                 errorSupplemental(b_field.loc, "(anonymous)");
                 return false;
@@ -5342,7 +5342,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             else if (a_field.ident != b_field.ident)
             {
                 incompatError();
-                errorSupplemental(a_field.loc, "Field %zu differs in name", i);
+                errorSupplemental(a_field.loc, "Field %u differs in name", cast(uint)i);
                 errorSupplemental(a_field.loc, "%s", a_field.ident.toChars());
                 errorSupplemental(b_field.loc, "%s", b_field.ident.toChars());
                 return false;
@@ -5356,7 +5356,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if ((bfa is null) != (bfb is null))
             {
                 incompatError();
-                errorSupplemental(a_field.loc, "Field %zu differs in being a bitfield", i);
+                errorSupplemental(a_field.loc, "Field %u differs in being a bitfield", cast(uint)i);
                 if (bfa is null)
                 {
                     errorSupplemental(a_field.loc, "`%s.%s` is not a bitfield",
@@ -5378,7 +5378,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (bfa.fieldWidth != bfb.fieldWidth)
                 {
                     incompatError();
-                    errorSupplemental(a_field.loc, "Field %zu differs in bitfield width", i);
+                    errorSupplemental(a_field.loc, "Field %u differs in bitfield width", cast(uint)i);
                     errorSupplemental(a_field.loc, "`%s.%s`: %u",
                             a.toPrettyChars(), a_field.toChars(), bfa.fieldWidth);
                     errorSupplemental(b_field.loc, "`%s.%s`: %u",

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -2522,7 +2522,7 @@ public:
                     }
                 }
 
-                buf.printf("%zu, ", se.len);
+                buf.printf("%u, ", cast(uint)se.len);
                 visit(se);
 
                 if (!isCtor)

--- a/compiler/src/dmd/glue/tocsym.d
+++ b/compiler/src/dmd/glue/tocsym.d
@@ -83,7 +83,7 @@ Symbol* toSymbolX(Dsymbol ds, const(char)* prefix, SC sclass, type* t, const(cha
     OutBuffer buf;
     buf.writestring("_D");
     mangleToBuffer(ds, buf);
-    buf.printf("%zd%s%s", strlen(prefix), prefix, suffix);
+    buf.printf("%d%s%s", cast(int)strlen(prefix), prefix, suffix);
     Symbol* s = symbol_name(buf[], sclass, t);
 
     //printf("-Dsymbol::toSymbolX() %s\n", buf.peekChars());

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -8028,7 +8028,7 @@ private bool resolveTemplateInstantiation(Scope* sc, TemplateParameters* paramet
 {
     for (size_t i = 0; 1; i++)
     {
-        //printf("\ttest: tempinst.tiargs[%zu]\n", i);
+        //printf("\ttest: tempinst.tiargs[%u]\n", cast(uint)i);
         RootObject o1 = null;
         if (i < tiargs.length)
             o1 = (*tiargs)[i];

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -2715,8 +2715,8 @@ private extern(D) MATCH matchTypeSafeVarArgs(TypeFunction tf, Parameter p,
             if (pMessage)
             {
                 OutBuffer buf;
-                getMatchError(buf, "expected %llu variadic argument(s), not %zu",
-                    sz, trailingArgs.length);
+                getMatchError(buf, "expected %llu variadic argument(s), not %u",
+                    sz, cast(int)trailingArgs.length);
                 *pMessage = buf.extractChars();
             }
             return MATCH.nomatch;


### PR DESCRIPTION
@LightBender  Adam Wilson writes on the n.g.:

> I recently got hit by a rather esoteric bug that looked like a real bug, but was actually not a bug, but also kind of a bug. Specifically, on Windows the printf %zd format would fail with a Segfault. The simple fix was to delete %zd and use %d with a cast to a fixed size int type. But it was the wrong fix.

I fixed it anyway.
