### PR TITLE
Add regression test for rvalue/ref parameter mismatch error message

### DIFF
--- a/compiler/test/fail_compilation/fail18705.d
+++ b/compiler/test/fail_compilation/fail18705.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail18705.d(19): Error: function `fail` is not callable using argument types `(string)`
+fail_compilation/fail18705.d(19):        cannot pass rvalue argument `val()` of type `string` to parameter `ref string v`
+fail_compilation/fail18705.d(15):        `fail18705.fail(ref string v)` declared here
+---
+*/
+
+// https://github.com/dlang/dmd/issues/18705
+// Confirms the "not callable" error explicitly mentions the rvalue/ref
+// mismatch instead of only a generic type list.
+string val() { return "3"; }
+
+void fail(ref string v) {}
+
+void test18705()
+{
+    int v = fail(val);
+}


### PR DESCRIPTION
Fixes #18705

DMD already reports "cannot pass rvalue argument ... to parameter ref ..." for this case. This PR just adds a test to lock that in.