### PR TITLE
place statements array inside CompoundStatements, it is non-empty most of the time.

### DIFF
--- a/compiler/include/dmd/statement.h
+++ b/compiler/include/dmd/statement.h
@@ -211,7 +211,7 @@ public:
 class CompoundStatement : public Statement
 {
 public:
-    Statements *statements;
+    Statements statements;
 
     static CompoundStatement *create(Loc loc, Statement *s1, Statement *s2);
     CompoundStatement *syntaxCopy() override;
@@ -234,7 +234,7 @@ public:
 class UnrolledLoopStatement final : public Statement
 {
 public:
-    Statements *statements;
+    Statements statements;
 
     UnrolledLoopStatement *syntaxCopy() override;
     bool hasBreak() const override;

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -2509,16 +2509,16 @@ struct ASTBase
     {
         Statements statements;
 
-        final extern (D) this(Loc loc, ref Statements statements)
+        final extern (D) this(Loc loc, Statements statements)
         {
             super(loc, STMT.Compound);
-            this.statements.moveFrom(statements);
+            this.statements = statements.move();
         }
 
-        final extern (D) this(Loc loc, ref Statements statements, STMT stmt)
+        final extern (D) this(Loc loc, Statements statements, STMT stmt)
         {
             super(loc, stmt);
-            this.statements.moveFrom(statements);
+            this.statements = statements.move();
         }
 
         final extern (D) this(Loc loc, Statement[] sts...)
@@ -2551,9 +2551,9 @@ struct ASTBase
 
     extern (C++) final class CompoundDeclarationStatement : CompoundStatement
     {
-        final extern (D) this(Loc loc, ref Statements statements)
+        final extern (D) this(Loc loc, Statements statements)
         {
-            super(loc, statements, STMT.CompoundDeclaration);
+            super(loc, statements.move(), STMT.CompoundDeclaration);
         }
 
         override void accept(Visitor v)
@@ -2566,9 +2566,9 @@ struct ASTBase
     {
         StorageClass stc;
 
-        final extern (D) this(Loc loc, ref Statements s, StorageClass stc)
+        final extern (D) this(Loc loc, Statements s, StorageClass stc)
         {
-            super(loc, s, STMT.CompoundAsm);
+            super(loc, s.move(), STMT.CompoundAsm);
             this.stc = stc;
         }
 

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -2507,24 +2507,23 @@ struct ASTBase
 
     extern (C++) class CompoundStatement : Statement
     {
-        Statements* statements;
+        Statements statements;
 
-        final extern (D) this(Loc loc, Statements* statements)
+        final extern (D) this(Loc loc, ref Statements statements)
         {
             super(loc, STMT.Compound);
-            this.statements = statements;
+            this.statements.moveFrom(statements);
         }
 
-        final extern (D) this(Loc loc, Statements* statements, STMT stmt)
+        final extern (D) this(Loc loc, ref Statements statements, STMT stmt)
         {
             super(loc, stmt);
-            this.statements = statements;
+            this.statements.moveFrom(statements);
         }
 
         final extern (D) this(Loc loc, Statement[] sts...)
         {
             super(loc, STMT.Compound);
-            statements = new Statements();
             statements.reserve(sts.length);
             foreach (s; sts)
                 statements.push(s);
@@ -2552,7 +2551,7 @@ struct ASTBase
 
     extern (C++) final class CompoundDeclarationStatement : CompoundStatement
     {
-        final extern (D) this(Loc loc, Statements* statements)
+        final extern (D) this(Loc loc, ref Statements statements)
         {
             super(loc, statements, STMT.CompoundDeclaration);
         }
@@ -2567,7 +2566,7 @@ struct ASTBase
     {
         StorageClass stc;
 
-        final extern (D) this(Loc loc, Statements* s, StorageClass stc)
+        final extern (D) this(Loc loc, ref Statements s, StorageClass stc)
         {
             super(loc, s, STMT.CompoundAsm);
             this.stc = stc;

--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -124,7 +124,7 @@ int blockExit(Statement s, FuncDeclaration func, ErrorSink eSink)
             // it sees through compound blocks and skips intermediate non-case statements (e.g.
             // static foreach loop variable declarations). https://github.com/dlang/dmd/issues/20242
             Statement slastCase = null;
-            foreach (s; *cs.statements)
+            foreach (s; cs.statements)
             {
                 if (!s)
                     continue;
@@ -163,7 +163,7 @@ int blockExit(Statement s, FuncDeclaration func, ErrorSink eSink)
         void visitUnrolledLoop(UnrolledLoopStatement uls)
         {
             result = BE.fallthru;
-            foreach (s; *uls.statements)
+            foreach (s; uls.statements)
             {
                 if (!s)
                     continue;

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1125,7 +1125,7 @@ private DtorDeclaration buildWindowsCppDtor(AggregateDeclaration ad, DtorDeclara
     call.directcall = true;
     stmts.push(new ExpStatement(loc, call));
     stmts.push(new ReturnStatement(loc, new CastExp(loc, new ThisExp(loc), Type.tvoidptr)));
-    func.fbody = new CompoundStatement(loc, stmts);
+    func.fbody = new CompoundStatement(loc, stmts.move());
     func.isGenerated = true;
 
     auto sc2 = sc.push();
@@ -1375,7 +1375,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
             }
 
             // put destructor calls in a `scope(failure)` block
-            postblitCalls.push(new ScopeGuardStatement(loc, TOK.onScopeFailure, new CompoundStatement(loc, dtors)));
+            postblitCalls.push(new ScopeGuardStatement(loc, TOK.onScopeFailure, new CompoundStatement(loc, dtors.move())));
         }
 
         // perform semantic on the member postblit in order to
@@ -1470,7 +1470,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         auto dd = new PostBlitDeclaration(declLoc, Loc.initial, stc, Id.__fieldPostblit);
         dd.isGenerated = true;
         dd.storage_class |= STC.inference | STC.scope_;
-        dd.fbody = (stc & STC.disable) ? null : new CompoundStatement(loc, postblitCalls);
+        dd.fbody = (stc & STC.disable) ? null : new CompoundStatement(loc, postblitCalls.move());
         sd.postblits.shift(dd);
         sd.members.push(dd);
         dd.dsymbolSemantic(sc);

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1120,7 +1120,7 @@ private DtorDeclaration buildWindowsCppDtor(AggregateDeclaration ad, DtorDeclara
 
     // Always generate the function with body, because it is not exported from DLLs.
     const loc = dtor.loc;
-    auto stmts = new Statements;
+    auto stmts = Statements();
     auto call = new CallExp(loc, dtor, null);
     call.directcall = true;
     stmts.push(new ExpStatement(loc, call));
@@ -1289,7 +1289,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         stc |= postblit.storage_class & STC.disable;
 
     VarDeclaration[] fieldsToDestroy;
-    auto postblitCalls = new Statements();
+    auto postblitCalls = Statements();
     // iterate through all the struct fields that are not disabled
     for (size_t i = 0; i < sd.fields.length && !(stc & STC.disable); i++)
     {
@@ -1368,7 +1368,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
             fieldsToDestroy = [];
 
             // aggregate the destructor calls
-            auto dtors = new Statements();
+            auto dtors = Statements();
             foreach_reverse(dc; dtorCalls)
             {
                 dtors.push(new ExpStatement(loc, dc));

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -386,7 +386,7 @@ final class CParser(AST) : Parser!AST
                     s = new AST.ExpStatement(loc, d);
                     as.push(s);
                 }
-                s = new AST.CompoundDeclarationStatement(loc, as);
+                s = new AST.CompoundDeclarationStatement(loc, as.move());
                 symbols.setDim(0);
             }
             else if (symbols.length == 1)
@@ -434,7 +434,7 @@ final class CParser(AST) : Parser!AST
                 *pEndloc = token.loc;
                 pEndloc = null; // don't set it again
             }
-            s = new AST.CompoundStatement(loc, statements);
+            s = new AST.CompoundStatement(loc, statements.move());
             if (flags & (ParseStatementFlags.scope_ | ParseStatementFlags.curlyScope))
                 s = new AST.ScopeStatement(loc, s, token.loc);
             check(TOK.rightCurly, "compound statement");
@@ -584,7 +584,7 @@ final class CParser(AST) : Parser!AST
                     if (cur && cur.isBreakStatement())
                         break;
                 }
-                s = new AST.CompoundStatement(loc, statements);
+                s = new AST.CompoundStatement(loc, statements.move());
             }
             else
             {
@@ -610,7 +610,7 @@ final class CParser(AST) : Parser!AST
                 {
                     statements.push(cparseStatement(ParseStatementFlags.curlyScope));
                 }
-                s = new AST.CompoundStatement(loc, statements);
+                s = new AST.CompoundStatement(loc, statements.move());
             }
             else
                 s = cparseStatement(0);
@@ -2270,7 +2270,7 @@ final class CParser(AST) : Parser!AST
 
         stmts.push(body);
 
-        body = new AST.CompoundStatement(locFunc, stmts);
+        body = new AST.CompoundStatement(locFunc, stmts.move());
         fd.fbody = body;
 
         // TODO add `symbols` to the function's local symbol table `sc2` in FuncDeclaration::semantic3()
@@ -3617,7 +3617,7 @@ final class CParser(AST) : Parser!AST
             break;
         }
         nextToken();
-        auto s = new AST.CompoundAsmStatement(loc, statements, STC.none);
+        auto s = new AST.CompoundAsmStatement(loc, statements.move(), STC.none);
         return s;
     }
 

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -379,7 +379,7 @@ final class CParser(AST) : Parser!AST
             cparseDeclaration(LVL.local);
             if (symbols.length > 1)
             {
-                auto as = new AST.Statements();
+                auto as = AST.Statements();
                 as.reserve(symbols.length);
                 foreach (d; (*symbols)[])
                 {
@@ -421,7 +421,7 @@ final class CParser(AST) : Parser!AST
              *    statement
              */
             nextToken();
-            auto statements = new AST.Statements();
+            auto statements = AST.Statements();
             while (token.value != TOK.rightCurly && token.value != TOK.endOfFile)
             {
                 statements.push(cparseStatement(ParseStatementFlags.curlyScope));
@@ -570,7 +570,7 @@ final class CParser(AST) : Parser!AST
 
             if (flags & ParseStatementFlags.curlyScope)
             {
-                auto statements = new AST.Statements();
+                auto statements = AST.Statements();
                 while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                 {
                     auto cur = cparseStatement(ParseStatementFlags.curlyScope);
@@ -605,7 +605,7 @@ final class CParser(AST) : Parser!AST
 
             if (flags & ParseStatementFlags.curlyScope)
             {
-                auto statements = new AST.Statements();
+                auto statements = AST.Statements();
                 while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                 {
                     statements.push(cparseStatement(ParseStatementFlags.curlyScope));
@@ -1680,13 +1680,13 @@ final class CParser(AST) : Parser!AST
         auto ss = fbody.isScopeStatement();
         auto cs = ss.statement.isCompoundStatement();
         assert(cs);
-        if (const len = (*cs.statements).length)
+        if (const len = cs.statements.length)
         {
-            auto s = (*cs.statements)[len - 1];
+            auto s = cs.statements[len - 1];
             if (s)   // error recovery should be with ErrorStatement, not null
             {
                 if (auto es = s.isExpStatement())
-                    (*cs.statements)[len - 1] = new AST.ReturnStatement(es.loc, es.exp);
+                    cs.statements[len - 1] = new AST.ReturnStatement(es.loc, es.exp);
             }
         }
 
@@ -2257,7 +2257,7 @@ final class CParser(AST) : Parser!AST
         auto fd = new AST.FuncDeclaration(id.loc, prevloc, id.name, stc, ft, specifier.noreturn);
         specifiersToFuncDeclaration(fd, specifier);
 
-        auto stmts = new AST.Statements();
+        auto stmts = AST.Statements();
 
         if (addFuncName)
             stmts.push(createFuncName(locFunc, id.name, Id.__func__));
@@ -3570,7 +3570,7 @@ final class CParser(AST) : Parser!AST
             error("string literal expected for Assembler Template, not `%s`", token.toChars());
         Token* toklist = null;
         Token** ptoklist = &toklist;
-        auto statements = new AST.Statements();
+        auto statements = AST.Statements();
 
         int parens;
         while (1)

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -379,7 +379,7 @@ final class CParser(AST) : Parser!AST
             cparseDeclaration(LVL.local);
             if (symbols.length > 1)
             {
-                auto as = AST.Statements();
+                AST.Statements as;
                 as.reserve(symbols.length);
                 foreach (d; (*symbols)[])
                 {
@@ -421,7 +421,7 @@ final class CParser(AST) : Parser!AST
              *    statement
              */
             nextToken();
-            auto statements = AST.Statements();
+            AST.Statements statements;
             while (token.value != TOK.rightCurly && token.value != TOK.endOfFile)
             {
                 statements.push(cparseStatement(ParseStatementFlags.curlyScope));
@@ -570,7 +570,7 @@ final class CParser(AST) : Parser!AST
 
             if (flags & ParseStatementFlags.curlyScope)
             {
-                auto statements = AST.Statements();
+                AST.Statements statements;
                 while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                 {
                     auto cur = cparseStatement(ParseStatementFlags.curlyScope);
@@ -605,7 +605,7 @@ final class CParser(AST) : Parser!AST
 
             if (flags & ParseStatementFlags.curlyScope)
             {
-                auto statements = AST.Statements();
+                AST.Statements statements;
                 while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                 {
                     statements.push(cparseStatement(ParseStatementFlags.curlyScope));
@@ -2257,7 +2257,7 @@ final class CParser(AST) : Parser!AST
         auto fd = new AST.FuncDeclaration(id.loc, prevloc, id.name, stc, ft, specifier.noreturn);
         specifiersToFuncDeclaration(fd, specifier);
 
-        auto stmts = AST.Statements();
+        AST.Statements stmts;
 
         if (addFuncName)
             stmts.push(createFuncName(locFunc, id.name, Id.__func__));
@@ -3570,7 +3570,7 @@ final class CParser(AST) : Parser!AST
             error("string literal expected for Assembler Template, not `%s`", token.toChars());
         Token* toklist = null;
         Token** ptoklist = &toklist;
-        auto statements = AST.Statements();
+        AST.Statements statements;
 
         int parens;
         while (1)

--- a/compiler/src/dmd/dfa/fast/statement.d
+++ b/compiler/src/dmd/dfa/fast/statement.d
@@ -654,7 +654,7 @@ final:
 
         case STMT.Compound:
             auto cs = st.isCompoundStatement;
-            if (cs.statements is null)
+            if (cs.statements.length == 0)
                 break;
 
             // We need to know which statement we are in and what the next ones are
@@ -664,7 +664,7 @@ final:
             this.startScope;
             dfaCommon.currentDFAScope.compoundStatement = cs;
 
-            foreach (i, st2; *cs.statements)
+            foreach (i, st2; cs.statements)
             {
                 dfaCommon.printStructureln("Compound statement:");
                 dfaCommon.currentDFAScope.inProgressCompoundStatement = i;
@@ -1043,14 +1043,14 @@ final:
             scope (exit)
                 inLoopyLabel--;
 
-            if (uls.statements !is null && uls.statements.length > 0)
+            if (uls.statements.length > 0)
             {
                 this.startScope;
 
                 dfaCommon.currentDFAScope.controlStatement = st;
                 dfaCommon.setScopeAsLoopyLabel;
 
-                foreach (stmt; *uls.statements)
+                foreach (stmt; uls.statements)
                 {
                     this.startScope;
                     this.visit(stmt);
@@ -1566,12 +1566,9 @@ final:
             case STMT.Compound:
                 auto cs = stmt.isCompoundStatement;
 
-                if (cs.statements !is null)
+                foreach (s; cs.statements)
                 {
-                    foreach (s; *cs.statements)
-                    {
-                        attempt(s);
-                    }
+                    attempt(s);
                 }
 
                 return ret;
@@ -1579,12 +1576,9 @@ final:
             case STMT.UnrolledLoop:
                 auto uls = stmt.isUnrolledLoopStatement;
 
-                if (uls.statements !is null)
+                foreach (s; uls.statements)
                 {
-                    foreach (s; *uls.statements)
-                    {
-                        attempt(s);
-                    }
+                    attempt(s);
                 }
 
                 return ret;

--- a/compiler/src/dmd/dfa/fast/structure.d
+++ b/compiler/src/dmd/dfa/fast/structure.d
@@ -493,13 +493,10 @@ struct DFACommon
                     return false;
                 case UnrolledLoop:
                     auto s2 = s.isUnrolledLoopStatement;
-                    if (s2.statements !is null)
+                    foreach (s3; s2.statements)
                     {
-                        foreach (s3; *s2.statements)
-                        {
-                            if (walkStatement(s3))
-                                return true;
-                        }
+                        if (walkStatement(s3))
+                            return true;
                     }
                     return false;
                 case Scope:
@@ -508,13 +505,10 @@ struct DFACommon
                 case Compound:
                 case CompoundDeclaration:
                     auto s2 = s.isCompoundStatement;
-                    if (s2.statements !is null)
+                    foreach (s3; s2.statements)
                     {
-                        foreach (s3; *s2.statements)
-                        {
-                            if (walkStatement(s3))
-                                return true;
-                        }
+                        if (walkStatement(s3))
+                            return true;
                     }
                     return false;
 
@@ -558,7 +552,7 @@ struct DFACommon
         {
             if (current.compoundStatement !is null)
             {
-                foreach (s; (*current.compoundStatement.statements)[current.inProgressCompoundStatement
+                foreach (s; current.compoundStatement.statements[current.inProgressCompoundStatement
                         .. $])
                 {
                     if (walkStatement(s))

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -861,10 +861,10 @@ Expression interpretStatement(UnionExp* pue, Statement s, InterState* istate)
         if (istate.start == s)
             istate.start = null;
 
-        const dim = s.statements ? s.statements.length : 0;
+        const dim = s.statements.length;
         foreach (i; 0 .. dim)
         {
-            Statement sx = (*s.statements)[i];
+            Statement sx = s.statements[i];
             result = interpretStatement(pue, sx, istate);
             if (result)
                 break;
@@ -889,10 +889,10 @@ Expression interpretStatement(UnionExp* pue, Statement s, InterState* istate)
         if (istate.start == s)
             istate.start = null;
 
-        const dim = s.statements ? s.statements.length : 0;
+        const dim = s.statements.length;
         foreach (i; 0 .. dim)
         {
-            Statement sx = (*s.statements)[i];
+            Statement sx = s.statements[i];
             Expression e = interpretStatement(pue, sx, istate);
             if (!e) // succeeds to interpret, or goto target was not found
                 continue;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4714,7 +4714,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (sd.fbody)
                 sa.push(sd.fbody);
 
-            sd.fbody = new CompoundStatement(Loc.initial, sa);
+            sd.fbody = new CompoundStatement(Loc.initial, sa.move());
             if (isDestructor)
                 (cast(StaticDtorDeclaration)sd).vgate = v;
         }

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4691,7 +4691,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             v.storage_class = STC.temp | STC.static_ | (isShared ? STC.shared_ : STC.none);
 
             Statement s = new ExpStatement(Loc.initial, v);
-            auto sa = new Statements(s);
+            auto sa = Statements(s);
 
             Expression e;
             if (isShared)
@@ -5958,7 +5958,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 auto ctor = new CtorDeclaration(cldec.loc, Loc.initial, STC.none, tf);
                 ctor.storage_class |= STC.inference | (fd.storage_class & STC.scope_);
                 ctor.isGenerated = true;
-                ctor.fbody = new CompoundStatement(Loc.initial, new Statements());
+                ctor.fbody = new CompoundStatement(Loc.initial);
 
                 cldec.members.push(ctor);
                 ctor.addMember(sc, cldec);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -19305,9 +19305,9 @@ void lowerNonArrayAggregate(StaticForeach sfe, Scope* sc)
     auto stmts = Statements();
     if (tplty) stmts.push(new ExpStatement(sfe.loc, tplty.sym));
     stmts.push(new ReturnStatement(aloc, res[0]));
-    auto s1 = Statements(sfe.createForeach(aloc, pparams[0], new CompoundStatement(aloc, stmts)),
+    auto s1 = Statements(sfe.createForeach(aloc, pparams[0], new CompoundStatement(aloc, stmts.move())),
                          new ExpStatement(aloc, new AssertExp(aloc, IntegerExp.literal!0)));
-    Type ety = new TypeTypeof(aloc, sfe.wrapAndCall(aloc, new CompoundStatement(aloc, s1)));
+    Type ety = new TypeTypeof(aloc, sfe.wrapAndCall(aloc, new CompoundStatement(aloc, s1.move())));
     auto aty = ety.arrayOf();
     auto idres = Identifier.generateId("__res");
     auto vard = new VarDeclaration(aloc, aty, idres, null, STC.temp);
@@ -19361,7 +19361,7 @@ void lowerNonArrayAggregate(StaticForeach sfe, Scope* sc)
     }
     else
     {
-        aggr = sfe.wrapAndCall(aloc, new CompoundStatement(aloc, s2));
+        aggr = sfe.wrapAndCall(aloc, new CompoundStatement(aloc, s2.move()));
         sc = sc.startCTFE();
         aggr = aggr.expressionSemantic(sc);
         aggr = resolveProperties(sc, aggr);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -19302,16 +19302,16 @@ void lowerNonArrayAggregate(StaticForeach sfe, Scope* sc)
         sfe.rangefe.upr = sfe.rangefe.upr.ctfeInterpret();
     }
 
-    auto stmts = new Statements();
+    auto stmts = Statements();
     if (tplty) stmts.push(new ExpStatement(sfe.loc, tplty.sym));
     stmts.push(new ReturnStatement(aloc, res[0]));
-    auto s1 = new Statements(sfe.createForeach(aloc, pparams[0], new CompoundStatement(aloc, stmts)),
-                             new ExpStatement(aloc, new AssertExp(aloc, IntegerExp.literal!0)));
+    auto s1 = Statements(sfe.createForeach(aloc, pparams[0], new CompoundStatement(aloc, stmts)),
+                         new ExpStatement(aloc, new AssertExp(aloc, IntegerExp.literal!0)));
     Type ety = new TypeTypeof(aloc, sfe.wrapAndCall(aloc, new CompoundStatement(aloc, s1)));
     auto aty = ety.arrayOf();
     auto idres = Identifier.generateId("__res");
     auto vard = new VarDeclaration(aloc, aty, idres, null, STC.temp);
-    auto s2 = new Statements();
+    auto s2 = Statements();
 
     // Run 'typeof' gagged to avoid duplicate errors and if it fails just create
     // an empty foreach to expose them.

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -388,7 +388,7 @@ extern (C++) class FuncDeclaration : Declaration
         //printf("FuncDeclaration::syntaxCopy('%s')\n", toChars());
         FuncDeclaration f = s ? cast(FuncDeclaration)s
                               : new FuncDeclaration(loc, endloc, ident, storage_class, type.syntaxCopy(), this.noreturn != 0);
-        f.frequires = frequires ? Statement.arraySyntaxCopy(frequires) : null;
+        f.frequires = frequires ? Statement.arraySyntaxCopy(frequires, null) : null;
         f.fensures = fensures ? Ensure.arraySyntaxCopy(fensures) : null;
         f.fbody = fbody ? fbody.syntaxCopy() : null;
         return f;

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2943,20 +2943,18 @@ void unpackFunctionParameters(FuncDeclaration thisfd)
     if (!thisfd.fbody || !thisfd.type || thisfd.type.ty != Tfunction)
         return;
     TypeFunction f = cast(TypeFunction)thisfd.type;
-    Statements* ups = null;
+    Statements ups;
     foreach (i, Parameter p; f.parameterList)
     {
         if (!p.unpack)
             continue;
-        if (ups is null)
-            ups = new Statements();
         p.unpack._init = new IdentifierExp(p.loc, p.ident);
         ups.push(new ExpStatement(p.unpack.loc, p.unpack));
     }
-    if (ups !is null)
+    if (ups.length)
     {
         ups.push(thisfd.fbody);
-        thisfd.fbody = new CompoundStatement(thisfd.fbody.loc, ups);
+        thisfd.fbody = new CompoundStatement(thisfd.fbody.loc, ups.move());
     }
 }
 
@@ -2975,7 +2973,7 @@ void buildEnsureRequire(FuncDeclaration thisfd)
          */
         assert(thisfd.frequires.length);
         auto loc = (*thisfd.frequires)[0].loc;
-        auto s = new Statements;
+        auto s = Statements();
         foreach (r; *thisfd.frequires)
         {
             s.push(new ScopeStatement(r.loc, r, r.loc));
@@ -2993,7 +2991,7 @@ void buildEnsureRequire(FuncDeclaration thisfd)
          */
         assert(thisfd.fensures.length);
         auto loc = (*thisfd.fensures)[0].ensure.loc;
-        auto s = new Statements;
+        auto s = Statements();
         foreach (r; *thisfd.fensures)
         {
             if (r.id && thisfd.canBuildResultVar())

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2978,7 +2978,7 @@ void buildEnsureRequire(FuncDeclaration thisfd)
         {
             s.push(new ScopeStatement(r.loc, r, r.loc));
         }
-        thisfd.frequire = new CompoundStatement(loc, s);
+        thisfd.frequire = new CompoundStatement(loc, s.move());
     }
     if (thisfd.fensures)
     {
@@ -3009,7 +3009,7 @@ void buildEnsureRequire(FuncDeclaration thisfd)
                 s.push(r.ensure);
             }
         }
-        thisfd.fensure = new CompoundStatement(loc, s);
+        thisfd.fensure = new CompoundStatement(loc, s.move());
     }
     if (!thisfd.isVirtual())
         return;

--- a/compiler/src/dmd/glue/s2ir.d
+++ b/compiler/src/dmd/glue/s2ir.d
@@ -717,9 +717,7 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
 
     void visitCompound(CompoundStatement s)
     {
-        if (!s.statements)
-            return;
-        foreach (s2; *s.statements)
+        foreach (s2; s.statements)
         {
             if (s2)
                 Statement_toIR(s2, irs, stmtstate);
@@ -752,7 +750,7 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
 
         block* bdox;
 
-        foreach (s2; *s.statements)
+        foreach (s2; s.statements)
         {
             if (s2)
             {

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -366,7 +366,7 @@ private void statementToBuffer(Statement s, ref OutBuffer buf, ref HdrGenState h
 
     void visitCompound(CompoundStatement s)
     {
-        foreach (sx; *s.statements)
+        foreach (sx; s.statements)
         {
             if (sx)
                 sx.statementToBuffer(buf, hgs);
@@ -381,7 +381,7 @@ private void statementToBuffer(Statement s, ref OutBuffer buf, ref HdrGenState h
     void visitCompoundDeclaration(CompoundDeclarationStatement s)
     {
         bool anywritten = false;
-        foreach (sx; *s.statements)
+        foreach (sx; s.statements)
         {
             auto ds = sx ? sx.isExpStatement() : null;
             if (ds && ds.exp.isDeclarationExp())
@@ -406,7 +406,7 @@ private void statementToBuffer(Statement s, ref OutBuffer buf, ref HdrGenState h
         buf.put("/*unrolled*/ {");
         buf.writenl();
         buf.level++;
-        foreach (sx; *s.statements)
+        foreach (sx; s.statements)
         {
             if (sx)
                 sx.statementToBuffer(buf, hgs);
@@ -3873,7 +3873,7 @@ private Expression arrowFuncLiteralResult(FuncLiteralDeclaration f)
     CompoundStatement cs = f.fbody.isCompoundStatement();
     Statement s1;
     if (f.semanticRun >= PASS.semantic3done && cs)
-        s1 = (*cs.statements)[cs.statements.length - 1];
+        s1 = cs.statements[cs.statements.length - 1];
     else
         s1 = !cs ? f.fbody : null;
 

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -192,7 +192,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
              */
             Type tf = new TypeFunction(ParameterList(), null, LINK.d);
             auto fd = new FuncLiteralDeclaration(i.loc, Loc.initial, tf, tok, null);
-            fd.fbody = new CompoundStatement(i.loc, new Statements());
+            fd.fbody = new CompoundStatement(i.loc);
             fd.endloc = i.loc;
             Expression e = new FuncExp(i.loc, fd);
             auto ie = new ExpInitializer(i.loc, e);

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -242,7 +242,7 @@ public:
         }
 
         static if (asStatements)
-            result = new CompoundStatement(s.loc, as);
+            result = new CompoundStatement(s.loc, as.move());
     }
 
     override void visit(UnrolledLoopStatement s)
@@ -1170,7 +1170,7 @@ public:
                     return null;
                 auto a = Statements(!s1 ? new ExpStatement(e.e1.loc, e.e1) : s1,
                                     !s2 ? new ExpStatement(e.e2.loc, e.e2) : s2);
-                return new CompoundStatement(exp.loc, a);
+                return new CompoundStatement(exp.loc, a.move());
             }
 
             // inline as an expression
@@ -2423,11 +2423,11 @@ private void expandInline(CallExp ecall, FuncDeclaration fd, FuncDeclaration par
         if (as2 != &as)
         {
             as.push(new TryFinallyStatement(callLoc,
-                        new CompoundStatement(callLoc, *as2),
+                        new CompoundStatement(callLoc, as2.move()),
                         new DtorExpStatement(callLoc, vthis.edtor, vthis)));
         }
 
-        sresult = new ScopeStatement(callLoc, new CompoundStatement(callLoc, as), callLoc);
+        sresult = new ScopeStatement(callLoc, new CompoundStatement(callLoc, as.move()), callLoc);
 
         static if (EXPANDINLINE_LOG)
             printf("\n[%s] %s expandInline sresult =\n%s\n",

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -181,11 +181,11 @@ public:
         //printf("CompoundStatement.doInlineAs!%s() %d\n", Result.stringof.ptr, s.statements.length);
         static if (asStatements)
         {
-            auto as = new Statements();
+            auto as = Statements();
             as.reserve(s.statements.length);
         }
 
-        foreach (i, sx; *s.statements)
+        foreach (i, sx; s.statements)
         {
             if (!sx)
                 continue;
@@ -207,7 +207,7 @@ public:
                     ifs.ifbody.endsWithReturnStatement() &&
                     !ifs.elsebody &&
                     i + 1 < s.statements.length &&
-                    (s3 = (*s.statements)[i + 1]) !is null &&
+                    (s3 = s.statements[i + 1]) !is null &&
                     s3.endsWithReturnStatement()
                    )
                 {
@@ -250,11 +250,11 @@ public:
         //printf("UnrolledLoopStatement.doInlineAs!%s() %d\n", Result.stringof.ptr, s.statements.length);
         static if (asStatements)
         {
-            auto as = new Statements();
+            auto as = Statements();
             as.reserve(s.statements.length);
         }
 
-        foreach (sx; *s.statements)
+        foreach (sx; s.statements)
         {
             if (!sx)
                 continue;
@@ -1168,8 +1168,8 @@ public:
                 auto s2 = inlineScanExpAsStatement(e.e2);
                 if (!s1 && !s2)
                     return null;
-                auto a = new Statements(!s1 ? new ExpStatement(e.e1.loc, e.e1) : s1,
-                                        !s2 ? new ExpStatement(e.e2.loc, e.e2) : s2);
+                auto a = Statements(!s1 ? new ExpStatement(e.e1.loc, e.e1) : s1,
+                                    !s2 ? new ExpStatement(e.e2.loc, e.e2) : s2);
                 return new CompoundStatement(exp.loc, a);
             }
 
@@ -1185,7 +1185,7 @@ public:
     {
         foreach (i; 0 .. s.statements.length)
         {
-            inlineScan((*s.statements)[i]);
+            inlineScan(s.statements[i]);
         }
     }
 
@@ -1193,7 +1193,7 @@ public:
     {
         foreach (i; 0 .. s.statements.length)
         {
-            inlineScan((*s.statements)[i]);
+            inlineScan(s.statements[i]);
         }
     }
 
@@ -2394,19 +2394,20 @@ private void expandInline(CallExp ecall, FuncDeclaration fd, FuncDeclaration par
          *  { eret; ethis; try { eparams; fd.fbody; } finally { vthis.edtor; } }
          */
 
-        auto as = new Statements();
+        auto as = Statements();
+        auto asDtor = Statements();
         if (eret)
             as.push(new ExpStatement(callLoc, eret));
         if (ethis)
             as.push(new ExpStatement(callLoc, ethis));
 
-        auto as2 = as;
+        auto as2 = &as;
         if (vthis && !vthis.isDataseg())
         {
             if (vthis.needsScopeDtor())
             {
                 // same with ExpStatement.scopeCode()
-                as2 = new Statements();
+                as2 = &asDtor;
                 vthis.storage_class |= STC.nodtor;
             }
         }
@@ -2419,10 +2420,10 @@ private void expandInline(CallExp ecall, FuncDeclaration fd, FuncDeclaration par
         fd.inlineNest--;
         as2.push(s);
 
-        if (as2 != as)
+        if (as2 != &as)
         {
             as.push(new TryFinallyStatement(callLoc,
-                        new CompoundStatement(callLoc, as2),
+                        new CompoundStatement(callLoc, *as2),
                         new DtorExpStatement(callLoc, vthis.edtor, vthis)));
         }
 

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -269,7 +269,7 @@ public:
         }
 
         static if (asStatements)
-            result = new UnrolledLoopStatement(s.loc, as);
+            result = new UnrolledLoopStatement(s.loc, as.move());
     }
 
     override void visit(ScopeStatement s)

--- a/compiler/src/dmd/inlinecost.d
+++ b/compiler/src/dmd/inlinecost.d
@@ -191,7 +191,7 @@ public:
         scope InlineCostVisitor icv = new InlineCostVisitor(this);
         foreach (i; 0 .. s.statements.length)
         {
-            if (Statement s2 = (*s.statements)[i])
+            if (Statement s2 = s.statements[i])
             {
                 /* Specifically allow:
                  *  if (condition)
@@ -205,7 +205,7 @@ public:
                     ifs.ifbody.endsWithReturnStatement() &&
                     !ifs.elsebody &&
                     i + 1 < s.statements.length &&
-                    (s3 = (*s.statements)[i + 1]) !is null &&
+                    (s3 = s.statements[i + 1]) !is null &&
                     s3.endsWithReturnStatement()
                    )
                 {
@@ -230,7 +230,7 @@ public:
     override void visit(UnrolledLoopStatement s)
     {
         scope InlineCostVisitor icv = new InlineCostVisitor(this);
-        foreach (s2; *s.statements)
+        foreach (s2; s.statements)
         {
             if (s2)
             {

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -409,12 +409,9 @@ void toObNodes(ref ObNodes obnodes, Statement s)
 
         void visitCompound(CompoundStatement s)
         {
-            if (s.statements)
+            foreach (s2; s.statements)
             {
-                foreach (s2; *s.statements)
-                {
-                    visit(s2, stmtstate);
-                }
+                visit(s2, stmtstate);
             }
         }
 
@@ -430,7 +427,7 @@ void toObNodes(ref ObNodes obnodes, Statement s)
 
             gotoNextNode();
 
-            foreach (s2; *s.statements)
+            foreach (s2; s.statements)
             {
                 if (s2)
                 {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -6414,7 +6414,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 AST.Dsymbols* a = parseDeclarations(false, null, null);
                 if (a.length > 1)
                 {
-                    auto as = new AST.Statements();
+                    auto as = AST.Statements();
                     as.reserve(a.length);
                     foreach (i; 0 .. a.length)
                     {
@@ -6503,7 +6503,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 nextToken();
                 //if (token.value == TOK.semicolon)
                 //    error("use `{ }` for an empty statement, not `;`");
-                auto statements = new AST.Statements();
+                auto statements = AST.Statements();
                 while (token.value != TOK.rightCurly && token.value != TOK.endOfFile)
                 {
                     statements.push(parseStatement(ParseStatementFlags.curlyScope | ParseStatementFlags.semiOk));
@@ -6808,7 +6808,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                 if (flags & ParseStatementFlags.curlyScope)
                 {
-                    auto statements = new AST.Statements();
+                    auto statements = AST.Statements();
                     while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                     {
                         auto cur = parseStatement(ParseStatementFlags.curlyScope);
@@ -6852,7 +6852,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                 if (flags & ParseStatementFlags.curlyScope)
                 {
-                    auto statements = new AST.Statements();
+                    auto statements = AST.Statements();
                     while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                     {
                         statements.push(parseStatement(ParseStatementFlags.curlyScope));
@@ -7424,7 +7424,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         Token* toklist = null;
         Token** ptoklist = &toklist;
         Identifier label = null;
-        auto statements = new AST.Statements();
+        auto statements = AST.Statements();
         size_t nestlevel = 0;
         while (1)
         {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -6414,7 +6414,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 AST.Dsymbols* a = parseDeclarations(false, null, null);
                 if (a.length > 1)
                 {
-                    auto as = AST.Statements();
+                    AST.Statements as;
                     as.reserve(a.length);
                     foreach (i; 0 .. a.length)
                     {
@@ -6503,7 +6503,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 nextToken();
                 //if (token.value == TOK.semicolon)
                 //    error("use `{ }` for an empty statement, not `;`");
-                auto statements = AST.Statements();
+                AST.Statements statements;
                 while (token.value != TOK.rightCurly && token.value != TOK.endOfFile)
                 {
                     statements.push(parseStatement(ParseStatementFlags.curlyScope | ParseStatementFlags.semiOk));
@@ -6808,7 +6808,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                 if (flags & ParseStatementFlags.curlyScope)
                 {
-                    auto statements = AST.Statements();
+                    AST.Statements statements;
                     while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                     {
                         auto cur = parseStatement(ParseStatementFlags.curlyScope);
@@ -6852,7 +6852,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                 if (flags & ParseStatementFlags.curlyScope)
                 {
-                    auto statements = AST.Statements();
+                    AST.Statements statements;
                     while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                     {
                         statements.push(parseStatement(ParseStatementFlags.curlyScope));
@@ -7424,7 +7424,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         Token* toklist = null;
         Token** ptoklist = &toklist;
         Identifier label = null;
-        auto statements = AST.Statements();
+        AST.Statements statements;
         size_t nestlevel = 0;
         while (1)
         {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -6422,7 +6422,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         s = new AST.ExpStatement(loc, d);
                         as.push(s);
                     }
-                    s = new AST.CompoundDeclarationStatement(loc, as);
+                    s = new AST.CompoundDeclarationStatement(loc, as.move());
                 }
                 else if (a.length == 1)
                 {
@@ -6516,7 +6516,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     *pEndloc = token.loc;
                     pEndloc = null; // don't set it again
                 }
-                s = new AST.CompoundStatement(loc, statements);
+                s = new AST.CompoundStatement(loc, statements.move());
                 if (flags & (ParseStatementFlags.scope_ | ParseStatementFlags.curlyScope))
                     s = new AST.ScopeStatement(loc, s, token.loc);
                 if (token.value != TOK.rightCurly)
@@ -6822,7 +6822,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         if (cur && cur.isBreakStatement())
                             break;
                     }
-                    s = new AST.CompoundStatement(loc, statements);
+                    s = new AST.CompoundStatement(loc, statements.move());
                 }
                 else
                 {
@@ -6857,7 +6857,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     {
                         statements.push(parseStatement(ParseStatementFlags.curlyScope));
                     }
-                    s = new AST.CompoundStatement(loc, statements);
+                    s = new AST.CompoundStatement(loc, statements.move());
                 }
                 else
                     s = parseStatement(0);
@@ -7508,7 +7508,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         nextToken();
         if (token.value == TOK.endOfLine)
             nextToken();
-        auto s = new AST.CompoundAsmStatement(loc, statements, stc);
+        auto s = new AST.CompoundAsmStatement(loc, statements.move(), stc);
         return s;
     }
 

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -333,24 +333,32 @@ public:
         return a;
     }
 
-    // convert to an rvalue leaving this empty
-    Array!T move() pure nothrow
+    // a custom ctor is necessary to keep the bootstrap compiler 2.079
+    //  from trying to use the disabled postblit ctor in move()
+    private this(uint len, uint alloc, T* ptr)
     {
-        Array!T a;
-        if (allocated <= SMALLARRAYCAP)
+        if (alloc <= SMALLARRAYCAP)
         {
-            for (size_t i = 0; i < length; i++)
-                a.smallarray[i] = smallarray[i];
+            for (size_t i = 0; i < len; i++)
+                smallarray[i] = ptr[i];
         }
         else
         {
-            a._ptr = _ptr;
+            _ptr = ptr;
         }
-        a.length = length;
-        a.allocated = allocated;
+        length = len;
+        allocated = alloc;
+    }
+
+    // convert to an rvalue leaving this empty
+    Array!T move() pure nothrow
+    {
+        uint len = length;
+        uint alloc = allocated;
+        T* ptr = data;
         length = 0;
         allocated = SMALLARRAYCAP;
-        return a;
+        return Array!T(len, alloc, ptr);
     }
 
     void shift(T ptr) pure nothrow

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -333,32 +333,55 @@ public:
         return a;
     }
 
-    // a custom ctor is necessary to keep the bootstrap compiler 2.079
-    //  from trying to use the disabled postblit ctor in move()
-    private this(uint len, uint alloc, T* ptr)
+    static if (__VERSION__ < 2095)
     {
-        if (alloc <= SMALLARRAYCAP)
+        // a custom ctor is necessary to keep the bootstrap compiler 2.079
+        //  from trying to use the disabled postblit ctor in move()
+        private this(uint len, uint alloc, T* ptr)
         {
-            for (size_t i = 0; i < len; i++)
-                smallarray[i] = ptr[i];
+            if (alloc <= SMALLARRAYCAP)
+            {
+                for (size_t i = 0; i < len; i++)
+                    smallarray[i] = ptr[i];
+            }
+            else
+            {
+                _ptr = ptr;
+            }
+            length = len;
+            allocated = alloc;
         }
-        else
-        {
-            _ptr = ptr;
-        }
-        length = len;
-        allocated = alloc;
-    }
 
-    // convert to an rvalue leaving this empty
-    Array!T move() pure nothrow
+        // convert to an rvalue leaving this empty
+        Array!T move() pure nothrow
+        {
+            uint len = length;
+            uint alloc = allocated;
+            T* ptr = data;
+            length = 0;
+            allocated = SMALLARRAYCAP;
+            return Array!T(len, alloc, ptr);
+        }
+    }
+    else
     {
-        uint len = length;
-        uint alloc = allocated;
-        T* ptr = data;
-        length = 0;
-        allocated = SMALLARRAYCAP;
-        return Array!T(len, alloc, ptr);
+        // convert to an rvalue leaving this empty
+        Array!T move() pure nothrow
+        {
+            Array!T a;
+            if (allocated <= SMALLARRAYCAP)
+            {
+                for (size_t i = 0; i < length; i++)
+                    a.smallarray[i] = smallarray[i];
+            }
+            else
+                a._ptr = _ptr;
+            a.allocated = allocated;
+            a.length = length;
+            length = 0;
+            allocated = SMALLARRAYCAP;
+            return a;
+        }
     }
 
     void shift(T ptr) pure nothrow

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -54,6 +54,7 @@ public:
 
     @disable this(this);
 
+@trusted:
     ~this() pure nothrow
     {
         debug (stomp)
@@ -65,7 +66,6 @@ public:
             mem.xfree(_ptr);
     }
 
-@trusted:
     // this is using a template constraint because of ambiguity with this(size_t) when T is
     // int, and c++ header generation doesn't accept wrapping this in static if
     extern(D) this()(T[] elems ...) pure nothrow if (is(T == struct) || is(T == class))
@@ -333,21 +333,24 @@ public:
         return a;
     }
 
-    void moveFrom(ref Array!T a) pure nothrow
+    // convert to an rvalue leaving this empty
+    Array!T move() pure nothrow
     {
-        if (a.allocated <= SMALLARRAYCAP)
+        Array!T a;
+        if (allocated <= SMALLARRAYCAP)
         {
-            for (size_t i = 0; i < a.length; i++)
-                smallarray[i] = a.smallarray[i];
+            for (size_t i = 0; i < length; i++)
+                a.smallarray[i] = smallarray[i];
         }
         else
         {
-            _ptr = a._ptr;
+            a._ptr = _ptr;
         }
-        length = a.length;
-        allocated = a.allocated;
-        a.length = 0;
-        a.allocated = SMALLARRAYCAP;
+        a.length = length;
+        a.allocated = allocated;
+        length = 0;
+        allocated = SMALLARRAYCAP;
+        return a;
     }
 
     void shift(T ptr) pure nothrow

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -333,6 +333,23 @@ public:
         return a;
     }
 
+    void moveFrom(ref Array!T a) pure nothrow
+    {
+        if (a.allocated <= SMALLARRAYCAP)
+        {
+            for (size_t i = 0; i < a.length; i++)
+                smallarray[i] = a.smallarray[i];
+        }
+        else
+        {
+            _ptr = a._ptr;
+        }
+        length = a.length;
+        allocated = a.allocated;
+        a.length = 0;
+        a.allocated = SMALLARRAYCAP;
+    }
+
     void shift(T ptr) pure nothrow
     {
         reserve(1);

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -615,7 +615,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 funcdecl.fbody = funcdecl.fbody.statementSemantic(sc2);
                 if (!funcdecl.fbody)
-                    funcdecl.fbody = new CompoundStatement(Loc.initial, new Statements());
+                    funcdecl.fbody = new CompoundStatement(Loc.initial);
 
                 if (funcdecl.isNaked)
                 {
@@ -1131,10 +1131,10 @@ private extern(C++) final class Semantic3Visitor : Visitor
             }
             else
             {
-                auto a = new Statements();
+                auto a = Statements();
 
                 size_t expectedSize = (funcdecl.parameters ? funcdecl.parameters.length : 0) + 7;
-                    a.reserve(expectedSize);
+                a.reserve(expectedSize);
 
                 // Merge in initialization of 'out' parameters
                 if (funcdecl.parameters)

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1224,7 +1224,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     a.push(s);
                 }
 
-                Statement sbody = new CompoundStatement(Loc.initial, a);
+                Statement sbody = new CompoundStatement(Loc.initial, a.move());
 
                 /* Append destructor calls for parameters as finally blocks.
                  */

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -558,7 +558,7 @@ extern (C++) class CompoundStatement : Statement
  */
 extern (C++) final class CompoundDeclarationStatement : CompoundStatement
 {
-    extern (D) this(Loc loc, Statements statements) @safe
+    extern (D) this(Loc loc, Statements statements) @safe nothrow
     {
         super(loc, statements.move(), STMT.CompoundDeclaration);
     }
@@ -1859,7 +1859,7 @@ extern (C++) final class CompoundAsmStatement : CompoundStatement
 {
     STC stc; // postfix attributes like nothrow/pure/@trusted
 
-    extern (D) this(Loc loc, Statements statements, STC stc) @safe
+    extern (D) this(Loc loc, Statements statements, STC stc) @safe nothrow
     {
         super(loc, statements.move(), STMT.CompoundAsm);
         this.stc = stc;

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -474,16 +474,16 @@ extern (C++) class CompoundStatement : Statement
      *   loc = Instantiation information
      *   statements   = An array of `Statement`s, that will referenced by this class
      */
-    final extern (D) this(Loc loc, ref Statements statements) @safe nothrow
+    final extern (D) this(Loc loc, Statements statements) @safe nothrow
     {
         super(loc, STMT.Compound);
-        this.statements.moveFrom(statements);
+        this.statements = statements.move();
     }
 
-    final extern (D) this(Loc loc, ref Statements statements, STMT stmt) @safe nothrow
+    final extern (D) this(Loc loc, Statements statements, STMT stmt) @safe nothrow
     {
         super(loc, stmt);
-        this.statements.moveFrom(statements);
+        this.statements = statements.move();
     }
     final extern (D) this(Loc loc) @safe nothrow
     {
@@ -558,16 +558,16 @@ extern (C++) class CompoundStatement : Statement
  */
 extern (C++) final class CompoundDeclarationStatement : CompoundStatement
 {
-    extern (D) this(Loc loc, ref Statements statements) @safe
+    extern (D) this(Loc loc, Statements statements) @safe
     {
-        super(loc, statements, STMT.CompoundDeclaration);
+        super(loc, statements.move(), STMT.CompoundDeclaration);
     }
 
     override CompoundDeclarationStatement syntaxCopy()
     {
         Statements nstmts;
         Statement.arraySyntaxCopy(&statements, &nstmts);
-        return new CompoundDeclarationStatement(loc, nstmts);
+        return new CompoundDeclarationStatement(loc, nstmts.move());
     }
 
     override void accept(Visitor v)
@@ -587,7 +587,7 @@ extern (C++) final class UnrolledLoopStatement : Statement
     extern (D) this(Loc loc, ref Statements statements) @safe nothrow
     {
         super(loc, STMT.UnrolledLoop);
-        this.statements.moveFrom(statements);
+        this.statements = statements.move();
     }
 
     override UnrolledLoopStatement syntaxCopy()
@@ -1859,9 +1859,9 @@ extern (C++) final class CompoundAsmStatement : CompoundStatement
 {
     STC stc; // postfix attributes like nothrow/pure/@trusted
 
-    extern (D) this(Loc loc, ref Statements statements, STC stc) @safe
+    extern (D) this(Loc loc, Statements statements, STC stc) @safe
     {
-        super(loc, statements, STMT.CompoundAsm);
+        super(loc, statements.move(), STMT.CompoundAsm);
         this.stc = stc;
     }
 
@@ -1869,7 +1869,7 @@ extern (C++) final class CompoundAsmStatement : CompoundStatement
     {
         Statements nstmts;
         Statement.arraySyntaxCopy(&statements, &nstmts);
-        return new CompoundAsmStatement(loc, nstmts, stc);
+        return new CompoundAsmStatement(loc, nstmts.move(), stc);
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -48,7 +48,7 @@ extern (C++) abstract class Statement : ASTNode
         return DYNCAST.statement;
     }
 
-    final extern (D) this(Loc loc, STMT stmt) @safe
+    final extern (D) this(Loc loc, STMT stmt) @safe nothrow
     {
         this.loc = loc;
         this.stmt = stmt;
@@ -64,17 +64,13 @@ extern (C++) abstract class Statement : ASTNode
     /*************************************
      * Do syntax copy of an array of Statement's.
      */
-    static Statements* arraySyntaxCopy(Statements* a)
+    static Statements* arraySyntaxCopy(Statements* a, Statements* b)
     {
-        Statements* b = null;
-        if (a)
-        {
-            b = a.copy();
-            foreach (i, s; *a)
-            {
-                (*b)[i] = s ? s.syntaxCopy() : null;
-            }
-        }
+        if (!b)
+            b = new Statements;
+        b.reserve(a.length);
+        foreach (s; *a)
+            b.push(s ? s.syntaxCopy() : null);
         return b;
     }
 
@@ -468,7 +464,7 @@ extern (C++) final class MixinStatement : Statement
  */
 extern (C++) class CompoundStatement : Statement
 {
-    Statements* statements;
+    Statements statements;
 
     /**
      * Construct a `CompoundStatement` using an already existing
@@ -478,17 +474,22 @@ extern (C++) class CompoundStatement : Statement
      *   loc = Instantiation information
      *   statements   = An array of `Statement`s, that will referenced by this class
      */
-    final extern (D) this(Loc loc, Statements* statements) @safe
+    final extern (D) this(Loc loc, ref Statements statements) @safe nothrow
     {
         super(loc, STMT.Compound);
-        this.statements = statements;
+        this.statements.moveFrom(statements);
     }
 
-    final extern (D) this(Loc loc, Statements* statements, STMT stmt) @safe
+    final extern (D) this(Loc loc, ref Statements statements, STMT stmt) @safe nothrow
     {
         super(loc, stmt);
-        this.statements = statements;
+        this.statements.moveFrom(statements);
     }
+    final extern (D) this(Loc loc) @safe nothrow
+    {
+        super(loc, STMT.Compound);
+    }
+
 
     /**
      * Construct a `CompoundStatement` from an array of `Statement`s
@@ -501,7 +502,6 @@ extern (C++) class CompoundStatement : Statement
     final extern (D) this(Loc loc, Statement[] sts...)
     {
         super(loc, STMT.Compound);
-        statements = new Statements();
         statements.reserve(sts.length);
         foreach (s; sts)
             statements.push(s);
@@ -514,12 +514,14 @@ extern (C++) class CompoundStatement : Statement
 
     override CompoundStatement syntaxCopy()
     {
-        return new CompoundStatement(loc, Statement.arraySyntaxCopy(statements));
+        auto cs = new CompoundStatement(loc);
+        Statement.arraySyntaxCopy(&statements, &cs.statements);
+        return cs;
     }
 
     override final inout(ReturnStatement) endsWithReturnStatement() inout nothrow pure
     {
-        foreach (s; *statements)
+        foreach (s; statements)
         {
             if (s)
             {
@@ -535,7 +537,7 @@ extern (C++) class CompoundStatement : Statement
         Statement s = null;
         for (size_t i = statements.length; i; --i)
         {
-            s = cast(Statement)(*statements)[i - 1];
+            s = cast(Statement)statements[i - 1];
             if (s)
             {
                 s = cast(Statement)s.last();
@@ -556,14 +558,16 @@ extern (C++) class CompoundStatement : Statement
  */
 extern (C++) final class CompoundDeclarationStatement : CompoundStatement
 {
-    extern (D) this(Loc loc, Statements* statements) @safe
+    extern (D) this(Loc loc, ref Statements statements) @safe
     {
         super(loc, statements, STMT.CompoundDeclaration);
     }
 
     override CompoundDeclarationStatement syntaxCopy()
     {
-        return new CompoundDeclarationStatement(loc, Statement.arraySyntaxCopy(statements));
+        Statements nstmts;
+        Statement.arraySyntaxCopy(&statements, &nstmts);
+        return new CompoundDeclarationStatement(loc, nstmts);
     }
 
     override void accept(Visitor v)
@@ -578,17 +582,19 @@ extern (C++) final class CompoundDeclarationStatement : CompoundStatement
  */
 extern (C++) final class UnrolledLoopStatement : Statement
 {
-    Statements* statements;
+    Statements statements;
 
-    extern (D) this(Loc loc, Statements* statements) @safe
+    extern (D) this(Loc loc, ref Statements statements) @safe nothrow
     {
         super(loc, STMT.UnrolledLoop);
-        this.statements = statements;
+        this.statements.moveFrom(statements);
     }
 
     override UnrolledLoopStatement syntaxCopy()
     {
-        return new UnrolledLoopStatement(loc, Statement.arraySyntaxCopy(statements));
+        Statements nstmts;
+        Statement.arraySyntaxCopy(&statements, &nstmts);
+        return new UnrolledLoopStatement(loc, nstmts);
     }
 
     override bool hasBreak() const pure nothrow
@@ -1853,7 +1859,7 @@ extern (C++) final class CompoundAsmStatement : CompoundStatement
 {
     STC stc; // postfix attributes like nothrow/pure/@trusted
 
-    extern (D) this(Loc loc, Statements* statements, STC stc) @safe
+    extern (D) this(Loc loc, ref Statements statements, STC stc) @safe
     {
         super(loc, statements, STMT.CompoundAsm);
         this.stc = stc;
@@ -1861,7 +1867,9 @@ extern (C++) final class CompoundAsmStatement : CompoundStatement
 
     override CompoundAsmStatement syntaxCopy()
     {
-        return new CompoundAsmStatement(loc, Statement.arraySyntaxCopy(statements), stc);
+        Statements nstmts;
+        Statement.arraySyntaxCopy(&statements, &nstmts);
+        return new CompoundAsmStatement(loc, nstmts, stc);
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -584,7 +584,7 @@ extern (C++) final class UnrolledLoopStatement : Statement
 {
     Statements statements;
 
-    extern (D) this(Loc loc, ref Statements statements) @safe nothrow
+    extern (D) this(Loc loc, Statements statements) @safe nothrow
     {
         super(loc, STMT.UnrolledLoop);
         this.statements = statements.move();
@@ -594,7 +594,7 @@ extern (C++) final class UnrolledLoopStatement : Statement
     {
         Statements nstmts;
         Statement.arraySyntaxCopy(&statements, &nstmts);
-        return new UnrolledLoopStatement(loc, nstmts);
+        return new UnrolledLoopStatement(loc, nstmts.move());
     }
 
     override bool hasBreak() const pure nothrow

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -283,7 +283,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         Statements* a = cs.flatten(sc);
         if (!a)
             return;
-        Statement s = new CompoundStatement(cs.loc, a);
+        Statement s = new CompoundStatement(cs.loc, *a);
         result = s.statementSemantic(sc);
     }
 
@@ -301,7 +301,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         for (size_t i = 0; i < cs.statements.length;)
         {
-            Statement s = (*cs.statements)[i];
+            Statement s = cs.statements[i];
             if (!s)
             {
                 ++i;
@@ -315,7 +315,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 continue;
             }
             s = s.statementSemantic(sc);
-            (*cs.statements)[i] = s;
+            cs.statements[i] = s;
             if (!s)
             {
                 /* Remove NULL statements from the list.
@@ -343,8 +343,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                         {
                             auto j = i;
                             cs.statements.insert(i, vd.aliasTuple.objects.length - 1, null);
-                            vd.aliasTuple.foreachVar((v) { (*cs.statements)[j++] = toStatement(v); });
-                            s = (*cs.statements)[i];
+                            vd.aliasTuple.foreachVar((v) { cs.statements[j++] = toStatement(v); });
+                            s = cs.statements[i];
                         }
                         else if (auto ei = vd._init ? vd._init.isExpInitializer() : null)
                         {
@@ -352,7 +352,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                             // https://github.com/dlang/dmd/issues/20842
                             if (auto te = ei.exp ? ei.exp.isTupleExp() : null)
                                 if (te.e0)
-                                    (*cs.statements)[i] = s = new ExpStatement(vd.loc, te.e0);
+                                    cs.statements[i] = s = new ExpStatement(vd.loc, te.e0);
                         }
                     }
                 }
@@ -366,7 +366,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             if (auto sgs = s.isScopeGuardStatement())
                 scopeGuardTok = sgs.tok;
 
-            (*cs.statements)[i] = s.scopeCode(sc, sentry, sexception, sfinally);
+            cs.statements[i] = s.scopeCode(sc, sentry, sexception, sfinally);
             if (sentry)
             {
                 sentry = sentry.statementSemantic(sc);
@@ -385,7 +385,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     {
                         if (const cs = s.isCompoundStatement())
                         {
-                            if (!isEmpty((*cs.statements)[]))
+                            if (!isEmpty(cs.statements[]))
                                 return false;
                         }
                         else
@@ -394,7 +394,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     return true;
                 }
 
-                if (!sfinally && isEmpty((*cs.statements)[i + 1 .. cs.statements.length]))
+                if (!sfinally && isEmpty(cs.statements[i + 1 .. cs.statements.length]))
                 {
                 }
                 else
@@ -407,8 +407,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                      *      catch (Throwable __o)
                      *      { sexception; throw __o; }
                      */
-                    auto a = new Statements();
-                    a.pushSlice((*cs.statements)[i + 1 .. cs.statements.length]);
+                    auto a = Statements();
+                    a.pushSlice(cs.statements[i + 1 .. cs.statements.length]);
                     cs.statements.setDim(i + 1);
 
                     Statement _body = new CompoundStatement(Loc.initial, a);
@@ -458,8 +458,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                      * As:
                      *      s; try { s1; s2; } finally { sfinally; }
                      */
-                    auto a = new Statements();
-                    a.pushSlice((*cs.statements)[i + 1 .. cs.statements.length]);
+                    auto a = Statements();
+                    a.pushSlice(cs.statements[i + 1 .. cs.statements.length]);
                     cs.statements.setDim(i + 1);
 
                     auto _body = new CompoundStatement(Loc.initial, a);
@@ -499,9 +499,9 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
          * 'semantic' may return another CompoundStatement
          * (eg. CaseRangeStatement), so flatten it here.
          */
-        flattenStatements(*cs.statements);
+        flattenStatements(cs.statements);
 
-        foreach (s; *cs.statements)
+        foreach (s; cs.statements)
         {
             if (!s)
                 continue;
@@ -515,7 +515,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         if (cs.statements.length == 1)
         {
-            result = (*cs.statements)[0];
+            result = cs.statements[0];
             return;
         }
         result = cs;
@@ -529,7 +529,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         scd.scontinue = uls;
 
         Statement serror = null;
-        foreach (i, ref s; *uls.statements)
+        foreach (i, ref s; uls.statements)
         {
             if (s)
             {
@@ -561,7 +561,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         Statements* a = ss.statement.flatten(sc);
         if (a)
         {
-            ss.statement = new CompoundStatement(ss.loc, a);
+            ss.statement = new CompoundStatement(ss.loc, *a);
         }
 
         ss.statement = ss.statement.statementSemantic(sc);
@@ -691,7 +691,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
              *    } finally { v2.~this(); }
              *  } finally { v1.~this(); }
              */
-            auto ainit = new Statements(fs._init);
+            auto ainit = Statements(fs._init);
             fs._init = null;
             ainit.push(fs);
             Statement s = new CompoundStatement(fs.loc, ainit);
@@ -967,24 +967,20 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         Statement unpackVariables(Statement _body)
         {
-            Statements* ups = null;
+            Statements ups;
             foreach (i; 0 .. dim)
             {
                 Parameter p = (*fs.parameters)[i];
                 if (p.unpack)
                 {
-                    if (ups is null)
-                    {
-                        ups = new Statements();
-                    }
                     p.unpack._init = new IdentifierExp(p.loc, p.ident);
                     ups.push(new ExpStatement(p.unpack.loc, p.unpack));
                 }
             }
-            if (ups !is null)
+            if (ups.length)
             {
                 ups.push(_body);
-                return new CompoundStatement(loc, ups);
+                return new CompoundStatement(loc, ups.move());
             }
             return _body;
         }
@@ -1259,7 +1255,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 else
                     fs.key._init = new ExpInitializer(loc, new IntegerExp(loc, 0, fs.key.type));
 
-                auto cs = new Statements();
+                auto cs = Statements();
                 if (vinit)
                     cs.push(new ExpStatement(loc, vinit));
                 cs.push(new ExpStatement(loc, tmp));
@@ -1650,7 +1646,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         auto tmp = new VarDeclaration(loc, fs.upr.type, id, ie);
         tmp.storage_class |= STC.temp;
 
-        auto cs = new Statements();
+        auto cs = Statements();
         // Keep order of evaluation as lwr, then upr
         if (fs.op == TOK.foreach_)
         {
@@ -1932,7 +1928,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
              * switch(a)
              *     { body }
              */
-            auto statements = new Statements();
+            auto statements = Statements();
             auto vardecl = new VarDeclaration(ss.param.loc,
                 ss.param.type,
                 ss.param.ident,
@@ -2128,7 +2124,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 error(ss.loc, "`switch` statement without a `default`; use `final switch` or add `default: assert(0);` or add `default: break;`");
 
             // Generate runtime error if the default is hit
-            auto a = new Statements();
+            auto a = Statements();
             CompoundStatement cs;
             Statement s;
 
@@ -2493,7 +2489,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
          *   s;
          */
 
-        auto statements = new Statements();
+        auto statements = Statements();
         for (uinteger_t i = fval; i != lval + 1; i++)
         {
             Statement s = crs.statement;
@@ -3273,7 +3269,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 auto tmp = copyToTemp(STC.none, "__sync", ss.exp);
                 tmp.dsymbolSemantic(sc);
 
-                auto cs = new Statements(new ExpStatement(ss.loc, tmp));
+                auto cs = Statements(new ExpStatement(ss.loc, tmp));
                 auto args = new Parameters(new Parameter(Loc.initial, STC.none, ClassDeclaration.object.type,
                                                          null, null, null, null));
 
@@ -3306,7 +3302,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             tmp.storage_class |= STC.temp | STC.shared_ | STC.static_;
             Expression tmpExp = new VarExp(ss.loc, tmp);
 
-            auto cs = new Statements(new ExpStatement(ss.loc, tmp));
+            auto cs = Statements(new ExpStatement(ss.loc, tmp));
 
             /* This is just a dummy variable for "goto skips declaration" error.
              * Backend optimizer could remove this unused variable.
@@ -3827,7 +3823,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
          * second for anything else.
          */
 
-        foreach (ref s; *cas.statements)
+        foreach (ref s; cas.statements)
         {
             if (s)
             {
@@ -3838,7 +3834,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             }
         }
 
-        foreach (ref s; *cas.statements)
+        foreach (ref s; cas.statements)
         {
             s = s ? s.statementSemantic(sc) : null;
         }
@@ -4150,7 +4146,7 @@ private extern(D) Statement loopReturn(Expression e, Statements* cases, Loc loc)
     // default: break; takes care of cases 0 and 1
     s = new BreakStatement(Loc.initial, null);
     s = new DefaultStatement(Loc.initial, s);
-    auto a = new Statements(s);
+    auto a = Statements(s);
 
     // cases 2...
     foreach (i, c; *cases)
@@ -4562,12 +4558,10 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
     Type tab = fs.aggr.type.toBasetype();
     TypeTuple tuple = tab.isTypeTuple();
 
-    Statements* statements;
+    Statements statements;
     Dsymbols* declarations;
     if (isDecl)
         declarations = new Dsymbols();
-    else
-        statements = new Statements();
 
     //printf("aggr: op = %d, %s\n", fs.aggr.op, fs.aggr.toChars());
     size_t n;
@@ -4594,12 +4588,10 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
             t = Parameter.getNth(tuple.arguments, k).type;
         Parameter p = (*fs.parameters)[0];
 
-        Statements* stmts;
+        Statements stmts;
         Dsymbols* decls;
         if (isDecl)
             decls = new Dsymbols();
-        else
-            stmts = new Statements();
 
         const bool skip = isStatic && needExpansion;
         if (!skip && dim == 2)
@@ -4922,7 +4914,7 @@ private Statements* flatten(Statement statement, Scope* sc)
     {
         case STMT.Compound:
         case STMT.CompoundDeclaration:
-            return (cast(CompoundStatement)statement).statements;
+            return &(cast(CompoundStatement)statement).statements;
 
         case STMT.Exp:
         case STMT.DtorExp:
@@ -5106,7 +5098,7 @@ private Statement toStatement(Dsymbol s)
 
     if (auto tm = s.isTemplateMixin())
     {
-        auto a = new Statements();
+        auto a = Statements();
         foreach (m; *tm.members)
         {
             if (Statement sx = toStatement(m))
@@ -5138,7 +5130,7 @@ private Statement toStatement(Dsymbol s)
          */
         if (Dsymbols* a = d.include(null))
         {
-            auto statements = new Statements();
+            auto statements = Statements();
             foreach (sx; *a)
             {
                 statements.push(toStatement(sx));

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -283,7 +283,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         Statements* a = cs.flatten(sc);
         if (!a)
             return;
-        Statement s = new CompoundStatement(cs.loc, *a);
+        Statement s = new CompoundStatement(cs.loc, a.move());
         result = s.statementSemantic(sc);
     }
 
@@ -411,7 +411,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     a.pushSlice(cs.statements[i + 1 .. cs.statements.length]);
                     cs.statements.setDim(i + 1);
 
-                    Statement _body = new CompoundStatement(Loc.initial, a);
+                    Statement _body = new CompoundStatement(Loc.initial, a.move());
                     _body = new ScopeStatement(Loc.initial, _body, Loc.initial);
 
                     Identifier id = Identifier.generateId("__o");
@@ -462,7 +462,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     a.pushSlice(cs.statements[i + 1 .. cs.statements.length]);
                     cs.statements.setDim(i + 1);
 
-                    auto _body = new CompoundStatement(Loc.initial, a);
+                    auto _body = new CompoundStatement(Loc.initial, a.move());
                     auto stf = new TryFinallyStatement(Loc.initial, _body, sfinally);
                     if (auto des = sfinally.isDtorExpStatement())
                         stf.loweredFrom = des.var;
@@ -561,7 +561,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         Statements* a = ss.statement.flatten(sc);
         if (a)
         {
-            ss.statement = new CompoundStatement(ss.loc, *a);
+            ss.statement = new CompoundStatement(ss.loc, a.move());
         }
 
         ss.statement = ss.statement.statementSemantic(sc);
@@ -694,7 +694,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             auto ainit = Statements(fs._init);
             fs._init = null;
             ainit.push(fs);
-            Statement s = new CompoundStatement(fs.loc, ainit);
+            Statement s = new CompoundStatement(fs.loc, ainit.move());
             s = new ScopeStatement(fs.loc, s, fs.endloc);
             s = s.statementSemantic(sc);
             if (!s.isErrorStatement())
@@ -1260,7 +1260,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     cs.push(new ExpStatement(loc, vinit));
                 cs.push(new ExpStatement(loc, tmp));
                 cs.push(new ExpStatement(loc, fs.key));
-                Statement forinit = new CompoundDeclarationStatement(loc, cs);
+                Statement forinit = new CompoundDeclarationStatement(loc, cs.move());
 
                 Expression cond;
                 if (fs.op == TOK.foreach_reverse_)
@@ -1658,7 +1658,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             cs.push(new ExpStatement(loc, tmp));
             cs.push(new ExpStatement(loc, fs.key));
         }
-        Statement forinit = new CompoundDeclarationStatement(loc, cs);
+        Statement forinit = new CompoundDeclarationStatement(loc, cs.move());
 
         Expression cond;
         if (fs.op == TOK.foreach_reverse_)
@@ -1942,7 +1942,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
             statements.push(ss);
 
-            Statement s = new CompoundStatement(ss.loc, statements);
+            Statement s = new CompoundStatement(ss.loc, statements.move());
             s = new ScopeStatement(ss.loc, s, ss.endloc);
             s = s.statementSemantic(sc);
             result = s;
@@ -2175,7 +2175,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             if (ss._body.blockExit(sc.func, null) & BE.fallthru)
                 a.push(new BreakStatement(Loc.initial, null));
             a.push(sc.switchStatement.sdefault);
-            cs = new CompoundStatement(ss.loc, a);
+            cs = new CompoundStatement(ss.loc, a.move());
             ss._body = cs;
         }
 
@@ -2499,7 +2499,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             Statement cs = new CaseStatement(crs.loc, e, s);
             statements.push(cs);
         }
-        Statement s = new CompoundStatement(crs.loc, statements);
+        Statement s = new CompoundStatement(crs.loc, statements.move());
         sc.ctorflow.orCSX(CSX.label);
         s = s.statementSemantic(sc);
         result = s;
@@ -3285,7 +3285,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 s = new TryFinallyStatement(ss.loc, ss._body, s);
                 cs.push(s);
 
-                s = new CompoundStatement(ss.loc, cs);
+                s = new CompoundStatement(ss.loc, cs.move());
                 result = s.statementSemantic(sc);
             }
         }
@@ -3329,7 +3329,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             s = new TryFinallyStatement(ss.loc, ss._body, s);
             cs.push(s);
 
-            s = new CompoundStatement(ss.loc, cs);
+            s = new CompoundStatement(ss.loc, cs.move());
             result = s.statementSemantic(sc);
         }
     }
@@ -4155,7 +4155,7 @@ private extern(D) Statement loopReturn(Expression e, Statements* cases, Loc loc)
         a.push(s);
     }
 
-    s = new CompoundStatement(loc, a);
+    s = new CompoundStatement(loc, a.move());
     return new SwitchStatement(loc, null, e, s, false, loc);
 }
 
@@ -4849,7 +4849,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
         else
         {
             stmts.push(fs._body.syntaxCopy());
-            s = new CompoundStatement(loc, stmts);
+            s = new CompoundStatement(loc, stmts.move());
         }
 
         if (!isStatic)
@@ -4884,7 +4884,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
     else if (isDecl)
         result.decl = declarations;
     else
-        result.statement = new CompoundStatement(loc, statements);
+        result.statement = new CompoundStatement(loc, statements.move());
 
     return result;
 }
@@ -5104,7 +5104,7 @@ private Statement toStatement(Dsymbol s)
             if (Statement sx = toStatement(m))
                 a.push(sx);
         }
-        result = new CompoundStatement(tm.loc, a);
+        result = new CompoundStatement(tm.loc, a.move());
     }
     else if (s.isVarDeclaration()       ||
              s.isAggregateDeclaration() ||
@@ -5135,7 +5135,7 @@ private Statement toStatement(Dsymbol s)
             {
                 statements.push(toStatement(sx));
             }
-            result = new CompoundStatement(d.loc, statements);
+            result = new CompoundStatement(d.loc, statements.move());
         }
     }
     else if (s.isStaticAssert() ||

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -558,10 +558,14 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         sym.endlinnum = ss.endloc.linnum;
         sc = sc.push(sym);
 
-        Statements* a = ss.statement.flatten(sc);
-        if (a)
+        // for CompoundStatement flatten just returns its statements, so no need
+        //  to wrap it in another CompoundStatement
+        if (ss.statement.stmt != STMT.Compound && ss.statement.stmt != STMT.CompoundDeclaration)
         {
-            ss.statement = new CompoundStatement(ss.loc, a.move());
+            if (Statements* a = ss.statement.flatten(sc))
+            {
+                ss.statement = new CompoundStatement(ss.loc, a.move());
+            }
         }
 
         ss.statement = ss.statement.statementSemantic(sc);
@@ -4874,7 +4878,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
 
     if (!isStatic)
     {
-        Statement res = new UnrolledLoopStatement(loc, statements);
+        Statement res = new UnrolledLoopStatement(loc, statements.move());
         if (LabelStatement ls = checkLabeledLoop(sc, fs))
             ls.gotoTarget = res;
         if (te && te.e0)

--- a/compiler/src/dmd/visitor/foreachvar.d
+++ b/compiler/src/dmd/visitor/foreachvar.d
@@ -175,12 +175,9 @@ void foreachExpAndVar(Statement s,
 
         void visitCompound(CompoundStatement s)
         {
-            if (s.statements)
+            foreach (s2; s.statements)
             {
-                foreach (s2; *s.statements)
-                {
-                    visit(s2);
-                }
+                visit(s2);
             }
         }
 
@@ -191,7 +188,7 @@ void foreachExpAndVar(Statement s,
 
         void visitUnrolledLoop(UnrolledLoopStatement s)
         {
-            foreach (s2; *s.statements)
+            foreach (s2; s.statements)
             {
                 visit(s2);
             }

--- a/compiler/src/dmd/visitor/package.d
+++ b/compiler/src/dmd/visitor/package.d
@@ -126,7 +126,7 @@ extern (C++) class SemanticTimeTransitiveVisitor : SemanticTimePermissiveVisitor
 
     override void visit(ASTCodegen.UnrolledLoopStatement s)
     {
-        foreach(sx; *s.statements)
+        foreach(sx; s.statements)
         {
             if (sx)
                 sx.accept(this);

--- a/compiler/src/dmd/visitor/postorder.d
+++ b/compiler/src/dmd/visitor/postorder.d
@@ -244,7 +244,7 @@ public:
     override void visit(CompoundStatement s)
     {
         for (size_t i = 0; i < s.statements.length; i++)
-            if (doCond((*s.statements)[i]))
+            if (doCond(s.statements[i]))
                 return;
         applyTo(s);
     }
@@ -252,7 +252,7 @@ public:
     override void visit(UnrolledLoopStatement s)
     {
         for (size_t i = 0; i < s.statements.length; i++)
-            if (doCond((*s.statements)[i]))
+            if (doCond(s.statements[i]))
                 return;
         applyTo(s);
     }

--- a/compiler/src/dmd/visitor/statement_rewrite_walker.d
+++ b/compiler/src/dmd/visitor/statement_rewrite_walker.d
@@ -48,13 +48,10 @@ public:
 
     override void visit(CompoundStatement s)
     {
-        if (s.statements && s.statements.length)
+        for (size_t i = 0; i < s.statements.length; i++)
         {
-            for (size_t i = 0; i < s.statements.length; i++)
-            {
-                if ((*s.statements)[i])
-                    visitStmt((*s.statements)[i]);
-            }
+            if (s.statements[i])
+                visitStmt(s.statements[i]);
         }
     }
 
@@ -65,13 +62,10 @@ public:
 
     override void visit(UnrolledLoopStatement s)
     {
-        if (s.statements && s.statements.length)
+        for (size_t i = 0; i < s.statements.length; i++)
         {
-            for (size_t i = 0; i < s.statements.length; i++)
-            {
-                if ((*s.statements)[i])
-                    visitStmt((*s.statements)[i]);
-            }
+            if (s.statements[i])
+                visitStmt(s.statements[i]);
         }
     }
 

--- a/compiler/src/dmd/visitor/transitive.d
+++ b/compiler/src/dmd/visitor/transitive.d
@@ -53,7 +53,7 @@ package(dmd.visitor) mixin template ParseVisitMethods(AST)
     override void visit(AST.CompoundStatement s)
     {
         //printf("Visiting CompoundStatement\n");
-        foreach (sx; *s.statements)
+        foreach (sx; s.statements)
         {
             if (sx)
                 sx.accept(this);
@@ -84,7 +84,7 @@ package(dmd.visitor) mixin template ParseVisitMethods(AST)
     override void visit(AST.CompoundDeclarationStatement s)
     {
         //printf("Visiting CompoundDeclarationStatement\n");
-        foreach (sx; *s.statements)
+        foreach (sx; s.statements)
         {
             if (!sx)
                 continue;

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1055,23 +1055,19 @@ public:
     }
     void visit(CompoundStatement *s) override
     {
-        if (s->statements == NULL)
-            return;
-        for (size_t i = 0; i < s->statements->length; i++)
+        for (size_t i = 0; i < s->statements.length; i++)
         {
-            Statement *statement = (*s->statements)[i];
+            Statement *statement = s->statements[i];
             if (statement)
                 statement->accept(this);
         }
     }
     void visit(UnrolledLoopStatement *s) override
     {
-        if (s->statements == NULL)
-            return;
         s->getRelatedLabeled()->accept(this);
-        for (size_t i = 0; i < s->statements->length; i++)
+        for (size_t i = 0; i < s->statements.length; i++)
         {
-            Statement *statement = (*s->statements)[i];
+            Statement *statement = s->statements[i];
             if (statement != NULL)
                 statement->accept(this);
         }

--- a/compiler/test/unit/semantic/control_flow.d
+++ b/compiler/test/unit/semantic/control_flow.d
@@ -772,7 +772,7 @@ auto getStatements(FuncDeclaration fd)
     assert(fd.fbody);
     auto cs = fd.fbody.isCompoundStatement();
     assert(cs);
-    auto stmts = cs.statements;
+    auto stmts = &cs.statements;
     assert(stmts);
 
     // Body sometimes wrapped in additional CompoundStatments?
@@ -781,7 +781,7 @@ auto getStatements(FuncDeclaration fd)
         auto s = (*stmts)[0].isCompoundStatement();
         if (!s)
             break;
-        stmts = s.statements;
+        stmts = &s.statements;
         assert(stmts);
     }
 


### PR DESCRIPTION
reduces size and avoids an extra allocation.

Also avoids the indirection on usage and makes the code a bit cleaner.

The downside is that constructing the CompoundStatement with an array of statements has to move the contents of the array if we don't want the extra copy - which might not be obvious from the code. This could be done a bit nicer with rvalues, but the bootstrap compilers don't have that.
