### PR TITLE
put extern Symbols last in machobj

### DIFF
--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -540,15 +540,15 @@ int mach_numbersyms()
         n++;
     }
 
-    foreach (s; machobj.externSymbols[])
-    {
-        s.Sxtrnnum = n;
-        n++;
-    }
-
     foreach (ref c; machobj.comdefs[])
     {
         c.sym.Sxtrnnum = n;
+        n++;
+    }
+
+    foreach (s; machobj.externSymbols[])
+    {
+        s.Sxtrnnum = n;
         n++;
     }
 


### PR DESCRIPTION
Putting the externSymbols[] array last will make it easier to squeeze out duplicates. Let's see if it breaks anything.