### PR TITLE
fix #23524 - Cross-compiling to macos crashes on Windows

### DIFF
--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -1259,15 +1259,7 @@ private void obj_start(ref OutBuffer objbuf, const(char)* srcfile)
     rtlsym_reset();
     clearStringTab();
 
-    version (Windows)
-    {
-        import dmd.backend.mscoffobj;
-        objmod = MsCoffObj_init(&objbuf, srcfile, null);
-    }
-    else
-    {
-        objmod = Obj.initialize(&objbuf, srcfile, null);
-    }
+    objmod = Obj.initialize(&objbuf, srcfile, null);
 
     OutBuffer buf;
     buf.write("DMD ");

--- a/compiler/test/compilable/objc_class.d
+++ b/compiler/test/compilable/objc_class.d
@@ -1,4 +1,7 @@
-// EXTRA_OBJC_SOURCES:
+// also check cross compilation, ensure targeting 64-bit
+// REQUIRED_ARGS: -m64 -os=osx
+// doesn't compile with mingw option -mscrtlib=msvcrt120
+// DISABLED: win32
 
 import core.attribute : selector;
 


### PR DESCRIPTION
missing call of MachObj_init

Not urgent, but also low risk for stable.