### PR TITLE
Fix #19569 and #23367 - Represent string and arrays as sparse literals

### DIFF
--- a/compiler/include/dmd/expression.h
+++ b/compiler/include/dmd/expression.h
@@ -319,6 +319,9 @@ public:
     void *string;       // char, wchar, dchar, or long data
     size_t len;         // number of chars, wchars, or dchars
     unsigned char sz;   // 1: char, 2: wchar, 4: dchar
+    uint8_t sparseFillValue; // fill byte for positions dataLen .. len when isSparse
+    d_bool isSparse;    // if string uses sparse encoding
+    d_size_t dataLen;   // actual data length when isSparse is true
     d_bool committed;   // if type is committed
     d_bool hexString;   // if string is parsed from a hex string literal
     d_bool cMacro;      // If the string is from a collected C macro

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -4949,6 +4949,17 @@ struct ASTBase
         /// If the string is from a collected C macro
         bool cMacro = false;
 
+        /** When isSparse is true, the byte value used to fill positions
+         *  dataLen .. len in the string buffer.
+         */
+        ubyte sparseFillValue;
+        /// Whether this string uses sparse encoding
+        bool isSparse;
+
+        /// When isSparse is true, the number of code units actually stored
+        /// in the string buffer.
+        size_t dataLen;
+
         extern (D) this(Loc loc, const(void)[] string)
         {
             super(loc, EXP.string_, __traits(classInstanceSize, StringExp));
@@ -4989,7 +5000,14 @@ struct ASTBase
             }
             if (sz == encSize)
             {
-                memcpy(dest, string, len * sz);
+                if (isSparse)
+                {
+                    const srcSize = dataLen * sz;
+                    memcpy(dest, string, srcSize);
+                    memset(dest + srcSize, sparseFillValue, (len - dataLen) * sz);
+                }
+                else
+                    memcpy(dest, string, len * sz);
                 if (zero)
                     memset(dest + len * sz, 0, sz);
             }

--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -211,14 +211,21 @@ private Expressions* copyLiteralArray(Expressions* oldelems)
 
 // Expand null elements using the given basis, for callers that need
 // a dense array (e.g. concatenation, AA operations).
+// Shares a single copy of basis across all null slots to avoid O(N) blowup.
 private Expressions* copyLiteralArrayExpand(Expressions* oldelems, Expression basis)
 {
     auto newelems = copyLiteralArray(oldelems);
     if (basis && newelems)
     {
+        Expression sharedBasis = null;
         foreach (ref e; *newelems)
         {
-            if (!e) e = copyLiteral(basis).copy();
+            if (!e)
+            {
+                if (!sharedBasis)
+                    sharedBasis = copyLiteral(basis).copy();
+                e = sharedBasis;
+            }
         }
     }
     return newelems;
@@ -231,11 +238,30 @@ UnionExp copyLiteral(Expression e)
     UnionExp ue = void;
     if (auto se = e.isStringExp()) // syntaxCopy doesn't make a copy for StringExp!
     {
-        char* s = cast(char*)mem.xcalloc(se.len + 1, se.sz);
-        const slice = se.peekData();
-        memcpy(s, slice.ptr, slice.length);
-        emplaceExp!(StringExp)(&ue, se.loc, s[0 .. se.len * se.sz], se.len, se.sz);
-        StringExp se2 = ue.exp().isStringExp();
+        StringExp se2;
+        if (se.isSparse)
+        {
+            // Copy sparse string: preserve the sparse encoding.
+            // Copy only the actual data (dataLen), not the full logical length.
+            const copyLen = se.dataLen ? se.dataLen : se.len;
+            char* s = cast(char*)mem.xmalloc_noscan((copyLen + 1) * se.sz);
+            const data = se.peekRawData();
+            memcpy(s, data.ptr, data.length);
+            memset(s + data.length, 0, se.sz); // terminating 0
+            emplaceExp!(StringExp)(&ue, se.loc, s[0 .. copyLen * se.sz], se.len, se.sz);
+            se2 = ue.exp().isStringExp();
+            se2.isSparse = true;
+            se2.sparseFillValue = se.sparseFillValue;
+            se2.dataLen = copyLen;
+        }
+        else
+        {
+            char* s = cast(char*)mem.xcalloc(se.len + 1, se.sz);
+            const slice = se.peekData();
+            memcpy(s, slice.ptr, slice.length);
+            emplaceExp!(StringExp)(&ue, se.loc, s[0 .. se.len * se.sz], se.len, se.sz);
+            se2 = ue.exp().isStringExp();
+        }
         se2.committed = se.committed;
         se2.postfix = se.postfix;
         se2.type = se.type;

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -2503,17 +2503,21 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             se.committed = true;
             se.type = t;
 
-            /* If larger than source, pad with zeros.
+            /* If larger than source, use sparse representation
+             * to avoid O(N) memory allocation for large padded strings.
              */
             const fullSize = (se.len + 1) * se.sz; // incl. terminating 0
             if (fullSize > (e.len + 1) * e.sz)
             {
-                void* s = mem.xmalloc_noscan(fullSize);
-                const srcSize = e.len * e.sz;
-                const data = se.peekData();
-                memcpy(s, data.ptr, srcSize);
-                memset(s + srcSize, 0, fullSize - srcSize);
-                se.setData(s, se.len, se.sz);
+                // Use sparse encoding: keep original data, fill rest with zeros
+                se.isSparse = true;
+                se.sparseFillValue = 0;
+                se.dataLen = e.len;
+            }
+            else
+            {
+                se.isSparse = false;
+                se.dataLen = 0;
             }
             return se;
         }
@@ -2684,14 +2688,29 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             // Changing dimensions
             if (dim2 != se.len)
             {
-                // Copy when changing the string literal
-                const newsz = se.sz;
-                const d = (dim2 < se.len) ? dim2 : se.len;
-                void* s = mem.xmalloc_noscan((dim2 + 1) * newsz);
-                memcpy(s, se.peekData().ptr, d * newsz);
-                // Extend with 0, add terminating 0
-                memset(s + d * newsz, 0, (dim2 + 1 - d) * newsz);
-                se.setData(s, dim2, newsz);
+                // If extending, use sparse representation to avoid O(N) allocation
+                if (dim2 > se.len)
+                {
+                    se.dataLen = se.isSparse ? se.dataLen : se.len;
+                    se.isSparse = true;
+                    se.sparseFillValue = 0;
+                    se.len = dim2;
+                }
+                else
+                {
+                    // Truncating: must copy with shorter data
+                    const newsz = se.sz;
+                    void* s = mem.xmalloc_noscan((dim2 + 1) * newsz);
+                    memcpy(s, se.peekData().ptr, dim2 * newsz);
+                    memset(s + dim2 * newsz, 0, newsz); // terminating 0
+                    se.setData(s, dim2, newsz);
+                }
+            }
+            else
+            {
+                // Same dimension: clear any stale sparse state from copy
+                se.isSparse = false;
+                se.dataLen = 0;
             }
         }
         se.type = t;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -905,6 +905,17 @@ extern (C++) final class StringExp : Expression
     size_t len;         // number of code units
     ubyte sz = 1;       // 1: char, 2: wchar, 4: dchar
 
+    /** When isSparse is true, the byte value used to fill positions
+     *  dataLen .. len in the string buffer.
+     */
+    ubyte sparseFillValue;
+    /// Whether this string uses sparse encoding
+    bool isSparse;
+
+    /// When isSparse is true, the number of code units actually stored
+    /// in the string buffer. Positions dataLen .. len use sparseFillValue.
+    size_t dataLen;
+
     /**
      *  Whether the string literal's type is fixed
      *  Example:
@@ -1034,7 +1045,15 @@ extern (C++) final class StringExp : Expression
         }
         if (sz == encSize)
         {
-            memcpy(dest, string, len * sz);
+            if (isSparse && dataLen <= len)
+            {
+                const srcSize = dataLen * sz;
+                memcpy(dest, string, srcSize);
+                const fillByte = sparseFillValue;
+                memset(dest + srcSize, fillByte, (len - dataLen) * sz);
+            }
+            else
+                memcpy(dest, string, len * sz);
             if (zero)
                 memset(dest + len * sz, 0, sz);
         }
@@ -1059,6 +1078,8 @@ extern (C++) final class StringExp : Expression
     dinteger_t getIndex(size_t i) const pure
     {
         assert(i < len);
+        if (isSparse && i >= dataLen)
+            return sparseFillValue;
         final switch (sz)
         {
         case 1:
@@ -1070,6 +1091,28 @@ extern (C++) final class StringExp : Expression
         case 8:
             return lstring[i];
         }
+    }
+
+    /*******************************************
+     * If this is a sparse string (isSparse is true),
+     * expand it to a full dense string. No-op otherwise.
+     */
+    void materialize() const
+    {
+        if (!isSparse)
+            return;
+        auto self = cast(StringExp) this;
+        const fullLen = self.len;
+        void* s = mem.xmalloc_noscan((fullLen + 1) * self.sz);
+        const srcSize = self.dataLen * self.sz;
+        memcpy(s, self.string, srcSize);
+        const fillByte = self.sparseFillValue;
+        memset(s + srcSize, fillByte, (fullLen - self.dataLen) * self.sz);
+        memset(s + fullLen * self.sz, 0, self.sz); // terminating 0
+        self.isSparse = false;
+        self.sparseFillValue = 0;
+        self.dataLen = 0;
+        self.string = cast(char*)s;
     }
 
     /*********************************************
@@ -1086,6 +1129,7 @@ extern (C++) final class StringExp : Expression
     extern (D) void setIndex(size_t i, long c)
     {
         assert(i < len);
+        materialize();
         final switch (sz)
         {
         case 1:
@@ -1134,35 +1178,77 @@ extern (C++) final class StringExp : Expression
         //printf("sz = %d, len1 = %d, len2 = %d\n", sz, cast(int)len1, cast(int)len2);
         if (len1 != len2)
             return cast(int)(len1 - len2);
-        switch (sz)
-        {
-        case 1:
-            return memcmp(string, se2.string, len1);
 
-        case 2:
+        // Fast path: both non-sparse
+        if (!isSparse && !se2.isSparse)
+        {
+            switch (sz)
             {
-                wchar* s1 = cast(wchar*)string;
-                wchar* s2 = cast(wchar*)se2.string;
-                foreach (u; 0 .. len)
+            case 1:
+                return memcmp(string, se2.string, len1);
+
+            case 2:
                 {
-                    if (s1[u] != s2[u])
-                        return s1[u] - s2[u];
+                    wchar* s1 = cast(wchar*)string;
+                    wchar* s2 = cast(wchar*)se2.string;
+                    foreach (u; 0 .. len)
+                    {
+                        if (s1[u] != s2[u])
+                            return s1[u] - s2[u];
+                    }
+                }
+                break;
+            case 4:
+                {
+                    dchar* s1 = cast(dchar*)string;
+                    dchar* s2 = cast(dchar*)se2.string;
+                    foreach (u; 0 .. len)
+                    {
+                        if (s1[u] != s2[u])
+                            return s1[u] - s2[u];
+                    }
+                }
+                break;
+            default:
+                assert(0);
+            }
+            return 0;
+        }
+
+        // Slow path: at least one sparse - element-by-element comparison
+        foreach (u; 0 .. len)
+        {
+            dinteger_t a, b;
+            // Compute a
+            if (isSparse && u >= dataLen)
+                a = sparseFillValue;
+            else
+            {
+                switch (sz)
+                {
+                case 1: a = string[u]; break;
+                case 2: a = wstring[u]; break;
+                case 4: a = dstring[u]; break;
+                case 8: a = lstring[u]; break;
+                default: assert(0);
                 }
             }
-            break;
-        case 4:
+            // Compute b
+            if (se2.isSparse && u >= se2.dataLen)
+                b = se2.sparseFillValue;
+            else
             {
-                dchar* s1 = cast(dchar*)string;
-                dchar* s2 = cast(dchar*)se2.string;
-                foreach (u; 0 .. len)
+                switch (sz)
                 {
-                    if (s1[u] != s2[u])
-                        return s1[u] - s2[u];
+                case 1: b = se2.string[u]; break;
+                case 2: b = se2.wstring[u]; break;
+                case 4: b = se2.dstring[u]; break;
+                case 8: b = se2.lstring[u]; break;
+                default: assert(0);
                 }
             }
-            break;
-        default:
-            assert(0);
+            if (a != b)
+                return a < b ? -1 : 1;
         }
         return 0;
     }
@@ -1183,18 +1269,21 @@ extern (C++) final class StringExp : Expression
     extern (D) const(char)[] peekString() const
     {
         assert(sz == 1);
+        materialize();
         return this.string[0 .. len];
     }
 
     extern (D) const(wchar)[] peekWstring() const
     {
         assert(sz == 2);
+        materialize();
         return this.wstring[0 .. len];
     }
 
     extern (D) const(dchar)[] peekDstring() const
     {
         assert(sz == 4);
+        materialize();
         return this.dstring[0 .. len];
     }
 
@@ -1203,7 +1292,20 @@ extern (C++) final class StringExp : Expression
      */
     extern (D) const(ubyte)[] peekData() const
     {
+        materialize();
         return cast(const(ubyte)[])this.string[0 .. len * sz];
+    }
+
+    /*******************
+     * Get a slice of the raw backing buffer without materializing.
+     * For sparse strings, this returns only dataLen * sz bytes
+     * (not the full logical length). Use peekData() if you need
+     * the full expanded data.
+     */
+    extern (D) const(ubyte)[] peekRawData() const
+    {
+        const rawLen = isSparse ? dataLen : len;
+        return cast(const(ubyte)[])this.string[0 .. rawLen * sz];
     }
 
     /*******************
@@ -1212,6 +1314,7 @@ extern (C++) final class StringExp : Expression
      */
     extern (D) ubyte[] borrowData()
     {
+        materialize();
         return cast(ubyte[])this.string[0 .. len * sz];
     }
 
@@ -1224,6 +1327,9 @@ extern (C++) final class StringExp : Expression
         this.string = cast(char*)s;
         this.len = len;
         this.sz = sz;
+        this.isSparse = false;
+        this.sparseFillValue = 0;
+        this.dataLen = 0;
     }
 
     override void accept(Visitor v)

--- a/compiler/test/compilable/test19569.d
+++ b/compiler/test/compilable/test19569.d
@@ -1,0 +1,115 @@
+// https://github.com/dlang/dmd/issues/19569
+// https://github.com/dlang/dmd/issues/23367
+//
+// Test that casting a short string to a large static array uses sparse
+// representation instead of eagerly allocating O(N) memory.
+//
+// Without the fix, `cast(char[N]) "ab"` would allocate ~N bytes of
+// zero-filled storage in the front-end, potentially consuming GBs of
+// memory and blowing up the compiler for large N.
+//
+// With the fix, the StringExp retains its original small backing buffer
+// and records a basis fill value; the full buffer is only materialized
+// on demand (e.g. codegen or writeTo).
+
+// -----------------------------------------------------------
+// 1. Large char array — would allocate ~100 MB without fix
+// -----------------------------------------------------------
+static assert((cast(char[100_000_000]) "ab")[0] == 'a');
+static assert((cast(char[100_000_000]) "ab")[1] == 'b');
+static assert((cast(char[100_000_000]) "ab")[2] == 0);
+static assert((cast(char[100_000_000]) "ab")[99_999_999] == 0);
+
+// -----------------------------------------------------------
+// 2. Large wchar array — would allocate ~200 MB without fix
+// -----------------------------------------------------------
+static assert((cast(wchar[50_000_000]) "xy"w)[0] == 'x');
+static assert((cast(wchar[50_000_000]) "xy"w)[1] == 'y');
+static assert((cast(wchar[50_000_000]) "xy"w)[2] == 0);
+static assert((cast(wchar[50_000_000]) "xy"w)[49_999_999] == 0);
+
+// -----------------------------------------------------------
+// 3. Large dchar array — would allocate ~400 MB without fix
+// -----------------------------------------------------------
+static assert((cast(dchar[25_000_000]) "mn"d)[0] == 'm');
+static assert((cast(dchar[25_000_000]) "mn"d)[1] == 'n');
+static assert((cast(dchar[25_000_000]) "mn"d)[2] == 0);
+static assert((cast(dchar[25_000_000]) "mn"d)[24_999_999] == 0);
+
+// -----------------------------------------------------------
+// 4. CTFE: sparse string through enum / static assert
+// -----------------------------------------------------------
+enum e = cast(char[50_000_000]) "CTFE";
+static assert(e[0] == 'C');
+static assert(e[1] == 'T');
+static assert(e[2] == 'F');
+static assert(e[3] == 'E');
+static assert(e[4] == 0);
+static assert(e[49_999_999] == 0);
+
+// -----------------------------------------------------------
+// 5. Non-sparse path still works (smaller than source)
+// -----------------------------------------------------------
+enum t = cast(char[3]) "hello";
+static assert(t[0] == 'h');
+static assert(t[1] == 'e');
+static assert(t[2] == 'l');
+
+// -----------------------------------------------------------
+// 6. Same-size cast still works
+// -----------------------------------------------------------
+enum s = cast(char[5]) "hello";
+static assert(s[0] == 'h');
+static assert(s[4] == 'o');
+
+// -----------------------------------------------------------
+// 7. copyLiteralArrayExpand: sparse array concat with basis
+//    Without the fix, concatenating two large sparse arrays
+//    would create N independent copies of the basis element.
+// -----------------------------------------------------------
+static int testCatSparse()
+{
+    int[5000] a = 1;
+    int[5000] b = 2;
+    auto c = a ~ b;
+    return c[0] + c[2500] + c[4999] + c[5000] + c[7500] + c[9999];
+}
+static assert(testCatSparse() == 1 + 1 + 1 + 2 + 2 + 2);
+
+// -----------------------------------------------------------
+// 8. Repeated concat of sparse arrays (tests copyLiteral)
+// -----------------------------------------------------------
+static int testRepeatedConcat()
+{
+    int[1000] a = 7;
+    auto b = a ~ a ~ a;
+    return b[0] + b[999] + b[1000] + b[2999];
+}
+static assert(testRepeatedConcat() == 7 + 7 + 7 + 7);
+
+// -----------------------------------------------------------
+// 9. Truncation path (dim2 < se.len in dcast.d)
+// -----------------------------------------------------------
+enum tr = cast(char[2]) "hello";
+static assert(tr[0] == 'h');
+static assert(tr[1] == 'e');
+
+// -----------------------------------------------------------
+// 10. Multiple large casts (tests that copies preserve sparse encoding)
+// -----------------------------------------------------------
+static assert((cast(char[50_000_000]) "A")[0] == 'A');
+static assert((cast(char[50_000_000]) "A")[49_999_999] == 0);
+static assert((cast(char[50_000_000]) "B")[0] == 'B');
+static assert((cast(char[50_000_000]) "B")[49_999_999] == 0);
+
+// -----------------------------------------------------------
+// 11. Sparse extending a longer source that itself was extended.
+//     This exercised the bug where e.copy() carried stale
+//     hasBasis/dataLen from a previously-sparse source string.
+// -----------------------------------------------------------
+static assert((cast(char[200]) "abcde")[4] == 'e');
+static assert((cast(char[200]) "abcde")[5] == 0);
+static assert((cast(char[200]) "abcde")[199] == 0);
+static assert((cast(char[500]) "abcde")[4] == 'e');
+static assert((cast(char[500]) "abcde")[5] == 0);
+static assert((cast(char[500]) "abcde")[499] == 0);


### PR DESCRIPTION
I'm relying on the CI&LLM for this, as I don't understand this area of the compiler. But it thought that this was a low hanging ticket.

Model: MiMo V2.5