### PR TITLE
Revert "mem.xrealloc: the GC version can also free unused memory (#23286)"

### DIFF
--- a/compiler/src/dmd/root/rmem.d
+++ b/compiler/src/dmd/root/rmem.d
@@ -73,13 +73,7 @@ extern (C++) struct Mem
     static void* xrealloc(void* p, size_t size) pure nothrow
     {
         if (isGCEnabled)
-        {
-            auto q = GC.realloc(p, size);
-            // used with C semantics, so can be free'd
-            if (p && q && p != q)
-                GC.free(p);
-            return q;
-        }
+            return GC.realloc(p, size);
 
         if (!size)
         {
@@ -93,13 +87,7 @@ extern (C++) struct Mem
     static void* xrealloc_noscan(void* p, size_t size) pure nothrow
     {
         if (isGCEnabled)
-        {
-            auto q = GC.realloc(p, size, GC.BlkAttr.NO_SCAN);
-            // used with C semantics, so can be free'd
-            if (p && q && p != q)
-                GC.free(p);
-            return q;
-        }
+            return GC.realloc(p, size, GC.BlkAttr.NO_SCAN);
 
         if (!size)
         {


### PR DESCRIPTION
The GC is allowed to free the memory passed in realloc, and it usually does, see https://github.com/dlang/dmd/blob/master/druntime/src/core/internal/gc/impl/conservative/gc.d#L736
