### PR TITLE
fix duplicate _Dmain() declaration

### DIFF
--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -2652,6 +2652,7 @@ void MachObj_pubdefsize(int seg, Symbol* s, targ_size_t offset, targ_size_t syms
 @trusted
 void MachObj_pubdef(int seg, Symbol* s, targ_size_t offset)
 {
+    //printf("MachObj_pubdef('%s') %p\n",s.Sident.ptr,s.Svalue);
     //printf("MachObj_pubdef(%d:x%llx s=%p, %s)\n", seg, offset, s, s.Sident.ptr);
     //symbol_print(*s);
     symbol_debug(s);

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -388,6 +388,7 @@ public:
  */
 extern (C++) bool onlyOneMain(FuncDeclaration fd)
 {
+    //printf("onlyOneMain() %s\n", fd.toPrettyChars());
     if (auto lastMain = FuncDeclaration.lastMain)
     {
         const format = (target.os == Target.OS.Windows)
@@ -950,9 +951,11 @@ Ldone:
         // Only mixin `_d_cmain` if it is defined
         if (cmainTemplateExists())
         {
-            // add `mixin _d_cmain!();` to the declaring module
+            // add `mixin _d_cmain!(funcdecl);` to the declaring module
             auto tqual = new TypeIdentifier(funcdecl.loc, Id.CMain);
-            auto tm = new TemplateMixin(funcdecl.loc, null, tqual, null);
+            auto tiargs = new Objects();
+            tiargs.push(funcdecl);
+            auto tm = new TemplateMixin(funcdecl.loc, null, tqual, tiargs);
             sc._module.members.push(tm);
         }
     }

--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -115,15 +115,14 @@ R!int
 		int elem;
 	}
 }
-mixin _d_cmain!();
+mixin _d_cmain!(main);
 {
 	extern (C)
 	{
 		extern (C) int _d_run_main(int argc, char** argv, void* mainFunc);
-		extern (C) int _Dmain(char[][] args);
 		extern (C) int main(int argc, char** argv)
 		{
-			return _d_run_main(argc, argv, & _Dmain);
+			return _d_run_main(argc, argv, & main);
 		}
 		version (Solaris)
 		{

--- a/compiler/test/dshell/extra-files/dwarf/excepted_results/fix21153.txt
+++ b/compiler/test/dshell/extra-files/dwarf/excepted_results/fix21153.txt
@@ -1,3 +1,3 @@
 DW_AT_name        : fix21153.i
 D main
-fix21153._d_cmain!().main
+fix21153._d_cmain!(main).main

--- a/compiler/test/dshell/extra-files/dwarf/excepted_results/fix22352.txt
+++ b/compiler/test/dshell/extra-files/dwarf/excepted_results/fix22352.txt
@@ -2,4 +2,4 @@ DW_AT_name        : fix22352.Foo
 DW_AT_name        : foo
 DW_AT_name        : fix22352.Foo[]
 D main
-fix22352._d_cmain!().main
+fix22352._d_cmain!(main).main

--- a/compiler/test/dshell/extra-files/dwarf/excepted_results/fix22471.txt
+++ b/compiler/test/dshell/extra-files/dwarf/excepted_results/fix22471.txt
@@ -1,3 +1,3 @@
 DW_AT_artificial  : 1
 DW_AT_name        : D main
-DW_AT_name        : __main._d_cmain!().main
+DW_AT_name        : __main._d_cmain!(main).main

--- a/compiler/test/dshell/extra-files/dwarf/excepted_results/issue22423.txt
+++ b/compiler/test/dshell/extra-files/dwarf/excepted_results/issue22423.txt
@@ -5,4 +5,4 @@ DW_AT_decl_column : 10
 DW_AT_decl_line   : 2000
 DW_AT_decl_column : 20
 D main
-issue22423._d_cmain!().main
+issue22423._d_cmain!(main).main

--- a/druntime/src/core/internal/entrypoint.d
+++ b/druntime/src/core/internal/entrypoint.d
@@ -16,13 +16,11 @@ call D main.  Any module containing a D main function declaration will
 cause the compiler to generate a `mixin _d_cmain();` statement to inject
 this code into the module.
 */
-template _d_cmain()
+template _d_cmain(alias _Dmain)
 {
     extern(C)
     {
         int _d_run_main(int argc, char **argv, void* mainFunc);
-
-        int _Dmain(char[][] args);
 
         int main(int argc, char **argv)
         {

--- a/spec/windows.dd
+++ b/spec/windows.dd
@@ -15,13 +15,11 @@ $(H2 All Console Programs)
     to be added. The `_d_cmain` template looks like:
     )
     ---
-    template _d_cmain()
+    template _d_cmain(alias _Dmain)
     {
         extern(C)
         {
             int _d_run_main(int argc, char **argv, void* mainFunc);
-
-            int _Dmain(char[][] args);
 
             int main(int argc, char **argv)
             {


### PR DESCRIPTION
I found the source of the duplicate declaration of _Dmain(), which causes the Mac Arm64 linker to fail. One is the one declared in the user's program, the other was in core.internal.entrypoint, where it was declared in the scope of _d_cmain(). The names were mangled the same (both as _Dmain).

The easiest way to fix that was to pass the correct _Dmain declaration in as an alias argument to the _d_cmain template.