### PR TITLE
Fix #Issue23409 - Avoid double copy in copyRegionExp()

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6721,6 +6721,13 @@ private Expression copyRegionExp(Expression e)
             copySE(sle);
             sle.isOriginal = sle is sle.origin;
 
+            /* copySE may have followed a self-reference back to this
+             * same SLE, in which case the recursive copyRegionExp
+             * already created a GC copy and stored it in sle.origin.
+             */
+            if (!ctfeGlobals.region.contains(cast(void*)sle.origin) && sle.origin != sle)
+                return sle.origin;
+
             auto slec = ctfeGlobals.region.contains(cast(void*)e)
                 ? e.copy().isStructLiteralExp()         // move sle out of region to slec
                 : sle;

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6718,14 +6718,16 @@ private Expression copyRegionExp(Expression e)
                  */
                 return sle.origin;
             }
+            // Track whether copySE triggers a recursive copy of this
+            // same SLE via a self-reference. If so, sle.origin will
+            // have been updated to a GC copy, and we must use that
+            // instead of creating a duplicate.
+            auto savedOrigin = sle.origin;
             copySE(sle);
+
             sle.isOriginal = sle is sle.origin;
 
-            /* copySE may have followed a self-reference back to this
-             * same SLE, in which case the recursive copyRegionExp
-             * already created a GC copy and stored it in sle.origin.
-             */
-            if (!ctfeGlobals.region.contains(cast(void*)sle.origin) && sle.origin != sle)
+            if (sle.origin != savedOrigin)
                 return sle.origin;
 
             auto slec = ctfeGlobals.region.contains(cast(void*)e)

--- a/compiler/test/runnable/xtest46.d
+++ b/compiler/test/runnable/xtest46.d
@@ -9,7 +9,7 @@ int
 !! immutable(int)[]
 int(int i, long j = 7L)
 long
-C10390(C10390(C10390(<recursion>)))
+C10390(C10390(<recursion>))
 AliasSeq!(height)
 AliasSeq!(get, get)
 AliasSeq!(clear)


### PR DESCRIPTION
It is related to #23409. After this patch, the expected outputs of the two tests are same: `C10390(C10390(<recursion>))`. Does it make more sense?