### PR TITLE
Hint that ~ concatenates arrays when both operands are pointers

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1505,9 +1505,23 @@ extern (D) Expression incompatibleTypes(BinExp e, Scope* sc = null)
         e.e1.type.toBasetype().ty == Tpointer &&
         e.e2.type.toBasetype().ty == Tpointer)
     {
-        errorSupplemental(e.loc,
-            "`~` concatenates arrays, not pointers; " ~
-            "convert the pointer to an array first, e.g. with `std.string.fromStringz`");
+        // Only point users at `fromStringz` when both pointers are to
+        // character types (e.g. `const(char)*`); for other pointer
+        // types (e.g. `int*`) that hint would be misleading.
+        auto e1Next = (cast(TypePointer)e.e1.type.toBasetype()).next.toBasetype();
+        auto e2Next = (cast(TypePointer)e.e2.type.toBasetype()).next.toBasetype();
+        bool isCharType(Type t) => t.ty == Tchar || t.ty == Twchar || t.ty == Tdchar;
+
+        if (isCharType(e1Next) && isCharType(e2Next))
+        {
+            errorSupplemental(e.loc,
+                "`~` concatenates arrays, not pointers; " ~
+                "convert the pointer to an array first, e.g. with `std.string.fromStringz`");
+        }
+        else
+        {
+            errorSupplemental(e.loc, "`~` concatenates arrays, not pointers");
+        }
     }
 
     if (sc && sc.tinst)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1510,7 +1510,10 @@ extern (D) Expression incompatibleTypes(BinExp e, Scope* sc = null)
         // types (e.g. `int*`) that hint would be misleading.
         auto e1Next = (cast(TypePointer)e.e1.type.toBasetype()).next.toBasetype();
         auto e2Next = (cast(TypePointer)e.e2.type.toBasetype()).next.toBasetype();
-        bool isCharType(Type t) => t.ty == Tchar || t.ty == Twchar || t.ty == Tdchar;
+        static bool isCharType(Type t)
+        {
+            return t.ty == Tchar || t.ty == Twchar || t.ty == Tdchar;
+        }
 
         if (isCharType(e1Next) && isCharType(e2Next))
         {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1496,6 +1496,20 @@ extern (D) Expression incompatibleTypes(BinExp e, Scope* sc = null)
             e.e1.toErrMsg(), thisOp, e.e2.toErrMsg(), ts[0], ts[1]);
     }
 
+    // https://github.com/dlang/dmd/issues/17758
+    // `~` concatenates arrays; using it on two pointers (e.g. two
+    // `const(char)*`) is a common mistake, typically when a C string
+    // was meant to be treated as a D array. Point users at the
+    // fix instead of leaving them to guess.
+    if (e.op == EXP.concatenate &&
+        e.e1.type.toBasetype().ty == Tpointer &&
+        e.e2.type.toBasetype().ty == Tpointer)
+    {
+        errorSupplemental(e.loc,
+            "`~` concatenates arrays, not pointers; " ~
+            "convert the pointer to an array first, e.g. with `std.string.fromStringz`");
+    }
+
     if (sc && sc.tinst)
         sc.tinst.printInstantiationTrace();
 

--- a/compiler/test/fail_compilation/fail17758.d
+++ b/compiler/test/fail_compilation/fail17758.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail17758.d(15): Error: incompatible types for `("hello") ~ (s)`: both operands are of type `const(char)*`
+fail_compilation/fail17758.d(15):        `~` concatenates arrays, not pointers; convert the pointer to an array first, e.g. with `std.string.fromStringz`
+---
+*/
+
+// https://github.com/dlang/dmd/issues/17758
+// Concatenating two pointers (a common mistake with C strings) should
+// hint that `~` is for arrays, not just report a generic type mismatch.
+void test17758()
+{
+    const(char)* s = "some literal";
+    auto ss = "hello" ~ s;
+}


### PR DESCRIPTION
Fixes #17758

`"hello" ~ s` where `s` is `const(char)*` only reported a generic type mismatch, giving no clue why. Concatenating two pointers is a common mistake with C strings; this adds a supplemental hint pointing at `std.string.fromStringz` as the fix.