### PR TITLE
typesem.d: Propagate UDAs from tuple parameters to expanded elements

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -3970,7 +3970,8 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                                 stc = stc1 | (stc & ~(STC.ref_ | STC.out_ | STC.lazy_));
                             }
                             (*newparams)[j] = new Parameter(
-                                loc, stc, narg.type, narg.ident, narg.defaultArg, narg.userAttribDecl);
+                                loc, stc, narg.type, narg.ident, narg.defaultArg,
+                                narg.userAttribDecl ? narg.userAttribDecl : fparam.userAttribDecl);
                         }
                         fparam.type = new TypeTuple(newparams);
                         fparam.type = fparam.type.typeSemantic(loc, argsc);

--- a/compiler/test/compilable/test_uda_tuple_propagation.d
+++ b/compiler/test/compilable/test_uda_tuple_propagation.d
@@ -1,0 +1,20 @@
+// Verify that UDAs on tuple parameters are propagated to their
+// expanded elements during semantic analysis.
+
+module test_uda_tuple_propagation;
+
+struct UDA {}
+
+auto testTwoElements(Args...)(@UDA Args args)
+{
+    static foreach (i; 0 .. Args.length)
+        static assert(__traits(getAttributes, args[i]).length >= 1,
+                      "UDA not propagated to expanded parameter " ~ i.stringof);
+    args[0] = args[0].init;
+}
+
+void main()
+{
+    int a; string b;
+    testTwoElements(a, b);
+}


### PR DESCRIPTION
When a function parameter has a TypeTuple type (e.g. a variadic template parameter like `Args args`), DMD expands it into individual parameters during semantic analysis. The expansion loop already propagates storage classes from the outer tuple parameter to each element, but`userAttribDecl` (UDAs) was not being propagated.

This means a UDA applied to a tuple parameter is silently dropped:
```d
    struct UDA {}
    void foo(Args...)(@UDA Args args) {}  // UDA lost after expansion
```

Fix: when creating the expanded `Parameter` for each tuple element, fall back to the outer tuple parameter's`userAttribDecl` if the element doesn't have its own.