### PR TITLE
[stable] Fix expression.h: Add missing fromOpAssignment member

### DIFF
--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -780,10 +780,11 @@ public:
     Expressions *arguments;     // function arguments
     ArgumentLabels* names;      // function argument Labels (name + location of name)
     FuncDeclaration *f;         // symbol to call
-    d_bool directcall;            // true if a virtual call is devirtualized
-    d_bool inDebugStatement;      // true if this was in a debug statement
-    d_bool ignoreAttributes;      // don't enforce attributes (e.g. call @gc function in @nogc code)
+    d_bool directcall;          // true if a virtual call is devirtualized
+    d_bool inDebugStatement;    // true if this was in a debug statement
+    d_bool ignoreAttributes;    // don't enforce attributes (e.g. call @gc function in @nogc code)
     d_bool isUfcsRewrite;       // the first argument was pushed in here by a UFCS rewrite
+    d_bool fromOpAssignment;    // set when operator overload method call from assignment (2024 edition)
     VarDeclaration *vthis2;     // container for multi-context
     Expression* loweredFrom;    // set if this is the result of a lowering
 


### PR DESCRIPTION
A regression introduced in #22369.