### PR TITLE
Show lambda source text instead of void in not-callable argument lists

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -3602,7 +3602,16 @@ void argExpTypesToCBuffer(ref OutBuffer buf, Expressions* arguments)
     {
         if (i)
             buf.put(", ");
-        typeToBuffer(arg.type, null, buf, hgs);
+        // An untyped lambda argument (e.g. `x => x`) that couldn't be
+        // matched against any candidate parameter type has no concrete
+        // signature to show here and would otherwise print as `void`,
+        // which isn't useful when several such arguments are involved.
+        // Show its source text instead.
+        // https://github.com/dlang/dmd/issues/18923
+        if (arg.type && arg.type.ty == Tvoid && arg.isFuncExp())
+            buf.writestring(arg.toErrMsg());
+        else
+            typeToBuffer(arg.type, null, buf, hgs);
     }
 }
 

--- a/compiler/test/fail_compilation/fail18923.d
+++ b/compiler/test/fail_compilation/fail18923.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail18923.d(17): Error: function `foo` is not callable using argument types `((x) => "hello", (x) => x)`
+fail_compilation/fail18923.d(17):        cannot pass argument `(x) => "hello"` of type `void` to parameter `double function(double) @safe __param_0`
+fail_compilation/fail18923.d(13):        `fail18923.foo(double function(double) @safe __param_0, double function(double) @safe __param_1)` declared here
+---
+*/
+
+// https://github.com/dlang/dmd/issues/18923
+// Untyped lambda arguments that couldn't be matched should show their
+// source text instead of a generic, unhelpful `void`.
+void foo(double function(double) @safe,
+         double function(double) @safe) {}
+void test18923()
+{
+    foo(x => "hello", x => x);
+}

--- a/compiler/test/fail_compilation/fail8009.d
+++ b/compiler/test/fail_compilation/fail8009.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8009.d(9): Error: template `filter` is not callable using argument types `!()(void)`
+fail_compilation/fail8009.d(9): Error: template `filter` is not callable using argument types `!()((r) => r)`
 fail_compilation/fail8009.d(8):        Candidate is: `filter(R)(scope bool delegate(ref BAD!R) func)`
 ---
 */


### PR DESCRIPTION
Fixes #18923

An unmatched lambda argument printed as `void` in the main error line, e.g. `(void, void)`. Now it shows the lambda's source text, e.g. `((x) => "hello", (x) => x)` — same as the existing supplemental line already does.

Also fixes an existing test (fail8009.d) that expected the old `(void)` output.