### PR TITLE
Fix release workflow failing to publish artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
     needs:
       - build-all-releases
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       #################################################################


### PR DESCRIPTION
Authored by Claude Opus 5

> The generate_release job creates a GitHub release, which needs contents: write. Without it ncipollo/release-action fails with 403 Resource not accessible by integration.