### PR TITLE
remove support for CodeView debug info other than CV8

### DIFF
--- a/compiler/src/dmd/backend/cgcv.d
+++ b/compiler/src/dmd/backend/cgcv.d
@@ -161,11 +161,7 @@ enum MARS = true;
 int cv_stringbytes(const(char)* name)
 {
     int len = cast(int)strlen(name);
-    if (config.fulltypes == CV8)
-        return len + 1;
-    if (len > CVIDMAX)
-        len = CVIDMAX;
-    return len + ((len > 255) ? 4 : 1);
+    return len + 1;
 }
 
 /******************************************
@@ -178,86 +174,17 @@ int cv_stringbytes(const(char)* name)
 int cv_namestring(ubyte* p, const(char)* name, int length = -1)
 {
     size_t len = (length >= 0) ? length : strlen(name);
-    if (config.fulltypes == CV8)
+    size_t numBytesWritten = len + ((length < 0) ? 1 : 0);
+    memcpy(p, name, numBytesWritten);
+    if(config.flags2 & CFG2gms)
     {
-        size_t numBytesWritten = len + ((length < 0) ? 1 : 0);
-        memcpy(p, name, numBytesWritten);
-        if(config.flags2 & CFG2gms)
+        for(int i = 0; i < len; i++)
         {
-            for(int i = 0; i < len; i++)
-            {
-                if(p[i] == '.')
-                    p[i] = '@';
-            }
-        }
-        return cast(int)numBytesWritten;
-    }
-    if (len > 255)
-    {   p[0] = 0xFF;
-        p[1] = 0;
-        if (len > CVIDMAX)
-            len = CVIDMAX;
-        TOWORD(p + 2,cast(uint)len);
-        memcpy(p + 4,name,len);
-        len += 4;
-    }
-    else
-    {   p[0] = cast(ubyte)len;
-        memcpy(p + 1,name,len);
-        len++;
-    }
-    return cast(int)len;
-}
-
-/***********************************
- * Compute debug register number for symbol s.
- * Returns:
- *      0..7    byte registers
- *      8..15   word registers
- *      16..23  dword registers
- */
-
-@trusted
-private int cv_regnum(Symbol* s)
-{
-    uint reg = s.Sreglsw;
-    if (s.Sclass == SC.pseudo)
-    {
-    }
-    else
-    {
-        assert(reg < 8);
-        assert(s.Sfl == FL.reg);
-        switch (type_size(s.Stype))
-        {
-            case LONGSIZE:
-            case 3:             reg += 8;
-                                goto case;
-
-            case SHORTSIZE:     reg += 8;
-                                goto case;
-
-            case CHARSIZE:      break;
-
-            case LLONGSIZE:
-                reg += (s.Sregmsw << 8) + (16 << 8) + 16;
-                if (config.fulltypes == CV4)
-                    reg += (1 << 8);
-                break;
-
-            default:
-static if (0)
-{
-                symbol_print(s);
-                type_print(s.Stype);
-                printf("size = %d\n",type_size(s.Stype));
-}
-                assert(0);
+            if(p[i] == '.')
+                p[i] = '@';
         }
     }
-    if (config.fulltypes == CV4)
-        reg++;
-    return reg;
+    return cast(int)numBytesWritten;
 }
 
 /***********************************
@@ -270,11 +197,9 @@ debtyp_t* debtyp_alloc(uint length)
     uint pad = 0;
 
     //printf("len = %u, x%x\n", length, length);
-    if (config.fulltypes == CV8)
-    {   // length+2 must lie on 4 byte boundary
-        pad = ((length + 2 + 3) & ~3) - (length + 2);
-        length += pad;
-    }
+    // length+2 must lie on 4 byte boundary
+    pad = ((length + 2 + 3) & ~3) - (length + 2);
+    length += pad;
 
     if (length > ushort.max)
         err_nomem();
@@ -479,98 +404,16 @@ void cv_init()
             cgcv.FD_code = 0x10;
     }
 
-    if (config.fulltypes >= CV4)
-    {   int flags;
-        __gshared ushort[5] memmodel = [0,0x100,0x20,0x120,0x120];
-        char[1 + (VERSION).sizeof] version_;
-        ubyte[8 + (version_).sizeof] debsym;
+    int flags;
+    __gshared ushort[5] memmodel = [0,0x100,0x20,0x120,0x120];
+    char[1 + (VERSION).sizeof] version_;
+    ubyte[8 + (version_).sizeof] debsym;
 
-        // Put out signature indicating CV4 format
-        switch (config.fulltypes)
-        {
-            case CV4:
-                cgcv.signature = 1;
-                break;
-
-            case CV8:
-                cgcv.signature = 4;
-                break;
-
-            default:
-            {   const(char)* x = "1MYS";
-                cgcv.signature = *cast(int*) x;
-                break;
-            }
-        }
-
-        cgcv.deb_offset = 0x1000;
-
-        if (config.fulltypes == CV8)
-        {   cgcv.sz_idx = 4;
-            return;     // figure out rest later
-        }
-
-        if (config.fulltypes >= CVSYM)
-        {   cgcv.sz_idx = 4;
-            if (!(config.flags2 & CFG2phgen))
-                cgcv.deb_offset = 0x80000000;
-        }
-
-        objmod.write_bytes(SegData[DEBSYM],(&cgcv.signature)[0 .. 1]);
-
-        // Allocate an LF_ARGLIST with no arguments
-        if (config.fulltypes == CV4)
-        {   d = debtyp_alloc(4);
-            TOWORD(d.data.ptr,LF_ARGLIST);
-            TOWORD(d.data.ptr + 2,0);
-        }
-        else
-        {   d = debtyp_alloc(6);
-            TOWORD(d.data.ptr,LF_ARGLIST);
-            TOLONG(d.data.ptr + 2,0);
-        }
-
-        // Put out S_COMPILE record
-        TOWORD(debsym.ptr + 2,S_COMPILE);
-        switch (config.target_cpu)
-        {
-            case TARGET_8086:   debsym[4] = 0;  break;
-            case TARGET_80286:  debsym[4] = 2;  break;
-            case TARGET_80386:  debsym[4] = 3;  break;
-            case TARGET_80486:  debsym[4] = 4;  break;
-
-            case TARGET_Pentium:
-            case TARGET_PentiumMMX:
-                                debsym[4] = 5;  break;
-
-            case TARGET_PentiumPro:
-            case TARGET_PentiumII:
-                                debsym[4] = 6;  break;
-            case TARGET_AArch64:
-                                debsym[4] = 7;  break; // made that up
-            default:    assert(0);
-        }
-        debsym[5] = 0;                  // 0==C, 1==C++
-        flags = (config.inline8087) ? (0<<3) : (1<<3);
-        if (I32)
-            flags |= 0x80;              // 32 bit addresses
-        flags |= memmodel[config.memmodel];
-        TOWORD(debsym.ptr + 6,flags);
-        version_[0] = 'Z';
-        strcpy(version_.ptr + 1,VERSION);
-        cv_namestring(debsym.ptr + 8,version_.ptr);
-        TOWORD(debsym.ptr,6 + (version_).sizeof);
-        objmod.write_bytes(SegData[DEBSYM], debsym[0 .. 8 + (version_).sizeof]);
-
-    }
-    else
-    {
-        assert(0);
-    }
-    if (config.fulltypes == CVTDB)
-        cgcv.deb_offset = cv_debtyp(d);
-    else
-        cv_debtyp(d);
+    // Put out signature indicating CV4 format
+    cgcv.signature = 4;
+    cgcv.deb_offset = 0x1000;
+    cgcv.sz_idx = 4;
+    // figure out rest later
 }
 
 /////////////////////////// CodeView 4 ///////////////////////////////
@@ -674,310 +517,26 @@ idx_t cv4_arglist(type* t,uint* pnparam)
     // Construct an LF_ARGLIST of those parameters
     if (nparam == 0)
     {
-        if (config.fulltypes == CV8)
-        {
-            d = debtyp_alloc(2 + 4 + 4);
-            TOWORD(d.data.ptr,LF_ARGLIST_V2);
-            TOLONG(d.data.ptr + 2,1);
-            TOLONG(d.data.ptr + 6,0);
-            paramidx = cv_debtyp(d);
-        }
-        else
-            paramidx = DEB_NULL;
+        d = debtyp_alloc(2 + 4 + 4);
+        TOWORD(d.data.ptr,LF_ARGLIST_V2);
+        TOLONG(d.data.ptr + 2,1);
+        TOLONG(d.data.ptr + 6,0);
+        paramidx = cv_debtyp(d);
     }
     else
     {
-        switch (config.fulltypes)
+        d = debtyp_alloc(2 + 4 + nparam * 4);
+        TOWORD(d.data.ptr,LF_ARGLIST_V2);
+        TOLONG(d.data.ptr + 2,nparam);
+
+        foreach (u; 0 .. nparam)
         {
-            case CV8:
-                d = debtyp_alloc(2 + 4 + nparam * 4);
-                TOWORD(d.data.ptr,LF_ARGLIST_V2);
-                TOLONG(d.data.ptr + 2,nparam);
-
-                foreach (u; 0 .. nparam)
-                {
-                    auto p = (*t.Tparamtypes)[u];
-                    TOLONG(d.data.ptr + 6 + u * 4,cv4_typidx(p.Ptype));
-                }
-                break;
-
-            case CV4:
-                d = debtyp_alloc(2 + 2 + nparam * 2);
-                TOWORD(d.data.ptr,LF_ARGLIST);
-                TOWORD(d.data.ptr + 2,nparam);
-
-                foreach (u; 0 .. nparam)
-                {
-                    auto p = (*t.Tparamtypes)[u];
-                    TOWORD(d.data.ptr + 4 + u * 2,cv4_typidx(p.Ptype));
-                }
-                break;
-
-            default:
-                d = debtyp_alloc(2 + 4 + nparam * 4);
-                TOWORD(d.data.ptr,LF_ARGLIST);
-                TOLONG(d.data.ptr + 2,nparam);
-
-                foreach (u; 0 .. nparam)
-                {
-                    auto p = (*t.Tparamtypes)[u];
-                    TOLONG(d.data.ptr + 6 + u * 4,cv4_typidx(p.Ptype));
-                }
-                break;
+            auto p = (*t.Tparamtypes)[u];
+            TOLONG(d.data.ptr + 6 + u * 4,cv4_typidx(p.Ptype));
         }
         paramidx = cv_debtyp(d);
     }
     return paramidx;
-}
-
-/****************************
- * Return type index of struct.
- * Input:
- *      s       struct tag symbol
- *      flags
- *          0   generate a reference to s
- *          1   just saw the definition of s
- *          2   saw key function for class s
- *          3   no longer have a key function for class s
- */
-
-@trusted
-idx_t cv4_struct(Classsym* s,int flags)
-{   targ_size_t size;
-    debtyp_t* d,dt;
-    uint len;
-    uint nfields,fnamelen;
-    idx_t typidx;
-    type* t;
-    struct_t* st;
-    const(char)* id;
-    uint numidx;
-    uint leaf;
-    uint property;
-    uint attribute;
-    ubyte* p;
-    int refonly;
-    int i;
-    int count;                  // COUNT field in LF_CLASS
-
-    symbol_debug(s);
-    assert(config.fulltypes >= CV4);
-    st = s.Sstruct;
-    if (st.Sflags & STRanonymous)      // if anonymous class/union
-        return 0;
-
-    //printf("cv4_struct(%s,%d)\n",s.Sident.ptr,flags);
-    t = s.Stype;
-    //printf("t = %p, Tflags = x%x\n", t, t.Tflags);
-    type_debug(t);
-
-    // Determine if we should do a reference or a definition
-    refonly = 1;                        // assume reference only
-    if (MARS || t.Tflags & TF.sizeunknown || st.Sflags & STRoutdef)
-    {
-        //printf("ref only\n");
-    }
-    else
-    {
-        // We have a definition that we have not put out yet
-        switch (flags)
-        {
-            case 0:                     // reference to s
-                refonly = 0;
-                break;
-
-            case 1:                     // saw def of s
-                if (!s.Stypidx)        // if not forward referenced
-                    return 0;
-                break;
-
-            default:
-                assert(0);
-        }
-    }
-
-    if (MARS || refonly)
-    {
-        if (s.Stypidx)                 // if reference already generated
-        {   //assert(s.Stypidx - cgcv.deb_offset < debtyp.length);
-            return s.Stypidx;          // use already existing reference
-        }
-        size = 0;
-        property = 0x80;                // class is forward referenced
-    }
-    else
-    {   size = type_size(t);
-        st.Sflags |= STRoutdef;
-        property = 0;
-    }
-
-    id = prettyident(s);
-    if (config.fulltypes == CV4)
-    {   numidx = (st.Sflags & STRunion) ? 8 : 12;
-        len = numidx + cv4_numericbytes(cast(uint)size);
-        d = debtyp_alloc(len + cv_stringbytes(id));
-        cv4_storenumeric(d.data.ptr + numidx,cast(uint)size);
-    }
-    else
-    {   numidx = (st.Sflags & STRunion) ? 10 : 18;
-        len = numidx + 4;
-        d = debtyp_alloc(len + cv_stringbytes(id));
-        TOLONG(d.data.ptr + numidx,cast(uint)size);
-    }
-    len += cv_namestring(d.data.ptr + len,id);
-    switch (s.Sclass)
-    {
-        case SC.struct_:
-            leaf = LF_STRUCTURE;
-            if (st.Sflags & STRunion)
-            {   leaf = LF_UNION;
-                break;
-            }
-            if (st.Sflags & STRclass)
-                leaf = LF_CLASS;
-            goto L1;
-        L1:
-            if (config.fulltypes == CV4)
-                TOWORD(d.data.ptr + 8,0);          // dList
-            else
-                TOLONG(d.data.ptr + 10,0);         // dList
-            if (config.fulltypes == CV4)
-                TOWORD(d.data.ptr + 10,0);         // vshape
-            else
-                TOLONG(d.data.ptr + 14,0);         // vshape
-            break;
-
-        default:
-            symbol_print(*s);
-            assert(0);
-    }
-    TOWORD(d.data.ptr,leaf);
-
-    // Assign a number to prevent infinite recursion if a struct member
-    // references the same struct.
-    if (config.fulltypes == CVTDB)
-    {
-    }
-    else
-    {
-        d.length = 0;                  // so cv_debtyp() will allocate new
-        s.Stypidx = cv_debtyp(d);
-        d.length = cast(ushort)len;    // restore length
-    }
-    reset_symbuf.write((&s)[0 .. 1]);
-
-    if (refonly)                        // if reference only
-    {
-        //printf("refonly\n");
-        TOWORD(d.data.ptr + 2,0);          // count: number of fields is 0
-        if (config.fulltypes == CV4)
-        {   TOWORD(d.data.ptr + 4,0);              // field list is 0
-            TOWORD(d.data.ptr + 6,property);
-        }
-        else
-        {   TOLONG(d.data.ptr + 6,0);              // field list is 0
-            TOWORD(d.data.ptr + 4,property);
-        }
-        return s.Stypidx;
-    }
-
-    // Compute the number of fields, and the length of the fieldlist record
-    nfields = 0;
-    fnamelen = 2;
-    count = nfields;
-    foreach (sf; st.Sfields[])
-    {
-        symbol_debug(sf);
-        const(char)* sfid = sf.Sident.ptr;
-        switch (sf.Sclass)
-        {
-            case SC.member:
-            case SC.field:
-                const offset = sf.Smemoff;
-                fnamelen += ((config.fulltypes == CV4) ? 6 : 8) +
-                            cv4_numericbytes(cast(uint)offset) + cv_stringbytes(sfid);
-                break;
-
-            default:
-                continue;
-        }
-        nfields++;
-        count++;
-    }
-
-    TOWORD(d.data.ptr + 2,count);
-    if (config.fulltypes == CV4)
-        TOWORD(d.data.ptr + 6,property);
-    else
-        TOWORD(d.data.ptr + 4,property);
-
-    // Generate fieldlist type record
-    dt = debtyp_alloc(fnamelen);
-    p = dt.data.ptr;
-    TOWORD(p,LF_FIELDLIST);
-
-    // And fill it in
-    p += 2;
-    foreach (sf; s.Sstruct.Sfields[])
-    {
-        symbol_debug(sf);
-        const(char)* sfid = sf.Sident.ptr;
-        switch (sf.Sclass)
-        {
-            case SC.field:
-            {   debtyp_t* db;
-
-                if (config.fulltypes == CV4)
-                {   db = debtyp_alloc(6);
-                    TOWORD(db.data.ptr,LF_BITFIELD);
-                    db.data.ptr[2] = sf.Swidth;
-                    db.data.ptr[3] = sf.Sbit;
-                    TOWORD(db.data.ptr + 4,cv4_symtypidx(sf));
-                }
-                else
-                {   db = debtyp_alloc(8);
-                    TOWORD(db.data.ptr,LF_BITFIELD_V2);
-                    db.data.ptr[6] = sf.Swidth;
-                    db.data.ptr[7] = sf.Sbit;
-                    TOLONG(db.data.ptr + 2,cv4_symtypidx(sf));
-                }
-                typidx = cv_debtyp(db);
-                goto L3;
-            }
-
-            case SC.member:
-                typidx = cv4_symtypidx(sf);
-            L3:
-                const offset = sf.Smemoff;
-                TOWORD(p,LF_MEMBER);
-                attribute = 0;
-                if (config.fulltypes == CV4)
-                {   TOWORD(p + 2,typidx);
-                    TOWORD(p + 4,attribute);
-                    p += 6;
-                }
-                else
-                {   TOLONG(p + 4,typidx);
-                    TOWORD(p + 2,attribute);
-                    p += 8;
-                }
-                cv4_storenumeric(p,cast(uint)offset);
-                p += cv4_numericbytes(cast(uint)offset);
-                p += cv_namestring(p,sfid);
-                break;
-
-            default:
-                continue;
-        }
-    }
-    //printf("fnamelen = %d, p-dt.data = %d\n",fnamelen,p-dt.data);
-    assert(p - dt.data.ptr == fnamelen);
-    if (config.fulltypes == CV4)
-        TOWORD(d.data.ptr + 4,cv_debtyp(dt));
-    else
-        TOLONG(d.data.ptr + 6,cv_debtyp(dt));
-
-    return s.Stypidx;
 }
 
 @trusted
@@ -989,29 +548,14 @@ private uint cv4_fwdenum(type* t)
     // fold with original definition from EnumDeclaration
     uint bty = dttab4[tybasic(t.Tnext.Tty)];
     const id = prettyident(s);
-    uint len = config.fulltypes == CV8 ? 14 : 10;
+    uint len = 14;
     debtyp_t* d = debtyp_alloc(len + cv_stringbytes(id));
-    switch (config.fulltypes)
-    {
-        case CV8:
-            TOWORD(d.data.ptr, LF_ENUM_V3);
-            TOLONG(d.data.ptr + 2, 0);    // count
-            TOWORD(d.data.ptr + 4, 0x80); // property : forward reference
-            TOLONG(d.data.ptr + 6, bty);  // memtype
-            TOLONG(d.data.ptr + 10, 0);   // fieldlist
-            break;
+    TOWORD(d.data.ptr, LF_ENUM_V3);
+    TOLONG(d.data.ptr + 2, 0);    // count
+    TOWORD(d.data.ptr + 4, 0x80); // property : forward reference
+    TOLONG(d.data.ptr + 6, bty);  // memtype
+    TOLONG(d.data.ptr + 10, 0);   // fieldlist
 
-        case CV4:
-            TOWORD(d.data.ptr,LF_ENUM);
-            TOWORD(d.data.ptr + 2, 0);    // count
-            TOWORD(d.data.ptr + 4, bty);  // memtype
-            TOLONG(d.data.ptr + 6, 0);    // fieldlist
-            TOWORD(d.data.ptr + 8, 0x80); // property : forward reference
-            break;
-
-        default:
-            assert(0);
-    }
     cv_namestring(d.data.ptr + len, id);
     s.Stypidx = cv_debtyp(d);
     return s.Stypidx;
@@ -1146,21 +690,6 @@ L1:
         case TYhptr:    attribute |= 2; goto L2;
 
         L2:
-            if (config.fulltypes == CV4)
-            {
-                // This is a hack to duplicate bugs in VC, so that the VC
-                // debugger will work.
-                tymnext = t.Tnext ? t.Tnext.Tty : TYint;
-                if (tymnext & (mTYconst | mTYimmutable | mTYvolatile) &&
-                    !tycv &&
-                    tyarithmetic(tymnext) &&
-                    !(attribute & 0xE0)
-                   )
-                {
-                    typidx = dt | dttab4[tybasic(tymnext)];
-                    break;
-                }
-            }
             if ((next < 0x100) && !(attribute & 0xE0)) // basic type?
                 typidx = next | dt;
             else
@@ -1170,143 +699,31 @@ L1:
                 if (tycv & mTYvolatile)
                     attribute |= 0x200;
                 tycv = 0;
-                switch (config.fulltypes)
-                {
-                    case CV4:
-                        d = debtyp_alloc(6);
-                        TOWORD(d.data.ptr,LF_POINTER);
-                        TOWORD(d.data.ptr + 2,attribute);
-                        TOWORD(d.data.ptr + 4,next);
-                        break;
-
-                    case CV8:
-                        d = debtyp_alloc(10);
-                        TOWORD(d.data.ptr,0x1002);
-                        TOLONG(d.data.ptr + 2,next);
-                        // see https://github.com/Microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L1514
-                        // add size and pointer type (PTR_64 or PTR_NEAR32)
-                        attribute |= (I64 ? (8 << 13) | 0xC : (4 << 13) | 0xA);
-                        // convert reference to r-value reference to remove & from type display in debugger
-                        if (attribute & 0x20)
-                            attribute |= 0x80;
-                        TOLONG(d.data.ptr + 6,attribute);
-                        break;
-
-                    default:
-                        d = debtyp_alloc(10);
-                        TOWORD(d.data.ptr,LF_POINTER);
-                        TOLONG(d.data.ptr + 2,attribute);
-                        TOLONG(d.data.ptr + 6,next);
-                        break;
-                }
+                d = debtyp_alloc(10);
+                TOWORD(d.data.ptr,0x1002);
+                TOLONG(d.data.ptr + 2,next);
+                // see https://github.com/Microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L1514
+                // add size and pointer type (PTR_64 or PTR_NEAR32)
+                attribute |= (I64 ? (8 << 13) | 0xC : (4 << 13) | 0xA);
+                // convert reference to r-value reference to remove & from type display in debugger
+                if (attribute & 0x20)
+                    attribute |= 0x80;
+                TOLONG(d.data.ptr + 6,attribute);
                 typidx = cv_debtyp(d);
             }
             break;
 
         Ldarray:
-            switch (config.fulltypes)
-            {
-                case CV8:
-                {
-                    typidx = cv8_darray(t, next);
-                    break;
-                }
-                case CV4:
-static if (1)
-{
-                    d = debtyp_alloc(12);
-                    TOWORD(d.data.ptr, LF_OEM);
-                    TOWORD(d.data.ptr + 2, OEM);
-                    TOWORD(d.data.ptr + 4, 1);     // 1 = dynamic array
-                    TOWORD(d.data.ptr + 6, 2);     // count of type indices to follow
-                    TOWORD(d.data.ptr + 8, 0x12);  // index type, T_LONG
-                    TOWORD(d.data.ptr + 10, next); // element type
-}
-else
-{
-                    d = debtyp_alloc(6);
-                    TOWORD(d.data.ptr,LF_DYN_ARRAY);
-                    TOWORD(d.data.ptr + 2, 0x12);  // T_LONG
-                    TOWORD(d.data.ptr + 4, next);
-}
-                    typidx = cv_debtyp(d);
-                    break;
-
-                default:
-                    assert(0);
-            }
-
+            typidx = cv8_darray(t, next);
             break;
 
         Laarray:
             key = cv4_typidx(t.Tkey);
-            switch (config.fulltypes)
-            {
-                case CV8:
-                    typidx = cv8_daarray(t, key, next);
-                    break;
-
-                case CV4:
-static if (1)
-{
-                    d = debtyp_alloc(12);
-                    TOWORD(d.data.ptr, LF_OEM);
-                    TOWORD(d.data.ptr + 2, OEM);
-                    TOWORD(d.data.ptr + 4, 2);     // 2 = associative array
-                    TOWORD(d.data.ptr + 6, 2);     // count of type indices to follow
-                    TOWORD(d.data.ptr + 8, key);   // key type
-                    TOWORD(d.data.ptr + 10, next); // element type
-}
-else
-{
-                    d = debtyp_alloc(6);
-                    TOWORD(d.data.ptr,LF_ASSOC_ARRAY);
-                    TOWORD(d.data.ptr + 2, key);   // key type
-                    TOWORD(d.data.ptr + 4, next);  // element type
-}
-                    typidx = cv_debtyp(d);
-                    break;
-
-                default:
-                    assert(0);
-            }
+            typidx = cv8_daarray(t, key, next);
             break;
 
         Ldelegate:
-            switch (config.fulltypes)
-            {
-                case CV8:
-                    typidx = cv8_ddelegate(t, next);
-                    break;
-
-                case CV4:
-                    tv = type_fake(TYnptr);
-                    tv.Tcount++;
-                    key = cv4_typidx(tv);
-                    type_free(tv);
-static if (1)
-{
-                    d = debtyp_alloc(12);
-                    TOWORD(d.data.ptr, LF_OEM);
-                    TOWORD(d.data.ptr + 2, OEM);
-                    TOWORD(d.data.ptr + 4, 3);     // 3 = delegate
-                    TOWORD(d.data.ptr + 6, 2);     // count of type indices to follow
-                    TOWORD(d.data.ptr + 8, key);   // type of 'this', which is void*
-                    TOWORD(d.data.ptr + 10, next); // function type
-}
-else
-{
-                    d = debtyp_alloc(6);
-                    TOWORD(d.data.ptr,LF_DELEGATE);
-                    TOWORD(d.data.ptr + 2, key);   // type of 'this', which is void*
-                    TOWORD(d.data.ptr + 4, next);  // function type
-}
-                    typidx = cv_debtyp(d);
-                    break;
-
-                default:
-                    assert(0);
-            }
+            typidx = cv8_ddelegate(t, next);
             break;
 
         case TYcent:
@@ -1335,35 +752,13 @@ else
                 idxtype = 0x23;                    // T_UQUAD
             if(next == dttab4[TYvoid])    // do not encode void[n], this confuses the debugger
                 next = dttab4[TYuchar];   // use ubyte instead
-            switch (config.fulltypes)
-            {
-                case CV8:
-                    d = debtyp_alloc(10 + u + 1);
-                    TOWORD(d.data.ptr,0x1503);
-                    TOLONG(d.data.ptr + 2,next);
-                    TOLONG(d.data.ptr + 6,idxtype);
-                    d.data.ptr[10 + u] = 0;             // no name
-                    cv4_storenumeric(d.data.ptr + 10,cast(uint)size);
-                    break;
 
-                case CV4:
-                    d = debtyp_alloc(6 + u + 1);
-                    TOWORD(d.data.ptr,LF_ARRAY);
-                    TOWORD(d.data.ptr + 2,next);
-                    TOWORD(d.data.ptr + 4,idxtype);
-                    d.data.ptr[6 + u] = 0;             // no name
-                    cv4_storenumeric(d.data.ptr + 6,cast(uint)size);
-                    break;
-
-                default:
-                    d = debtyp_alloc(10 + u + 1);
-                    TOWORD(d.data.ptr,LF_ARRAY);
-                    TOLONG(d.data.ptr + 2,next);
-                    TOLONG(d.data.ptr + 6,idxtype);
-                    d.data.ptr[10 + u] = 0;            // no name
-                    cv4_storenumeric(d.data.ptr + 10,cast(uint)size);
-                    break;
-            }
+            d = debtyp_alloc(10 + u + 1);
+            TOWORD(d.data.ptr,0x1503);
+            TOLONG(d.data.ptr + 2,next);
+            TOLONG(d.data.ptr + 6,idxtype);
+            d.data.ptr[10 + u] = 0;             // no name
+            cv4_storenumeric(d.data.ptr + 10,cast(uint)size);
             typidx = cv_debtyp(d);
             break;
         }
@@ -1389,38 +784,13 @@ else
             paramidx = cv4_arglist(t,&nparam);
 
             // Construct an LF_PROCEDURE
-            switch (config.fulltypes)
-            {
-                case CV8:
-                    d = debtyp_alloc(2 + 4 + 1 + 1 + 2 + 4);
-                    TOWORD(d.data.ptr,LF_PROCEDURE_V2);
-                    TOLONG(d.data.ptr + 2,next);       // return type
-                    d.data.ptr[6] = call;
-                    d.data.ptr[7] = 0;                 // reserved
-                    TOWORD(d.data.ptr + 8,nparam);
-                    TOLONG(d.data.ptr + 10,paramidx);
-                    break;
-
-                case CV4:
-                    d = debtyp_alloc(2 + 2 + 1 + 1 + 2 + 2);
-                    TOWORD(d.data.ptr,LF_PROCEDURE);
-                    TOWORD(d.data.ptr + 2,next);               // return type
-                    d.data.ptr[4] = call;
-                    d.data.ptr[5] = 0;                 // reserved
-                    TOWORD(d.data.ptr + 6,nparam);
-                    TOWORD(d.data.ptr + 8,paramidx);
-                    break;
-
-                default:
-                    d = debtyp_alloc(2 + 4 + 1 + 1 + 2 + 4);
-                    TOWORD(d.data.ptr,LF_PROCEDURE);
-                    TOLONG(d.data.ptr + 2,next);               // return type
-                    d.data.ptr[6] = call;
-                    d.data.ptr[7] = 0;                 // reserved
-                    TOWORD(d.data.ptr + 8,nparam);
-                    TOLONG(d.data.ptr + 10,paramidx);
-                    break;
-            }
+            d = debtyp_alloc(2 + 4 + 1 + 1 + 2 + 4);
+            TOWORD(d.data.ptr,LF_PROCEDURE_V2);
+            TOLONG(d.data.ptr + 2,next);       // return type
+            d.data.ptr[6] = call;
+            d.data.ptr[7] = 0;                 // reserved
+            TOWORD(d.data.ptr + 8,nparam);
+            TOLONG(d.data.ptr + 10,paramidx);
 
             typidx = cv_debtyp(d);
             break;
@@ -1428,16 +798,7 @@ else
 
         case TYstruct:
         {
-            if (config.fulltypes == CV8)
-            {
-                typidx = cv8_fwdref(t.Ttag);
-            }
-            else
-            {
-                int foo = t.Ttag.Stypidx;
-                typidx = cv4_struct(t.Ttag,0);
-                //printf("struct '%s' %x %x\n", t.Ttag.Sident.ptr, foo, typidx);
-            }
+            typidx = cv8_fwdref(t.Ttag);
             break;
         }
 
@@ -1504,566 +865,15 @@ else
 
         modifier = (tycv & (mTYconst | mTYimmutable)) ? 1 : 0;
         modifier |= (tycv & mTYvolatile) ? 2 : 0;
-        switch (config.fulltypes)
-        {
-            case CV8:
-                d = debtyp_alloc(8);
-                TOWORD(d.data.ptr,0x1001);
-                TOLONG(d.data.ptr + 2,typidx);
-                TOWORD(d.data.ptr + 6,modifier);
-                break;
-
-            case CV4:
-                d = debtyp_alloc(6);
-                TOWORD(d.data.ptr,LF_MODIFIER);
-                TOWORD(d.data.ptr + 2,modifier);
-                TOWORD(d.data.ptr + 4,typidx);
-                break;
-
-            default:
-                d = debtyp_alloc(10);
-                TOWORD(d.data.ptr,LF_MODIFIER);
-                TOLONG(d.data.ptr + 2,modifier);
-                TOLONG(d.data.ptr + 6,typidx);
-                break;
-        }
+        d = debtyp_alloc(8);
+        TOWORD(d.data.ptr,0x1001);
+        TOLONG(d.data.ptr + 2,typidx);
+        TOWORD(d.data.ptr + 6,modifier);
         typidx = cv_debtyp(d);
     }
 
     assert(typidx);
     return typidx;
-}
-
-/******************************************
- * Write out symbol s.
- */
-
-@trusted
-private void cv4_outsym(Symbol* s)
-{
-    uint len;
-    type* t;
-    uint length;
-    uint u;
-    tym_t tym;
-    const(char)* id;
-    ubyte* debsym = null;
-    ubyte[64] buf = void;
-
-    //printf("cv4_outsym(%s)\n",s.Sident.ptr);
-    symbol_debug(s);
-    if (s.Sflags & SFLnodebug)
-        return;
-    t = s.Stype;
-    type_debug(t);
-    tym = tybasic(t.Tty);
-    if (tyfunc(tym) && s.Sclass != SC.typedef_)
-    {   int framedatum,targetdatum,fd;
-        char idfree;
-        idx_t typidx;
-
-        if (s != funcsym_p)
-            return;
-        id = s.prettyIdent ? s.prettyIdent : s.Sident.ptr;
-        len = cv_stringbytes(id);
-
-        // Length of record
-        length = 2 + 2 + 4 * 3 + _tysize[TYint] * 4 + 2 + cgcv.sz_idx + 1;
-        debsym = (length + len <= (buf).sizeof) ? buf.ptr : cast(ubyte*) malloc(length + len);
-        if (!debsym)
-            err_nomem();
-        memset(debsym,0,length + len);
-
-        // Symbol type
-        u = (s.Sclass == SC.static_) ? S_LPROC16 : S_GPROC16;
-        if (I32)
-            u += S_GPROC32 - S_GPROC16;
-        TOWORD(debsym + 2,u);
-
-        if (config.fulltypes == CV4)
-        {
-            // Offsets
-            if (I32)
-            {   TOLONG(debsym + 16,cast(uint)s.Ssize);           // proc length
-                TOLONG(debsym + 20,cast(uint)cgstate.startoffset);        // debug start
-                TOLONG(debsym + 24,cast(uint)cgstate.retoffset);          // debug end
-                u = 28;                                 // offset to fixup
-            }
-            else
-            {   TOWORD(debsym + 16,cast(uint)s.Ssize);           // proc length
-                TOWORD(debsym + 18,cast(uint)cgstate.startoffset);        // debug start
-                TOWORD(debsym + 20,cast(uint)cgstate.retoffset);          // debug end
-                u = 22;                                 // offset to fixup
-            }
-            length += cv_namestring(debsym + u + _tysize[TYint] + 2 + cgcv.sz_idx + 1,id);
-            typidx = cv4_symtypidx(s);
-            TOIDX(debsym + u + _tysize[TYint] + 2,typidx);     // proc type
-            debsym[u + _tysize[TYint] + 2 + cgcv.sz_idx] = tyfarfunc(tym) ? 4 : 0;
-            TOWORD(debsym,length - 2);
-        }
-        else
-        {
-            // Offsets
-            if (I32)
-            {   TOLONG(debsym + 16 + cgcv.sz_idx,cast(uint)s.Ssize);             // proc length
-                TOLONG(debsym + 20 + cgcv.sz_idx,cast(uint)cgstate.startoffset);  // debug start
-                TOLONG(debsym + 24 + cgcv.sz_idx,cast(uint)cgstate.retoffset);            // debug end
-                u = 28;                                         // offset to fixup
-            }
-            else
-            {   TOWORD(debsym + 16 + cgcv.sz_idx,cast(uint)s.Ssize);             // proc length
-                TOWORD(debsym + 18 + cgcv.sz_idx,cast(uint)cgstate.startoffset);  // debug start
-                TOWORD(debsym + 20 + cgcv.sz_idx,cast(uint)cgstate.retoffset);            // debug end
-                u = 22;                                         // offset to fixup
-            }
-            u += cgcv.sz_idx;
-            length += cv_namestring(debsym + u + _tysize[TYint] + 2 + 1,id);
-            typidx = cv4_symtypidx(s);
-            TOIDX(debsym + 16,typidx);                  // proc type
-            debsym[u + _tysize[TYint] + 2] = tyfarfunc(tym) ? 4 : 0;
-            TOWORD(debsym,length - 2);
-        }
-
-        uint soffset = cast(uint)Offset(DEBSYM);
-        objmod.write_bytes(SegData[DEBSYM],debsym[0 .. length]);
-
-        // Put out fixup for function start offset
-        objmod.reftoident(DEBSYM,soffset + u,s,0,CF.seg | CF.off);
-    }
-    else
-    {   targ_size_t base;
-        int reg;
-        uint fd;
-        uint idx1,idx2;
-        uint value;
-        uint fixoff;
-        idx_t typidx;
-
-        typidx = cv4_typidx(t);
-        id = s.prettyIdent ? s.prettyIdent : prettyident(s);
-        len = cast(uint)strlen(id);
-        debsym = (39 + IDOHD + len <= (buf).sizeof) ? buf.ptr : cast(ubyte*) malloc(39 + IDOHD + len);
-        if (!debsym)
-            err_nomem();
-        switch (s.Sclass)
-        {
-            case SC.parameter:
-            case SC.regpar:
-                if (s.Sfl == FL.reg)
-                {
-                    s.Sfl = FL.para;
-                    cv4_outsym(s);
-                    s.Sfl = FL.reg;
-                    goto case_register;
-                }
-                base = cgstate.Para.size - cgstate.BPoff;    // cancel out add of BPoff
-                goto L1;
-
-            case SC.auto_:
-                if (s.Sfl == FL.reg)
-                    goto case_register;
-            case_auto:
-                base = cgstate.Auto.size;
-            L1:
-                if (s.Sscope) // local variables moved into the closure cannot be emitted directly
-                    goto Lret;
-                TOWORD(debsym + 2,I32 ? S_BPREL32 : S_BPREL16);
-                if (config.fulltypes == CV4)
-                {   TOOFFSET(debsym + 4,s.Soffset + base + cgstate.BPoff);
-                    TOIDX(debsym + 4 + _tysize[TYint],typidx);
-                }
-                else
-                {   TOOFFSET(debsym + 4 + cgcv.sz_idx,s.Soffset + base + cgstate.BPoff);
-                    TOIDX(debsym + 4,typidx);
-                }
-                length = 2 + 2 + _tysize[TYint] + cgcv.sz_idx;
-                length += cv_namestring(debsym + length,id);
-                TOWORD(debsym,length - 2);
-                break;
-
-            case SC.bprel:
-                base = -cgstate.BPoff;
-                goto L1;
-
-            case SC.fastpar:
-                if (s.Sfl != FL.reg)
-                {   base = cgstate.Fast.size;
-                    goto L1;
-                }
-                goto case_register;
-
-            case SC.register:
-                if (s.Sfl != FL.reg)
-                    goto case_auto;
-                goto case_register;
-
-            case SC.pseudo:
-            case_register:
-                TOWORD(debsym + 2,S_REGISTER);
-                reg = cv_regnum(s);
-                TOIDX(debsym + 4,typidx);
-                TOWORD(debsym + 4 + cgcv.sz_idx,reg);
-                length = 2 * 3 + cgcv.sz_idx;
-                length += 1 + cv_namestring(debsym + length,id);
-                TOWORD(debsym,length - 2);
-                break;
-
-            case SC.extern_:
-            case SC.comdef:
-                // Common blocks have a non-zero Sxtrnnum and an UNKNOWN seg
-                if (!(s.Sxtrnnum && s.Sseg == UNKNOWN)) // if it's not really a common block
-                {
-                        goto Lret;
-                }
-                goto case;
-            case SC.global:
-            case SC.comdat:
-                u = S_GDATA16;
-                goto L2;
-
-            case SC.static_:
-            case SC.locstat:
-                u = S_LDATA16;
-            L2:
-                if (I32)
-                    u += S_GDATA32 - S_GDATA16;
-                TOWORD(debsym + 2,u);
-                if (config.fulltypes == CV4)
-                {
-                    fixoff = 4;
-                    length = 2 + 2 + _tysize[TYint] + 2;
-                    TOOFFSET(debsym + fixoff,s.Soffset);
-                    TOWORD(debsym + fixoff + _tysize[TYint],0);
-                    TOIDX(debsym + length,typidx);
-                }
-                else
-                {
-                    fixoff = 8;
-                    length = 2 + 2 + _tysize[TYint] + 2;
-                    TOOFFSET(debsym + fixoff,s.Soffset);
-                    TOWORD(debsym + fixoff + _tysize[TYint],0);        // segment
-                    TOIDX(debsym + 4,typidx);
-                }
-                length += cgcv.sz_idx;
-                length += cv_namestring(debsym + length,id);
-                TOWORD(debsym,length - 2);
-                assert(length <= 40 + len);
-
-                if (s.Sseg == UNKNOWN || s.Sclass == SC.comdat) // if common block
-                {
-                    if (config.exe & EX_flat)
-                    {
-                        fd = 0x16;
-                        idx1 = DGROUPIDX;
-                        idx2 = s.Sxtrnnum;
-                    }
-                    else
-                    {
-                        fd = 0x26;
-                        idx1 = idx2 = s.Sxtrnnum;
-                    }
-                }
-                else if (s.ty() & (mTYfar | mTYcs))
-                {
-                    fd = 0x04;
-                    idx1 = idx2 = SegData[s.Sseg].segidx;
-                }
-                else
-                {   fd = 0x14;
-                    idx1 = DGROUPIDX;
-                    idx2 = SegData[s.Sseg].segidx;
-                }
-                /* Because of the linker limitations, the length cannot
-                 * exceed 0x1000.
-                 * See optlink\cv\cvhashes.asm
-                 */
-                assert(length <= 0x1000);
-                if (idx2 != 0)
-                {
-                    assert(0);
-                }
-                goto Lret;
-
-static if (1)
-{
-            case SC.typedef_:
-                s.Stypidx = typidx;
-                reset_symbuf.write((&s)[0 .. 1]);
-                goto L4;
-
-            case SC.struct_:
-                if (s.Sstruct.Sflags & STRnotagname)
-                    goto Lret;
-                goto L4;
-
-            case SC.enum_:
-            L4:
-                // Output a 'user-defined type' for the tag name
-                TOWORD(debsym + 2,S_UDT);
-                TOIDX(debsym + 4,typidx);
-                length = 2 + 2 + cgcv.sz_idx;
-                length += cv_namestring(debsym + length,id);
-                TOWORD(debsym,length - 2);
-                break;
-
-            case SC.const_:
-                // The only constants are enum members
-                value = cast(uint)el_tolong(s.Svalue);
-                TOWORD(debsym + 2,S_CONST);
-                TOIDX(debsym + 4,typidx);
-                length = 4 + cgcv.sz_idx;
-                cv4_storenumeric(debsym + length,value);
-                length += cv4_numericbytes(value);
-                length += cv_namestring(debsym + length,id);
-                TOWORD(debsym,length - 2);
-                break;
-}
-            default:
-                goto Lret;
-        }
-        assert(length <= 40 + len);
-        objmod.write_bytes(SegData[DEBSYM],debsym[0 .. length]);
-    }
-Lret:
-    if (debsym != buf.ptr)
-        free(debsym);
-}
-
-
-/******************************************
- * Write out symbol table for current function.
- */
-
-@trusted
-private void cv4_func(Funcsym* s, ref symtab_t symtab)
-{
-    int endarg;
-
-    cv4_outsym(s);              // put out function symbol
-    __gshared Funcsym* sfunc;
-    __gshared int cntOpenBlocks;
-    sfunc = s;
-    cntOpenBlocks = 0;
-
-    struct cv4
-    {
-    nothrow:
-        // record for CV record S_BLOCK32
-        struct block32_data
-        {
-            ushort len;
-            ushort id;
-            uint pParent;
-            uint pEnd;
-            uint length;
-            uint offset;
-            ushort seg;
-            ubyte[2] name;
-        }
-
-
-        static void endArgs()
-        {
-            __gshared ushort[2] endargs = [ 2, S_ENDARG ];
-            objmod.write_bytes(SegData[DEBSYM],endargs[]);
-        }
-        static void beginBlock(int offset, int length)
-        {
-            if (++cntOpenBlocks >= 255)
-                return; // optlink does not like more than 255 scope blocks
-
-            uint soffset = cast(uint)Offset(DEBSYM);
-            // parent and end to be filled by linker
-            block32_data block32 = { (block32_data).sizeof - 2, S_BLOCK32, 0, 0, length, 0, 0, [ 0, '\0' ] };
-            objmod.write_bytes(SegData[DEBSYM], (&block32)[0 .. 1]);
-            size_t offOffset = cast(char*)&block32.offset - cast(char*)&block32;
-            objmod.reftoident(DEBSYM, soffset + offOffset, sfunc, offset + sfunc.Soffset, CF.seg | CF.off);
-        }
-        static void endBlock()
-        {
-            if (cntOpenBlocks-- >= 255)
-                return; // optlink does not like more than 255 scope blocks
-
-            __gshared ushort[2] endargs = [ 2, S_END ];
-            objmod.write_bytes(SegData[DEBSYM],endargs[]);
-        }
-    }
-
-    varStats_writeSymbolTable(sfunc, symtab, &cv4_outsym, &cv4.endArgs, &cv4.beginBlock, &cv4.endBlock);
-
-    // Put out function return record
-    if (1)
-    {
-        ubyte[2+2+2+1+1+4] sreturn;
-        ushort flags;
-        ubyte style;
-        tym_t ty;
-        tym_t tyret;
-        uint u;
-
-        u = 2+2+1;
-        ty = tybasic(s.ty());
-
-        flags = tyrevfunc(ty) ? 0 : 1;
-        flags |= typfunc(ty) ? 0 : 2;
-        TOWORD(sreturn.ptr + 4,flags);
-
-        tyret = tybasic(s.Stype.Tnext.Tty);
-        switch (tyret)
-        {
-            case TYvoid:
-            default:
-                style = 0;
-                break;
-
-            case TYbool:
-            case TYchar:
-            case TYschar:
-            case TYuchar:
-                sreturn[7] = 1;
-                sreturn[8] = 1;         // AL
-                goto L1;
-
-            case TYwchar_t:
-            case TYchar16:
-            case TYshort:
-            case TYushort:
-                goto case_ax;
-
-            case TYint:
-            case TYuint:
-            case TYsptr:
-            case TYcptr:
-            case TYnullptr:
-            case TYnptr:
-            case TYnref:
-                if (I32)
-                    goto case_eax;
-                else
-                    goto case_ax;
-
-            case TYfloat:
-            case TYifloat:
-                if (config.exe & EX_flat)
-                    goto case_st0;
-                goto case;
-
-            case TYlong:
-            case TYulong:
-            case TYdchar:
-                if (I32)
-                    goto case_eax;
-                else
-                    goto case_dxax;
-
-            case TYfptr:
-            case TYhptr:
-                if (I32)
-                    goto case_edxeax;
-                else
-                    goto case_dxax;
-
-            case TYvptr:
-                if (I32)
-                    goto case_edxebx;
-                else
-                    goto case_dxbx;
-
-            case TYdouble:
-            case TYidouble:
-            case TYdouble_alias:
-                if (config.exe & EX_flat)
-                    goto case_st0;
-                if (I32)
-                    goto case_edxeax;
-                else
-                    goto case_axbxcxdx;
-
-            case TYllong:
-            case TYullong:
-                assert(I32);
-                goto case_edxeax;
-
-            case TYreal:
-            case TYireal:
-                goto case_st0;
-
-            case TYcfloat:
-            case TYcdouble:
-            case TYcreal:
-                goto case_st01;
-
-            case_ax:
-                sreturn[7] = 1;
-                sreturn[8] = 9;         // AX
-                goto L1;
-
-            case_eax:
-                sreturn[7] = 1;
-                sreturn[8] = 17;        // EAX
-                goto L1;
-
-
-            case_dxax:
-                sreturn[7] = 2;
-                sreturn[8] = 11;        // DX
-                sreturn[9] = 9;         // AX
-                goto L1;
-
-            case_dxbx:
-                sreturn[7] = 2;
-                sreturn[8] = 11;        // DX
-                sreturn[9] = 12;        // BX
-                goto L1;
-
-            case_axbxcxdx:
-                sreturn[7] = 4;
-                sreturn[8] = 9;         // AX
-                sreturn[9] = 12;        // BX
-                sreturn[10] = 10;       // CX
-                sreturn[11] = 11;       // DX
-                goto L1;
-
-            case_edxeax:
-                sreturn[7] = 2;
-                sreturn[8] = 19;        // EDX
-                sreturn[9] = 17;        // EAX
-                goto L1;
-
-            case_edxebx:
-                sreturn[7] = 2;
-                sreturn[8] = 19;        // EDX
-                sreturn[9] = 20;        // EBX
-                goto L1;
-
-            case_st0:
-                sreturn[7] = 1;
-                sreturn[8] = 128;       // ST0
-                goto L1;
-
-            case_st01:
-                sreturn[7] = 2;
-                sreturn[8] = 128;       // ST0 (imaginary)
-                sreturn[9] = 129;       // ST1 (real)
-                goto L1;
-
-            L1:
-                style = 1;
-                u += sreturn[7] + 1;
-                break;
-        }
-        sreturn[6] = style;
-
-        TOWORD(sreturn.ptr,u);
-        TOWORD(sreturn.ptr + 2,S_RETURN);
-        objmod.write_bytes(SegData[DEBSYM],sreturn[0 .. u + 2]);
-    }
-
-    // Put out end scope
-    {   __gshared ushort[2] endproc = [ 2,S_END ];
-
-        objmod.write_bytes(SegData[DEBSYM],endproc[]);
-    }
 }
 
 //////////////////////////////////////////////////////////
@@ -2079,62 +889,17 @@ void cv_term()
 
     segidx_t typeseg = objmod.seg_debugT();
 
-    switch (config.fulltypes)
-    {
-        case CV4:
-        case CVSYM:
-            assert(0);  // obsolete
+    objmod.write_bytes(SegData[typeseg],(&cgcv.signature)[0 .. 1]);
+    for (uint u = 0; u < debtyp.length; u++)
+    {   debtyp_t* d = debtyp[u];
 
-        case CV8:
-            objmod.write_bytes(SegData[typeseg],(&cgcv.signature)[0 .. 1]);
-            if (debtyp.length != 1 || config.fulltypes == CV8)
-            {
-                for (uint u = 0; u < debtyp.length; u++)
-                {   debtyp_t* d = debtyp[u];
-
-                    objmod.write_bytes(SegData[typeseg],(cast(void*)d)[uint.sizeof .. uint.sizeof + 2 + d.length]);
-                    debtyp_free(d);
-                }
-            }
-            else if (debtyp.length)
-            {
-                debtyp_free(debtyp[0]);
-            }
-            break;
-
-
-        default:
-            assert(0);
+        objmod.write_bytes(SegData[typeseg],(cast(void*)d)[uint.sizeof .. uint.sizeof + 2 + d.length]);
+        debtyp_free(d);
     }
 
     // debtyp.dtor();  // save for later
     vec_free(debtypvec);
     debtypvec = null;
-}
-
-/******************************************
- * Write out symbol table for current function.
- */
-
-@trusted
-void cv_func(Funcsym* s)
-{
-
-    //printf("cv_func('%s')\n",s.Sident.ptr);
-    if (s.Sflags & SFLnodebug)
-        return;
-
-    switch (config.fulltypes)
-    {
-        case CV4:
-        case CVSYM:
-        case CVTDB:
-            cv4_func(s, globsym);
-            break;
-
-        default:
-            assert(0);
-    }
 }
 
 /******************************************
@@ -2148,21 +913,8 @@ void cv_outsym(Symbol* s)
     symbol_debug(s);
     if (s.Sflags & SFLnodebug)
         return;
-    switch (config.fulltypes)
-    {
-        case CV4:
-        case CVSYM:
-        case CVTDB:
-            cv4_outsym(s);
-            break;
 
-        case CV8:
-            cv8_outsym(s);
-            break;
-
-        default:
-            assert(0);
-    }
+    cv8_outsym(s);
 }
 
 /******************************************
@@ -2174,21 +926,7 @@ uint cv_typidx(type* t)
 {   uint ti;
 
     //printf("cv_typidx(%p)\n",t);
-    switch (config.fulltypes)
-    {
-        case CV4:
-        case CVTDB:
-        case CVSYM:
-        case CV8:
-            ti = cv4_typidx(t);
-            break;
-
-        default:
-            debug
-            printf("fulltypes = %d\n",config.fulltypes);
-
-            assert(0);
-    }
+    ti = cv4_typidx(t);
     return ti;
 }
 

--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -1062,12 +1062,6 @@ void writefunc2(Symbol* sfunc, ref GlobalOptimizer go, ref BlockOpt bo)
         sfunc.ty() & mTYexport)
         objmod.export_symbol(sfunc,cast(uint)cgstate.Para.offset);      // export function definition
 
-    if (config.fulltypes && config.fulltypes != CV8)
-    {
-        if (config.objfmt == OBJ_MSCOFF)
-            cv_func(sfunc);                 // debug info for function
-    }
-
     /* This is to make uplevel references to SCfastpar variables
      * from nested functions work.
      */

--- a/compiler/src/dmd/glue/tocvdebug.d
+++ b/compiler/src/dmd/glue/tocvdebug.d
@@ -108,41 +108,18 @@ uint cv4_memfunctypidx(FuncDeclaration fd)
 
     const ubyte call = cv4_callconv(t);
 
-    switch (config.fulltypes)
-    {
-        case CV4:
-        {
-            debtyp_t* d = debtyp_alloc(18);
-            ubyte* p = &d.data[0];
-            TOWORD(p,LF_MFUNCTION);
-            TOWORD(p + 2,cv4_typidx(t.Tnext));
-            TOWORD(p + 4,cv4_typidx(Type_toCtype(ad.type)));
-            TOWORD(p + 6,thisidx);
-            p[8] = call;
-            p[9] = 0;                               // reserved
-            TOWORD(p + 10,nparam);
-            TOWORD(p + 12,paramidx);
-            TOLONG(p + 14,0);                       // thisadjust
-            return cv_debtyp(d);
-        }
-        case CV8:
-        {
-            debtyp_t* d = debtyp_alloc(26);
-            ubyte* p = &d.data[0];
-            TOWORD(p,0x1009);
-            TOLONG(p + 2,cv4_typidx(t.Tnext));
-            TOLONG(p + 6,cv4_typidx(Type_toCtype(ad.type)));
-            TOLONG(p + 10,thisidx);
-            p[14] = call;
-            p[15] = 0;                               // reserved
-            TOWORD(p + 16,nparam);
-            TOLONG(p + 18,paramidx);
-            TOLONG(p + 22,0);                       // thisadjust
-            return cv_debtyp(d);
-        }
-        default:
-            assert(0);
-    }
+    debtyp_t* d = debtyp_alloc(26);
+    ubyte* p = &d.data[0];
+    TOWORD(p,0x1009);
+    TOLONG(p + 2,cv4_typidx(t.Tnext));
+    TOLONG(p + 6,cv4_typidx(Type_toCtype(ad.type)));
+    TOLONG(p + 10,thisidx);
+    p[14] = call;
+    p[15] = 0;                               // reserved
+    TOWORD(p + 16,nparam);
+    TOLONG(p + 18,paramidx);
+    TOLONG(p + 22,0);                       // thisadjust
+    return cv_debtyp(d);
 }
 
 enum CV4_NAMELENMAX = 0x3b9f;                   // found by trial and error
@@ -179,29 +156,13 @@ uint cv4_Denum(EnumDeclaration e)
     uint len;
     debtyp_t* d;
     const uint memtype = e.memtype ? cv4_typidx(Type_toCtype(e.memtype)) : 0;
-    switch (config.fulltypes)
-    {
-        case CV8:
-            len = 14;
-            d = debtyp_alloc(len + cv_stringbytes(id));
-            TOWORD(d.data.ptr,LF_ENUM_V3);
-            TOLONG(d.data.ptr + 6,memtype);
-            TOWORD(d.data.ptr + 4,property);
-            len += cv_namestring(d.data.ptr + len,id);
-            break;
+    len = 14;
+    d = debtyp_alloc(len + cv_stringbytes(id));
+    TOWORD(d.data.ptr,LF_ENUM_V3);
+    TOLONG(d.data.ptr + 6,memtype);
+    TOWORD(d.data.ptr + 4,property);
+    len += cv_namestring(d.data.ptr + len,id);
 
-        case CV4:
-            len = 10;
-            d = debtyp_alloc(len + cv_stringbytes(id));
-            TOWORD(d.data.ptr,LF_ENUM);
-            TOWORD(d.data.ptr + 4,memtype);
-            TOWORD(d.data.ptr + 8,property);
-            len += cv_namestring(d.data.ptr + len,id);
-            break;
-
-        default:
-            assert(0);
-    }
     const length_save = d.length;
     d.length = 0;                      // so cv_debtyp() will allocate new
     const idx_t typidx = cv_debtyp(d);
@@ -224,7 +185,7 @@ uint cv4_Denum(EnumDeclaration e)
 
             ubyte* p = mc.writePtr();
             dinteger_t value = sf.value().toInteger();
-            TOWORD(p, (config.fulltypes == CV8) ? LF_ENUMERATE_V3 : LF_ENUMERATE);
+            TOWORD(p, LF_ENUMERATE_V3);
             uint attribute = 0;
             TOWORD(p + 2, attribute);
             cv4_storenumeric(p + 4,cast(uint)value);
@@ -233,21 +194,12 @@ uint cv4_Denum(EnumDeclaration e)
             j += cv_namestring(p + j, sf.toChars());
             j = cv_align(p + j, j);
             mc.written(j);
-            // If enum is not a member of a class, output enum members as constants
-    //      if (!isclassmember(s))
-    //      {
-    //          cv4_outsym(sf);
-    //      }
         }
         fieldlist = mc.debtyp();
     }
 
-    if (config.fulltypes == CV8)
-        TOLONG(d.data.ptr + 10,fieldlist);
-    else
-        TOWORD(d.data.ptr + 6,fieldlist);
+    TOLONG(d.data.ptr + 10,fieldlist);
 
-//    cv4_outsym(s);
     return typidx;
 }
 
@@ -258,20 +210,17 @@ uint cv4_Denum(EnumDeclaration e)
  */
 uint cv_align(ubyte* p, uint n)
 {
-    if (config.fulltypes == CV8)
+    if (p)
     {
-        if (p)
+        uint npad = -n & 3;
+        while (npad)
         {
-            uint npad = -n & 3;
-            while (npad)
-            {
-                *p = cast(ubyte)(0xF0 + npad);
-                ++p;
-                --npad;
-            }
+            *p = cast(ubyte)(0xF0 + npad);
+            ++p;
+            --npad;
         }
-        n = (n + 3) & ~3;
     }
+    n = (n + 3) & ~3;
     return n;
 }
 
@@ -284,34 +233,11 @@ uint cv_align(ubyte* p, uint n)
  */
 void cv_udt(Dsymbol s, const char* id, uint typidx)
 {
-    if (config.fulltypes == CV8)
-    {
-        cv8_udt(id, typidx);
-        // Record the source file and line where the type is defined
-        // (LF_UDT_SRC_LINE); the CV4 path has no equivalent record.
-        if (s)
-            cast(void)cv8_udt_src_line(typidx, s.loc.filename, s.loc.linnum);
-        return;
-    }
-
-    const len = strlen(id);
-    version (AArch64) // TODO AArch64
-    {
-        ubyte* debsym = cast(ubyte *) Mem.xmalloc(39 + IDOHD + len);
-        scope (exit) Mem.xfree(debsym);
-    }
-    else
-        ubyte* debsym = cast(ubyte *) alloca(39 + IDOHD + len);
-
-    // Output a 'user-defined type' for the tag name
-    TOWORD(debsym + 2,S_UDT);
-    TOIDX(debsym + 4,typidx);
-    uint length = 2 + 2 + cgcv.sz_idx;
-    length += cv_namestring(debsym + length,id);
-    TOWORD(debsym,length - 2);
-
-    assert(length <= 40 + len);
-    objmod.write_bytes(SegData[DEBSYM],debsym[0 .. length]);
+    cv8_udt(id, typidx);
+    // Record the source file and line where the type is defined
+    // (LF_UDT_SRC_LINE); the CV4 path has no equivalent record.
+    if (s)
+        cast(void)cv8_udt_src_line(typidx, s.loc.filename, s.loc.linnum);
 }
 
 /* ==================================================================== */
@@ -380,9 +306,9 @@ struct CvFieldList
 
     this(uint fields, uint len) scope
     {
-        canSplitList = config.fulltypes == CV8; // optlink bails out with LF_INDEX
-        fieldIndexLen = canSplitList ? (config.fulltypes == CV8 ? 2 + 2 + 4 : 2 + 2) : 0;
-        fieldLenMax = (config.fulltypes == CV8 ? CV8_NAMELENMAX : CV4_NAMELENMAX) - fieldIndexLen;
+        canSplitList = true; // optlink bails out with LF_INDEX
+        fieldIndexLen = 2 + 2 + 4;
+        fieldLenMax = CV8_NAMELENMAX - fieldIndexLen;
 
         assert(len < fieldLenMax);
         nfields = fields;
@@ -407,7 +333,7 @@ struct CvFieldList
         foreach (i, ref fld; fieldLists)
         {
             fld.dt = debtyp_alloc(fld.length + (i < fieldLists.length - 1 ? fieldIndexLen : 0));
-            TOWORD(fld.dt.data.ptr, config.fulltypes == CV8 ? LF_FIELDLIST_V2 : LF_FIELDLIST);
+            TOWORD(fld.dt.data.ptr, LF_FIELDLIST_V2);
             fld.writepos = 2;
         }
     }
@@ -444,17 +370,9 @@ struct CvFieldList
             if (typidx)
             {
                 ubyte* p = fld.dt.data.ptr + fld.writepos;
-                if (config.fulltypes == CV8)
-                {
-                    TOWORD (p, LF_INDEX_V2);
-                    TOWORD (p + 2, 0); // padding
-                    TOLONG (p + 4, typidx);
-                }
-                else
-                {
-                    TOWORD (p, LF_INDEX);
-                    TOWORD (p + 2, typidx);
-                }
+                TOWORD (p, LF_INDEX_V2);
+                TOWORD (p + 2, 0); // padding
+                TOLONG (p + 4, typidx);
             }
             typidx = cv_debtyp(fld.dt);
         }
@@ -521,30 +439,16 @@ void toDebug(StructDeclaration sd)
 
     const char* id = sd.toPrettyChars(true);
 
-    uint leaf = sd.isUnionDeclaration() ? LF_UNION : LF_STRUCTURE;
-    if (config.fulltypes == CV8)
-        leaf = leaf == LF_UNION ? LF_UNION_V3 : LF_STRUCTURE_V3;
+    uint leaf = sd.isUnionDeclaration() ? LF_UNION_V3 : LF_STRUCTURE_V3;
 
-    uint numidx;
-    final switch (leaf)
-    {
-        case LF_UNION:        numidx = 8;       break;
-        case LF_UNION_V3:     numidx = 10;      break;
-        case LF_STRUCTURE:    numidx = 12;      break;
-        case LF_STRUCTURE_V3: numidx = 18;      break;
-    }
+    uint numidx = leaf == LF_UNION_V3 ? 10 : 18;
 
     const len1 = numidx + cv4_numericbytes(cast(uint)size);
     debtyp_t* d = debtyp_alloc(len1 + cv_stringbytes(id));
     cv4_storenumeric(d.data.ptr + numidx, cast(uint)size);
     cv_namestring(d.data.ptr + len1, id);
 
-    if (leaf == LF_STRUCTURE)
-    {
-        TOWORD(d.data.ptr + 8,0);          // dList
-        TOWORD(d.data.ptr + 10,0);         // vshape is 0 (no virtual functions)
-    }
-    else if (leaf == LF_STRUCTURE_V3)
+    if (leaf == LF_STRUCTURE_V3)
     {
         TOLONG(d.data.ptr + 10,0);         // dList
         TOLONG(d.data.ptr + 14,0);         // vshape is 0 (no virtual functions)
@@ -560,18 +464,9 @@ void toDebug(StructDeclaration sd)
 
     if (!sd.members)                       // if reference only
     {
-        if (config.fulltypes == CV8)
-        {
-            TOWORD(d.data.ptr + 2,0);          // count: number of fields is 0
-            TOLONG(d.data.ptr + 6,0);          // field list is 0
-            TOWORD(d.data.ptr + 4,property);
-        }
-        else
-        {
-            TOWORD(d.data.ptr + 2,0);          // count: number of fields is 0
-            TOWORD(d.data.ptr + 4,0);          // field list is 0
-            TOWORD(d.data.ptr + 6,property);
-        }
+        TOWORD(d.data.ptr + 2,0);          // count: number of fields is 0
+        TOLONG(d.data.ptr + 6,0);          // field list is 0
+        TOWORD(d.data.ptr + 4,property);
         return /*typidx*/;
     }
 
@@ -599,18 +494,8 @@ void toDebug(StructDeclaration sd)
     const idx_t fieldlist = mc.debtyp();
 
     TOWORD(d.data.ptr + 2, nfields);
-    if (config.fulltypes == CV8)
-    {
-        TOWORD(d.data.ptr + 4,property);
-        TOLONG(d.data.ptr + 6,fieldlist);
-    }
-    else
-    {
-        TOWORD(d.data.ptr + 4,fieldlist);
-        TOWORD(d.data.ptr + 6,property);
-    }
-
-//    cv4_outsym(s);
+    TOWORD(d.data.ptr + 4,property);
+    TOLONG(d.data.ptr + 6,fieldlist);
 
     cv_udt(sd, id, typidx);
 
@@ -656,9 +541,8 @@ void toDebug(ClassDeclaration cd)
 //      property |= 0x20;               // class has overloaded assignment
 
     const id = cd.isCPPinterface() ? cd.ident.toChars() : cd.toPrettyChars(true);
-    const uint leaf = config.fulltypes == CV8 ? LF_CLASS_V3 : LF_CLASS;
-
-    const uint numidx = (leaf == LF_CLASS_V3) ? 18 : 12;
+    const uint leaf = LF_CLASS_V3;
+    const uint numidx = 18;
     const uint len1 = numidx + cv4_numericbytes(cast(uint)size);
     debtyp_t* d = debtyp_alloc(len1 + cv_stringbytes(id));
     cv4_storenumeric(d.data.ptr + numidx, cast(uint)size);
@@ -687,16 +571,8 @@ void toDebug(ClassDeclaration cd)
             vshapeidx = cv_debtyp(vshape);
         }
     }
-    if (leaf == LF_CLASS)
-    {
-        TOWORD(d.data.ptr + 8,0);          // dList
-        TOWORD(d.data.ptr + 10,vshapeidx);
-    }
-    else if (leaf == LF_CLASS_V3)
-    {
-        TOLONG(d.data.ptr + 10,0);         // dList
-        TOLONG(d.data.ptr + 14,vshapeidx);
-    }
+    TOLONG(d.data.ptr + 10,0);         // dList
+    TOLONG(d.data.ptr + 14,vshapeidx);
     TOWORD(d.data.ptr,leaf);
 
     // Assign a number to prevent infinite recursion if a struct member
@@ -708,18 +584,9 @@ void toDebug(ClassDeclaration cd)
 
     if (!cd.members)                       // if reference only
     {
-        if (leaf == LF_CLASS_V3)
-        {
-            TOWORD(d.data.ptr + 2,0);          // count: number of fields is 0
-            TOLONG(d.data.ptr + 6,0);          // field list is 0
-            TOWORD(d.data.ptr + 4,property);
-        }
-        else
-        {
-            TOWORD(d.data.ptr + 2,0);          // count: number of fields is 0
-            TOWORD(d.data.ptr + 4,0);          // field list is 0
-            TOWORD(d.data.ptr + 6,property);
-        }
+        TOWORD(d.data.ptr + 2,0);          // count: number of fields is 0
+        TOLONG(d.data.ptr + 6,0);          // field list is 0
+        TOWORD(d.data.ptr + 4,property);
         return /*typidx*/;
     }
 
@@ -770,22 +637,10 @@ void toDebug(ClassDeclaration cd)
                 const uint attribute = visibilityToCVAttr(Visibility.Kind.public_);
 
                 uint elementlen;
-                final switch (config.fulltypes)
-                {
-                    case CV8:
-                        TOWORD(p, LF_BCLASS_V2);
-                        TOWORD(p + 2,attribute);
-                        TOLONG(p + 4,typidx2);
-                        elementlen = 8;
-                        break;
-
-                    case CV4:
-                        TOWORD(p, LF_BCLASS);
-                        TOWORD(p + 2,typidx2);
-                        TOWORD(p + 4,attribute);
-                        elementlen = 6;
-                        break;
-                }
+                TOWORD(p, LF_BCLASS_V2);
+                TOWORD(p + 2,attribute);
+                TOLONG(p + 4,typidx2);
+                elementlen = 8;
 
                 cv4_storenumeric(p + elementlen, bc.offset);
                 elementlen += cv4_numericbytes(bc.offset);
@@ -800,18 +655,8 @@ void toDebug(ClassDeclaration cd)
 
     const idx_t fieldlist = mc.debtyp();
 
-    if (config.fulltypes == CV8)
-    {
-        TOWORD(d.data.ptr + 4,property);
-        TOLONG(d.data.ptr + 6,fieldlist);
-    }
-    else
-    {
-        TOWORD(d.data.ptr + 4,fieldlist);
-        TOWORD(d.data.ptr + 6,property);
-    }
-
-//    cv4_outsym(s);
+    TOWORD(d.data.ptr + 4,property);
+    TOLONG(d.data.ptr + 6,fieldlist);
 
     cv_udt(cd, id, typidx);
 
@@ -820,25 +665,13 @@ void toDebug(ClassDeclaration cd)
 
 private uint writeField(ubyte* p, const char* id, uint attr, uint typidx, uint offset)
 {
-    if (config.fulltypes == CV8)
-    {
-        TOWORD(p,LF_MEMBER_V3);
-        TOWORD(p + 2,attr);
-        TOLONG(p + 4,typidx);
-        cv4_storesignednumeric(p + 8, offset);
-        uint len = 8 + cv4_signednumericbytes(offset);
-        len += cv_namestring(p + len, id);
-        return cv_align(p + len, len);
-    }
-    else
-    {
-        TOWORD(p,LF_MEMBER);
-        TOWORD(p + 2,typidx);
-        TOWORD(p + 4,attr);
-        cv4_storesignednumeric(p + 6, offset);
-        uint len = 6 + cv4_signednumericbytes(offset);
-        return len + cv_namestring(p + len, id);
-    }
+    TOWORD(p,LF_MEMBER_V3);
+    TOWORD(p + 2,attr);
+    TOLONG(p + 4,typidx);
+    cv4_storesignednumeric(p + 8, offset);
+    uint len = 8 + cv4_signednumericbytes(offset);
+    len += cv_namestring(p + len, id);
+    return cv_align(p + len, len);
 }
 
 void toDebugClosure(Symbol* closstru)
@@ -850,8 +683,8 @@ void toDebugClosure(Symbol* closstru)
 
     assert(config.fulltypes >= CV4);
 
-    uint leaf = config.fulltypes == CV8 ? LF_STRUCTURE_V3 : LF_STRUCTURE;
-    uint numidx = leaf == LF_STRUCTURE ? 12 : 18;
+    uint leaf = LF_STRUCTURE_V3;
+    uint numidx = 18;
     uint structsize = cast(uint)(closstru.Sstruct.Sstructsize);
     const char* closname = closstru.Sident.ptr;
 
@@ -860,16 +693,8 @@ void toDebugClosure(Symbol* closstru)
     cv4_storenumeric(d.data.ptr + numidx, structsize);
     cv_namestring(d.data.ptr + len1, closname);
 
-    if (leaf == LF_STRUCTURE)
-    {
-        TOWORD(d.data.ptr + 8,0);          // dList
-        TOWORD(d.data.ptr + 10,0);         // vshape is 0 (no virtual functions)
-    }
-    else // LF_STRUCTURE_V3
-    {
-        TOLONG(d.data.ptr + 10,0);         // dList
-        TOLONG(d.data.ptr + 14,0);         // vshape is 0 (no virtual functions)
-    }
+    TOLONG(d.data.ptr + 10,0);         // dList
+    TOLONG(d.data.ptr + 14,0);         // vshape is 0 (no virtual functions)
     TOWORD(d.data.ptr,leaf);
 
     // Assign a number to prevent infinite recursion if a struct member
@@ -883,13 +708,10 @@ void toDebugClosure(Symbol* closstru)
     uint flistlen = 2;
     foreach (sf; closstru.Sstruct.Sfields)
     {
-        uint thislen = (config.fulltypes == CV8 ? 8 : 6);
+        uint thislen = 8;
         thislen += cv4_signednumericbytes(cast(uint)sf.Smemoff);
         thislen += cv_stringbytes(sf.Sident.ptr);
         thislen = cv_align(null, thislen);
-
-        if (config.fulltypes != CV8 && flistlen + thislen > CV4_NAMELENMAX)
-            break; // Too long, fail gracefully
 
         flistlen += thislen;
     }
@@ -899,7 +721,7 @@ void toDebugClosure(Symbol* closstru)
     ubyte* p = dt.data.ptr;
 
     // And fill it in
-    TOWORD(p, config.fulltypes == CV8 ? LF_FIELDLIST_V2 : LF_FIELDLIST);
+    TOWORD(p, LF_FIELDLIST_V2);
     uint flistoff = 2;
     foreach (sf; closstru.Sstruct.Sfields)
     {
@@ -915,16 +737,8 @@ void toDebugClosure(Symbol* closstru)
 
     uint property = 0;
     TOWORD(d.data.ptr + 2, cast(int)closstru.Sstruct.Sfields.length);
-    if (config.fulltypes == CV8)
-    {
-        TOWORD(d.data.ptr + 4,property);
-        TOLONG(d.data.ptr + 6,fieldlist);
-    }
-    else
-    {
-        TOWORD(d.data.ptr + 4,fieldlist);
-        TOWORD(d.data.ptr + 6,property);
-    }
+    TOWORD(d.data.ptr + 4,property);
+    TOLONG(d.data.ptr + 6,fieldlist);
 
     cv_udt(null, closname, typidx);
 }
@@ -965,39 +779,18 @@ private extern (C++) class CVMember : Visitor
         if (!p)
             result = cv_stringbytes(id);
 
-        switch (config.fulltypes)
+        if (!p)
         {
-            case CV8:
-                if (!p)
-                {
-                    result += 8;
-                    result = cv_align(null, result);
-                }
-                else
-                {
-                    TOWORD(p,LF_NESTTYPE_V3);
-                    TOWORD(p + 2,0);
-                    TOLONG(p + 4,typidx);
-                    result = 8 + cv_namestring(p + 8, id);
-                    result = cv_align(p + result, result);
-                }
-                break;
-
-            case CV4:
-                if (!p)
-                {
-                    result += 4;
-                }
-                else
-                {
-                    TOWORD(p,LF_NESTTYPE);
-                    TOWORD(p + 2,typidx);
-                    result = 4 + cv_namestring(p + 4, id);
-                }
-                break;
-
-            default:
-                assert(0);
+            result += 8;
+            result = cv_align(null, result);
+        }
+        else
+        {
+            TOWORD(p,LF_NESTTYPE_V3);
+            TOWORD(p + 2,0);
+            TOLONG(p + 4,typidx);
+            result = 8 + cv_namestring(p + 8, id);
+            result = cv_align(p + result, result);
         }
         debug
         {
@@ -1049,7 +842,7 @@ private extern (C++) class CVMember : Visitor
             // Allocate and fill it in
             debtyp_t* d = debtyp_alloc(mlen);
             ubyte* q = d.data.ptr;
-            TOWORD(q,config.fulltypes == CV8 ? LF_METHODLIST_V2 : LF_METHODLIST);
+            TOWORD(q,LF_METHODLIST_V2);
             q += 2;
     //      for (s = sf; s; s = s.Sfunc.Foversym)
             {
@@ -1102,24 +895,12 @@ private extern (C++) class CVMember : Visitor
             idx_t typidx = cv_debtyp(d);
             if (typidx)
             {
-                switch (config.fulltypes)
-                {
-                    case CV8:
-                        TOWORD(p,LF_METHOD_V3);
-                        goto Lmethod;
-                    case CV4:
-                        TOWORD(p,LF_METHOD);
-                    Lmethod:
-                        TOWORD(p + 2,count);
-                        result = 4;
-                        TOIDX(p + result, typidx);
-                        result += cgcv.sz_idx;
-                        result += cv_namestring(p + result, id);
-                        break;
-
-                    default:
-                        assert(0);
-                }
+                TOWORD(p,LF_METHOD_V3);
+                TOWORD(p + 2,count);
+                result = 4;
+                TOIDX(p + result, typidx);
+                result += cgcv.sz_idx;
+                result += cv_namestring(p + result, id);
             }
             result = cv_align(p + result, result);
             debug
@@ -1147,15 +928,13 @@ private extern (C++) class CVMember : Visitor
         {
             if (vd.isField())
             {
-                if (config.fulltypes == CV8)
-                    result += 2;
+                result += 2;
                 result += 6 + cv_stringbytes(id);
                 result += cv4_numericbytes(vd.offset);
             }
             else if (staticMember)
             {
-                if (config.fulltypes == CV8)
-                    result += 2;
+                result += 2;
                 result += 6 + cv_stringbytes(id);
             }
             result = cv_align(null, result);
@@ -1166,69 +945,32 @@ private extern (C++) class CVMember : Visitor
             if (auto bfd = vd.isBitFieldDeclaration())
             {
                 debtyp_t* db;
-                if (config.fulltypes == CV4)
-                {
-                    db = debtyp_alloc(6);
-                    TOWORD(db.data.ptr, LF_BITFIELD);
-                    db.data.ptr[2] = cast(ubyte) bfd.fieldWidth;
-                    db.data.ptr[3] = cast(ubyte) bfd.bitOffset;
-                    TOWORD(db.data.ptr + 4, typidx);
-                }
-                else
-                {   db = debtyp_alloc(8);
-                    TOWORD(db.data.ptr, LF_BITFIELD_V2);
-                    db.data.ptr[6] = cast(ubyte) bfd.fieldWidth;
-                    db.data.ptr[7] = cast(ubyte) bfd.bitOffset;
-                    TOLONG(db.data.ptr + 2, typidx);
-                }
+                db = debtyp_alloc(8);
+                TOWORD(db.data.ptr, LF_BITFIELD_V2);
+                db.data.ptr[6] = cast(ubyte) bfd.fieldWidth;
+                db.data.ptr[7] = cast(ubyte) bfd.bitOffset;
+                TOLONG(db.data.ptr + 2, typidx);
                 typidx = cv_debtyp(db);
             }
             uint attribute = visibilityToCVAttr(vd.visible().kind);
             assert((attribute & ~3) == 0);
-            switch (config.fulltypes)
+
+            if (vd.isField())
             {
-                case CV8:
-                    if (vd.isField())
-                    {
-                        TOWORD(p,LF_MEMBER_V3);
-                        TOWORD(p + 2,attribute);
-                        TOLONG(p + 4,typidx);
-                        cv4_storenumeric(p + 8, vd.offset);
-                        result = 8 + cv4_numericbytes(vd.offset);
-                        result += cv_namestring(p + result, id);
-                    }
-                    else if (staticMember)
-                    {
-                        TOWORD(p,LF_STMEMBER_V3);
-                        TOWORD(p + 2,attribute);
-                        TOLONG(p + 4,typidx);
-                        result = 8;
-                        result += cv_namestring(p + result, id);
-                    }
-                    break;
-
-                case CV4:
-                    if (vd.isField())
-                    {
-                        TOWORD(p,LF_MEMBER);
-                        TOWORD(p + 2,typidx);
-                        TOWORD(p + 4,attribute);
-                        cv4_storenumeric(p + 6, vd.offset);
-                        result = 6 + cv4_numericbytes(vd.offset);
-                        result += cv_namestring(p + result, id);
-                    }
-                    else if (staticMember)
-                    {
-                        TOWORD(p,LF_STMEMBER);
-                        TOWORD(p + 2,typidx);
-                        TOWORD(p + 4,attribute);
-                        result = 6;
-                        result += cv_namestring(p + result, id);
-                    }
-                    break;
-
-                 default:
-                    assert(0);
+                TOWORD(p,LF_MEMBER_V3);
+                TOWORD(p + 2,attribute);
+                TOLONG(p + 4,typidx);
+                cv4_storenumeric(p + 8, vd.offset);
+                result = 8 + cv4_numericbytes(vd.offset);
+                result += cv_namestring(p + result, id);
+            }
+            else if (staticMember)
+            {
+                TOWORD(p,LF_STMEMBER_V3);
+                TOWORD(p + 2,attribute);
+                TOLONG(p + 4,typidx);
+                result = 8;
+                result += cv_namestring(p + result, id);
             }
 
             result = cv_align(p + result, result);


### PR DESCRIPTION
CV4 was only selected by removed OMF. This is just removing dead code, some more cleanup could be done, e.g. combining declaration and assignment of variables that are now unconditional.

@WalterBright are you ok with this?

FYI @LightBender 