### PR TITLE
make ArrayLiteralExp more abstract

### DIFF
--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1564,7 +1564,7 @@ private CtorDeclaration generateCtorDeclaration(StructDeclaration sd, const STC 
 {
     auto structType = sd.type;
     STC stc = move ? STC.none : STC.ref_;     // the only difference between copy or move
-	auto fparams = new Parameters(new Parameter(Loc.initial, paramStc | stc, structType, Id.p, null, null, null));
+    auto fparams = new Parameters(new Parameter(Loc.initial, paramStc | stc, structType, Id.p, null, null, null));
     ParameterList pList = ParameterList(fparams);
     auto tf = new TypeFunction(pList, structType, LINK.d, STC.ref_);
     auto ccd = new CtorDeclaration(sd.loc, Loc.initial, STC.ref_, tf);

--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -625,7 +625,7 @@ UnionExp Equal(EXP op, Loc loc, Type type, Expression e1, Expression e2)
         }
         else if (ArrayLiteralExp es2 = e2.isArrayLiteralExp())
         {
-            cmp = !es2.elements || (0 == es2.elements.length);
+            cmp = (0 == es2.length);
         }
         else
         {
@@ -641,7 +641,7 @@ UnionExp Equal(EXP op, Loc loc, Type type, Expression e1, Expression e2)
         }
         else if (ArrayLiteralExp es1 = e1.isArrayLiteralExp())
         {
-            cmp = !es1.elements || (0 == es1.elements.length);
+            cmp = (0 == es1.length);
         }
         else
         {
@@ -670,15 +670,10 @@ UnionExp Equal(EXP op, Loc loc, Type type, Expression e1, Expression e2)
     {
         ArrayLiteralExp es1 = e1.isArrayLiteralExp();
         ArrayLiteralExp es2 = e2.isArrayLiteralExp();
-        if ((!es1.elements || !es1.elements.length) && (!es2.elements || !es2.elements.length))
-            cmp = 1; // both arrays are empty
-        else if (!es1.elements || !es2.elements)
-            cmp = 0;
-        else if (es1.elements.length != es2.elements.length)
-            cmp = 0;
-        else
+        if (es1.length == es2.length)
         {
-            for (size_t i = 0; i < es1.elements.length; i++)
+            cmp = 1;
+            foreach (size_t i; 0 .. es1.length)
             {
                 auto ee1 = es1[i];
                 auto ee2 = es2[i];
@@ -705,7 +700,7 @@ UnionExp Equal(EXP op, Loc loc, Type type, Expression e1, Expression e2)
         StringExp es1 = e1.isStringExp();
         ArrayLiteralExp es2 = e2.isArrayLiteralExp();
         size_t dim1 = es1.len;
-        size_t dim2 = es2.elements ? es2.elements.length : 0;
+        size_t dim2 = es2.length;
         if (dim1 != dim2)
             cmp = 0;
         else
@@ -1106,7 +1101,7 @@ UnionExp ArrayLength(Type type, Expression e1)
     }
     else if (ArrayLiteralExp ale = e1.isArrayLiteralExp())
     {
-        size_t dim = ale.elements ? ale.elements.length : 0;
+        size_t dim = ale.length;
         emplaceExp!(IntegerExp)(&ue, loc, dim, type);
     }
     else if (AssocArrayLiteralExp ale = e1.isAssocArrayLiteralExp)
@@ -1179,9 +1174,9 @@ UnionExp Index(Type type, Expression e1, Expression e2, bool indexIsInBounds)
         uinteger_t i = e2.toInteger();
         if (ArrayLiteralExp ale = e1.isArrayLiteralExp())
         {
-            if (i >= ale.elements.length)
+            if (i >= ale.length)
             {
-                error(e1.loc, "array index %llu is out of bounds `%s[0 .. %llu]`", i, e1.toErrMsg(), cast(ulong) ale.elements.length);
+                error(e1.loc, "array index %llu is out of bounds `%s[0 .. %llu]`", i, e1.toErrMsg(), cast(ulong) ale.length);
                 emplaceExp!(ErrorExp)(&ue);
             }
             else
@@ -1277,7 +1272,7 @@ UnionExp Slice(Type type, Expression e1, Expression lwr, Expression upr)
         ArrayLiteralExp es1 = e1.isArrayLiteralExp();
         const uinteger_t ilwr = lwr.toInteger();
         const uinteger_t iupr = upr.toInteger();
-        if (sliceBoundsCheck(0, es1.elements.length, ilwr, iupr))
+        if (sliceBoundsCheck(0, es1.length, ilwr, iupr))
             cantExp(ue);
         else
         {
@@ -1321,7 +1316,7 @@ void sliceAssignArrayLiteralFromString(ArrayLiteralExp existingAE, const StringE
 void sliceAssignStringFromArrayLiteral(StringExp existingSE, ArrayLiteralExp newae, size_t firstIndex)
 {
     assert(existingSE.ownedByCtfe != OwnedBy.code);
-    foreach (j; 0 .. newae.elements.length)
+    foreach (j; 0 .. newae.length)
     {
         existingSE.setCodeUnit(firstIndex + j, cast(dchar)newae[j].toInteger());
     }
@@ -1526,15 +1521,15 @@ UnionExp Cat(Loc loc, Type type, Expression e1, Expression e2)
         // [chars] ~ string --> [chars]
         StringExp es = e2.isStringExp();
         ArrayLiteralExp ea = e1.isArrayLiteralExp();
-        size_t len = es.len + ea.elements.length;
+        size_t len = es.len + ea.length;
         auto elems = new Expressions(len);
-        for (size_t i = 0; i < ea.elements.length; ++i)
+        for (size_t i = 0; i < ea.length; ++i)
         {
             (*elems)[i] = ea[i];
         }
         emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, elems);
         ArrayLiteralExp dest = ue.exp().isArrayLiteralExp();
-        sliceAssignArrayLiteralFromString(dest, es, ea.elements.length);
+        sliceAssignArrayLiteralFromString(dest, es, ea.length);
         assert(ue.exp().type);
         return ue;
     }
@@ -1543,9 +1538,9 @@ UnionExp Cat(Loc loc, Type type, Expression e1, Expression e2)
         // string ~ [chars] --> [chars]
         StringExp es = e1.isStringExp();
         ArrayLiteralExp ea = e2.isArrayLiteralExp();
-        size_t len = es.len + ea.elements.length;
+        size_t len = es.len + ea.length;
         auto elems = new Expressions(len);
-        for (size_t i = 0; i < ea.elements.length; ++i)
+        for (size_t i = 0; i < ea.length; ++i)
         {
             (*elems)[es.len + i] = ea[i];
         }

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -276,7 +276,7 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
             {
                 Type tb = t.toBasetype();
                 Type tx = (tb.ty == Tsarray)
-                    ? tb.nextOf().sarrayOf(ale.elements ? ale.elements.length : 0)
+                    ? tb.nextOf().sarrayOf(ale.length)
                     : tb.nextOf().arrayOf();
                 se.e1 = ale.implicitCastTo(sc, tx);
             }
@@ -849,12 +849,12 @@ MATCH implicitConvTo(Expression e, Type t)
 
             if (auto tsa = tb.isTypeSArray())
             {
-                if (e.elements.length != tsa.dim.toInteger())
+                if (e.length != tsa.dim.toInteger())
                     result = MATCH.nomatch;
             }
 
             Type telement = tb.nextOf();
-            if (!e.elements.length)
+            if (!e.length)
             {
                 if (typen.ty != Tvoid)
                     result = typen.implicitConvTo(telement);
@@ -867,9 +867,9 @@ MATCH implicitConvTo(Expression e, Type t)
                     if (m < result)
                         result = m;
                 }
-                for (size_t i = 0; i < e.elements.length; i++)
+                foreach (i; 0 .. e.length)
                 {
-                    Expression el = (*e.elements)[i];
+                    Expression el = e[i];
                     if (result == MATCH.nomatch)
                         break;
                     if (!el)
@@ -892,7 +892,7 @@ MATCH implicitConvTo(Expression e, Type t)
             TypeVector tv = tb.isTypeVector();
             TypeSArray tbase = tv.basetype.isTypeSArray();
             assert(tbase);
-            const edim = e.elements.length;
+            const edim = e.length;
             const tbasedim = tbase.dim.toInteger();
             if (edim > tbasedim)
             {
@@ -2852,7 +2852,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             {
                 if (auto tsa = tb.isTypeSArray())
                 {
-                    if (e.elements.length != tsa.dim.toInteger())
+                    if (e.length != tsa.dim.toInteger())
                         return visit(ae);
                 }
 
@@ -2860,9 +2860,9 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                 if (e.basis)
                     ae.basis = e.basis.castTo(sc, tb.nextOf());
                 ae.elements = e.elements.copy();
-                for (size_t i = 0; i < e.elements.length; i++)
+                foreach (i; 0 .. e.length)
                 {
-                    Expression ex = (*e.elements)[i];
+                    Expression ex = e[i];
                     if (!ex)
                         continue;
                     ex = ex.castTo(sc, tb.nextOf());
@@ -2888,7 +2888,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             TypeVector tv = tb.isTypeVector();
             TypeSArray tbase = tv.basetype.isTypeSArray();
             assert(tbase.ty == Tsarray);
-            const edim = e.elements.length;
+            const edim = e.length;
             const tbasedim = tbase.dim.toInteger();
             if (edim > tbasedim)
                 return visit(ae);
@@ -3261,12 +3261,12 @@ Expression inferType(Expression e, Type t, int flag = 0)
         Type tn = tb.nextOf();
         if (ale.basis)
             ale.basis = inferType(ale.basis, tn, flag);
-        for (size_t i = 0; i < ale.elements.length; i++)
+        foreach (i; 0 .. ale.length)
         {
-            if (Expression e = (*ale.elements)[i])
+            if (Expression e = ale[i])
             {
                 e = inferType(e, tn, flag);
-                (*ale.elements)[i] = e;
+                ale[i] = e;
             }
         }
 
@@ -3398,7 +3398,7 @@ Expression scaleFactor(BinExp be, Scope* sc)
  */
 private bool isVoidArrayLiteral(Expression e, Type other)
 {
-    while (e.op == EXP.arrayLiteral && e.type.ty == Tarray && (e.isArrayLiteralExp().elements.length == 1))
+    while (e.op == EXP.arrayLiteral && e.type.ty == Tarray && (e.isArrayLiteralExp().length == 1))
     {
         auto ale = e.isArrayLiteralExp();
         e = ale[0];
@@ -3410,7 +3410,7 @@ private bool isVoidArrayLiteral(Expression e, Type other)
     if (other.ty != Tsarray && other.ty != Tarray)
         return false;
     Type t = e.type;
-    return (e.op == EXP.arrayLiteral && t.ty == Tarray && t.nextOf().ty == Tvoid && e.isArrayLiteralExp().elements.length == 0);
+    return (e.op == EXP.arrayLiteral && t.ty == Tarray && t.nextOf().ty == Tvoid && e.isArrayLiteralExp().length == 0);
 }
 
 /**

--- a/compiler/src/dmd/dfa/fast/expression.d
+++ b/compiler/src/dmd/dfa/fast/expression.d
@@ -1906,7 +1906,7 @@ struct ExpressionWalker
                     // [foo = new int]
                     DFALatticeRef ret = this.callFunction(null, null, null, ale.elements, ale.loc);
 
-                    if (ale.elements !is null && ale.elements.length > 0)
+                    if (ale.elements !is null && ale.length > 0)
                     {
                         DFAObject* obj = ret.getContextObject();
 
@@ -1919,7 +1919,7 @@ struct ExpressionWalker
 
                         cctx.truthiness = Truthiness.True;
                         cctx.nullable = Nullable.NonNull;
-                        cctx.pa = DFAPAValue(ale.elements.length);
+                        cctx.pa = DFAPAValue(ale.length);
                         cctx.obj = obj;
                     }
                     else

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -3173,7 +3173,7 @@ public:
                     emplaceExp!ArrayLiteralExp(&ue, loc, type, cast(Expressions*) null);
                     return ue;
                 }
-                const length = aex.elements.length;
+                const length = aex.length;
                 Expressions* elements = new Expressions(length);
 
                 emplaceExp!ArrayLiteralExp(&ue, loc, type, elements);
@@ -3975,7 +3975,7 @@ public:
             if (auto ale = e1.isArrayLiteralExp())
             {
                 lowerbound = 0;
-                upperbound = ale.elements.length;
+                upperbound = ale.length;
             }
             else if (auto se = e1.isStringExp())
             {
@@ -4211,9 +4211,9 @@ public:
                 bool needsPostblit;
                 bool needsDtor;
 
-                Expression assignTo(ArrayLiteralExp ae)
+                Expression assignTo(ArrayLiteralExp ale)
                 {
-                    return assignTo(ae, 0, ae.elements.length);
+                    return assignTo(ale, 0, ale.length);
                 }
 
                 Expression assignTo(ArrayLiteralExp ae, size_t lwr, size_t upr)
@@ -5738,7 +5738,7 @@ public:
                     {
                         ArrayLiteralExp ale = ie.e1.isArrayLiteralExp();
                         const indx = cast(size_t)ie.e2.toInteger();
-                        if (indx < ale.elements.length)
+                        if (indx < ale.length) // xyzzy
                         {
                             Expression xx = (*ale.elements)[indx];
                             if (!xx) xx = ale.basis;
@@ -6028,10 +6028,9 @@ public:
              * Dereference it only if result should be an rvalue
              */
             auto ae = result.isArrayLiteralExp();
-            if (ae.elements.length == 1)
+            if (ae.length == 1)
             {
-                result = (*ae.elements)[0];
-                if (!result) result = ae.basis;
+                result = ae[0];
                 return;
             }
         }
@@ -7188,7 +7187,7 @@ private Expression interpret_aaApply(UnionExp* pue, InterState* istate, Expressi
 /// Returns: equivalent `StringExp` from `ArrayLiteralExp ale` containing only `IntegerExp` elements
 StringExp arrayLiteralToString(ArrayLiteralExp ale)
 {
-    const len = ale.elements ? ale.elements.length : 0;
+    const len = ale.elements ? ale.length : 0;
     const size = ale.type.nextOf().size();
 
     StringExp impl(T)()

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2458,7 +2458,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (auto ale = e.isArrayLiteralExp())
             {
-                len = ale.elements.length;
+                len = ale.length;
                 return true;
             }
 
@@ -2519,13 +2519,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (auto ale = ie.isArrayLiteralExp())
             {
-                dinteger_t len = ale.elements.length;
+                dinteger_t len = ale.length;
                 tsa.dim = new IntegerExp(loc, len, Type.tsize_t);
                 if (auto innerTsa = tsa.next.isTypeSArray())
                 {
-                    if (ale.elements.length > 0)
+                    if (len)
                     {
-                        auto firstElem = (*ale.elements)[0];
+                        auto firstElem = ale[0];
                         inferSArrayDim(innerTsa, firstElem, loc, sc);
                     }
                 }
@@ -10095,7 +10095,7 @@ bool _isZeroInit(Expression exp)
         {
             auto ale = cast(ArrayLiteralExp)exp;
 
-            const dim = ale.elements ? ale.elements.length : 0;
+            const dim = ale.length;
 
             if (ale.type.toBasetype().ty == Tarray) // if initializing a dynamic array
                 return dim == 0;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -1383,6 +1383,14 @@ extern (C++) final class ArrayLiteralExp : Expression
         return el ? el : basis;
     }
 
+    extern (D) Expression opIndexAssign(Expression value, size_t i)
+    {
+        (*elements)[i] = value;
+        return value;
+    }
+
+    extern (D) size_t length() { return elements ? elements.length : 0; }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -2909,7 +2909,7 @@ elem* toElem(Expression e, ref IRState irs)
             {
                 ArrayLiteralExp ale = cast(ArrayLiteralExp)ae.e2;
                 elem* e;
-                if (ale.elements.length == 0)
+                if (ale.length == 0)
                 {
                     e = e1;
                 }
@@ -4089,7 +4089,7 @@ elem* toElem(Expression e, ref IRState irs)
 
     elem* visitArrayLiteral(ArrayLiteralExp ale)
     {
-        size_t dim = ale.elements ? ale.elements.length : 0;
+        size_t dim = ale.length;
 
         //printf("ArrayLiteralExp.toElem() %s, type = %s\n", ale.toChars(), ale.type.toChars());
         Type tb = ale.type.toBasetype();
@@ -4526,7 +4526,7 @@ elem* ExpressionsToStaticArray(ref IRState irs, Loc loc, Expressions* exps, Symb
             el.type.toBasetype().ty == Tsarray)
         {
             ArrayLiteralExp ale = cast(ArrayLiteralExp)el;
-            if (ale.elements && ale.elements.length)
+            if (ale.length)
             {
                 elem* ex = ExpressionsToStaticArray(irs,
                     ale.loc, ale.elements, &stmp, cast(uint)(offset + i * szelem), ale.basis);

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -259,7 +259,7 @@ void Expression_toDt(Expression e, ref DtBuilder dtb)
         if (auto strExp = e.e1.isStringExp())
             len = strExp.len;
         else if (auto arrExp = e.e1.isArrayLiteralExp())
-            len = arrExp.elements.length;
+            len = arrExp.length;
         else
             return nonConstExpError(e);
 
@@ -489,7 +489,7 @@ void Expression_toDt(Expression e, ref DtBuilder dtb)
         //printf("ArrayLiteralExp.toDt() '%s', type = %s\n", e.toChars(), e.type.toChars());
 
         auto dtbarray = DtBuilder(0);
-        foreach (i; 0 .. e.elements.length)
+        foreach (i; 0 .. e.length)
         {
             Expression_toDt(e[i], dtbarray);
         }
@@ -502,7 +502,7 @@ void Expression_toDt(Expression e, ref DtBuilder dtb)
                 break;
 
             case Tarray:
-                dtb.size(e.elements.length);
+                dtb.size(e.length);
                 goto case Tpointer;
 
             case Tpointer:
@@ -1163,7 +1163,7 @@ private void toDtElem(TypeSArray tsa, ref DtBuilder dtb, Expression e, bool isCt
                 len /= se.numberOfCodeUnits(0, s);
             }
             else if (auto ae = e.isArrayLiteralExp())
-                len /= ae.elements.length;
+                len /= ae.length;
         }
 
         auto dtb2 = DtBuilder(0);

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -928,8 +928,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
         static void tlsToDt(VarDeclaration vd, Symbol* s, uint sz, ref DtBuilder dtb, bool isCfile)
         {
             assert(config.objfmt == OBJ_MACH &&
-		(target.isX86_64 || target.isAArch64) &&
-		(s.Stype.Tty & mTYLINK) == mTYthread);
+                (target.isX86_64 || target.isAArch64) &&
+                (s.Stype.Tty & mTYLINK) == mTYthread);
 
             Symbol* tlvInit = createTLVDataSymbol(vd, s);
             auto tlvInitDtb = DtBuilder(0);

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -604,7 +604,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                 uinteger_t dim2 = dim1;
                 if (auto ale = i.exp.isArrayLiteralExp())
                 {
-                    dim2 = ale.elements ? ale.elements.length : 0;
+                    dim2 = ale.length;
                 }
                 else if (auto se = i.exp.isSliceExp())
                 {

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -1041,7 +1041,7 @@ public:
 
     override void visit(ArrayLiteralExp e)
     {
-        const dim = e.elements ? e.elements.length : 0;
+        const dim = e.elements.length;
         buf.writeByte('A');
         buf.print(dim);
         foreach (i; 0 .. dim)

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -149,7 +149,7 @@ public:
 
     override void visit(ArrayLiteralExp e)
     {
-        const dim = e.elements ? e.elements.length : 0;
+        const dim = e.length;
         if (e.type.toBasetype().isTypeSArray() || dim == 0 || e.onstack)
             return;
         if (setGC(e, "this array literal"))

--- a/compiler/src/dmd/objc.d
+++ b/compiler/src/dmd/objc.d
@@ -568,10 +568,10 @@ extern(C++) private final class Supported : Objc
             if (!e.isStructLiteralExp())
                 return 0;
 
-            auto literal = e.isStructLiteralExp();
-            assert(literal.sd);
+            auto sle = e.isStructLiteralExp();
+            assert(sle.sd);
 
-            if (!isCoreUda(literal.sd, Id.udaSelector))
+            if (!isCoreUda(sle.sd, Id.udaSelector))
                 return 0;
 
             if (fd.objc.selector)
@@ -580,8 +580,8 @@ extern(C++) private final class Supported : Objc
                 return 1;
             }
 
-            assert(literal.elements.length == 1);
-            auto se = (*literal.elements)[0].toStringExp();
+            assert(sle.elements.length == 1);
+            auto se = (*sle.elements)[0].toStringExp();
             assert(se);
 
             fd.objc.selector = ObjcSelector.lookup(se.toUTF8(sc).peekString().ptr);

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -227,7 +227,7 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Expression arr)
     if (auto se = arr.isStringExp())
         len = se.len;
     else if (auto ale = arr.isArrayLiteralExp())
-        len = ale.elements.length;
+        len = ale.length;
     else
     {
         auto tsa = arr.type.toBasetype().isTypeSArray();

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1112,7 +1112,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                             // check if overflow is possible
                             const maxLen = intRangeFromType(tindex).imax.value + 1;
                             if (auto ale = fs.aggr.isArrayLiteralExp())
-                                err = ale.elements.length > maxLen;
+                                err = ale.length > maxLen;
                             else if (auto se = fs.aggr.isSliceExp())
                                 err = !(se.upr && se.upr.isConst() && se.upr.toInteger() <= maxLen);
                         }
@@ -1221,7 +1221,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 if (fs.aggr.isArrayLiteralExp() && !valueIsRef)
                 {
                     auto ale = fs.aggr.isArrayLiteralExp();
-                    size_t edim = ale.elements ? ale.elements.length : 0;
+                    size_t edim = ale.length;
                     auto telem = (*fs.parameters)[dim - 1].type;
 
                     // https://issues.dlang.org/show_bug.cgi?id=12936

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -622,10 +622,10 @@ private size_t expressionHash(Expression e)
 
     case EXP.arrayLiteral:
     {
-        auto ae = e.isArrayLiteralExp();
+        auto ale = e.isArrayLiteralExp();
         size_t hash;
-        foreach (i; 0 .. ae.elements.length)
-            hash = mixHash(hash, expressionHash(ae[i]));
+        foreach (i; 0 .. ale.length)
+            hash = mixHash(hash, expressionHash(ale[i]));
         return hash;
     }
 
@@ -4776,9 +4776,9 @@ private MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, TemplateIn
                         {
                             argtype = se.type.nextOf().sarrayOf(se.len);
                         }
-                        else if (ArrayLiteralExp ae = farg.isArrayLiteralExp())
+                        else if (ArrayLiteralExp ale = farg.isArrayLiteralExp())
                         {
-                            argtype = ae.type.nextOf().sarrayOf(ae.elements.length);
+                            argtype = ale.type.nextOf().sarrayOf(ale.length);
                         }
                         else if (SliceExp se = farg.isSliceExp())
                         {
@@ -7655,7 +7655,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 return;
             }
 
-            if (tparam.ty == Tarray && e.elements && e.elements.length)
+            if (tparam.ty == Tarray && e.elements && e.length)
             {
                 Type tn = (cast(TypeDArray)tparam).next;
                 result = MATCH.exact;
@@ -7682,7 +7682,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
             if (e.type.ty == Tarray && (tparam.ty == Tsarray || tparam.ty == Taarray && (taai = (cast(TypeAArray)tparam).index).ty == Tident && (cast(TypeIdentifier)taai).idents.length == 0))
             {
                 // Consider compile-time known boundaries
-                e.type.nextOf().sarrayOf(e.elements.length).accept(this);
+                e.type.nextOf().sarrayOf(e.length).accept(this);
                 return;
             }
             visit(cast(Expression)e);


### PR DESCRIPTION
In attempting to fix https://github.com/dlang/dmd/issues/23367, @ntrel submitted https://github.com/dlang/dmd/pull/23372.

But, he ran into problems. The problem is that ArrayLiteralExp has not sufficiently abstracted `elements`. What's necessary is to make it a sparse array. This PR is a step in that direction by abstracting `length`. Trying to do this all in one go would be too difficult to review.
 