### PR TITLE
disambiguate inferType() overloads

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -3246,11 +3246,12 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
 }
 
 /****************************************
- * Set type inference target
- *      t       Target type
- *      flag    1: don't put an error when inference fails
+ * If t, set type of e to t skipping past array, function type or conditional type.
+ * Params:
+ *	e = expression to set type to
+ *      t = type to infer from
  */
-Expression inferType(Expression e, Type t, int flag = 0)
+Expression inferExpType(Expression e, Type t)
 {
     Expression visitAle(ArrayLiteralExp ale)
     {
@@ -3260,12 +3261,12 @@ Expression inferType(Expression e, Type t, int flag = 0)
 
         Type tn = tb.nextOf();
         if (ale.basis)
-            ale.basis = inferType(ale.basis, tn, flag);
+            ale.basis = inferExpType(ale.basis, tn);
         foreach (i; 0 .. ale.length)
         {
             if (Expression e = ale[i])
             {
-                e = inferType(e, tn, flag);
+                e = inferExpType(e, tn);
                 ale[i] = e;
             }
         }
@@ -3286,7 +3287,7 @@ Expression inferType(Expression e, Type t, int flag = 0)
         {
             if (Expression e = (*aale.keys)[i])
             {
-                e = inferType(e, ti, flag);
+                e = inferExpType(e, ti);
                 (*aale.keys)[i] = e;
             }
         }
@@ -3294,7 +3295,7 @@ Expression inferType(Expression e, Type t, int flag = 0)
         {
             if (Expression e = (*aale.values)[i])
             {
-                e = inferType(e, tv, flag);
+                e = inferExpType(e, tv);
                 (*aale.values)[i] = e;
             }
         }
@@ -3304,7 +3305,7 @@ Expression inferType(Expression e, Type t, int flag = 0)
 
     Expression visitFun(FuncExp fe)
     {
-        //printf("FuncExp::inferType('%s'), to=%s\n", fe.type ? fe.type.toChars() : "null", t.toChars());
+        //printf("FuncExp::inferExpType('%s'), to=%s\n", fe.type ? fe.type.toChars() : "null", t.toChars());
         if (t.ty == Tdelegate || t.ty == Tpointer && t.nextOf().ty == Tfunction)
         {
             fe.fd.treq = t;
@@ -3315,8 +3316,8 @@ Expression inferType(Expression e, Type t, int flag = 0)
     Expression visitTer(CondExp ce)
     {
         Type tb = t.toBasetype();
-        ce.e1 = inferType(ce.e1, tb, flag);
-        ce.e2 = inferType(ce.e2, tb, flag);
+        ce.e1 = inferExpType(ce.e1, tb);
+        ce.e2 = inferExpType(ce.e2, tb);
         return ce;
     }
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2379,7 +2379,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 return;
             }
             //printf("inferring type for %s with init %s\n", dsym.toChars(), dsym._init.toChars());
-            dsym._init = dsym._init.inferType(sc, dsym.type);
+            dsym._init = dsym._init.inferInitializerType(sc, dsym.type);
             dsym.type = dsym._init.initializerToExpression(null, sc.inCfile).type;
 
             if (autoDollarDims.length)
@@ -3235,7 +3235,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (ei) // https://issues.dlang.org/show_bug.cgi?id=13424
                     // Preset the required type to fail in FuncLiteralDeclaration::semantic3
-                ei.exp = inferType(ei.exp, dsym.type);
+                ei.exp = inferExpType(ei.exp, dsym.type);
 
             /*
              * https://issues.dlang.org/show_bug.cgi?id=24474

--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -411,7 +411,7 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
         Expression e = em.value;
         assert(e.dyncast() == DYNCAST.expression);
         if (em.ed.memtype)
-            e = inferType(e, em.ed.memtype);
+            e = inferExpType(e, em.ed.memtype);
         e = e.expressionSemantic(sc);
         e = resolveProperties(sc, e);
         e = e.ctfeInterpret();

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -10864,7 +10864,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             // When e1 is a template lambda, this cast may instantiate it with
             // the type 'to'.
-            exp.e1 = inferType(exp.e1, exp.to);
+            exp.e1 = inferExpType(exp.e1, exp.to);
         }
 
         if (auto e = unaSemantic(exp, sc))
@@ -12295,7 +12295,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          * depends on the result of e1 in assignments.
          */
         {
-            Expression e2x = inferType(exp.e2, t1.baseElemOf());
+            Expression e2x = inferExpType(exp.e2, t1.baseElemOf());
             e2x = e2x.expressionSemantic(sc);
             if (!t1.isTypeSArray())
                 e2x = e2x.arrayFuncConv(sc);

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1221,7 +1221,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
  * Returns:
  *      an equivalent `ExpInitializer` if successful, or `ErrorInitializer` if it cannot be translated
  */
-Initializer inferType(Initializer init, Scope* sc, Type itype)
+Initializer inferInitializerType(Initializer init, Scope* sc, Type itype)
 {
     Initializer visitVoid(VoidInitializer i)
     {
@@ -1248,7 +1248,7 @@ Initializer inferType(Initializer init, Scope* sc, Type itype)
 
     Initializer visitArray(ArrayInitializer init)
     {
-        //printf("ArrayInitializer::inferType() %s\n", toChars());
+        //printf("ArrayInitializer::inferInitializerType() %s\n", toChars());
         Expressions* keys = null;
         Expressions* values = new Expressions(init.value.length);
         Initializer no()
@@ -1303,7 +1303,7 @@ Initializer inferType(Initializer init, Scope* sc, Type itype)
             Initializer iz = init.value[i];
             if (!iz)
                 return no();
-            iz = iz.inferType(sc, itype ? itype.nextOf() : null);
+            iz = iz.inferInitializerType(sc, itype ? itype.nextOf() : null);
             if (iz.isErrorInitializer())
             {
                 return iz;
@@ -1317,12 +1317,12 @@ Initializer inferType(Initializer init, Scope* sc, Type itype)
             ? new AssocArrayLiteralExp(init.loc, keys, values)
             : new ArrayLiteralExp(init.loc, null, values);
         auto ei = new ExpInitializer(init.loc, e);
-        return ei.inferType(sc, itype);
+        return ei.inferInitializerType(sc, itype);
     }
 
     Initializer visitExp(ExpInitializer init)
     {
-        //printf("ExpInitializer::inferType() %s\n", init.toChars());
+        //printf("ExpInitializer::inferInitializerType() %s\n", init.toChars());
         init.exp = init.exp.expressionSemantic(sc);
 
         // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
@@ -1375,8 +1375,8 @@ Initializer inferType(Initializer init, Scope* sc, Type itype)
 
     Initializer visitC(CInitializer i)
     {
-        //printf("CInitializer.inferType()\n");
-        error(i.loc, "TODO C inferType initializers not supported yet");
+        //printf("CInitializer.inferInitializerType()\n");
+        error(i.loc, "TODO C inferInitializerType initializers not supported yet");
         return new ErrorInitializer();
     }
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2726,9 +2726,9 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
             FuncLiteralDeclaration fld = fd.isFuncLiteralDeclaration();
             if (tret)
-                rs.exp = inferType(rs.exp, tret);
+                rs.exp = inferExpType(rs.exp, tret);
             else if (fld && fld.treq)
-                rs.exp = inferType(rs.exp, fld.treq.nextOf().nextOf());
+                rs.exp = inferExpType(rs.exp, fld.treq.nextOf().nextOf());
 
             rs.exp = rs.exp.expressionSemantic(sc);
             rs.exp = rs.exp.arrayFuncConv(sc);

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -3864,7 +3864,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
             }
             else
             {
-                e = inferType(e, fparam.type);
+                e = inferExpType(e, fparam.type);
                 Scope* sc2 = sc.push();
                 sc2.inDefaultArg = true;
                 Initializer iz = new ExpInitializer(e.loc, e);


### PR DESCRIPTION
I spent some confusing time until realizing there were two different inferType functions that did different things. Renamed them so there is no longer confusion. Also eliminated unused `flag` parameter.