### PR TITLE
Fix __traits(getMember, this, ...) not capturing enclosing this in nested functions

### DIFF
--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1167,6 +1167,22 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                         return ErrorExp.get();
                 }
             }
+            // getMember with wantsym returns the member VarDeclaration
+            // without a ThisExp use, so nested functions that only access
+            // a field through getMember(this, ...) never register a nested
+            // reference to the enclosing `this`.  Force that here.
+            if (ex && !ex.isErrorExp())
+            {
+                if (auto e0 = isExpression(o))
+                {
+                    e0 = e0.expressionSemantic(sc);
+                    if (auto te = e0.isThisExp())
+                    {
+                        if (te.var && te.var.checkNestedReference(sc, e.loc))
+                            return ErrorExp.get();
+                    }
+                }
+            }
             return ex;
         }
         else if (e.ident == Id.getVirtualFunctions ||

--- a/compiler/test/runnable/test_getMember_nested_this.d
+++ b/compiler/test/runnable/test_getMember_nested_this.d
@@ -1,0 +1,25 @@
+// https://github.com/dlang/dmd/issues/23436
+// __traits(getMember, this, "field") in a nested function must register
+// a nested reference to the enclosing `this` so vthis appears in the
+// closure frame.
+
+struct Struct
+{
+    int field = 42;
+
+    auto nestedThunk()
+    {
+        int inner()
+        {
+            return __traits(getMember, this, "field");
+        }
+        return &inner;
+    }
+}
+
+void main()
+{
+    auto s = Struct();
+    auto dg = s.nestedThunk();
+    assert(dg() == 42);
+}


### PR DESCRIPTION
## Summary

`__traits(getMember, this, "field")` inside a nested function does not register a nested reference to the enclosing member `this`. The compiler then omits `vthis` from the closure frame, causing a segfault when the delegate runs.

`getMember` with `wantsym` returns the member `VarDeclaration` without keeping a `ThisExp` use. After `expressionSemantic` on the resolved member, when the lookup object is `this`, this patch calls `checkNestedReference` on `te.var` so closure building matches a direct field access.

## Test plan

Added `compiler/test/runnable/test_getMember_nested_this.d`: nested function returned as a delegate that reads a field via `getMember` on `this`.

Fixes #23436.
Also fixes ldc-developers/ldc#5203.
