### PR TITLE
Fix/17596 ambiguous opbinary loc

### DIFF
--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1089,6 +1089,8 @@ private Expression pickBestBinaryOverload(Scope* sc, Objects* tiargs, Dsymbol s,
         {
             // Error, ambiguous
             error(e.loc, "overloads `%s` and `%s` both match argument list for `%s`", m.lastf.type.toErrMsg(), m.nextf.type.toErrMsg(), m.lastf.toErrMsg());
+            errorSupplemental(m.lastf.loc, "`%s` is declared here", m.lastf.toPrettyChars());
+            errorSupplemental(m.nextf.loc, "`%s` is declared here", m.nextf.toPrettyChars());
         }
     }
     else if (m.last == MATCH.nomatch)

--- a/compiler/test/fail_compilation/test17596.d
+++ b/compiler/test/fail_compilation/test17596.d
@@ -19,7 +19,7 @@ struct S2
     int opBinaryRight(string op)(S1 lhs) if (true) { return 2; }
 }
 
-void main()
+void test17596()
 {
     auto x = S1.init + S2.init;
 }

--- a/compiler/test/fail_compilation/test17596.d
+++ b/compiler/test/fail_compilation/test17596.d
@@ -1,0 +1,25 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test17596.d(24): Error: overloads `(S1 lhs)` and `(S1 lhs)` both match argument list for `opBinaryRight`
+fail_compilation/test17596.d(18):        `test17596.S2.opBinaryRight!"+".opBinaryRight` is declared here
+fail_compilation/test17596.d(19):        `test17596.S2.opBinaryRight!"+".opBinaryRight` is declared here
+fail_compilation/test17596.d(24): Error: forward reference to template `opBinaryRight`
+fail_compilation/test17596.d(24): Error: function `test17596.S2.opBinaryRight!"+".opBinaryRight(S1 lhs)` is not callable using argument types `(S1)`
+fail_compilation/test17596.d(24): Error: forward reference to template `opBinaryRight`
+---
+*/
+
+// https://github.com/dlang/dmd/issues/17596
+
+struct S1 {}
+struct S2
+{
+    int opBinaryRight(string op)(S1 lhs) if (op == "+") { return 1; }
+    int opBinaryRight(string op)(S1 lhs) if (true) { return 2; }
+}
+
+void main()
+{
+    auto x = S1.init + S2.init;
+}


### PR DESCRIPTION
Fixes #17596

The ambiguous-overload error only printed each candidate's
signature, with no indication of where it was declared. This adds
the declaration location (with FQN) for each candidate, using the
same errorSupplemental pattern already used elsewhere in this file.

Note: the exact case from the original report no longer triggers
ambiguity (an unrelated workaround already resolves it silently to
opBinary). This improves the message for cases that still do hit
the ambiguous path.