### PR TITLE
Fix Issue #23356 - ImportC: The preprocessor is improperly invoked, on macOS, when cross-compiling.

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1196,7 +1196,7 @@ public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, c
         // need to redefine some macros in importc.h
         argv.push("-Wno-builtin-macro-redefined");
 
-        if (target.os == Target.OS.OSX)
+        version (OSX)
         {
             argv.push("-fno-blocks");       // disable clang blocks extension
             argv.push("-E");                // run preprocessor only for clang

--- a/compiler/test/compilable/test23356.c
+++ b/compiler/test/compilable/test23356.c
@@ -1,0 +1,14 @@
+// DISABLED: win linux freebsd openbsd netbsd dragonflybsd hurd
+// REQUIRED_ARGS: -os=linux
+// If clang is invoked improperly as a preprocessor,
+// then this will fail to compile and link due to `__check` being undefined.
+// If clang is invoked properly as a preprocessor then this will succeed
+// as clang won't attempt to compile nor link the file.
+
+// https://github.com/dlang/dmd/issues/23356
+
+int main(void)
+{
+    __check(1);
+    return 0;
+}


### PR DESCRIPTION
When DMD is run on macOS, the preprocessor is expected to be clang instead of GCC, and clang requires a different command-line than GCC does to solely preprocess a file without compiling and linking it.

DMD currently uses the clang-logic when the _target_ is macOS--this is the wrong way 'round: the clang-logic should be used when the _host_ is macOS.