### PR TITLE
Run `-ftime-trace` compiles serially in perfrunner

### DIFF
--- a/tools/perfrunner/source/app.d
+++ b/tools/perfrunner/source/app.d
@@ -6,7 +6,7 @@ import std.parallelism : task;
 import std.path : buildPath, dirName;
 import std.stdio : stderr, writeln;
 
-import metrics : measure, initials;
+import metrics : collectTraces, initials, measure;
 import report : CommitRecord, MetricResult, render, renderCommit, Report;
 import vibed : describeFlags;
 
@@ -73,8 +73,9 @@ int main(string[] args)
     if (!diff)
     {
         auto m = measure(headDmd, workload, headPhobos, vibedRoot, vibedFlags, tmp, "head");
+        auto t = collectTraces(headDmd, workload, headPhobos, tmp, "head");
         write(outPath, renderCommit(CommitRecord(headSha, committedAt, before, commits,
-            os, hostDmd, m.metrics, m.helloTrace, m.phobosTrace)));
+            os, hostDmd, m, t.hello, t.phobos)));
         writeln("wrote ", outPath);
         return 0;
     }
@@ -85,13 +86,16 @@ int main(string[] args)
     auto head = measure(headDmd, workload, headPhobos, vibedRoot, vibedFlags, tmp, "head");
     auto base = baseTask.yieldForce;
 
+    auto baseTraces = collectTraces(baseDmd, workload, basePhobos, tmp, "base");
+    auto headTraces = collectTraces(headDmd, workload, headPhobos, tmp, "head");
+
     MetricResult[] metrics;
     foreach (def; initials)
         metrics ~= MetricResult(def.id, def.label, def.unit, def.method,
-            base.metrics[def.id], head.metrics[def.id]);
+            base[def.id], head[def.id]);
 
     auto rep = Report(baseSha, "merge-base", headSha, pr, os, hostDmd, metrics,
-        base.helloTrace, head.helloTrace, base.phobosTrace, head.phobosTrace);
+        baseTraces.hello, headTraces.hello, baseTraces.phobos, headTraces.phobos);
     write(outPath, render(rep));
     writeln("wrote ", outPath);
     return 0;

--- a/tools/perfrunner/source/metrics.d
+++ b/tools/perfrunner/source/metrics.d
@@ -32,27 +32,26 @@ immutable MetricDef[] initials = [
     MetricDef("vibed_max_rss",                "peak RSS (compile vibe.d)",      "kb",    "time -v"),
 ];
 
-struct Measurement
+enum phobosFlags = ["-i=std", "-preview=dip1000"];
+
+struct Traces
 {
-    long[string] metrics;
-    Trace helloTrace;
-    Trace phobosTrace;
+    Trace hello;
+    Trace phobos;
 }
 
 // Measure every metric for one dmd binary. `tag` ("base"/"head")
 // keeps the two runs' temp files apart
-Measurement measure(string dmd, string workload, string phobos,
+long[string] measure(string dmd, string workload, string phobos,
     string vibed, string[] vibedFlags, string tmp, string tag)
 {
     auto stdPackage = buildPath(phobos, "std", "package.d");
-    auto phobosFlags = ["-i=std", "-preview=dip1000"];
     // Unlike a dub build, which compiles one package per invocation, this pulls
     // the whole vibe.d tree into a single compile.
     auto vibeFlags = "-i" ~ vibedFlags;
     auto phobosInstr = instructions(dmd, phobosFlags, stdPackage, tmp, tag ~ "-phobos");
     auto phobosFrontend = instructions(dmd, "-o-" ~ phobosFlags, stdPackage, tmp, tag ~ "-phobos-fe");
-    Measurement m;
-    m.metrics = [
+    return [
         "compile_hello_debug_instr":    instructions(dmd, [], workload, tmp, tag ~ "-dbg"),
         "compile_hello_release_instr":  instructions(dmd, ["-O", "-release"], workload, tmp, tag ~ "-rel"),
         "compile_phobos_instr":         phobosInstr,
@@ -64,9 +63,15 @@ Measurement measure(string dmd, string workload, string phobos,
         "phobos_max_rss":               maxRss(dmd, phobosFlags, stdPackage, tmp, tag ~ "-phobos"),
         "vibed_max_rss":                maxRss(dmd, vibeFlags, vibed, tmp, tag ~ "-vibed"),
     ];
-    m.helloTrace = collectTrace(dmd, [], workload, tmp, tag ~ "-hello");
-    m.phobosTrace = collectTrace(dmd, phobosFlags, stdPackage, tmp, tag ~ "-phobos");
-    return m;
+}
+
+// -ftime-trace phase times for hello and phobos
+Traces collectTraces(string dmd, string workload, string phobos, string tmp, string tag)
+{
+    auto stdPackage = buildPath(phobos, "std", "package.d");
+    return Traces(
+        collectTrace(dmd, [], workload, tmp, tag ~ "-hello"),
+        collectTrace(dmd, phobosFlags, stdPackage, tmp, tag ~ "-phobos"));
 }
 
 // Byte size of `binary`


### PR DESCRIPTION
Measuring cachegrind in parallel is fine, but wall time shouldn't be