### PR TITLE
Use bit fields for small fields in ClassDeclaration

### DIFF
--- a/compiler/include/dmd/aggregate.h
+++ b/compiler/include/dmd/aggregate.h
@@ -261,13 +261,30 @@ public:
                                         // their own vtbl[]
 
     TypeInfoClassDeclaration *vclassinfo;       // the ClassInfo object for this ClassDeclaration
-    d_bool com;                           // true if this is a COM class (meaning it derives from IUnknown)
-    d_bool stack;                         // true if this is a scope class
-    int cppDtorVtblIndex;               // slot reserved for the virtual destructor [extern(C++)]
-    d_bool inuse;                         // to prevent recursive attempts
 
-    ThreeState isabstract;              // if abstract class
-    Baseok baseok;                      // set the progress of base classes resolving
+    uint32_t bitFields;
+
+    // true if this is a COM class (meaning it derives from IUnknown)
+    d_bool com() const;
+    d_bool com(d_bool v);
+
+    // true if this is a scope class
+    d_bool stack() const;
+    d_bool stack(d_bool v);
+
+    // to prevent recursive attempts
+    d_bool inuse() const;
+    d_bool inuse(d_bool v);
+
+    // if abstract class
+    ThreeState isabstract() const;
+    ThreeState isabstract(ThreeState v);
+
+    // set the progress of base classes resolving
+    Baseok baseok() const;
+    Baseok baseok(Baseok v);
+
+    int cppDtorVtblIndex;               // slot reserved for the virtual destructor [extern(C++)]
     ObjcClassDeclaration objc;          // Data for a class declaration that is needed for the Objective-C integration
 
     static ClassDeclaration *create(Loc loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -126,22 +126,29 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     // the ClassInfo object for this ClassDeclaration
     TypeInfoClassDeclaration vclassinfo;
 
-    // true if this is a COM class
-    bool com;
+    /// Bit fields for small fields
+    private extern (D) struct ClassBitFields
+    {
+        // true if this is a COM class
+        bool com;
 
-    /// true if this is a scope class
-    bool stack;
+        /// true if this is a scope class
+        bool stack;
+
+        /// to prevent recursive attempts
+        bool inuse;
+
+        ThreeState isabstract;
+
+        /// set the progress of base classes resolving
+        Baseok baseok;
+    }
+
+    import dmd.common.bitfields : generateBitFields;
+    mixin(generateBitFields!(ClassBitFields, uint));
 
     /// if this is a C++ class, this is the slot reserved for the virtual destructor
     int cppDtorVtblIndex = -1;
-
-    /// to prevent recursive attempts
-    bool inuse;
-
-    ThreeState isabstract;
-
-    /// set the progress of base classes resolving
-    Baseok baseok;
 
     /**
      * Data for a class declaration that is needed for the Objective-C


### PR DESCRIPTION
This saves 8 bytes for ClassDeclaration on 64-bit platforms.

It was suggested here: https://github.com/dlang/dmd/pull/23459#discussion_r3650199944