### PR TITLE
fix #23431 - Windows: libraries built with debug symbols often emit warnings…

### DIFF
--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1604,7 +1604,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, out Param 
             params.ehnogc = true;
         }
         else if (arg == "-lib")         // https://dlang.org/dmd.html#switch-lib
-            driverParams.lib = true;
+            driverParams.lib = params.fullyQualifiedObjectFiles = true;
         else if (arg == "-nofloat")
             driverParams.nofloat = true;
         else if (arg == "-quiet")

--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -438,7 +438,7 @@ ifeq ($(HAS_ADDITIONAL_TESTS),1)
         test/aa test/cpuid test/gc test/hash test/lifetime test/shared \
         test/thread test/unittest test/imports test/betterc test/stdcpp test/config test/traits test/importc_compare
     ifeq (windows,$(OS))
-        ADDITIONAL_TESTS+=test/uuid
+        ADDITIONAL_TESTS+=test/uuid test/link
     else
         ADDITIONAL_TESTS+=test/valgrind
     endif

--- a/druntime/test/link/Makefile
+++ b/druntime/test/link/Makefile
@@ -1,0 +1,7 @@
+# Windows only
+TESTS := test23431
+
+include ../common.mak
+
+# error out on generating any warning
+$(OBJDIR)/test23431$(DOTEXE): private DFLAGS += -L/WX

--- a/druntime/test/link/test23431.d
+++ b/druntime/test/link/test23431.d
@@ -1,0 +1,7 @@
+// https://github.com/dlang/dmd/issues/23431
+// test linking against debug build of druntime.lib producing
+// druntime.lib(package.obj) : warning LNK4255: library contain multiple objects of the same name; linking object as if no debug info
+
+void main()
+{
+}


### PR DESCRIPTION
… about multiple objects of the same name

emit fully qualified object name into library

It doesn't appear in reduced test cases, so I added one that shows the issue when linking against a debug druntime.lib.