### PR TITLE
Provide largefile version of statvfs on Solaris

### DIFF
--- a/druntime/src/core/sys/posix/sys/statvfs.d
+++ b/druntime/src/core/sys/posix/sys/statvfs.d
@@ -9,6 +9,7 @@
  +/
 module core.sys.posix.sys.statvfs;
 import core.stdc.config;
+import core.stdc.stdint;
 import core.sys.posix.config;
 public import core.sys.posix.sys.types;
 
@@ -283,6 +284,105 @@ else version (FreeBSD)
     {
         pragma(mangle, "fstatvfs@FBSD_1.0") int fstatvfs(int, statvfs_t*);
         pragma(mangle, "statvfs@FBSD_1.0")  int statvfs(const char*, statvfs_t*);
+    }
+}
+else version (Solaris)
+{
+    private enum _FSTYPSZ = 16;
+
+    version (D_LP64)
+    {
+        struct statvfs_t
+        {
+            c_ulong f_bsize;
+            c_ulong f_frsize;
+            fsblkcnt_t f_blocks;
+            fsblkcnt_t f_bfree;
+            fsblkcnt_t f_bavail;
+            fsfilcnt_t f_files;
+            fsfilcnt_t f_ffree;
+            fsfilcnt_t f_favail;
+            c_ulong f_fsid;
+            char[_FSTYPSZ] f_basetype;
+            c_ulong f_flag;
+            c_ulong f_namemax;
+            char[32] f_fstr;
+        }
+
+        static if (__USE_LARGEFILE64) alias statvfs64_t = statvfs_t;
+    }
+    else
+    {
+        struct statvfs_t
+        {
+            c_ulong f_bsize;
+            c_ulong f_frsize;
+            fsblkcnt_t f_blocks;
+            fsblkcnt_t f_bfree;
+            fsblkcnt_t f_bavail;
+            fsfilcnt_t f_files;
+            fsfilcnt_t f_ffree;
+            fsfilcnt_t f_favail;
+            c_ulong f_fsid;
+            char[_FSTYPSZ] f_basetype;
+            c_ulong f_flag;
+            c_ulong f_namemax;
+            char[32] f_fstr;
+            char[16] f_filler;
+        }
+
+        struct statvfs64_t
+        {
+            c_ulong f_bsize;
+            c_ulong f_frsize;
+            fsblkcnt64_t f_blocks;
+            fsblkcnt64_t f_bfree;
+            fsblkcnt64_t f_bavail;
+            fsfilcnt64_t f_files;
+            fsfilcnt64_t f_ffree;
+            fsfilcnt64_t f_favail;
+            c_ulong f_fsid;
+            char[_FSTYPSZ] f_basetype;
+            c_ulong f_flag;
+            c_ulong f_namemax;
+            char[32] f_fstr;
+            uint32_t[16] f_filler;
+        }
+    }
+
+    enum FFlag
+    {
+        ST_RDONLY = 1,           /* read-only file system */
+        ST_NOSUID = 2,           /* does not support setuid/setgid semantics */
+        ST_NOTRUNC = 4           /* does not truncate long file names */
+    }
+
+    version (D_LP64)
+    {
+        int statvfs (const char * file, statvfs_t* buf);
+        int fstatvfs (int fildes, statvfs_t *buf);
+
+        static if (__USE_LARGEFILE64)
+        {
+            alias statvfs64 = statvfs;
+            alias fstatvfs64 = fstatvfs;
+        }
+    }
+    else
+    {
+        static if (__USE_LARGEFILE64)
+        {
+            int statvfs64 (const char * file, statvfs_t* buf);
+            alias statvfs = statvfs64;
+
+            int fstatvfs64 (int fildes, statvfs_t *buf);
+            alias fstatvfs = fstatvfs64;
+        }
+        else
+        {
+            int statvfs (const char * file, statvfs_t* buf);
+            int fstatvfs (int fildes, statvfs_t *buf);
+        }
     }
 }
 else

--- a/druntime/src/core/sys/posix/sys/types.d
+++ b/druntime/src/core/sys/posix/sys/types.d
@@ -288,6 +288,9 @@ else version (DragonFlyBSD)
 }
 else version (Solaris)
 {
+    alias longlong_t = __c_longlong;
+    alias u_longlong_t = __c_ulonglong;
+
     alias caddr_t = char*;
     alias daddr_t = c_long;
     alias cnt_t = short;
@@ -297,12 +300,16 @@ else version (Solaris)
         alias blkcnt_t = long;
         alias ino_t = ulong;
         alias off_t = long;
+        alias fsblkcnt_t = u_longlong_t;
+        alias fsfilcnt_t = u_longlong_t;
     }
     else
     {
         alias blkcnt_t = c_long;
         alias ino_t = c_ulong;
         alias off_t = c_long;
+        alias fsblkcnt_t = ulong_t;
+        alias fsfilcnt_t = ulong_t;
     }
 
     version (D_LP64)
@@ -310,12 +317,18 @@ else version (Solaris)
         alias blkcnt64_t = blkcnt_t;
         alias ino64_t = ino_t;
         alias off64_t = off_t;
+        alias fsblkcnt64_t = fsblkcnt_t;
+        alias fsfilcnt64_t = fsfilcnt_t;
     }
     else
     {
         alias blkcnt64_t = long;
         alias ino64_t = ulong;
         alias off64_t = long;
+        alias fsblkcnt32_t = uint32_t;
+        alias fsfilcnt32_t = uint32_t;
+        alias fsblkcnt64_t = ulong;
+        alias fsfilcnt64_t = ulong;
     }
 
     alias blksize_t = uint;
@@ -442,17 +455,6 @@ else version (DragonFlyBSD)
 }
 else version (Solaris)
 {
-    static if (__USE_FILE_OFFSET64)
-    {
-        alias fsblkcnt_t = ulong;
-        alias fsfilcnt_t = ulong;
-    }
-    else
-    {
-        alias fsblkcnt_t = c_ulong;
-        alias fsfilcnt_t = c_ulong;
-    }
-
     alias clock_t = c_long;
     alias id_t = int;
     alias key_t = int;


### PR DESCRIPTION
When testing libphobos on Solaris, the 32-bit version of the `libphobos.phobos/std_file.d` execution test fails regularly:

```
FAIL: libphobos.phobos/std_file.d execution test

std.file.FileException@std/file.d(5507): Cannot get available disk space: Value too large for defined data type
```

This `EOVERFLOW` error happens because the Solaris version of `statvfs` isn't largefile aware.  This patch fixes this.

Tested on `i386-pc-solaris2.11` and `sparc-sun-solaris2.11`.