### PR TITLE
Fix #23551 - extern(C++) class has wrong vtbl pointer for interface

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -8634,20 +8634,55 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // if super is defined in C++, it sets the vtable pointer to the base class
                 // so we have to restore it, but still return 'this' from super() call:
                 // (auto __vptrTmp = this.__vptr, auto __superTmp = super()), (this.__vptr = __vptrTmp, __superTmp)
+                // the same is done for every interface vptr
                 Loc loc = exp.loc;
 
-                auto vptr = new DotIdExp(loc, new ThisExp(loc), Id.__vptr);
-                auto vptrTmpDecl = copyToTemp(STC.none, "__vptrTmp", vptr);
-                auto declareVptrTmp = new DeclarationExp(loc, vptrTmpDecl);
+                // Build expressions for accessing the vptrs.
+                Expressions *vptrs = new Expressions();
+
+                // Add expression for normal vptr
+                vptrs.push(new DotIdExp(loc, new ThisExp(loc), Id.__vptr));
+
+                // Add expressions for interface vptrs
+                for (ClassDeclaration pc = cd.baseClass; pc; pc = pc.baseClass)
+                {
+                    foreach (i; 0 .. pc.vtblInterfaces.length)
+                    {
+                        BaseClass* b = (*pc.vtblInterfaces)[i];
+
+                        // Add expression `*cast(void**)(cast(void*)this) + offset)` for accessing the interface vptr
+                        Expression vptr = new CastExp(loc, new ThisExp(loc), Type.tvoidptr);
+                        vptr = new AddExp(loc, vptr, new IntegerExp(loc, b.offset, Type.tsize_t));
+                        vptr = new PtrExp(loc, new CastExp(loc, vptr, Type.tvoidptr.pointerTo()));
+                        vptrs.push(vptr);
+                    }
+                }
 
                 auto superTmpDecl = copyToTemp(STC.none, "__superTmp", result);
                 auto declareSuperTmp = new DeclarationExp(loc, superTmpDecl);
 
-                auto declareTmps = new CommaExp(loc, declareVptrTmp, declareSuperTmp);
+                // Build expressions for declaring the temporary variables and restoring them
+                Expression declareTmps = null;
+                Expression restoreVptrs = null;
+                foreach (vptr; *vptrs)
+                {
+                    auto vptrTmpDecl = copyToTemp(STC.none, "__vptrTmp", vptr);
+                    auto declareTmp = new DeclarationExp(loc, vptrTmpDecl);
+                    if (declareTmps !is null)
+                        declareTmps = new CommaExp(loc, declareTmps, declareTmp);
+                    else
+                        declareTmps = declareTmp;
 
-                auto restoreVptr = new AssignExp(loc, vptr.syntaxCopy(), new VarExp(loc, vptrTmpDecl));
+                    auto restoreVptr = new AssignExp(loc, vptr.syntaxCopy(), new VarExp(loc, vptrTmpDecl));
+                    if (restoreVptrs !is null)
+                        restoreVptrs = new CommaExp(loc, restoreVptrs, restoreVptr);
+                    else
+                        restoreVptrs = restoreVptr;
+                }
 
-                Expression e = new CommaExp(loc, declareTmps, new CommaExp(loc, restoreVptr, new VarExp(loc, superTmpDecl)));
+                declareTmps = new CommaExp(loc, declareTmps, declareSuperTmp);
+
+                Expression e = new CommaExp(loc, declareTmps, new CommaExp(loc, restoreVptrs, new VarExp(loc, superTmpDecl)));
                 result = e.expressionSemantic(sc);
             }
         }

--- a/compiler/test/runnable_cxx/extra-files/test23551.cpp
+++ b/compiler/test/runnable_cxx/extra-files/test23551.cpp
@@ -1,0 +1,38 @@
+#include "test23551.h"
+#include <stdio.h>
+
+Base::Base()
+{
+}
+int Base::f()
+{
+    return 1000 + i;
+}
+
+C::C()
+{
+}
+int C::g()
+{
+    return 3000 + i;
+}
+
+E::E()
+{
+}
+int E::g2()
+{
+    return 5200 + i;
+}
+int E::g3()
+{
+    return 5300 + i;
+}
+int E::g4()
+{
+    return 5400 + i;
+}
+int E::g5()
+{
+    return 5500 + i;
+}

--- a/compiler/test/runnable_cxx/extra-files/test23551.h
+++ b/compiler/test/runnable_cxx/extra-files/test23551.h
@@ -1,0 +1,44 @@
+class Base
+{
+public:
+    int i;
+    Base();
+    virtual int f();
+};
+
+class Interface
+{
+public:
+    virtual int g() = 0;
+};
+
+class C : public Base, public Interface
+{
+public:
+    C();
+    int g();
+};
+
+class Interface2
+{
+public:
+    virtual int g2() = 0;
+    virtual int g3() = 0;
+};
+
+class Interface3
+{
+public:
+    virtual int g4() = 0;
+    virtual int g5() = 0;
+};
+
+class E : public C, public Interface2, public Interface3
+{
+public:
+    E();
+    int g2();
+    int g3();
+    int g4();
+    int g5();
+};

--- a/compiler/test/runnable_cxx/test23551.d
+++ b/compiler/test/runnable_cxx/test23551.d
@@ -1,0 +1,125 @@
+// https://github.com/dlang/dmd/issues/23551
+// EXTRA_CPP_SOURCES: test23551.cpp
+// EXTRA_FILES: test23551.h
+
+extern(C++)
+class Base
+{
+    int i;
+    this();
+    int f();
+}
+
+extern(C++) interface Interface
+{
+    int g();
+}
+
+extern(C++) class C : Base, Interface
+{
+    this();
+    int g();
+}
+
+class D : C
+{
+    this(){}
+    override extern(C++) int g()
+    {
+        return 4000 + i;
+    }
+}
+
+extern(C++) interface Interface2
+{
+    int g2();
+    int g3();
+}
+
+extern(C++) interface Interface3
+{
+    int g4();
+    int g5();
+}
+
+extern(C++) class E : C, Interface2, Interface3
+{
+    this();
+    int g2();
+    int g3();
+    int g4();
+    int g5();
+}
+
+class F : E
+{
+    this(){}
+    override extern(C++) int g()
+    {
+        return 6100 + i;
+    }
+    override extern(C++) int g2()
+    {
+        return 6200 + i;
+    }
+    override extern(C++) int g5()
+    {
+        return 6500 + i;
+    }
+}
+
+void main()
+{
+    {
+        auto o = new C();
+        o.i = 1;
+        assert(o.f() == 1001);
+        assert(o.g() == 3001);
+        Interface x = o;
+        assert(x.g() == 3001);
+    }
+    {
+        auto o = new D();
+        o.i = 2;
+        assert(o.f() == 1002);
+        assert(o.g() == 4002);
+        Interface x = o;
+        assert(x.g() == 4002);
+    }
+    {
+        auto o = new E();
+        o.i = 3;
+        assert(o.f() == 1003);
+        assert(o.g() == 3003);
+        assert(o.g2() == 5203);
+        assert(o.g3() == 5303);
+        assert(o.g4() == 5403);
+        assert(o.g5() == 5503);
+        Interface x = o;
+        assert(x.g() == 3003);
+        Interface2 x2 = o;
+        assert(x2.g2() == 5203);
+        assert(x2.g3() == 5303);
+        Interface3 x3 = o;
+        assert(x3.g4() == 5403);
+        assert(x3.g5() == 5503);
+    }
+    {
+        auto o = new F();
+        o.i = 4;
+        assert(o.f() == 1004);
+        assert(o.g() == 6104);
+        assert(o.g2() == 6204);
+        assert(o.g3() == 5304);
+        assert(o.g4() == 5404);
+        assert(o.g5() == 6504);
+        Interface x = o;
+        assert(x.g() == 6104);
+        Interface2 x2 = o;
+        assert(x2.g2() == 6204);
+        assert(x2.g3() == 5304);
+        Interface3 x3 = o;
+        assert(x3.g4() == 5404);
+        assert(x3.g5() == 6504);
+    }
+}


### PR DESCRIPTION
D and C++ initialize the vtbl pointers in classes differently. D first copies the whole init value for the class and the constructors then don't change the vtbl pointer. In C++ every constructor in the chain sets the vtbl pointers and overwrites the previous values.

When a class implemented in D inherits from a class implemented in C++ and instantiated from D this is mixed: First the init value is copied, like for D classes. Then the base C++ constructor is called and overwrites the vtbl pointers. The D constructor then has to restore the vtbl pointer. This was already done for the normal base class vtbl pointer, but not for interfaces.

This change could break code relying on the bug. This can happen when a C++ interface layout is wrong, but this was never seen, because the vtbl still came from C++. Now the vtbl comes from D and a wrong layout could result in crashes or wrong functions being called.