### PR TITLE
druntime: Allow thread resume/suspend to work on WASI

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -3337,9 +3337,7 @@ Lmark:
                 rangesLock.unlock();
                 rootsLock.unlock();
             }
-
-            version (WASI) {} // WASI is single-threaded
-            else thread_suspendAll();
+            thread_suspendAll();
 
             prepare();
 

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -1502,7 +1502,10 @@ private void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
     }
     else version (WASI)
     {
-        onThreadError( "Unable to suspend thread" );
+        if (sameThread && !t.m_lock)
+        {
+            t.m_curr.tstack = getStackTop();
+        }
     }
     else
         static assert(0, "unsupported os");
@@ -1526,8 +1529,6 @@ extern (C) void thread_preStopTheWorld() nothrow {
  */
 extern (C) void thread_suspendAll() nothrow
 {
-    version (WASI) onThreadError( "Unable to suspend all threads" );
-
     // NOTE: We've got an odd chicken & egg problem here, because while the GC
     //       is required to call thread_init before calling any other thread
     //       routines, thread_init may allocate memory which could in turn
@@ -1664,7 +1665,8 @@ private void purgeStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
     }
     else version (WASI)
     {
-        onThreadError( "Unable to resume thread" );
+        if (sameThread)
+            t.unloadStackInfo();
     }
     else
         static assert(false, "Platform not supported.");

--- a/druntime/src/core/thread/wasi_impl.d
+++ b/druntime/src/core/thread/wasi_impl.d
@@ -181,8 +181,7 @@ class Thread : ThreadBase
 
 package ThreadID gettid() @nogc nothrow
 {
-    onThreadError( "Unable to get WASI thread ID" );
-    assert(0);
+    return 1; // dummy main thread
 }
 
 // Returns true on success


### PR DESCRIPTION
Rather than erroring out always, allows "suspending" and "resuming" the main thread (which on POSIX, and now WASI, just marks the stack top).

Prevents issues with code expecting thread_suspendAll to be called before hand.

------

Upstreaming of ldc-developers/ldc#5212