### PR TITLE
add checking for out of bounds symbol index

### DIFF
--- a/compiler/src/dmd/backend/mach.d
+++ b/compiler/src/dmd/backend/mach.d
@@ -444,8 +444,11 @@ struct relocation_info  // https://developer.apple.com/documentation/kernel/relo
     void r_extern   (uint r) { assert(!(r & ~1));           xxx = (xxx & ~0x0800_0000) | (r << (24 + 1 + 2)); }
     void r_type     (uint r) { assert(!(r & ~0xF));         xxx = (xxx & ~0xF000_0000) | (r << (24 + 1 + 2 + 1)); }
 
-    uint r_pcrel() { return (xxx >> 24) &   1; }
-    uint r_type()  { return (xxx >> 28) & 0xF; }
+    uint r_symbolnum() { return (xxx & 0x00FF_FFFF); }
+    uint r_pcrel    () { return (xxx >> 24) &   1; }
+    uint r_length   () { return (xxx >> 25) &   3; }
+    uint r_extern   () { return (xxx >> 27) &   1; }
+    uint r_type     () { return (xxx >> 28) & 0xF; }
 }
 
 struct scattered_relocation_info

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -556,9 +556,11 @@ void patch(seg_data* pseg, targ_size_t offset, int seg, targ_size_t value)
 /***************************
  * Number symbols so they are
  * ordered as locals, public and then extern/comdef
+ * Return:
+ *      nsyms (number of symbols)
  */
 @trusted
-void mach_numbersyms()
+int mach_numbersyms()
 {
     //printf("mach_numbersyms()\n");
     int n = 0;
@@ -591,6 +593,8 @@ void mach_numbersyms()
         c.sym.Sxtrnnum = n;
         n++;
     }
+    //printf("n: %d\n", n);
+    return n;
 }
 
 
@@ -869,7 +873,7 @@ void MachObj_term(const(char)[] objfilename)
     // Put out relocation data
     // See mach-o/reloc.h for some examples of what should be generated and when:
     // https://github.com/apple-oss-distributions/xnu/blob/rel/xnu-10002/EXTERNAL_HEADERS/mach-o/x86_64/reloc.h
-    mach_numbersyms();
+    int nsyms = mach_numbersyms();
     for (int seg = 1; seg < SegData.length; seg++)
     {
         static if (0)
@@ -938,6 +942,8 @@ void MachObj_term(const(char)[] objfilename)
                             rel.r_pcrel = 0;
                             rel.r_length = 3;
                             rel.r_extern = r.funcsym.Sclass == SC.locstat ? 0 : 1;
+                            if (rel.r_extern == 1)
+                                assert(s.Sxtrnnum < nsyms);
                             machobj.fobjbuf.write(&rel, rel.sizeof);
                             foffset += (rel).sizeof;
                             ++nreloc;
@@ -992,6 +998,7 @@ void MachObj_term(const(char)[] objfilename)
                                         goto case SC.global;
                                     rel.r_address = cast(int)r.offset;
                                     rel.r_symbolnum = s.Sxtrnnum;
+                                    assert(s.Sxtrnnum < nsyms);
                                     rel.r_length = 2;
                                     rel.r_extern = 1;
                                     machobj.fobjbuf.write(&rel, rel.sizeof);
@@ -1010,6 +1017,7 @@ void MachObj_term(const(char)[] objfilename)
                                     rel.r_pcrel = r.rtype == REL.add ? 0 : 1;
                                     rel.r_address = cast(int)r.offset;
                                     rel.r_symbolnum = s.Sxtrnnum;
+                                    assert(s.Sxtrnnum < nsyms);
                                     rel.r_length = 2;
                                     rel.r_extern = 1;
                                     machobj.fobjbuf.write(&rel, rel.sizeof);
@@ -1025,6 +1033,7 @@ void MachObj_term(const(char)[] objfilename)
                                     rel.r_pcrel = r.rtype == REL.add ? 0 : 1;
                                     rel.r_address = cast(int)r.offset;
                                     rel.r_symbolnum = s.Sxtrnnum;
+                                    assert(s.Sxtrnnum < nsyms);
                                     rel.r_length = 2;
                                     rel.r_extern = 1; // 0?
                                     machobj.fobjbuf.write(&rel, rel.sizeof);
@@ -1037,6 +1046,7 @@ void MachObj_term(const(char)[] objfilename)
                                     assert(0);
                             }
                             //dumpFixup(*s, rel.r_type);
+                            //assert(rel.r_address < section.size);
 
                             /* Ensure relocation matches instruction */
                             //import dmd.backend.x86.cgcod : disassemble;
@@ -1069,6 +1079,7 @@ static if (0)
                             {
                                 rel.r_address = cast(int)r.offset;
                                 rel.r_symbolnum = s.Sxtrnnum;
+                                assert(s.Sxtrnnum < nsyms);
                                 rel.r_pcrel = 0;
                                 rel.r_length = 3;
                                 rel.r_extern = 1;
@@ -1087,6 +1098,7 @@ static if (0)
                             {
                                 rel.r_address = cast(int)r.offset;
                                 rel.r_symbolnum = s.Sxtrnnum;
+                                assert(s.Sxtrnnum < nsyms);
                                 if (r.rtype == REL.rel)
                                 {
                                     rel.r_pcrel = 1;
@@ -2011,8 +2023,8 @@ int MachObj_comdat(Symbol* s)
     int flags;
 
     //printf("MachObj_comdat(Symbol* %s)\n",s.Sident.ptr);
-    //symbol_print(s);
-    symbol_debug(s);
+    //symbol_print(*s);
+    //symbol_debug(s);
 
     if (tyfunc(s.ty()))
     {


### PR DESCRIPTION
I was getting a crash in the Mac ld linker over the symbol indices being out of range. So I added asserts to find them, and the problem with ld went away. Hmmpf. But, anyway, it's good to add the sanity checks.

On to the next crash in ld. Sigh.

I also get weird warnings from ld, and randomly false information from chatgpt on how the object files are supposed to work.