### PR TITLE
Provide closefrom on NetBSD

### DIFF
--- a/druntime/src/core/sys/netbsd/unistd.d
+++ b/druntime/src/core/sys/netbsd/unistd.d
@@ -1,0 +1,19 @@
+//Written in the D programming language
+
+/++
+    D header file for NetBSD's extensions to POSIX's unistd.h.
+
+    Copyright: Copyright 2018
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)
+ +/
+module core.sys.netbsd.unistd;
+
+public import core.sys.posix.unistd;
+
+version (NetBSD):
+extern(C):
+@nogc:
+nothrow:
+
+void closefrom(int);


### PR DESCRIPTION
When testing D in the GCC tree on NetBSD/amd64, every test using the shared libgphobos fails to run:

	libgphobos.so: undefined reference to `dirfd'

NetBSD has the same issue as FreeBSD and OpenBSD: dirfd is a macro in dirent.h.  Just like those two, this patch provides closefrom in druntime.

Tested on amd64-pc-netbsd10.1.

I'll post a companion phobos patch to use this immediately.