### PR TITLE
reduce size of Array!T from 32 to 16 bytes

### DIFF
--- a/compiler/include/dmd/root/array.h
+++ b/compiler/include/dmd/root/array.h
@@ -14,27 +14,32 @@
 template <typename TYPE>
 struct Array
 {
-    d_size_t length;
+    uint32_t length;
 
   private:
-    DArray<TYPE> data;
+    uint32_t allocated;
     #define SMALLARRAYCAP       1
-    TYPE smallarray[SMALLARRAYCAP];    // inline storage for small arrays
+    union
+    {
+        TYPE smallarray[SMALLARRAYCAP];    // inline storage for small arrays
+        TYPE* _ptr;
+    };
+    TYPE* data() { return allocated <= SMALLARRAYCAP ? smallarray : _ptr; }
+    const TYPE* data() const { return allocated <= SMALLARRAYCAP ? smallarray : _ptr; }
 
     Array(const Array&);
 
   public:
     Array()
     {
-        data.ptr = nullptr;
         length = 0;
-        data.length = 0;
+        allocated = SMALLARRAYCAP;
     }
 
     ~Array()
     {
-        if (data.ptr != &smallarray[0])
-            mem.xfree(data.ptr);
+        if (allocated > SMALLARRAYCAP)
+            mem.xfree(_ptr);
     }
 
     char *toChars() const
@@ -43,7 +48,7 @@ struct Array
         d_size_t len = 2;
         for (d_size_t u = 0; u < length; u++)
         {
-            buf[u] = ((TYPE)data.ptr[u])->toChars();
+            buf[u] = (data()[u])->toChars();
             len += strlen(buf[u]) + 1;
         }
         char *str = (char *)mem.xmalloc(len);
@@ -67,7 +72,7 @@ struct Array
     void push(TYPE ptr)
     {
         reserve(1);
-        data.ptr[length++] = ptr;
+        data()[length++] = ptr;
     }
 
     void append(Array *a)
@@ -77,38 +82,38 @@ struct Array
 
     void reserve(d_size_t nentries)
     {
-        //printf("Array::reserve: length = %d, data.length = %d, nentries = %d\n", (int)length, (int)data.length, (int)nentries);
-        if (data.length - length < nentries)
+        //printf("Array::reserve: length = %d, allocated = %d, nentries = %d\n", (int)length, (int)allocated, (int)nentries);
+        if (allocated - length < nentries)
         {
-            if (data.length == 0)
+            if (allocated == 0)
             {
                 // Not properly initialized, someone memset it to zero
                 if (nentries <= SMALLARRAYCAP)
                 {
-                    data.length = SMALLARRAYCAP;
-                    data.ptr = SMALLARRAYCAP ? &smallarray[0] : nullptr;
+                    allocated = SMALLARRAYCAP;
                 }
                 else
                 {
-                    data.length = nentries;
-                    data.ptr = (TYPE *)mem.xmalloc(data.length * sizeof(TYPE));
+                    allocated = nentries;
+                    _ptr = (TYPE *)mem.xmalloc(allocated * sizeof(TYPE));
                 }
             }
-            else if (data.length == SMALLARRAYCAP)
+            else if (allocated <= SMALLARRAYCAP)
             {
-                data.length = length + nentries;
-                data.ptr = (TYPE *)mem.xmalloc(data.length * sizeof(TYPE));
-                memcpy(data.ptr, &smallarray[0], length * sizeof(TYPE));
+                allocated = length + nentries;
+                TYPE* p = (TYPE *)mem.xmalloc(allocated * sizeof(TYPE));
+                memcpy(p, &smallarray[0], length * sizeof(TYPE));
+                _ptr = p;
             }
             else
             {
                 /* Increase size by 1.5x to avoid excessive memory fragmentation
                  */
-                d_size_t increment = length / 2;
+                auto increment = length / 2;
                 if (nentries > increment)       // if 1.5 is not enough
-                    increment = nentries;
-                data.length = length + increment;
-                data.ptr = (TYPE *)mem.xrealloc(data.ptr, data.length * sizeof(TYPE));
+                    increment = (uint32_t)nentries;
+                allocated = length + increment;
+                _ptr = (TYPE *)mem.xrealloc(_ptr, allocated * sizeof(TYPE));
             }
         }
     }
@@ -116,7 +121,7 @@ struct Array
     void remove(d_size_t i)
     {
         if (length - i - 1)
-            memmove(data.ptr + i, data.ptr + i + 1, (length - i - 1) * sizeof(TYPE));
+            memmove(data() + i, data() + i + 1, (length - i - 1) * sizeof(TYPE));
         length--;
     }
 
@@ -124,11 +129,11 @@ struct Array
     {
         if (a)
         {
-            d_size_t d = a->length;
+            auto d = a->length;
             reserve(d);
             if (length != index)
-                memmove(data.ptr + index + d, data.ptr + index, (length - index) * sizeof(TYPE));
-            memcpy(data.ptr + index, a->data.ptr, d * sizeof(TYPE));
+                memmove(data() + index + d, data() + index, (length - index) * sizeof(TYPE));
+            memcpy(data() + index, a->data(), d * sizeof(TYPE));
             length += d;
         }
     }
@@ -136,8 +141,8 @@ struct Array
     void insert(d_size_t index, TYPE ptr)
     {
         reserve(1);
-        memmove(data.ptr + index + 1, data.ptr + index, (length - index) * sizeof(TYPE));
-        data.ptr[index] = ptr;
+        memmove(data() + index + 1, data() + index, (length - index) * sizeof(TYPE));
+        data()[index] = ptr;
         length++;
     }
 
@@ -154,7 +159,7 @@ struct Array
     {
         for (d_size_t i = 0; i < length; i++)
         {
-            if (data.ptr[i] == ptr)
+            if (data()[i] == ptr)
                 return i;
         }
         return SIZE_MAX;
@@ -170,37 +175,37 @@ struct Array
 #ifdef DEBUG
         assert(index < length);
 #endif
-        return data.ptr[index];
+        return data()[index];
     }
 
     TYPE *tdata()
     {
-        return data.ptr;
+        return data();
     }
 
     Array *copy()
     {
         Array *a = new Array();
         a->setDim(length);
-        memcpy(a->data.ptr, data.ptr, length * sizeof(TYPE));
+        memcpy(a->data(), data(), length * sizeof(TYPE));
         return a;
     }
 
     void shift(TYPE ptr)
     {
         reserve(1);
-        memmove(data.ptr + 1, data.ptr, length * sizeof(TYPE));
-        data.ptr[0] = ptr;
+        memmove(data() + 1, data(), length * sizeof(TYPE));
+        data()[0] = ptr;
         length++;
     }
 
     void zero()
     {
-        memset(data.ptr, 0, length * sizeof(TYPE));
+        memset(data(), 0, length * sizeof(TYPE));
     }
 
     TYPE pop()
     {
-        return data.ptr[--length];
+        return data()[--length];
     }
 };

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6894,7 +6894,7 @@ private Expression interpret_aaDel(UnionExp* pue, InterState* istate, Expression
     AssocArrayLiteralExp aae = agg.isAssocArrayLiteralExp();
     Expressions* keysx = aae.keys;
     Expressions* valuesx = aae.values;
-    size_t removed = 0;
+    uint removed = 0;
     foreach (j, evalue; *valuesx)
     {
         Expression ekey = (*keysx)[j];

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -5083,7 +5083,7 @@ void highlightCode(Scope* sc, Dsymbols* a, ref OutBuffer buf, size_t offset)
 
                 // build the template parameters
                 Array!(size_t) paramLens;
-                paramLens.reserve(td.parameters.length);
+                paramLens.setDim(td.parameters.length);
 
                 OutBuffer parametersBuf;
                 HdrGenState hgs;

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -29,12 +29,17 @@ debug
 
 extern (C++) struct Array(T)
 {
-    size_t length;
+    uint length;
 
 private:
-    T[] data;
     enum SMALLARRAYCAP = 1;
-    T[SMALLARRAYCAP] smallarray; // inline storage for small arrays
+    uint allocated = SMALLARRAYCAP;
+    union
+    {
+        T[SMALLARRAYCAP] smallarray; // inline storage for small arrays
+        T* _ptr;
+    }
+    extern(D) inout(T)* data() inout pure nothrow { return allocated <= SMALLARRAYCAP ? smallarray.ptr : _ptr; }
 
 public:
     /*******************
@@ -44,7 +49,7 @@ public:
     this(size_t dim) pure nothrow scope
     {
         reserve(dim);
-        this.length = dim;
+        this.length = cast(uint)dim;
     }
 
     @disable this(this);
@@ -53,13 +58,14 @@ public:
     {
         debug (stomp)
         {
-            if (data.ptr)
-                memset(data.ptr, 0xFF, data.length * T.sizeof);
+            if (allocated > SMALLARRAYCAP)
+                memset(_ptr, 0xFF, allocated * T.sizeof);
         }
-        if (data.ptr && data.ptr != &smallarray[0])
-            mem.xfree(data.ptr);
+        if (allocated > SMALLARRAYCAP)
+            mem.xfree(_ptr);
     }
 
+@trusted:
     // this is using a template constraint because of ambiguity with this(size_t) when T is
     // int, and c++ header generation doesn't accept wrapping this in static if
     extern(D) this()(T[] elems ...) pure nothrow if (is(T == struct) || is(T == class))
@@ -152,7 +158,7 @@ public:
     {
         const oldLength = length;
         setDim(oldLength + a.length);
-        memcpy(data.ptr + oldLength, a.ptr, a.length * T.sizeof);
+        memcpy(data + oldLength, a.ptr, a.length * T.sizeof);
         return this;
     }
 
@@ -164,31 +170,32 @@ public:
 
     void reserve(size_t nentries) pure nothrow
     {
-        //printf("Array::reserve: length = %d, data.length = %d, nentries = %d\n", cast(int)length, cast(int)data.length, cast(int)nentries);
+        //printf("Array::reserve: length = %u, allocated = %u, nentries = %d\n", length, allocated, cast(int)nentries);
 
         // Cold path
         void enlarge(size_t nentries)
         {
+            static if (uint.max < size_t.max)
+                assert(length + nentries <= uint.max);
+
             pragma(inline, false);      // never inline cold path
-            if (data.length == 0)
+            if (allocated == 0)
             {
                 // Not properly initialized, someone memset it to zero
-                if (nentries <= SMALLARRAYCAP)
-                {
-                    data = SMALLARRAYCAP ? smallarray[] : null;
-                }
-                else
+                if (nentries > SMALLARRAYCAP)
                 {
                     auto p = cast(T*)mem.xmalloc(nentries * T.sizeof);
-                    data = p[0 .. nentries];
+                    _ptr = p;
                 }
+                allocated = cast(uint)nentries;
             }
-            else if (data.length == SMALLARRAYCAP)
+            else if (allocated <= SMALLARRAYCAP)
             {
                 const allocdim = length + nentries;
                 auto p = cast(T*)mem.xmalloc(allocdim * T.sizeof);
                 memcpy(p, smallarray.ptr, length * T.sizeof);
-                data = p[0 .. allocdim];
+                _ptr = p;
+                allocated = cast(uint)allocdim;
             }
             else
             {
@@ -196,55 +203,49 @@ public:
                  */
                 auto increment = length / 2;
                 if (nentries > increment)       // if 1.5 is not enough
-                    increment = nentries;
+                    increment = cast(uint)nentries;
                 const allocdim = length + increment;
                 debug (stomp)
                 {
                     // always move using allocate-copy-stomp-free
                     auto p = cast(T*)mem.xmalloc(allocdim * T.sizeof);
-                    memcpy(p, data.ptr, length * T.sizeof);
-                    memset(data.ptr, 0xFF, data.length * T.sizeof);
-                    mem.xfree(data.ptr);
-                    data = p[0 .. allocdim];
+                    memcpy(p, _ptr, length * T.sizeof);
+                    memset(_ptr, 0xFF, allocated * T.sizeof);
+                    mem.xfree(_ptr);
                 }
                 else
                 {
-                    auto p = cast(T*)mem.xrealloc(data.ptr, allocdim * T.sizeof);
-                    data = p[0 .. allocdim];
+                    auto p = cast(T*)mem.xrealloc(_ptr, allocdim * T.sizeof);
                 }
+                _ptr = p;
+                allocated = cast(uint)allocdim;
             }
 
             debug (stomp)
             {
-                if (data.ptr)
-                {
-                    if (length < data.length)
-                        memset(data.ptr + length, 0xFF, (data.length - length) * T.sizeof);
-                }
+                if (length < allocated)
+                    memset(data + length, 0xFF, (allocated - length) * T.sizeof);
             }
             else
             {
                 if (mem.isGCEnabled)
                 {
-                    if (data.ptr)
-                    {
-                        if (length < data.length)
-                            memset(data.ptr + length, 0xFF, (data.length - length) * T.sizeof);
-                    }
+                    if (length < allocated)
+                        memset(data + length, 0xFF, (allocated - length) * T.sizeof);
                 }
             }
         }
 
-        if (data.length - length < nentries)  // false means hot path
+        if (allocated - length < nentries)  // false means hot path
             enlarge(nentries);
     }
 
     void remove(size_t i) pure nothrow @nogc
     {
         if (length - i - 1)
-            memmove(data.ptr + i, data.ptr + i + 1, (length - i - 1) * T.sizeof);
+            memmove(data + i, data + i + 1, (length - i - 1) * T.sizeof);
         length--;
-        debug (stomp) memset(data.ptr + length, 0xFF, T.sizeof);
+        debug (stomp) memset(data + length, 0xFF, T.sizeof);
     }
 
     void insert(size_t index, typeof(this)* a) pure nothrow
@@ -254,8 +255,8 @@ public:
             size_t d = a.length;
             reserve(d);
             if (length != index)
-                memmove(data.ptr + index + d, data.ptr + index, (length - index) * T.sizeof);
-            memcpy(data.ptr + index, a.data.ptr, d * T.sizeof);
+                memmove(data + index + d, data + index, (length - index) * T.sizeof);
+            memcpy(data + index, a.data, d * T.sizeof);
             length += d;
         }
     }
@@ -265,15 +266,15 @@ public:
         size_t d = a.length;
         reserve(d);
         if (length != index)
-            memmove(data.ptr + index + d, data.ptr + index, (length - index) * T.sizeof);
-        memcpy(data.ptr + index, a.ptr, d * T.sizeof);
+            memmove(data + index + d, data + index, (length - index) * T.sizeof);
+        memcpy(data + index, a.ptr, d * T.sizeof);
         length += d;
     }
 
     void insert(size_t index, T ptr) pure nothrow
     {
         reserve(1);
-        memmove(data.ptr + index + 1, data.ptr + index, (length - index) * T.sizeof);
+        memmove(data + index + 1, data + index, (length - index) * T.sizeof);
         data[index] = ptr;
         length++;
     }
@@ -285,7 +286,7 @@ public:
             return;
         reserve(count);
         if (length != index)
-            memmove(data.ptr + index + count, data.ptr + index, (length - index) * T.sizeof);
+            memmove(data + index + count, data + index, (length - index) * T.sizeof);
         data[index .. index + count] = value;
         length += count;
     }
@@ -296,13 +297,13 @@ public:
         {
             reserve(newdim - length);
         }
-        length = newdim;
+        length = cast(uint)newdim;
     }
 
     size_t find(T ptr) const nothrow pure
     {
         foreach (i; 0 .. length)
-            if (data[i] is ptr)
+            if (this[i] is ptr)
                 return i;
         return size_t.max;
     }
@@ -314,30 +315,28 @@ public:
 
     ref inout(T) opIndex(size_t i) inout nothrow pure
     {
-        debug
-            // This is called so often the array bounds become expensive
-            return data[i];
-        else
-            return data.ptr[i];
+        // This is called so often the array bounds become expensive
+        debug assert(i < length);
+        return allocated <= SMALLARRAYCAP ? smallarray.ptr[i] : _ptr[i];
     }
 
     inout(T)* tdata() inout pure nothrow @nogc @trusted
     {
-        return data.ptr;
+        return data;
     }
 
     Array!T* copy() const pure nothrow
     {
         auto a = new Array!T();
         a.setDim(length);
-        memcpy(a.data.ptr, data.ptr, length * T.sizeof);
+        memcpy(a.data, data, length * T.sizeof);
         return a;
     }
 
     void shift(T ptr) pure nothrow
     {
         reserve(1);
-        memmove(data.ptr + 1, data.ptr, length * T.sizeof);
+        memmove(data + 1, data, length * T.sizeof);
         data[0] = ptr;
         length++;
     }
@@ -390,7 +389,7 @@ public:
     {
         if (this.length < 2)
             return this;
-        qsort(this.data.ptr, this.length, T.sizeof, &arraySortWrapper!(T, pred));
+        qsort(this.data, this.length, T.sizeof, &arraySortWrapper!(T, pred));
         return this;
     }
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -6688,9 +6688,9 @@ private MATCH deduceParentInstance(Scope* sc, Dsymbol sym, TypeInstance tpi,
     if (!tparent)
         return MATCH.nomatch;
 
-    tpi.idents.length--;
+    tpi.idents.pop();
     auto m = deduceType(tparent, sc, tpi, parameters, dedtypes, wm);
-    tpi.idents.length++;
+    tpi.idents.push(id);
     return m;
 }
 


### PR DESCRIPTION
- allocates a maximum of uint.max entries (source code locations are limited to that as well)
- overlaps single entry with pointer to array of more entries

With my test case of building all phobos unittests with a single invocation (Win64 dmd built with ldc), this reduces the process memory from 18399 MB to 17616 MB, so almost 5% less memory. Note that compiling with -o- uses about 5 GB less memory, so that part is used by the glue layer and backend.

One downside is that the struct is not as digestible in a debugger as before. 
The C++ header is not yet adapted, making length a function might be annoying for GDC and LDC.

Let's see what the performance tester reports...