### PR TITLE
druntime: Re-enable `profilegc.d` on WASI

### DIFF
--- a/druntime/src/rt/profilegc.d
+++ b/druntime/src/rt/profilegc.d
@@ -13,12 +13,6 @@
 
 module rt.profilegc;
 
-// On Wasm, it increases codesize noticably.
-// Meanwhile, ldc (ldmd2) does not support `-profile-gc`, so there's no point
-// keeping it around on Wasm targets
-version (WASI) {}
-else:
-
 private:
 
 import core.stdc.errno : errno;


### PR DESCRIPTION
Between #23408 and #22859, this should no longer be an issue.