### PR TITLE
Improve diagnostic for struct with semantic errors when compiling

### DIFF
--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -380,6 +380,11 @@ void toObjFile(Dsymbol ds, bool multiobj)
             if (sd.type.ty == Terror)
             {
                 .error(sd.loc, "%s `%s` had semantic errors when compiling", sd.kind, sd.toPrettyChars);
+                foreach (field; sd.fields)
+                {
+                    if (field.errors)
+                        errorSupplemental(field.loc, "field `%s` failed semantic analysis", field.toChars());
+                }
                 return;
             }
 

--- a/compiler/test/fail_compilation/ice19762.d
+++ b/compiler/test/fail_compilation/ice19762.d
@@ -4,7 +4,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice19762.d(13): Error: struct `ice19762.X` had semantic errors when compiling
+fail_compilation/ice19762.d(14): Error: struct `ice19762.X` had semantic errors when compiling
+fail_compilation/ice19762.d(17):        field `err` failed semantic analysis
 ---
 */
 


### PR DESCRIPTION
Fixes #20560 

When a struct's type is Terror due to a field failing semantic analysis (often because the real error was swallowed inside a gagged/speculative semantic context), point to the specific field that failed instead of only printing a generic message.