### PR TITLE
Fix Issue 23225 - ImportC: support C23 digit separators in numeric li…

### DIFF
--- a/changelog/dmd.importc-c23-digit-separators.dd
+++ b/changelog/dmd.importc-c23-digit-separators.dd
@@ -1,0 +1,16 @@
+ImportC supports C23 digit separators (`'`) in numeric literals
+
+C23 allows a single quote as a digit separator inside integer and floating
+constants (for example `1'000'000`, `0x1'2'3'4`, `0b1010'0001`, `3.141'592`).
+The separators are ignored when computing the value.
+
+ImportC now accepts them unconditionally. A digit immediately followed by `'`
+was never valid in C11, so enabling this cannot change the meaning of any
+valid C11 program.
+
+-------
+_Static_assert(1'000'000 == 1000000);
+_Static_assert(0xFF'FF == 0xFFFF);
+_Static_assert(0b1010'0001 == 0xA1);
+_Static_assert(3.141'592 == 3.141592);
+-------

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -446,7 +446,8 @@ class Lexer
                 goto default;
 
             case '0':
-                if (!isZeroSecond(p[1]))        // if numeric literal does not continue
+                // C23 6.4.4.2: `'` may continue a numeric literal as a digit separator
+                if (!isZeroSecond(p[1]) && !(Ccompile && p[1] == '\''))
                 {
                     ++p;
                     t.unsvalue = 0;
@@ -456,7 +457,8 @@ class Lexer
                 goto Lnumber;
 
             case '1': .. case '9':
-                if (!isDigitSecond(p[1]))       // if numeric literal does not continue
+                // C23 6.4.4.2: `'` may continue a numeric literal as a digit separator
+                if (!isDigitSecond(p[1]) && !(Ccompile && p[1] == '\''))
                 {
                     t.unsvalue = *p - '0';
                     ++p;
@@ -2449,6 +2451,13 @@ class Lexer
                 ++p;
                 base = 8;
                 break;
+            case '\'':
+                /* C23 6.4.4.2: `0'123` is an octal-constant.
+                 * Digits after the separator are consumed in the main loop.
+                 */
+                if (Ccompile)
+                    base = 8;
+                break;
             case 'L':
                 if (p[1] == 'i')
                     goto Lreal;
@@ -2533,6 +2542,30 @@ class Lexer
                     goto default;
                 ++p;
                 continue;
+            case '\'':
+                /* C23 6.4.4.2 digit separators: skip `'` when it sits between
+                 * digits of the current base. Not after `0x`/`0b` before the
+                 * first digit (grammar: separator is inside *-digit-sequence).
+                 */
+                if (Ccompile)
+                {
+                    const char next = p[1];
+                    bool ok;
+                    if (base == 16)
+                        ok = anyHexDigitsNoSingleUS && ishex(next);
+                    else if (base == 2)
+                        ok = anyBinaryDigitsNoSingleUS && (next == '0' || next == '1');
+                    else if (base == 8)
+                        ok = next >= '0' && next <= '7';
+                    else
+                        ok = next >= '0' && next <= '9';
+                    if (ok)
+                    {
+                        ++p;
+                        continue;
+                    }
+                }
+                goto Ldone;
             default:
                 goto Ldone;
             }
@@ -2976,6 +3009,9 @@ class Lexer
             }
         }
         // Digits to left of '.'
+        // C23 6.4.4.3: `'` digit separators are allowed between digits of a
+        // digit-sequence, but not at the start or end of one.
+        bool anyDigits = false;
         while (1)
         {
             if (c == '.')
@@ -2985,15 +3021,30 @@ class Lexer
             }
             if (isdigit(c) || (hex && isxdigit(c)) || c == '_')
             {
+                if (c != '_')
+                    anyDigits = true;
+                c = *p++;
+                continue;
+            }
+            if (Ccompile && c == '\'' && anyDigits && (isdigit(*p) || (hex && isxdigit(*p))))
+            {
                 c = *p++;
                 continue;
             }
             break;
         }
         // Digits to right of '.'
+        anyDigits = false;
         while (1)
         {
             if (isdigit(c) || (hex && isxdigit(c)) || c == '_')
+            {
+                if (c != '_')
+                    anyDigits = true;
+                c = *p++;
+                continue;
+            }
+            if (Ccompile && c == '\'' && anyDigits && (isdigit(*p) || (hex && isxdigit(*p))))
             {
                 c = *p++;
                 continue;
@@ -3023,6 +3074,12 @@ class Lexer
                     c = *p++;
                     continue;
                 }
+                // C23 6.4.4.3: separators in the exponent digit-sequence
+                if (Ccompile && c == '\'' && anyexp && isdigit(*p))
+                {
+                    c = *p++;
+                    continue;
+                }
                 if (!anyexp)
                 {
                     error("missing exponent");
@@ -3039,7 +3096,8 @@ class Lexer
         --p;
         while (pstart < p)
         {
-            if (*pstart != '_')
+            // Strip D `_` and C23 `'` digit separators before parsing
+            if (*pstart != '_' && *pstart != '\'')
                 stringbuffer.writeByte(*pstart);
             ++pstart;
         }

--- a/compiler/test/compilable/test23225.i
+++ b/compiler/test/compilable/test23225.i
@@ -1,0 +1,23 @@
+/* Preprocessed C (.i) so the host C preprocessor cannot mangle C23 `'` digit separators. */
+
+// https://github.com/dlang/dmd/issues/23225
+
+// C23 6.4.4.2 — integer digit separators
+_Static_assert(1'000'000 == 1000000, "decimal");
+_Static_assert(0x1'2'3'4 == 0x1234, "hex");
+_Static_assert(0XAB'CD == 0xABCD, "hex upper");
+_Static_assert(0b1010'0001 == 0xa1, "binary");
+_Static_assert(0B1010'0001 == 0xa1, "binary upper");
+_Static_assert(0'123 == 0123, "octal");
+_Static_assert(0'7 == 07, "octal single");
+
+// C23 6.4.4.2 — binary literals (confirming 0b/0B with separators)
+_Static_assert(0b11'10'11'01 == 0xED, "binary grouped");
+
+// C23 6.4.4.3 — floating digit separators
+_Static_assert(3.141'592 == 3.141592, "decimal float");
+_Static_assert(1'2.3'4 == 12.34, "decimal float both sides");
+_Static_assert(1.0e1'2 == 1.0e12, "decimal exponent");
+_Static_assert(0x1.8p3 == 12.0, "hex float baseline");
+_Static_assert(0x1.8'0p3 == 0x1.80p3, "hex float fraction");
+_Static_assert(0x1'2.3'4p5 == 0x12.34p5, "hex float both sides");

--- a/compiler/test/fail_compilation/test23225.i
+++ b/compiler/test/fail_compilation/test23225.i
@@ -1,0 +1,25 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test23225.i(11): Error: `0x` isn't a valid integer literal, use `0x0` instead
+fail_compilation/test23225.i(11): Error: unterminated string constant starting at fail_compilation/test23225.i(11)
+fail_compilation/test23225.i(11): Error: empty character constant
+fail_compilation/test23225.i(14): Error: `0b` isn't a valid integer literal, use `0b0` instead
+fail_compilation/test23225.i(14): Error: unterminated string constant starting at fail_compilation/test23225.i(14)
+fail_compilation/test23225.i(14): Error: empty character constant
+fail_compilation/test23225.i(18): Error: `=`, `;` or `,` expected to end declaration instead of `2`
+---
+*/
+
+// https://github.com/dlang/dmd/issues/23225
+// C23 6.4.4.2 — `'` after a base prefix is not a digit separator;
+// it begins a character constant (N3220 6.4.4.2 EXAMPLE 1 style).
+
+#line 11
+int a = 0x'FF;
+
+#line 14
+int b = 0b'1;
+
+// Adjacent character constant and digit do not form an integer
+#line 18
+int c = '1'2;


### PR DESCRIPTION
## Summary

- ImportC now accepts C23 digit separators (`'`) in integer and floating numeric literals (e.g. `1'000'000`, `0x1'2'3'4`, `0b1010'0001`, `3.141'592`).
- Separators are ignored when computing the value; they are only allowed between digits of the current base (not after `0x`/`0b` before the first digit).
- Adds compilable/fail_compilation coverage (as `.i` to avoid host-preprocessor issues) and a changelog entry.

Fixes #23225

## Test plan

- [x] `./build.d` (compiler rebuild from `compiler/src`)
- [x] `./build.d unittest`
- [x] `./run.d compilable/test23225.i fail_compilation/test23225.i`
- [x] Spot-check existing ImportC numeric tests (`testcstuff1.c`, `testcstuff2.c`, `ctests2.c`, `failcstuff1.c`, `failcstuff3.c`)