### PR TITLE
use ErrorSink in toAssocArrayLiteral()

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -3248,7 +3248,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
 /****************************************
  * If t, set type of e to t skipping past array, function type or conditional type.
  * Params:
- *	e = expression to set type to
+ *      e = expression to set type to
  *      t = type to infer from
  */
 Expression inferExpType(Expression e, Type t)

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3259,7 +3259,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         ArrayInitializer ai = dsym._init.isArrayInitializer();
                         Expression e;
                         if (ai && tb.ty == Taarray)
-                            e = ai.toAssocArrayLiteral(tb);
+                            e = ai.toAssocArrayLiteral(tb, global.errorSink);
                         else
                             e = dsym._init.initializerToExpression(dsym.type, sc.inCfile);
                         if (!e)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15276,16 +15276,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (eNext && !eNext.toBasetype().isTypeStruct())
                     e.type = e.type.unqualify(MODFlags.const_);
 
-		auto ale = e.isArrayLiteralExp();
+                auto ale = e.isArrayLiteralExp();
                 if (!ale)
                     return;
 
-		foreach (i; 0 .. ale.length)
-		{
-		    Expression ex = ale[i];
-		    if (ex)
-			unqualifyExp(ex);
-		}
+                foreach (i; 0 .. ale.length)
+                {
+                    Expression ex = ale[i];
+                    if (ex)
+                        unqualifyExp(ex);
+                }
             }
             unqualifyExp(e1c);
             unqualifyExp(e2c);

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -25,6 +25,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.dtemplate;
 import dmd.errors;
+import dmd.errorsink;
 import dmd.expression;
 import dmd.expressionsem;
 import dmd.func;
@@ -51,25 +52,23 @@ import dmd.typesem;
  *  Params:
  *     ai = array initializer to be converted
  *     itype = if not `null`, the AA type to coerce the initializer to
+ *     eSink = error message sink
  *
  *  Returns:
  *     The converted associative array initializer or ErrorExp if `ai`
  *     is not an associative array initializer.
  */
-Expression toAssocArrayLiteral(ArrayInitializer ai, Type itype)
+Expression toAssocArrayLiteral(ArrayInitializer ai, Type itype, ErrorSink eSink)
 {
     //printf("ArrayInitializer::toAssocArrayInitializer(%s)\n", ai.toChars());
     //static int i; if (++i == 2) assert(0);
 
-    auto no(const char* format, Initializer i)
-    {
-        error(i.loc, format, toChars(i));
-        return ErrorExp.get();
-    }
-
     const dim = ai.value.length;
     if (!dim)
-        return no("invalid associative array initializer `%s`, use `null` instead", ai);
+    {
+        eSink.error(ai.loc, "invalid associative array initializer `%s`, use `null` instead", toChars(ai));
+        return ErrorExp.get();
+    }
 
     auto vtype  = itype ? itype.nextOf() : null;
     auto keys   = new Expressions(dim);
@@ -79,12 +78,18 @@ Expression toAssocArrayLiteral(ArrayInitializer ai, Type itype)
         assert(iz);
         auto ev = iz.initializerToExpression(vtype);
         if (!ev)
-            return no("invalid value `%s` in initializer", iz);
+        {
+            eSink.error(iz.loc, "invalid value `%s` in initializer", toChars(iz));
+            return ErrorExp.get();
+        }
         (*values)[i] = ev;
 
         auto ei = ai.index[i];
         if (!ei)
-            return no("missing key for value `%s` in initializer", iz);
+        {
+            eSink.error(iz.loc, "missing key for value `%s` in initializer", toChars(iz));
+            return ErrorExp.get();
+        }
         (*keys)[i] = ei;
     }
     return new AssocArrayLiteralExp(ai.loc, keys, values);
@@ -226,7 +231,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                 Expression e;
                 // note: MyStruct foo = [1:2, 3:4] is correct code if MyStruct has a this(int[int])
                 if (t.ty == Taarray || i.isAssociativeArray())
-                    e = i.toAssocArrayLiteral(t);
+                    e = i.toAssocArrayLiteral(t, global.errorSink);
                 else
                     e = i.initializerToExpression();
                 // Bugzilla 13987
@@ -1435,7 +1440,7 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
         if (!itype || itype.toBasetype().isTypeAArray())
             if (!init.type || init.type.isTypeAArray())
                 if (init.isAssociativeArray())
-                    return init.toAssocArrayLiteral(itype);
+                    return init.toAssocArrayLiteral(itype, global.errorSink);
 
         uint edim;      // the length of the resulting array literal
         const(uint) amax = 0x80000000;


### PR DESCRIPTION
and my detabber caught some unrelated tabs.