### PR TITLE
Fix #22269 - cast(T[1]) succeeds for structs and static arrays, but fails for basic types

### DIFF
--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -1048,6 +1048,22 @@ UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
     {
         cantExp(ue);
     }
+    else if (tb.ty == Tsarray && e1.op == EXP.int64)
+    {
+        TypeSArray tsa = cast(TypeSArray)tb;
+        Type telem = tsa.nextOf();
+        dinteger_t dim = tsa.dim.toInteger();
+        if (dim == 1 && e1.type.size() == telem.size())
+        {
+            auto elements = new Expressions();
+            elements.push(Cast(loc, telem, telem, e1).exp().copy());
+            emplaceExp!(ArrayLiteralExp)(&ue, loc, type, elements);
+        }
+        else
+        {
+            cantExp(ue);
+        }
+    }
     else if (tb.ty == Tstruct && e1.op == EXP.int64)
     {
         // Struct = 0;

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -2271,6 +2271,9 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         // arithmetic values vs. references or fat values
         if (tob_isA && (t1b_isR || t1b_isFV) || t1b_isA && (tob_isR || tob_isFV))
         {
+            // Allow arithmetic <-> static array cast when sizes match
+            if (t1b.size(e.loc) == tob.size(e.loc) && (tob.ty == Tsarray || t1b.ty == Tsarray))
+                return ok();
             return fail();
         }
 

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -4784,6 +4784,18 @@ elem* toElemCast(CastExp ce, elem* e, bool isLvalue, ref IRState irs)
     if (ftym == ttym)
         return Lret(ce, e);
 
+    // Allow same-size cast between basic types and aggregate types (structs, static arrays)
+    if ((tty == Tstruct || tty == Tsarray) && tfrom.size() == t.size())
+    {
+        e.Ety = ttym;
+        return Lret(ce, e);
+    }
+    else if ((fty == Tstruct || fty == Tsarray) && tfrom.size() == t.size())
+    {
+        e.Ety = ttym;
+        return Lret(ce, e);
+    }
+
     // OSX AArch64 long doubles are 64 bits
     bool RealIsDouble = target.os == Target.os.OSX && target.isAArch64;
 

--- a/compiler/test/fail_compilation/fail_casting.d
+++ b/compiler/test/fail_compilation/fail_casting.d
@@ -53,19 +53,15 @@ void test10646()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(69): Error: cannot cast expression `x` of type `int[1]` to `int`
-fail_compilation/fail_casting.d(70): Error: cannot cast expression `x` of type `int` to `int[1]`
-fail_compilation/fail_casting.d(71): Error: cannot cast expression `x` of type `float[1]` to `int`
-fail_compilation/fail_casting.d(72): Error: cannot cast expression `x` of type `int` to `float[1]`
-fail_compilation/fail_casting.d(75): Error: cannot cast expression `x` of type `int[]` to `int`
-fail_compilation/fail_casting.d(76): Error: cannot cast expression `x` of type `int` to `int[]`
-fail_compilation/fail_casting.d(77): Error: cannot cast expression `x` of type `float[]` to `int`
-fail_compilation/fail_casting.d(78): Error: cannot cast expression `x` of type `int` to `float[]`
+fail_compilation/fail_casting.d(71): Error: cannot cast expression `x` of type `int[]` to `int`
+fail_compilation/fail_casting.d(72): Error: cannot cast expression `x` of type `int` to `int[]`
+fail_compilation/fail_casting.d(73): Error: cannot cast expression `x` of type `float[]` to `int`
+fail_compilation/fail_casting.d(74): Error: cannot cast expression `x` of type `int` to `float[]`
 ---
 */
 void test11484()
 {
-    // Tsarray <--> integer
+    // Tsarray <--> integer (same-size OK)
     { int[1]   x; auto y = cast(int     ) x; }
     { int      x; auto y = cast(int[1]  ) x; }
     { float[1] x; auto y = cast(int     ) x; }
@@ -81,10 +77,10 @@ void test11484()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(97): Error: cannot cast expression `x` of type `int` to `fail_casting.test11485.C`
-fail_compilation/fail_casting.d(98): Error: cannot cast expression `x` of type `int` to `fail_casting.test11485.I`
-fail_compilation/fail_casting.d(101): Error: cannot cast expression `x` of type `fail_casting.test11485.C` to `int`
-fail_compilation/fail_casting.d(102): Error: cannot cast expression `x` of type `fail_casting.test11485.I` to `int`
+fail_compilation/fail_casting.d(93): Error: cannot cast expression `x` of type `int` to `fail_casting.test11485.C`
+fail_compilation/fail_casting.d(94): Error: cannot cast expression `x` of type `int` to `fail_casting.test11485.I`
+fail_compilation/fail_casting.d(97): Error: cannot cast expression `x` of type `fail_casting.test11485.C` to `int`
+fail_compilation/fail_casting.d(98): Error: cannot cast expression `x` of type `fail_casting.test11485.I` to `int`
 ---
 */
 
@@ -105,8 +101,8 @@ void test11485()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(114): Error: cannot cast expression `x` of type `typeof(null)` to `int[2]`
-fail_compilation/fail_casting.d(115): Error: cannot cast expression `x` of type `int[2]` to `typeof(null)`
+fail_compilation/fail_casting.d(110): Error: cannot cast expression `x` of type `typeof(null)` to `int[2]`
+fail_compilation/fail_casting.d(111): Error: cannot cast expression `x` of type `int[2]` to `typeof(null)`
 ---
 */
 void test8179()
@@ -118,8 +114,8 @@ void test8179()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(128): Error: cannot cast expression `x` of type `S` to `int*`
-fail_compilation/fail_casting.d(130): Error: cannot cast expression `x` of type `void*` to `S`
+fail_compilation/fail_casting.d(124): Error: cannot cast expression `x` of type `S` to `int*`
+fail_compilation/fail_casting.d(126): Error: cannot cast expression `x` of type `void*` to `S`
 ---
 */
 void test13959()
@@ -133,7 +129,7 @@ void test13959()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(144): Error: cannot cast expression `mi` of type `MyInt14154` to `MyUbyte14154` because of different sizes
+fail_compilation/fail_casting.d(140): Error: cannot cast expression `mi` of type `MyInt14154` to `MyUbyte14154` because of different sizes
 ---
 */
 struct MyUbyte14154 { ubyte x; alias x this; }
@@ -147,7 +143,7 @@ void test14154()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(179): Error: cannot cast expression `point` of type `Tuple14093!(int, "x", int, "y")` to `object.Object`
+fail_compilation/fail_casting.d(175): Error: cannot cast expression `point` of type `Tuple14093!(int, "x", int, "y")` to `object.Object`
 ---
 */
 
@@ -182,8 +178,8 @@ void test14093()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(192): Error: cannot cast expression `p` of type `void*` to `char[]`
-fail_compilation/fail_casting.d(193): Error: cannot cast expression `p` of type `void*` to `char[2]`
+fail_compilation/fail_casting.d(188): Error: cannot cast expression `p` of type `void*` to `char[]`
+fail_compilation/fail_casting.d(189): Error: cannot cast expression `p` of type `void*` to `char[2]`
 ---
 */
 void test14596()
@@ -196,12 +192,12 @@ void test14596()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(217): Error: cannot cast expression `c` of type `fail_casting.test14629.C` to `typeof(null)`
-fail_compilation/fail_casting.d(218): Error: cannot cast expression `p` of type `int*` to `typeof(null)`
-fail_compilation/fail_casting.d(219): Error: cannot cast expression `da` of type `int[]` to `typeof(null)`
-fail_compilation/fail_casting.d(220): Error: cannot cast expression `aa` of type `int[int]` to `typeof(null)`
-fail_compilation/fail_casting.d(221): Error: cannot cast expression `fp` of type `int function()` to `typeof(null)`
-fail_compilation/fail_casting.d(222): Error: cannot cast expression `dg` of type `int delegate()` to `typeof(null)`
+fail_compilation/fail_casting.d(213): Error: cannot cast expression `c` of type `fail_casting.test14629.C` to `typeof(null)`
+fail_compilation/fail_casting.d(214): Error: cannot cast expression `p` of type `int*` to `typeof(null)`
+fail_compilation/fail_casting.d(215): Error: cannot cast expression `da` of type `int[]` to `typeof(null)`
+fail_compilation/fail_casting.d(216): Error: cannot cast expression `aa` of type `int[int]` to `typeof(null)`
+fail_compilation/fail_casting.d(217): Error: cannot cast expression `fp` of type `int function()` to `typeof(null)`
+fail_compilation/fail_casting.d(218): Error: cannot cast expression `dg` of type `int delegate()` to `typeof(null)`
 ---
 */
 void test14629()

--- a/compiler/test/fail_compilation/fail_casting1.d
+++ b/compiler/test/fail_compilation/fail_casting1.d
@@ -180,23 +180,20 @@ void test3()    // between reference types
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting1.d(206): Error: cannot cast expression `0` of type `int` to `int delegate()`
-fail_compilation/fail_casting1.d(207): Error: cannot cast expression `0` of type `int` to `int[]`
-fail_compilation/fail_casting1.d(208): Error: cannot cast expression `0` of type `int` to `int[1]`
-fail_compilation/fail_casting1.d(209): Error: cannot cast expression `0` of type `int` to `int[int]`
-fail_compilation/fail_casting1.d(210): Error: cannot cast expression `0` of type `int` to `fail_casting1.C`
-fail_compilation/fail_casting1.d(211): Error: cannot cast expression `0` of type `int` to `typeof(null)`
-fail_compilation/fail_casting1.d(215): Error: cannot cast expression `i` of type `int` to `int delegate()`
-fail_compilation/fail_casting1.d(216): Error: cannot cast expression `i` of type `int` to `int[]`
-fail_compilation/fail_casting1.d(217): Error: cannot cast expression `i` of type `int` to `int[1]`
-fail_compilation/fail_casting1.d(218): Error: cannot cast expression `i` of type `int` to `int[int]`
-fail_compilation/fail_casting1.d(219): Error: cannot cast expression `i` of type `int` to `fail_casting1.C`
-fail_compilation/fail_casting1.d(220): Error: cannot cast expression `i` of type `int` to `typeof(null)`
-fail_compilation/fail_casting1.d(224): Error: cannot cast expression `dg` of type `int delegate()` to `int`
-fail_compilation/fail_casting1.d(225): Error: cannot cast expression `da` of type `int[]` to `int`
-fail_compilation/fail_casting1.d(226): Error: cannot cast expression `sa` of type `int[1]` to `int`
-fail_compilation/fail_casting1.d(227): Error: cannot cast expression `aa` of type `int[int]` to `int`
-fail_compilation/fail_casting1.d(228): Error: cannot cast expression `c` of type `fail_casting1.C` to `int`
+fail_compilation/fail_casting1.d(203): Error: cannot cast expression `0` of type `int` to `int delegate()`
+fail_compilation/fail_casting1.d(204): Error: cannot cast expression `0` of type `int` to `int[]`
+fail_compilation/fail_casting1.d(206): Error: cannot cast expression `0` of type `int` to `int[int]`
+fail_compilation/fail_casting1.d(207): Error: cannot cast expression `0` of type `int` to `fail_casting1.C`
+fail_compilation/fail_casting1.d(208): Error: cannot cast expression `0` of type `int` to `typeof(null)`
+fail_compilation/fail_casting1.d(212): Error: cannot cast expression `i` of type `int` to `int delegate()`
+fail_compilation/fail_casting1.d(213): Error: cannot cast expression `i` of type `int` to `int[]`
+fail_compilation/fail_casting1.d(215): Error: cannot cast expression `i` of type `int` to `int[int]`
+fail_compilation/fail_casting1.d(216): Error: cannot cast expression `i` of type `int` to `fail_casting1.C`
+fail_compilation/fail_casting1.d(217): Error: cannot cast expression `i` of type `int` to `typeof(null)`
+fail_compilation/fail_casting1.d(221): Error: cannot cast expression `dg` of type `int delegate()` to `int`
+fail_compilation/fail_casting1.d(222): Error: cannot cast expression `da` of type `int[]` to `int`
+fail_compilation/fail_casting1.d(224): Error: cannot cast expression `aa` of type `int[int]` to `int`
+fail_compilation/fail_casting1.d(225): Error: cannot cast expression `c` of type `fail_casting1.C` to `int`
 ---
 */
 void test4()
@@ -205,7 +202,7 @@ void test4()
     { auto x = cast(FP) 0; }    // Accept
     { auto x = cast(DG) 0; }    // Reject (from constfold)
     { auto x = cast(DA) 0; }    // Reject (Bugzilla 11484)
-    { auto x = cast(SA) 0; }    // Reject (Bugzilla 11484)
+    { auto x = cast(SA) 0; }    // Accept (same-size basic <-> sarray)
     { auto x = cast(AA) 0; }    // Reject (from constfold)
     { auto x = cast( C) 0; }    // Reject (Bugzilla 11485)
     { auto x = cast( N) 0; }    // Reject (from constfold)
@@ -214,7 +211,7 @@ void test4()
     { auto x = cast(FP) i; }    // Accept
     { auto x = cast(DG) i; }    // Reject (from e2ir)
     { auto x = cast(DA) i; }    // Reject (Bugzilla 11484)
-    { auto x = cast(SA) i; }    // Reject (Bugzilla 11484)
+    { auto x = cast(SA) i; }    // Accept (same-size basic <-> sarray)
     { auto x = cast(AA) i; }    // Reject (from e2ir)
     { auto x = cast( C) i; }    // Reject (Bugzilla 11485)
     { auto x = cast( N) i; }    // Reject (from e2ir)
@@ -223,7 +220,7 @@ void test4()
     { auto x = cast(int)fp; }   // Accept
     { auto x = cast(int)dg; }   // Reject (from e2ir)
     { auto x = cast(int)da; }   // Reject (Bugzilla 11484)
-    { auto x = cast(int)sa; }   // Reject (Bugzilla 11484)
+    { auto x = cast(int)sa; }   // Accept (same-size basic <-> sarray)
     { auto x = cast(int)aa; }   // Reject (from e2ir)
     { auto x = cast(int) c; }   // Reject (Bugzilla 7472)
     { auto x = cast(int) n; }   // Accept
@@ -232,27 +229,24 @@ void test4()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting1.d(249): Error: cannot cast expression `0` of type `int` to `int[1]`
-fail_compilation/fail_casting1.d(250): Error: cannot cast expression `0` of type `int` to `S`
-fail_compilation/fail_casting1.d(251): Error: cannot cast expression `i` of type `int` to `int[1]`
-fail_compilation/fail_casting1.d(252): Error: cannot cast expression `i` of type `int` to `S`
-fail_compilation/fail_casting1.d(253): Error: cannot cast expression `f` of type `double` to `int[1]`
-fail_compilation/fail_casting1.d(254): Error: cannot cast expression `f` of type `double` to `S`
-fail_compilation/fail_casting1.d(255): Error: cannot cast expression `sa` of type `int[1]` to `int`
-fail_compilation/fail_casting1.d(256): Error: cannot cast expression `s` of type `S` to `int`
-fail_compilation/fail_casting1.d(257): Error: cannot cast expression `sa` of type `int[1]` to `double`
-fail_compilation/fail_casting1.d(258): Error: cannot cast expression `s` of type `S` to `double`
+fail_compilation/fail_casting1.d(244): Error: cannot cast expression `0` of type `int` to `S`
+fail_compilation/fail_casting1.d(246): Error: cannot cast expression `i` of type `int` to `S`
+fail_compilation/fail_casting1.d(247): Error: cannot cast expression `f` of type `double` to `int[1]`
+fail_compilation/fail_casting1.d(248): Error: cannot cast expression `f` of type `double` to `S`
+fail_compilation/fail_casting1.d(250): Error: cannot cast expression `s` of type `S` to `int`
+fail_compilation/fail_casting1.d(251): Error: cannot cast expression `sa` of type `int[1]` to `double`
+fail_compilation/fail_casting1.d(252): Error: cannot cast expression `s` of type `S` to `double`
 ---
 */
 void test5()
 {
-    { auto x = cast(SA) 0; }        // Reject (Bugzilla 14154)
+    { auto x = cast(SA) 0; }        // Accept (same-size basic <-> sarray)
     { auto x = cast( S) 0; }        // Reject (Bugzilla 14154)
-    { auto x = cast(SA) i; }        // Reject (Bugzilla 14154)
+    { auto x = cast(SA) i; }        // Accept (same-size basic <-> sarray)
     { auto x = cast( S) i; }        // Reject (Bugzilla 14154)
     { auto x = cast(SA) f; }        // Reject (Bugzilla 14154)
     { auto x = cast( S) f; }        // Reject (Bugzilla 14154)
-    { auto x = cast(int)sa; }       // Reject (Bugzilla 14154)
+    { auto x = cast(int)sa; }       // Accept (same-size basic <-> sarray)
     { auto x = cast(int) s; }       // Reject (Bugzilla 14154)
     { auto x = cast(double)sa; }    // Reject (Bugzilla 14154)
     { auto x = cast(double) s; }    // Reject (Bugzilla 14154)

--- a/compiler/test/runnable/casting.d
+++ b/compiler/test/runnable/casting.d
@@ -212,6 +212,28 @@ void test14218()
 
 /***************************************************/
 
+void test22269()
+{
+    // cast(T[1]) from basic type to static array of same size
+    int foo = 42;
+    (cast(int[1])foo)[] = 1;
+    assert(foo == 1);
+
+    // cast(T) from static array to basic type of same size
+    int bar = 42;
+    auto sa = cast(int[1])bar;
+    bar = 0;
+    bar = cast(int)sa;
+    assert(bar == 42);
+
+    // float <-> int same size (both 4 bytes)
+    float f = 3.14f;
+    int[1] fi = cast(int[1])f;
+    assert(fi[0] != 0); // value was reinterpreted, not zeroed
+}
+
+/***************************************************/
+
 int main()
 {
     test3133();
@@ -223,6 +245,7 @@ int main()
     test10842();
     test11722();
     test14218();
+    test22269();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Looks like it was made to not work due to: https://bugzilla-archive.dlang.org/bugs/11484/

Model: MiMo v2.5