### PR TITLE
fix #17259: GC doesn't respect type alignments > 16 bytes

### DIFF
--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -175,9 +175,8 @@ _d_arrayliteralTX!(__c_wchar_t)
 			import core.memory : GC;
 			import core.internal.traits : hasIndirections;
 			alias BlkAttr = BlkAttr;
-			uint attrs = 8u;
-			attrs |= BlkAttr.NO_SCAN;
-			return malloc(allocsize, attrs, typeid(__c_wchar_t));
+			enum uint attrs = 778u;
+			return malloc(allocsize, 778u, typeid(__c_wchar_t));
 		}
 	}
 

--- a/compiler/test/compilable/test3004.d
+++ b/compiler/test/compilable/test3004.d
@@ -1,7 +1,7 @@
 // https://issues.dlang.org/show_bug.cgi?id=3004
 /*
 REQUIRED_ARGS: -ignore -v
-TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|inline|.*_d_newarrayU|import|\(imported|semantic|entry|library|function  object|function  core|\s*$)")
+TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|inline|.*_d_newarrayU|import|\(imported|semantic|entry|library|function  object|function  core|scan pragma\(inline\)|\s*$)")
 TEST_OUTPUT:
 ---
 pragma    GNU_attribute (__error)

--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -290,7 +290,7 @@ private size_t _d_arraysetlengthT_(Tarr : T[], T)(return ref scope Tarr arr, siz
 
     debug(PRINTF) printf("newsize = %zx\n", newsize);
 
-    enum uint gcAttrs = BlkAttr.APPENDABLE | GC.BlkAttrAlignment(T.alignof)
+    enum uint gcAttrs = BlkAttr.APPENDABLE | GC.convertAlignmentToBlkAttr(T.alignof)
         | (__traits(hasMember, T, "xdtor") ? BlkAttr.FINALIZE : 0);
 
     if (!arr.ptr)

--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -291,7 +291,7 @@ private size_t _d_arraysetlengthT_(Tarr : T[], T)(return ref scope Tarr arr, siz
     debug(PRINTF) printf("newsize = %zx\n", newsize);
 
     enum uint gcAttrs = BlkAttr.APPENDABLE | GC.convertAlignmentToBlkAttr(T.alignof)
-        | (__traits(hasMember, T, "xdtor") ? BlkAttr.FINALIZE : 0);
+        | (is(T == struct) && __traits(hasMember, T, "xdtor") ? BlkAttr.FINALIZE : 0);
 
     if (!arr.ptr)
     {

--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -290,11 +290,8 @@ private size_t _d_arraysetlengthT_(Tarr : T[], T)(return ref scope Tarr arr, siz
 
     debug(PRINTF) printf("newsize = %zx\n", newsize);
 
-    uint gcAttrs = BlkAttr.APPENDABLE;
-    static if (is(T == struct) && __traits(hasMember, T, "xdtor"))
-    {
-        gcAttrs |= BlkAttr.FINALIZE;
-    }
+    enum uint gcAttrs = BlkAttr.APPENDABLE | GC.BlkAttrAlignment(T.alignof)
+        | (__traits(hasMember, T, "xdtor") ? BlkAttr.FINALIZE : 0);
 
     if (!arr.ptr)
     {

--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -612,11 +612,9 @@ void* _d_arrayliteralTX(T)(size_t length) @trusted pure nothrow
         *  but don't use a nested template function call here to avoid
         *  possible linking errors.
         */
-        uint attrs = BlkAttr.APPENDABLE;
-        static if (!hasIndirections!T)
-            attrs |= BlkAttr.NO_SCAN;
-        static if (is(T == struct) && __traits(needsDestruction, T))
-            attrs |= BlkAttr.FINALIZE;
+        enum uint attrs = BlkAttr.APPENDABLE | GC.BlkAttrAlignment(T.alignof)
+            | (!hasIndirections!T ? BlkAttr.NO_SCAN : 0)
+            | (is(T == struct) && __traits(needsDestruction, T) ? BlkAttr.FINALIZE : 0);
 
         version (D_TypeInfo)
             return GC.malloc(allocsize, attrs, typeid(T));

--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -612,7 +612,7 @@ void* _d_arrayliteralTX(T)(size_t length) @trusted pure nothrow
         *  but don't use a nested template function call here to avoid
         *  possible linking errors.
         */
-        enum uint attrs = BlkAttr.APPENDABLE | GC.BlkAttrAlignment(T.alignof)
+        enum uint attrs = BlkAttr.APPENDABLE | GC.convertAlignmentToBlkAttr(T.alignof)
             | (!hasIndirections!T ? BlkAttr.NO_SCAN : 0)
             | (is(T == struct) && __traits(needsDestruction, T) ? BlkAttr.FINALIZE : 0);
 

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -56,15 +56,9 @@ void[] __arrayAlloc(T)(size_t arrSize) @trusted
     import core.internal.traits : hasIndirections;
 
     enum typeInfoSize = TypeInfoSize!T;
-    BlkAttr attr = BlkAttr.APPENDABLE;
-
-    /* `extern(C++)` classes don't have a classinfo pointer in their vtable,
-     * so the GC can't finalize them.
-     */
-    static if (typeInfoSize)
-        attr |= BlkAttr.FINALIZE;
-    static if (!hasIndirections!T)
-        attr |= BlkAttr.NO_SCAN;
+    enum uint attr = BlkAttr.APPENDABLE | GC.BlkAttrAlignment(T.alignof)
+        | (typeInfoSize ? BlkAttr.FINALIZE : 0)
+        | (!hasIndirections!T ? BlkAttr.NO_SCAN : 0);
 
     version(D_TypeInfo)
         auto ptr = GC.malloc(arrSize, attr, typeid(T));
@@ -160,15 +154,12 @@ uint __typeAttrs(T)(void *copyAttrsFrom = null)
         // try to copy attrs from the given block
         auto info = GC.query(copyAttrsFrom);
         if (info.base)
-            return info.attr;
+            return info.attr | GC.BlkAttrAlignment(T.alignof);
     }
 
-    uint attrs = 0;
-    static if (!hasIndirections!T)
-        attrs |= BlkAttr.NO_SCAN;
-
-    static if (is(T == struct) && __traits(needsDestruction, T))
-        attrs |= BlkAttr.FINALIZE;
+    enum uint attrs = GC.BlkAttrAlignment(T.alignof)
+        | (!hasIndirections!T ? BlkAttr.NO_SCAN : 0)
+        | (is(T == struct) && __traits(needsDestruction, T) ? BlkAttr.FINALIZE : 0);
 
     return attrs;
 }

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -56,7 +56,7 @@ void[] __arrayAlloc(T)(size_t arrSize) @trusted
     import core.internal.traits : hasIndirections;
 
     enum typeInfoSize = TypeInfoSize!T;
-    enum uint attr = BlkAttr.APPENDABLE | GC.BlkAttrAlignment(T.alignof)
+    enum uint attr = BlkAttr.APPENDABLE | GC.convertAlignmentToBlkAttr(T.alignof)
         | (typeInfoSize ? BlkAttr.FINALIZE : 0)
         | (!hasIndirections!T ? BlkAttr.NO_SCAN : 0);
 
@@ -154,10 +154,10 @@ uint __typeAttrs(T)(void *copyAttrsFrom = null)
         // try to copy attrs from the given block
         auto info = GC.query(copyAttrsFrom);
         if (info.base)
-            return info.attr | GC.BlkAttrAlignment(T.alignof);
+            return info.attr | GC.convertAlignmentToBlkAttr(T.alignof);
     }
 
-    enum uint attrs = GC.BlkAttrAlignment(T.alignof)
+    enum uint attrs = GC.convertAlignmentToBlkAttr(T.alignof)
         | (!hasIndirections!T ? BlkAttr.NO_SCAN : 0)
         | (is(T == struct) && __traits(needsDestruction, T) ? BlkAttr.FINALIZE : 0);
 

--- a/druntime/src/core/internal/gc/blockmeta.d
+++ b/druntime/src/core/internal/gc/blockmeta.d
@@ -16,11 +16,56 @@ enum : size_t
     BIGLENGTHMASK = ~(PAGESIZE - 1),
     SMALLPAD = 1,
     MEDPAD = ushort.sizeof,
-    LARGEPREFIX = 16, // 16 bytes padding at the front of the array
-    LARGEPAD = LARGEPREFIX + 1,
+    LARGEPREFIX_MIN = 16,
     MAXSMALLSIZE = 256-SMALLPAD,
     MAXMEDSIZE = (PAGESIZE / 2) - MEDPAD
 }
+
+struct LargeArrayHeader
+{
+    size_t size;
+    size_t ti_alignvalid;   // TypeInfo + alignment-valid-bit, assuming typeinfo always word aligned
+    size_t align_;          // only valid if lowest bit in ti_alignvalid
+    size_t pad32;           // padding on 32-bit
+
+    size_t alignment() pure nothrow @nogc
+    {
+        return ti_alignvalid & 1 ? align_ : LARGEPREFIX_MIN;
+    }
+    void alignment(size_t a) pure nothrow @nogc
+    {
+        if (a > LARGEPREFIX_MIN)
+        {
+            ti_alignvalid |= 1;
+            align_ = a;
+        }
+        else
+            ti_alignvalid &= ~cast(size_t)1;
+    }
+    const(TypeInfo) typeInfo() pure nothrow @nogc
+    {
+        return cast(const(TypeInfo))cast(void*)(ti_alignvalid & ~cast(size_t)1);
+    }
+    void typeInfo(const(TypeInfo) ti) pure nothrow @nogc
+    {
+        assert((cast(size_t)cast(void*)ti & 1) == 0);
+        ti_alignvalid = (ti_alignvalid & 1) | (cast(size_t)cast(void*)ti);
+    }
+}
+
+size_t LARGEPREFIX(size_t alignment) pure nothrow @nogc
+{
+    return alignment > LARGEPREFIX_MIN ? alignment : LARGEPREFIX_MIN;
+}
+
+size_t LARGEPREFIX(scope void* base) pure nothrow @nogc
+{
+    // padding at the front of the array
+    return (cast(LargeArrayHeader*)base).alignment;
+}
+size_t LARGEPAD(size_t alignment) pure nothrow @nogc { return LARGEPREFIX(alignment) + 1; }
+
+size_t LARGEPAD(scope void* base) pure nothrow @nogc { return LARGEPREFIX(base) + 1; }
 
 // size used to store the TypeInfo at the end of an allocation for structs that have a destructor
 size_t structTypeInfoSize(const TypeInfo ti) pure nothrow @nogc
@@ -56,7 +101,7 @@ size_t structTypeInfoSize(const TypeInfo ti) pure nothrow @nogc
   future that the block is unshared, we may be able to change this, but I'm not
   sure it's important.
 
-  In order to do put the length at the front, we have to provide 16 bytes
+  In order to do put the length at the front, we have to provide at least 16 bytes
   buffer space in case the block has to be aligned properly.  In x86, certain
   SSE instructions will only work if the data is 16-byte aligned.  In addition,
   we need the sentinel byte to prevent accidental pointers to the next block.
@@ -69,16 +114,7 @@ size_t structTypeInfoSize(const TypeInfo ti) pure nothrow @nogc
 
   where elem0 starts 16 bytes after the first byte.
   */
-bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, const TypeInfo tinext, size_t oldlength = size_t.max) pure nothrow
-{
-    __setBlockFinalizerInfo(info, tinext);
-
-    size_t typeInfoSize = (info.attr & BlkAttr.STRUCTFINAL) ? size_t.sizeof : 0;
-    return __setArrayAllocLengthImpl(info, newlength, isshared, oldlength, typeInfoSize);
-}
-
-// the impl function, used both above and in core.internal.array.utils
-bool __setArrayAllocLengthImpl(ref BlkInfo info, size_t newlength, bool isshared, size_t oldlength, size_t typeInfoSize) pure nothrow
+bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, size_t oldlength, size_t typeInfoSize) pure nothrow
 {
     import core.atomic;
 
@@ -144,7 +180,7 @@ bool __setArrayAllocLengthImpl(ref BlkInfo info, size_t newlength, bool isshared
     }
     else
     {
-        if (newlength + LARGEPAD > info.size)
+        if (newlength + LARGEPAD(info.base) > info.size)
             // new size does not fit inside block
             return false;
         auto length = cast(size_t *)(info.base);
@@ -172,30 +208,29 @@ bool __setArrayAllocLengthImpl(ref BlkInfo info, size_t newlength, bool isshared
 }
 
 /**
-  The block finalizer info is set separately from the array length, as that is
+  The block finalizer and the alignment info is set separately from the array length, as that is
   only needed on the initial setup of the block. No shared is needed, since
   this should only happen when the block is new.
   If the STRUCTFINAL bit is not set, no finalizer is stored (but if needed the
   slot is zeroed)
   */
-void __setBlockFinalizerInfo(ref BlkInfo info, const TypeInfo ti) pure nothrow
+void __setBlockMetaInfo(ref BlkInfo info, const TypeInfo ti, size_t alignment) pure nothrow
 {
     if ((info.attr & BlkAttr.APPENDABLE) && info.size > PAGESIZE / 2)
     {
         // if the structfinal bit is not set, we don't have a finalizer. But we
         // should still zero out the finalizer slot.
-        auto context = (info.attr & BlkAttr.STRUCTFINAL) ? cast(void*)ti : null;
+        auto context = (info.attr & BlkAttr.STRUCTFINAL) ? ti : null;
 
-        // array used size goes at the beginning. We can stuff the typeinfo
-        // right after it, as we need to use 16 bytes anyway.
-        //
-        auto typeInfo = cast(void**)info.base + 1;
-        *typeInfo = context;
+        auto hdr = cast(LargeArrayHeader*)info.base;
         version (D_LP64) {} else
         {
             // zero out the extra padding
-            (cast(size_t*)info.base)[2 .. 4] = 0;
+            hdr.align_ = 0;
+            hdr.pad32 = 0;
         }
+        hdr.typeInfo = context;
+        hdr.alignment = alignment;
     }
     else if(info.attr & BlkAttr.STRUCTFINAL)
     {
@@ -222,10 +257,10 @@ const(TypeInfo) __getBlockFinalizerInfo(void* base, size_t size, uint attr) pure
 
     bool isLargeArray = (attr & BlkAttr.APPENDABLE) && size > PAGESIZE / 2;
     auto typeInfo = isLargeArray ?
-        base + size_t.sizeof :
-        base + size - size_t.sizeof;
-    assert(*cast(size_t*)typeInfo != 0);
-    return *cast(TypeInfo*)typeInfo;
+        (cast(LargeArrayHeader*)base).typeInfo :
+        *cast(TypeInfo*)(base + size - size_t.sizeof);
+    assert(typeInfo !is null);
+    return typeInfo;
 }
 
 /**
@@ -241,7 +276,7 @@ size_t __arrayAllocLength(ref BlkInfo info) pure nothrow
     if (info.size <= PAGESIZE / 2)
         return *cast(ushort *)(info.base + info.size - typeInfoSize - MEDPAD);
 
-    return *cast(size_t *)(info.base);
+    return (cast(LargeArrayHeader*)(info.base)).size;
 }
 
 /**
@@ -258,7 +293,7 @@ size_t __arrayAllocLengthAtomic(ref BlkInfo info) pure nothrow
     if (info.size <= PAGESIZE / 2)
         return atomicLoad(*cast(shared(ushort)*)(info.base + info.size - typeInfoSize - MEDPAD));
 
-    return atomicLoad(*cast(shared(size_t)*)(info.base));
+    return atomicLoad((cast(LargeArrayHeader*)(info.base)).size);
 }
 
 /**
@@ -269,7 +304,7 @@ size_t __arrayAllocCapacity(ref BlkInfo info) pure nothrow
 {
     // Capacity is a calculation based solely on the block info.
     if (info.size > PAGESIZE / 2)
-        return info.size - LARGEPAD;
+        return info.size - LARGEPAD(info.base);
 
     auto typeInfoSize = (info.attr & BlkAttr.STRUCTFINAL) ? size_t.sizeof : 0;
     auto padsize = info.size <= 256 ? SMALLPAD : MEDPAD;
@@ -281,22 +316,22 @@ size_t __arrayAllocCapacity(ref BlkInfo info) pure nothrow
   NOT included in the passed in size.  Therefore, do NOT call this function
   with the size of an allocated block.
   */
-size_t __arrayPad(size_t size, const TypeInfo tinext) nothrow pure @trusted
+size_t __arrayPad(size_t size, size_t alignment, const TypeInfo tinext) nothrow pure @trusted
 {
-    return size > MAXMEDSIZE ? LARGEPAD : ((size > MAXSMALLSIZE ? MEDPAD : SMALLPAD) + structTypeInfoSize(tinext));
+    return size > MAXMEDSIZE ? LARGEPAD(alignment) : ((size > MAXSMALLSIZE ? MEDPAD : SMALLPAD) + structTypeInfoSize(tinext));
 }
 
 /**
   get the padding required to allocate size bytes, use the bits to determine
   which metadata must be stored.
   */
-size_t __allocPad(size_t size, uint bits) nothrow pure @trusted
+size_t __allocPad(size_t size, size_t alignment, uint bits) nothrow pure @trusted
 {
     auto finalizerSize = (bits & BlkAttr.STRUCTFINAL) ? (void*).sizeof : 0;
     if (bits & BlkAttr.APPENDABLE)
     {
         if (size > MAXMEDSIZE - finalizerSize)
-            return LARGEPAD;
+            return LARGEPAD(alignment);
         auto pad = (size > MAXSMALLSIZE - finalizerSize) ? MEDPAD : SMALLPAD;
         return pad + finalizerSize;
     }
@@ -321,7 +356,7 @@ void *__arrayStart()(return scope BlkInfo info) nothrow pure
 /// Ditto
 void *__arrayStart()(return scope void* base, size_t size) nothrow pure
 {
-    return base + ((size & BIGLENGTHMASK) ? LARGEPREFIX : 0);
+    return base + ((size & BIGLENGTHMASK) ? LARGEPREFIX(base) : 0);
 }
 
 /**
@@ -334,9 +369,10 @@ void __trimExtents(ref scope void* base, ref size_t blockSize, uint attr) nothro
     {
         if (blockSize > PAGESIZE / 2)
         {
-            // large block, it's always LARGEPREFIX bytes at the front.
-            blockSize = *(cast(size_t*)base);
-            base += LARGEPREFIX;
+            // large block, metadata in header at the front.
+            auto hdr = cast(LargeArrayHeader*)base;
+            blockSize = hdr.size;
+            base += hdr.alignment;
             return;
         }
 

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -2203,8 +2203,9 @@ struct Gcx
         auto alignAttr = bits & BlkAttr.ALIGNMENT_MASK;
         if (alignAttr > BlkAttr.ALIGNMENT_16)
         {
-            while (bin < Bins.B_NUMSMALL && binAlignAttr[bin] < alignAttr)
-                bin++;
+            while (binAlignAttr[bin] < alignAttr)
+                if (++bin >= Bins.B_NUMSMALL)
+                    return bigAlloc(size, alloc_size, bits, ti); // large alignment needs big alloc
         }
         alloc_size = binsize[bin];
 
@@ -2287,6 +2288,10 @@ struct Gcx
     {
         debug(PRINTF) printf("In bigAlloc.  Size:  %zd\n", size);
 
+        auto alignAttr = cast(BlkAttr)(bits & BlkAttr.ALIGNMENT_MASK);
+        size_t pageAlign = alignAttr <= BlkAttr.ALIGNMENT_4K ? 1
+            : core.memory.GC.convertBlkAttrToAlignment(alignAttr) / PAGESIZE;
+
         LargeObjectPool* pool;
         size_t pn;
         immutable npages = LargeObjectPool.numPages(size);
@@ -2300,7 +2305,7 @@ struct Gcx
                 if (!p.isLargeObject || p.freepages < npages)
                     continue;
                 auto lpool = cast(LargeObjectPool*) p;
-                if ((pn = lpool.allocPages(npages)) == OPFAIL)
+                if ((pn = lpool.allocPages(npages, pageAlign)) == OPFAIL)
                     continue;
                 pool = lpool;
                 return true;
@@ -2310,9 +2315,9 @@ struct Gcx
 
         bool tryAllocNewPool() nothrow
         {
-            pool = cast(LargeObjectPool*) newPool(npages, true);
+            pool = cast(LargeObjectPool*) newPool(npages + pageAlign - 1, true);
             if (!pool) return false;
-            pn = pool.allocPages(npages);
+            pn = pool.allocPages(npages, pageAlign);
             assert(pn != OPFAIL);
             return true;
         }
@@ -4433,9 +4438,14 @@ struct LargeObjectPool
 
     /**
      * Allocate n pages from Pool.
-     * Returns OPFAIL on failure.
+     *
+     * Params:
+     *  n = number of pages to allocate
+     *  pageAlign = required alignment of resulting page (including base address)
+     * Returns:
+     *  OPFAIL on failure.
      */
-    size_t allocPages(size_t n) nothrow
+    size_t allocPages(size_t n, size_t pageAlign) nothrow
     {
         if (largestFree < n || searchStart + n > npages)
             return OPFAIL;
@@ -4450,11 +4460,26 @@ struct LargeObjectPool
         while (searchStart < npages && pagetable[searchStart] == Bins.B_PAGE)
             searchStart += bPageOffsets[searchStart];
 
+        size_t basePage = (cast(size_t)baseAddr / PAGESIZE);
         for (size_t i = searchStart; i < npages; )
         {
             assert(pagetable[i] == Bins.B_FREE);
 
             auto p = bPageOffsets[i];
+            if (pageAlign > 1)
+            {
+                size_t ialigned = ((basePage + i + pageAlign - 1) & -pageAlign) - basePage;
+                if (ialigned + n > i + p)
+                    goto L_next;
+                if (ialigned + n < i + p)
+                    setFreePageOffsets(ialigned + n, i + p - (ialigned + n));
+                if (ialigned > i)
+                {
+                    setFreePageOffsets(i, ialigned - i);
+                    i = ialigned;
+                }
+                goto L_found;
+            }
             if (p > n)
             {
                 setFreePageOffsets(i + n, p - n);
@@ -4474,6 +4499,7 @@ struct LargeObjectPool
                 freepages -= n;
                 return i;
             }
+            L_next:
             if (p > largest)
                 largest = p;
 

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -485,11 +485,11 @@ class ConservativeGC : GC
 
         adjustAttrs(bits, ti);
 
-        uint alignAttr = bits & BlkAttr.ALIGNMENT_MASK;
+        auto alignAttr = cast(BlkAttr)(bits & BlkAttr.ALIGNMENT_MASK);
         size_t alignment = alignAttr <= BlkAttr.ALIGNMENT_16 ? 16
-            : 1 << (alignAttr / BlkAttr.ALIGNMENT_BYTE);
-        immutable padding = __allocPad(size, alignment, bits);
+            : core.memory.GC.convertBlkAttrToAlignment(alignAttr);
 
+        immutable padding = __allocPad(size, alignment, bits);
         bool overflow;
         import core.checkedint : addu;
         immutable needed = addu(size, padding, overflow);
@@ -595,9 +595,9 @@ class ConservativeGC : GC
 
         adjustAttrs(bits, ti);
 
-        uint alignAttr = bits & BlkAttr.ALIGNMENT_MASK;
+        auto alignAttr = cast(BlkAttr)(bits & BlkAttr.ALIGNMENT_MASK);
         size_t alignment = alignAttr <= BlkAttr.ALIGNMENT_16 ? 16
-            : 1 << (alignAttr / BlkAttr.ALIGNMENT_BYTE);
+            : core.memory.GC.convertBlkAttrToAlignment(alignAttr);
 
         immutable padding = __allocPad(size, alignment, bits);
         bool overflow;
@@ -1694,8 +1694,7 @@ struct List
 }
 
 // non power of two sizes optimized for small remainder within page (<= 64 bytes)
-immutable short[Bins.B_NUMSMALL + 1] binsize  = [ 16, 32, 48, 64, 96, 128, 176, 256, 368, 512, 816, 1024, 1360, 2048, 4096 ];
-immutable short[Bins.B_NUMSMALL + 1] binalign = [ 16, 32, 16, 64, 32, 128,  16, 256,  16, 512,  16, 1024,   16, 2048, 4096 ];
+immutable short[Bins.B_NUMSMALL + 1] binsize = [ 16, 32, 48, 64, 96, 128, 176, 256, 368, 512, 816, 1024, 1360, 2048, 4096 ];
 immutable short[PAGESIZE / 16][Bins.B_NUMSMALL + 1] binbase = calcBinBase();
 
 short[PAGESIZE / 16][Bins.B_NUMSMALL + 1] calcBinBase()
@@ -1721,7 +1720,7 @@ immutable binAlignAttr = ()
 {
     uint[Bins.B_NUMSMALL + 1] attr;
     for (int i = 0; i <= Bins.B_NUMSMALL; i++)
-        attr[i] = core.memory.GC.BlkAttrAlignment(binalign[i]);
+        attr[i] = core.memory.GC.convertAlignmentToBlkAttr(binsize[i] & -binsize[i]); // extract lowest bit
     return attr;
 }();
 

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -485,7 +485,10 @@ class ConservativeGC : GC
 
         adjustAttrs(bits, ti);
 
-        immutable padding = __allocPad(size, bits);
+        uint alignAttr = bits & BlkAttr.ALIGNMENT_MASK;
+        size_t alignment = alignAttr <= BlkAttr.ALIGNMENT_16 ? 16
+            : 1 << (alignAttr / BlkAttr.ALIGNMENT_BYTE);
+        immutable padding = __allocPad(size, alignment, bits);
 
         bool overflow;
         import core.checkedint : addu;
@@ -501,7 +504,7 @@ class ConservativeGC : GC
 
         invalidate(p[0 .. localAllocSize], 0xF0, true);
 
-        auto ret = setupMetadata(p[0 .. localAllocSize], bits, padding, size, ti);
+        auto ret = setupMetadata(p[0 .. localAllocSize], bits, padding, size, alignment, ti);
 
         if (!(bits & BlkAttr.NO_SCAN))
         {
@@ -592,7 +595,11 @@ class ConservativeGC : GC
 
         adjustAttrs(bits, ti);
 
-        immutable padding = __allocPad(size, bits);
+        uint alignAttr = bits & BlkAttr.ALIGNMENT_MASK;
+        size_t alignment = alignAttr <= BlkAttr.ALIGNMENT_16 ? 16
+            : 1 << (alignAttr / BlkAttr.ALIGNMENT_BYTE);
+
+        immutable padding = __allocPad(size, alignment, bits);
         bool overflow;
         import core.checkedint : addu;
         immutable needed = addu(size, padding, overflow);
@@ -608,7 +615,7 @@ class ConservativeGC : GC
 
         debug (VALGRIND) makeMemUndefined(p[0..size]);
 
-        auto ret = setupMetadata(p[0 .. localAllocSize], bits, padding, size, ti);
+        auto ret = setupMetadata(p[0 .. localAllocSize], bits, padding, size, alignment, ti);
 
         invalidate((ret.ptr + size)[0 .. ret.length - size], 0xF0, true);
 
@@ -1518,7 +1525,7 @@ class ConservativeGC : GC
         auto existingUsed = slice.length + offset;
 
         size_t typeInfoSize = (info.attr & BlkAttr.STRUCTFINAL) ? size_t.sizeof : 0;
-        if (__setArrayAllocLengthImpl(info, newUsed, atomic, existingUsed, typeInfoSize))
+        if (__setArrayAllocLength(info, newUsed, atomic, existingUsed, typeInfoSize))
         {
             // could expand without extending
             if (!bic && !atomic)
@@ -1533,7 +1540,7 @@ class ConservativeGC : GC
             return false;
 
         // try extending the block into subsequent pages.
-        immutable requiredExtension = newUsed - (info.size - LARGEPAD);
+        immutable requiredExtension = newUsed - (info.size - LARGEPAD(info.base));
         auto extendedSize = extend(info.base, requiredExtension, requiredExtension, null);
         if (extendedSize == 0)
             // could not extend, can't satisfy the request
@@ -1546,7 +1553,7 @@ class ConservativeGC : GC
             __insertBlkInfoCache(info, null);
 
         // this should always work.
-        return __setArrayAllocLengthImpl(info, newUsed, atomic, existingUsed, typeInfoSize);
+        return __setArrayAllocLength(info, newUsed, atomic, existingUsed, typeInfoSize);
     }
 
     bool shrinkArrayUsed(void[] slice, size_t existingUsed, bool atomic = false) nothrow
@@ -1575,7 +1582,7 @@ class ConservativeGC : GC
 
         size_t typeInfoSize = (info.attr & BlkAttr.STRUCTFINAL) ? size_t.sizeof : 0;
 
-        if (__setArrayAllocLengthImpl(info, newUsed, atomic, existingUsed, typeInfoSize))
+        if (__setArrayAllocLength(info, newUsed, atomic, existingUsed, typeInfoSize))
         {
             if (!bic && !atomic)
                 __insertBlkInfoCache(info, null);
@@ -1687,7 +1694,8 @@ struct List
 }
 
 // non power of two sizes optimized for small remainder within page (<= 64 bytes)
-immutable short[Bins.B_NUMSMALL + 1] binsize = [ 16, 32, 48, 64, 96, 128, 176, 256, 368, 512, 816, 1024, 1360, 2048, 4096 ];
+immutable short[Bins.B_NUMSMALL + 1] binsize  = [ 16, 32, 48, 64, 96, 128, 176, 256, 368, 512, 816, 1024, 1360, 2048, 4096 ];
+immutable short[Bins.B_NUMSMALL + 1] binalign = [ 16, 32, 16, 64, 32, 128,  16, 256,  16, 512,  16, 1024,   16, 2048, 4096 ];
 immutable short[PAGESIZE / 16][Bins.B_NUMSMALL + 1] binbase = calcBinBase();
 
 short[PAGESIZE / 16][Bins.B_NUMSMALL + 1] calcBinBase()
@@ -1708,6 +1716,14 @@ short[PAGESIZE / 16][Bins.B_NUMSMALL + 1] calcBinBase()
     }
     return bin;
 }
+
+immutable binAlignAttr = ()
+{
+    uint[Bins.B_NUMSMALL + 1] attr;
+    for (int i = 0; i <= Bins.B_NUMSMALL; i++)
+        attr[i] = core.memory.GC.BlkAttrAlignment(binalign[i]);
+    return attr;
+}();
 
 size_t baseOffset(size_t offset, Bins bin) @nogc nothrow
 {
@@ -2184,7 +2200,13 @@ struct Gcx
 
     void* smallAlloc(size_t size, ref size_t alloc_size, uint bits, const TypeInfo ti) nothrow
     {
-        immutable bin = binTable[size];
+        Bins bin = binTable[size];
+        auto alignAttr = bits & BlkAttr.ALIGNMENT_MASK;
+        if (alignAttr > BlkAttr.ALIGNMENT_16)
+        {
+            while (bin < Bins.B_NUMSMALL && binAlignAttr[bin] < alignAttr)
+                bin++;
+        }
         alloc_size = binsize[bin];
 
         void* p = bucket[bin];
@@ -5529,7 +5551,7 @@ private void adjustAttrs(ref uint attrs, const TypeInfo ti) nothrow
 // metadata.
 //
 // The return value is the true data that the user can use.
-private void[] setupMetadata(void[] block, uint bits, size_t padding, size_t used, const TypeInfo ti) nothrow
+private void[] setupMetadata(void[] block, uint bits, size_t padding, size_t used, size_t alignment, const TypeInfo ti) nothrow
 {
     import core.internal.gc.blockmeta;
     import core.internal.array.utils;
@@ -5541,11 +5563,11 @@ private void[] setupMetadata(void[] block, uint bits, size_t padding, size_t use
     );
 
 
-    __setBlockFinalizerInfo(info, ti);
+    __setBlockMetaInfo(info, ti, alignment);
 
     if (bits & BlkAttr.APPENDABLE) {
         auto typeInfoSize = (bits & BlkAttr.STRUCTFINAL) ? (void*).sizeof : 0;
-        auto success = __setArrayAllocLengthImpl(info, used, false, size_t.max, typeInfoSize);
+        auto success = __setArrayAllocLength(info, used, false, size_t.max, typeInfoSize);
         assert(success);
         return __arrayStart(info)[0 .. block.length - padding];
     }

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -2662,7 +2662,7 @@ if (is(T == class))
     }
     else
     {
-        BlkAttr attr = BlkAttr.NONE;
+        BlkAttr attr = GC.BlkAttrAlignment(__traits(classInstanceAlignment, T));
 
         /* `extern(C++)`` classes don't have a classinfo pointer in their vtable,
          * so the GC can't finalize them.
@@ -2726,10 +2726,10 @@ T* _d_newitemT(T)() @trusted
     import core.internal.traits : hasIndirections;
     import core.memory : GC;
 
-    auto flags = !hasIndirections!T ? GC.BlkAttr.NO_SCAN : GC.BlkAttr.NONE;
     immutable itemSize = T.sizeof;
-    if (TypeInfoSize!T)
-        flags |= GC.BlkAttr.FINALIZE;
+    enum flags = (!hasIndirections!T ? GC.BlkAttr.NO_SCAN : GC.BlkAttr.NONE)
+               | (TypeInfoSize!T ?GC.BlkAttr.FINALIZE : 0)
+               | GC.BlkAttrAlignment(T.alignof);
 
     version(D_TypeInfo)
         auto p = GC.malloc(itemSize, flags, typeid(T));

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -2662,15 +2662,12 @@ if (is(T == class))
     }
     else
     {
-        BlkAttr attr = GC.BlkAttrAlignment(__traits(classInstanceAlignment, T));
-
+        enum attr = GC.convertAlignmentToBlkAttr(__traits(classInstanceAlignment, T))
         /* `extern(C++)`` classes don't have a classinfo pointer in their vtable,
          * so the GC can't finalize them.
          */
-        static if (__traits(hasMember, T, "__dtor") && __traits(getLinkage, T) != "C++")
-            attr |= BlkAttr.FINALIZE;
-        static if (!hasIndirections!T)
-            attr |= BlkAttr.NO_SCAN;
+            | (__traits(hasMember, T, "__dtor") && __traits(getLinkage, T) != "C++" ? BlkAttr.FINALIZE : 0)
+            | (!hasIndirections!T ? BlkAttr.NO_SCAN : 0);
 
         version(D_TypeInfo)
             p = GC.malloc(init.length, attr, typeid(T));
@@ -2728,8 +2725,8 @@ T* _d_newitemT(T)() @trusted
 
     immutable itemSize = T.sizeof;
     enum flags = (!hasIndirections!T ? GC.BlkAttr.NO_SCAN : GC.BlkAttr.NONE)
-               | (TypeInfoSize!T ?GC.BlkAttr.FINALIZE : 0)
-               | GC.BlkAttrAlignment(T.alignof);
+               | (TypeInfoSize!T ? GC.BlkAttr.FINALIZE : 0)
+               | GC.convertAlignmentToBlkAttr(T.alignof);
 
     version(D_TypeInfo)
         auto p = GC.malloc(itemSize, flags, typeid(T));

--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -376,11 +376,33 @@ extern(D):
         ALIGNMENT_RSVD1 = 0xe00,
         ALIGNMENT_RSVD2 = 0xf00,
     }
-    static BlkAttr BlkAttrAlignment(size_t sz) @safe @nogc nothrow pure
+
+    /**
+     * Returns the ALIGNMENT_* attribute corresponding to the given alignment
+     *
+     * Params:
+     *  alignment = must be a power of 2 between 1 and 4096
+     * Returns:
+     *  one of ALIGNMENT_BYTE to ALIGNMENT_4096
+     */
+    static BlkAttr convertAlignmentToBlkAttr(size_t alignment) @safe @nogc nothrow pure
     {
-        pragma(inline, true);
         import core.bitop;
-        return cast(BlkAttr)(BlkAttr.ALIGNMENT_BYTE * (bsf(sz) + 1));
+        debug assert((alignment & (alignment - 1)) == 0 && alignment > 0 && alignment <= 4096);
+        return cast(BlkAttr)(BlkAttr.ALIGNMENT_BYTE * (bsf(alignment) + 1));
+    }
+    /**
+     * Returns the alignment corresponding to the given ALIGNMENT_* attribute
+     *
+     * Params:
+     *  attr = one of ALIGNMENT_BYTE to ALIGNMENT_4096
+     * Returns:
+     *  alignment corresponding to the given attribute
+     */
+    static size_t convertBlkAttrToAlignment(BlkAttr attr) @safe @nogc nothrow pure
+    {
+        debug assert(attr >= BlkAttr.ALIGNMENT_BYTE && attr <= BlkAttr.ALIGNMENT_4096);
+        return 1 << (attr / BlkAttr.ALIGNMENT_BYTE - 1);
     }
 
     /**

--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -358,50 +358,59 @@ extern(D):
         STRUCTFINAL = 0b0010_0000, // the block has a finalizer for (an array of) structs
 
         // specify alignment requirements for block (might not be supported by all GC)
-        ALIGNMENT_MASK  = 0xf00,
-        ALIGNMENT_NONE  = 0x000, // default is 16
-        ALIGNMENT_BYTE  = 0x100,
-        ALIGNMENT_WORD  = 0x200,
-        ALIGNMENT_DWORD = 0x300,
-        ALIGNMENT_QWORD = 0x400,
-        ALIGNMENT_16    = 0x500,
-        ALIGNMENT_32    = 0x600,
-        ALIGNMENT_64    = 0x700,
-        ALIGNMENT_128   = 0x800,
-        ALIGNMENT_256   = 0x900,
-        ALIGNMENT_512   = 0xa00,
-        ALIGNMENT_1024  = 0xb00,
-        ALIGNMENT_2048  = 0xc00,
-        ALIGNMENT_4096  = 0xd00,
-        ALIGNMENT_RSVD1 = 0xe00,
-        ALIGNMENT_RSVD2 = 0xf00,
+        ALIGNMENT_MASK  = 0x1f00,
+        ALIGNMENT_NONE  = 0x0000, // default is 16
+        ALIGNMENT_BYTE  = 0x0100,
+        ALIGNMENT_WORD  = 0x0200,
+        ALIGNMENT_DWORD = 0x0300,
+        ALIGNMENT_QWORD = 0x0400,
+        ALIGNMENT_16    = 0x0500,
+        ALIGNMENT_32    = 0x0600,
+        ALIGNMENT_64    = 0x0700,
+        ALIGNMENT_128   = 0x0800,
+        ALIGNMENT_256   = 0x0900,
+        ALIGNMENT_512   = 0x0a00,
+        ALIGNMENT_1K    = 0x0b00,
+        ALIGNMENT_2K    = 0x0c00,
+        ALIGNMENT_4K    = 0x0d00,
+        ALIGNMENT_8K    = 0x0e00,
+        ALIGNMENT_16K   = 0x0f00,
+        ALIGNMENT_32K   = 0x1000,
+        ALIGNMENT_64K   = 0x1100,
+        ALIGNMENT_128K  = 0x1200,
+        ALIGNMENT_256K  = 0x1300,
+        ALIGNMENT_512K  = 0x1400,
+        ALIGNMENT_1M    = 0x1500,
+        ALIGNMENT_2M    = 0x1600,
+        ALIGNMENT_4M    = 0x1700,
+        ALIGNMENT_MAX   = ALIGNMENT_4M,
     }
 
     /**
      * Returns the ALIGNMENT_* attribute corresponding to the given alignment
      *
      * Params:
-     *  alignment = must be a power of 2 between 1 and 4096
+     *  alignment = must be a power of 2 between 1 and 1<<22
      * Returns:
-     *  one of ALIGNMENT_BYTE to ALIGNMENT_4096
+     *  one of ALIGNMENT_BYTE to ALIGNMENT_MAX
      */
     static BlkAttr convertAlignmentToBlkAttr(size_t alignment) @safe @nogc nothrow pure
     {
         import core.bitop;
-        debug assert((alignment & (alignment - 1)) == 0 && alignment > 0 && alignment <= 4096);
+        debug assert((alignment & (alignment - 1)) == 0 && alignment > 0 && alignment <= 1 << 22);
         return cast(BlkAttr)(BlkAttr.ALIGNMENT_BYTE * (bsf(alignment) + 1));
     }
     /**
      * Returns the alignment corresponding to the given ALIGNMENT_* attribute
      *
      * Params:
-     *  attr = one of ALIGNMENT_BYTE to ALIGNMENT_4096
+     *  attr = one of ALIGNMENT_BYTE to ALIGNMENT_MAX
      * Returns:
      *  alignment corresponding to the given attribute
      */
     static size_t convertBlkAttrToAlignment(BlkAttr attr) @safe @nogc nothrow pure
     {
-        debug assert(attr >= BlkAttr.ALIGNMENT_BYTE && attr <= BlkAttr.ALIGNMENT_4096);
+        debug assert(attr >= BlkAttr.ALIGNMENT_BYTE && attr <= BlkAttr.ALIGNMENT_MAX);
         return 1 << (attr / BlkAttr.ALIGNMENT_BYTE - 1);
     }
 

--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -356,8 +356,32 @@ extern(D):
         NO_INTERIOR = 0b0001_0000,
 
         STRUCTFINAL = 0b0010_0000, // the block has a finalizer for (an array of) structs
-    }
 
+        // specify alignment requirements for block (might not be supported by all GC)
+        ALIGNMENT_MASK  = 0xf00,
+        ALIGNMENT_NONE  = 0x000, // default is 16
+        ALIGNMENT_BYTE  = 0x100,
+        ALIGNMENT_WORD  = 0x200,
+        ALIGNMENT_DWORD = 0x300,
+        ALIGNMENT_QWORD = 0x400,
+        ALIGNMENT_16    = 0x500,
+        ALIGNMENT_32    = 0x600,
+        ALIGNMENT_64    = 0x700,
+        ALIGNMENT_128   = 0x800,
+        ALIGNMENT_256   = 0x900,
+        ALIGNMENT_512   = 0xa00,
+        ALIGNMENT_1024  = 0xb00,
+        ALIGNMENT_2048  = 0xc00,
+        ALIGNMENT_4096  = 0xd00,
+        ALIGNMENT_RSVD1 = 0xe00,
+        ALIGNMENT_RSVD2 = 0xf00,
+    }
+    static BlkAttr BlkAttrAlignment(size_t sz) @safe @nogc nothrow pure
+    {
+        pragma(inline, true);
+        import core.bitop;
+        return cast(BlkAttr)(BlkAttr.ALIGNMENT_BYTE * (bsf(sz) + 1));
+    }
 
     /**
      * Contains aggregate information about a block of managed memory.  The

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -1058,8 +1058,8 @@ unittest
     GC.free(larr1);
 
     auto larr2 = new S[255];
-    import core.internal.gc.blockmeta : LARGEPREFIX;
-    if (cast(void*)larr1 is cast(void*)larr2.ptr - LARGEPREFIX) // reusage not guaranteed
+    import core.internal.gc.blockmeta : LARGEPREFIX_MIN;
+    if (cast(void*)larr1 is cast(void*)larr2.ptr - LARGEPREFIX_MIN) // reusage not guaranteed
     {
         auto ptr = cast(S**)larr1;
         assert(ptr[0] != p1); // 16 bytes array header
@@ -1121,4 +1121,39 @@ unittest
     {
         s.thisptr = &s;
     }
+}
+
+// test alignment
+debug(SENTINEL) {} else
+unittest
+{
+    void testAlign(int algn)()
+    {
+        struct S
+        {
+            align(algn) int x;
+        }
+        auto s = new S;
+        assert((cast(size_t)(&s.x) & (algn - 1)) == 0);
+
+        S[] a;
+        a ~= S(0);
+        assert((cast(size_t)(a.ptr) & (algn - 1)) == 0);
+
+        // reallocate array until deep inside large array handling
+        for (int i = 1; i < 2048; i++)
+        {
+            a ~= S(i);
+            assert((cast(size_t)(a.ptr) & (algn - 1)) == 0);
+        }
+
+        class C
+        {
+            align(algn) int x;
+        }
+        auto c = new C;
+        assert((cast(size_t)(&c.x) & (algn - 1)) == 0);
+    }
+    static foreach (algn; [4, 8, 16, 32, 64, 128, 256, 512, 1024])
+        testAlign!algn();
 }

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -1127,7 +1127,7 @@ unittest
 debug(SENTINEL) {} else
 unittest
 {
-    void testAlign(int algn)()
+    static void testAlign(int algn)()
     {
         struct S
         {
@@ -1154,6 +1154,15 @@ unittest
         auto c = new C;
         assert((cast(size_t)(&c.x) & (algn - 1)) == 0);
     }
-    static foreach (algn; [4, 8, 16, 32, 64, 128, 256, 512, 1024])
-        testAlign!algn();
+    static foreach (algn; 0..16) // compiler does not support alignment > 32768
+        testAlign!(1 << algn)();
+
+    static void testAlignMalloc(int algn)()
+    {
+        // alignment larger than size
+        void* p = GC.malloc(4, GC.convertAlignmentToBlkAttr(algn));
+        assert((cast(size_t)(p) & (algn - 1)) == 0);
+    }
+    static foreach (algn; 0..23)
+        testAlignMalloc!(1 << algn)();
 }


### PR DESCRIPTION
- add alignment info to the GC.BlkAttr bits
- for small allocations, use an appropriate bin
- for large array allocations adjust the padding at the front