### PR TITLE
druntime: Move `accumulatePure` from `core.internal.array` to `rt.profilegc`

### DIFF
--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -23,8 +23,13 @@ auto gcStatsPure() nothrow pure
 
 version (D_ProfileGC)
 {
-    import core.internal.traits : externDFunc;
-    alias accumulatePure = externDFunc!("rt.profilegc.accumulatePure", ulong function(string file, uint line, string funcname, string name, ulong size) @nogc nothrow pure);
+    // Needs to be templated to emit only as needed.
+    ulong accumulatePure()(string file, uint line, string funcname, string name, ulong size) @nogc nothrow pure
+    {
+        import core.internal.traits : externDFunc;
+        alias impl = externDFunc!("rt.profilegc.accumulatePure", ulong function(string file, uint line, string funcname, string name, ulong size) @nogc nothrow pure);
+        return impl(file, line, funcname, name, size);
+    }
 
     /**
      * TraceGC wrapper generator around the runtime hook `Hook`.

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -21,23 +21,11 @@ auto gcStatsPure() nothrow pure
     return impureBypass();
 }
 
-ulong accumulatePure(string file, int line, string funcname, string name, ulong size) nothrow pure
-{
-    static ulong impureBypass(string file, int line, string funcname, string name, ulong size) @nogc nothrow
-    {
-        import core.internal.traits : externDFunc;
-
-        alias accumulate = externDFunc!("rt.profilegc.accumulate", void function(string file, uint line, string funcname, string type, ulong sz) @nogc nothrow);
-        accumulate(file, line, funcname, name, size);
-        return size;
-    }
-
-    auto func = cast(ulong function(string file, int line, string funcname, string name, ulong size) @nogc nothrow pure)&impureBypass;
-    return func(file, line, funcname, name, size);
-}
-
 version (D_ProfileGC)
 {
+    import core.internal.traits : externDFunc;
+    alias accumulatePure = externDFunc!("rt.profilegc.accumulatePure", void function(string file, uint line, string funcname, string name, ulong size) @nogc nothrow pure);
+
     /**
      * TraceGC wrapper generator around the runtime hook `Hook`.
      * Params:

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -24,7 +24,7 @@ auto gcStatsPure() nothrow pure
 version (D_ProfileGC)
 {
     import core.internal.traits : externDFunc;
-    alias accumulatePure = externDFunc!("rt.profilegc.accumulatePure", void function(string file, uint line, string funcname, string name, ulong size) @nogc nothrow pure);
+    alias accumulatePure = externDFunc!("rt.profilegc.accumulatePure", ulong function(string file, uint line, string funcname, string name, ulong size) @nogc nothrow pure);
 
     /**
      * TraceGC wrapper generator around the runtime hook `Hook`.

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -24,10 +24,10 @@ auto gcStatsPure() nothrow pure
 version (D_ProfileGC)
 {
     // Needs to be templated to emit only as needed.
-    ulong accumulatePure()(string file, uint line, string funcname, string name, ulong size) @nogc nothrow pure
+    ulong accumulatePure()(string file, int line, string funcname, string name, ulong size) @nogc nothrow pure
     {
         import core.internal.traits : externDFunc;
-        alias impl = externDFunc!("rt.profilegc.accumulatePure", ulong function(string file, uint line, string funcname, string name, ulong size) @nogc nothrow pure);
+        alias impl = externDFunc!("rt.profilegc.accumulatePure", ulong function(string file, int line, string funcname, string name, ulong size) @nogc nothrow pure);
         return impl(file, line, funcname, name, size);
     }
 

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -23,13 +23,12 @@ auto gcStatsPure() nothrow pure
 
 version (D_ProfileGC)
 {
-    // Needs to be templated to emit only as needed.
-    ulong accumulatePure()(string file, int line, string funcname, string name, ulong size) @nogc nothrow pure
-    {
-        import core.internal.traits : externDFunc;
-        alias impl = externDFunc!("rt.profilegc.accumulatePure", ulong function(string file, int line, string funcname, string name, ulong size) @nogc nothrow pure);
-        return impl(file, line, funcname, name, size);
-    }
+    // Cannot use `externD` template, because then it will cause
+    // cyclic dependencies (and error out) as CTFE string appending
+    // expands runtime hooks, which on -profilegc call this.
+    pragma(mangle, "_D2rt9profilegc14accumulatePureFNaNbNiAyaiQeQgmZm")
+    ulong accumulatePure(string file, int line, string funcname, string name, ulong size) @nogc nothrow pure;
+
 
     /**
      * TraceGC wrapper generator around the runtime hook `Hook`.

--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -147,24 +147,17 @@ template externDFunc(string fqn, T:FT*, FT) if (is(FT == function))
     static if (is(FT RT == return) && is(FT Args == function))
     {
         import core.demangle : mangleFunc;
-
-        // We can't do this with a CTFE lambda because we need
-        // to avoid triggering runtime hooks (specifically -profile-gc)
-        // allocation hooks; due to the array appending
-        enum initial = "extern(D) RT externDFunc(Args)";
-        alias decl = initial;
-        static foreach (attr; __traits(getFunctionAttributes, FT))
-            decl = strConcat!(decl, " " ~ attr);
-        decl = strConcat!(decl, ";");
-
+        enum decl = {
+            string s = "extern(D) RT externDFunc(Args)";
+            foreach (attr; __traits(getFunctionAttributes, FT))
+                s ~= " " ~ attr;
+            return s ~ ";";
+        }();
         pragma(mangle, mangleFunc!T(fqn)) mixin(decl);
     }
     else
         static assert(0);
 }
-// private helper for externDFunc
-private enum strConcat(string a, string b) = a ~ b;
-
 
 template staticIota(int beg, int end)
 {

--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -147,17 +147,24 @@ template externDFunc(string fqn, T:FT*, FT) if (is(FT == function))
     static if (is(FT RT == return) && is(FT Args == function))
     {
         import core.demangle : mangleFunc;
-        enum decl = {
-            string s = "extern(D) RT externDFunc(Args)";
-            foreach (attr; __traits(getFunctionAttributes, FT))
-                s ~= " " ~ attr;
-            return s ~ ";";
-        }();
+
+        // We can't do this with a CTFE lambda because we need
+        // to avoid triggering runtime hooks (specifically -profile-gc)
+        // allocation hooks; due to the array appending
+        enum initial = "extern(D) RT externDFunc(Args)";
+        alias decl = initial;
+        static foreach (attr; __traits(getFunctionAttributes, FT))
+            decl = strConcat!(decl, " " ~ attr);
+        decl = strConcat!(decl, ";");
+
         pragma(mangle, mangleFunc!T(fqn)) mixin(decl);
     }
     else
         static assert(0);
 }
+// private helper for externDFunc
+private enum strConcat(string a, string b) = a ~ b;
+
 
 template staticIota(int beg, int end)
 {

--- a/druntime/src/rt/profilegc.d
+++ b/druntime/src/rt/profilegc.d
@@ -89,7 +89,7 @@ public void accumulate(string file, uint line, string funcname, string type, ulo
     }
 }
 
-public ulong accumulatePure(string file, int line, string funcname, string name, ulong size) nothrow pure
+public ulong accumulatePure(string file, int line, string funcname, string name, ulong size) @nogc nothrow pure
 {
     static ulong impureBypass(string file, int line, string funcname, string name, ulong size) @nogc nothrow
     {

--- a/druntime/src/rt/profilegc.d
+++ b/druntime/src/rt/profilegc.d
@@ -89,6 +89,18 @@ public void accumulate(string file, uint line, string funcname, string type, ulo
     }
 }
 
+public ulong accumulatePure(string file, int line, string funcname, string name, ulong size) nothrow pure
+{
+    static ulong impureBypass(string file, int line, string funcname, string name, ulong size) @nogc nothrow
+    {
+        accumulate(file, line, funcname, name, size);
+        return size;
+    }
+
+    auto func = cast(ulong function(string file, int line, string funcname, string name, ulong size) @nogc nothrow pure)&impureBypass;
+    return func(file, line, funcname, name, size);
+}
+
 // Merge thread local newCounts into globalNewCounts
 static ~this()
 {


### PR DESCRIPTION
Moves `accumulatePure` (which is a thin wrapper around `rt.profilegc.accumulate`, adding forcing purity on it) out of `core.internal.array` and into `rt.profilegc`.

This helps prevent `rt.profilegc` from being dragged in (and thus its module destructors) when `D_ProfileGC` isn't enabled, reducing the size of statically linked binaries.

See https://github.com/ldc-developers/ldc/pull/5186#discussion_r3604960715

-------

This problem should be solved on `master` by dlang/dmd#22859. This improvement is for 1.113.