### PR TITLE
Make rt.alloca module is empty for non-DMD builds

### DIFF
--- a/druntime/src/rt/alloca.d
+++ b/druntime/src/rt/alloca.d
@@ -208,6 +208,7 @@ extern (C) void* __alloca(int nbytes)
         static assert(0);
 }
 else
+extern (C) void* __alloca(int nbytes)
 {
     static assert(false, "Not implemented for this compiler");
 }

--- a/druntime/src/rt/alloca.d
+++ b/druntime/src/rt/alloca.d
@@ -11,6 +11,8 @@
 
 module rt.alloca;
 
+version (DigitalMars):
+
 /*******************************************
  * Allocate data from the caller's stack frame.
  * This is a 'magic' function that needs help from the compiler to
@@ -24,7 +26,6 @@ module rt.alloca;
  *      EAX     allocated data, null if stack overflows
  */
 
-version (DigitalMars)
 extern (C) void* __alloca(int nbytes)
 {
   version (D_InlineAsm_X86)
@@ -206,9 +207,4 @@ extern (C) void* __alloca(int nbytes)
   }
   else
         static assert(0);
-}
-else
-extern (C) void* __alloca(int nbytes)
-{
-    static assert(false, "Not implemented for this compiler");
 }


### PR DESCRIPTION
Addition to #23500 