### PR TITLE
Fix #23470 - Reject unimplemented methods in final interfaces

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -830,6 +830,9 @@ void funcDeclarationSemantic(Scope* sc, FuncDeclaration funcdecl)
             .error(funcdecl.loc, "%s `%s` constructors, destructors, postblits, invariants, new and delete functions are not allowed in interface `%s`", funcdecl.kind, funcdecl.toPrettyChars, id.toErrMsg());
         if (funcdecl.fbody && funcdecl.isVirtual())
             .error(funcdecl.loc, "%s `%s` function body only allowed in `final` functions in interface `%s`", funcdecl.kind, funcdecl.toPrettyChars, id.toErrMsg());
+
+        if (!funcdecl.fbody && (id.storage_class & STC.final_))
+            .error(funcdecl.loc, "%s `%s` cannot be `abstract` in `final` interface `%s`", funcdecl.kind, funcdecl.toPrettyChars, id.toErrMsg());
     }
 
     if (UnionDeclaration ud = parent.isUnionDeclaration())

--- a/compiler/test/compilable/issue23470.d
+++ b/compiler/test/compilable/issue23470.d
@@ -1,0 +1,3 @@
+final interface I { void foo() {} }
+interface J { final void foo(); }
+interface K { final void foo() {} }

--- a/compiler/test/fail_compilation/issue23470.d
+++ b/compiler/test/fail_compilation/issue23470.d
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/issue23470.d(8): Error: function `issue23470.I.foo` cannot be `abstract` in `final` interface `I`
+---
+*/
+
+final interface I { void foo(); }


### PR DESCRIPTION
## Problem

A `final interface` implicitly makes its methods final. An interface method without a body is implicitly abstract, creating a contradictory declaration that should be rejected during semantic analysis.

Previously, the compiler accepted this construct and only produced a semantic error later when a class attempted to implement the interface (for example, "cannot override final function").

## Solution

Add a targeted semantic check during interface member analysis that rejects methods without a body inside a `final interface`.

The implementation reuses the existing compiler diagnostic for methods that cannot be both `final` and `abstract`, keeping the behavior and error reporting consistent with the rest of the compiler.

## Testing

Added regression tests covering:

- `final interface I { void foo(); }` (fails)
- valid interface declarations that should continue to compile