### PR TITLE
accessing globals is slow, use pointer instead

### DIFF
--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -603,6 +603,9 @@ void MachObj_termfile()
 void MachObj_term(const(char)[] objfilename)
 {
     //printf("MachObj_term() ======================================== \n");
+
+    auto machobj = &machobj; // make global a local for faster access
+
     outfixlist();           // backpatches
 
     if (config.addlinenumbers)


### PR DESCRIPTION
Accessing a global takes multiple instructions. This is second best to adding machobj as a ref parameter.