### PR TITLE
Don't suggest an alias as a spelling fix for its own undefined target

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -631,8 +631,23 @@ Dsymbol search_correct(Scope* _this, Identifier ident)
 
         // Do not show `@disable`d declarations
         if (auto decl = s.isDeclaration())
+        {
             if (decl.storage_class & STC.disable)
                 return null;
+            // Do not suggest an alias as a fix for its own undefined
+            // target while it is still resolving that target (`inuse`
+            // is set for the duration of that resolution). Using the
+            // suggestion would make the alias refer to itself, e.g.
+            // `alias Foo = Foo1;` with an undefined `Foo1` would
+            // otherwise suggest `Foo`, which is circular by
+            // construction: `alias Foo = Foo;`. This is specific to
+            // aliases: e.g. `Foo foo;` legitimately suggesting the
+            // variable `foo` itself is not circular in the same way
+            // and should still be shown.
+            // https://github.com/dlang/dmd/issues/18763
+            if (decl.isAliasDeclaration() && decl.inuse)
+                return null;
+        }
         // Or `deprecated` ones if we're not in a deprecated scope
         if (s.isDeprecated() && !sc.isDeprecated())
             return null;

--- a/compiler/test/fail_compilation/fail18763.d
+++ b/compiler/test/fail_compilation/fail18763.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail18763.d(11): Error: undefined identifier `Foo1`
+---
+*/
+
+// https://github.com/dlang/dmd/issues/18763
+// The spellchecker should not suggest `Foo` as a fix for `Foo1` here,
+// since `Foo` is the very alias being declared (a recursive suggestion).
+alias Foo = Foo1;


### PR DESCRIPTION
Fixes #18763

`alias Foo = Foo1;` with an undefined `Foo1` suggested `Foo` back as a fix ("did you mean alias Foo?"), which is circular: using it would make the alias refer to itself.

The fix is narrowed to aliases specifically — a plain declaration like `Foo foo;` legitimately suggesting the variable `foo` itself is not circular in the same way and is left unchanged (see `dip22b.d`).

Verified against the 58 existing `fail_compilation` tests containing "did you mean" no regressions.