### PR TITLE
fix #23642 - e2ir: no index lowering for associative array literal

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12019,6 +12019,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         return setResult(res);
                     exp.e2 = res;
 
+                    if (auto ie1 = ae.e1.isIndexExp())
+                        ae.e1 = ie1.revertIndexAssignToRvalues(sc);
+
                     /* Rewrite (a[arguments] = e2) as:
                      *      a.opIndexAssign(e2, arguments)
                      */
@@ -12047,6 +12050,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         return setResult(res);
 
                     exp.e2 = res;
+
+                    if (auto ie1 = ae.e1.isIndexExp())
+                        ae.e1 = ie1.revertIndexAssignToRvalues(sc);
 
                     /* Rewrite (a[i..j] = e2) as:
                      *      a.opSliceAssign(e2, i, j)

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -354,6 +354,10 @@ Expression opOverloadArray(ArrayExp ae, Scope* sc)
                 goto Lfallback;
             if (ae2.isErrorExp())
                 return ae2;
+
+            if (auto ie1 = ae.e1.isIndexExp())
+                ae.e1 = ie1.revertIndexAssignToRvalues(sc);
+
             /* Rewrite e1[arguments] as:
              *      e1.opIndex(arguments)
              */
@@ -942,6 +946,9 @@ Expression opOverloadBinaryAssign(BinAssignExp e, Scope* sc, Type[2] aliasThisSt
                 e.e2 = e.e2.expressionSemantic(sc);
                 if (e.e2.isErrorExp())
                     return e.e2;
+
+                if (auto ie1 = ae.e1.isIndexExp())
+                    ae.e1 = ie1.revertIndexAssignToRvalues(sc);
 
                 /* Rewrite a[arguments] op= e2 as:
                  *      a.opIndexOpAssign!(op)(e2, arguments)

--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -555,6 +555,48 @@ void test19829()
     assert(bar == [true]);
 }
 
+// https://github.com/dlang/dmd/issues/23642
+void test23642()
+{
+    Bson23642[string] fts;
+    fts["key"] = Bson23642();
+    fts["key"]["1"] = 1;
+    fts["key"]["2".."3"] = 23;
+    assert(fts["key"]["1"] == 1);
+    assert(fts["key"]["2"] == 2);
+    assert(fts["key"]["3"] == 3);
+
+    fts["key"]["1"] += 10;
+    fts["key"]["2"]++;
+    --fts["key"]["3"];
+    assert(fts["key"]["1"] == 11);
+    assert(fts["key"]["2"] == 3);
+    assert(fts["key"]["3"] == 2);
+}
+
+struct Bson23642
+{
+    int[string] data;
+
+    ref int opIndex(string idx)
+    {
+        return data[idx];
+    }
+    void opIndexAssign(int val, string idx)
+    {
+        data[idx] = val;
+    }
+    void opSliceAssign(int val, string idx1, string idx2)
+    {
+        data[idx1] = val / 10;
+        data[idx2] = val % 10;
+    }
+    void opIndexOpAssign(string op)(int val, string idx)
+    {
+        data[idx] += val;
+    }
+}
+
 /***************************************************/
 
 void main()
@@ -588,4 +630,5 @@ void main()
     test22556();
     test19829();
     test23182();
+    test23642();
 }


### PR DESCRIPTION
revert assumption than an ArrayExp/IndexExp on an AA on the left side of an assignment is an lvalue if opIndexAssign, opIndexOpAssign or opSliceAssign overloads are used, lower to rvalue access instead