### PR TITLE
Fix#23485--auto[$] infer length from sparse array initializers

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2391,39 +2391,31 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (autoDollarDims.length && dsym.type.ty == Taarray)
             {
                 auto initExp = dsym._init.isExpInitializer();
-                if (initExp)
+                auto aale = initExp ? initExp.exp.isAssocArrayLiteralExp() : null;
+                if (aale && aale.keys && aale.values)
                 {
-                    if (auto aale = initExp.exp.isAssocArrayLiteralExp())
+                    // Compute array length from max key + 1
+                    dinteger_t maxKey = 0;
+                    foreach (k; *aale.keys)
                     {
-                        if (aale.keys && aale.values)
-                        {
-                            // Compute array length from max key + 1
-                            dinteger_t maxKey = 0;
-                            foreach (k; *aale.keys)
-                            {
-                                dinteger_t val = k.ctfeInterpret().toInteger();
-                                if (val > maxKey)
-                                    maxKey = val;
-                            }
-                            if (maxKey > 0 || aale.keys.length > 0)
-                            {
-                                Type elemType = dsym.type.nextOf();
-                                size_t len = cast(size_t)(maxKey + 1);
-                                auto elements = new Expressions(len);
-                                Expression defElem = elemType.defaultInit(dsym.loc);
-                                for (size_t i = 0; i < len; i++)
-                                    (*elements)[i] = defElem;
-                                foreach (j; 0 .. aale.keys.length)
-                                {
-                                    auto idx = cast(size_t)(*aale.keys)[j].ctfeInterpret().toInteger();
-                                    (*elements)[idx] = (*aale.values)[j];
-                                }
-                                dsym._init = new ExpInitializer(dsym.loc,
-                                    ArrayLiteralExp.create(dsym.loc, elements));
-                                dsym.type = elemType.arrayOf();
-                            }
-                        }
+                        dinteger_t val = k.ctfeInterpret().toInteger();
+                        if (val > maxKey)
+                            maxKey = val;
                     }
+                    Type elemType = dsym.type.nextOf();
+                    size_t len = cast(size_t)(maxKey + 1);
+                    auto elements = new Expressions(len);
+                    Expression defElem = elemType.defaultInit(dsym.loc);
+                    for (size_t i = 0; i < len; i++)
+                        (*elements)[i] = defElem;
+                    foreach (j; 0 .. aale.keys.length)
+                    {
+                        auto idx = cast(size_t)(*aale.keys)[j].ctfeInterpret().toInteger();
+                        (*elements)[idx] = (*aale.values)[j];
+                    }
+                    dsym._init = new ExpInitializer(dsym.loc,
+                        ArrayLiteralExp.create(dsym.loc, elements));
+                    dsym.type = elemType.arrayOf();
                 }
             }
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2385,6 +2385,48 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym._init = dsym._init.inferType(sc);
             dsym.type = dsym._init.initializerToExpression(null, sc.inCfile).type;
 
+            // When auto[$] is used with an all-indexed initializer like [3:42],
+            // inferType produces an AA type but the user wants a static array.
+            // Convert the AA literal to a sparse static array.
+            if (autoDollarDims.length && dsym.type.ty == Taarray)
+            {
+                auto initExp = dsym._init.isExpInitializer();
+                if (initExp)
+                {
+                    if (auto aale = initExp.exp.isAssocArrayLiteralExp())
+                    {
+                        if (aale.keys && aale.values)
+                        {
+                            // Compute array length from max key + 1
+                            dinteger_t maxKey = 0;
+                            foreach (k; *aale.keys)
+                            {
+                                dinteger_t val = k.ctfeInterpret().toInteger();
+                                if (val > maxKey)
+                                    maxKey = val;
+                            }
+                            if (maxKey > 0 || aale.keys.length > 0)
+                            {
+                                Type elemType = dsym.type.nextOf();
+                                size_t len = cast(size_t)(maxKey + 1);
+                                auto elements = new Expressions(len);
+                                Expression defElem = elemType.defaultInit(dsym.loc);
+                                for (size_t i = 0; i < len; i++)
+                                    (*elements)[i] = defElem;
+                                foreach (j; 0 .. aale.keys.length)
+                                {
+                                    auto idx = cast(size_t)(*aale.keys)[j].ctfeInterpret().toInteger();
+                                    (*elements)[idx] = (*aale.values)[j];
+                                }
+                                dsym._init = new ExpInitializer(dsym.loc,
+                                    ArrayLiteralExp.create(dsym.loc, elements));
+                                dsym.type = elemType.arrayOf();
+                            }
+                        }
+                    }
+                }
+            }
+
             if (autoDollarDims.length)
             {
                 // dysm.type here is dynamic array type with `auto` element type,

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2658,7 +2658,19 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         return;
                     }
                     if (auto ale = ie.isArrayLiteralExp())
+                    {
+                        // Fill null gaps left by sparse auto[$] inference,
+                        // now that dimensions are fully resolved.
+                        if (ale.elements)
+                        {
+                            foreach (ref e; (*ale.elements)[])
+                            {
+                                if (!e)
+                                    e = tsa.next.toBasetype().defaultInitLiteral(dsym.loc);
+                            }
+                        }
                         dsym._init = new ExpInitializer(dsym.loc, ale);
+                    }
                 }
             }
         }

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1264,18 +1264,15 @@ Initializer inferType(Initializer init, Scope* sc)
         bool isSparse = false;
         if (isAssoc)
         {
-            bool hasNull = false;
             foreach (idx; init.index)
             {
                 if (!idx)
                 {
-                    hasNull = true;
+                    isSparse = true;
                     break;
                 }
             }
-            if (hasNull)
-                isSparse = true;
-            else
+            if (!isSparse)
                 keys = new Expressions(init.value.length);
         }
         else
@@ -1284,7 +1281,8 @@ Initializer inferType(Initializer init, Scope* sc)
         if (isSparse)
         {
             // Sparse static array initializer, e.g. [0, 2:2, 3]
-            // Infer element type from values, then fill gaps with default init.
+
+            // Run semantic on each index and value to get typed expressions
             for (size_t i = 0; i < init.value.length; i++)
             {
                 if (auto idx = init.index[i])
@@ -1319,6 +1317,9 @@ Initializer inferType(Initializer init, Scope* sc)
 
             // Determine element type by running semantic on a temporary
             // dense ArrayLiteralExp containing only the provided values.
+            // This uses arrayExpressionToCommonType to find the common type
+            // across all values (e.g. int and double → double), rather than
+            // relying on any single value's type.
             auto tempElems = new Expressions();
             foreach (i; 0 .. init.value.length)
                 tempElems.push((*values)[i]);

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1259,10 +1259,95 @@ Initializer inferType(Initializer init, Scope* sc)
             return new ErrorInitializer();
         }
         const bool isAssoc = init.isAssociativeArray();
+
+        // Check for sparse static array: some indices non-null, some null
+        bool isSparse = false;
         if (isAssoc)
-            keys = new Expressions(init.value.length);
+        {
+            bool hasNull = false;
+            foreach (idx; init.index)
+            {
+                if (!idx)
+                {
+                    hasNull = true;
+                    break;
+                }
+            }
+            if (hasNull)
+                isSparse = true;
+            else
+                keys = new Expressions(init.value.length);
+        }
         else
             values.zero();
+
+        if (isSparse)
+        {
+            // Sparse static array initializer, e.g. [0, 2:2, 3]
+            // Infer element type from values, then fill gaps with default init.
+            for (size_t i = 0; i < init.value.length; i++)
+            {
+                if (auto idx = init.index[i])
+                {
+                    idx = idx.expressionSemantic(sc);
+                    idx = idx.ctfeInterpret();
+                    init.index[i] = idx;
+                    if (idx.op == EXP.error)
+                        return new ErrorInitializer();
+                }
+                Initializer iz = init.value[i];
+                if (!iz)
+                    return no();
+                iz = iz.inferType(sc);
+                if (iz.isErrorInitializer())
+                    return iz;
+                (*values)[i] = iz.isExpInitializer().exp;
+                assert(!(*values)[i].isErrorExp());
+            }
+
+            // Compute total array length from max index + trailing sequential elements
+            uint edim = 0;
+            size_t pos = 0;
+            foreach (i; 0 .. init.value.length)
+            {
+                if (auto idx = init.index[i])
+                    pos = cast(size_t)idx.toInteger();
+                ++pos;
+                if (pos > edim)
+                    edim = cast(uint)pos;
+            }
+
+            // Determine element type by running semantic on a temporary
+            // dense ArrayLiteralExp containing only the provided values.
+            auto tempElems = new Expressions();
+            foreach (i; 0 .. init.value.length)
+                tempElems.push((*values)[i]);
+            auto tempAle = ArrayLiteralExp.create(init.loc, tempElems);
+            auto tempExp = tempAle.expressionSemantic(sc);
+            if (tempExp.op == EXP.error)
+                return new ErrorInitializer();
+
+            Type elemType = tempExp.type.nextOf();
+            Expression defaultElem = elemType.defaultInit(Loc.initial);
+
+            // Fill positions with values, using default init for gaps
+            auto elements = new Expressions(edim);
+            for (size_t i = 0; i < edim; i++)
+                (*elements)[i] = defaultElem;
+
+            pos = 0;
+            foreach (i; 0 .. init.value.length)
+            {
+                if (auto idx = init.index[i])
+                    pos = cast(size_t)idx.toInteger();
+                (*elements)[pos] = (*values)[i];
+                ++pos;
+            }
+
+            auto ale = ArrayLiteralExp.create(init.loc, elements);
+            auto ei = new ExpInitializer(init.loc, ale);
+            return ei.inferType(sc);
+        }
 
         for (size_t i = 0; i < init.value.length; i++)
         {

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1315,27 +1315,11 @@ Initializer inferType(Initializer init, Scope* sc)
                     edim = cast(uint)pos;
             }
 
-            // Determine element type by running semantic on a temporary
-            // dense ArrayLiteralExp containing only the provided values.
-            // This uses arrayExpressionToCommonType to find the common type
-            // across all values (e.g. int and double → double), rather than
-            // relying on any single value's type.
-            auto tempElems = new Expressions();
-            foreach (i; 0 .. init.value.length)
-                tempElems.push((*values)[i]);
-            auto tempAle = ArrayLiteralExp.create(init.loc, tempElems);
-            auto tempExp = tempAle.expressionSemantic(sc);
-            if (tempExp.op == EXP.error)
-                return new ErrorInitializer();
-
-            Type elemType = tempExp.type.nextOf();
-            Expression defaultElem = elemType.defaultInit(Loc.initial);
-
-            // Fill positions with values, using default init for gaps
+            // Create sparse elements with null gaps. Gaps will be filled
+            // with the correct default init after $ resolution (in dsymbolsem.d),
+            // when the element type is fully known.
             auto elements = new Expressions(edim);
-            for (size_t i = 0; i < edim; i++)
-                (*elements)[i] = defaultElem;
-
+            elements.zero();
             pos = 0;
             foreach (i; 0 .. init.value.length)
             {

--- a/compiler/test/runnable/staticarray.d
+++ b/compiler/test/runnable/staticarray.d
@@ -164,6 +164,16 @@ void main()
 	assert(sparse4[1] != sparse4[1]); // double.init = NaN
 	assert(sparse4[3] == 3.5);
 
+	// nested sparse: outer gap filled with inner array default init
+	auto[$][$] sparse5 = [[0, 1], 2:[1, 1]];
+	assert(sparse5.length == 3);
+	assert(sparse5[0] == [0, 1]);
+	assert(sparse5[1] == [0, 0]);
+	assert(sparse5[2] == [1, 1]);
+	static assert(sparse5.length == 3);
+	static assert(sparse5[0].length == 2);
+	static assert(is(typeof(sparse5) == int[2][3]));
+
 	// regression: auto without $ still produces AA
 	auto aa = [3:42];
 	assert(aa.length == 1);

--- a/compiler/test/runnable/staticarray.d
+++ b/compiler/test/runnable/staticarray.d
@@ -156,6 +156,14 @@ void main()
 	assert(sparse3[1] != sparse3[1]); // NaN
 	assert(sparse3[3] == 3.5);
 
+	// mixed types: element type is the common type (int + double → double)
+	auto[$] sparse4 = [ 1, 3:3.5 ];
+	assert(sparse4.length == 4);
+	static assert(is(typeof(sparse4[0]) == double));
+	assert(sparse4[0] == 1);
+	assert(sparse4[1] != sparse4[1]); // double.init = NaN
+	assert(sparse4[3] == 3.5);
+
 	// regression: auto without $ still produces AA
 	auto aa = [3:42];
 	assert(aa.length == 1);

--- a/compiler/test/runnable/staticarray.d
+++ b/compiler/test/runnable/staticarray.d
@@ -132,4 +132,33 @@ void main()
 	assert(arr12[0] == 'a');
 	assert(arr12[1] == 'b');
 	assert(arr12[2] == 'c');
+
+	// sparse static array initializer: mixed null and non-null indices
+	auto[$] sparse1 = [ 0, 2:2, 3];
+	assert(sparse1.length == 4);
+	assert(sparse1[0] == 0);
+	assert(sparse1[1] == 0);
+	assert(sparse1[2] == 2);
+	assert(sparse1[3] == 3);
+	static assert(sparse1.length == 4);
+
+	// all-indexed (like [3:42]) with auto[$]
+	auto[$] sparse2 = [ 3:42 ];
+	assert(sparse2.length == 4);
+	assert(sparse2[0] == 0);
+	assert(sparse2[3] == 42);
+	static assert(sparse2.length == 4);
+
+	// float sparse: gaps filled with float.init (NaN)
+	auto[$] sparse3 = [ 1.5, 3:3.5 ];
+	assert(sparse3.length == 4);
+	assert(sparse3[0] == 1.5);
+	assert(sparse3[1] != sparse3[1]); // NaN
+	assert(sparse3[3] == 3.5);
+
+	// regression: auto without $ still produces AA
+	auto aa = [3:42];
+	assert(aa.length == 1);
+	assert(aa[3] == 42);
+	static assert(is(typeof(aa) == int[int]));
 }


### PR DESCRIPTION
Fixes: #23485 .

Two code paths are affected, since sparse initializers come in two forms:

**compiler/src/dmd/initsem.d — mixed indices** (`[0, 2:2, 3]`) `inferType`'s `visitArray` previously only handled all-null (sequential) or all-non-null (associative) indices. A mix of null and non-null (sparse static array) was not recognized. Added detection for this case: process values, compute the array length from max index + trailing sequential elements, and create a dense `ArrayLiteralExp` with null gaps. The gaps are filled later in dsymbolsem.d once the element type is fully resolved.

**compiler/src/dmd/dsymbolsem.d — all-indexed** (`[3:42]`) When all indices are non-null, `inferType` produces an associative array type. For `auto[$]` the user explicitly requests a static array, so the AA literal is converted back to a sparse static array interpretation. Also handles gap filling after `$` resolution so that nested sparse arrays (e.g. `auto[$][$] = [[0,1], 2:[1,1]]`) work correctly.