### PR TITLE
Two small fixes for `__builtins_msvc` when targeting AArch64.

### DIFF
--- a/druntime/src/__builtins_msvc.d
+++ b/druntime/src/__builtins_msvc.d
@@ -1527,13 +1527,13 @@ version (MSVCIntrinsics)
             prefetchData!(false, 3)(address);
         }
 
-        /* This is trusted so that it's @safe without DIP1000 enabled. */
         @safe pure nothrow @nogc unittest
         {
             static bool test()
             {
                 immutable(int) x;
-                __prefetch(&x);
+                /* This is trusted so that it's @safe without DIP1000 enabled. */
+                __prefetch((() @trusted => &x)());
                 return true;
             }
 

--- a/druntime/src/__builtins_msvc.d
+++ b/druntime/src/__builtins_msvc.d
@@ -1357,9 +1357,18 @@ version (MSVCIntrinsics)
         }
     }
 
+    version (X86_64_Or_X86)
+    {
+        /* prfchw forces prefetchw to be emitted on x86 (which is how MSVC behaves). */
+        private enum prefetchWriteTarget = "prfchw";
+    }
+    else
+    {
+        private enum prefetchWriteTarget = "";
+    }
+
     /* This is trusted so that it's @safe without DIP1000 enabled. */
-    /* prfchw forces prefetchw to be emitted on x86 (which is how MSVC behaves). */
-    @llvm_target("prfchw")
+    @llvm_target(prefetchWriteTarget)
     extern(C)
     pragma(inline, true)
     private void prefetchData(bool write, ubyte level)(scope const(void)* address) @trusted pure nothrow @nogc


### PR DESCRIPTION
This PR fixes a unittest of `__builtins_msvc` failing to compile when targeting AArch64 without `-dip1000`.

Additionally, the `prfchw` target, for `prefetchData`, is now restricted to x86 to prevent LDC from displaying `'+prfchw' is not a recognized feature for this target (ignoring feature)` in the console when targeting AArch64.