### PR TITLE
rename isMain to isDMain for consistency

### DIFF
--- a/compiler/include/dmd/declaration.h
+++ b/compiler/include/dmd/declaration.h
@@ -703,7 +703,7 @@ public:
     LabelDsymbol *searchLabel(Identifier *ident, Loc loc);
     const char *toPrettyChars(bool QualifyTypes = false, bool keepOneMember = false) override;
     const char *toFullSignature();  // for diagnostics, e.g. 'int foo(int x, int y) pure'
-    bool isMain() const;
+    bool isDMain() const;
     bool isCMain() const;
     bool isWinMain() const;
     bool isDllMain() const;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -454,7 +454,7 @@ extern (C++) class FuncDeclaration : Declaration
 
     override const(char)* toPrettyChars(bool QualifyTypes = false, bool keepOneMember = false)
     {
-        if (isMain())
+        if (isDMain())
             return "D main";
         return Dsymbol.toPrettyChars(QualifyTypes, keepOneMember);
     }
@@ -467,7 +467,7 @@ extern (C++) class FuncDeclaration : Declaration
         return buf.extractChars();
     }
 
-    final bool isMain() const
+    final bool isDMain() const
     {
         return ident == Id.main && resolvedLinkage() != LINK.c && !isMember() && !isNested();
     }

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -917,7 +917,7 @@ Ldone:
     __gshared bool printedMain = false; // semantic might run more than once
     if (global.params.v.verbose && !printedMain)
     {
-        const(char)* type = funcdecl.isMain() ? "main" : funcdecl.isWinMain() ? "winmain" : funcdecl.isDllMain() ? "dllmain" : cast(const(char)*)null;
+        const(char)* type = funcdecl.isDMain() ? "main" : funcdecl.isWinMain() ? "winmain" : funcdecl.isDllMain() ? "dllmain" : cast(const(char)*)null;
         Module mod = sc._module;
 
         if (type && mod)
@@ -930,10 +930,10 @@ Ldone:
     }
 
     if (funcdecl.fbody && sc._module.isRoot() &&
-        (funcdecl.isMain() || funcdecl.isWinMain() || funcdecl.isDllMain() || funcdecl.isCMain()))
+        (funcdecl.isDMain() || funcdecl.isWinMain() || funcdecl.isDllMain() || funcdecl.isCMain()))
         global.hasMainFunction = true;
 
-    if (funcdecl.fbody && funcdecl.isMain() && sc._module.isRoot())
+    if (funcdecl.fbody && funcdecl.isDMain() && sc._module.isRoot())
     {
         // check if `_d_cmain` is defined
         bool cmainTemplateExists()

--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -1722,7 +1722,7 @@ private UnitTestDeclaration needsDeferredNested(FuncDeclaration fd)
 private bool entryPointFunctions(Obj objmod, FuncDeclaration fd)
 {
     // D main()
-    if (fd.isMain() && onlyOneMain(fd))
+    if (fd.isDMain() && onlyOneMain(fd))
     {
         /* Reference the C main() to pull it in to the executable
          */

--- a/compiler/src/dmd/glue/tocsym.d
+++ b/compiler/src/dmd/glue/tocsym.d
@@ -513,7 +513,7 @@ Symbol* toSymbol(Dsymbol s)
                 type_setty(&t, t.Tty | mTYnaked);
 
             const msave = t.Tmangle;
-            if (fd.isMain())
+            if (fd.isDMain())
             {
                 t.Tty = TYnfunc;
                 t.Tmangle = Mangle.c;

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -717,7 +717,7 @@ public:
             buf.writestring(fd.mangleOverride);
             return;
         }
-        if (fd.isMain())
+        if (fd.isDMain())
         {
             buf.writestring("_Dmain");
             return;

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1767,7 +1767,7 @@ private struct FuncDeclSem3
         if (sc.inCfile && funcdecl.isCMain() && f.next.ty == Tint32)
             return true;
 
-        return f.next.ty == Tvoid && (funcdecl.isMain() || funcdecl.isCMain());
+        return f.next.ty == Tvoid && (funcdecl.isDMain() || funcdecl.isCMain());
     }
 }
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2955,7 +2955,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 }
                 errors = true;
             }
-            else if (fd.isMain())
+            else if (fd.isDMain())
             {
                 // main() returns 0, even if it returns void
                 rs.exp = IntegerExp.literal!0;

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1007,7 +1007,7 @@ public:
             return;
         TypeFunction *tf = func->type->toTypeFunction();
         Type *type = func->tintro != NULL ? func->tintro->nextOf() : tf->nextOf();
-        if ((func->isMain() || func->isCMain()) && type->toBasetype()->ty == TY::Tvoid)
+        if ((func->isDMain() || func->isCMain()) && type->toBasetype()->ty == TY::Tvoid)
             type = Type::tint32;
         if (func->shidden)
         {


### PR DESCRIPTION
Be consistent with isCMain() etc. I got tired of having to remind myself that isMain is really about DMain,