### PR TITLE
Fix compiler/test/dshell/dwarf.d for FreeBSD.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,11 +224,12 @@ jobs:
             export FULL_BUILD=true
             export CI_DFLAGS="-version=TARGET_FREEBSD${freebsd_major}"
 
-            #if [[ "$freebsd_major" == 12 ]]; then
-            #  sudo sed -i '' -e 's|pkg.FreeBSD.org|mirrors.xtom.com/freebsd-pkg|' /etc/pkg/FreeBSD.conf
-            #fi
-
             bash --version
+
+            # compiler/test/dshell/dwarf.d needs objdump from binutils.
+            # It will also optionally use llvm-dwarfdump from llvm.
+            # So, this installs both.
+            sudo pkg install -y binutils llvm
 
             echo '::group::Install prerequisites'
             sudo -E ci/cirrusci.sh

--- a/compiler/test/dshell/dwarf.d
+++ b/compiler/test/dshell/dwarf.d
@@ -31,13 +31,29 @@ int main()
     else
         immutable slash = "/";
 
+    version (FreeBSD)
+    {
+        // FreeBSD 13 removed GNU's objdump. They were using an old GPLv2
+        // version before and hadn't updated it, because GPLv3 code is not
+        // allowed in FreeBSD itself (as opposed to ports/packages).
+        // In FreeBSD 14, they added LLVM's objdump, whose functionality differs
+        // from the GNU version (so it doesn't work with these tests).
+        // So, for these tests to be run and pass, binutils needs to be installed.
+        assert(executeShell("pkg info binutils").status == 0,
+               "This test requires binutil's objdump. Please install binutils from ports/packages.");
+
+        immutable objdumpEXE = "/usr/local/bin/objdump";
+    }
+    else
+        immutable objdumpEXE = "objdump";
+
     // Some systems are configured for binutils to output localized strings.
     // Specify LANG=C to disable localization as we test for fixed strings in the output.
     // https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html
     // As an example (assuming binutils is compiled with localization), run
     //     LANG=ja_JP LANGUAGE=ja_JP objdump -H
     // to see translated output in action.
-    auto sysObjdump = executeShell("objdump --version", ["LANG": "C"]);
+    auto sysObjdump = executeShell(objdumpEXE ~ " --version", ["LANG": "C"]);
 
     // If the Unix system doesn't have objdump, disable the tests
     if (sysObjdump.status)
@@ -101,7 +117,7 @@ int main()
 
         auto objdump_file = File(objdump, "w");
         // Also disable localization here.
-        run("objdump -W " ~ exe, objdump_file, stderr, ["LANG": "C"]);
+        run(objdumpEXE ~ " -W " ~ exe, objdump_file, stderr, ["LANG": "C"]);
         objdump_file.close();
 
         auto llvmDwarfdump = executeShell("llvm-dwarfdump --version");


### PR DESCRIPTION
In FreeBSD 13, GNU's objdump was removed (they were previously using an old version which was still under the GPLv2, because GPLv3 code is not allowed in FreeBSD itself, though it can certainly be included in the ports/packages). So, the tests from dshell/dwarf.d have not been being run in CI for a while now, because they see that there is no objdump and then get skipped.

In FreeBSD 14, LLVM's objdump was added, which does not have the same functionality as GNU's objdump and therefore does not work with the tests. If the user has binutils installed with /usr/local/bin in their path prior to /usr/bin, then the tests pass, but the default PATH has /usr/bin prior to /usr/local/bin, and binutils is not installed by default (and isn't currently installed in CI).

The simplest fix is to make it so that on FreeBSD, the tests check whether binutils is installed and then explicitly use /usr/bin/objdump (leaving Linux to still use naked objdump).

The two approaches which can be taken with that are to install binutils in the CI job and then either skip the tests if binutils hasn't been installed or to require that binutils be installed. I've chosen to do the latter on the grounds that having it be optional makes it too easy to not have it be tested (like has been happening in CI ever since we switched from FreeBSD 12 to 13).

I also added llvm to the FreeBSD CI job in addition to binutils, because that installs llvm-dwarfdump, and dshell/dwarf.d will use that in the tests where DWARF_VERIFY is true if it's available. I _think_ that the current situation is that DWARF_VERIFY is false in all cases, so llvm-dwarfdump isn't actually used, but by installing it, it will get used if any test sets DWARF_VERIFY to true, whereas it would definitely never be used if it's not available.

This is needed in order to update CI from FreeBSD 13 to 14, and 13 has hit EOL, so we really should be switching.