### PR TITLE
fix malloc/mem.xfree inconsistency in isSameFuncLiteral

### DIFF
--- a/compiler/src/dmd/lambdacomp.d
+++ b/compiler/src/dmd/lambdacomp.d
@@ -64,17 +64,17 @@ private enum ExpType
 bool isSameFuncLiteral(FuncLiteralDeclaration l1, FuncLiteralDeclaration l2, Scope* sc)
 {
     bool result;
-    if (auto ser1 = getSerialization(l1, sc))
+    OutBuffer buf1;
+    if (getSerialization(l1, sc, buf1))
     {
+        OutBuffer buf2;
         //printf("l1 serialization: %.*s\n", cast(int)ser1.length, &ser1[0]);
-        if (auto ser2 = getSerialization(l2, sc))
+        if (getSerialization(l2, sc, buf2))
         {
             //printf("l2 serialization: %.*s\n", cast(int)ser2.length, &ser2[0]);
-            if (ser1 == ser2)
+            if (buf1.peekSlice() == buf2.peekSlice())
                 result = true;
-            mem.xfree(cast(void*)ser2.ptr);
         }
-        mem.xfree(cast(void*)ser1.ptr);
     }
     return result;
 }
@@ -95,19 +95,17 @@ bool isSameFuncLiteral(FuncLiteralDeclaration l1, FuncLiteralDeclaration l2, Sco
  * Params:
  *  fld = the starting AST node for the lambda function
  *  sc = the scope in which the lambda function is located
+ *  buf = serialization of `fld` is written to this buffer
  *
  * Returns:
- *  The serialization of `fld` allocated with mem.
+ *  true if serialization was successful and was added to buf
  */
-private string getSerialization(FuncLiteralDeclaration fld, Scope* sc)
+private bool getSerialization(FuncLiteralDeclaration fld, Scope* sc, ref OutBuffer buf)
 {
-    scope serVisitor = new SerializeVisitor(fld.parent._scope);
+    buf.setsize(0);
+    scope serVisitor = new SerializeVisitor(fld.parent._scope, &buf);
     fld.accept(serVisitor);
-    const len = serVisitor.buf.length;
-    if (len == 0)
-        return null;
-
-    return cast(string)serVisitor.buf.extractSlice();
+    return buf.length != 0;
 }
 
 private extern (C++) class SerializeVisitor : SemanticTimeTransitiveVisitor
@@ -119,12 +117,13 @@ private:
     Dsymbol d;
 
 public:
-    OutBuffer buf;
+    OutBuffer* buf;
     alias visit = SemanticTimeTransitiveVisitor.visit;
 
-    this(Scope* sc) scope
+    this(Scope* sc, OutBuffer* buf) scope
     {
         this.sc = sc;
+        this.buf = buf;
     }
 
     /**


### PR DESCRIPTION
OutBuffer uses C malloc, but memory is released with mem.xfree

This can cause memory leaks when mem.xfree is using the GC.

Moving the OutBuffer up the call tree keeps memory management encapsulated.