### PR TITLE
change SDrel to Relocation for Machobj

### DIFF
--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -276,7 +276,13 @@ struct seg_data
     //ELFOBJ || MACHOBJ
     IDXSEC           SDshtidx;          // section header table index
     OutBuffer       *SDbuf;             // buffer to hold data
-    OutBuffer       *SDrel;             // buffer to hold relocation info
+    union
+    {
+        // ELFOBJ MSCOFFOBJ
+        OutBuffer        *SDrel;        // buffer to hold segment relocation info
+        // MACHOBJ
+        Barray!Relocation relocations;  // hold relocations for this segment
+    }
 
     //ELFOBJ
     IDXSYM           SDsymidx;          // each section is in the symbol table
@@ -294,6 +300,27 @@ struct seg_data
     @trusted
     int isCode() { return config.objfmt == OBJ_MACH ? mach_seg_data_isCode(this) : mscoff_seg_data_isCode(this); }
 }
+
+/*******************************************************
+ * For Machobj
+ * Because the relocations cannot be computed until after
+ * all the segments are written out, and we need more information
+ * than the relocations provide, make our own relocation
+ * type. Later, translate to Mach-O relocation structures `relocation_info` and `scattered_relocation_info`.
+ */
+struct Relocation
+{   // Relocations are attached to the struct seg_data they refer to
+    targ_size_t offset; // location in segment to be fixed up
+    Symbol* funcsym;    // function in which offset lies, if any
+    Symbol* targsym;    // if !=null, then location is to be fixed up
+                        // to address of this symbol
+    uint targseg;       // if !=0, then location is to be fixed up
+                        // to address of start of this segment
+    REL rtype;          // REL.address or REL.rel or REL.add
+    bool subtractor;    // true: emit SUBTRACTOR/UNSIGNED pair
+    short val;          // 0, -1, -2, -4
+}
+
 
 public import dmd.backend.machobj : mach_seg_data_isCode;
 public import dmd.backend.mscoffobj : mscoff_seg_data_isCode;

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -241,25 +241,6 @@ int mach_seg_data_isCode(const ref seg_data sd)
 
 import dmd.backend.code: SegData;
 
-/*******************************************************
- * Because the relocations cannot be computed until after
- * all the segments are written out, and we need more information
- * than the relocations provide, make our own relocation
- * type. Later, translate to Mach-O relocation structure.
- */
-struct Relocation
-{   // Relocations are attached to the struct seg_data they refer to
-    targ_size_t offset; // location in segment to be fixed up
-    Symbol* funcsym;    // function in which offset lies, if any
-    Symbol* targsym;    // if !=null, then location is to be fixed up
-                        // to address of this symbol
-    uint targseg;       // if !=0, then location is to be fixed up
-                        // to address of start of this segment
-    REL rtype;          // REL.address or REL.rel or REL.add
-    bool subtractor;    // true: emit SUBTRACTOR/UNSIGNED pair
-    short val;          // 0, -1, -2, -4
-}
-
 
 /*******************************
  * Output a string into a string table
@@ -901,11 +882,10 @@ void MachObj_term(const(char)[] objfilename)
         uint reloff = foffset;
         uint nreloc = 0;
 
-        if (pseg.SDrel)
-        {   Relocation* r = cast(Relocation*)pseg.SDrel.buf;
-            Relocation* rend = cast(Relocation*)(pseg.SDrel.buf + pseg.SDrel.length());
-            for (; r != rend; r++)
-            {   Symbol* s = r.targsym;
+        {
+            foreach (ref r; pseg.relocations[])
+            {
+                Symbol* s = r.targsym;
                 const(char)* rs = r.rtype == REL.address ? "address" :  // 32 bit address
                                   r.rtype == REL.add     ? "add"  :
                                   r.rtype == REL.rel26   ? "rel26"  :
@@ -2208,15 +2188,15 @@ int MachObj_getsegment(const(char)* sectname, const(char)* segname,
 
     if (pseg)
     {
-        OutBuffer* b1 = pseg.SDbuf;
-        OutBuffer* b2 = pseg.SDrel;
-        memset(pseg, 0, seg_data.sizeof);
-        if (b1)
-            b1.reset();
-        if (b2)
-            b2.reset();
-        pseg.SDbuf = b1;
-        pseg.SDrel = b2;
+         // recycle memory used
+         pseg.relocations.reset();
+         auto save = pseg.relocations;
+         OutBuffer* b1 = pseg.SDbuf;
+         memset(pseg, 0, seg_data.sizeof);
+         if (b1)
+             b1.reset();
+         pseg.relocations = save;
+         pseg.SDbuf = b1;
     }
     else
     {
@@ -2910,14 +2890,9 @@ void MachObj_addrel(int seg, targ_size_t offset, Symbol* targsym,
     rel.subtractor = false;
     rel.funcsym = funcsym_p;
     rel.val = cast(short)val;
+
     seg_data* pseg = SegData[seg];
-    if (!pseg.SDrel)
-    {
-        pseg.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        if (!pseg.SDrel)
-            err_nomem();
-    }
-    pseg.SDrel.write(&rel, rel.sizeof);
+    pseg.relocations.push(rel);
 }
 
 /*******************************
@@ -3146,14 +3121,9 @@ int MachObj_reftoident(int seg, targ_size_t offset, Symbol* s, targ_size_t val,
                     rel.subtractor = false;
                     rel.funcsym = null;
                     rel.val = 0;
+
                     seg_data* pseg2 = SegData[seg];
-                    if (!pseg2.SDrel)
-                    {
-                        pseg2.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-                        if (!pseg2.SDrel)
-                            err_nomem();
-                    }
-                    pseg2.SDrel.write(&rel, rel.sizeof);
+                    pseg2.relocations.push(rel);
                 }
                 else
                     MachObj_addrel(seg, offset, null, machobj.pointersSeg, REL.address);
@@ -3444,14 +3414,9 @@ int dwarf_eh_frame_fixup(int dfseg, targ_size_t offset, Symbol* s, targ_size_t v
     rel.subtractor = !machobj.AArch64;
     rel.funcsym = fdesym;
     rel.val = 0;
+
     seg_data* pseg = SegData[dfseg];
-    if (!pseg.SDrel)
-    {
-        pseg.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        if (!pseg.SDrel)
-            err_nomem();
-    }
-    pseg.SDrel.write(&rel, rel.sizeof);
+    pseg.relocations.push(rel);
 
     return I64 ? 8 : 4;
 }

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -151,9 +151,9 @@ struct Relocation
     Symbol* funcsym;    // function in which offset lies, if any
     Symbol* targsym;    // if !=null, then location is to be fixed up
                         // to address of this symbol
-    uint targseg;   // if !=0, then location is to be fixed up
+    uint targseg;       // if !=0, then location is to be fixed up
                         // to address of start of this segment
-    ubyte rtype;   // RELxxxx
+    REL rtype;          // RELxxxx
     short val;          // 0, -1, -2, -3, -4, -5
 }
 
@@ -2128,7 +2128,7 @@ void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol* targsym,
     rel.offset = offset;
     rel.targsym = targsym;
     rel.targseg = targseg;
-    rel.rtype = cast(ubyte)rtype;
+    rel.rtype = rtype;
     rel.funcsym = funcsym_p;
     rel.val = cast(short)val;
     seg_data* pseg = SegData[seg];


### PR DESCRIPTION
Using a Barray makes for much less confusing casting with OutBuffer.

Will do this for elfobj and mscoffobj later.