### PR TITLE
osthread:attachThread code deduplication

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -644,12 +644,6 @@ private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow
     thisThread.tlsRTdataInit();
     Thread.setThis( thisThread );
 
-    version (Darwin)
-    {
-        thisThread.m_tmach = pthread_mach_thread_np( thisThread.m_tdescr.tid );
-        assert( thisThread.m_tmach != thisThread.m_tmach.init );
-    }
-
     Thread.add( thisThread, false );
     Thread.add( thisContext );
     if ( Thread.sm_main !is null )
@@ -1174,7 +1168,7 @@ private void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
             x86_thread_state32_t    state = void;
             mach_msg_type_number_t  count = x86_THREAD_STATE32_COUNT;
 
-            if ( thread_get_state( t.m_tmach, x86_THREAD_STATE32, &state, &count ) != KERN_SUCCESS )
+            if ( thread_get_state( t.m_tdescr.tmach, x86_THREAD_STATE32, &state, &count ) != KERN_SUCCESS )
                 onThreadError( "Unable to load thread state" );
             if ( !t.m_lock )
                 t.m_curr.tstack = cast(void*) state.esp;
@@ -1193,7 +1187,7 @@ private void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
             x86_thread_state64_t    state = void;
             mach_msg_type_number_t  count = x86_THREAD_STATE64_COUNT;
 
-            if ( thread_get_state( t.m_tmach, x86_THREAD_STATE64, &state, &count ) != KERN_SUCCESS )
+            if ( thread_get_state( t.m_tdescr.tmach, x86_THREAD_STATE64, &state, &count ) != KERN_SUCCESS )
                 onThreadError( "Unable to load thread state" );
             if ( !t.m_lock )
                 t.m_curr.tstack = cast(void*) state.rsp;
@@ -1221,7 +1215,7 @@ private void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
             arm_thread_state64_t state = void;
             mach_msg_type_number_t count = ARM_THREAD_STATE64_COUNT;
 
-            if (thread_get_state(t.m_tmach, ARM_THREAD_STATE64, &state, &count) != KERN_SUCCESS)
+            if (thread_get_state(t.m_tdescr.tmach, ARM_THREAD_STATE64, &state, &count) != KERN_SUCCESS)
                 onThreadError("Unable to load thread state");
             // TODO: ThreadException here recurses forever!  Does it
             //still using onThreadError?
@@ -1242,7 +1236,7 @@ private void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
 
             // Thought this would be ARM_THREAD_STATE32, but that fails.
             // Mystery
-            if (thread_get_state(t.m_tmach, ARM_THREAD_STATE, &state, &count) != KERN_SUCCESS)
+            if (thread_get_state(t.m_tdescr.tmach, ARM_THREAD_STATE, &state, &count) != KERN_SUCCESS)
                 onThreadError("Unable to load thread state");
             // TODO: in past, ThreadException here recurses forever!  Does it
             //still using onThreadError?
@@ -1260,7 +1254,7 @@ private void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
             ppc_thread_state_t state = void;
             mach_msg_type_number_t count = PPC_THREAD_STATE_COUNT;
 
-            if (thread_get_state(t.m_tmach, PPC_THREAD_STATE, &state, &count) != KERN_SUCCESS)
+            if (thread_get_state(t.m_tdescr.tmach, PPC_THREAD_STATE, &state, &count) != KERN_SUCCESS)
                 onThreadError("Unable to load thread state");
             if (!t.m_lock)
                 t.m_curr.tstack = cast(void*) state.r[1];
@@ -1271,7 +1265,7 @@ private void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
             ppc_thread_state64_t state = void;
             mach_msg_type_number_t count = PPC_THREAD_STATE64_COUNT;
 
-            if (thread_get_state(t.m_tmach, PPC_THREAD_STATE64, &state, &count) != KERN_SUCCESS)
+            if (thread_get_state(t.m_tdescr.tmach, PPC_THREAD_STATE64, &state, &count) != KERN_SUCCESS)
                 onThreadError("Unable to load thread state");
             if (!t.m_lock)
                 t.m_curr.tstack = cast(void*) state.r[1];
@@ -1626,8 +1620,8 @@ extern (C) void thread_init() @nogc nothrow
             }
             thisThread.m_tdescr.tid = pthread_self();
             assert( thisThread.m_tdescr.tid != thisThread.m_tdescr.tid.init );
-            thisThread.m_tmach = pthread_mach_thread_np( thisThread.m_tdescr.tid );
-            assert( thisThread.m_tmach != thisThread.m_tmach.init );
+            thisThread.m_tdescr.tmach = pthread_mach_thread_np( thisThread.m_tdescr.tid );
+            assert( thisThread.m_tdescr.tmach != thisThread.m_tdescr.tmach.init );
        }
         pthread_atfork(null, null, &initChildAfterFork);
     }

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -633,28 +633,13 @@ private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow
     StackContext* thisContext = &thisThread.m_main;
     assert( thisContext == thisThread.m_curr );
 
-    version (Windows)
-    {
-        thisThread.m_tdescr = Thread.getCurrentThreadDescr();
-        thisContext.bstack = getStackBottom();
-        thisContext.tstack = thisContext.bstack;
-    }
-    else version (Posix)
-    {
-        thisThread.m_tdescr = Thread.getCurrentThreadDescr();
-        thisContext.bstack = getStackBottom();
-        thisContext.tstack = thisContext.bstack;
+    thisThread.m_tdescr = Thread.getCurrentThreadDescr();
+    thisContext.bstack = getStackBottom();
+    thisContext.tstack = thisContext.bstack;
 
+    version (Posix)
         atomicStore!(MemoryOrder.raw)(thisThread.toThread.m_isRunning, true);
-    }
-    else version (WASI)
-    {
-        thisThread.m_tdescr = Thread.getCurrentThreadDescr();
-        thisContext.bstack = getStackBottom();
-        thisContext.tstack = thisContext.bstack;
-    }
-    else
-        static assert(0, "unsupported os");
+
     thisThread.m_isDaemon = true;
     thisThread.tlsRTdataInit();
     Thread.setThis( thisThread );

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -635,14 +635,13 @@ private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow
 
     version (Windows)
     {
-        thisThread.m_addr  = GetCurrentThreadId();
-        thisThread.m_hndl  = GetCurrentThreadHandle();
+        thisThread.m_tdescr = Thread.getCurrentThreadDescr();
         thisContext.bstack = getStackBottom();
         thisContext.tstack = thisContext.bstack;
     }
     else version (Posix)
     {
-        thisThread.m_addr  = pthread_self();
+        thisThread.m_tdescr = Thread.getCurrentThreadDescr();
         thisContext.bstack = getStackBottom();
         thisContext.tstack = thisContext.bstack;
 
@@ -650,7 +649,7 @@ private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow
     }
     else version (WASI)
     {
-        thisThread.m_addr  = 1; // assumes this is done only once
+        thisThread.m_tdescr = Thread.getCurrentThreadDescr();
         thisContext.bstack = getStackBottom();
         thisContext.tstack = thisContext.bstack;
     }

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -715,13 +715,13 @@ version (Windows)
 
         if ( addr == GetCurrentThreadId() )
         {
-            thisThread.m_hndl = GetCurrentThreadHandle();
+            thisThread.m_tdescr.hndl = GetCurrentThreadHandle();
             thisThread.tlsRTdataInit();
             Thread.setThis( thisThread );
         }
         else
         {
-            thisThread.m_hndl = OpenThreadHandle( addr );
+            thisThread.m_tdescr.hndl = OpenThreadHandle( addr );
             impersonate_thread(addr,
             {
                 thisThread.tlsRTdataInit();
@@ -1123,7 +1123,7 @@ private void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
         CONTEXT context = void;
         context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL;
 
-        if ( !GetThreadContext( t.m_hndl, &context ) )
+        if ( !GetThreadContext( t.m_tdescr.hndl, &context ) )
             onThreadError( "Unable to load thread context" );
         version (X86)
         {

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -646,7 +646,7 @@ private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow
 
     version (Darwin)
     {
-        thisThread.m_tmach = pthread_mach_thread_np( thisThread.m_addr );
+        thisThread.m_tmach = pthread_mach_thread_np( thisThread.m_tdescr.tid );
         assert( thisThread.m_tmach != thisThread.m_tmach.init );
     }
 
@@ -707,7 +707,7 @@ version (Windows)
         StackContext* thisContext = &thisThread.m_main;
         assert( thisContext == thisThread.m_curr );
 
-        thisThread.m_addr  = addr;
+        thisThread.m_tdescr.tid  = addr;
         thisContext.bstack = bstack;
         thisContext.tstack = thisContext.bstack;
 
@@ -1095,7 +1095,7 @@ private extern (D) bool suspend( Thread t ) nothrow @nogc
         return false;
     }
 
-    const sameThread = t.m_addr == gettid();
+    const sameThread = t.m_tdescr.tid == gettid();
 
     if (!sameThread)
     {
@@ -1327,7 +1327,7 @@ private void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
             }
 
             lwpstatus_t status = void;
-            if (getLwpStatus(t.m_addr, status) != 0)
+            if (getLwpStatus(t.m_tdescr.tid, status) != 0)
                 onThreadError("Unable to load thread state");
 
             version (X86)
@@ -1538,7 +1538,7 @@ extern (C) void thread_suspendAll() nothrow
 private extern (D) void resume(ThreadBase _t) nothrow @nogc
 {
     Thread t = _t.toThread;
-    const sameThread = t.m_addr == gettid();
+    const sameThread = t.m_tdescr.tid == gettid();
 
     if (!sameThread)
     {
@@ -1624,9 +1624,9 @@ extern (C) void thread_init() @nogc nothrow
                 // In such case getThis will return null.
                 return;
             }
-            thisThread.m_addr = pthread_self();
-            assert( thisThread.m_addr != thisThread.m_addr.init );
-            thisThread.m_tmach = pthread_mach_thread_np( thisThread.m_addr );
+            thisThread.m_tdescr.tid = pthread_self();
+            assert( thisThread.m_tdescr.tid != thisThread.m_tdescr.tid.init );
+            thisThread.m_tmach = pthread_mach_thread_np( thisThread.m_tdescr.tid );
             assert( thisThread.m_tmach != thisThread.m_tmach.init );
        }
         pthread_atfork(null, null, &initChildAfterFork);

--- a/druntime/src/core/thread/posix_impl.d
+++ b/druntime/src/core/thread/posix_impl.d
@@ -17,6 +17,7 @@ import core.exception : onOutOfMemoryError;
 import core.internal.traits : externDFunc;
 import core.thread.osthread;
 import core.thread.threadbase;
+import core.thread.types : ThreadDescr;
 import core.time;
 
 version (Posix):
@@ -280,7 +281,7 @@ class Thread : ThreadBase
                     if (ps is null) onOutOfMemoryError();
                     ps[0] = cast(void*)this;
                     ps[1] = cast(void*)libs;
-                    if ( pthread_create( &m_addr, &attr, &thread_entryPoint, ps ) != 0 )
+                    if ( pthread_create( &m_tdescr.tid, &attr, &thread_entryPoint, ps ) != 0 )
                     {
                         externDFunc!("rt.sections_elf_shared.unpinLoadedLibraries",
                                      void function(void*) @nogc nothrow)(libs);
@@ -290,7 +291,7 @@ class Thread : ThreadBase
                 }
                 else
                 {
-                    if ( pthread_create( &m_addr, &attr, &thread_entryPoint, cast(void*) this ) != 0 )
+                    if ( pthread_create( &m_tdescr.tid, &attr, &thread_entryPoint, cast(void*) this ) != 0 )
                         onThreadError( "Error creating thread" );
                 }
                 if ( pthread_attr_destroy( &attr ) != 0 )
@@ -584,6 +585,11 @@ class Thread : ThreadBase
     static void yield() @nogc nothrow
     {
         sched_yield();
+    }
+
+    package static ThreadDescr getCurrentThreadDescr() nothrow @nogc
+    {
+        return ThreadDescr(tid: gettid);
     }
 }
 

--- a/druntime/src/core/thread/posix_impl.d
+++ b/druntime/src/core/thread/posix_impl.d
@@ -50,7 +50,6 @@ version (all)
     {
         // Use macOS threads for suspend/resume
         import core.sys.darwin.mach.kern_return : KERN_SUCCESS;
-        import core.sys.darwin.mach.port : mach_port_t;
         import core.sys.darwin.mach.thread_act : mach_msg_type_number_t,
             thread_get_state, thread_resume, thread_suspend;
         import core.sys.darwin.pthread : pthread_mach_thread_np;
@@ -107,11 +106,6 @@ class Thread : ThreadBase
 {
     package shared bool     m_isRunning;
 
-    version (Darwin)
-    {
-        package mach_port_t     m_tmach;
-    }
-
     version (Solaris)
     {
         private __gshared bool m_isRTClass;
@@ -146,7 +140,7 @@ class Thread : ThreadBase
             m_tdescr.tid = m_tdescr.tid.init;
             version (Darwin)
             {
-                m_tmach = m_tmach.init;
+                m_tdescr.tmach = m_tdescr.tmach.init;
             }
         }
     }
@@ -299,8 +293,8 @@ class Thread : ThreadBase
 
                 version (Darwin)
                 {
-                    m_tmach = pthread_mach_thread_np( m_tdescr.tid );
-                    if ( m_tmach == m_tmach.init )
+                    m_tdescr.tmach = pthread_mach_thread_np( m_tdescr.tid );
+                    if ( m_tdescr.tmach == m_tdescr.tmach.init )
                         onThreadError( "Error creating thread" );
                 }
             }
@@ -589,7 +583,16 @@ class Thread : ThreadBase
 
     package static ThreadDescr getCurrentThreadDescr() nothrow @nogc
     {
-        return ThreadDescr(tid: gettid);
+        version (Darwin)
+        {
+            auto tid = gettid();
+            auto tmach = pthread_mach_thread_np(tid);
+            assert(tmach != tmach.init);
+
+            return ThreadDescr(tid: tid, tmach: tmach);
+        }
+        else
+            return ThreadDescr(tid: gettid);
     }
 }
 
@@ -637,7 +640,7 @@ package __gshared int resumeSignalNumber;
 package bool suspendThreadImpl(Thread t) @nogc nothrow
 {
     version (Darwin)
-        return thread_suspend(t.m_tmach) == KERN_SUCCESS;
+        return thread_suspend(t.m_tdescr.tmach) == KERN_SUCCESS;
     else version (Solaris)
         return thr_suspend(t.m_tdescr.tid) == 0;
     else
@@ -648,7 +651,7 @@ package bool suspendThreadImpl(Thread t) @nogc nothrow
 package bool resumeThreadImpl(Thread t) @nogc nothrow
 {
     version (Darwin)
-        return thread_resume(t.m_tmach) == KERN_SUCCESS;
+        return thread_resume(t.m_tdescr.tmach) == KERN_SUCCESS;
     else version (Solaris)
         return thr_continue(t.m_tdescr.tid) == 0;
     else

--- a/druntime/src/core/thread/posix_impl.d
+++ b/druntime/src/core/thread/posix_impl.d
@@ -141,9 +141,9 @@ class Thread : ThreadBase
 
         version (all)
         {
-            if (m_addr != m_addr.init)
-                pthread_detach( m_addr );
-            m_addr = m_addr.init;
+            if (m_tdescr.tid != m_tdescr.tid.init)
+                pthread_detach( m_tdescr.tid );
+            m_tdescr.tid = m_tdescr.tid.init;
             version (Darwin)
             {
                 m_tmach = m_tmach.init;
@@ -299,7 +299,7 @@ class Thread : ThreadBase
 
                 version (Darwin)
                 {
-                    m_tmach = pthread_mach_thread_np( m_addr );
+                    m_tmach = pthread_mach_thread_np( m_tdescr.tid );
                     if ( m_tmach == m_tmach.init )
                         onThreadError( "Error creating thread" );
                 }
@@ -311,13 +311,13 @@ class Thread : ThreadBase
 
     override final Throwable join( bool rethrow = true )
     {
-        if ( m_addr != m_addr.init && pthread_join( m_addr, null ) != 0 )
+        if ( m_tdescr.tid != m_tdescr.tid.init && pthread_join( m_tdescr.tid, null ) != 0 )
             throw new ThreadException( "Unable to join thread" );
         // NOTE: pthread_join acts as a substitute for pthread_detach,
-        //       which is normally called by the dtor.  Setting m_addr
+        //       which is normally called by the dtor.  Setting tid
         //       to zero ensures that pthread_detach will not be called
         //       on object destruction.
-        m_addr = m_addr.init;
+        m_tdescr.tid = m_tdescr.tid.init;
 
         return super.join(rethrow);
     }
@@ -463,7 +463,7 @@ class Thread : ThreadBase
             int         policy;
             sched_param param;
 
-            if (auto err = pthread_getschedparam(m_addr, &policy, &param))
+            if (auto err = pthread_getschedparam(m_tdescr.tid, &policy, &param))
             {
                 // ignore error if thread is not running => Bugzilla 8960
                 if (!atomicLoad(m_isRunning)) return PRIORITY_DEFAULT;
@@ -517,7 +517,7 @@ class Thread : ThreadBase
             {
                 import core.sys.posix.pthread : pthread_setschedprio;
 
-                if (auto err = pthread_setschedprio(m_addr, val))
+                if (auto err = pthread_setschedprio(m_tdescr.tid, val))
                 {
                     // ignore error if thread is not running => Bugzilla 8960
                     if (!atomicLoad(m_isRunning)) return;
@@ -531,14 +531,14 @@ class Thread : ThreadBase
                 int         policy;
                 sched_param param;
 
-                if (auto err = pthread_getschedparam(m_addr, &policy, &param))
+                if (auto err = pthread_getschedparam(m_tdescr.tid, &policy, &param))
                 {
                     // ignore error if thread is not running => Bugzilla 8960
                     if (!atomicLoad(m_isRunning)) return;
                     throw new ThreadException("Unable to set thread priority");
                 }
                 param.sched_priority = val;
-                if (auto err = pthread_setschedparam(m_addr, policy, &param))
+                if (auto err = pthread_setschedparam(m_tdescr.tid, policy, &param))
                 {
                     // ignore error if thread is not running => Bugzilla 8960
                     if (!atomicLoad(m_isRunning)) return;
@@ -639,9 +639,9 @@ package bool suspendThreadImpl(Thread t) @nogc nothrow
     version (Darwin)
         return thread_suspend(t.m_tmach) == KERN_SUCCESS;
     else version (Solaris)
-        return thr_suspend(t.m_addr) == 0;
+        return thr_suspend(t.m_tdescr.tid) == 0;
     else
-        return pthread_kill(t.m_addr, suspendSignalNumber) == 0;
+        return pthread_kill(t.m_tdescr.tid, suspendSignalNumber) == 0;
 }
 
 // Returns true on success
@@ -650,9 +650,9 @@ package bool resumeThreadImpl(Thread t) @nogc nothrow
     version (Darwin)
         return thread_resume(t.m_tmach) == KERN_SUCCESS;
     else version (Solaris)
-        return thr_continue(t.m_addr) == 0;
+        return thr_continue(t.m_tdescr.tid) == 0;
     else
-        return pthread_kill(t.m_addr, resumeSignalNumber) == 0;
+        return pthread_kill(t.m_tdescr.tid, resumeSignalNumber) == 0;
 }
 
 package alias gettid = imported!"core.sys.posix.pthread".pthread_self;

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -483,12 +483,15 @@ package:
     //
     // Standard thread data
     //
-    ThreadID            m_addr;
+    ThreadDescr         m_tdescr;
     Callable            m_call;
     string              m_name;
     size_t              m_sz;
     bool                m_isDaemon;
     Throwable           m_unhandled;
+
+    //TODO: remove
+    final ref ThreadID m_addr() nothrow @nogc @safe => m_tdescr.tid;
 
     ///////////////////////////////////////////////////////////////////////////
     // Storage of Active Thread

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -119,7 +119,7 @@ class ThreadBase
     {
         destroyDataStorageIfAvail();
 
-        bool no_context = m_addr == m_addr.init;
+        bool no_context = m_tdescr.tid == m_tdescr.tid.init;
         bool not_registered = !next && !prev && (sm_tbeg !is this);
 
         return (no_context || not_registered);
@@ -234,7 +234,7 @@ class ThreadBase
     {
         synchronized(this)
         {
-            return m_addr;
+            return m_tdescr.tid;
         }
     }
 
@@ -326,7 +326,7 @@ class ThreadBase
      */
     @property bool isRunning() nothrow @nogc
     {
-        if (m_addr == m_addr.init)
+        if (m_tdescr.tid == m_tdescr.tid.init)
             return false;
 
         return true;
@@ -489,9 +489,6 @@ package:
     size_t              m_sz;
     bool                m_isDaemon;
     Throwable           m_unhandled;
-
-    //TODO: remove
-    final ref ThreadID m_addr() nothrow @nogc @safe => m_tdescr.tid;
 
     ///////////////////////////////////////////////////////////////////////////
     // Storage of Active Thread
@@ -960,11 +957,11 @@ static ThreadBase thread_findByAddr(ThreadID addr)
     // also return just spawned thread so that
     // DLL_THREAD_ATTACH knows it's a D thread
     foreach (t; ThreadBase.pAboutToStart[0 .. ThreadBase.nAboutToStart])
-        if (t.m_addr == addr)
+        if (t.m_tdescr.tid == addr)
             return t;
 
     foreach (t; ThreadBase)
-        if (t.m_addr == addr)
+        if (t.m_tdescr.tid == addr)
             return t;
 
     return null;

--- a/druntime/src/core/thread/types.d
+++ b/druntime/src/core/thread/types.d
@@ -38,7 +38,7 @@ package struct ThreadDescr
     {
         import core.sys.windows.basetsd;
 
-        HANDLE m_hndl;
+        HANDLE hndl;
     }
 }
 

--- a/druntime/src/core/thread/types.d
+++ b/druntime/src/core/thread/types.d
@@ -30,6 +30,18 @@ version (WASI)
     alias ThreadID = ubyte; // dummy; always 1
 }
 
+package struct ThreadDescr
+{
+    ThreadID tid;
+
+    version (Windows)
+    {
+        import core.sys.windows.basetsd;
+
+        HANDLE m_hndl;
+    }
+}
+
 struct ll_ThreadData
 {
     ThreadID tid;

--- a/druntime/src/core/thread/types.d
+++ b/druntime/src/core/thread/types.d
@@ -23,6 +23,15 @@ version (Posix)
     import core.sys.posix.sys.types : pthread_t;
 
     alias ThreadID = pthread_t;
+
+    version (OSX)
+        version = Darwin;
+    else version (iOS)
+        version = Darwin;
+    else version (TVOS)
+        version = Darwin;
+    else version (WatchOS)
+        version = Darwin;
 }
 else
 version (WASI)
@@ -34,7 +43,13 @@ package struct ThreadDescr
 {
     ThreadID tid;
 
-    version (Windows)
+    version (Darwin)
+    {
+        import core.sys.darwin.mach.port : mach_port_t;
+
+        mach_port_t tmach;
+    }
+    else version (Windows)
     {
         import core.sys.windows.basetsd;
 

--- a/druntime/src/core/thread/wasi_impl.d
+++ b/druntime/src/core/thread/wasi_impl.d
@@ -17,6 +17,7 @@ import core.exception : onOutOfMemoryError;
 import core.internal.traits : externDFunc;
 import core.thread.osthread;
 import core.thread.threadbase;
+import core.thread.types : ThreadDescr;
 import core.time;
 
 version (WASI):
@@ -176,6 +177,13 @@ class Thread : ThreadBase
     {
         version (WASIp1) schedYield();
         // else do nothing
+    }
+
+    package static ThreadDescr getCurrentThreadDescr() nothrow @nogc
+    {
+        return ThreadDescr(
+            tid: 1 // assumes this is done only once
+        );
     }
 }
 

--- a/druntime/src/core/thread/windows_impl.d
+++ b/druntime/src/core/thread/windows_impl.d
@@ -50,8 +50,6 @@ package enum isSingleThreaded = false;
 version (CoreDdoc) {} else
 class Thread : ThreadBase
 {
-    //TODO: remove
-    final package ref HANDLE m_hndl() nothrow @nogc @safe => m_tdescr.m_hndl;
     alias TLSKey = uint;
 
     this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
@@ -75,8 +73,8 @@ class Thread : ThreadBase
             return;
 
         m_tdescr.tid = m_tdescr.tid.init;
-        CloseHandle( m_hndl );
-        m_hndl = m_hndl.init;
+        CloseHandle( m_tdescr.hndl );
+        m_tdescr.hndl = m_tdescr.hndl.init;
     }
 
     static Thread getThis() @safe nothrow @nogc
@@ -133,8 +131,8 @@ class Thread : ThreadBase
             // Solution: Create the thread in suspended state and then
             //       add and resume it with slock acquired
             assert(m_sz <= uint.max, "m_sz must be less than or equal to uint.max");
-            m_hndl = cast(HANDLE) _beginthreadex( null, cast(uint) m_sz, &thread_entryPoint, cast(void*) this, CREATE_SUSPENDED, &m_tdescr.tid );
-            if ( cast(size_t) m_hndl == 0 )
+            m_tdescr.hndl = cast(HANDLE) _beginthreadex( null, cast(uint) m_sz, &thread_entryPoint, cast(void*) this, CREATE_SUSPENDED, &m_tdescr.tid );
+            if ( cast(size_t) m_tdescr.hndl == 0 )
                 onThreadError( "Error creating thread" );
         }
 
@@ -143,7 +141,7 @@ class Thread : ThreadBase
         {
             incrementAboutToStart(this);
 
-            if ( ResumeThread( m_hndl ) == -1 )
+            if ( ResumeThread( m_tdescr.hndl ) == -1 )
                 onThreadError( "Error resuming thread" );
 
             return this;
@@ -152,14 +150,14 @@ class Thread : ThreadBase
 
     override final Throwable join( bool rethrow = true )
     {
-        if ( m_tdescr.tid != m_tdescr.tid.init && WaitForSingleObject( m_hndl, INFINITE ) != WAIT_OBJECT_0 )
+        if ( m_tdescr.tid != m_tdescr.tid.init && WaitForSingleObject( m_tdescr.hndl, INFINITE ) != WAIT_OBJECT_0 )
             throw new ThreadException( "Unable to join thread" );
-        // NOTE: tid must be cleared before m_hndl is closed to avoid
+        // NOTE: tid must be cleared before hndl is closed to avoid
         //       a race condition with isRunning. The operation is done
         //       with atomicStore to prevent compiler reordering.
         atomicStore!(MemoryOrder.raw)(*cast(shared)&m_tdescr.tid, m_tdescr.tid.init);
-        CloseHandle( m_hndl );
-        m_hndl = m_hndl.init;
+        CloseHandle( m_tdescr.hndl );
+        m_tdescr.hndl = m_tdescr.hndl.init;
 
         return super.join(rethrow);
     }
@@ -184,7 +182,7 @@ class Thread : ThreadBase
 
     final @property int priority()
     {
-        return GetThreadPriority( m_hndl );
+        return GetThreadPriority( m_tdescr.hndl );
     }
 
     final @property void priority( int val )
@@ -195,7 +193,7 @@ class Thread : ThreadBase
     }
     do
     {
-        if ( !SetThreadPriority( m_hndl, val ) )
+        if ( !SetThreadPriority( m_tdescr.hndl, val ) )
             throw new ThreadException( "Unable to set thread priority" );
     }
 
@@ -205,7 +203,7 @@ class Thread : ThreadBase
             return false;
 
         uint ecode = 0;
-        GetExitCodeThread( m_hndl, &ecode );
+        GetExitCodeThread( m_tdescr.hndl, &ecode );
         return ecode == STILL_ACTIVE;
     }
 
@@ -250,7 +248,7 @@ class Thread : ThreadBase
     {
         return ThreadDescr(
             tid: gettid,
-            m_hndl: GetCurrentThreadHandle()
+            hndl: GetCurrentThreadHandle()
         );
     }
 }
@@ -260,11 +258,11 @@ package alias gettid = imported!"core.sys.windows.winbase".GetCurrentThreadId;
 // Returns true on success
 package bool suspendThreadImpl(Thread t) @nogc nothrow
 {
-    return SuspendThread(t.m_hndl) != 0xFFFFFFFF;
+    return SuspendThread(t.m_tdescr.hndl) != 0xFFFFFFFF;
 }
 
 // Returns true on success
 package bool resumeThreadImpl(Thread t) @nogc nothrow
 {
-    return ResumeThread(t.m_hndl) != 0xFFFFFFFF;
+    return ResumeThread(t.m_tdescr.hndl) != 0xFFFFFFFF;
 }

--- a/druntime/src/core/thread/windows_impl.d
+++ b/druntime/src/core/thread/windows_impl.d
@@ -17,6 +17,7 @@ import core.exception : onOutOfMemoryError;
 import core.internal.traits : externDFunc;
 import core.thread.osthread;
 import core.thread.threadbase;
+import core.thread.types : ThreadDescr;
 import core.time;
 
 version (Windows):
@@ -49,7 +50,8 @@ package enum isSingleThreaded = false;
 version (CoreDdoc) {} else
 class Thread : ThreadBase
 {
-    package HANDLE m_hndl;
+    //TODO: remove
+    final package ref HANDLE m_hndl() nothrow @nogc @safe => m_tdescr.m_hndl;
     alias TLSKey = uint;
 
     this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
@@ -131,7 +133,7 @@ class Thread : ThreadBase
             // Solution: Create the thread in suspended state and then
             //       add and resume it with slock acquired
             assert(m_sz <= uint.max, "m_sz must be less than or equal to uint.max");
-            m_hndl = cast(HANDLE) _beginthreadex( null, cast(uint) m_sz, &thread_entryPoint, cast(void*) this, CREATE_SUSPENDED, &m_addr );
+            m_hndl = cast(HANDLE) _beginthreadex( null, cast(uint) m_sz, &thread_entryPoint, cast(void*) this, CREATE_SUSPENDED, &m_tdescr.tid );
             if ( cast(size_t) m_hndl == 0 )
                 onThreadError( "Error creating thread" );
         }
@@ -155,7 +157,7 @@ class Thread : ThreadBase
         // NOTE: m_addr must be cleared before m_hndl is closed to avoid
         //       a race condition with isRunning. The operation is done
         //       with atomicStore to prevent compiler reordering.
-        atomicStore!(MemoryOrder.raw)(*cast(shared)&m_addr, m_addr.init);
+        atomicStore!(MemoryOrder.raw)(*cast(shared)&m_tdescr.tid, m_addr.init);
         CloseHandle( m_hndl );
         m_hndl = m_hndl.init;
 
@@ -242,6 +244,14 @@ class Thread : ThreadBase
     static void yield() @nogc nothrow
     {
         SwitchToThread();
+    }
+
+    package static ThreadDescr getCurrentThreadDescr() nothrow @nogc
+    {
+        return ThreadDescr(
+            tid: gettid,
+            m_hndl: GetCurrentThreadHandle()
+        );
     }
 }
 

--- a/druntime/src/core/thread/windows_impl.d
+++ b/druntime/src/core/thread/windows_impl.d
@@ -74,7 +74,7 @@ class Thread : ThreadBase
         if (super.destructBeforeDtor())
             return;
 
-        m_addr = m_addr.init;
+        m_tdescr.tid = m_tdescr.tid.init;
         CloseHandle( m_hndl );
         m_hndl = m_hndl.init;
     }
@@ -152,12 +152,12 @@ class Thread : ThreadBase
 
     override final Throwable join( bool rethrow = true )
     {
-        if ( m_addr != m_addr.init && WaitForSingleObject( m_hndl, INFINITE ) != WAIT_OBJECT_0 )
+        if ( m_tdescr.tid != m_tdescr.tid.init && WaitForSingleObject( m_hndl, INFINITE ) != WAIT_OBJECT_0 )
             throw new ThreadException( "Unable to join thread" );
-        // NOTE: m_addr must be cleared before m_hndl is closed to avoid
+        // NOTE: tid must be cleared before m_hndl is closed to avoid
         //       a race condition with isRunning. The operation is done
         //       with atomicStore to prevent compiler reordering.
-        atomicStore!(MemoryOrder.raw)(*cast(shared)&m_tdescr.tid, m_addr.init);
+        atomicStore!(MemoryOrder.raw)(*cast(shared)&m_tdescr.tid, m_tdescr.tid.init);
         CloseHandle( m_hndl );
         m_hndl = m_hndl.init;
 


### PR DESCRIPTION
`attachThread()` code deduplication resulted in a transfer to a new `ThreadDescr` struct which contains all system-related info about thread: `tid`, `handler` or `mach_port_t`

This PR is big, but can be reviewed by one commit at a time

(What is happening is part of the process of separating code from different platforms into different modules)