### PR TITLE
[spec/type] Improve implicit conversions

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -1560,7 +1560,8 @@ void main()
 $(H2 $(LNAME2 implicit-conversions, Implicit Conversions))
 
         $(P A static array $(D T[dim]) can be implicitly converted to a dynamic
-        array `T[]`.)
+        array `T[]`. The dynamic array's elements must not be used outside the
+        lifetime of the static array. This can be enforced with `-preview=dip1000`.)
 
         $(P An array/pointer with a class element type may have
         $(DDSUBLINK spec/type, class-conversions, implicit conversions).)

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -1488,7 +1488,7 @@ $(H3 $(LNAME2 void_arrays, Void Arrays))
     This is because the void array may hold pointers.
     A void array cannot be $(RELATIVE_LINK2 array-setting, filled).)
 
-    $(P Arrays of any type can be $(DDSUBLINK spec/type, implicit-conversions,
+    $(P Arrays of any type can be $(RELATIVE_LINK2 void-element-conversion,
     implicitly converted) to a (tail qualified) void array - the
     compiler inserts the appropriate calculations so that the $(D .length) of
     the resulting array's size is in bytes rather than number of elements. Void

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -1566,6 +1566,14 @@ $(H2 $(LNAME2 implicit-conversions, Implicit Conversions))
         $(P An array/pointer with a class element type may have
         $(DDSUBLINK spec/type, class-conversions, implicit conversions).)
 
+        $(P Array literals can be implicitly converted to static array
+        types. See $(DDSUBLINK spec/expression, array_literals, Array Literals)
+        for details.)
+
+        $(P String literals can be implicitly converted to static array
+        types and character pointer types. See $(DDSUBLINK spec/expression, string_literals,
+        String Literals) for details.)
+
 $(H3 $(LNAME2 void-element-conversion, Void Element Conversion))
 
         $(P A pointer $(D T*) can be implicitly converted to a
@@ -1597,16 +1605,6 @@ void test()
 }
 ---
 )
-
-$(H3 $(LNAME2 literal-conversion, Literal Conversion))
-
-        $(P Array literals can also be implicitly converted to static array
-        types. See $(DDSUBLINK spec/expression, array_literals, Array Literals)
-        for details.)
-
-        $(P String literals can also be implicitly converted to static array
-        types and character pointer types. See $(DDSUBLINK spec/expression, string_literals,
-        String Literals) for details.)
 
 
 $(SPEC_SUBNAV_PREV_NEXT statement, Statements, hash-map, Associative Arrays)

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -1581,7 +1581,8 @@ $(H3 $(LNAME2 void-element-conversion, Void Element Conversion))
 
         $(UL
         $(LI `void*` if `T` has no type qualifier)
-        $(LI $(D *qualifier*(void)*) if `T` has *qualifier*)
+        $(LI A pointer to a type-qualified `void` if `T` has
+            $(DDSUBLINK spec/const3, implicit_qualifier_conversions, compatible type qualifiers))
         )
 
         $(P A dynamic array $(D T[]) can be implicitly
@@ -1589,17 +1590,22 @@ $(H3 $(LNAME2 void-element-conversion, Void Element Conversion))
 
         $(UL
         $(LI $(D void[]) if `T` has no type qualifier)
-        $(LI $(D *qualifier*(void)[]) if `T` has *qualifier*)
+        $(LI A dynamic array of a type-qualified `void` if `T` has
+            $(DDSUBLINK spec/const3, implicit_qualifier_conversions, compatible type qualifiers))
         )
 
         $(P Similarly, a static array $(D T[dim]) can be implicitly
-        converted to a static array with a (qualified) `void` element type.)
+        converted to a static array with a (compatibly qualified) `void` element type.)
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 void test()
 {
-    const int[] a;
+    const int* ip;
+    //void* vp = ip; // error
+    const(void)* vp = ip;
+
+    immutable int[] a;
     //void[] va = a; // error
     const(void)[] va = a;
 }

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -1559,34 +1559,45 @@ void main()
 
 $(H2 $(LNAME2 implicit-conversions, Implicit Conversions))
 
-        $(P A pointer $(D T*) can be implicitly converted to
-        one of the following:)
+        $(P A static array $(D T[dim]) can be implicitly converted to a dynamic
+        array `T[]`.)
+
+        $(P An array/pointer with a class element type may have
+        $(DDSUBLINK spec/type, class-conversions, implicit conversions).)
+
+$(H3 $(LNAME2 void-element-conversion, Void Element Conversion))
+
+        $(P A pointer $(D T*) can be implicitly converted to a
+        $(DDSUBLINK spec/type, void, void) pointer as:)
 
         $(UL
-        $(LI $(D void*))
+        $(LI `void*` if `T` has no type qualifier)
+        $(LI $(D *qualifier*(void)*) if `T` has *qualifier*)
         )
 
-        $(P A static array $(D T[dim]) can be implicitly
-        converted to
-        one of the following ($(D U) is a base class of $(D T)):
-        )
+        $(P A dynamic array $(D T[]) can be implicitly
+        $(RELATIVE_LINK2 void_arrays, converted to a void array) as:)
 
         $(UL
-        $(LI $(D T[]))
-
-        $(LI $(D const(U)[]))
-        $(LI $(D const(U[])))
-        $(LI $(D void[]))
+        $(LI $(D void[]) if `T` has no type qualifier)
+        $(LI $(D *qualifier*(void)[]) if `T` has *qualifier*)
         )
 
-        $(P A dynamic array $(D T[]) can be implicitly converted to one of the
-        following ($(D U) is a base class of $(D T)):)
+        $(P Similarly, a static array $(D T[dim]) can be implicitly
+        converted to a static array with a (qualified) `void` element type.)
 
-        $(UL
-        $(LI $(D const(U)[]))
-        $(LI $(D const(U[])))
-        $(LI $(D void[]))
-        )
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+---
+void test()
+{
+    const int[] a;
+    //void[] va = a; // error
+    const(void)[] va = a;
+}
+---
+)
+
+$(H3 $(LNAME2 literal-conversion, Literal Conversion))
 
         $(P Array literals can also be implicitly converted to static array
         types. See $(DDSUBLINK spec/expression, array_literals, Array Literals)
@@ -1595,6 +1606,7 @@ $(H2 $(LNAME2 implicit-conversions, Implicit Conversions))
         $(P String literals can also be implicitly converted to static array
         types and character pointer types. See $(DDSUBLINK spec/expression, string_literals,
         String Literals) for details.)
+
 
 $(SPEC_SUBNAV_PREV_NEXT statement, Statements, hash-map, Associative Arrays)
 )

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -282,9 +282,6 @@ $(H2 $(LNAME2 type-conversions, Type Conversions))
 
 $(H3 $(LEGACY_LNAME2 Pointer Conversions, pointer-conversions, Pointer Conversions))
 
-    $(P Any $(RELATIVE_LINK2 pointers, pointer) implicitly converts to a `void` pointer -
-    see below.)
-
     $(P $(DDSUBLINK spec/expression, cast_pointers, Casting between)
     pointers and non-pointers is allowed. Some pointer casts
     are disallowed in $(DDLINK spec/memory-safe-d, Memory-Safe-D-Spec, `@safe` code).)
@@ -309,17 +306,18 @@ $(H3 $(LEGACY_LNAME2 Implicit Conversions, implicit-conversions, Implicit Conver
     $(LI An enum can be $(DDSUBLINK spec/enum, named_enums, implicitly converted) to its base
     type (but going the other way requires an explicit conversion).)
     $(LI $(RELATIVE_LINK2 noreturn, `noreturn`) implicitly converts to any type.)
-    $(LI Static and dynamic arrays implicitly convert to $(DDSUBLINK spec/arrays, void_arrays, `void` arrays).
-        The `void` element type for the array may need a
-        $(DDLINK spec/const3, Type Qualifiers, type qualifier), depending on the source
-        element type:
-    )
-        * An array with non-mutable elements will implicitly convert to `const(void)[]`, but not `void[]`.
-        * An array with `shared` elements will implicitly convert to `shared(void)[]`, but not `void[]`.
-    $(LI Any pointer implicitly converts to a void pointer. As for void arrays, the
-        `void` element type may need a type qualifier.)
+    $(LI A struct may implicitly convert to the target of its
+        $(GLINK2 struct, AliasThis).)
+    $(LI A class instance implicitly converts to its
+        $(DDSUBLINK spec/class, super_class, base class) or interfaces.)
+    $(LI A static array $(DDSUBLINK spec/arrays, implicit-conversions, implicitly
+        converts) to a dynamic array.)
+    $(LI Static arrays, dynamic arrays and pointers implicitly
+        $(DDSUBLINK spec/arrays, void-element-conversion, convert to void element type).)
+    $(LI Static arrays, dynamic arrays and pointers of class element type may have
+        $(RELATIVE_LINK2 class-conversions, implicit conversions).)
     $(LI $(DDSUBLINK spec/function, function-pointers-delegates, Function pointers and delegates)
-        can convert to covariant types.)
+        can convert to $(RELATIVE_LINK2 covariance, covariant types).)
     )
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
@@ -332,11 +330,6 @@ void test(bool b)
 
     noreturn n();
     i = n();
-    void* p = &i;
-
-    const int[] a;
-    const(void)[] cv = a;
-    //void[] va = a; // error
 }
 
 void f(int x) pure;


### PR DESCRIPTION
Move void array conversion info to arrays.dd and generalize it for type qualifiers.

arrays.dd:
Sliced static array elements should not be used outside the static array lifetime.
Link to class element type conversions instead of repeating info in type.dd.
Add void array conversion subheading, link to void and void arrays.

type.dd:
List struct alias this, classes, link to void array conversion, class element conversion, link to covariant function types.