### PR TITLE
druntime: Implement dummy WASI `getpid`

### DIFF
--- a/druntime/src/core/sys/posix/unistd.d
+++ b/druntime/src/core/sys/posix/unistd.d
@@ -114,15 +114,9 @@ else
 
 version (CRuntime_WASI)
 {
-    version (WASI_EMULATED_GETPID)
-        pid_t   getpid() @trusted;
-    else
-        deprecated("WASI lacks process identifiers; to enable emulation of"~
-                   " the `getpid` function using a placeholder value, which"~
-                   " doesn't reflect the host PID of the program, compile"~
-                   " with --d-version=WASI_EMULATED_GETPID and link with"~
-                   " -lwasi-emulated-getpid")
-        pid_t   getpid() @trusted;
+    // WASI has no processes, and wasi-libc requires you to jump through hoops
+    // to link this in. We just let D code use it silently.
+    extern(D) pid_t getpid()() @trusted => 42;
 } else
     pid_t   getpid() @trusted;
 


### PR DESCRIPTION
Allows any users of `core.sys.posix.unistd : getpid` to use the emulated `getpid` without having to jump through hoops.

The current definition matches `wasi-libc`, but requires either Phobos to hack around it, or any program using applicable parts of Phobos to link against an extra library. 