### PR TITLE
[stable] Fix invalid arrayop test

### DIFF
--- a/compiler/test/runnable/arrayop.d
+++ b/compiler/test/runnable/arrayop.d
@@ -751,7 +751,7 @@ void test11525()
 
     auto a = [Complex!double(2, 2)];
     assert(a.length == 1 && a[0].re == 2 && a[0].im == 2);
-    a[] *= a[];
+    a[] *= a.dup[];
     assert(a.length == 1 && a[0].re == 0 && a[0].im == 8);
 }
 


### PR DESCRIPTION
From https://dlang.org/spec/arrays.html#array-operations:

> 6. The slice on the left and any slices on the right must not overlap.
>    All operands are evaluated exactly once, even if the array slice
>    has zero elements in it.