### PR TITLE
Remove redundant explanatory comment in intpromote message

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -4398,10 +4398,6 @@ void fix16997(Scope* sc, UnaExp ue)
         case Twchar:
         case Tdchar:
             // https://github.com/dlang/dmd/issues/17834
-            // Show the operand's type (previously omitted, forcing the
-            // reader to look it up themselves) and word the suggested
-            // rewrite as "rewrite as" so the leading `-` isn't misread
-            // as a second compiler switch alongside `-revert=intpromote`.
             deprecation(ue.loc, "integral promotion not done for `%s` (operand type `%s`), remove '-revert=intpromote' switch or rewrite as `%scast(int)(%s)`",
                 ue.toErrMsg(), ue.e1.type.toErrMsg(), EXPtoString(ue.op).ptr, ue.e1.toErrMsg());
             return;


### PR DESCRIPTION
Follow-up to #23646 the comment restating why the message was changed wasn't merged before dkorpel's review comment asking to remove it landed.