### PR TITLE
druntime: Use `convClockFreq` in `TickDuration` `from`/`to`

### DIFF
--- a/druntime/src/core/time.d
+++ b/druntime/src/core/time.d
@@ -1899,7 +1899,7 @@ T to(string units, T, D)(D td) @safe pure nothrow @nogc
     {
         enum unitsPerSec = convert!("seconds", units)(1);
 
-        return cast(T) (td.length / (TickDuration.ticksPerSec / cast(real) unitsPerSec));
+        return cast(T) convClockFreq(td.length, TickDuration.ticksPerSec, unitsPerSec);
     }
     else static if (__traits(isFloating, T))
     {
@@ -3184,7 +3184,7 @@ deprecated:
     {
         enum unitsPerSec = convert!("seconds", units)(1);
 
-        return TickDuration(cast(long)(length * (ticksPerSec / cast(real)unitsPerSec)));
+        return TickDuration(convClockFreq(length, unitsPerSec, ticksPerSec));
     }
 
     version (CoreUnittest) unittest


### PR DESCRIPTION
For the exact reason described in `convClockFreq`:
> This would be more straightforward with floating point arithmetic,
> but we avoid it here in order to avoid the rounding errors that that
> introduces.

I ran into this issue when testing WASIp1. Wasm uses software-emulated fp128 as "real". And for the roundtrip from/to test of 1000 nsecs (which just so happens to be the reported clock resolution; so ticksPerSec is 1,000,000) some rounding error happens that makes what `printf("%Lf")`s as 1.000000 collpase to 0 when converted to `long`, breaking the test.