### PR TITLE
Fix #22054 - a thread that starts non-D-fibers can cause the GC to crash…

### DIFF
--- a/druntime/src/core/sys/windows/threadaux.d
+++ b/druntime/src/core/sys/windows/threadaux.d
@@ -137,10 +137,14 @@ struct thread_aux
     // get the thread environment block (TEB) of the thread with the given handle
     static void** getTEB( HANDLE hnd ) nothrow @nogc
     {
-        HANDLE nthnd = GetModuleHandleA( "NTDLL" );
-        assert( nthnd, "cannot get module handle for ntdll" );
-        fnNtQueryInformationThread fn = cast(fnNtQueryInformationThread) GetProcAddress( nthnd, "NtQueryInformationThread" );
-        assert( fn, "cannot find NtQueryInformationThread in ntdll" );
+        __gshared fnNtQueryInformationThread fn;
+        if( !fn )
+        {
+            HANDLE nthnd = GetModuleHandleA( "NTDLL" );
+            assert( nthnd, "cannot get module handle for ntdll" );
+            fn = cast(fnNtQueryInformationThread) GetProcAddress( nthnd, "NtQueryInformationThread" );
+            assert( fn, "cannot find NtQueryInformationThread in ntdll" );
+        }
 
         THREAD_BASIC_INFORMATION tbi;
         int Status = (*fn)(hnd, ThreadBasicInformation, &tbi, tbi.sizeof, null);

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -1160,6 +1160,12 @@ private void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
         {
             static assert(false, "Architecture not supported." );
         }
+        // a thread might change the stack, e.g. using non-D fibers, so we must not
+        // rely on the stack bottom saved when attaching/starting. Multiple fiber stacks cannot be
+        // captured, but make sure scanning does not crash accessing invalid memory ranges
+        // between stacks
+        if ( !t.m_lock )
+            t.m_curr.bstack = getThreadStackBottom( t.m_tdescr.hndl );
     }
     else version (Darwin)
     {

--- a/druntime/test/thread/Makefile
+++ b/druntime/test/thread/Makefile
@@ -3,7 +3,9 @@ TESTS := tlsgc_sections test_import tlsstack filterthrownglobal filterthrownmeth
 #TESTS += join_detach
 
 # some .d files support Posix only
-ifneq ($(OS),windows)
+ifeq ($(OS),windows)
+    TESTS += winfiber
+else
     TESTS += fiber_guard_page external_threads
 endif
 

--- a/druntime/test/thread/src/winfiber.d
+++ b/druntime/test/thread/src/winfiber.d
@@ -1,0 +1,68 @@
+// https://github.com/dlang/dmd/issues/22054
+
+import core.sys.windows.winbase;
+import core.sys.windows.winnt;
+import core.stdc.stdio;
+import core.stdc.stdlib;
+import core.memory;
+
+// comment to use core.stdc.stdio.printf
+void printf(const(char)* fmt, ...) {}
+
+extern(Windows)
+void workerFiberFunc(LPVOID param)
+{
+    LPVOID mainFiber = cast(LPVOID)param;
+
+    printf("Worker Fiber: Started, stack = %p\n", &mainFiber);
+
+    // scanning stack ranges must not crash here
+    GC.collect();
+
+    // Yield control back to the main fiber
+    SwitchToFiber(mainFiber);
+
+    // Execution resumes here when switched back to
+    printf("Worker Fiber: Resumed\n");
+
+    GC.collect();
+
+    SwitchToFiber(mainFiber);
+}
+
+void main()
+{
+    // Convert the current thread to a fiber
+    // This must be done before creating any other fibers
+    LPVOID mainFiber = ConvertThreadToFiber(null);
+    mainFiber || assert(false, "Failed to convert thread to fiber");
+    printf("Main Thread converted to Fiber: %p\n", mainFiber);
+
+    // run multiple times to hopefully get a variety of fiber stack adresses
+    for (int i = 0; i < 10; i++)
+    {
+        // Create a new fiber
+        LPVOID workerFiber = CreateFiber(0, &workerFiberFunc, mainFiber);
+        workerFiber || assert(false, "Failed to create fiber");
+        printf("Worker Fiber created: %p\n", workerFiber);
+
+        // Switch execution to the worker fiber
+        printf("Main Fiber: Switching to worker...\n");
+        SwitchToFiber(workerFiber);
+
+        // Execution resumes here after worker yields back
+        printf("Main Fiber: Resumed from worker\n");
+
+        GC.collect();
+
+        // Resume worker fiber
+        SwitchToFiber(workerFiber);
+
+        // Clean up
+        DeleteFiber(workerFiber);
+        printf("Worker Fiber deleted\n");
+    }
+
+    // Optional: Convert back to a normal thread if no longer using fibers
+    ConvertFiberToThread();
+}


### PR DESCRIPTION
…while scanning the stack

A thread might change the stack, e.g. using non-D fibers, so we must not rely on the stack bottom saved when attaching/starting. Multiple fiber stacks cannot be captured, but make sure scanning does not crash accessing invalid memory ranges between stacks by reading the stack bottom from the TEB before scanning.