### PR TITLE
Show operand type and clarify rewrite suggestion in intpromote message

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -4397,8 +4397,13 @@ void fix16997(Scope* sc, UnaExp ue)
         case Tchar:
         case Twchar:
         case Tdchar:
-            deprecation(ue.loc, "integral promotion not done for `%s`, remove '-revert=intpromote' switch or `%scast(int)(%s)`",
-                ue.toErrMsg(), EXPtoString(ue.op).ptr, ue.e1.toErrMsg());
+            // https://github.com/dlang/dmd/issues/17834
+            // Show the operand's type (previously omitted, forcing the
+            // reader to look it up themselves) and word the suggested
+            // rewrite as "rewrite as" so the leading `-` isn't misread
+            // as a second compiler switch alongside `-revert=intpromote`.
+            deprecation(ue.loc, "integral promotion not done for `%s` (operand type `%s`), remove '-revert=intpromote' switch or rewrite as `%scast(int)(%s)`",
+                ue.toErrMsg(), ue.e1.type.toErrMsg(), EXPtoString(ue.op).ptr, ue.e1.toErrMsg());
             return;
 
         default:

--- a/compiler/test/fail_compilation/fail16997.d
+++ b/compiler/test/fail_compilation/fail16997.d
@@ -2,24 +2,24 @@
 REQUIRED_ARGS: -de -revert=intpromote
 TEST_OUTPUT:
 ---
-fail_compilation/fail16997.d(31): Deprecation: integral promotion not done for `~c`, remove '-revert=intpromote' switch or `~cast(int)(c)`
-fail_compilation/fail16997.d(32): Deprecation: integral promotion not done for `-c`, remove '-revert=intpromote' switch or `-cast(int)(c)`
-fail_compilation/fail16997.d(33): Deprecation: integral promotion not done for `+c`, remove '-revert=intpromote' switch or `+cast(int)(c)`
-fail_compilation/fail16997.d(36): Deprecation: integral promotion not done for `~w`, remove '-revert=intpromote' switch or `~cast(int)(w)`
-fail_compilation/fail16997.d(37): Deprecation: integral promotion not done for `-w`, remove '-revert=intpromote' switch or `-cast(int)(w)`
-fail_compilation/fail16997.d(38): Deprecation: integral promotion not done for `+w`, remove '-revert=intpromote' switch or `+cast(int)(w)`
-fail_compilation/fail16997.d(41): Deprecation: integral promotion not done for `~sb`, remove '-revert=intpromote' switch or `~cast(int)(sb)`
-fail_compilation/fail16997.d(42): Deprecation: integral promotion not done for `-sb`, remove '-revert=intpromote' switch or `-cast(int)(sb)`
-fail_compilation/fail16997.d(43): Deprecation: integral promotion not done for `+sb`, remove '-revert=intpromote' switch or `+cast(int)(sb)`
-fail_compilation/fail16997.d(46): Deprecation: integral promotion not done for `~ub`, remove '-revert=intpromote' switch or `~cast(int)(ub)`
-fail_compilation/fail16997.d(47): Deprecation: integral promotion not done for `-ub`, remove '-revert=intpromote' switch or `-cast(int)(ub)`
-fail_compilation/fail16997.d(48): Deprecation: integral promotion not done for `+ub`, remove '-revert=intpromote' switch or `+cast(int)(ub)`
-fail_compilation/fail16997.d(51): Deprecation: integral promotion not done for `~s`, remove '-revert=intpromote' switch or `~cast(int)(s)`
-fail_compilation/fail16997.d(52): Deprecation: integral promotion not done for `-s`, remove '-revert=intpromote' switch or `-cast(int)(s)`
-fail_compilation/fail16997.d(53): Deprecation: integral promotion not done for `+s`, remove '-revert=intpromote' switch or `+cast(int)(s)`
-fail_compilation/fail16997.d(56): Deprecation: integral promotion not done for `~us`, remove '-revert=intpromote' switch or `~cast(int)(us)`
-fail_compilation/fail16997.d(57): Deprecation: integral promotion not done for `-us`, remove '-revert=intpromote' switch or `-cast(int)(us)`
-fail_compilation/fail16997.d(58): Deprecation: integral promotion not done for `+us`, remove '-revert=intpromote' switch or `+cast(int)(us)`
+fail_compilation/fail16997.d(31): Deprecation: integral promotion not done for `~c` (operand type `char`), remove '-revert=intpromote' switch or rewrite as `~cast(int)(c)`
+fail_compilation/fail16997.d(32): Deprecation: integral promotion not done for `-c` (operand type `char`), remove '-revert=intpromote' switch or rewrite as `-cast(int)(c)`
+fail_compilation/fail16997.d(33): Deprecation: integral promotion not done for `+c` (operand type `char`), remove '-revert=intpromote' switch or rewrite as `+cast(int)(c)`
+fail_compilation/fail16997.d(36): Deprecation: integral promotion not done for `~w` (operand type `wchar`), remove '-revert=intpromote' switch or rewrite as `~cast(int)(w)`
+fail_compilation/fail16997.d(37): Deprecation: integral promotion not done for `-w` (operand type `wchar`), remove '-revert=intpromote' switch or rewrite as `-cast(int)(w)`
+fail_compilation/fail16997.d(38): Deprecation: integral promotion not done for `+w` (operand type `wchar`), remove '-revert=intpromote' switch or rewrite as `+cast(int)(w)`
+fail_compilation/fail16997.d(41): Deprecation: integral promotion not done for `~sb` (operand type `byte`), remove '-revert=intpromote' switch or rewrite as `~cast(int)(sb)`
+fail_compilation/fail16997.d(42): Deprecation: integral promotion not done for `-sb` (operand type `byte`), remove '-revert=intpromote' switch or rewrite as `-cast(int)(sb)`
+fail_compilation/fail16997.d(43): Deprecation: integral promotion not done for `+sb` (operand type `byte`), remove '-revert=intpromote' switch or rewrite as `+cast(int)(sb)`
+fail_compilation/fail16997.d(46): Deprecation: integral promotion not done for `~ub` (operand type `ubyte`), remove '-revert=intpromote' switch or rewrite as `~cast(int)(ub)`
+fail_compilation/fail16997.d(47): Deprecation: integral promotion not done for `-ub` (operand type `ubyte`), remove '-revert=intpromote' switch or rewrite as `-cast(int)(ub)`
+fail_compilation/fail16997.d(48): Deprecation: integral promotion not done for `+ub` (operand type `ubyte`), remove '-revert=intpromote' switch or rewrite as `+cast(int)(ub)`
+fail_compilation/fail16997.d(51): Deprecation: integral promotion not done for `~s` (operand type `short`), remove '-revert=intpromote' switch or rewrite as `~cast(int)(s)`
+fail_compilation/fail16997.d(52): Deprecation: integral promotion not done for `-s` (operand type `short`), remove '-revert=intpromote' switch or rewrite as `-cast(int)(s)`
+fail_compilation/fail16997.d(53): Deprecation: integral promotion not done for `+s` (operand type `short`), remove '-revert=intpromote' switch or rewrite as `+cast(int)(s)`
+fail_compilation/fail16997.d(56): Deprecation: integral promotion not done for `~us` (operand type `ushort`), remove '-revert=intpromote' switch or rewrite as `~cast(int)(us)`
+fail_compilation/fail16997.d(57): Deprecation: integral promotion not done for `-us` (operand type `ushort`), remove '-revert=intpromote' switch or rewrite as `-cast(int)(us)`
+fail_compilation/fail16997.d(58): Deprecation: integral promotion not done for `+us` (operand type `ushort`), remove '-revert=intpromote' switch or rewrite as `+cast(int)(us)`
 ---
 */
 


### PR DESCRIPTION
Fixes #17834

`integral promotion not done for -header, ... or -cast(int)(header)` didn't show the operand's type, and the leading `-` in the suggestion could be misread as a compiler switch. This adds the operand type and says "rewrite as" to make it clear.