### PR TITLE
osthread: thread info invalidation instead of purge

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -1644,35 +1644,21 @@ private extern (D) void resume(ThreadBase _t) nothrow @nogc
         }
     }
 
-    storeStackAndRegInfo(t, sameThread);
+    purgeStackAndRegInfo(t, sameThread);
 }
 
-private void storeStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
+private void purgeStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
 {
     version (Windows)
-    {
-        if ( !t.m_lock )
-            t.m_curr.tstack = t.m_curr.bstack;
-        t.m_reg[0 .. $] = 0;
-    }
+        t.dropStackInfo();
     else version (Darwin)
-    {
-        if ( !t.m_lock )
-            t.m_curr.tstack = t.m_curr.bstack;
-        t.m_reg[0 .. $] = 0;
-    }
+        t.dropStackInfo();
     else version (Solaris)
-    {
-        if (!t.m_lock)
-            t.m_curr.tstack = t.m_curr.bstack;
-        t.m_reg[0 .. $] = 0;
-    }
+        t.dropStackInfo();
     else version (Posix)
     {
-        if (sameThread && !t.m_lock)
-        {
-            t.m_curr.tstack = t.m_curr.bstack;
-        }
+        if (sameThread)
+            t.dropStackInfo();
     }
     else version (WASI)
     {
@@ -1680,6 +1666,10 @@ private void storeStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
     }
     else
         static assert(false, "Platform not supported.");
+
+    // zeroing registers info if available
+    static if (__traits(compiles, t.m_reg))
+        t.m_reg[0 .. $] = 0;
 }
 
 

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -1644,21 +1644,21 @@ private extern (D) void resume(ThreadBase _t) nothrow @nogc
         }
     }
 
-    purgeStackAndRegInfo(t, sameThread);
+    debug invalidateStackAndRegInfo(t, sameThread);
 }
 
-private void purgeStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
+debug private void invalidateStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
 {
     version (Windows)
-        t.dropStackInfo();
+        t.invalidateStackInfo();
     else version (Darwin)
-        t.dropStackInfo();
+        t.invalidateStackInfo();
     else version (Solaris)
-        t.dropStackInfo();
+        t.invalidateStackInfo();
     else version (Posix)
     {
         if (sameThread)
-            t.dropStackInfo();
+            t.invalidateStackInfo();
     }
     else version (WASI)
     {
@@ -1667,9 +1667,9 @@ private void purgeStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
     else
         static assert(false, "Platform not supported.");
 
-    // zeroing registers info if available
+    // invalidate registers info if available
     static if (__traits(compiles, t.m_reg))
-        t.m_reg[0 .. $] = 0;
+        t.m_reg[0 .. $] = 0x00defec7;
 }
 
 

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -806,10 +806,10 @@ package(core.thread):
         add(t, rmAboutToStart);
     }
 
-    package final void dropStackInfo() nothrow @nogc
+    debug package final void invalidateStackInfo() nothrow @nogc
     {
         if (!m_lock)
-            m_curr.tstack = m_curr.bstack;
+            m_curr.tstack = cast(void*) 0xabadbabe;
     }
 }
 

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -806,6 +806,11 @@ package(core.thread):
         add(t, rmAboutToStart);
     }
 
+    package final void dropStackInfo() nothrow @nogc
+    {
+        if (!m_lock)
+            m_curr.tstack = m_curr.bstack;
+    }
 }
 
 


### PR DESCRIPTION
In addition to #23439:
It seems like `storeStackAndRegInfo()` should be debug-only code?