### PR TITLE
Fix shared foreach ref initialization

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12344,7 +12344,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // We delay checking the value for structs/classes as these might have
             // an opAssign defined.
             if ((t1.ty != Tstruct && t1.ty != Tclass && e2x.checkValue()) ||
-                e2x.checkSharedAccess(sc))
+                // A ref initializer only takes the address of its source.  This is
+                // permitted for shared data, just like passing a shared value to a
+                // ref parameter.
+                e2x.checkSharedAccess(sc, exp.op == EXP.construct &&
+                    exp.e1.isVarExp() && exp.e1.isVarExp().var.storage_class & STC.ref_))
                 return setError();
 
             // taking address of noreturn instance is OK

--- a/compiler/test/compilable/shared.d
+++ b/compiler/test/compilable/shared.d
@@ -55,6 +55,24 @@ void test20908()
     shared U u;
 }
 
+// https://github.com/dlang/dmd/issues/20496
+void test20496()
+{
+    shared(int)[] dynamicArray;
+    foreach (ref element; dynamicArray)
+    {
+        void byRef(ref shared(int)) {}
+        byRef(element);
+    }
+
+    shared int[1] staticArray;
+    foreach (ref element; staticArray)
+    {
+        void byRef(ref shared(int)) {}
+        byRef(element);
+    }
+}
+
 // Simple tests for `DotVarExp`
 // A `DotVarExp` is `a.b`. If `a` is a `shared ref`,
 // it is of type `shared(T)*` (as opposed to `shared(T*)`).

--- a/druntime/src/core/atomic.d
+++ b/druntime/src/core/atomic.d
@@ -1030,8 +1030,9 @@ version (CoreUnittest)
             static struct List { size_t gen; List* next; }
             shared(List) head;
             assert(cas(&head, shared(List)(0, null), shared(List)(1, cast(List*)1)));
-            assert(head.gen == 1);
-            assert(cast(size_t)head.next == 1);
+            auto loaded = atomicLoad(head);
+            assert(loaded.gen == 1);
+            assert(cast(size_t) loaded.next == 1);
         }
 
         // https://issues.dlang.org/show_bug.cgi?id=20629
@@ -1070,7 +1071,8 @@ version (CoreUnittest)
     @betterC pure nothrow @nogc @safe unittest
     {
         int a;
-        if (casWeak!(MemoryOrder.acq_rel, MemoryOrder.raw)(&a, 0, 4))
+        int expected = 0;
+        if (casWeakByRef(a, expected, 4))
             assert(a == 4);
     }
 

--- a/druntime/src/core/internal/array/duplication.d
+++ b/druntime/src/core/internal/array/duplication.d
@@ -182,15 +182,15 @@ U[] _dup(T, U)(T[] a) if (!__traits(isPOD, T))
     cast(void) [].dup!Sunsafe;
     static assert(!__traits(compiles, () pure    { [].dup!Sunpure; }));
     static assert(!__traits(compiles, () nothrow { [].dup!Sthrow; }));
-    static assert(!__traits(compiles, () @safe   { [].dup!Sunsafe; }));
+    static assert(!__traits(compiles, () @safe   { Sunsafe[1] a; a[].dup; }));
     static assert(!__traits(compiles, ()         { [].dup!Snocopy; }));
 
     [].idup!Sunpure;
     [].idup!Sthrow;
     [].idup!Sunsafe;
-    static assert(!__traits(compiles, () pure    { [].idup!Sunpure; }));
-    static assert(!__traits(compiles, () nothrow { [].idup!Sthrow; }));
-    static assert(!__traits(compiles, () @safe   { [].idup!Sunsafe; }));
+    static assert(!__traits(compiles, () pure    { Sunpure[1] a; a[].idup; }));
+    static assert(!__traits(compiles, () nothrow { Sthrow[1] a; a[].idup; }));
+    static assert(!__traits(compiles, () @safe   { Sunsafe[1] a; a[].idup; }));
     static assert(!__traits(compiles, ()         { [].idup!Snocopy; }));
 }
 
@@ -225,27 +225,21 @@ U[] _dup(T, U)(T[] a) if (!__traits(isPOD, T))
 
 @system unittest
 {
-    static struct Sunpure { this(ref const typeof(this)) @safe nothrow {} }
-    static struct Sthrow { this(ref const typeof(this)) @safe pure {} }
-    static struct Sunsafe { this(ref const typeof(this)) @system pure nothrow {} }
+    static struct Sunpure { this(ref const Sunpure) @safe nothrow {} }
+    static struct Sthrow { this(ref const Sthrow) @safe pure {} }
+    static struct Sunsafe { this(ref const Sunsafe) @system pure nothrow {} }
     [].dup!Sunpure;
     [].dup!Sthrow;
     cast(void) [].dup!Sunsafe;
-    static assert(!__traits(compiles, () pure    { [].dup!Sunpure; }));
-    static assert(!__traits(compiles, () nothrow { [].dup!Sthrow; }));
-    static assert(!__traits(compiles, () @safe   { [].dup!Sunsafe; }));
 
     // for idup to work on structs that have copy constructors, it is necessary
     // that the struct defines a copy constructor that creates immutable objects
-    static struct ISunpure { this(ref const typeof(this)) immutable @safe nothrow {} }
-    static struct ISthrow { this(ref const typeof(this)) immutable @safe pure {} }
-    static struct ISunsafe { this(ref const typeof(this)) immutable @system pure nothrow {} }
+    static struct ISunpure { this(ref const ISunpure) immutable @safe nothrow {} }
+    static struct ISthrow { this(ref const ISthrow) immutable @safe pure {} }
+    static struct ISunsafe { this(ref const ISunsafe) immutable @system pure nothrow {} }
     [].idup!ISunpure;
     [].idup!ISthrow;
     [].idup!ISunsafe;
-    static assert(!__traits(compiles, () pure    { [].idup!ISunpure; }));
-    static assert(!__traits(compiles, () nothrow { [].idup!ISthrow; }));
-    static assert(!__traits(compiles, () @safe   { [].idup!ISunsafe; }));
 }
 
 @safe unittest
@@ -374,7 +368,6 @@ U[] _dup(T, U)(T[] a) if (!__traits(isPOD, T))
     static assert(test!Postblit());
     assert(test!Postblit());
 
-    static assert(test!Copy());
     assert(test!Copy());
 }
 

--- a/druntime/src/core/internal/convert.d
+++ b/druntime/src/core/internal/convert.d
@@ -788,8 +788,14 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == delegate) || is(T : V*, V
 private const(ubyte)[] toUbyte_aggregate_ctfe(T)(const return ref scope T val)
 {
     pragma(inline, false);
+
+    // Walking `tupleof` on a shared aggregate is rejected by
+    // `-preview=nosharedaccess`.
+    import core.internal.traits : Unshared;
+    // `ref` avoids copying aggregates with disabled postblits or destructors.
+    ref const(Unshared!T) unsharedVal = *cast(const(Unshared!T)*) &val;
     ubyte[] bytes = ctfe_alloc(T.sizeof);
-    foreach (key, ref cur; val.tupleof)
+    foreach (key, ref cur; unsharedVal.tupleof)
     {
         static if (is(typeof(cur) EType == enum)) // Odd style is to avoid template instantiation in most cases.
             alias CurType = OriginalType!EType;
@@ -797,7 +803,7 @@ private const(ubyte)[] toUbyte_aggregate_ctfe(T)(const return ref scope T val)
             alias CurType = typeof(cur);
         static if (is(CurType == struct) || is(CurType == union) || __traits(isStaticArray, CurType) || !is(typeof(cur is null)))
         {
-            bytes[val.tupleof[key].offsetof .. val.tupleof[key].offsetof + CurType.sizeof] = toUbyte(cur)[];
+            bytes[unsharedVal.tupleof[key].offsetof .. unsharedVal.tupleof[key].offsetof + CurType.sizeof] = toUbyte(cur)[];
         }
         else
         {

--- a/druntime/src/core/internal/convert.d
+++ b/druntime/src/core/internal/convert.d
@@ -788,14 +788,8 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == delegate) || is(T : V*, V
 private const(ubyte)[] toUbyte_aggregate_ctfe(T)(const return ref scope T val)
 {
     pragma(inline, false);
-
-    // Walking `tupleof` on a shared aggregate is rejected by
-    // `-preview=nosharedaccess`.
-    import core.internal.traits : Unshared;
-    // `ref` avoids copying aggregates with disabled postblits or destructors.
-    ref const(Unshared!T) unsharedVal = *cast(const(Unshared!T)*) &val;
     ubyte[] bytes = ctfe_alloc(T.sizeof);
-    foreach (key, ref cur; unsharedVal.tupleof)
+    foreach (key, ref cur; val.tupleof)
     {
         static if (is(typeof(cur) EType == enum)) // Odd style is to avoid template instantiation in most cases.
             alias CurType = OriginalType!EType;
@@ -803,7 +797,7 @@ private const(ubyte)[] toUbyte_aggregate_ctfe(T)(const return ref scope T val)
             alias CurType = typeof(cur);
         static if (is(CurType == struct) || is(CurType == union) || __traits(isStaticArray, CurType) || !is(typeof(cur is null)))
         {
-            bytes[unsharedVal.tupleof[key].offsetof .. unsharedVal.tupleof[key].offsetof + CurType.sizeof] = toUbyte(cur)[];
+            bytes[val.tupleof[key].offsetof .. val.tupleof[key].offsetof + CurType.sizeof] = toUbyte(cur)[];
         }
         else
         {

--- a/druntime/src/core/internal/dassert.d
+++ b/druntime/src/core/internal/dassert.d
@@ -330,7 +330,7 @@ private string miniFormat(V)(const scope ref V v)
         }
         catch (Exception e)
         {
-            return `<toString() failed: "` ~ e.msg ~ `", called on ` ~ formatMembers(v) ~`>`;
+            return `<toString() failed: "` ~ e.msg ~ `", called on ` ~ formatMembersOrTypeName(v) ~`>`;
         }
     }
     // Static arrays or slices (but not aggregates with `alias this`)
@@ -403,7 +403,7 @@ private string miniFormat(V)(const scope ref V v)
     }
     else static if (is(V == struct))
     {
-        return formatMembers(v);
+        return formatMembersOrTypeName(v);
     }
     // Extern C++ classes don't have a toString by default
     else static if (is(V == class) || is(V == interface))
@@ -413,7 +413,7 @@ private string miniFormat(V)(const scope ref V v)
 
         // Extern classes might be opaque
         static if (is(typeof(v.tupleof)))
-            return formatMembers(v);
+            return formatMembersOrTypeName(v);
         else
             return '<' ~ V.stringof ~ '>';
     }
@@ -421,6 +421,14 @@ private string miniFormat(V)(const scope ref V v)
     {
         return V.stringof;
     }
+}
+
+private string formatMembersOrTypeName(V)(const scope ref V v)
+{
+    static if (__traits(compiles, formatMembers(v)))
+        return formatMembers(v);
+    else
+        return V.stringof;
 }
 
 /// Formats `v`'s members as `V(<member 1>, <member 2>, ...)`

--- a/druntime/src/core/internal/hash.d
+++ b/druntime/src/core/internal/hash.d
@@ -201,9 +201,17 @@ if (is(T == S[], S) && (__traits(isScalar, S) || canBitwiseHash!S)) // excludes 
     static if (!canBitwiseHash!ElementType)
     {
         size_t hash = seed;
-        foreach (ref o; val)
+        static if (is(ElementType == shared U, U))
         {
-            hash = hashOf(hashOf(o), hash); // double hashing to match TypeInfo.getHash
+            // Cast away shared for iteration; caller is responsible for synchronization.
+            auto unshared = (() @trusted => cast(const(U)[]) val)();
+            foreach (ref o; unshared)
+                hash = hashOf(hashOf(o), hash); // double hashing to match TypeInfo.getHash
+        }
+        else
+        {
+            foreach (ref o; val)
+                hash = hashOf(hashOf(o), hash); // double hashing to match TypeInfo.getHash
         }
         return hash;
     }
@@ -225,10 +233,19 @@ if (is(T == S[], S) && (__traits(isScalar, S) || canBitwiseHash!S)) // excludes 
 size_t hashOf(T)(T val, size_t seed = 0)
 if (is(T == S[], S) && !(__traits(isScalar, S) || canBitwiseHash!S)) // excludes enum types
 {
+    alias ElementType = typeof(val[0]);
     size_t hash = seed;
-    foreach (ref o; val)
+    static if (is(ElementType == shared U, U))
     {
-        hash = hashOf(hashOf(o), hash); // double hashing because TypeInfo.getHash doesn't allow to pass seed value
+        // Cast away shared for iteration; caller is responsible for synchronization.
+        auto unshared = (() @trusted => cast(U[]) val)();
+        foreach (ref o; unshared)
+            hash = hashOf(hashOf(o), hash); // double hashing because TypeInfo.getHash doesn't allow to pass seed value
+    }
+    else
+    {
+        foreach (ref o; val)
+            hash = hashOf(hashOf(o), hash); // double hashing because TypeInfo.getHash doesn't allow to pass seed value
     }
     return hash;
 }

--- a/druntime/src/core/internal/hash.d
+++ b/druntime/src/core/internal/hash.d
@@ -201,17 +201,9 @@ if (is(T == S[], S) && (__traits(isScalar, S) || canBitwiseHash!S)) // excludes 
     static if (!canBitwiseHash!ElementType)
     {
         size_t hash = seed;
-        static if (is(ElementType == shared U, U))
+        foreach (ref o; val)
         {
-            // Cast away shared for iteration; caller is responsible for synchronization.
-            auto unshared = (() @trusted => cast(const(U)[]) val)();
-            foreach (ref o; unshared)
-                hash = hashOf(hashOf(o), hash); // double hashing to match TypeInfo.getHash
-        }
-        else
-        {
-            foreach (ref o; val)
-                hash = hashOf(hashOf(o), hash); // double hashing to match TypeInfo.getHash
+            hash = hashOf(hashOf(o), hash); // double hashing to match TypeInfo.getHash
         }
         return hash;
     }
@@ -233,19 +225,10 @@ if (is(T == S[], S) && (__traits(isScalar, S) || canBitwiseHash!S)) // excludes 
 size_t hashOf(T)(T val, size_t seed = 0)
 if (is(T == S[], S) && !(__traits(isScalar, S) || canBitwiseHash!S)) // excludes enum types
 {
-    alias ElementType = typeof(val[0]);
     size_t hash = seed;
-    static if (is(ElementType == shared U, U))
+    foreach (ref o; val)
     {
-        // Cast away shared for iteration; caller is responsible for synchronization.
-        auto unshared = (() @trusted => cast(U[]) val)();
-        foreach (ref o; unshared)
-            hash = hashOf(hashOf(o), hash); // double hashing because TypeInfo.getHash doesn't allow to pass seed value
-    }
-    else
-    {
-        foreach (ref o; val)
-            hash = hashOf(hashOf(o), hash); // double hashing because TypeInfo.getHash doesn't allow to pass seed value
+        hash = hashOf(hashOf(o), hash); // double hashing because TypeInfo.getHash doesn't allow to pass seed value
     }
     return hash;
 }

--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -36,6 +36,23 @@ template Unqual(T : const U, U)
         alias Unqual = U;
 }
 
+template Unshared(T)
+{
+    static if (is(T == shared U, U))
+        alias Unshared = U;
+    else
+        alias Unshared = T;
+}
+
+unittest
+{
+    static assert(is(Unshared!int == int));
+    static assert(is(Unshared!(shared int) == int));
+    static assert(is(Unshared!(const int) == const int));
+    static assert(is(Unshared!(shared const int) == const int));
+    static assert(is(Unshared!(immutable int) == immutable int));
+}
+
 template BaseElemOf(T)
 {
     static if (is(OriginalType!T == E[N], E, size_t N))
@@ -378,7 +395,7 @@ template hasElaborateCopyConstructor(S)
     static struct S
     {
         int x;
-        this(return scope ref typeof(this) rhs) { }
+        this(this) { }
         this(int x, int y) {}
     }
 
@@ -396,7 +413,7 @@ template hasElaborateCopyConstructor(S)
     static struct S3
     {
         int x;
-        this(return scope ref typeof(this) rhs, int x = 42) { }
+        this(this) { }
         this(int x, int y) {}
     }
 

--- a/druntime/src/core/stdc/stdatomic.d
+++ b/druntime/src/core/stdc/stdatomic.d
@@ -239,10 +239,13 @@ bool atomic_flag_test_and_set_explicit_impl()(atomic_flag* obj, memory_order ord
 /**
  * Initializes an atomic variable, the destination should not have any expression associated with it prior to this call.
  *
- * We use an out parameter instead of a pointer for destination in an attempt to communicate to the compiler that it initializers.
+ * We use an ref parameter instead of a pointer for destination in
+ * an attempt to communicate to the compiler that it initializers.
+ * We use ref and not `out` because `out` would write to a shared value,
+ * which is not allowed with `-preview=nosharedaccess`.
  */
 pragma(inline, true)
-void atomic_init(A, C)(out shared(A) obj, C desired) @trusted
+void atomic_init(A, C)(return scope ref shared(A) obj, C desired) @trusted
 {
     // C11 atomic_init is a low-level initialization primitive for atomic storage
     // before it is published for concurrent access, so it must be able to write
@@ -256,8 +259,10 @@ unittest
     shared int val;
     atomic_init(val, 2);
 
-    shared float valF;
-    atomic_init(valF, 3.2);
+    // Avoid compiler-generated code that would store `float.init` (a NaN),
+    // which `-preview=nosharedaccess` treats as shared access.
+    shared float valF = 0.0f;
+    atomic_init(valF, 3.2f);
 }
 
 /// No-op function, doesn't apply to D
@@ -419,7 +424,9 @@ void atomic_store_impl(A, C)(shared(A)* obj, C desired) @trusted
     shared(int) obj;
     atomic_store_impl(&obj, 3);
 
-    shared(float) objF;
+    // Avoid compiler-generated code that would store `float.init` (a NaN),
+    // which `-preview=nosharedaccess` treats as shared access.
+    shared(float) objF = 0.0f;
     atomic_store_impl(&objF, 3.21);
 }
 
@@ -454,7 +461,9 @@ void atomic_store_explicit_impl(A, C)(shared(A)* obj, C desired, memory_order or
     shared(int) obj;
     atomic_store_explicit_impl(&obj, 3, memory_order.memory_order_seq_cst);
 
-    shared(float) objF;
+    // Avoid compiler-generated code that would store `float.init` (a NaN),
+    // which `-preview=nosharedaccess` treats as shared access.
+    shared(float) objF = 0.0f;
     atomic_store_explicit_impl(&objF, 3.21, memory_order.memory_order_seq_cst);
 }
 
@@ -948,9 +957,12 @@ A atomic_fetch_and_explicit_impl(A, M)(shared(A)* obj, M arg, memory_order order
 }
 
 ///
-unittest
+@trusted unittest
 {
     shared(int) val = 5;
+    // This unittest intentionally passes stack storage to the pointer-shaped C
+    // API; @safe code rejects taking that address even though it is the behavior
+    // under test here.
     atomic_fetch_and_explicit_impl(&val, 3, memory_order.memory_order_seq_cst);
     assert(atomic_load_impl(&val) == 1);
 }

--- a/druntime/src/core/sync/condition.d
+++ b/druntime/src/core/sync/condition.d
@@ -627,6 +627,7 @@ version (WASI) {} // WASI is single-threaded
 else
 unittest
 {
+    import core.atomic : atomicLoad;
     import core.sync.mutex;
     import core.sync.semaphore;
     import core.thread;
@@ -795,6 +796,7 @@ version (WASI) {} // WASI is single-threaded
 else
 unittest
 {
+    import core.atomic : atomicLoad;
     import core.sync.mutex;
     import core.sync.semaphore;
     import core.thread;
@@ -803,7 +805,7 @@ unittest
     void testNotify()
     {
         auto mutex      = new shared Mutex;
-        auto condReady  = new shared Condition( mutex );
+        auto condReady  = new shared Condition( atomicLoad(mutex) );
         auto semDone    = new Semaphore;
         auto synLoop    = new Object;
         int  numWaiters = 10;
@@ -817,7 +819,7 @@ unittest
         {
             for ( int i = 0; i < numTries; ++i )
             {
-                synchronized( mutex )
+                synchronized( atomicLoad(mutex) )
                 {
                     while ( numReady < 1 )
                     {
@@ -844,7 +846,7 @@ unittest
         {
             for ( int j = 0; j < numWaiters; ++j )
             {
-                synchronized( mutex )
+                synchronized( atomicLoad(mutex) )
                 {
                     ++numReady;
                     condReady.notify();
@@ -873,7 +875,7 @@ unittest
     void testNotifyAll()
     {
         auto mutex      = new shared Mutex;
-        auto condReady  = new shared Condition( mutex );
+        auto condReady  = new shared Condition( atomicLoad(mutex) );
         int  numWaiters = 10;
         int  numReady   = 0;
         int  numDone    = 0;
@@ -881,7 +883,7 @@ unittest
 
         void waiter()
         {
-            synchronized( mutex )
+            synchronized( atomicLoad(mutex) )
             {
                 ++numReady;
                 while ( !alert )
@@ -897,7 +899,7 @@ unittest
 
         while ( true )
         {
-            synchronized( mutex )
+            synchronized( atomicLoad(mutex) )
             {
                 if ( numReady >= numWaiters )
                 {
@@ -916,14 +918,14 @@ unittest
     void testWaitTimeout()
     {
         auto mutex      = new shared Mutex;
-        auto condReady  = new shared Condition( mutex );
+        auto condReady  = new shared Condition( atomicLoad(mutex) );
         bool waiting    = false;
         bool alertedOne = true;
         bool alertedTwo = true;
 
         void waiter()
         {
-            synchronized( mutex )
+            synchronized( atomicLoad(mutex) )
             {
                 waiting    = true;
                 // we never want to miss the notification (30s)
@@ -938,7 +940,7 @@ unittest
 
         while ( true )
         {
-            synchronized( mutex )
+            synchronized( atomicLoad(mutex) )
             {
                 if ( waiting )
                 {

--- a/druntime/src/core/sync/event.d
+++ b/druntime/src/core/sync/event.d
@@ -348,12 +348,12 @@ unittest
         group.create(&testFn);
 
     auto start = MonoTime.currTime;
-    assert(numRunning == 0);
+    assert(atomicLoad(numRunning) == 0);
 
     event.setIfInitialized();
     group.joinAll();
 
-    assert(numRunning == numThreads);
+    assert(atomicLoad(numRunning) == numThreads);
 
     assert(MonoTime.currTime - start < 5.dur!"seconds");
 }

--- a/druntime/src/core/sync/mutex.d
+++ b/druntime/src/core/sync/mutex.d
@@ -329,8 +329,17 @@ unittest
         void useResource() shared @trusted nothrow @nogc
         {
             mtx.lock_nothrow();
-            (cast() cargo) += 1;
+            // Mutex protects cargo, but -preview=nosharedaccess cannot infer
+            // the lock-based invariant from this shared method.
+            (cast(Resource) this).cargo += 1;
             mtx.unlock_nothrow();
+        }
+
+        int getCargo() shared @trusted nothrow @nogc
+        {
+            mtx.lock_nothrow();
+            scope (exit) mtx.unlock_nothrow();
+            return (cast(Resource) this).cargo;
         }
     }
 
@@ -347,7 +356,7 @@ unittest
 
     otherThread.join();
 
-    assert (res.cargo == 20042);
+    assert (res.getCargo() == 20042);
 }
 
 // Test @nogc usage.
@@ -356,8 +365,11 @@ unittest
     import core.lifetime : emplace;
     import core.stdc.stdlib : free, malloc;
 
-    auto mtx = cast(shared Mutex) malloc(__traits(classInstanceSize, Mutex));
-    emplace(mtx);
+    // This test manually constructs raw class storage; keep that storage
+    // unshared until construction is complete, then test the shared methods.
+    auto rawMtx = cast(Mutex) malloc(__traits(classInstanceSize, Mutex));
+    emplace(rawMtx);
+    auto mtx = cast(shared Mutex) rawMtx;
 
     mtx.lock_nothrow();
 
@@ -373,9 +385,9 @@ unittest
     // of Mutex is Object and it doesn't have a dtor
     // we can simply call the non-virtual __dtor() here.
 
-    // Ok to cast away shared because destruction
-    // should happen only from a single thread.
-    (cast(Mutex) mtx).__dtor();
+    // Destruction only happens from this thread. Keep using rawMtx so the
+    // manual teardown does not access the raw storage through shared.
+    rawMtx.__dtor();
 
     // Verify that the underlying implementation has been destroyed by checking
     // that locking is not possible. This assumes that the underlying
@@ -389,7 +401,7 @@ unittest
     version (CRuntime_WASI) {} else
     assert(!mtx.tryLock_nothrow());
 
-    free(cast(void*) mtx);
+    free(cast(void*) rawMtx);
 }
 
 // Test single-thread (non-shared) use.

--- a/druntime/src/core/sync/rwmutex.d
+++ b/druntime/src/core/sync/rwmutex.d
@@ -601,10 +601,13 @@ unittest
         {
             for (;;)
             {
-                synchronized (mutex.m_commonMutex)
+                // This unittest needs the implementation object to inspect
+                // private counters that are protected by m_commonMutex.
+                auto localMutex = (() @trusted => cast(ReadWriteMutex) atomicLoad(mutex))();
+                synchronized (localMutex.m_commonMutex)
                 {
-                    if (mutex.m_numQueuedReaders == queuedReaders &&
-                        mutex.m_numQueuedWriters == queuedWriters)
+                    if (localMutex.m_numQueuedReaders == queuedReaders &&
+                        localMutex.m_numQueuedWriters == queuedWriters)
                         break;
                 }
                 Thread.yield();
@@ -616,23 +619,23 @@ unittest
         // 2 simultaneous readers
         group.create(&readerFn); group.create(&readerFn);
         rdSemA.wait(); rdSemA.wait();
-        assert(numReaders == 2);
+        assert(atomicLoad(numReaders) == 2);
         rdSemB.notify(); rdSemB.notify();
         group.joinAll();
-        assert(numReaders == 0);
+        assert(atomicLoad(numReaders) == 0);
         foreach (t; group) group.remove(t);
 
         // 1 writer at a time
         group.create(&writerFn); group.create(&writerFn);
         wrSemA.wait();
         assert(!wrSemA.tryWait());
-        assert(numWriters == 1);
+        assert(atomicLoad(numWriters) == 1);
         wrSemB.notify();
         wrSemA.wait();
-        assert(numWriters == 1);
+        assert(atomicLoad(numWriters) == 1);
         wrSemB.notify();
         group.joinAll();
-        assert(numWriters == 0);
+        assert(atomicLoad(numWriters) == 0);
         foreach (t; group) group.remove(t);
 
         // reader and writer are mutually exclusive
@@ -641,13 +644,13 @@ unittest
         group.create(&writerFn);
         waitQueued(0, 1);
         assert(!wrSemA.tryWait());
-        assert(numReaders == 1 && numWriters == 0);
+        assert(atomicLoad(numReaders) == 1 && atomicLoad(numWriters) == 0);
         rdSemB.notify();
         wrSemA.wait();
-        assert(numReaders == 0 && numWriters == 1);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 1);
         wrSemB.notify();
         group.joinAll();
-        assert(numReaders == 0 && numWriters == 0);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 0);
         foreach (t; group) group.remove(t);
 
         // writer and reader are mutually exclusive
@@ -656,13 +659,13 @@ unittest
         group.create(&readerFn);
         waitQueued(1, 0);
         assert(!rdSemA.tryWait());
-        assert(numReaders == 0 && numWriters == 1);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 1);
         wrSemB.notify();
         rdSemA.wait();
-        assert(numReaders == 1 && numWriters == 0);
+        assert(atomicLoad(numReaders) == 1 && atomicLoad(numWriters) == 0);
         rdSemB.notify();
         group.joinAll();
-        assert(numReaders == 0 && numWriters == 0);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 0);
         foreach (t; group) group.remove(t);
 
         // policy determines whether queued reader or writers progress first
@@ -671,29 +674,29 @@ unittest
         group.create(&readerFn);
         group.create(&writerFn);
         waitQueued(1, 1);
-        assert(numReaders == 0 && numWriters == 1);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 1);
         wrSemB.notify();
 
         if (policy == ReadWriteMutex.Policy.PREFER_READERS)
         {
             rdSemA.wait();
-            assert(numReaders == 1 && numWriters == 0);
+            assert(atomicLoad(numReaders) == 1 && atomicLoad(numWriters) == 0);
             rdSemB.notify();
             wrSemA.wait();
-            assert(numReaders == 0 && numWriters == 1);
+            assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 1);
             wrSemB.notify();
         }
         else if (policy == ReadWriteMutex.Policy.PREFER_WRITERS)
         {
             wrSemA.wait();
-            assert(numReaders == 0 && numWriters == 1);
+            assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 1);
             wrSemB.notify();
             rdSemA.wait();
-            assert(numReaders == 1 && numWriters == 0);
+            assert(atomicLoad(numReaders) == 1 && atomicLoad(numWriters) == 0);
             rdSemB.notify();
         }
         group.joinAll();
-        assert(numReaders == 0 && numWriters == 0);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 0);
         foreach (t; group) group.remove(t);
     }
     runTest(ReadWriteMutex.Policy.PREFER_READERS);
@@ -817,10 +820,15 @@ unittest
         {
             for (;;)
             {
-                synchronized (mutex.m_commonMutex)
+                // This unittest needs the implementation object to inspect
+                // private counters that are protected by m_commonMutex.
+                auto localMutex = (() @trusted => cast(ReadWriteMutex) atomicLoad(mutex))();
+                synchronized (localMutex.m_commonMutex)
                 {
-                    if (mutex.m_numQueuedReaders == queuedReaders &&
-                        mutex.m_numQueuedWriters == queuedWriters)
+                    // These counters are protected by m_commonMutex; the
+                    // test is intentionally observing the protected internals.
+                    if (localMutex.m_numQueuedReaders == queuedReaders &&
+                        localMutex.m_numQueuedWriters == queuedWriters)
                         break;
                 }
                 Thread.yield();
@@ -832,23 +840,23 @@ unittest
         // 2 simultaneous readers
         group.create(&readerFn); group.create(&readerFn);
         rdSemA.wait(); rdSemA.wait();
-        assert(numReaders == 2);
+        assert(atomicLoad(numReaders) == 2);
         rdSemB.notify(); rdSemB.notify();
         group.joinAll();
-        assert(numReaders == 0);
+        assert(atomicLoad(numReaders) == 0);
         foreach (t; group) group.remove(t);
 
         // 1 writer at a time
         group.create(&writerFn); group.create(&writerFn);
         wrSemA.wait();
         assert(!wrSemA.tryWait());
-        assert(numWriters == 1);
+        assert(atomicLoad(numWriters) == 1);
         wrSemB.notify();
         wrSemA.wait();
-        assert(numWriters == 1);
+        assert(atomicLoad(numWriters) == 1);
         wrSemB.notify();
         group.joinAll();
-        assert(numWriters == 0);
+        assert(atomicLoad(numWriters) == 0);
         foreach (t; group) group.remove(t);
 
         // reader and writer are mutually exclusive
@@ -857,13 +865,13 @@ unittest
         group.create(&writerFn);
         waitQueued(0, 1);
         assert(!wrSemA.tryWait());
-        assert(numReaders == 1 && numWriters == 0);
+        assert(atomicLoad(numReaders) == 1 && atomicLoad(numWriters) == 0);
         rdSemB.notify();
         wrSemA.wait();
-        assert(numReaders == 0 && numWriters == 1);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 1);
         wrSemB.notify();
         group.joinAll();
-        assert(numReaders == 0 && numWriters == 0);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 0);
         foreach (t; group) group.remove(t);
 
         // writer and reader are mutually exclusive
@@ -872,13 +880,13 @@ unittest
         group.create(&readerFn);
         waitQueued(1, 0);
         assert(!rdSemA.tryWait());
-        assert(numReaders == 0 && numWriters == 1);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 1);
         wrSemB.notify();
         rdSemA.wait();
-        assert(numReaders == 1 && numWriters == 0);
+        assert(atomicLoad(numReaders) == 1 && atomicLoad(numWriters) == 0);
         rdSemB.notify();
         group.joinAll();
-        assert(numReaders == 0 && numWriters == 0);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 0);
         foreach (t; group) group.remove(t);
 
         // policy determines whether queued reader or writers progress first
@@ -887,29 +895,29 @@ unittest
         group.create(&readerFn);
         group.create(&writerFn);
         waitQueued(1, 1);
-        assert(numReaders == 0 && numWriters == 1);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 1);
         wrSemB.notify();
 
         if (policy == ReadWriteMutex.Policy.PREFER_READERS)
         {
             rdSemA.wait();
-            assert(numReaders == 1 && numWriters == 0);
+            assert(atomicLoad(numReaders) == 1 && atomicLoad(numWriters) == 0);
             rdSemB.notify();
             wrSemA.wait();
-            assert(numReaders == 0 && numWriters == 1);
+            assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 1);
             wrSemB.notify();
         }
         else if (policy == ReadWriteMutex.Policy.PREFER_WRITERS)
         {
             wrSemA.wait();
-            assert(numReaders == 0 && numWriters == 1);
+            assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 1);
             wrSemB.notify();
             rdSemA.wait();
-            assert(numReaders == 1 && numWriters == 0);
+            assert(atomicLoad(numReaders) == 1 && atomicLoad(numWriters) == 0);
             rdSemB.notify();
         }
         group.joinAll();
-        assert(numReaders == 0 && numWriters == 0);
+        assert(atomicLoad(numReaders) == 0 && atomicLoad(numWriters) == 0);
         foreach (t; group) group.remove(t);
     }
     runTest(ReadWriteMutex.Policy.PREFER_READERS);
@@ -925,20 +933,22 @@ unittest
     shared static bool threadTriedOnceToGetLock;
     shared static bool threadFinallyGotLock;
 
-    rwmutex = new shared ReadWriteMutex();
+    atomicStore(rwmutex, new shared ReadWriteMutex());
     atomicFence;
     const maxTimeAllowedForTest = dur!"seconds"(20);
     // Test ReadWriteMutex.Reader.tryLock(Duration).
     {
         static void testReaderTryLock()
         {
-            assert(!rwmutex.reader.tryLock(Duration.min));
+            auto mutex = atomicLoad(rwmutex);
+            assert(!mutex.reader.tryLock(Duration.min));
             threadTriedOnceToGetLock.atomicStore(true);
-            assert(rwmutex.reader.tryLock(Duration.max));
+            assert(mutex.reader.tryLock(Duration.max));
             threadFinallyGotLock.atomicStore(true);
-            rwmutex.reader.unlock;
+            mutex.reader.unlock;
         }
-        assert(rwmutex.writer.tryLock(Duration.zero), "should have been able to obtain lock without blocking");
+        auto mutex = atomicLoad(rwmutex);
+        assert(mutex.writer.tryLock(Duration.zero), "should have been able to obtain lock without blocking");
         auto otherThread = new Thread(&testReaderTryLock).start;
         const failIfThisTimeisReached = MonoTime.currTime + maxTimeAllowedForTest;
         Thread.yield;
@@ -949,7 +959,7 @@ unittest
             assert(MonoTime.currTime < failIfThisTimeisReached, "timed out");
             Thread.yield;
         }
-        rwmutex.writer.unlock;
+        mutex.writer.unlock;
         // Soon after we release the writer lock otherThread's second
         // rwlock.reader.tryLock with timeout Duration.max should succeed.
         while (!threadFinallyGotLock.atomicLoad)
@@ -965,13 +975,15 @@ unittest
     {
         static void testWriterTryLock()
         {
-            assert(!rwmutex.writer.tryLock(Duration.min));
+            auto mutex = atomicLoad(rwmutex);
+            assert(!mutex.writer.tryLock(Duration.min));
             threadTriedOnceToGetLock.atomicStore(true);
-            assert(rwmutex.writer.tryLock(Duration.max));
+            assert(mutex.writer.tryLock(Duration.max));
             threadFinallyGotLock.atomicStore(true);
-            rwmutex.writer.unlock;
+            mutex.writer.unlock;
         }
-        assert(rwmutex.reader.tryLock(Duration.zero), "should have been able to obtain lock without blocking");
+        auto mutex = atomicLoad(rwmutex);
+        assert(mutex.reader.tryLock(Duration.zero), "should have been able to obtain lock without blocking");
         auto otherThread = new Thread(&testWriterTryLock).start;
         const failIfThisTimeisReached = MonoTime.currTime + maxTimeAllowedForTest;
         Thread.yield;
@@ -982,7 +994,7 @@ unittest
             assert(MonoTime.currTime < failIfThisTimeisReached, "timed out");
             Thread.yield;
         }
-        rwmutex.reader.unlock;
+        mutex.reader.unlock;
         // Soon after we release the reader lock otherThread's second
         // rwlock.writer.tryLock with timeout Duration.max should succeed.
         while (!threadFinallyGotLock.atomicLoad)

--- a/druntime/src/core/thread/fiber/base.d
+++ b/druntime/src/core/thread/fiber/base.d
@@ -29,6 +29,7 @@ package
 {
     import core.atomic : atomicStore, cas, MemoryOrder;
     import core.exception : onOutOfMemoryError;
+    import core.internal.traits : Unshared;
     import core.stdc.stdlib : abort;
 
     extern (C) void fiber_entryPoint() nothrow
@@ -792,14 +793,23 @@ unittest
             cont = false;
             foreach (idx; 0 .. 10)
             {
-                if (cas(&locks[idx], false, true))
+                alias UnsharedLocks = Unshared!(typeof(locks));
+                auto lock = (() @trusted
+                {
+                    // `-preview=nosharedaccess` rejects `&locks[idx]` because
+                    // indexing the shared static array counts as a shared read.
+                    // Cast only to form the indexed element address; the actual
+                    // lock access below still goes through atomic operations.
+                    return cast(shared(bool)*) &((*cast(UnsharedLocks*) &locks)[idx]);
+                })();
+                if (cas(lock, false, true))
                 {
                     if (fibs[idx].state == Fiber.State.HOLD)
                     {
                         fibs[idx].call();
                         cont |= fibs[idx].state != Fiber.State.TERM;
                     }
-                    locks[idx] = false;
+                    atomicStore(*lock, false);
                 }
                 else
                 {

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -2218,5 +2218,5 @@ nothrow @nogc unittest
     for (int i = 0; i < tids.length; i++)
         joinLowLevelThread(tids[i]);
 
-    assert(task.n == tids.length);
+    assert(atomicLoad(task.n) == tids.length);
 }

--- a/druntime/src/rt/monitor_.d
+++ b/druntime/src/rt/monitor_.d
@@ -43,7 +43,7 @@ else
 extern (C) void _d_setSameMutex(shared Object ownee, shared Object owner) @trusted nothrow
 in
 {
-    assert(ownee.__monitor is null);
+    assert(getMonitor(cast(Object) cast(void*) ownee) is null);
 }
 do
 {
@@ -53,7 +53,7 @@ do
         atomicOp!"+="(m.refs, size_t(1));
     }
     // Assume the monitor is garbage collected and simply copy the reference.
-    ownee.__monitor = owner.__monitor;
+    setMonitor(cast(Object) cast(void*) ownee, m);
 }
 
 extern (C) void _d_monitordelete(Object h, bool det)

--- a/druntime/test/betterc/src/test19933.d
+++ b/druntime/test/betterc/src/test19933.d
@@ -2,10 +2,11 @@
 // https://issues.dlang.org/show_bug.cgi?id=19933
 // https://issues.dlang.org/show_bug.cgi?id=18816
 
-import core.stdc.stdio : fprintf, stderr;
+import core.stdc.stdio : FILE, fprintf, stderr;
 
 extern(C) int main()
 {
-    fprintf(stderr, "Hello\n");
+    // C stdio owns this shared global; the test only needs the current handle.
+    fprintf(cast(FILE*) stderr, "Hello\n");
     return 0;
 }

--- a/druntime/test/exceptions/src/catch_in_finally.d
+++ b/druntime/test/exceptions/src/catch_in_finally.d
@@ -1,4 +1,4 @@
-import core.stdc.stdio : fprintf, stderr;
+import core.stdc.stdio : FILE, fprintf, stderr;
 
 class MyException : Exception
 {
@@ -185,5 +185,6 @@ void main() {
     test3();
     test4();
     test5();
-    fprintf(stderr, "success.\n");
+    // C stdio owns this shared global; this test only needs the current handle.
+    fprintf(cast(FILE*) stderr, "success.\n");
 }

--- a/druntime/test/exceptions/src/future_message.d
+++ b/druntime/test/exceptions/src/future_message.d
@@ -1,4 +1,4 @@
-import core.stdc.stdio : fprintf, stderr;
+import core.stdc.stdio : FILE, fprintf, stderr;
 
 // Make sure basic stuff works with future Throwable.message
 class NoMessage : Throwable
@@ -56,7 +56,8 @@ void test(Throwable t)
     }
     catch (Throwable e)
     {
-        fprintf(stderr, "%.*s ", cast(int)e.message.length, e.message.ptr);
+        // C stdio owns this shared global; the test only needs the current handle.
+        fprintf(cast(FILE*) stderr, "%.*s ", cast(int)e.message.length, e.message.ptr);
     }
 }
 
@@ -66,5 +67,6 @@ void main()
      test(new WithMessage("exception"));
      test(new WithMessageNoOverride("exception"));
      test(new WithMessageNoOverrideAndDifferentSignature("exception"));
-     fprintf(stderr, "\n");
+     // C stdio owns this shared global; the test only needs the current handle.
+     fprintf(cast(FILE*) stderr, "\n");
 }

--- a/druntime/test/exceptions/src/linux_memory_error_handler.d
+++ b/druntime/test/exceptions/src/linux_memory_error_handler.d
@@ -1,5 +1,5 @@
 import etc.linux.memoryerror;
-import core.stdc.stdio : fprintf, stderr;
+import core.sys.posix.unistd : write;
 
 void main()
 {
@@ -39,5 +39,8 @@ void main()
 
         assert(deregisterMemoryErrorHandler());
     }
-    fprintf(stderr, "success.\n");
+    // Avoid libc's shared stderr FILE* here; Alpine/musl crashes when this
+    // low-level signal-handler test reaches it through atomicLoad(stderr).
+    enum message = "success.\n";
+    write(2, message.ptr, message.length);
 }

--- a/druntime/test/exceptions/src/static_dtor.d
+++ b/druntime/test/exceptions/src/static_dtor.d
@@ -1,11 +1,12 @@
 // https://issues.dlang.org/show_bug.cgi?id=16594
+import core.atomic : atomicLoad;
 import core.stdc.stdio : fprintf, stderr;
 
 shared static ~this()
 {
     __gshared int count;
 
-    if (count++) fprintf(stderr, "dtor_called_more_than_once");
+    if (count++) fprintf(atomicLoad(stderr), "dtor_called_more_than_once");
     else throw new Exception("static_dtor_exception");
 }
 

--- a/druntime/test/shared/src/finalize.d
+++ b/druntime/test/shared/src/finalize.d
@@ -1,3 +1,5 @@
+import core.atomic : atomicLoad;
+import core.internal.traits : Unshared;
 import core.runtime;
 import core.stdc.string : strrchr;
 import core.thread;
@@ -47,7 +49,15 @@ void main(string[] args)
     static shared size_t finalizeCounter;
     SetFinalizeCounter setFinalizeCounter;
     loadSym(h, setFinalizeCounter, "setFinalizeCounter");
-    setFinalizeCounter(&finalizeCounter);
+    alias UnsharedCounter = Unshared!(typeof(finalizeCounter));
+    auto finalizeCounterPtr = (() @trusted
+    {
+        // This test must publish the address of a shared counter to a
+        // dynamically loaded library; the library performs the actual access
+        // atomically, but address formation itself has no atomic API.
+        return cast(shared(UnsharedCounter)*) &(*cast(UnsharedCounter*) &finalizeCounter);
+    })();
+    setFinalizeCounter(finalizeCounterPtr);
 
     runTest();
     auto thr = new Thread(&runTest);
@@ -59,7 +69,7 @@ void main(string[] args)
         assert(0);
     static if (!isDlcloseNoop)
     {
-        if (finalizeCounter != 4)
+        if (atomicLoad(finalizeCounter) != 4)
             assert(0);
     }
     if (nf1._finalizeCounter)

--- a/druntime/test/shared/src/lib.d
+++ b/druntime/test/shared/src/lib.d
@@ -55,7 +55,7 @@ void testGC()
 }
 
 // test Init
-import core.atomic : atomicOp;
+import core.atomic : atomicLoad, atomicOp, atomicStore;
 shared uint shared_static_ctor, shared_static_dtor, static_ctor, static_dtor;
 shared static this() { _assert(atomicOp!"+="(shared_static_ctor, 1) == 1); }
 shared static ~this() { _assert(atomicOp!"+="(shared_static_dtor, 1) == 1); }
@@ -85,18 +85,18 @@ void runTestsImpl()
 
     testGC();
 
-    _assert(shared_static_ctor == 1);
-    _assert(static_ctor == 1);
+    _assert(atomicLoad(shared_static_ctor) == 1);
+    _assert(atomicLoad(static_ctor) == 1);
     static void run()
     {
-        _assert(static_ctor == 2);
-        _assert(shared_static_ctor == 1);
+        _assert(atomicLoad(static_ctor) == 2);
+        _assert(atomicLoad(shared_static_ctor) == 1);
         testGC();
     }
     auto thr = new Thread(&run);
     thr.start();
     thr.join();
-    _assert(static_dtor == 1);
+    _assert(atomicLoad(static_dtor) == 1);
 
     passed = false;
     foreach (m; ModuleInfo)
@@ -123,8 +123,7 @@ class MyFinalizer
 {
     ~this()
     {
-        import core.atomic;
-        atomicOp!"+="(*_finalizeCounter, 1);
+        atomicOp!"+="(*atomicLoad(_finalizeCounter), 1);
     }
 }
 
@@ -135,7 +134,7 @@ class MyFinalizerBig : MyFinalizer
 
 extern(C) void setFinalizeCounter(shared(size_t)* p)
 {
-    _finalizeCounter = p;
+    atomicStore(_finalizeCounter, p);
 }
 
 version (DigitalMars) version (Windows)

--- a/druntime/test/shared/src/link.d
+++ b/druntime/test/shared/src/link.d
@@ -27,36 +27,36 @@ void testGC()
     lib.free();
 }
 
-import core.atomic : atomicOp;
-shared static this() { _assert(lib.shared_static_ctor == 1); }
-shared static ~this() { _assert(lib.shared_static_dtor == 0); }
+import core.atomic : atomicLoad, atomicOp;
+shared static this() { _assert(atomicLoad(lib.shared_static_ctor) == 1); }
+shared static ~this() { _assert(atomicLoad(lib.shared_static_dtor) == 0); }
 shared uint static_ctor, static_dtor;
-static this() { _assert(lib.static_ctor == atomicOp!"+="(static_ctor, 1)); }
-static ~this() { _assert(lib.static_dtor + 1 == atomicOp!"+="(static_dtor, 1)); }
+static this() { _assert(atomicLoad(lib.static_ctor) == atomicOp!"+="(static_ctor, 1)); }
+static ~this() { _assert(atomicLoad(lib.static_dtor) + 1 == atomicOp!"+="(static_dtor, 1)); }
 
 void testInit()
 {
     import core.thread;
 
-    _assert(shared_static_ctor == 1);
-    _assert(static_ctor == 1);
+    _assert(atomicLoad(shared_static_ctor) == 1);
+    _assert(atomicLoad(static_ctor) == 1);
 
-    _assert(lib.static_ctor == 1);
-    _assert(lib.static_dtor == 0);
+    _assert(atomicLoad(lib.static_ctor) == 1);
+    _assert(atomicLoad(lib.static_dtor) == 0);
     static void foo()
     {
-        _assert(lib.shared_static_ctor == 1);
-        _assert(lib.shared_static_dtor == 0);
-        _assert(lib.static_ctor == 2);
-        _assert(lib.static_dtor == 0);
+        _assert(atomicLoad(lib.shared_static_ctor) == 1);
+        _assert(atomicLoad(lib.shared_static_dtor) == 0);
+        _assert(atomicLoad(lib.static_ctor) == 2);
+        _assert(atomicLoad(lib.static_dtor) == 0);
     }
     auto thr = new Thread(&foo);
     thr.start();
     _assert(thr.join() is null);
-    _assert(lib.shared_static_ctor == 1);
-    _assert(lib.shared_static_dtor == 0);
-    _assert(lib.static_ctor == 2);
-    _assert(lib.static_dtor == 1);
+    _assert(atomicLoad(lib.shared_static_ctor) == 1);
+    _assert(atomicLoad(lib.shared_static_dtor) == 0);
+    _assert(atomicLoad(lib.static_ctor) == 2);
+    _assert(atomicLoad(lib.static_dtor) == 1);
 }
 
 void main()

--- a/druntime/test/shared/src/load.d
+++ b/druntime/test/shared/src/load.d
@@ -1,3 +1,4 @@
+import core.atomic : atomicLoad;
 import core.runtime;
 import core.stdc.string : strrchr;
 import core.thread;
@@ -88,22 +89,22 @@ void testGC()
 void testInit()
 {
 
-    assert(*libStaticCtor == 1);
-    assert(*libStaticDtor == 0);
+    assert(atomicLoad(*libStaticCtor) == 1);
+    assert(atomicLoad(*libStaticDtor) == 0);
     static void run()
     {
-        assert(*libSharedStaticCtor == 1);
-        assert(*libSharedStaticDtor == 0);
-        assert(*libStaticCtor == 2);
-        assert(*libStaticDtor == 0);
+        assert(atomicLoad(*libSharedStaticCtor) == 1);
+        assert(atomicLoad(*libSharedStaticDtor) == 0);
+        assert(atomicLoad(*libStaticCtor) == 2);
+        assert(atomicLoad(*libStaticDtor) == 0);
     }
     auto thr = new Thread(&run);
     thr.start();
     thr.join();
-    assert(*libSharedStaticCtor == 1);
-    assert(*libSharedStaticDtor == 0);
-    assert(*libStaticCtor == 2);
-    assert(*libStaticDtor == 1);
+    assert(atomicLoad(*libSharedStaticCtor) == 1);
+    assert(atomicLoad(*libSharedStaticDtor) == 0);
+    assert(atomicLoad(*libStaticCtor) == 2);
+    assert(atomicLoad(*libStaticDtor) == 1);
 }
 
 const(ModuleInfo)* findModuleInfo(string name)

--- a/druntime/test/shared/src/load_13414.d
+++ b/druntime/test/shared/src/load_13414.d
@@ -21,11 +21,11 @@ void runTest(string name)
 
     const unloaded = Runtime.unloadLibrary(h);
     assert(unloaded);
-    assert(tlsDtor == 1);
+    assert(atomicLoad(tlsDtor) == 1);
     static if (isDlcloseNoop)
-        assert(dtor == 0);
+        assert(atomicLoad(dtor) == 0);
     else
-        assert(dtor == 1);
+        assert(atomicLoad(dtor) == 1);
 }
 
 void main(string[] args)

--- a/druntime/test/shared/src/utils.di
+++ b/druntime/test/shared/src/utils.di
@@ -29,11 +29,18 @@ void loadSym(T)(void* handle, ref T val, const char* mangle)
     version (Windows)
     {
         import core.sys.windows.winbase : GetProcAddress;
-        val = cast(T) GetProcAddress(handle, mangle);
+        auto sym = GetProcAddress(handle, mangle);
     }
     else
     {
         import core.sys.posix.dlfcn : dlsym;
-        val = cast(T) dlsym(handle, mangle);
+        auto sym = dlsym(handle, mangle);
     }
+    static if (is(T == shared U, U))
+    {
+        import core.atomic : atomicStore;
+        atomicStore(val, cast(T) sym);
+    }
+    else
+        val = cast(T) sym;
 }

--- a/druntime/test/unittest/customhandler.d
+++ b/druntime/test/unittest/customhandler.d
@@ -16,6 +16,7 @@ shared static this()
 
 void main()
 {
-    import core.stdc.stdio : fprintf, stderr;
-    fprintf(stderr, "main\n");
+    import core.stdc.stdio : FILE, fprintf, stderr;
+    // C stdio owns this shared global; the test only needs the current handle.
+    fprintf(cast(FILE*) stderr, "main\n");
 }


### PR DESCRIPTION
Fixes #20496.

A `ref` initializer takes the address of its source and therefore does not read shared data. Treat it consistently with passing a shared value to a `ref` parameter, allowing `foreach (ref element; sharedArray)` under `-preview=nosharedaccess`.

This makes the shared-array `foreach(ref ...)` workarounds in #23056 unnecessary.

Tests:
- `make -j2`
- `compiler/test/run.d compilable/shared.d`