### PR TITLE
druntime: __alloca should not be called from compilers other than DMD

### DIFF
--- a/druntime/src/rt/alloca.d
+++ b/druntime/src/rt/alloca.d
@@ -24,6 +24,7 @@ module rt.alloca;
  *      EAX     allocated data, null if stack overflows
  */
 
+version (DigitalMars)
 extern (C) void* __alloca(int nbytes)
 {
   version (D_InlineAsm_X86)
@@ -205,4 +206,8 @@ extern (C) void* __alloca(int nbytes)
   }
   else
         static assert(0);
+}
+else
+{
+    static assert(false, "Not implemented for this compiler");
 }


### PR DESCRIPTION
Faced during write https://github.com/dlang/dmd/pull/23499

`__alloca` function description contains:
```
 * This is a 'magic' function that needs help from the compiler to
 * work right, do not change its name, do not call it from other compilers.
 ```