### PR TITLE
druntime: Fix `rt_term` deadlock when a `Thread.start` fails

### DIFF
--- a/druntime/src/core/thread/posix_impl.d
+++ b/druntime/src/core/thread/posix_impl.d
@@ -270,6 +270,7 @@ class Thread : ThreadBase
         scope(exit) slock.unlock_nothrow();
         {
             incrementAboutToStart(this);
+            scope(failure) decrementAboutToStart(this);
 
             version (all)
             {

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -699,6 +699,25 @@ package(core.thread):
         pAboutToStart[nAboutToStart - 1] = t;
     }
 
+    package static void decrementAboutToStart(ThreadBase t) nothrow @nogc
+    {
+        size_t idx = -1;
+        foreach (i, thr; pAboutToStart[0 .. nAboutToStart])
+        {
+            if (thr is t)
+            {
+                idx = i;
+                break;
+            }
+        }
+        assert(idx != -1);
+        import core.stdc.string : memmove;
+        memmove(pAboutToStart + idx, pAboutToStart + idx + 1, size_t.sizeof * (nAboutToStart - idx - 1));
+        pAboutToStart =
+            cast(ThreadBase*)realloc(pAboutToStart, size_t.sizeof * --nAboutToStart);
+    }
+
+
     //
     // Add a thread to the global thread list.
     //
@@ -715,23 +734,7 @@ package(core.thread):
         assert(t.isRunning); // check this with slock to ensure pthread_create already returned
         assert(!suspendDepth); // must be 0 b/c it's only set with slock held
 
-        if (rmAboutToStart)
-        {
-            size_t idx = -1;
-            foreach (i, thr; pAboutToStart[0 .. nAboutToStart])
-            {
-                if (thr is t)
-                {
-                    idx = i;
-                    break;
-                }
-            }
-            assert(idx != -1);
-            import core.stdc.string : memmove;
-            memmove(pAboutToStart + idx, pAboutToStart + idx + 1, size_t.sizeof * (nAboutToStart - idx - 1));
-            pAboutToStart =
-                cast(ThreadBase*)realloc(pAboutToStart, size_t.sizeof * --nAboutToStart);
-        }
+        if (rmAboutToStart) decrementAboutToStart(t);
 
         if (sm_tbeg)
         {

--- a/druntime/src/core/thread/windows_impl.d
+++ b/druntime/src/core/thread/windows_impl.d
@@ -140,6 +140,7 @@ class Thread : ThreadBase
         scope(exit) slock.unlock_nothrow();
         {
             incrementAboutToStart(this);
+            scope(failure) decrementAboutToStart(this);
 
             if ( ResumeThread( m_tdescr.hndl ) == -1 )
                 onThreadError( "Error resuming thread" );


### PR DESCRIPTION
An issue I found while testing WASI.

When `Thread.start` fails, the `incrementAboutToStart` is never undone, as `Thread.add` never gets called.

`rt_term` calls `thread_joinAll`. This imbalance causes `thread_joinAll` to deadlock waiting for `ThreadBase.nAboutToStart` to zero out. 