### PR TITLE
druntime: Disable some unittests on WASI

### DIFF
--- a/druntime/src/core/math.d
+++ b/druntime/src/core/math.d
@@ -99,6 +99,11 @@ float ldexp(float n, int exp);   /* intrinsic */
 double ldexp(double n, int exp); /* intrinsic */ /// ditto
 real ldexp(real n, int exp);     /* intrinsic */ /// ditto
 
+// Wasm is always cross-compiled, so we are subject to
+// https://wiki.dlang.org/Cross-compiling_with_LDC#Limitations
+// (precision issues with `real`)
+version (WebAssembly) {}
+else
 unittest {
     static if (real.mant_dig == 113)
     {

--- a/druntime/src/core/sync/barrier.d
+++ b/druntime/src/core/sync/barrier.d
@@ -106,6 +106,8 @@ private:
 // Unit Tests
 ////////////////////////////////////////////////////////////////////////////////
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.thread;

--- a/druntime/src/core/sync/condition.d
+++ b/druntime/src/core/sync/condition.d
@@ -647,6 +647,8 @@ private:
 // Unit Tests
 ////////////////////////////////////////////////////////////////////////////////
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.sync.mutex;
@@ -813,6 +815,8 @@ unittest
     testWaitTimeout();
 }
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.sync.mutex;

--- a/druntime/src/core/sync/event.d
+++ b/druntime/src/core/sync/event.d
@@ -330,6 +330,8 @@ private:
 }
 
 // Test single-thread (non-shared) use.
+version (WASI) {} // WASI is single-threaded
+else
 @nogc nothrow unittest
 {
     // auto-reset, initial state false
@@ -347,6 +349,8 @@ private:
     assert(!ev2.wait(1.dur!"msecs"));
 }
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.atomic;

--- a/druntime/src/core/sync/mutex.d
+++ b/druntime/src/core/sync/mutex.d
@@ -317,6 +317,8 @@ package:
 ///
 /* @safe nothrow -> see druntime PR 1726 */
 // Test regular usage.
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.thread : Thread;
@@ -392,6 +394,7 @@ unittest
     version (CRuntime_Musl) {} else
     version (DragonFlyBSD) {} else
     version (Solaris) {} else
+    version (WASI) {} else
     assert(!mtx.tryLock_nothrow());
 
     free(cast(void*) mtx);
@@ -410,6 +413,8 @@ unittest
     m.unlock();
 }
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.thread;

--- a/druntime/src/core/sync/rwmutex.d
+++ b/druntime/src/core/sync/rwmutex.d
@@ -562,7 +562,8 @@ private:
 // Unit Tests
 ////////////////////////////////////////////////////////////////////////////////
 
-
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.atomic, core.thread, core.sync.semaphore;
@@ -699,6 +700,8 @@ unittest
     runTest(ReadWriteMutex.Policy.PREFER_WRITERS);
 }
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.atomic, core.thread;
@@ -775,6 +778,8 @@ unittest
     }
 }
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.atomic, core.thread, core.sync.semaphore;
@@ -911,6 +916,8 @@ unittest
     runTest(ReadWriteMutex.Policy.PREFER_WRITERS);
 }
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.atomic, core.thread;

--- a/druntime/src/core/sync/semaphore.d
+++ b/druntime/src/core/sync/semaphore.d
@@ -393,6 +393,8 @@ protected:
 // Unit Tests
 ////////////////////////////////////////////////////////////////////////////////
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.atomic;

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -441,6 +441,8 @@ private extern(D) static void thread_yield() @nogc nothrow
 }
 
 ///
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     class DerivedThread : Thread
@@ -470,6 +472,8 @@ unittest
     }).start();
 }
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     int x = 0;
@@ -481,7 +485,8 @@ unittest
     assert( x == 1 );
 }
 
-
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     enum MSG = "Test message.";
@@ -502,7 +507,8 @@ unittest
     }
 }
 
-
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     // use >pageSize to avoid stack overflow (e.g. in an syscall)
@@ -510,7 +516,8 @@ unittest
     thr.join();
 }
 
-
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.memory : GC;
@@ -527,6 +534,8 @@ unittest
     t2.join();
 }
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest
 {
     import core.sync.semaphore;
@@ -580,6 +589,8 @@ unittest
     }
 }
 
+version (WASI) {} // WASI is single-threaded
+else
 unittest // Bugzilla 8960
 {
     import core.sync.semaphore;
@@ -2605,6 +2616,8 @@ void joinLowLevelThread(ThreadID tid) nothrow @nogc
         static assert(0, "unsupported os");
 }
 
+version (WASI) {} // WASI is single-threaded
+else
 nothrow @nogc unittest
 {
     struct TaskWithContect

--- a/druntime/src/core/thread/package.d
+++ b/druntime/src/core/thread/package.d
@@ -22,6 +22,8 @@ public import core.thread.context;
 
 // this test is here to avoid a cyclic dependency between
 // core.thread and core.atomic
+version (WASI) {} // WASI is single-threaded
+else
 @system unittest
 {
     import core.atomic;


### PR DESCRIPTION
Disable some runtime tests (mainly ones relating to multithreading) that can't work on WASI (or Wasm) currently.