### PR TITLE
Add caching for dub packages in perfrunner

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -111,6 +111,12 @@ jobs:
           fi
           deactivate
 
+      - name: Cache dub packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.dub/packages
+          key: dub-packages-${{ hashFiles('tools/perfrunner/workloads/vibed/dub.selections.json') }}
+
       - name: Measure
         run: |
           set -uexo pipefail


### PR DESCRIPTION
Avoids fetching the vibe.d packages from code.dlang.org every run.
No effect on the metrics