### PR TITLE
druntime: Enable conservative GC on WASI

### DIFF
--- a/druntime/src/core/gc/config.d
+++ b/druntime/src/core/gc/config.d
@@ -19,12 +19,7 @@ struct Config
     bool disable;            // start disabled
     bool fork = false;       // optional concurrent behaviour
     ubyte profile;           // enable profiling with summary when terminating program
-
-    // TODO: support full `conservative` GC on Wasm
-    version (WebAssembly)
-        string gc = "manual"; // select gc implementation conservative|precise|manual
-    else
-        string gc = "conservative"; // select gc implementation conservative|precise|manual
+    string gc = "conservative"; // select gc implementation conservative|precise|manual
 
     @MemVal size_t initReserve;      // initial reserve (bytes)
     @MemVal size_t minPoolSize = 1  << 20;  // initial and minimum pool size (bytes)

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -29,21 +29,11 @@ module core.internal.gc.impl.conservative.gc;
 //debug = VALGRIND;             // Valgrind memcheck integration
 
 /***************************************************/
-version = COLLECT_PARALLEL;  // parallel scanning
+version (WASI) {} // WASI is single-threaded
+else version = COLLECT_PARALLEL;  // parallel scanning
+
 version (Posix)
     version = COLLECT_FORK;
-
-version (WASI) {
-    // TODO: get GC working on WASI
-
-    enum PAGESIZE = 65536;
-
-    extern(C) void _d_register_conservative_gc()
-    {
-        // no-op
-    }
-}
-else:
 
 import core.internal.gc.bits;
 import core.internal.gc.os;
@@ -3347,7 +3337,9 @@ Lmark:
                 rangesLock.unlock();
                 rootsLock.unlock();
             }
-            thread_suspendAll();
+
+            version (WASI) {} // WASI is single-threaded
+            else thread_suspendAll();
 
             prepare();
 

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -982,7 +982,13 @@ in (fn)
     else version (WebAssembly)
     {
         // Wasm is special in that this isn't really possible
-        // Spilling has to be done somehow else...
+        // to dump "registers" (Wasm locals & value stack) onto
+        // the linear-memory "C" stack easily.
+        //
+        // Spilling has to be done somehow else.
+
+        import ldc.intrinsics : llvm_stackaddress;
+        sp = llvm_stackaddress();
     }
     else
     {

--- a/druntime/src/rt/sections_wasm.d
+++ b/druntime/src/rt/sections_wasm.d
@@ -28,11 +28,11 @@ struct SectionGroup
 
     @property inout(void[])[] gcRanges() inout return nothrow @nogc
     {
-        return null;
+        return _gcRanges[];
     }
-
 private:
     ModuleGroup _moduleGroup;
+    void[][1] _gcRanges;
 }
 
 void initSections() nothrow @nogc
@@ -40,6 +40,11 @@ void initSections() nothrow @nogc
     auto mbeg = cast(immutable ModuleInfo**)&__start___minfo;
     auto mend = cast(immutable ModuleInfo**)&__stop___minfo;
     _sections.moduleGroup = ModuleGroup(mbeg[0 .. mend - mbeg]);
+
+    // TODO: PIC support
+    auto pbeg = cast(void*)&__global_base;
+    auto pend = cast(void*)&__data_end;
+    _sections._gcRanges[0] = pbeg[0 .. pend - pbeg];
 }
 
 void finiSections() nothrow @nogc
@@ -70,5 +75,8 @@ extern(C)
     {
         void* __start___minfo;
         void* __stop___minfo;
+
+        void* __global_base;
+        void* __data_end;
     }
 }


### PR DESCRIPTION
Some DRuntime tweaks to enable the use of the conservative GC on WASI.

More work needs to be done on the codegen side (LDC) to make sure pointers are spilled onto the stack, before the GC will work as intended (i.e. not free memory when references to it exist on the stack).