### PR TITLE
fix unittest when building with optimizing LDC

### DIFF
--- a/compiler/src/dmd/backend/arm/disasmarm.d
+++ b/compiler/src/dmd/backend/arm/disasmarm.d
@@ -3084,7 +3084,8 @@ ulong decodeNImmrImms(uint N, uint immr, uint imms)
     if (immr >= size)
         return 0;       // cannot decode it
     ulong pattern = (1L << (length + 1)) - 1;
-    pattern = (pattern >> immr) | (pattern << size - immr); // rotate right
+    if (immr > 0) // avoid shifting by 64
+        pattern = (pattern >> immr) | (pattern << size - immr); // rotate right
     ulong result = 0;
     foreach (i; 0 .. 64 / size)
     {


### PR DESCRIPTION
The test

    assert(decodeNImmrImms(1,   0,   0) == 0x0000_0000_0000_0001);
at https://github.com/rainers/dmd/blob/ad918bb23323dccda8a86694322bacc61e9584e5/compiler/src/dmd/backend/arm/disasmarm.d#L3109

fails for me when building with LDC 1.42 and optimizations enabled, probably because shifting by 64 trots into undefined behavior.