### PR TITLE
druntime: Remove `ClockType`s `processCPUTime` and `threadCPUTime` on WASIp1

### DIFF
--- a/druntime/src/core/time.d
+++ b/druntime/src/core/time.d
@@ -356,16 +356,7 @@ else version (Hurd) enum ClockType
     // threadCPUTime = 7,
 
 }
-else version (WASIp1) enum ClockType
-{
-    normal = 0,
-    coarse = 2,
-    precise = 3,
-    processCPUTime = 4,
-    second = 6,
-    threadCPUTime = 7,
-}
-else version (WASIp2) enum ClockType
+else version (WASI) enum ClockType
 {
     normal = 0,
     coarse = 2,
@@ -519,9 +510,7 @@ version (WASIp1)
             case coarse: return ClockID.monotonic;
             case normal: return ClockID.monotonic;
             case precise: return ClockID.monotonic;
-            case processCPUTime: return ClockID.processCPUTimeID;
             case second: assert(0);
-            case threadCPUTime: return ClockID.threadCPUTimeID;
         }
     }
 }


### PR DESCRIPTION
Wasmtime doesn't support them (`clockGetRes` fails; triggering unittest failures). And WASIp2 removes them anyway.