### PR TITLE
ImportC: When targeting Windows, define `wchar_t` as `wchar`.

### DIFF
--- a/compiler/test/compilable/importc_wchar_t.d
+++ b/compiler/test/compilable/importc_wchar_t.d
@@ -1,0 +1,67 @@
+// EXTRA_SOURCES: imports/importc_wchar_t_c.c
+
+import importc_wchar_t_c;
+
+version (Windows)
+{
+    /+ On Windows, we expect C's `wchar_t` to be D's `wchar`. +/
+
+    static assert(is(typeof(wchar_t_aggregate.w) == wchar));
+
+    alias Func = extern(C) void function(const(wchar)* str);
+
+    Func wcharT()
+    {
+        wchar c = 0;
+        wchar_t_aggregate w = wchar_t_aggregate('W');
+        w.p = &c;
+
+        accept_wchar_t_string("Hello, World!");
+        accept_wchar_t_string("Hello, World!"w.ptr);
+        accept_wchar_t_string(&w.w);
+        accept_wchar_t_string(w.p);
+
+        static if (__traits(hasMember, importc_wchar_t_c, "accept_msvc___wchar_t_string"))
+        {
+            accept_msvc___wchar_t_string("Hello, World!");
+            accept_msvc___wchar_t_string("Hello, World!"w.ptr);
+            accept_msvc___wchar_t_string(&w.w);
+        }
+
+        return &accept_wchar_t_string;
+    }
+}
+else
+{
+    /+ On non-Windows platforms, we expect C's `wchar_t` to be whatever `<stddef.h>` defined it as. +/
+
+    alias WCharT = typeof(wchar_t_aggregate.w);
+    static assert(__traits(isScalar, WCharT));
+
+    alias Func = extern(C) void function(const(WCharT)* str);
+
+    Func wcharT()
+    {
+        WCharT c = 0;
+        wchar_t_aggregate w = wchar_t_aggregate('W');
+        w.p = &c;
+
+        accept_wchar_t_string(&w.w);
+        accept_wchar_t_string(w.p);
+
+        static if (WCharT.sizeof == 4)
+        {
+            accept_wchar_t_string(cast(const(WCharT)*) "Hello, World!"d.ptr);
+        }
+        else static if (WCharT.sizeof == 2)
+        {
+            accept_wchar_t_string(cast(const(WCharT)*) "Hello, World!"w.ptr);
+        }
+        else static if (WCharT.sizeof == 1)
+        {
+            accept_wchar_t_string(cast(const(WCharT)*) "Hello, World!".ptr);
+        }
+
+        return &accept_wchar_t_string;
+    }
+}

--- a/compiler/test/compilable/imports/importc_wchar_t_c.c
+++ b/compiler/test/compilable/imports/importc_wchar_t_c.c
@@ -1,0 +1,20 @@
+
+#include <stddef.h>
+
+_Static_assert(sizeof(__importc_char) == 1, "sizeof(__importc_char) == 1");
+_Static_assert(sizeof(__importc_wchar) == 2, "sizeof(__importc_wchar) == 2");
+_Static_assert(sizeof(__importc_dchar) == 4, "sizeof(__importc_dchar) == 4");
+
+typedef struct
+{
+    wchar_t w;
+    wchar_t *p;
+} wchar_t_aggregate;
+
+void accept_wchar_t_string(const wchar_t *str)
+{}
+
+#ifdef _MSC_VER
+    void accept_msvc___wchar_t_string(const __wchar_t *str)
+    {}
+#endif

--- a/druntime/src/__importc_builtins.di
+++ b/druntime/src/__importc_builtins.di
@@ -49,6 +49,12 @@ version (CRuntime_Microsoft)
     alias __int64 = long;
 }
 
+/* Make D's character types available in ImportC.
+ */
+alias __importc_char = char;
+alias __importc_wchar = wchar;
+alias __importc_dchar = dchar;
+
 /*********** floating point *************/
 
 /* https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -75,6 +75,21 @@ typedef unsigned short __uint16_t;
 typedef unsigned int __uint32_t;
 typedef unsigned long long __uint64_t;
 
+/* wchar_t */
+#if defined(_WIN32)
+#ifndef _WCHAR_T_DEFINED
+// On Windows, wchar_t is defined as an unsigned 16-bit integer: the same as D's wchar.
+typedef __importc_wchar wchar_t;
+#define _WCHAR_T_DEFINED 1
+#define _NATIVE_WCHAR_T_DEFINED 1
+
+#ifdef _MSC_VER
+// Microsoft go a step further and have a proper built-in type.
+typedef __importc_wchar __wchar_t;
+#endif
+#endif
+#endif
+
 /*********************
  * Obsolete detritus
  */

--- a/spec/importc.dd
+++ b/spec/importc.dd
@@ -487,6 +487,12 @@ $(H2 $(LNAME2 implementation, Implementation))
     C compiler) on the target platform.
     )
 
+    $(H3 $(LNAME2 wchar_t, `wchar_t`))
+
+    $(P When targeting Windows, `wchar_t` is a `typedef` for $(RELATIVE_LINK2 d-character-types, `__importc_wchar`).
+    When targeting platforms other than Windows, `wchar_t` receives no special treatment
+    and thus is defined by the `<stddef.h>` header, as usual.)
+
     $(H3 $(LNAME2 implicit-function-declaration, Implicit Function Declarations))
 
     $(P Implicit function declarations:)

--- a/spec/importc.dd
+++ b/spec/importc.dd
@@ -731,6 +731,11 @@ _Static_assert(sizeof(A) == 1, "A should be size 1");
 )
 
 
+    $(H3 $(LNAME2 d-character-types, D Character Types))
+
+    $(P D's character types are available in ImportC via the
+    `__importc_char`, `__importc_wchar`, and `__importc_dchar` aliases.)
+
     $(H3 $(LNAME2 register, Register Storage Class))
 
     $(P Objects with `register` storage class are treated as `auto` declarations.)


### PR DESCRIPTION
The purpose of ImportC is to make it convenient to use C libraries in D.

Presently, ImportC does not handle C's `wchar_t` pseudo-type in any special way, thus `wchar_t` will be defined as an integer type by `stddef.h`. \
Consequently, when C code that uses `wchar_t` is imported into D, uses of `wchar_t` will translate into uses of a D integer type.

This is jolly for C, as C will happily convert string-literals to contiguous-integer-spans. \
D, unlike C, will not happily convert string-literals to contiguous-integer-spans: in D, character types are distinct from integer types, unlike in C.

The ultimate result of this is that when a user attempts to use ImportC to `#include <windows.h>` (or some other header) and whip up a "Hello, World!", they can't simply:

```d
MessageBoxW(null, "Hello, World!", "ImportC rocks!", MB_OK);
```
they instead have to:
```d
MessageBoxW(null, cast(const(ushort)*)"Hello, World!"w.ptr, cast(const(ushort)*)"ImportC sucks!"w.ptr, MB_OK);
```

Mocking ImportC and D on [the orange site](https://news.ycombinator.com/news) afterwards is an optional follow-on step.

This is an objectively horrible user-experience, and should be remedied.

---

This PR makes D's character types available to C via three aliases in the `__builtins` module: `__importc_char`; `__importc_wchar`; `__importc_dchar`.
(`__importc_char` is somewhat superfluous, but it's provided for consistency and ease of code-generation.)

[On Windows, `wchar_t` is an unsigned 16-bit integer which represents a UTF-16 code-unit](https://learn.microsoft.com/windows/win32/midl/wchar-t#:~:text=The%20wchar%5Ft%20type%20is%20a%2016%2Dbit%20integer%20which%20represents%20a%20UTF%2D16%20code%20unit). MSVC goes a step further and [defines `wchar_t`/`__wchar_t` as built-in compiler-provided types](https://learn.microsoft.com/cpp/cpp/fundamental-types-cpp#:~:text=The%20%5F%5Fwchar%5Ft%20type%20is%20a%20Microsoft%2Dspecific%20synonym%20for%20the%20native%20wchar%5Ft%20type).

Windows' and MSVC's definition of `wchar_t` matches D's definition of `wchar`.
Thus, in `importc.h`, when targeting Windows, this PR typedefs `wchar_t` as `__importc_wchar` and [defines `_WCHAR_T_DEFINED` and `_NATIVE_WCHAR_T_DEFINED` as `1` appropriately](https://learn.microsoft.com/cpp/preprocessor/predefined-macros#:~:text=%5FWCHAR%5FT%5FDEFINED).
If `_MSC_VER` is defined, `__wchar_t` is also typedef-ed so as to match MSVC's behaviour.

---

The reason why I began this PR's description with ImportC's raison d'être and a user story in an obnoxious patter is because a [previous attempt to handle `wchar_t` in ImportC](https://github.com/dlang/dmd/pull/15757) was rejected/abandoned—mainly due to concerns about its implementation, and its mishandling of non-Windows `wchar_t`.

I think this PR's way of implementing `wchar_t` should be fine: `typedef <type> wchar_t;` is how `wchar_t` is typically defined in `stddef.h`.

Likewise, this PR is something of a Pareto implementation as it simply does not do anything about `wchar_t` on non-Windows targets. \
Outside of Windows, `wchar_t` can be four bytes, or two bytes, or one byte, or it could be something else! Moreover, it can be signed or unsigned. \
Thus, handling `wchar_t` on non-Windows platforms will require a more complicated/involved solution.

However, given that usage of `wchar_t` is much more common on Windows than it is on other platforms (I'm asserting this without evidence): I think handling `wchar_t` on Windows, and engaging the Somebody Else's Problem field for `wchar_t` elsewhere, is highly beneficial to ImportC's usability.


P.S. Sorry for the wall of text. Thank you for reading.
