### PR TITLE
avoid allocation of closures

### DIFF
--- a/compiler/src/dmd/argtypes_sysv_x64.d
+++ b/compiler/src/dmd/argtypes_sysv_x64.d
@@ -340,7 +340,7 @@ extern (C++) final class ToClassesVisitor : Visitor
         classifyFields(baseOffset, cast(size_t) t.dim.toInteger(), &getNthElement);
     }
 
-    extern(D) void classifyFields(uint baseOffset, size_t nfields, Type delegate(size_t, out uint, out uint) getFieldInfo)
+    extern(D) void classifyFields(uint baseOffset, size_t nfields, scope Type delegate(size_t, out uint, out uint) getFieldInfo)
     {
         // classify each field (recursively for aggregates) and merge all classes per eightbyte
         foreach (n; 0 .. nfields)

--- a/compiler/src/dmd/argtypes_x86.d
+++ b/compiler/src/dmd/argtypes_x86.d
@@ -327,7 +327,7 @@ TypeTuple toArgTypes_x86(Type t)
          *      nfields = number of fields in the aggregate (dimension for static arrays)
          *      getFieldInfo = get information about the nth field in the aggregate
          */
-        extern (D) void aggregate(ulong sz, size_t nfields, Type delegate(size_t, out uint, out uint) getFieldInfo)
+        extern (D) void aggregate(ulong sz, size_t nfields, scope Type delegate(size_t, out uint, out uint) getFieldInfo)
         {
             if (nfields == 0)
                 return memory();

--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -1003,7 +1003,7 @@ bool isCoreUda(Dsymbol sym, Identifier ident)
  *  If `dg` returns `!= 0`, stops the iteration and returns that value.
  *  Otherwise, returns 0.
  */
-int foreachUdaNoSemantic(Dsymbol sym, int delegate(Expression) dg)
+int foreachUdaNoSemantic(Dsymbol sym, scope int delegate(Expression) dg)
 {
     if (sym.userAttribDecl is null || sym.userAttribDecl.atts is null)
         return 0;

--- a/compiler/src/dmd/attribsem.d
+++ b/compiler/src/dmd/attribsem.d
@@ -61,7 +61,7 @@ Expressions* getAttributes(UserAttributeDeclaration a)
  *  If `dg` returns `!= 0`, stops the iteration and returns that value.
  *  Otherwise, returns 0.
  */
-int foreachUda(Dsymbol sym, Scope* sc, int delegate(Expression) dg)
+int foreachUda(Dsymbol sym, Scope* sc, scope int delegate(Expression) dg)
 {
     if (!sym.userAttribDecl)
         return 0;

--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -62,10 +62,14 @@ CT canThrow(Expression e, FuncDeclaration func, ErrorSink eSink)
     {
         alias visit = typeof(super).visit;
         CT result;
+        FuncDeclaration func;
+        ErrorSink eSink;
 
     public:
-        extern (D) this() scope @safe
+        extern (D) this(FuncDeclaration func, ErrorSink eSink) scope @safe
         {
+            this.func = func;
+            this.eSink = eSink;
         }
 
         void checkFuncThrows(Expression e, FuncDeclaration f)
@@ -213,7 +217,7 @@ CT canThrow(Expression e, FuncDeclaration func, ErrorSink eSink)
         }
     }
 
-    scope CanThrow ct = new CanThrow();
+    scope CanThrow ct = new CanThrow(func, eSink);
     walkPostorder(e, ct);
     return ct.result;
 }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -8030,7 +8030,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         FuncDeclaration resolveOverloadSet(Loc loc, Scope* sc,
-            OverloadSet os, Objects* tiargs, Type tthis, ArgumentList argumentList)
+            OverloadSet os, Objects* tiargs, Type tthis, ArgumentList argumentList) scope
         {
             FuncDeclaration f = null;
             foreach (s; os.a)

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -170,17 +170,17 @@ void toObjFile(Dsymbol ds, bool multiobj)
 {
     //printf("toObjFile(%s %s)\n", ds.kind(), ds.toChars());
 
-    bool isCfile = ds.isCsymbol();
-
     extern (C++) final class ToObjFile : Visitor
     {
         alias visit = Visitor.visit;
     public:
         bool multiobj;
+        bool isCfile;
 
-        this(bool multiobj) scope @safe
+        this(bool multiobj, bool isCfile) scope @safe
         {
             this.multiobj = multiobj;
+            this.isCfile = isCfile;
         }
 
         void visitNoMultiObj(Dsymbol ds)
@@ -1020,7 +1020,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
         }
     }
 
-    scope v = new ToObjFile(multiobj);
+    scope v = new ToObjFile(multiobj, ds.isCsymbol());
     ds.accept(v);
 }
 

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -978,6 +978,20 @@ private void dsymbolToBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 
 void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 {
+    scope v = new DsymbolPrettyPrintVisitor();
+    v.buf = &buf;
+    v.hgs = &hgs;
+    s.accept(v);
+}
+
+extern (C++)
+private final class DsymbolPrettyPrintVisitor : Visitor
+{
+    alias visit = Visitor.visit;
+
+    OutBuffer* buf;
+    HdrGenState* hgs;
+
     void visitDsymbol(Dsymbol s)
     {
         buf.put(s.toChars());
@@ -987,13 +1001,13 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     {
         buf.put(s.kind());
         buf.put('(');
-        s.exp.expressionToBuffer(buf, hgs);
+        s.exp.expressionToBuffer(*buf, *hgs);
         if (s.msgs)
         {
             foreach (m; (*s.msgs)[])
             {
                 buf.put(", ");
-                m.expressionToBuffer(buf, hgs);
+                m.expressionToBuffer(*buf, *hgs);
             }
         }
         buf.put(");");
@@ -1019,13 +1033,13 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     void visitEnumMember(EnumMember em)
     {
         if (em.type)
-            typeToBuffer(em.type, em.ident, buf, hgs);
+            typeToBuffer(em.type, em.ident, *buf, *hgs);
         else
             buf.put(em.ident.toString());
         if (em.value)
         {
             buf.put(" = ");
-            em.value.expressionToBuffer(buf, hgs);
+            em.value.expressionToBuffer(*buf, *hgs);
         }
     }
 
@@ -1076,7 +1090,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         bool hasSTC;
         if (auto stcd = d.isStorageClassDeclaration)
         {
-            hasSTC = stcToBuffer(buf, stcd.stc);
+            hasSTC = stcToBuffer(*buf, stcd.stc);
         }
 
         if (!d.decl)
@@ -1094,7 +1108,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         else if (d.decl.length == 1)
         {
             if (hasSTC) buf.put(' ');
-            toCBuffer((*d.decl)[0], buf, hgs);
+            toCBuffer((*d.decl)[0], *buf, *hgs);
             return;
         }
         else
@@ -1104,7 +1118,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
             buf.writenl();
             buf.level++;
             foreach (de; *d.decl)
-                toCBuffer(de, buf, hgs);
+                toCBuffer(de, *buf, *hgs);
             buf.level--;
             buf.put('}');
         }
@@ -1119,7 +1133,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     void visitDeprecatedDeclaration(DeprecatedDeclaration d)
     {
         buf.put("deprecated(");
-        d.msg.expressionToBuffer(buf, hgs);
+        d.msg.expressionToBuffer(*buf, *hgs);
         buf.put(") ");
         visitAttribDeclaration(d);
     }
@@ -1154,7 +1168,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 
     void visitVisibilityDeclaration(VisibilityDeclaration d)
     {
-        visibilityToBuffer(buf, d.visibility);
+        visibilityToBuffer(*buf, d.visibility);
         AttribDeclaration ad = cast(AttribDeclaration)d;
         if (ad.decl.length <= 1)
             buf.put(' ');
@@ -1173,7 +1187,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
                 if (i)
                     buf.put(' ');
                 buf.put("align (");
-                toCBuffer(exp, buf, hgs);
+                toCBuffer(exp, *buf, *hgs);
                 buf.put(')');
             }
             if (d.decl && d.decl.length < 2)
@@ -1195,7 +1209,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         if (d.decl)
         {
             foreach (de; *d.decl)
-                toCBuffer(de, buf, hgs);
+                toCBuffer(de, *buf, *hgs);
         }
         buf.level--;
         buf.put("}");
@@ -1209,7 +1223,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         if (d.args && d.args.length)
         {
             buf.put(", ");
-            argsToBuffer(d.args, buf, hgs);
+            argsToBuffer(d.args, *buf, *hgs);
         }
 
         buf.put(')');
@@ -1227,7 +1241,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 
     void visitConditionalDeclaration(ConditionalDeclaration d)
     {
-        d.condition.conditionToBuffer(buf, hgs);
+        d.condition.conditionToBuffer(*buf, *hgs);
         if (d.decl || d.elsedecl)
         {
             buf.writenl();
@@ -1237,7 +1251,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
             if (d.decl)
             {
                 foreach (de; *d.decl)
-                    toCBuffer(de, buf, hgs);
+                    toCBuffer(de, *buf, *hgs);
             }
             buf.level--;
             buf.put('}');
@@ -1250,7 +1264,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
                 buf.writenl();
                 buf.level++;
                 foreach (de; *d.elsedecl)
-                    toCBuffer(de, buf, hgs);
+                    toCBuffer(de, *buf, *hgs);
                 buf.level--;
                 buf.put('}');
             }
@@ -1270,15 +1284,15 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
             {
                 if (i)
                     buf.put(", ");
-                if (stcToBuffer(buf, p.storageClass))
+                if (stcToBuffer(*buf, p.storageClass))
                     buf.put(' ');
                 if (p.type)
-                    typeToBuffer(p.type, p.ident, buf, hgs);
+                    typeToBuffer(p.type, p.ident, *buf, *hgs);
                 else
                     buf.put(p.ident.toString());
             }
             buf.put("; ");
-            s.aggr.expressionToBuffer(buf, hgs);
+            s.aggr.expressionToBuffer(*buf, *hgs);
             buf.put(')');
             buf.writenl();
         }
@@ -1286,17 +1300,17 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         void foreachRangeWithoutBody(ForeachRangeStatement s)
         {
             /* s.op ( param ; lwr .. upr )
-             */
+                */
             buf.put(Token.toString(s.op));
             buf.put(" (");
             if (s.param.type)
-                typeToBuffer(s.param.type, s.param.ident, buf, hgs);
+                typeToBuffer(s.param.type, s.param.ident, *buf, *hgs);
             else
                 buf.put(s.param.ident.toString());
             buf.put("; ");
-            s.lwr.expressionToBuffer(buf, hgs);
+            s.lwr.expressionToBuffer(*buf, *hgs);
             buf.put(" .. ");
-            s.upr.expressionToBuffer(buf, hgs);
+            s.upr.expressionToBuffer(*buf, *hgs);
             buf.put(')');
             buf.writenl();
         }
@@ -1316,7 +1330,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         buf.level++;
         if (s.decl)
             foreach (de; *s.decl)
-                toCBuffer(de, buf, hgs);
+                toCBuffer(de, *buf, *hgs);
         buf.level--;
         buf.put('}');
         buf.writenl();
@@ -1326,7 +1340,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     void visitMixinDeclaration(MixinDeclaration d)
     {
         buf.put("mixin(");
-        argsToBuffer(d.exps, buf, hgs, null);
+        argsToBuffer(d.exps, *buf, *hgs, null);
         buf.put(");");
         buf.writenl();
     }
@@ -1334,7 +1348,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     void visitUserAttributeDeclaration(UserAttributeDeclaration d)
     {
         buf.put("@(");
-        argsToBuffer(d.atts, buf, hgs);
+        argsToBuffer(d.atts, *buf, *hgs);
         buf.put(')');
         visitAttribDeclaration(d);
     }
@@ -1344,7 +1358,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         if (!constraint)
             return;
         buf.put(" if (");
-        constraint.expressionToBuffer(buf, hgs);
+        constraint.expressionToBuffer(*buf, *hgs);
         buf.put(')');
     }
 
@@ -1362,7 +1376,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
                 {
                     assert(es.exp && es.exp.op == EXP.assert_);
                     buf.put(" (");
-                    (cast(AssertExp)es.exp).e1.expressionToBuffer(buf, hgs);
+                    (cast(AssertExp)es.exp).e1.expressionToBuffer(*buf, *hgs);
                     buf.put(')');
                     buf.writenl();
                     requireDo = false;
@@ -1370,7 +1384,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
                 else
                 {
                     buf.writenl();
-                    frequire.statementToBuffer(buf, hgs);
+                    frequire.statementToBuffer(*buf, *hgs);
                     requireDo = true;
                 }
             }
@@ -1390,7 +1404,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
                         buf.put(fensure.id.toString());
                     }
                     buf.put("; ");
-                    (cast(AssertExp)es.exp).e1.expressionToBuffer(buf, hgs);
+                    (cast(AssertExp)es.exp).e1.expressionToBuffer(*buf, *hgs);
                     buf.put(')');
                     buf.writenl();
                     requireDo = false;
@@ -1404,7 +1418,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
                         buf.put(')');
                     }
                     buf.writenl();
-                    fensure.ensure.statementToBuffer(buf, hgs);
+                    fensure.ensure.statementToBuffer(*buf, *hgs);
                     requireDo = true;
                 }
             }
@@ -1452,7 +1466,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         buf.put('{');
         buf.writenl();
         buf.level++;
-        f.fbody.statementToBuffer(buf, hgs);
+        f.fbody.statementToBuffer(*buf, *hgs);
         buf.level--;
         buf.put('}');
         buf.writenl();
@@ -1470,7 +1484,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         {
             if (i)
                 buf.put(", ");
-            typeToBuffer(b.type, null, buf, hgs);
+            typeToBuffer(b.type, null, *buf, *hgs);
         }
     }
 
@@ -1484,9 +1498,9 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         if (FuncDeclaration fd = onemember.isFuncDeclaration())
         {
             assert(fd.type);
-            if (stcToBuffer(buf, fd.storage_class))
+            if (stcToBuffer(*buf, fd.storage_class))
                 buf.put(' ');
-            functionToBufferFull(cast(TypeFunction)fd.type, buf, d.ident, hgs, d);
+            functionToBufferFull(cast(TypeFunction)fd.type, *buf, d.ident, *hgs, d);
             visitTemplateConstraint(d.constraint);
             hgs.tpltMember++;
             bodyToBuffer(fd);
@@ -1499,7 +1513,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
             buf.put(' ');
             buf.put(ad.ident.toString());
             buf.put('(');
-            visitTemplateParameters(hgs.ddoc ? d.origParameters : d.parameters, buf, hgs);
+            visitTemplateParameters(hgs.ddoc ? d.origParameters : d.parameters, *buf, *hgs);
             buf.put(')');
             visitTemplateConstraint(d.constraint);
             visitBaseClasses(ad.isClassDeclaration());
@@ -1511,7 +1525,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
                 buf.writenl();
                 buf.level++;
                 foreach (s; *ad.members)
-                    toCBuffer(s, buf, hgs);
+                    toCBuffer(s, *buf, *hgs);
                 buf.level--;
                 buf.put('}');
             }
@@ -1525,23 +1539,23 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         {
             if (d.constraint)
                 return false;
-            if (stcToBuffer(buf, vd.storage_class))
+            if (stcToBuffer(*buf, vd.storage_class))
                 buf.put(' ');
             if (vd.type)
-                typeToBuffer(vd.type, vd.ident, buf, hgs);
+                typeToBuffer(vd.type, vd.ident, *buf, *hgs);
             else
                 buf.put(vd.ident.toString());
             buf.put('(');
-            visitTemplateParameters(hgs.ddoc ? d.origParameters : d.parameters, buf, hgs);
+            visitTemplateParameters(hgs.ddoc ? d.origParameters : d.parameters, *buf, *hgs);
             buf.put(')');
             if (vd._init)
             {
                 buf.put(" = ");
                 ExpInitializer ie = vd._init.isExpInitializer();
                 if (ie && (ie.exp.op == EXP.construct || ie.exp.op == EXP.blit))
-                    (cast(AssignExp)ie.exp).e2.expressionToBuffer(buf, hgs);
+                    (cast(AssignExp)ie.exp).e2.expressionToBuffer(*buf, *hgs);
                 else
-                    vd._init.initializerToBuffer(buf, hgs);
+                    vd._init.initializerToBuffer(*buf, *hgs);
             }
             buf.put(';');
             buf.writenl();
@@ -1567,7 +1581,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         buf.put(' ');
         buf.put(d.ident.toString());
         buf.put('(');
-        visitTemplateParameters(hgs.ddoc ? d.origParameters : d.parameters, buf, hgs);
+        visitTemplateParameters(hgs.ddoc ? d.origParameters : d.parameters, *buf, *hgs);
         buf.put(')');
         if (!hgs.skipConstraints)
             visitTemplateConstraint(d.constraint);
@@ -1579,7 +1593,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
             buf.writenl();
             buf.level++;
             foreach (s; *d.members)
-                toCBuffer(s, buf, hgs);
+                toCBuffer(s, *buf, *hgs);
             buf.level--;
             buf.put('}');
             buf.writenl();
@@ -1590,20 +1604,20 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     void visitTemplateInstance(TemplateInstance ti)
     {
         buf.put(ti.name.toChars());
-        tiargsToBuffer(ti, buf, hgs);
+        tiargsToBuffer(ti, *buf, *hgs);
 
         if (hgs.fullDump)
         {
             buf.writenl();
-            dumpTemplateInstance(ti, buf, hgs);
+            dumpTemplateInstance(ti, *buf, *hgs);
         }
     }
 
     void visitTemplateMixin(TemplateMixin tm)
     {
         buf.put("mixin ");
-        typeToBuffer(tm.tqual, null, buf, hgs);
-        tiargsToBuffer(tm, buf, hgs);
+        typeToBuffer(tm.tqual, null, *buf, *hgs);
+        tiargsToBuffer(tm, *buf, *hgs);
         if (tm.ident && memcmp(tm.ident.toString().ptr, cast(const(char)*) "__mixin", 7) != 0)
         {
             buf.put(' ');
@@ -1612,7 +1626,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         buf.put(';');
         buf.writenl();
         if (hgs.fullDump)
-            dumpTemplateInstance(tm, buf, hgs);
+            dumpTemplateInstance(tm, *buf, *hgs);
     }
 
     void visitEnumDeclaration(EnumDeclaration d)
@@ -1628,7 +1642,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         if (d.memtype)
         {
             buf.put(" : ");
-            typeToBuffer(d.memtype, null, buf, hgs);
+            typeToBuffer(d.memtype, null, *buf, *hgs);
         }
         if (!d.members)
         {
@@ -1644,7 +1658,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         {
             if (!em)
                 continue;
-            toCBuffer(em, buf, hgs);
+            toCBuffer(em, *buf, *hgs);
             buf.put(',');
             buf.writenl();
         }
@@ -1685,7 +1699,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         buf.writenl();
         buf.level++;
         foreach (s; *d.members)
-            toCBuffer(s, buf, hgs);
+            toCBuffer(s, *buf, *hgs);
         buf.level--;
         buf.put('}');
         buf.writenl();
@@ -1710,7 +1724,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         buf.level++;
         hgs.insideAggregate++;
         foreach (s; *d.members)
-            toCBuffer(s, buf, hgs);
+            toCBuffer(s, *buf, *hgs);
         hgs.insideAggregate--;
         buf.level--;
         buf.put('}');
@@ -1734,7 +1748,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
             buf.level++;
             hgs.insideAggregate++;
             foreach (s; *d.members)
-                toCBuffer(s, buf, hgs);
+                toCBuffer(s, *buf, *hgs);
             hgs.insideAggregate--;
             buf.level--;
             buf.put('}');
@@ -1755,7 +1769,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         {
             buf.put(d.ident.toString());
             buf.put(" = ");
-            if (stcToBuffer(buf, d.storage_class))
+            if (stcToBuffer(*buf, d.storage_class))
                 buf.put(' ');
             /*
                 https://issues.dlang.org/show_bug.cgi?id=23223
@@ -1769,23 +1783,23 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
             if (!d.aliassym.isFuncLiteralDeclaration() && d.aliassym.ident)
                 buf.put(d.aliassym.ident.toString());
             else
-                toCBuffer(d.aliassym, buf, hgs);
+                toCBuffer(d.aliassym, *buf, *hgs);
         }
         else if (d.type.ty == Tfunction)
         {
-            if (stcToBuffer(buf, d.storage_class))
+            if (stcToBuffer(*buf, d.storage_class))
                 buf.put(' ');
-            typeToBuffer(d.type, d.ident, buf, hgs);
+            typeToBuffer(d.type, d.ident, *buf, *hgs);
         }
         else if (d.ident)
         {
             hgs.declstring = (d.ident == Id.string || d.ident == Id.wstring || d.ident == Id.dstring);
             buf.put(d.ident.toString());
             buf.put(" = ");
-            if (stcToBuffer(buf, d.storage_class))
+            if (stcToBuffer(*buf, d.storage_class))
                 buf.put(' ');
             hgs.inCAlias = hgs.importcHdr;
-            typeToBuffer(d.type, null, buf, hgs);
+            typeToBuffer(d.type, null, *buf, *hgs);
             hgs.inCAlias = false;
             hgs.declstring = false;
         }
@@ -1798,9 +1812,9 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         buf.put(d.ident.toString());
         buf.put(" = ");
         if (d.aliassym)
-            toCBuffer(d.aliassym, buf, hgs);
+            toCBuffer(d.aliassym, *buf, *hgs);
         else // d.type
-            typeToBuffer(d.type, null, buf, hgs);
+            typeToBuffer(d.type, null, *buf, *hgs);
         buf.put(';');
         buf.writenl();
     }
@@ -1809,7 +1823,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     {
         if (d.storage_class & STC.local)
             return;
-        visitVarDecl(d, false, buf, hgs);
+        visitVarDecl(d, false, *buf, *hgs);
         buf.put(';');
         buf.writenl();
     }
@@ -1820,9 +1834,9 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 
         // https://issues.dlang.org/show_bug.cgi?id=24891
         // return/scope storage classes are printed as part of function type
-        if (stcToBuffer(buf, f.storage_class & ~(STC.scope_ | STC.return_ | STC.returnScope | STC.returnRef)))
+        if (stcToBuffer(*buf, f.storage_class & ~(STC.scope_ | STC.return_ | STC.returnScope | STC.returnRef)))
             buf.put(' ');
-        typeToBuffer(f.type, f.ident, buf, hgs);
+        typeToBuffer(f.type, f.ident, *buf, *hgs);
         auto tf = f.type.isTypeFunction();
 
         if (hgs.hdrgen && tf)
@@ -1871,8 +1885,8 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         TypeFunction tf = cast(TypeFunction)f.type;
 
         if (!f.inferRetType && tf.next)
-            typeToBuffer(tf.next, null, buf, hgs);
-        parametersToBuffer(tf.parameterList, buf, hgs);
+            typeToBuffer(tf.next, null, *buf, *hgs);
+        parametersToBuffer(tf.parameterList, *buf, *hgs);
 
         // https://issues.dlang.org/show_bug.cgi?id=20074
         void printAttribute(string str)
@@ -1887,7 +1901,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
         if (auto result = arrowFuncLiteralResult(f))
         {
             buf.put(" => ");
-            result.expressionToBuffer(buf, hgs);
+            result.expressionToBuffer(*buf, *hgs);
         }
         else
         {
@@ -1899,7 +1913,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 
     void visitPostBlitDeclaration(PostBlitDeclaration d)
     {
-        if (stcToBuffer(buf, d.storage_class))
+        if (stcToBuffer(*buf, d.storage_class))
             buf.put(' ');
         buf.put("this(this)");
         bodyToBuffer(d);
@@ -1907,7 +1921,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 
     void visitDtorDeclaration(DtorDeclaration d)
     {
-        if (stcToBuffer(buf, d.storage_class))
+        if (stcToBuffer(*buf, d.storage_class))
             buf.put(' ');
         buf.put("~this()");
         bodyToBuffer(d);
@@ -1915,7 +1929,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 
     void visitStaticCtorDeclaration(StaticCtorDeclaration d)
     {
-        if (stcToBuffer(buf, d.storage_class & ~STC.static_))
+        if (stcToBuffer(*buf, d.storage_class & ~STC.static_))
             buf.put(' ');
         if (d.isSharedStaticCtorDeclaration())
             buf.put("shared ");
@@ -1931,7 +1945,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 
     void visitStaticDtorDeclaration(StaticDtorDeclaration d)
     {
-        if (stcToBuffer(buf, d.storage_class & ~STC.static_))
+        if (stcToBuffer(*buf, d.storage_class & ~STC.static_))
             buf.put(' ');
         if (d.isSharedStaticDtorDeclaration())
             buf.put("shared ");
@@ -1949,14 +1963,14 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     {
         if (hgs.hdrgen)
             return;
-        if (stcToBuffer(buf, d.storage_class))
+        if (stcToBuffer(*buf, d.storage_class))
             buf.put(' ');
         buf.put("invariant");
         auto es = d.fbody.isExpStatement();
         if (es && es.exp && es.exp.op == EXP.assert_)
         {
             buf.put(" (");
-            (cast(AssertExp)es.exp).e1.expressionToBuffer(buf, hgs);
+            (cast(AssertExp)es.exp).e1.expressionToBuffer(*buf, *hgs);
             buf.put(");");
             buf.writenl();
         }
@@ -1970,7 +1984,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     {
         if (hgs.hdrgen)
             return;
-        if (stcToBuffer(buf, d.storage_class))
+        if (stcToBuffer(*buf, d.storage_class))
             buf.put(' ');
         buf.put("unittest");
         bodyToBuffer(d);
@@ -1978,80 +1992,71 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 
     void visitBitFieldDeclaration(BitFieldDeclaration d)
     {
-        if (stcToBuffer(buf, d.storage_class))
+        if (stcToBuffer(*buf, d.storage_class))
             buf.put(' ');
         Identifier id = d.isAnonymous() ? null : d.ident;
-        typeToBuffer(d.type, id, buf, hgs);
+        typeToBuffer(d.type, id, *buf, *hgs);
         buf.put(" : ");
-        d.width.expressionToBuffer(buf, hgs);
+        d.width.expressionToBuffer(*buf, *hgs);
         buf.put(';');
         buf.writenl();
     }
 
     void visitNewDeclaration(NewDeclaration d)
     {
-        if (stcToBuffer(buf, d.storage_class & ~STC.static_))
+        if (stcToBuffer(*buf, d.storage_class & ~STC.static_))
             buf.put(' ');
         buf.put("new();");
     }
 
     void visitModule(Module m)
     {
-        moduleToBuffer2(m, buf, hgs);
+        moduleToBuffer2(m, *buf, *hgs);
     }
 
-    extern (C++)
-    final class DsymbolPrettyPrintVisitor : Visitor
-    {
-        alias visit = Visitor.visit;
-
-      public:
-      override:
-        void visit(Dsymbol s)                  { visitDsymbol(s); }
-        void visit(StaticAssert s)             { visitStaticAssert(s); }
-        void visit(DebugSymbol s)              { visitDebugSymbol(s); }
-        void visit(VersionSymbol s)            { visitVersionSymbol(s); }
-        void visit(EnumMember em)              { visitEnumMember(em); }
-        void visit(Import imp)                 { visitImport(imp); }
-        void visit(AliasThis d)                { visitAliasThis(d); }
-        void visit(AttribDeclaration d)        { visitAttribDeclaration(d); }
-        void visit(StorageClassDeclaration d)  { visitStorageClassDeclaration(d); }
-        void visit(DeprecatedDeclaration d)    { visitDeprecatedDeclaration(d); }
-        void visit(LinkDeclaration d)          { visitLinkDeclaration(d); }
-        void visit(CPPMangleDeclaration d)     { visitCPPMangleDeclaration(d); }
-        void visit(VisibilityDeclaration d)    { visitVisibilityDeclaration(d); }
-        void visit(AlignDeclaration d)         { visitAlignDeclaration(d); }
-        void visit(AnonDeclaration d)          { visitAnonDeclaration(d); }
-        void visit(PragmaDeclaration d)        { visitPragmaDeclaration(d); }
-        void visit(ConditionalDeclaration d)   { visitConditionalDeclaration(d); }
-        void visit(StaticForeachDeclaration s) { visitStaticForeachDeclaration(s); }
-        void visit(MixinDeclaration d)         { visitMixinDeclaration(d); }
-        void visit(UserAttributeDeclaration d) { visitUserAttributeDeclaration(d); }
-        void visit(TemplateDeclaration d)      { visitTemplateDeclaration(d); }
-        void visit(TemplateInstance ti)        { visitTemplateInstance(ti); }
-        void visit(TemplateMixin tm)           { visitTemplateMixin(tm); }
-        void visit(EnumDeclaration d)          { visitEnumDeclaration(d); }
-        void visit(Nspace d)                   { visitNspace(d); }
-        void visit(StructDeclaration d)        { visitStructDeclaration(d); }
-        void visit(ClassDeclaration d)         { visitClassDeclaration(d); }
-        void visit(AliasDeclaration d)         { visitAliasDeclaration(d); }
-        void visit(AliasAssign d)              { visitAliasAssign(d); }
-        void visit(VarDeclaration d)           { visitVarDeclaration(d); }
-        void visit(FuncDeclaration f)          { visitFuncDeclaration(f); }
-        void visit(FuncLiteralDeclaration f)   { visitFuncLiteralDeclaration(f); }
-        void visit(PostBlitDeclaration d)      { visitPostBlitDeclaration(d); }
-        void visit(DtorDeclaration d)          { visitDtorDeclaration(d); }
-        void visit(StaticCtorDeclaration d)    { visitStaticCtorDeclaration(d); }
-        void visit(StaticDtorDeclaration d)    { visitStaticDtorDeclaration(d); }
-        void visit(InvariantDeclaration d)     { visitInvariantDeclaration(d); }
-        void visit(UnitTestDeclaration d)      { visitUnitTestDeclaration(d); }
-        void visit(BitFieldDeclaration d)      { visitBitFieldDeclaration(d); }
-        void visit(NewDeclaration d)           { visitNewDeclaration(d); }
-        void visit(Module m)                   { visitModule(m); }
-    }
-
-    scope v = new DsymbolPrettyPrintVisitor();
-    s.accept(v);
+    public:
+    override:
+    void visit(Dsymbol s)                  { visitDsymbol(s); }
+    void visit(StaticAssert s)             { visitStaticAssert(s); }
+    void visit(DebugSymbol s)              { visitDebugSymbol(s); }
+    void visit(VersionSymbol s)            { visitVersionSymbol(s); }
+    void visit(EnumMember em)              { visitEnumMember(em); }
+    void visit(Import imp)                 { visitImport(imp); }
+    void visit(AliasThis d)                { visitAliasThis(d); }
+    void visit(AttribDeclaration d)        { visitAttribDeclaration(d); }
+    void visit(StorageClassDeclaration d)  { visitStorageClassDeclaration(d); }
+    void visit(DeprecatedDeclaration d)    { visitDeprecatedDeclaration(d); }
+    void visit(LinkDeclaration d)          { visitLinkDeclaration(d); }
+    void visit(CPPMangleDeclaration d)     { visitCPPMangleDeclaration(d); }
+    void visit(VisibilityDeclaration d)    { visitVisibilityDeclaration(d); }
+    void visit(AlignDeclaration d)         { visitAlignDeclaration(d); }
+    void visit(AnonDeclaration d)          { visitAnonDeclaration(d); }
+    void visit(PragmaDeclaration d)        { visitPragmaDeclaration(d); }
+    void visit(ConditionalDeclaration d)   { visitConditionalDeclaration(d); }
+    void visit(StaticForeachDeclaration s) { visitStaticForeachDeclaration(s); }
+    void visit(MixinDeclaration d)         { visitMixinDeclaration(d); }
+    void visit(UserAttributeDeclaration d) { visitUserAttributeDeclaration(d); }
+    void visit(TemplateDeclaration d)      { visitTemplateDeclaration(d); }
+    void visit(TemplateInstance ti)        { visitTemplateInstance(ti); }
+    void visit(TemplateMixin tm)           { visitTemplateMixin(tm); }
+    void visit(EnumDeclaration d)          { visitEnumDeclaration(d); }
+    void visit(Nspace d)                   { visitNspace(d); }
+    void visit(StructDeclaration d)        { visitStructDeclaration(d); }
+    void visit(ClassDeclaration d)         { visitClassDeclaration(d); }
+    void visit(AliasDeclaration d)         { visitAliasDeclaration(d); }
+    void visit(AliasAssign d)              { visitAliasAssign(d); }
+    void visit(VarDeclaration d)           { visitVarDeclaration(d); }
+    void visit(FuncDeclaration f)          { visitFuncDeclaration(f); }
+    void visit(FuncLiteralDeclaration f)   { visitFuncLiteralDeclaration(f); }
+    void visit(PostBlitDeclaration d)      { visitPostBlitDeclaration(d); }
+    void visit(DtorDeclaration d)          { visitDtorDeclaration(d); }
+    void visit(StaticCtorDeclaration d)    { visitStaticCtorDeclaration(d); }
+    void visit(StaticDtorDeclaration d)    { visitStaticDtorDeclaration(d); }
+    void visit(InvariantDeclaration d)     { visitInvariantDeclaration(d); }
+    void visit(UnitTestDeclaration d)      { visitUnitTestDeclaration(d); }
+    void visit(BitFieldDeclaration d)      { visitBitFieldDeclaration(d); }
+    void visit(NewDeclaration d)           { visitNewDeclaration(d); }
+    void visit(Module m)                   { visitModule(m); }
 }
 
 // Note: this function is not actually `const`, because iterating the

--- a/compiler/src/dmd/iasm/dmdx86.d
+++ b/compiler/src/dmd/iasm/dmdx86.d
@@ -2407,7 +2407,7 @@ L2:
  */
 
 void asm_make_modrm_byte(
-        void delegate(ubyte) emit,
+        scope void delegate(ubyte) emit,
         code* pc,
         opflag_t usFlags,
         scope OPND[] opnds)

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -3363,7 +3363,7 @@ class Lexer
      * Params:
      *    sink = send characters in the line to this delegate
      */
-    final void skipToNextLine(void delegate(char c) nothrow sink = null)
+    final void skipToNextLine(scope void delegate(char c) nothrow sink = null)
     {
         while (1)
         {

--- a/compiler/src/dmd/lib/scanelf.d
+++ b/compiler/src/dmd/lib/scanelf.d
@@ -34,7 +34,7 @@ enum LOG = false;
  *      eSink =       where the error messages go
  */
 package(dmd.lib)
-void scanElfObjModule(void delegate(const(char)[] name, int pickAny) nothrow pAddSymbol,
+void scanElfObjModule(scope void delegate(const(char)[] name, int pickAny) nothrow pAddSymbol,
         scope const ubyte[] base, const char* module_name, const(char)[] filename, ErrorSink eSink)
 {
     static if (LOG)

--- a/compiler/src/dmd/lib/scanmach.d
+++ b/compiler/src/dmd/lib/scanmach.d
@@ -35,7 +35,7 @@ private enum LOG = false;
  *      eSink =       where the error messages go
  */
 package(dmd.lib)
-void scanMachObjModule(void delegate(const(char)[] name, int pickAny) nothrow pAddSymbol,
+void scanMachObjModule(scope void delegate(const(char)[] name, int pickAny) nothrow pAddSymbol,
         const ubyte[] base, const char* module_name, const(char)[] filename, ErrorSink eSink)
 {
     static if (LOG)

--- a/compiler/src/dmd/lib/scanmscoff.d
+++ b/compiler/src/dmd/lib/scanmscoff.d
@@ -35,7 +35,7 @@ private enum LOG = false;
  *      eSink =       where the error messages go
  */
 package(dmd.lib)
-void scanMSCoffObjModule(void delegate(const(char)[] name, int pickAny) nothrow pAddSymbol,
+void scanMSCoffObjModule(scope void delegate(const(char)[] name, int pickAny) nothrow pAddSymbol,
         scope const ubyte[] base, const char* module_name, const(char)[] filename, ErrorSink eSink)
 {
     static if (LOG)

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1335,7 +1335,7 @@ public int runPreprocessor(Loc loc, const(char)[] cpp, const(char)[] filename, c
  *      https://github.com/dlang/visuald/blob/master/tools/pipedmd.d#L252
  */
 version (Windows)
-int runProcessCollectStdout(const(wchar)* szCommand, ubyte[] buffer, void delegate(ubyte[]) sink)
+int runProcessCollectStdout(const(wchar)* szCommand, ubyte[] buffer, scope void delegate(ubyte[]) sink)
 {
     //printf("runProcess() command: %ls\n", szCommand);
     // Set the bInheritHandle flag so pipe handles are inherited.

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2615,7 +2615,7 @@ const(char*)[2] toAutoQualChars(Type t1, Type t2)
  * For each active modifier (MODFlags.const_, MODFlags.immutable_, etc) call `fp` with a
  * void* for the work param and a string representation of the attribute.
  */
-void modifiersApply(const TypeFunction tf, void delegate(string) dg)
+void modifiersApply(const TypeFunction tf, scope void delegate(string) dg)
 {
     immutable ubyte[4] modsArr = [MODFlags.const_, MODFlags.immutable_, MODFlags.wild, MODFlags.shared_];
 
@@ -2632,7 +2632,7 @@ void modifiersApply(const TypeFunction tf, void delegate(string) dg)
  * For each active attribute (ref/const/nogc/etc) call `fp` with a void* for the
  * work param and a string representation of the attribute.
  */
-void attributesApply(const TypeFunction tf, void delegate(string) dg, TRUSTformat trustFormat = TRUSTformatDefault)
+void attributesApply(const TypeFunction tf, scope void delegate(string) dg, TRUSTformat trustFormat = TRUSTformatDefault)
 {
     if (tf.purity)
         dg("pure");

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -1353,8 +1353,8 @@ void genKill(ref ObState obstate, ObNode* ob)
             ObNode* ob;
             ObState* obstate;
 
-            extern (D) this(void delegate(ObNode*, VarDeclaration, Expression, bool) dgWriteVar,
-                            void delegate(Loc loc, ObNode* ob, VarDeclaration v, bool mutable) dgReadVar,
+            extern (D) this(scope void delegate(ObNode*, VarDeclaration, Expression, bool) dgWriteVar,
+                            scope void delegate(Loc loc, ObNode* ob, VarDeclaration v, bool mutable) dgReadVar,
                             ObNode* ob, ref ObState obstate) scope
             {
                 this.dgWriteVar = dgWriteVar;
@@ -2108,8 +2108,8 @@ void checkObErrors(ref ObState obstate)
             ObNode* ob;
             ObState* obstate;
 
-            extern (D) this(void delegate(Loc loc, ObNode* ob, VarDeclaration v, bool mutable, PtrVarState[]) dgReadVar,
-                            void delegate(ObNode*, PtrVarState[], VarDeclaration, Expression) dgWriteVar,
+            extern (D) this(scope void delegate(Loc loc, ObNode* ob, VarDeclaration v, bool mutable, PtrVarState[]) dgReadVar,
+                            scope void delegate(ObNode*, PtrVarState[], VarDeclaration, Expression) dgWriteVar,
                             PtrVarState[] cpvs, ObNode* ob, ref ObState obstate) scope
             {
                 this.dgReadVar  = dgReadVar;

--- a/compiler/src/dmd/root/rmem.d
+++ b/compiler/src/dmd/root/rmem.d
@@ -385,6 +385,8 @@ class BumpPointerGC : GCInterface
     {
         if (bits & GC.BlkAttr.APPENDABLE)
             return gc.malloc(size, bits, ti);
+        version (none)
+            assert(ti, "unexpected malloc, this usually happens for closure allocations");
         allocated += size;
         return allocmemoryNoFree(size);
     }

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -78,6 +78,8 @@ bool hasSideEffect(Expression e, bool assumeImpureCalls = false)
     extern (C++) final class LambdaHasSideEffect : StoppableVisitor
     {
         alias visit = typeof(super).visit;
+        Expression e;
+        bool assumeImpureCalls;
     public:
         extern (D) this() scope @safe
         {
@@ -91,6 +93,8 @@ bool hasSideEffect(Expression e, bool assumeImpureCalls = false)
     }
 
     scope LambdaHasSideEffect v = new LambdaHasSideEffect();
+    v.e = e;
+    v.assumeImpureCalls = assumeImpureCalls;
     return walkPostorder(e, v);
 }
 

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -5707,7 +5707,7 @@ bool TemplateInstance_semanticTiargs(Loc loc, Scope* sc, Objects* tiargs, int fl
  *      errorHelper = delegate to send error message to if not null
  */
 void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiargs,
-    Type tthis, ArgumentList argumentList, void delegate(const(char)*, Loc argloc = Loc.initial) scope errorHelper = null)
+    Type tthis, ArgumentList argumentList, scope void delegate(const(char)*, Loc argloc = Loc.initial) scope errorHelper = null)
 {
     version (none)
     {
@@ -6760,6 +6760,15 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
         alias visit = Visitor.visit;
     public:
         MATCH result;
+        RootObject o;
+
+        Scope* sc;
+        Type tparam;
+        TemplateParameters* parameters;
+        Objects* dedtypes;
+        uint* wm;
+        size_t inferStart;
+        bool ignoreAliasThis;
 
         extern (D) this() @safe
         {
@@ -6777,25 +6786,25 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
             if (tparam.ty == Tident)
             {
                 // Determine which parameter tparam is
-                size_t i = templateParameterLookup(tparam, &parameters);
+                size_t i = templateParameterLookup(tparam, parameters);
                 if (i == IDX_NOTFOUND)
                 {
                     if (!sc)
                         goto Lnomatch;
 
                     /* Need a loc to go with the semantic routine. */
-                    Loc loc = semanticLoc(parameters);
+                    Loc loc = semanticLoc(*parameters);
 
                     /* BUG: what if tparam is a template instance, that
                      * has as an argument another Tident?
                      */
                     tparam = tparam.typeSemantic(loc, sc);
                     assert(tparam.ty != Tident);
-                    result = deduceType(t, sc, tparam, parameters, dedtypes, wm);
+                    result = deduceType(t, sc, tparam, *parameters, *dedtypes, wm);
                     return;
                 }
 
-                TemplateParameter tp = parameters[i];
+                TemplateParameter tp = (*parameters)[i];
 
                 TypeIdentifier tident = tparam.isTypeIdentifier();
                 if (tident.idents.length > 0)
@@ -6835,21 +6844,21 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                         Type tt = dmd.dsymbolsem.getType(s);
                         if (!tt)
                             goto Lnomatch;
-                        Type at = cast(Type)dedtypes[i];
+                        Type at = cast(Type)(*dedtypes)[i];
                         if (at && at.ty == Tnone)
                             at = (cast(TypeDeduced)at).tded;
                         if (!at || tt.equals(at))
                         {
-                            dedtypes[i] = tt;
+                            (*dedtypes)[i] = tt;
                             goto Lexact;
                         }
                     }
                     if (tp.isTemplateAliasParameter())
                     {
-                        Dsymbol s2 = cast(Dsymbol)dedtypes[i];
+                        Dsymbol s2 = cast(Dsymbol)(*dedtypes)[i];
                         if (!s2 || s == s2)
                         {
-                            dedtypes[i] = s;
+                            (*dedtypes)[i] = s;
                             goto Lexact;
                         }
                     }
@@ -6871,7 +6880,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 +/
                 if (auto ta = tp.isTemplateAliasParameter())
                 {
-                    dedtypes[i] = t;
+                    (*dedtypes)[i] = t;
                     goto Lexact;
                 }
                 // (23578) - ensure previous behaviour for non-alias template params
@@ -6880,14 +6889,14 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                     goto Lnomatch;
                 }
 
-                Type at = cast(Type)dedtypes[i];
+                Type at = cast(Type)(*dedtypes)[i];
                 Type tt;
                 if (ubyte wx = wm ? deduceWildHelper(t, &tt, tparam) : 0)
                 {
                     // type vs (none)
                     if (!at)
                     {
-                        dedtypes[i] = tt;
+                        (*dedtypes)[i] = tt;
                         *wm |= wx;
                         result = MATCH.constant;
                         return;
@@ -6900,7 +6909,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                         result = xt.matchAll(tt);
                         if (result > MATCH.nomatch)
                         {
-                            dedtypes[i] = tt;
+                            (*dedtypes)[i] = tt;
                             if (result > MATCH.constant)
                                 result = MATCH.constant; // limit level for inout matches
                         }
@@ -6910,18 +6919,18 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                     // type vs type
                     if (tt.equals(at))
                     {
-                        dedtypes[i] = tt; // Prefer current type match
+                        (*dedtypes)[i] = tt; // Prefer current type match
                         goto Lconst;
                     }
                     if (tt.implicitConvTo(at.constOf()))
                     {
-                        dedtypes[i] = at.constOf().mutableOf();
+                        (*dedtypes)[i] = at.constOf().mutableOf();
                         *wm |= MODFlags.const_;
                         goto Lconst;
                     }
                     if (at.implicitConvTo(tt.constOf()))
                     {
-                        dedtypes[i] = tt.constOf().mutableOf();
+                        (*dedtypes)[i] = tt.constOf().mutableOf();
                         *wm |= MODFlags.const_;
                         goto Lconst;
                     }
@@ -6932,7 +6941,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                     // type vs (none)
                     if (!at)
                     {
-                        dedtypes[i] = tt;
+                        (*dedtypes)[i] = tt;
                         result = m;
                         return;
                     }
@@ -6944,7 +6953,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                         result = xt.matchAll(tt);
                         if (result > MATCH.nomatch)
                         {
-                            dedtypes[i] = tt;
+                            (*dedtypes)[i] = tt;
                         }
                         return;
                     }
@@ -6970,7 +6979,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
             if (tparam.ty == Ttypeof)
             {
                     /* Need a loc to go with the semantic routine. */
-                    Loc loc = semanticLoc(parameters);
+                    Loc loc = semanticLoc(*parameters);
 
                 tparam = tparam.typeSemantic(loc, sc);
             }
@@ -6985,7 +6994,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 MATCH m = t.implicitConvTo(tparam);
                 if (m == MATCH.nomatch && !ignoreAliasThis)
                 {
-                    m = deduceAliasThis(t, sc, tparam, parameters, dedtypes, wm);
+                    m = deduceAliasThis(t, sc, tparam, *parameters, *dedtypes, wm);
                 }
                 result = m;
                 return;
@@ -7007,7 +7016,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                     tpn = tpn.substWildTo(MODFlags.mutable);
                 }
 
-                result = deduceType(t.nextOf(), sc, tpn, parameters, dedtypes, wm);
+                result = deduceType(t.nextOf(), sc, tpn, *parameters, *dedtypes, wm);
                 return;
             }
 
@@ -7027,7 +7036,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
         {
             if (auto tp = tparam.isTypeVector())
             {
-                result = deduceType(t.basetype, sc, tp.basetype, parameters, dedtypes, wm);
+                result = deduceType(t.basetype, sc, tp.basetype, *parameters, *dedtypes, wm);
                 return;
             }
             visit(cast(Type)t);
@@ -7049,7 +7058,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
 
             if (tparam.ty == Tarray)
             {
-                MATCH m = deduceType(t.next, sc, tparam.nextOf(), parameters, dedtypes, wm);
+                MATCH m = deduceType(t.next, sc, tparam.nextOf(), *parameters, *dedtypes, wm);
                 result = (m >= MATCH.constant) ? MATCH.convert : MATCH.nomatch;
                 return;
             }
@@ -7062,18 +7071,18 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 if (tsa.dim.isVarExp() && tsa.dim.isVarExp().var.storage_class & STC.templateparameter)
                 {
                     Identifier id = tsa.dim.isVarExp().var.ident;
-                    i = templateIdentifierLookup(id, &parameters);
+                    i = templateIdentifierLookup(id, parameters);
                     assert(i != IDX_NOTFOUND);
-                    tp = parameters[i];
+                    tp = (*parameters)[i];
                 }
                 else
                     edim = tsa.dim;
             }
             else if (auto taa = tparam.isTypeAArray())
             {
-                i = templateParameterLookup(taa.index, &parameters);
+                i = templateParameterLookup(taa.index, parameters);
                 if (i != IDX_NOTFOUND)
-                    tp = parameters[i];
+                    tp = (*parameters)[i];
                 else
                 {
                     Loc loc;
@@ -7082,7 +7091,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                     // so we use that for the resolution (better error message).
                     if (inferStart < parameters.length)
                     {
-                        TemplateParameter loctp = parameters[inferStart];
+                        TemplateParameter loctp = (*parameters)[inferStart];
                         loc = loctp.loc;
                     }
 
@@ -7093,11 +7102,11 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                     edim = s ? getValue(s) : getValue(e);
                 }
             }
-            if ((tp && tp.matchArg(sc, t.dim, i, &parameters, dedtypes, null)) ||
+            if ((tp && tp.matchArg(sc, t.dim, i, parameters, *dedtypes, null)) ||
                 (edim && edim.isIntegerExp() && edim.toInteger() == t.dim.toInteger())
             )
             {
-                result = deduceType(t.next, sc, tparam.nextOf(), parameters, dedtypes, wm);
+                result = deduceType(t.next, sc, tparam.nextOf(), *parameters, *dedtypes, wm);
                 return;
             }
 
@@ -7110,7 +7119,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
             if (tparam && tparam.ty == Taarray)
             {
                 TypeAArray tp = tparam.isTypeAArray();
-                if (!deduceType(t.index, sc, tp.index, parameters, dedtypes))
+                if (!deduceType(t.index, sc, tp.index, *parameters, *dedtypes))
                 {
                     result = MATCH.nomatch;
                     return;
@@ -7147,7 +7156,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
 
                 // https://issues.dlang.org/show_bug.cgi?id=15243
                 // Resolve parameter type if it's not related with template parameters
-                if (!reliesOnTemplateParameters(fparam.type, parameters[inferStart .. parameters.length]))
+                if (!reliesOnTemplateParameters(fparam.type, (*parameters)[inferStart .. parameters.length]))
                 {
                     auto tx = fparam.type.typeSemantic(Loc.initial, sc);
                     if (tx.ty == Terror)
@@ -7162,7 +7171,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
             const size_t nfargs = t.parameterList.length;
             size_t nfparams = tp.parameterList.length;
 
-            if (!deduceFunctionTuple(t, tp, parameters, dedtypes, nfargs, nfparams))
+            if (!deduceFunctionTuple(t, tp, *parameters, *dedtypes, nfargs, nfparams))
             {
                 result = MATCH.nomatch;
                 return;
@@ -7178,7 +7187,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 Parameter a = t.parameterList[i];
 
                 if (!a.isCovariant(t.isRef, ap) ||
-                    !deduceType(a.type, sc, ap.type, parameters, dedtypes))
+                    !deduceType(a.type, sc, ap.type, *parameters, *dedtypes))
                 {
                     result = MATCH.nomatch;
                     return;
@@ -7231,7 +7240,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 /* Handle case of:
                  *  template Foo(T : sa!(T), alias sa)
                  */
-                size_t i = templateIdentifierLookup(tp.tempinst.name, &parameters);
+                size_t i = templateIdentifierLookup(tp.tempinst.name, parameters);
                 if (i == IDX_NOTFOUND)
                 {
                     /* Didn't find it as a parameter identifier. Try looking
@@ -7276,15 +7285,15 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                     goto Lnomatch;
                 }
 
-                TemplateParameter tpx = parameters[i];
-                if (!tpx.matchArg(sc, tempdecl, i, &parameters, dedtypes, null))
+                TemplateParameter tpx = (*parameters)[i];
+                if (!tpx.matchArg(sc, tempdecl, i, parameters, *dedtypes, null))
                     goto Lnomatch;
             }
             else if (tempdecl != tp.tempinst.tempdecl)
                 goto Lnomatch;
 
         L2:
-            if (!resolveTemplateInstantiation(sc, &parameters, t.tempinst.tiargs, &t.tempinst.tdtypes, tempdecl, tp, &dedtypes))
+            if (!resolveTemplateInstantiation(sc, parameters, t.tempinst.tiargs, &t.tempinst.tdtypes, tempdecl, tp, dedtypes))
                 goto Lnomatch;
 
             visit(cast(Type)t);
@@ -7308,7 +7317,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 if (ti && ti.toAlias() == t.sym)
                 {
                     auto tx = new TypeInstance(Loc.initial, ti);
-                    auto m = deduceType(tx, sc, tparam, parameters, dedtypes, wm);
+                    auto m = deduceType(tx, sc, tparam, *parameters, *dedtypes, wm);
                     // if we have a no match we still need to check alias this
                     if (m != MATCH.nomatch)
                     {
@@ -7318,7 +7327,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 }
 
                 TypeInstance tpi = tparam.isTypeInstance();
-                auto m = deduceParentInstance(sc, t.sym, tpi, parameters, dedtypes, wm);
+                auto m = deduceParentInstance(sc, t.sym, tpi, *parameters, *dedtypes, wm);
                 if (m != MATCH.nomatch)
                 {
                     result = m;
@@ -7358,7 +7367,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
             Type tb = t.toBasetype();
             if (tb.ty == tparam.ty || tb.ty == Tsarray && tparam.ty == Taarray)
             {
-                result = deduceType(tb, sc, tparam, parameters, dedtypes, wm);
+                result = deduceType(tb, sc, tparam, *parameters, *dedtypes, wm);
                 if (result == MATCH.exact)
                     result = MATCH.convert;
                 return;
@@ -7381,7 +7390,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 if (ti && ti.toAlias() == t.sym)
                 {
                     auto tx = new TypeInstance(Loc.initial, ti);
-                    MATCH m = deduceType(tx, sc, tparam, parameters, dedtypes, wm);
+                    MATCH m = deduceType(tx, sc, tparam, *parameters, *dedtypes, wm);
                     // Even if the match fails, there is still a chance it could match
                     // a base class.
                     if (m != MATCH.nomatch)
@@ -7392,7 +7401,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 }
 
                 TypeInstance tpi = tparam.isTypeInstance();
-                auto m = deduceParentInstance(sc, t.sym, tpi, parameters, dedtypes, wm);
+                auto m = deduceParentInstance(sc, t.sym, tpi, *parameters, *dedtypes, wm);
                 if (m != MATCH.nomatch)
                 {
                     result = m;
@@ -7418,12 +7427,12 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 while (s && s.baseclasses.length > 0)
                 {
                     // Test the base class
-                    deduceBaseClassParameters(*(*s.baseclasses)[0], sc, tparam, parameters, dedtypes, *best, numBaseClassMatches);
+                    deduceBaseClassParameters(*(*s.baseclasses)[0], sc, tparam, *parameters, *dedtypes, *best, numBaseClassMatches);
 
                     // Test the interfaces inherited by the base class
                     foreach (b; s.interfaces)
                     {
-                        deduceBaseClassParameters(*b, sc, tparam, parameters, dedtypes, *best, numBaseClassMatches);
+                        deduceBaseClassParameters(*b, sc, tparam, *parameters, *dedtypes, *best, numBaseClassMatches);
                     }
                     s = (*s.baseclasses)[0].sym;
                 }
@@ -7460,26 +7469,26 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
         override void visit(Expression e)
         {
             //printf("Expression.deduceType(e = %s)\n", e.toChars());
-            size_t i = templateParameterLookup(tparam, &parameters);
+            size_t i = templateParameterLookup(tparam, parameters);
             if (i == IDX_NOTFOUND || tparam.isTypeIdentifier().idents.length > 0)
             {
                 if (e == emptyArrayElement && tparam.ty == Tarray)
                 {
                     Type tn = (cast(TypeNext)tparam).next;
-                    result = deduceType(emptyArrayElement, sc, tn, parameters, dedtypes, wm);
+                    result = deduceType(emptyArrayElement, sc, tn, *parameters, *dedtypes, wm);
                     return;
                 }
                 e.type.accept(this);
                 return;
             }
 
-            TemplateTypeParameter tp = parameters[i].isTemplateTypeParameter();
+            TemplateTypeParameter tp = (*parameters)[i].isTemplateTypeParameter();
             if (!tp)
                 return; // nomatch
 
             if (e == emptyArrayElement)
             {
-                if (dedtypes[i])
+                if ((*dedtypes)[i])
                 {
                     result = MATCH.exact;
                     return;
@@ -7491,7 +7500,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 }
             }
 
-            Type at = cast(Type)dedtypes[i];
+            Type at = cast(Type)(*dedtypes)[i];
             Type tt;
             if (ubyte wx = deduceWildHelper(e.type, &tt, tparam))
             {
@@ -7519,7 +7528,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
             // expression vs (none)
             if (!at)
             {
-                dedtypes[i] = new TypeDeduced(tt, e, tparam);
+                (*dedtypes)[i] = new TypeDeduced(tt, e, tparam);
                 return;
             }
 
@@ -7577,7 +7586,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 if (xt)
                     xt.update(tt, e, tparam);
                 else
-                    dedtypes[i] = tt;
+                    (*dedtypes)[i] = tt;
                 result = match1;
                 return;
             }
@@ -7597,7 +7606,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 if (xt)
                     xt.update(t, e, tparam);
                 else
-                    dedtypes[i] = t;
+                    (*dedtypes)[i] = t;
 
                 pt = tt.addMod(tparam.mod);
                 if (*wm)
@@ -7619,7 +7628,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
             assert(tparam.ty == Tarray);
 
             Type tn = (cast(TypeNext)tparam).next;
-            return deduceType(emptyArrayElement, sc, tn, parameters, dedtypes, wm);
+            return deduceType(emptyArrayElement, sc, tn, *parameters, *dedtypes, wm);
         }
 
         override void visit(NullExp e)
@@ -7661,7 +7670,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 result = MATCH.exact;
                 if (e.basis)
                 {
-                    MATCH m = deduceType(e.basis, sc, tn, parameters, dedtypes, wm);
+                    MATCH m = deduceType(e.basis, sc, tn, *parameters, *dedtypes, wm);
                     if (m < result)
                         result = m;
                 }
@@ -7671,7 +7680,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                         break;
                     if (!el)
                         continue;
-                    MATCH m = deduceType(el, sc, tn, parameters, dedtypes, wm);
+                    MATCH m = deduceType(el, sc, tn, *parameters, *dedtypes, wm);
                     if (m < result)
                         result = m;
                 }
@@ -7696,12 +7705,12 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 result = MATCH.exact;
                 foreach (i, key; *e.keys)
                 {
-                    MATCH m1 = deduceType(key, sc, taa.index, parameters, dedtypes, wm);
+                    MATCH m1 = deduceType(key, sc, taa.index, *parameters, *dedtypes, wm);
                     if (m1 < result)
                         result = m1;
                     if (result == MATCH.nomatch)
                         break;
-                    MATCH m2 = deduceType((*e.values)[i], sc, taa.next, parameters, dedtypes, wm);
+                    MATCH m2 = deduceType((*e.values)[i], sc, taa.next, *parameters, *dedtypes, wm);
                     if (m2 < result)
                         result = m2;
                     if (result == MATCH.nomatch)
@@ -7742,7 +7751,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 foreach (pto; *tof.parameterList.parameters)
                 {
                     Type pt = pto.type;
-                    if (!reliesOnTemplateParameters(pt, parameters[inferStart .. parameters.length]))
+                    if (!reliesOnTemplateParameters(pt, (*parameters)[inferStart .. parameters.length]))
                     {
                         pt = pt.syntaxCopy().typeSemantic(e.loc, sc);
                         if (pt.ty == Terror)
@@ -7782,7 +7791,7 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                     Type t = (*expandedTypes)[u];
                     if (!t)
                         break;
-                    if (reliesOnTemplateParameters(t, parameters[inferStart .. parameters.length]))
+                    if (reliesOnTemplateParameters(t, (*parameters)[inferStart .. parameters.length]))
                         return;
                     // https://issues.dlang.org/show_bug.cgi?id=11774
                     t = t.syntaxCopy();
@@ -7852,6 +7861,13 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
     }
 
     scope DeduceType v = new DeduceType();
+    v.sc = sc;
+    v.tparam = tparam;
+    v.parameters = &parameters;
+    v.dedtypes = &dedtypes;
+    v.wm = wm;
+    v.inferStart = inferStart;
+    v.ignoreAliasThis = ignoreAliasThis;
     if (Type t = isType(o))
         t.accept(v);
     else if (Expression e = isExpression(o))

--- a/compiler/src/dmd/timetrace.d
+++ b/compiler/src/dmd/timetrace.d
@@ -151,7 +151,7 @@ void timeTraceEndEvent(TimeTraceEventType eventType, Dsymbol sym, scope const(ch
         timeTraceProfiler.endScope(
             eventType,
             () => sym.isImport() ? sym.toPrettyChars().toDString() : sym.toChars().toDString(),
-            detail ? detail : () => sym.toPrettyChars().toDString(),
+            () => detail ? detail() : sym.toPrettyChars().toDString(),
             sym.loc
         );
     }

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -410,7 +410,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         return null;
     }
 
-    IntegerExp isX(T)(bool delegate(T) fp)
+    IntegerExp isX(T)(scope bool delegate(T) fp)
     {
         if (!dim)
             return False();
@@ -443,7 +443,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     alias isDeclX = isX!Declaration;
     alias isFuncX = isX!FuncDeclaration;
 
-    Expression isPkgX(bool function(Package) fp)
+    Expression isPkgX(scope bool function(Package) fp)
     {
         return isDsymX((Dsymbol sym) {
             Package p = resolveIsPackage(sym);

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -2171,7 +2171,7 @@ extern(D) Expressions* resolveNamedArgs(TypeFunction tf, ArgumentList argumentLi
  *      MATCHxxxx
  */
 extern (D) MATCH callMatch(FuncDeclaration fd, TypeFunction tf, Type tthis, ArgumentList argumentList,
-        int flag = 0, void delegate(const(char)*, Loc argloc = Loc.initial) scope errorHelper = null, Scope* sc = null)
+        int flag = 0, scope void delegate(const(char)*, Loc argloc = Loc.initial) scope errorHelper = null, Scope* sc = null)
 {
     //printf("callMatch() fd: %s, tf: %s\n", fd ? fd.ident.toChars() : "null", toChars(tf));
     MATCH match = MATCH.exact; // assume exact match


### PR DESCRIPTION
While debugging #23557 I noticed quite a few closure allocations happen during compilation. I guess these are unexpected in dmd, so let's get rid of them.

The assert in BumpGC.malloc triggers for such an allocation in debug builds, maybe it needs to be versioned for older host compiler versions or other backends that don't yet fully support the templated `new`.