### PR TITLE
osthread: joinLowLevelThread() split over OS modules

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -2192,39 +2192,8 @@ ThreadID createLowLevelThread(void delegate() nothrow dg, uint stacksize = 0,
  * Params:
  *  tid = the thread ID returned by `createLowLevelThread`.
  */
-void joinLowLevelThread(ThreadID tid) nothrow @nogc
-{
-    version (Windows)
-    {
-        HANDLE handle = OpenThreadHandle(tid);
-        if (!handle)
-            return;
-
-        if (thread_DLLProcessDetaching)
-        {
-            // When being called from DllMain/DLL_DETACH_PROCESS, threads cannot stop
-            //  due to the loader lock being held by the current thread.
-            // On the other hand, the thread must not continue to run as it will crash
-            //  if the DLL is unloaded. The best guess is to terminate it immediately.
-            TerminateThread(handle, 1);
-            WaitForSingleObject(handle, 10); // give it some time to terminate, but don't wait indefinitely
-        }
-        else
-            WaitForSingleObject(handle, INFINITE);
-        CloseHandle(handle);
-    }
-    else version (Posix)
-    {
-        if (pthread_join(tid, null) != 0)
-            onThreadError("Unable to join thread");
-    }
-    else version (WASI)
-    {
-        onThreadError("Unable to join thread");
-    }
-    else
-        static assert(0, "unsupported os");
-}
+version (CoreDdoc)
+void joinLowLevelThread(ThreadID tid) nothrow @nogc {}
 
 static if (!isSingleThreaded)
 nothrow @nogc unittest

--- a/druntime/src/core/thread/posix_impl.d
+++ b/druntime/src/core/thread/posix_impl.d
@@ -871,3 +871,10 @@ package bool launchLLThread(LLThreadProperties* tprop, ref LLThreadContext conte
 
     return true;
 }
+
+version (CoreDdoc) {} else
+void joinLowLevelThread(ThreadID tid) nothrow @nogc
+{
+    if (pthread_join(tid, null) != 0)
+        onThreadError("Unable to join thread");
+}

--- a/druntime/src/core/thread/windows_impl.d
+++ b/druntime/src/core/thread/windows_impl.d
@@ -17,7 +17,7 @@ import core.exception : onOutOfMemoryError;
 import core.internal.traits : externDFunc;
 import core.thread.osthread;
 import core.thread.threadbase;
-import core.thread.types : ThreadDescr, ll_ThreadData;
+import core.thread.types : ThreadID, ThreadDescr, ll_ThreadData;
 import core.time;
 
 version (Windows):
@@ -511,4 +511,26 @@ package bool launchLLThread(LLThreadProperties* tprop, ref LLThreadContext conte
         ll_startDLLUnloadThread();
 
     return true;
+}
+
+version (CoreDdoc) {} else
+void joinLowLevelThread(ThreadID tid) nothrow @nogc
+{
+    HANDLE handle = OpenThreadHandle(tid);
+    if (!handle)
+        return;
+
+    if (thread_DLLProcessDetaching)
+    {
+        // When being called from DllMain/DLL_DETACH_PROCESS, threads cannot stop
+        //  due to the loader lock being held by the current thread.
+        // On the other hand, the thread must not continue to run as it will crash
+        //  if the DLL is unloaded. The best guess is to terminate it immediately.
+        TerminateThread(handle, 1);
+        WaitForSingleObject(handle, 10); // give it some time to terminate, but don't wait indefinitely
+    }
+    else
+        WaitForSingleObject(handle, INFINITE);
+
+    CloseHandle(handle);
 }

--- a/druntime/src/core/thread/windows_impl.d
+++ b/druntime/src/core/thread/windows_impl.d
@@ -269,10 +269,8 @@ package bool resumeThreadImpl(Thread t) @nogc nothrow
     return ResumeThread(t.m_tdescr.hndl) != 0xFFFFFFFF;
 }
 
-//TODO: private
-package
+private
 {
-    version (Windows):
     // If the runtime is dynamically loaded as a DLL, there is a problem with
     // threads still running when the DLL is supposed to be unloaded:
     //


### PR DESCRIPTION
`joinLowLevelThread()` splitted over appropriate OS modules

Created as a separate PR to reduce the size of other PRs

What is happening is part of the process of separating code from different platforms into different modules