### PR TITLE
remove obsolete extern declaration of main()

### DIFF
--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -1726,6 +1726,7 @@ private bool entryPointFunctions(Obj objmod, FuncDeclaration fd)
     {
         /* Reference the C main() to pull it in to the executable
          */
+        static if (0) // superceded by object's import of core.internal.entrypoint : _d_cmain
         final switch (target.objectFormat())
         {
             case Target.ObjectFormat.elf:


### PR DESCRIPTION
That extern declaration was causing the Mac linker to error out. And it took me a while to figure out where the extra declaration was coming from.