### PR TITLE
[spec/statement] Tweak ScopeGuardStatement formatting

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -2354,12 +2354,15 @@ $(GNAME ScopeGuardStatement):
     $(D scope ( failure )) $(GLINK NonEmptyOrScopeBlockStatement)
 )
 
-$(P The $(I ScopeGuardStatement) executes *NonEmptyOrScopeBlockStatement* at the close of the
-current scope, rather than at the point where the $(I ScopeGuardStatement)
-appears. $(D scope(exit)) executes *NonEmptyOrScopeBlockStatement* when the scope exits normally
-or when it exits due to exception unwinding. $(D scope(failure)) executes
-*NonEmptyOrScopeBlockStatement* when the scope exits due to exception unwinding.
-`scope(success)` executes *NonEmptyOrScopeBlockStatement* when the scope exits normally.)
+        $(P If *NonEmptyOrScopeBlockStatement* is executed, it will occur at the close of the
+        current scope, rather than at the point where the $(I ScopeGuardStatement)
+        appears:)
+
+        - $(D scope(exit)) executes *NonEmptyOrScopeBlockStatement* when the scope exits normally
+          or when it exits due to exception unwinding.
+        - $(D scope(failure)) executes *NonEmptyOrScopeBlockStatement* only when the scope exits due
+          to exception unwinding.
+        - `scope(success)` executes *NonEmptyOrScopeBlockStatement* only when the scope exits normally.
 
         $(P If there are multiple $(I ScopeGuardStatement)s in a scope, they
         will be executed in the reverse lexical order in which they appear.


### PR DESCRIPTION
Change confusing first sentence about executing at the close of current scope (only `exit` always does this).
Use list for 3 variants.