### PR TITLE
Fix #23605 - extern(C++) destructor uses wrong ABI on x86 in derived …

### DIFF
--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1021,6 +1021,11 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
             dtors.push(cldec.baseClass.aggrDtor);
     }
 
+    bool landsInCppVtbl;
+    if (auto cldec = ad.isClassDeclaration())
+        if (cldec.classKind == ClassKind.cpp)
+            landsInCppVtbl = true;
+
     // Set/build `ad.aggrDtor`
     switch (dtors.length)
     {
@@ -1028,6 +1033,9 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
         break;
 
     case 1:
+        // Always build the aggregate destructor if the linkage needs to match the vtbl.
+        if (landsInCppVtbl && dtors[0]._linkage != LINK.cpp)
+            goto default;
         // Use the single existing dtor directly as aggregate dtor.
         // Note that this might be `cldec.baseClass.aggrDtor`.
         ad.aggrDtor = dtors[0];
@@ -1053,13 +1061,21 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
             ce.directcall = true;
             e = Expression.combine(e, ce);
         }
+
+        auto sc2 = sc.push();
+        sc2.stc &= ~STC.static_; // not a static destructor
+        if (landsInCppVtbl)
+            sc2.linkage = LINK.cpp;
+
         auto dd = new DtorDeclaration(declLoc, Loc.initial, stc, Id.__aggrDtor);
         dd.isGenerated = true;
         dd.storage_class |= STC.inference;
         dd.fbody = new ExpStatement(loc, e);
         ad.members.push(dd);
-        dd.dsymbolSemantic(sc);
+        dd.dsymbolSemantic(sc2);
         ad.aggrDtor = dd;
+
+        sc2.pop();
         break;
     }
 

--- a/compiler/test/runnable_cxx/extra-files/test23605.cpp
+++ b/compiler/test/runnable_cxx/extra-files/test23605.cpp
@@ -1,0 +1,15 @@
+#include "test23605.h"
+#include <stdio.h>
+
+int lastDeleteA;
+
+A::~A()
+{
+    printf("A::~A() %d\n", i); // printf is required to trigger the crash
+    lastDeleteA = i;
+}
+
+void deleteFromCpp(A *obj)
+{
+    delete obj;
+}

--- a/compiler/test/runnable_cxx/extra-files/test23605.h
+++ b/compiler/test/runnable_cxx/extra-files/test23605.h
@@ -1,0 +1,6 @@
+class A
+{
+public:
+    int i;
+    virtual ~A();
+};

--- a/compiler/test/runnable_cxx/test23605.d
+++ b/compiler/test/runnable_cxx/test23605.d
@@ -1,0 +1,48 @@
+// https://github.com/dlang/dmd/issues/23605
+// EXTRA_CPP_SOURCES: test23605.cpp
+// EXTRA_FILES: extra-files/test23605.h
+// CXXFLAGS(osx linux freebsd openbsd netbsd dragonflybsd solaris): -std=c++11 -O2
+
+import core.stdcpp.new_;
+
+extern(C++) class A
+{
+    int i;
+    ~this();
+}
+
+extern(C++) extern __gshared int lastDeleteA;
+
+int lastDeleteB;
+
+class B : A
+{
+    ~this()
+    {
+        lastDeleteB = i;
+    }
+}
+
+static assert(__traits(getLinkage, B) == "C++");
+static assert(__traits(getLinkage, B.__dtor) == "D");
+static assert(__traits(getLinkage, B.__xdtor) == "C++");
+
+extern(C++) void deleteFromCpp(A obj);
+
+void main()
+{
+    {
+        A obj = cpp_new!B();
+        obj.i = 1;
+        cpp_delete(obj);
+        assert(lastDeleteA == 1);
+        assert(lastDeleteB == 1);
+    }
+    {
+        A obj = cpp_new!B();
+        obj.i = 2;
+        deleteFromCpp(obj);
+        assert(lastDeleteA == 2);
+        assert(lastDeleteB == 2);
+    }
+}


### PR DESCRIPTION
…class

Destructors in a C++ vtbl need C++ linkage.