### PR TITLE
Make `__builtins_msvc.llvm_target` private.

### DIFF
--- a/druntime/src/__builtins_msvc.d
+++ b/druntime/src/__builtins_msvc.d
@@ -203,7 +203,8 @@ version (MSVCIntrinsics)
     }
     else
     {
-        struct llvm_target
+        /* An inert placeholder for compilers that aren't LDC. */
+        private struct llvm_target
         {
             string specifier;
         }


### PR DESCRIPTION
This wasn't intended to be public.