### PR TITLE
remove redundant extern Symbols

### DIFF
--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -562,7 +562,7 @@ struct Symbol
     nothrow:
 
     Symbol* Sl, Sr;             // left, right child
-    Symbol* Snext;              // next in threaded list
+    Symbol* Sforward;           // forward to another Symbol
     Symbol* Sisym;              // import version of this symbol
     dt_t* Sdt;                  // variables: initializer
     int Salignment;             // variables: alignment, 0 or -1 means default alignment

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -44,33 +44,10 @@ nothrow:
 
 private enum log = false;
 
-alias _compare_fp_t = extern(C) nothrow int function(const void*, const void*);
-extern(C) void qsort(void* base, size_t nmemb, size_t size, _compare_fp_t compar);
-
 import dmd.backend.dwarf;
 import dmd.backend.mach;
 
 alias nlist = dmd.backend.mach.nlist;   // avoid conflict with dmd.backend.dlist.nlist
-
-/****************************************
- * Sort the relocation entry buffer.
- * put before nothrow because qsort was not marked nothrow until version 2.086
- */
-
-extern (C)
-@trusted
-private int mach_rel_fp(scope const(void*) e1, scope const(void*) e2)
-{   Relocation* r1 = cast(Relocation*)e1;
-    Relocation* r2 = cast(Relocation*)e2;
-
-    return cast(int)(r1.offset - r2.offset);
-}
-
-@trusted
-void mach_relsort(OutBuffer* buf)
-{
-    qsort(buf.buf, buf.length() / Relocation.sizeof, Relocation.sizeof, &mach_rel_fp);
-}
 
 struct MachObj
 {
@@ -3701,3 +3678,29 @@ void dumpFixup(ref Symbol s, uint fixup)
     symbol_print(s);
     printf("fixup %s RELOC_%s\n", s.Sident.ptr, reloc[fixup]);
 }
+
+/****************************************
+ * Sort the array of Symbol pointers by their identifiers.
+ * Params:
+ *	symbols = array to be in-place sorted
+ */
+
+@trusted
+private void sortSymbols(Symbol*[] symbols)
+{
+    qsort(symbols.ptr, symbols.length, symbols.ptr.sizeof, &symbolQsortFp);
+}
+
+/** qsort() comparison function
+  */
+extern (C)
+@trusted
+private int symbolQsortFp(scope const(void*) e1, scope const(void*) e2)
+{   Symbol* s1 = *cast(Symbol**)e1;
+    Symbol* s2 = *cast(Symbol**)e2;
+
+    return strcmp(s1.Sident.ptr, s2.Sident.ptr);
+}
+
+alias _compare_fp_t = extern(C) nothrow int function(const void*, const void*);
+extern(C) void qsort(void* base, size_t nmemb, size_t size, _compare_fp_t compar);

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -502,6 +502,13 @@ void patch(seg_data* pseg, targ_size_t offset, int seg, targ_size_t value)
 @trusted
 int mach_numbersyms()
 {
+    // Sort Symbols for faster searching
+    sortSymbols(machobj.localSymbols[]);
+    sortSymbols(machobj.publicSymbols[]);
+    //sortSymbols(machobj.externSymbols[]); // no need to sort these
+    //sortComdefs(machobj.comdefs[]);       // not implemented yet
+
+
     //printf("mach_numbersyms()\n");
     int n = 0;
 
@@ -3682,7 +3689,7 @@ void dumpFixup(ref Symbol s, uint fixup)
 /****************************************
  * Sort the array of Symbol pointers by their identifiers.
  * Params:
- *	symbols = array to be in-place sorted
+ *      symbols = array to be in-place sorted
  */
 
 @trusted

--- a/compiler/src/dmd/backend/symbol.d
+++ b/compiler/src/dmd/backend/symbol.d
@@ -625,7 +625,7 @@ Symbol* symbol_copy(ref Symbol s)
     /*printf("symbol_copy(%s)\n",s.Sident.ptr);*/
     scopy = symbol_calloc(s.Sident.ptr[0 .. strlen(s.Sident.ptr)]);
     memcpy(scopy, &s, Symbol.sizeof - s.Sident.sizeof);
-    scopy.Sl = scopy.Sr = scopy.Snext = null;
+    scopy.Sl = scopy.Sr = scopy.Sforward = null;
     scopy.Ssymnum = SYMIDX.max;
     if (scopy.Sdt)
     {


### PR DESCRIPTION
This is a totally different attempt at https://github.com/dlang/dmd/pull/23484, i.e. removing duplicate symbols from the Mach object file.