### PR TITLE
druntime: Re-enable the failing `core.math` test on Wasm

### DIFF
--- a/druntime/src/core/math.d
+++ b/druntime/src/core/math.d
@@ -99,11 +99,6 @@ float ldexp(float n, int exp);   /* intrinsic */
 double ldexp(double n, int exp); /* intrinsic */ /// ditto
 real ldexp(real n, int exp);     /* intrinsic */ /// ditto
 
-// Wasm is always cross-compiled, so we are subject to
-// https://wiki.dlang.org/Cross-compiling_with_LDC#Limitations
-// (precision issues with `real`)
-version (WebAssembly) {}
-else
 unittest {
     static if (real.mant_dig == 113)
     {


### PR DESCRIPTION
Rather than disable it and cover up the issue, allow it to fail on incompatible hosts.

-----

Upstreaming of the change made in ldc-developers/ldc#5207