### PR TITLE
Fix Issue 23326 - Lambda missing parens in generated D import file

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -1879,19 +1879,10 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         if (!hgs.errorMsg)
             tf.attributesApply(&printAttribute);
 
-        CompoundStatement cs = f.fbody.isCompoundStatement();
-        Statement s1;
-        if (f.semanticRun >= PASS.semantic3done && cs)
-        {
-            s1 = (*cs.statements)[cs.statements.length - 1];
-        }
-        else
-            s1 = !cs ? f.fbody : null;
-        ReturnStatement rs = s1 ? s1.endsWithReturnStatement() : null;
-        if (rs && rs.exp)
+        if (auto result = arrowFuncLiteralResult(f))
         {
             buf.put(" => ");
-            rs.exp.expressionToBuffer(buf, hgs);
+            result.expressionToBuffer(buf, hgs);
         }
         else
         {
@@ -3863,6 +3854,28 @@ private void expressionToBuffer(Expression e, ref OutBuffer buf, ref HdrGenState
     expressionPrettyPrint(e, buf, hgs);
 }
 
+/**************************************************
+ * Returns the expression result if `f` is printed with `=>` syntax, otherwise `null`.
+ *
+ * Arrow function literals have an AssignExpression body, so they bind less tightly
+ * than postfix operators and must be parenthesized when used as a call callee etc.
+ */
+private Expression arrowFuncLiteralResult(FuncLiteralDeclaration f)
+{
+    if (!f.fbody)
+        return null;
+
+    CompoundStatement cs = f.fbody.isCompoundStatement();
+    Statement s1;
+    if (f.semanticRun >= PASS.semantic3done && cs)
+        s1 = (*cs.statements)[cs.statements.length - 1];
+    else
+        s1 = !cs ? f.fbody : null;
+
+    ReturnStatement rs = s1 ? s1.endsWithReturnStatement() : null;
+    return rs && rs.exp ? rs.exp : null;
+}
+
 // to be called if e could be loweredFrom another expression instead of acessing precedence[e.op] directly
 private PREC expPrecedence(ref HdrGenState hgs, Expression e)
 {
@@ -3876,6 +3889,13 @@ private PREC expPrecedence(ref HdrGenState hgs, Expression e)
         else if (auto ne = e.isNotExp())
             if (ne.loweredFrom)
                 e = ne.loweredFrom;
+    }
+    // https://github.com/dlang/dmd/issues/23326
+    // Arrow lambdas are not true primaries; treat like assign-level expressions for paren insertion.
+    if (auto fe = e.isFuncExp())
+    {
+        if (fe.fd && arrowFuncLiteralResult(fe.fd))
+            return PREC.assign;
     }
     return precedence[e.op];
 }

--- a/compiler/test/compilable/header23326.d
+++ b/compiler/test/compilable/header23326.d
@@ -1,0 +1,18 @@
+/*
+REQUIRED_ARGS: -o- -Hf${RESULTS_DIR}/compilable/header23326.di
+OUTPUT_FILES: ${RESULTS_DIR}/compilable/header23326.di
+
+TEST_OUTPUT:
+---
+=== ${RESULTS_DIR}/compilable/header23326.di
+// D import file generated from 'compilable/header23326.d'
+enum i = ((x) => x * 2)(3);
+enum j = ((x) => x * 2)(4);
+extern typeof(((x) => x * 2)(5)) d;
+---
+*/
+
+// https://github.com/dlang/dmd/issues/23326
+enum i = (x => x * 2)(3);
+enum j = ((x) => x * 2)(4);
+auto d = (x => x * 2)(5);

--- a/compiler/test/fail_compilation/ice10259.d
+++ b/compiler/test/fail_compilation/ice10259.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice10259.d(11): Error: circular reference to `ice10259.D.d`
-fail_compilation/ice10259.d(11):        called from here: `(*function () pure nothrow @safe => x)()`
+fail_compilation/ice10259.d(11):        called from here: `(*(function () pure nothrow @safe => x))()`
 ---
 */
 class D
@@ -16,7 +16,7 @@ enum x = new D;
 TEST_OUTPUT:
 ---
 fail_compilation/ice10259.d(25): Error: circular reference to `ice10259.D2.d`
-fail_compilation/ice10259.d(25):        called from here: `(*function () pure nothrow @safe => x)()`
+fail_compilation/ice10259.d(25):        called from here: `(*(function () pure nothrow @safe => x))()`
 ---
 */
 class D2

--- a/compiler/test/fail_compilation/test23170.d
+++ b/compiler/test/fail_compilation/test23170.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test23170.d(10): Error: this array literal causes a GC allocation in `@nogc` delegate `() => (*(int[] array) => id(array))([1, 2, 3])`
+fail_compilation/test23170.d(10): Error: this array literal causes a GC allocation in `@nogc` delegate `() => (*((int[] array) => id(array)))([1, 2, 3])`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=23170

--- a/compiler/test/fail_compilation/test23185.d
+++ b/compiler/test/fail_compilation/test23185.d
@@ -4,7 +4,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/test23185.d(11): Error: no `default` or `case` for `3` in `switch` statement
-fail_compilation/test23185.d(15):        called from here: `(*function () pure nothrow @nogc @safe => 0)()`
+fail_compilation/test23185.d(15):        called from here: `(*(function () pure nothrow @nogc @safe => 0))()`
 ---
 */
 enum x = () {

--- a/compiler/test/fail_compilation/test24036.d
+++ b/compiler/test/fail_compilation/test24036.d
@@ -5,7 +5,7 @@ Issue 24036 - assert message in CTFE becomes `['m', 'e', 's', 's', 'a', 'g', 'e'
 TEST_OUTPUT:
 ---
 fail_compilation/test24036.d(19): Error: message
-fail_compilation/test24036.d(21):        called from here: `(*function () pure nothrow @safe => 42)()`
+fail_compilation/test24036.d(21):        called from here: `(*(function () pure nothrow @safe => 42))()`
 ---
 */
 

--- a/compiler/test/fail_compilation/traits_initSymbol.d
+++ b/compiler/test/fail_compilation/traits_initSymbol.d
@@ -21,7 +21,7 @@ void test1()
 TEST_OUTPUT:
 ---
 fail_compilation/traits_initSymbol.d(203): Error: cannot determine the address of the initializer symbol during CTFE
-fail_compilation/traits_initSymbol.d(203):        called from here: `(*function () pure nothrow @nogc @safe => S)()`
+fail_compilation/traits_initSymbol.d(203):        called from here: `(*(function () pure nothrow @nogc @safe => S))()`
 ---
 */
 #line 200


### PR DESCRIPTION
## Summary

- Fix `.di` / hdrgen output for immediately-invoked arrow lambdas so the call stays outside the lambda body.
- Arrow `=>` literals are treated as assign-level expressions for parenthesis insertion (they are not true primaries), matching how D parses `=> AssignExpression`.
- Add `compilable/header23326.d` covering called arrow lambdas in `enum` and `auto` initializers.

Fixes #23326

## Test plan

- [x] `./build.d` (compiler rebuild)
- [x] `./run.d compilable/header23326.d`
- [x] Spot-check: `dmd -H -c -o-` on `(x => x * 2)(3)` produces `enum i = ((x) => x * 2)(3);`
- [x] Generated form `((x) => x * 2)(3)` evaluates to `6` / `8` under `static assert`