### PR TITLE
improve #23490 - infer length from sparse array initializers

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2306,10 +2306,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             auto tid = t ? t.isTypeIdentifier() : null;
             auto autoIdent = Identifier.idPool(Token.toString(TOK.auto_));
-            if (autoDollarDims.length && tid && tid.ident == autoIdent)
-                // Intentionally set type to null to trigger type inference,
-                dsym.type = null;
-            else
+            if (!tid || tid.ident != autoIdent)
                 autoDollarDims = null;
         }
         static bool hasDollarDimension(TypeSArray tsa)
@@ -2361,7 +2358,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     resolveDollarToZero(next, loc);
             }
         }
-        if (!dsym.type)
+        if (!dsym.type || autoDollarDims.length)
         {
             dsym.inuse++;
 
@@ -2382,42 +2379,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 return;
             }
             //printf("inferring type for %s with init %s\n", dsym.toChars(), dsym._init.toChars());
-            dsym._init = dsym._init.inferType(sc);
+            dsym._init = dsym._init.inferType(sc, dsym.type);
             dsym.type = dsym._init.initializerToExpression(null, sc.inCfile).type;
-
-            // When auto[$] is used with an all-indexed initializer like [3:42],
-            // inferType produces an AA type but the user wants a static array.
-            // Convert the AA literal to a sparse static array.
-            if (autoDollarDims.length && dsym.type.ty == Taarray)
-            {
-                auto initExp = dsym._init.isExpInitializer();
-                auto aale = initExp ? initExp.exp.isAssocArrayLiteralExp() : null;
-                if (aale && aale.keys && aale.values)
-                {
-                    // Compute array length from max key + 1
-                    dinteger_t maxKey = 0;
-                    foreach (k; *aale.keys)
-                    {
-                        dinteger_t val = k.ctfeInterpret().toInteger();
-                        if (val > maxKey)
-                            maxKey = val;
-                    }
-                    Type elemType = dsym.type.nextOf();
-                    size_t len = cast(size_t)(maxKey + 1);
-                    auto elements = new Expressions(len);
-                    Expression defElem = elemType.defaultInit(dsym.loc);
-                    for (size_t i = 0; i < len; i++)
-                        (*elements)[i] = defElem;
-                    foreach (j; 0 .. aale.keys.length)
-                    {
-                        auto idx = cast(size_t)(*aale.keys)[j].ctfeInterpret().toInteger();
-                        (*elements)[idx] = (*aale.values)[j];
-                    }
-                    dsym._init = new ExpInitializer(dsym.loc,
-                        ArrayLiteralExp.create(dsym.loc, elements));
-                    dsym.type = elemType.arrayOf();
-                }
-            }
 
             if (autoDollarDims.length)
             {
@@ -2633,7 +2596,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
             else
             {
-                Expression ie = dsym._init.initializerToExpression(null, sc.inCfile);
+                Expression ie = dsym._init.initializerToExpression(tsa, sc.inCfile);
                 if (ie && ie.op != EXP.error)
                 {
                     // Infer from literal syntax first to avoid prematurely
@@ -2663,11 +2626,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         // now that dimensions are fully resolved.
                         if (ale.elements)
                         {
-                            foreach (ref e; (*ale.elements)[])
-                            {
+                            foreach (e; (*ale.elements)[])
                                 if (!e)
-                                    e = tsa.next.toBasetype().defaultInitLiteral(dsym.loc);
-                            }
+                                {
+                                    ale.basis = tsa.next.toBasetype().defaultInitLiteral(dsym.loc);
+                                    break;
+                                }
                         }
                         dsym._init = new ExpInitializer(dsym.loc, ale);
                     }

--- a/compiler/src/dmd/init.d
+++ b/compiler/src/dmd/init.d
@@ -194,12 +194,15 @@ extern (C++) final class ArrayInitializer : Initializer
 
     bool isAssociativeArray() const pure
     {
+        if (!index.length)
+            return false;
+
         foreach (idx; index)
         {
-            if (idx)
-                return true;
+            if (!idx)
+                return false;
         }
-        return false;
+        return true;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1217,10 +1217,11 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
  * Params:
  *      init = `Initializer` AST node
  *      sc = context
+ *      itype = the type of the parsed declaration, null for `auto`
  * Returns:
  *      an equivalent `ExpInitializer` if successful, or `ErrorInitializer` if it cannot be translated
  */
-Initializer inferType(Initializer init, Scope* sc)
+Initializer inferType(Initializer init, Scope* sc, Type itype)
 {
     Initializer visitVoid(VoidInitializer i)
     {
@@ -1258,103 +1259,57 @@ Initializer inferType(Initializer init, Scope* sc)
                 error(init.loc, "cannot infer type from array initializer");
             return new ErrorInitializer();
         }
-        const bool isAssoc = init.isAssociativeArray();
-
-        // Check for sparse static array: some indices non-null, some null
-        bool isSparse = false;
+        const bool isAssoc = itype && itype.ty == Taarray ||
+            !itype && init.isAssociativeArray();
         if (isAssoc)
-        {
-            foreach (idx; init.index)
-            {
-                if (!idx)
-                {
-                    isSparse = true;
-                    break;
-                }
-            }
-            if (!isSparse)
-                keys = new Expressions(init.value.length);
-        }
+            keys = new Expressions(init.value.length);
         else
             values.zero();
 
-        if (isSparse)
-        {
-            // Sparse static array initializer, e.g. [0, 2:2, 3]
-
-            // Run semantic on each index and value to get typed expressions
-            for (size_t i = 0; i < init.value.length; i++)
-            {
-                if (auto idx = init.index[i])
-                {
-                    idx = idx.expressionSemantic(sc);
-                    idx = idx.ctfeInterpret();
-                    init.index[i] = idx;
-                    if (idx.op == EXP.error)
-                        return new ErrorInitializer();
-                }
-                Initializer iz = init.value[i];
-                if (!iz)
-                    return no();
-                iz = iz.inferType(sc);
-                if (iz.isErrorInitializer())
-                    return iz;
-                (*values)[i] = iz.isExpInitializer().exp;
-                assert(!(*values)[i].isErrorExp());
-            }
-
-            // Compute total array length from max index + trailing sequential elements
-            uint edim = 0;
-            size_t pos = 0;
-            foreach (i; 0 .. init.value.length)
-            {
-                if (auto idx = init.index[i])
-                    pos = cast(size_t)idx.toInteger();
-                ++pos;
-                if (pos > edim)
-                    edim = cast(uint)pos;
-            }
-
-            // Create sparse elements with null gaps. Gaps will be filled
-            // with the correct default init after $ resolution (in dsymbolsem.d),
-            // when the element type is fully known.
-            auto elements = new Expressions(edim);
-            elements.zero();
-            pos = 0;
-            foreach (i; 0 .. init.value.length)
-            {
-                if (auto idx = init.index[i])
-                    pos = cast(size_t)idx.toInteger();
-                (*elements)[pos] = (*values)[i];
-                ++pos;
-            }
-
-            auto ale = ArrayLiteralExp.create(init.loc, elements);
-            auto ei = new ExpInitializer(init.loc, ale);
-            return ei.inferType(sc);
-        }
-
-        for (size_t i = 0; i < init.value.length; i++)
+        size_t idx = 0;
+        for (size_t i = 0; i < init.value.length; i++, idx++)
         {
             if (isAssoc)
             {
                 Expression e = init.index[i];
-                if (!e)
-                    return no();
+                assert(e); // already asserted by isAssociativeArray()
                 (*keys)[i] = e;
             }
             else
-                assert(!init.index[i]); // already asserted by isAssociativeArray()
+            {
+                if (Expression e = init.index[i])
+                {
+                    dinteger_t nidx = e.toInteger();
+                    // sanity check: some arbitrary limit that allows a 32-bit process to continue
+                    if (nidx > uint.max / 32)
+                    {
+                        error(init.loc, "array index %lld not supported", nidx);
+                        return new ErrorInitializer();
+                    }
+                    idx = cast(uint)nidx;
+                }
+                if (idx >= values.length)
+                {
+                    size_t olddim = values.length;
+                    values.setDim(idx + 1);
+                    (*values)[olddim .. idx + 1][] = null;
+                }
+                else if ((*values)[idx])
+                {
+                    error(init.loc, "array index %d initialized twice", cast(int)idx);
+                    return new ErrorInitializer();
+                }
+            }
             Initializer iz = init.value[i];
             if (!iz)
                 return no();
-            iz = iz.inferType(sc);
+            iz = iz.inferType(sc, itype ? itype.nextOf() : null);
             if (iz.isErrorInitializer())
             {
                 return iz;
             }
-            (*values)[i] = iz.isExpInitializer().exp;
-            assert(!(*values)[i].isErrorExp());
+            (*values)[idx] = iz.isExpInitializer().exp;
+            assert(!(*values)[idx].isErrorExp());
         }
 
         Expression e;
@@ -1362,7 +1317,7 @@ Initializer inferType(Initializer init, Scope* sc)
             ? new AssocArrayLiteralExp(init.loc, keys, values)
             : new ArrayLiteralExp(init.loc, null, values);
         auto ei = new ExpInitializer(init.loc, e);
-        return ei.inferType(sc);
+        return ei.inferType(sc, itype);
     }
 
     Initializer visitExp(ExpInitializer init)
@@ -1499,10 +1454,15 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
                 goto case Tsarray;
 
             case Tsarray:
-                uinteger_t adim = t.isTypeSArray().dim.toInteger();
-                if (adim >= amax)
-                    return null;
-                edim = cast(uint)adim;
+                auto dim = t.isTypeSArray().dim;
+                auto ide = dim.isIdentifierExp();
+                if (!ide || ide.ident != Id.dollar)
+                {
+                    uinteger_t adim = dim.toInteger();
+                    if (adim >= amax)
+                        return null;
+                    edim = cast(uint)adim;
+                }
                 break;
 
             case Tpointer:
@@ -1544,9 +1504,13 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
             {
                 if (auto tsa = itype.isTypeSArray())
                 {
-                    uinteger_t adim = tsa.dim.toInteger();
-                    if (adim > edim && adim < amax)
-                        edim = cast(uint)adim;
+                    auto ide = tsa.dim.isIdentifierExp();
+                    if (!ide || ide.ident != Id.dollar)
+                    {
+                        uinteger_t adim = tsa.dim.toInteger();
+                        if (adim > edim && adim < amax)
+                            edim = cast(uint)adim;
+                    }
                 }
             }
         }

--- a/compiler/test/fail_compilation/staticarray.d
+++ b/compiler/test/fail_compilation/staticarray.d
@@ -1,28 +1,34 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/staticarray.d(27): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(28): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(29): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(30): Error: cannot infer static array length from `$` in this type position; only direct static array declarations can infer `$` from an initializer
-fail_compilation/staticarray.d(31): Error: cannot infer static array length from `$` in this type position; only direct static array declarations can infer `$` from an initializer
-fail_compilation/staticarray.d(32): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(36): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(34): Error: struct `staticarray.ForwardRef1` circular or forward reference
-fail_compilation/staticarray.d(45): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(43): Error: struct `staticarray.ForwardRef3` circular or forward reference
-fail_compilation/staticarray.d(50): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(48): Error: struct `staticarray.ForwardRef4` circular or forward reference
-fail_compilation/staticarray.d(57): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(54): Error: struct `staticarray.ForwardRef5` circular or forward reference
-fail_compilation/staticarray.d(62): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(60): Error: struct `staticarray.ForwardRef6` circular or forward reference
-fail_compilation/staticarray.d(67): Error: cannot infer static array length from `$`, provide an initializer
-fail_compilation/staticarray.d(65): Error: struct `staticarray.ForwardRef7` circular or forward reference
-fail_compilation/staticarray.d(73): Error: struct `staticarray.ForwardRef8` cannot have field `arr` with static array of same struct type
-fail_compilation/staticarray.d(40): Error: variable `staticarray.ForwardRef2.arr` recursive initialization of field
+fail_compilation\staticarray.d(33): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation\staticarray.d(34): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation\staticarray.d(35): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation\staticarray.d(36): Error: cannot infer static array length from `$` in this type position; only direct static array declarations can infer `$` from an initializer
+fail_compilation\staticarray.d(37): Error: cannot infer static array length from `$` in this type position; only direct static array declarations can infer `$` from an initializer
+fail_compilation\staticarray.d(38): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation\staticarray.d(42): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation\staticarray.d(40): Error: struct `staticarray.ForwardRef1` circular or forward reference
+fail_compilation\staticarray.d(51): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation\staticarray.d(49): Error: struct `staticarray.ForwardRef3` circular or forward reference
+fail_compilation\staticarray.d(56): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation\staticarray.d(54): Error: struct `staticarray.ForwardRef4` circular or forward reference
+fail_compilation\staticarray.d(63): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation\staticarray.d(60): Error: struct `staticarray.ForwardRef5` circular or forward reference
+fail_compilation\staticarray.d(68): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation\staticarray.d(66): Error: struct `staticarray.ForwardRef6` circular or forward reference
+fail_compilation\staticarray.d(73): Error: cannot infer static array length from `$`, provide an initializer
+fail_compilation\staticarray.d(71): Error: struct `staticarray.ForwardRef7` circular or forward reference
+fail_compilation\staticarray.d(79): Error: struct `staticarray.ForwardRef8` cannot have field `arr` with static array of same struct type
+fail_compilation\staticarray.d(82): Error: array index 3 initialized twice
+fail_compilation\staticarray.d(82): Error: cannot infer static array element type for `auto[$]`, provide an array initializer
+fail_compilation\staticarray.d(83): Error: array index 4294901760 not supported
+fail_compilation\staticarray.d(83): Error: cannot infer static array element type for `auto[$]`, provide an array initializer
+fail_compilation\staticarray.d(46): Error: variable `staticarray.ForwardRef2.arr` recursive initialization of field
+fail_compilation\staticarray.d(84): Error: array initializer has 4 elements, but array length is 3
 ---
 */
+
 
 int[$] arr1;
 int[$] arr2 = void;
@@ -72,3 +78,7 @@ struct ForwardRef8
 {
     ForwardRef8[$][$] arr = [[ForwardRef8.init]];
 }
+
+auto[$] arr7 = [ 0, 3:3, 2:2, 4 ];
+auto[$] arr8 = [ 0, 3:3, 0xffff_0000:99 ];
+int[3] arr9 = [ 0, 3:3 ];


### PR DESCRIPTION
- fix inconsistent definition of ArrayInitializer.isAssociativeArray
- reduce code duplication
- derive static/associative array type from parsed type instead of converting AA back to static array (avoiding instantiating AA templates)
- use ArrayLiteralExp basis instead of default for every element

FYI @gulugulubing 