### PR TITLE
Draft: reduce size of IntegerExp for small numbers...

### DIFF
--- a/compiler/include/dmd/expression.h
+++ b/compiler/include/dmd/expression.h
@@ -99,10 +99,12 @@ public:
     bool rvalue() const;
     bool rvalue(bool v);
 
-    size_t size() const;
-    virtual size_t classInstanceSize() const;
+    virtual size_t size() const;
 
     static void _init();
+    static void deinitialize();
+
+    virtual Expression copy();
     virtual Expression *syntaxCopy();
 
     // kludge for template.isExpression()

--- a/compiler/include/dmd/expression.h
+++ b/compiler/include/dmd/expression.h
@@ -92,6 +92,7 @@ public:
     Loc loc;                    // file location
     EXP op;                     // to minimize use of dynamic_cast
     uint8_t bitFields;
+    uint16_t astNodeBitFields;
 
     bool parens() const;
     bool parens(bool v);
@@ -99,6 +100,8 @@ public:
     bool rvalue(bool v);
 
     size_t size() const;
+    virtual size_t classInstanceSize() const;
+
     static void _init();
     virtual Expression *syntaxCopy();
 
@@ -227,16 +230,18 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class IntegerExp final : public Expression
+class IntegerExp : public Expression
 {
 public:
-    dinteger_t value;
 
     static IntegerExp *create(Loc loc, dinteger_t value, Type *type);
     void accept(Visitor *v) override { v->visit(this); }
-    dinteger_t getInteger() { return value; }
+    virtual dinteger_t value() const = 0;
+    virtual dinteger_t getInteger() = 0;
+    virtual void setInteger(dinteger_t val) = 0;
     template<int v>
-    static IntegerExp literal();
+    static IntegerExp* literal();
+    static IntegerExp* createBool(bool b);
 };
 
 class ErrorExp final : public Expression

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -4724,6 +4724,11 @@ struct ASTBase
             setInteger(value);
         }
 
+        static IntegerExp create(Loc loc, dinteger_t value, Type type)
+        {
+            return new IntegerExp(loc, value, type);
+        }
+
         void setInteger(dinteger_t value)
         {
             this.value = value;
@@ -5762,7 +5767,7 @@ struct ASTBase
     {
         extern (D) this(EXP op, Loc loc, Expression e)
         {
-            super(loc, op, __traits(classInstanceSize, PostExp), e, new IntegerExp(loc, 1, Type.tint32));
+            super(loc, op, __traits(classInstanceSize, PostExp), e, IntegerExp.create(loc, 1, Type.tint32));
         }
 
         override void accept(Visitor v)

--- a/compiler/src/dmd/builtin.d
+++ b/compiler/src/dmd/builtin.d
@@ -383,7 +383,7 @@ Expression eval_bsf(Loc loc, FuncDeclaration fd, Expression[] arguments)
         auto eSink = global.errorSink;
         eSink.error(loc, "`bsf(0)` is undefined");
     }
-    return new IntegerExp(loc, core.bitop.bsf(n), Type.tint32);
+    return IntegerExp.create(loc, core.bitop.bsf(n), Type.tint32);
 }
 
 Expression eval_bsr(Loc loc, FuncDeclaration fd, Expression[] arguments)
@@ -397,7 +397,7 @@ Expression eval_bsr(Loc loc, FuncDeclaration fd, Expression[] arguments)
         auto eSink = global.errorSink;
         eSink.error(loc, "`bsr(0)` is undefined");
     }
-    return new IntegerExp(loc, core.bitop.bsr(n), Type.tint32);
+    return IntegerExp.create(loc, core.bitop.bsr(n), Type.tint32);
 }
 
 Expression eval_bswap(Loc loc, FuncDeclaration fd, Expression[] arguments)
@@ -407,9 +407,9 @@ Expression eval_bswap(Loc loc, FuncDeclaration fd, Expression[] arguments)
     auto n = arg0.toInteger();
     TY ty = arg0.type.toBasetype().ty;
     if (ty == Tint64 || ty == Tuns64)
-        return new IntegerExp(loc, core.bitop.bswap(cast(ulong) n), arg0.type);
+        return IntegerExp.create(loc, core.bitop.bswap(cast(ulong) n), arg0.type);
     else
-        return new IntegerExp(loc, core.bitop.bswap(cast(uint) n), arg0.type);
+        return IntegerExp.create(loc, core.bitop.bswap(cast(uint) n), arg0.type);
 }
 
 Expression eval_popcnt(Loc loc, FuncDeclaration fd, Expression[] arguments)
@@ -417,7 +417,7 @@ Expression eval_popcnt(Loc loc, FuncDeclaration fd, Expression[] arguments)
     Expression arg0 = arguments[0];
     assert(arg0.op == EXP.int64);
     auto n = arg0.toInteger();
-    return new IntegerExp(loc, core.bitop.popcnt(n), Type.tint32);
+    return IntegerExp.create(loc, core.bitop.popcnt(n), Type.tint32);
 }
 
 Expression eval_yl2x(Loc loc, FuncDeclaration fd, Expression[] arguments)

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1063,8 +1063,8 @@ private DtorDeclaration buildFieldDtor(AggregateDeclaration ad, Loc declLoc, ref
             if (stc & STC.safe)
                 stc = (stc & ~STC.safe) | STC.trusted;
 
-            SliceExp se = new SliceExp(loc, ex, new IntegerExp(loc, 0, Type.tsize_t),
-                                       new IntegerExp(loc, n, Type.tsize_t));
+            SliceExp se = new SliceExp(loc, ex, IntegerExp.create(loc, 0, Type.tsize_t),
+                                       IntegerExp.create(loc, n, Type.tsize_t));
             // Prevent redundant bounds check
             se.upperIsInBounds = true;
             se.lowerIsLessThanUpper = true;
@@ -1161,7 +1161,7 @@ private DtorDeclaration buildWindowsCppDtor(AggregateDeclaration ad, DtorDeclara
     //   // TODO: if (del) delete (char*)this;
     //   return (void*) this;
     // }
-    Parameter delparam = new Parameter(Loc.initial, STC.none, Type.tuns32, Identifier.idPool("del"), new IntegerExp(dtor.loc, 0, Type.tuns32), null, null);
+    Parameter delparam = new Parameter(Loc.initial, STC.none, Type.tuns32, Identifier.idPool("del"), IntegerExp.create(dtor.loc, 0, Type.tuns32), null, null);
     Parameters* params = new Parameters;
     params.push(delparam);
     const stc = dtor.storage_class & ~STC.scope_; // because we add the `return this;` later
@@ -1406,8 +1406,8 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
                     if (stc & STC.safe)
                         stc = (stc & ~STC.safe) | STC.trusted;
 
-                    auto se = new SliceExp(loc, ex, new IntegerExp(loc, 0, Type.tsize_t),
-                                                    new IntegerExp(loc, length, Type.tsize_t));
+                    auto se = new SliceExp(loc, ex, IntegerExp.create(loc, 0, Type.tsize_t),
+                                                    IntegerExp.create(loc, length, Type.tsize_t));
                     // Prevent redundant bounds check
                     se.upperIsInBounds = true;
                     se.lowerIsLessThanUpper = true;
@@ -1484,8 +1484,8 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
             if (stc & STC.safe)
                 stc = (stc & ~STC.safe) | STC.trusted;
 
-            auto se = new SliceExp(loc, ex, new IntegerExp(loc, 0, Type.tsize_t),
-                                            new IntegerExp(loc, length, Type.tsize_t));
+            auto se = new SliceExp(loc, ex, IntegerExp.create(loc, 0, Type.tsize_t),
+                                            IntegerExp.create(loc, length, Type.tsize_t));
             // Prevent redundant bounds check
             se.upperIsInBounds = true;
             se.lowerIsLessThanUpper = true;

--- a/compiler/src/dmd/compiler.d
+++ b/compiler/src/dmd/compiler.d
@@ -93,12 +93,12 @@ extern (C++) struct Compiler
         {
         case Tint32:
         case Tuns32:
-            emplaceExp!(IntegerExp)(pue, e.loc, u.int32value, type);
+            emplaceExp!(Integer64Exp)(pue, e.loc, u.int32value, type);
             break;
 
         case Tint64:
         case Tuns64:
-            emplaceExp!(IntegerExp)(pue, e.loc, u.int64value, type);
+            emplaceExp!(Integer64Exp)(pue, e.loc, u.int64value, type);
             break;
 
         case Tfloat32:

--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -85,7 +85,7 @@ UnionExp Neg(Type type, Expression e1)
     }
     else
     {
-        emplaceExp!(IntegerExp)(&ue, loc, -e1.toInteger(), type);
+        emplaceExp!(Integer64Exp)(&ue, loc, -e1.toInteger(), type);
     }
     return ue;
 }
@@ -94,7 +94,7 @@ UnionExp Com(Type type, Expression e1)
 {
     UnionExp ue = void;
     Loc loc = e1.loc;
-    emplaceExp!(IntegerExp)(&ue, loc, ~e1.toInteger(), type);
+    emplaceExp!(Integer64Exp)(&ue, loc, ~e1.toInteger(), type);
     return ue;
 }
 
@@ -105,7 +105,7 @@ UnionExp Not(Type type, Expression e1)
     // BUG: Should be replaced with e1.toBool().get(), but this is apparently
     //      executed for some expressions that cannot be const-folded
     //      To be fixed in another PR
-    emplaceExp!(IntegerExp)(&ue, loc, e1.toBool().hasValue(false) ? 1 : 0, type);
+    emplaceExp!(Integer64Exp)(&ue, loc, e1.toBool().hasValue(false) ? 1 : 0, type);
     return ue;
 }
 
@@ -210,7 +210,7 @@ UnionExp Add(Loc loc, Type type, Expression e1, Expression e2)
         ue.exp().type = type;
     }
     else
-        emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() + e2.toInteger(), type);
+        emplaceExp!(Integer64Exp)(&ue, loc, e1.toInteger() + e2.toInteger(), type);
     return ue;
 }
 
@@ -266,7 +266,7 @@ UnionExp Mul(Loc loc, Type type, Expression e1, Expression e2)
     }
     else
     {
-        emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() * e2.toInteger(), type);
+        emplaceExp!(Integer64Exp)(&ue, loc, e1.toInteger() * e2.toInteger(), type);
     }
     return ue;
 }
@@ -342,7 +342,7 @@ UnionExp Div(Loc loc, Type type, Expression e1, Expression e2)
             n = (cast(dinteger_t)n1) / (cast(dinteger_t)n2);
         else
             n = n1 / n2;
-        emplaceExp!(IntegerExp)(&ue, loc, n, type);
+        emplaceExp!(Integer64Exp)(&ue, loc, n, type);
     }
     return ue;
 }
@@ -408,7 +408,7 @@ UnionExp Mod(Loc loc, Type type, Expression e1, Expression e2)
             n = (cast(dinteger_t)n1) % (cast(dinteger_t)n2);
         else
             n = n1 % n2;
-        emplaceExp!(IntegerExp)(&ue, loc, n, type);
+        emplaceExp!(Integer64Exp)(&ue, loc, n, type);
     }
     return ue;
 }
@@ -448,8 +448,8 @@ UnionExp Pow(Loc loc, Type type, Expression e1, Expression e2)
         }
         else
         {
-            emplaceExp!(IntegerExp)(&ur, loc, e1.toInteger(), e1.type);
-            emplaceExp!(IntegerExp)(&uv, loc, 1, e1.type);
+            emplaceExp!(Integer64Exp)(&ur, loc, e1.toInteger(), e1.type);
+            emplaceExp!(Integer64Exp)(&uv, loc, 1, e1.type);
         }
         Expression r = ur.exp();
         Expression v = uv.exp();
@@ -474,7 +474,7 @@ UnionExp Pow(Loc loc, Type type, Expression e1, Expression e2)
         if (type.isComplex())
             emplaceExp!(ComplexExp)(&ue, loc, v.toComplex(), type);
         else if (type.isIntegral())
-            emplaceExp!(IntegerExp)(&ue, loc, v.toInteger(), type);
+            emplaceExp!(Integer64Exp)(&ue, loc, v.toInteger(), type);
         else
             emplaceExp!(RealExp)(&ue, loc, v.toReal(), type);
     }
@@ -496,7 +496,7 @@ UnionExp Pow(Loc loc, Type type, Expression e1, Expression e2)
 UnionExp Shl(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
-    emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() << e2.toInteger(), type);
+    emplaceExp!(Integer64Exp)(&ue, loc, e1.toInteger() << e2.toInteger(), type);
     return ue;
 }
 
@@ -542,7 +542,7 @@ UnionExp Shr(Loc loc, Type type, Expression e1, Expression e2)
     default:
         assert(0);
     }
-    emplaceExp!(IntegerExp)(&ue, loc, value, type);
+    emplaceExp!(Integer64Exp)(&ue, loc, value, type);
     return ue;
 }
 
@@ -582,21 +582,21 @@ UnionExp Ushr(Loc loc, Type type, Expression e1, Expression e2)
     default:
         assert(0);
     }
-    emplaceExp!(IntegerExp)(&ue, loc, value, type);
+    emplaceExp!(Integer64Exp)(&ue, loc, value, type);
     return ue;
 }
 
 UnionExp And(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
-    emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() & e2.toInteger(), type);
+    emplaceExp!(Integer64Exp)(&ue, loc, e1.toInteger() & e2.toInteger(), type);
     return ue;
 }
 
 UnionExp Or(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
-    emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() | e2.toInteger(), type);
+    emplaceExp!(Integer64Exp)(&ue, loc, e1.toInteger() | e2.toInteger(), type);
     return ue;
 }
 
@@ -604,7 +604,7 @@ UnionExp Xor(Loc loc, Type type, Expression e1, Expression e2)
 {
     //printf("Xor(linnum = %d, e1 = %s, e2 = %s)\n", loc.linnum, e1.toChars(), e2.toChars());
     UnionExp ue = void;
-    emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() ^ e2.toInteger(), type);
+    emplaceExp!(Integer64Exp)(&ue, loc, e1.toInteger() ^ e2.toInteger(), type);
     return ue;
 }
 
@@ -799,7 +799,7 @@ UnionExp Equal(EXP op, Loc loc, Type type, Expression e1, Expression e2)
     }
     if (op == EXP.notEqual)
         cmp ^= 1;
-    emplaceExp!(IntegerExp)(&ue, loc, cmp, type);
+    emplaceExp!(Integer64Exp)(&ue, loc, cmp, type);
     return ue;
 }
 
@@ -844,7 +844,7 @@ UnionExp Identity(EXP op, Loc loc, Type type, Expression e1, Expression e2)
     }
     if (op == EXP.notIdentity)
         cmp ^= 1;
-    emplaceExp!(IntegerExp)(&ue, loc, cmp, type);
+    emplaceExp!(Integer64Exp)(&ue, loc, cmp, type);
     return ue;
 }
 
@@ -904,7 +904,7 @@ UnionExp Cmp(EXP op, Loc loc, Type type, Expression e1, Expression e2)
         else
             n = intSignedCmp(op, n1, n2);
     }
-    emplaceExp!(IntegerExp)(&ue, loc, n, type);
+    emplaceExp!(Integer64Exp)(&ue, loc, n, type);
     return ue;
 }
 
@@ -976,7 +976,7 @@ UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
             return ue;
         }
 
-        emplaceExp!(IntegerExp)(&ue, loc, opt.get(), type);
+        emplaceExp!(Integer64Exp)(&ue, loc, opt.get(), type);
     }
     else if (type.isIntegral())
     {
@@ -1016,12 +1016,12 @@ UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
             default:
                 assert(0);
             }
-            emplaceExp!(IntegerExp)(&ue, loc, result, type);
+            emplaceExp!(Integer64Exp)(&ue, loc, result, type);
         }
         else if (type.isUnsigned())
-            emplaceExp!(IntegerExp)(&ue, loc, e1.toUInteger(), type);
+            emplaceExp!(Integer64Exp)(&ue, loc, e1.toUInteger(), type);
         else
-            emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger(), type);
+            emplaceExp!(Integer64Exp)(&ue, loc, e1.toInteger(), type);
     }
     else if (tb.isReal())
     {
@@ -1040,7 +1040,7 @@ UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
     }
     else if (tb.isScalar())
     {
-        emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger(), type);
+        emplaceExp!(Integer64Exp)(&ue, loc, e1.toInteger(), type);
     }
     else if (tb.ty == Tvoid)
     {
@@ -1072,7 +1072,7 @@ UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
         {
             VarDeclaration v = sd.fields[i];
             UnionExp zero;
-            emplaceExp!(IntegerExp)(&zero, 0);
+            emplaceExp!(Integer64Exp)(&zero, 0);
             ue = Cast(loc, v.type, v.type, zero.exp());
             if (ue.exp().op == EXP.cantExpression)
                 return ue;
@@ -1101,17 +1101,17 @@ UnionExp ArrayLength(Type type, Expression e1)
     Loc loc = e1.loc;
     if (StringExp es1 = e1.isStringExp())
     {
-        emplaceExp!(IntegerExp)(&ue, loc, es1.len, type);
+        emplaceExp!(Integer64Exp)(&ue, loc, es1.len, type);
     }
     else if (ArrayLiteralExp ale = e1.isArrayLiteralExp())
     {
         size_t dim = ale.length;
-        emplaceExp!(IntegerExp)(&ue, loc, dim, type);
+        emplaceExp!(Integer64Exp)(&ue, loc, dim, type);
     }
     else if (AssocArrayLiteralExp ale = e1.isAssocArrayLiteralExp)
     {
         size_t dim = ale.keys.length;
-        emplaceExp!(IntegerExp)(&ue, loc, dim, type);
+        emplaceExp!(Integer64Exp)(&ue, loc, dim, type);
     }
     else if (e1.type.toBasetype().ty == Tsarray)
     {
@@ -1120,7 +1120,7 @@ UnionExp ArrayLength(Type type, Expression e1)
     }
     else if (e1.isNullExp())
     {
-        emplaceExp!(IntegerExp)(&ue, loc, 0, type);
+        emplaceExp!(Integer64Exp)(&ue, loc, 0, type);
     }
     else
         cantExp(ue);
@@ -1147,7 +1147,7 @@ UnionExp Index(Type type, Expression e1, Expression e2, bool indexIsInBounds)
         }
         else
         {
-            emplaceExp!(IntegerExp)(&ue, loc, es1.getIndex(cast(size_t) i), type);
+            emplaceExp!(Integer64Exp)(&ue, loc, es1.getIndex(cast(size_t) i), type);
         }
     }
     else if (e1.type.toBasetype().ty == Tsarray && e2.op == EXP.int64)
@@ -1311,7 +1311,7 @@ void sliceAssignArrayLiteralFromString(ArrayLiteralExp existingAE, const StringE
     foreach (j; 0 .. len)
     {
         const val = newval.getIndex(j);
-        (*existingAE.elements)[j + firstIndex] = new IntegerExp(newval.loc, val, elemType);
+        (*existingAE.elements)[j + firstIndex] = Integer64Exp.create(newval.loc, val, elemType);
     }
 }
 

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -781,28 +781,28 @@ final class CParser(AST) : Parser!AST
 
         case TOK.charLiteral:
         case TOK.int32Literal:
-            e = new AST.IntegerExp(loc, token.intvalue, AST.Type.tint32);
+            e = AST.IntegerExp.create(loc, token.intvalue, AST.Type.tint32);
             nextToken();
             break;
 
         case TOK.wcharLiteral:
-            e = new AST.IntegerExp(loc, token.intvalue, AST.Type.tuns16);
+            e = AST.IntegerExp.create(loc, token.intvalue, AST.Type.tuns16);
             nextToken();
             break;
 
         case TOK.dcharLiteral:
         case TOK.uns32Literal:
-            e = new AST.IntegerExp(loc, token.unsvalue, AST.Type.tuns32);
+            e = AST.IntegerExp.create(loc, token.unsvalue, AST.Type.tuns32);
             nextToken();
             break;
 
         case TOK.int64Literal:
-            e = new AST.IntegerExp(loc, token.intvalue, AST.Type.tint64);
+            e = AST.IntegerExp.create(loc, token.intvalue, AST.Type.tint64);
             nextToken();
             break;
 
         case TOK.uns64Literal:
-            e = new AST.IntegerExp(loc, token.unsvalue, AST.Type.tuns64);
+            e = AST.IntegerExp.create(loc, token.unsvalue, AST.Type.tuns64);
             nextToken();
             break;
 
@@ -893,7 +893,7 @@ final class CParser(AST) : Parser!AST
         default:
             error("expression expected, not `%s`", token.toChars());
             // Anything for e, as long as it's not NULL
-            e = new AST.IntegerExp(loc, 0, AST.Type.tint32);
+            e = AST.IntegerExp.create(loc, 0, AST.Type.tint32);
             nextToken();
             break;
         }
@@ -1969,7 +1969,7 @@ final class CParser(AST) : Parser!AST
 
                 if (specifier.vector_size)
                 {
-                    auto length = new AST.IntegerExp(token.loc, specifier.vector_size / dt.size(), AST.Type.tuns32);
+                    auto length = AST.IntegerExp.create(token.loc, specifier.vector_size / dt.size(), AST.Type.tuns32);
                     auto tsa = new AST.TypeSArray(dt, length);
                     dt = new AST.TypeVector(tsa);
                     specifier.vector_size = 0;          // used it up
@@ -3077,7 +3077,7 @@ final class CParser(AST) : Parser!AST
 
         if (specifier.vector_size)
         {
-            auto length = new AST.IntegerExp(token.loc, specifier.vector_size / tbase.size(), AST.Type.tuns32);
+            auto length = AST.IntegerExp.create(token.loc, specifier.vector_size / tbase.size(), AST.Type.tuns32);
             auto tsa = new AST.TypeSArray(tbase, length);
             AST.Type tv = new AST.TypeVector(tsa);
             specifier.vector_size = 0;          // used it up
@@ -3439,7 +3439,7 @@ final class CParser(AST) : Parser!AST
                             error("__decspec(align(%lld)) must be an integer positive power of 2 and be <= 8,192", cast(ulong)n);
                         else
                         {
-                            auto e = new AST.IntegerExp(token.loc, n, AST.Type.tuns32);
+                            auto e = AST.IntegerExp.create(token.loc, n, AST.Type.tuns32);
                             if (!specifier.alignAttrs)
                                 specifier.alignAttrs = new AST.Expressions();
                             specifier.alignAttrs.push(e);
@@ -4906,7 +4906,7 @@ final class CParser(AST) : Parser!AST
         const fn = id.toString();  // function-name
         auto efn = new AST.StringExp(loc, fn, fn.length, 1, 'c');
         auto ifn = new AST.ExpInitializer(loc, efn);
-        auto lenfn = new AST.IntegerExp(loc, fn.length + 1, AST.Type.tuns32); // +1 for terminating 0, ditto for __pretty_chars__
+        auto lenfn = AST.IntegerExp.create(loc, fn.length + 1, AST.Type.tuns32); // +1 for terminating 0, ditto for __pretty_chars__
         auto tfn = new AST.TypeSArray(AST.Type.tchar, lenfn);
         efn.type = tfn.makeImmutable();
         efn.committed = true;
@@ -4936,7 +4936,7 @@ final class CParser(AST) : Parser!AST
 
         auto efn = new AST.StringExp(loc, funcSig);
         auto ifn = new AST.ExpInitializer(loc, efn);
-        auto lenfn = new AST.IntegerExp(loc, funcSig.length + 1, AST.Type.tuns32); // +1 for terminating 0
+        auto lenfn = AST.IntegerExp.create(loc, funcSig.length + 1, AST.Type.tuns32); // +1 for terminating 0
         auto tfn = new AST.TypeSArray(AST.Type.tchar, lenfn);
         efn.type = tfn.makeImmutable();
         efn.committed = true;
@@ -5898,7 +5898,7 @@ final class CParser(AST) : Parser!AST
                                 /* Declare manifest constant:
                                  *  enum id = intvalue;
                                  */
-                                AST.Expression e = new AST.IntegerExp(scanloc, intvalue, t);
+                                AST.Expression e = AST.IntegerExp.create(scanloc, intvalue, t);
                                 if (hasMinus)
                                     e = new AST.NegExp(scanloc, e);
                                 auto v = new AST.VarDeclaration(scanloc, t, id, new AST.ExpInitializer(scanloc, e), STC.manifest);

--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -102,15 +102,7 @@ private:
     _AnonStruct_u u;
 }
 
-void emplaceExp(T : Expression, Args...)(void* p, Args args)
-{
-    static if (__VERSION__ < 2099)
-        const init = typeid(T).initializer;
-    else
-        const init = __traits(initSymbol, T);
-    p[0 .. __traits(classInstanceSize, T)] = init[];
-    (cast(T)p).__ctor(args);
-}
+alias emplaceExp = emplaceClass;
 
 void emplaceExp(T : UnionExp)(T* p, Expression e) nothrow
 {

--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -81,7 +81,7 @@ private:
     align(8) union _AnonStruct_u
     {
         char[__traits(classInstanceSize, Expression)] exp;
-        char[__traits(classInstanceSize, IntegerExp)] integerexp;
+        char[__traits(classInstanceSize, Integer64Exp)] integerexp;
         char[__traits(classInstanceSize, ErrorExp)] errorexp;
         char[__traits(classInstanceSize, RealExp)] realexp;
         char[__traits(classInstanceSize, ComplexExp)] complexexp;
@@ -439,12 +439,12 @@ private UnionExp paintTypeOntoLiteralCopy(Type type, Expression lit)
     }
     else if (lit.op == EXP.arrayLiteral)
     {
-        emplaceExp!(SliceExp)(&ue, lit.loc, lit, ctfeEmplaceExp!IntegerExp(Loc.initial, 0, Type.tsize_t), ArrayLength(Type.tsize_t, lit).copy());
+        emplaceExp!(SliceExp)(&ue, lit.loc, lit, ctfeEmplaceExp!Integer64Exp(Loc.initial, 0, Type.tsize_t), ArrayLength(Type.tsize_t, lit).copy());
     }
     else if (lit.op == EXP.string_)
     {
         // For strings, we need to introduce another level of indirection
-        emplaceExp!(SliceExp)(&ue, lit.loc, lit, ctfeEmplaceExp!IntegerExp(Loc.initial, 0, Type.tsize_t), ArrayLength(Type.tsize_t, lit).copy());
+        emplaceExp!(SliceExp)(&ue, lit.loc, lit, ctfeEmplaceExp!Integer64Exp(Loc.initial, 0, Type.tsize_t), ArrayLength(Type.tsize_t, lit).copy());
     }
     else if (auto aae = lit.isAssocArrayLiteralExp())
     {
@@ -775,19 +775,19 @@ Expression pointerDifference(UnionExp* pue, Loc loc, Type type, Expression e1, E
     {
         Type pointee = agg1.type.nextOf();
         const sz = pointee.size();
-        emplaceExp!(IntegerExp)(pue, loc, (ofs1 - ofs2) * sz, type);
+        emplaceExp!(Integer64Exp)(pue, loc, (ofs1 - ofs2) * sz, type);
     }
     else if (agg1.op == EXP.string_ && agg2.op == EXP.string_ &&
              agg1.isStringExp().peekString().ptr == agg2.isStringExp().peekString().ptr)
     {
         Type pointee = agg1.type.nextOf();
         const sz = pointee.size();
-        emplaceExp!(IntegerExp)(pue, loc, (ofs1 - ofs2) * sz, type);
+        emplaceExp!(Integer64Exp)(pue, loc, (ofs1 - ofs2) * sz, type);
     }
     else if (agg1.op == EXP.symbolOffset && agg2.op == EXP.symbolOffset &&
              agg1.isSymOffExp().var == agg2.isSymOffExp().var)
     {
-        emplaceExp!(IntegerExp)(pue, loc, ofs1 - ofs2, type);
+        emplaceExp!(Integer64Exp)(pue, loc, ofs1 - ofs2, type);
     }
     else
     {
@@ -879,15 +879,15 @@ Expression pointerArithmetic(UnionExp* pue, Loc loc, EXP op, Type type, Expressi
         dinteger_t dim = tsa.dim.toInteger();
         // Create a CTFE pointer &agg1[indx .. indx+dim]
         auto se = ctfeEmplaceExp!SliceExp(loc, agg1,
-                ctfeEmplaceExp!IntegerExp(loc, indx, Type.tsize_t),
-                ctfeEmplaceExp!IntegerExp(loc, indx + dim, Type.tsize_t));
+                ctfeEmplaceExp!Integer64Exp(loc, indx, Type.tsize_t),
+                ctfeEmplaceExp!Integer64Exp(loc, indx + dim, Type.tsize_t));
         se.type = type.toBasetype().nextOf();
         emplaceExp!(AddrExp)(pue, loc, se);
         pue.exp().type = type;
         return pue.exp();
     }
     // Create a CTFE pointer &agg1[indx]
-    auto ofs = ctfeEmplaceExp!IntegerExp(loc, indx, Type.tsize_t);
+    auto ofs = ctfeEmplaceExp!Integer64Exp(loc, indx, Type.tsize_t);
     Expression ie = ctfeEmplaceExp!IndexExp(loc, agg1, ofs);
     ie.type = type.toBasetype().nextOf(); // https://issues.dlang.org/show_bug.cgi?id=13992
     emplaceExp!(AddrExp)(pue, loc, ie);
@@ -1526,7 +1526,7 @@ Expression ctfeIndex(UnionExp* pue, Loc loc, Type type, Expression e1, uinteger_
             eSink.error(loc, "string index %llu is out of bounds `[0 .. %llu]`", indx, cast(ulong)es1.len);
             return CTFEExp.cantexp;
         }
-        emplaceExp!IntegerExp(pue, loc, es1.getIndex(cast(size_t) indx), type);
+        emplaceExp!Integer64Exp(pue, loc, es1.getIndex(cast(size_t) indx), type);
         return pue.exp();
     }
 

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -3356,7 +3356,7 @@ Expression scaleFactor(BinExp be, Scope* sc)
         if (!t.equals(t2b))
             be.e2 = be.e2.castTo(sc, t);
         eoff = be.e2;
-        be.e2 = new MulExp(be.loc, be.e2, new IntegerExp(Loc.initial, stride, t));
+        be.e2 = new MulExp(be.loc, be.e2, IntegerExp.create(Loc.initial, stride, t));
         be.e2.type = t;
         be.type = be.e1.type;
     }
@@ -3373,7 +3373,7 @@ Expression scaleFactor(BinExp be, Scope* sc)
         else
             e = be.e1;
         eoff = e;
-        e = new MulExp(be.loc, e, new IntegerExp(Loc.initial, stride, t));
+        e = new MulExp(be.loc, e, IntegerExp.create(Loc.initial, stride, t));
         e.type = t;
         be.type = be.e2.type;
         be.e1 = be.e2;

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -1915,8 +1915,8 @@ public:
             if (val.type.ty == Tsarray && pointee.ty == Tsarray && elemsize == pointee.nextOf().size())
             {
                 size_t d = cast(size_t)(cast(TypeSArray)pointee).dim.toInteger();
-                Expression elwr = ctfeEmplaceExp!IntegerExp(e.loc, e.offset / elemsize, Type.tsize_t);
-                Expression eupr = ctfeEmplaceExp!IntegerExp(e.loc, e.offset / elemsize + d, Type.tsize_t);
+                Expression elwr = ctfeEmplaceExp!Integer64Exp(e.loc, e.offset / elemsize, Type.tsize_t);
+                Expression eupr = ctfeEmplaceExp!Integer64Exp(e.loc, e.offset / elemsize + d, Type.tsize_t);
 
                 // Create a CTFE pointer &val[ofs..ofs+d]
                 auto se = ctfeEmplaceExp!SliceExp(e.loc, val, elwr, eupr);
@@ -1961,7 +1961,7 @@ public:
             if (aggregate)
             {
                 // Create a CTFE pointer &aggregate[ofs]
-                auto ofs = ctfeEmplaceExp!IntegerExp(e.loc, indx, Type.tsize_t);
+                auto ofs = ctfeEmplaceExp!Integer64Exp(e.loc, indx, Type.tsize_t);
                 auto ei = ctfeEmplaceExp!IndexExp(e.loc, aggregate, ofs);
                 ei.type = elemtype;
                 emplaceExp!(AddrExp)(pue, e.loc, ei, e.type);
@@ -2122,7 +2122,7 @@ public:
                 assert(e.type);
 
                 // There's a terrible hack in `dmd.dsymbolsem` that special case
-                // a struct with all zeros to an `ExpInitializer(BlitExp(IntegerExp(0)))`
+                // a struct with all zeros to an `ExpInitializer(BlitExp(Integer64Exp(0)))`
                 // There's matching code for it in e2ir (toElem's visitAssignExp),
                 // so we need the same hack here.
                 // This does not trigger for global as they get a normal initializer.
@@ -3004,7 +3004,7 @@ public:
             auto ae = ctfeEmplaceExp!ArrayLiteralExp(e.loc, e.newtype.arrayOf(), elements);
             ae.ownedByCtfe = OwnedBy.ctfe;
 
-            auto ei = ctfeEmplaceExp!IndexExp(e.loc, ae, ctfeEmplaceExp!IntegerExp(Loc.initial, 0, Type.tsize_t));
+            auto ei = ctfeEmplaceExp!IndexExp(e.loc, ae, ctfeEmplaceExp!Integer64Exp(Loc.initial, 0, Type.tsize_t));
             ei.type = e.newtype;
             emplaceExp!(AddrExp)(pue, e.loc, ei, e.type);
             result = pue.exp();
@@ -3248,7 +3248,7 @@ public:
                 result = IntegerExp.createBool(cmp != 0);
             else
             {
-                emplaceExp!(IntegerExp)(pue, e.loc, cmp, e.type);
+                emplaceExp!(Integer64Exp)(pue, e.loc, cmp, e.type);
                 result = (*pue).exp();
             }
             return;
@@ -3276,7 +3276,7 @@ public:
             result = IntegerExp.createBool(cmp);
         else
         {
-            emplaceExp!(IntegerExp)(pue, e.loc, cmp, e.type);
+            emplaceExp!(Integer64Exp)(pue, e.loc, cmp, e.type);
             result = (*pue).exp();
         }
     }
@@ -4075,8 +4075,8 @@ public:
             if (goal == CTFEGoal.Nothing)
                 return null; // avoid creating an unused literal
             auto retslice = ctfeEmplaceExp!SliceExp(e.loc, existingSE,
-                        ctfeEmplaceExp!IntegerExp(e.loc, firstIndex, Type.tsize_t),
-                        ctfeEmplaceExp!IntegerExp(e.loc, firstIndex + upperbound - lowerbound, Type.tsize_t));
+                        ctfeEmplaceExp!Integer64Exp(e.loc, firstIndex, Type.tsize_t),
+                        ctfeEmplaceExp!Integer64Exp(e.loc, firstIndex + upperbound - lowerbound, Type.tsize_t));
             retslice.type = e.type;
             return interpret(pue, retslice, istate);
         }
@@ -4278,8 +4278,8 @@ public:
             if (goal == CTFEGoal.Nothing)
                 return null; // avoid creating an unused literal
             auto retslice = ctfeEmplaceExp!SliceExp(e.loc, existingAE,
-                ctfeEmplaceExp!IntegerExp(e.loc, firstIndex, Type.tsize_t),
-                ctfeEmplaceExp!IntegerExp(e.loc, firstIndex + upperbound - lowerbound, Type.tsize_t));
+                ctfeEmplaceExp!Integer64Exp(e.loc, firstIndex, Type.tsize_t),
+                ctfeEmplaceExp!Integer64Exp(e.loc, firstIndex + upperbound - lowerbound, Type.tsize_t));
             retslice.type = e.type;
             return interpret(pue, retslice, istate);
         }
@@ -4504,7 +4504,7 @@ public:
                 (dir1 != dir2 && pointToSameMemoryBlock(agg1, agg3) && pointToSameMemoryBlock(agg2, agg4)))
             {
                 // it's a legal two-sided comparison
-                emplaceExp!(IntegerExp)(pue, e.loc, (e.op == EXP.andAnd) ? 0 : 1, e.type);
+                emplaceExp!(Integer64Exp)(pue, e.loc, (e.op == EXP.andAnd) ? 0 : 1, e.type);
                 result = pue.exp();
                 return;
             }
@@ -4563,7 +4563,7 @@ public:
             result = interpret(pue, e.e2, istate);
             return;
         }
-        emplaceExp!(IntegerExp)(pue, e.loc, (e.op == EXP.andAnd) ? 0 : 1, e.type);
+        emplaceExp!(Integer64Exp)(pue, e.loc, (e.op == EXP.andAnd) ? 0 : 1, e.type);
         result = pue.exp();
     }
 
@@ -4624,7 +4624,7 @@ public:
                 result = IntegerExp.createBool(res);
             else
             {
-                emplaceExp!(IntegerExp)(pue, e.loc, res, e.type);
+                emplaceExp!(Integer64Exp)(pue, e.loc, res, e.type);
                 result = pue.exp();
             }
         }
@@ -4995,7 +4995,7 @@ public:
             result = CTFEExp.cantexp;
             return;
         }
-        emplaceExp!(IntegerExp)(pue, e.loc, resolveArrayLength(e1), e.type);
+        emplaceExp!(Integer64Exp)(pue, e.loc, resolveArrayLength(e1), e.type);
         result = pue.exp();
     }
 
@@ -5192,7 +5192,7 @@ public:
 
         if (e.lengthVar)
         {
-            Expression dollarExp = ctfeEmplaceExp!IntegerExp(e.loc, len, Type.tsize_t);
+            Expression dollarExp = ctfeEmplaceExp!Integer64Exp(e.loc, len, Type.tsize_t);
             ctfeGlobals.stack.push(e.lengthVar);
             setValue(e.lengthVar, dollarExp);
         }
@@ -5256,7 +5256,7 @@ public:
                 {
                     // if we need a reference, IndexExp shouldn't be interpreting
                     // the expression to a value, it should stay as a reference
-                    emplaceExp!(IndexExp)(pue, e.loc, agg, ctfeEmplaceExp!IntegerExp(e.e2.loc, indexToAccess, e.e2.type));
+                    emplaceExp!(IndexExp)(pue, e.loc, agg, ctfeEmplaceExp!Integer64Exp(e.e2.loc, indexToAccess, e.e2.type));
                     result = pue.exp();
                     result.type = e.type;
                     return;
@@ -5290,7 +5290,7 @@ public:
 
         if (goal == CTFEGoal.LValue)
         {
-            Expression e2 = ctfeEmplaceExp!IntegerExp(e.e2.loc, indexToAccess, Type.tsize_t);
+            Expression e2 = ctfeEmplaceExp!Integer64Exp(e.e2.loc, indexToAccess, Type.tsize_t);
             emplaceExp!(IndexExp)(pue, e.loc, agg, e2);
             result = pue.exp();
             result.type = e.type;
@@ -5380,8 +5380,8 @@ public:
             }
             if (ofs != 0)
             {
-                lwr = ctfeEmplaceExp!IntegerExp(e.loc, ilwr, lwr.type);
-                upr = ctfeEmplaceExp!IntegerExp(e.loc, iupr, upr.type);
+                lwr = ctfeEmplaceExp!Integer64Exp(e.loc, ilwr, lwr.type);
+                upr = ctfeEmplaceExp!Integer64Exp(e.loc, iupr, upr.type);
             }
             emplaceExp!(SliceExp)(pue, e.loc, agg, lwr, upr);
             result = pue.exp();
@@ -5433,7 +5433,7 @@ public:
          */
         if (e.lengthVar)
         {
-            auto dollarExp = ctfeEmplaceExp!IntegerExp(e.loc, dollar, Type.tsize_t);
+            auto dollarExp = ctfeEmplaceExp!Integer64Exp(e.loc, dollar, Type.tsize_t);
             ctfeGlobals.stack.push(e.lengthVar);
             setValue(e.lengthVar, dollarExp);
         }
@@ -5485,8 +5485,8 @@ public:
             ilwr += lo1;
             iupr += lo1;
             emplaceExp!(SliceExp)(pue, e.loc, se.e1,
-                ctfeEmplaceExp!IntegerExp(e.loc, ilwr, lwr.type),
-                ctfeEmplaceExp!IntegerExp(e.loc, iupr, upr.type));
+                ctfeEmplaceExp!Integer64Exp(e.loc, ilwr, lwr.type),
+                ctfeEmplaceExp!Integer64Exp(e.loc, iupr, upr.type));
             result = pue.exp();
             result.type = e.type;
             return;
@@ -5721,7 +5721,7 @@ public:
             if (e1.op == EXP.arrayLiteral || e1.op == EXP.string_)
             {
                 // Create a CTFE pointer &[1,2,3][0] or &"abc"[0]
-                auto ei = ctfeEmplaceExp!IndexExp(e.loc, e1, ctfeEmplaceExp!IntegerExp(e.loc, 0, Type.tsize_t));
+                auto ei = ctfeEmplaceExp!IndexExp(e.loc, e1, ctfeEmplaceExp!Integer64Exp(e.loc, 0, Type.tsize_t));
                 ei.type = e.type.nextOf();
                 emplaceExp!(AddrExp)(pue, e.loc, ei, e.type);
                 result = pue.exp();
@@ -5782,7 +5782,7 @@ public:
                     dinteger_t dim = (cast(TypeSArray)pointee.toBasetype()).dim.toInteger();
                     IndexExp ie = ae.e1.isIndexExp();
                     Expression lwr = ie.e2;
-                    Expression upr = ctfeEmplaceExp!IntegerExp(ie.e2.loc, ie.e2.toInteger() + dim, Type.tsize_t);
+                    Expression upr = ctfeEmplaceExp!Integer64Exp(ie.e2.loc, ie.e2.toInteger() + dim, Type.tsize_t);
 
                     // Create a CTFE pointer &val[idx..idx+dim]
                     auto er = ctfeEmplaceExp!SliceExp(e.loc, ie.e1, lwr, upr);
@@ -5883,14 +5883,14 @@ public:
         auto tobt = e.to.toBasetype();
         if (tobt.ty == Tbool && e1.type.ty == Tpointer)
         {
-            emplaceExp!(IntegerExp)(pue, e.loc, e1.op != EXP.null_, e.to);
+            emplaceExp!(Integer64Exp)(pue, e.loc, e1.op != EXP.null_, e.to);
             result = pue.exp();
             return;
         }
         else if (tobt.isTypeBasic() && e1.op == EXP.null_)
         {
             if (tobt.isIntegral())
-                emplaceExp!(IntegerExp)(pue, e.loc, 0, e.to);
+                emplaceExp!(Integer64Exp)(pue, e.loc, 0, e.to);
             else if (tobt.isReal())
                 emplaceExp!(RealExp)(pue, e.loc, CTFloat.zero, e.to);
             result = pue.exp();
@@ -6874,7 +6874,7 @@ private Expression interpret_length(UnionExp* pue, InterState* istate, Expressio
         len = aae.keys.length;
     else
         assert(earg.op == EXP.null_);
-    emplaceExp!(IntegerExp)(pue, earg.loc, len, Type.tsize_t);
+    emplaceExp!(Integer64Exp)(pue, earg.loc, len, Type.tsize_t);
     return pue.exp();
 }
 
@@ -7115,7 +7115,7 @@ private Expression pointerToAAValue(UnionExp* pue, Expression aa, AssocArrayLite
     auto arr = ctfeEmplaceExp!(ArrayLiteralExp)(aa.loc, aa.type.nextOf().arrayOf(), aalit.values);
     arr.ownedByCtfe = aalit.ownedByCtfe;
     arr.aaLiteral = aalit;
-    auto len = ctfeEmplaceExp!(IntegerExp)(aa.loc, idx, Type.tsize_t);
+    auto len = ctfeEmplaceExp!(Integer64Exp)(aa.loc, idx, Type.tsize_t);
     auto idxexp = ctfeEmplaceExp!(IndexExp)(aa.loc, arr, len);
     idxexp.type = arr.type.nextOf();
     emplaceExp!(AddrExp)(pue, aa.loc, idxexp);
@@ -7131,7 +7131,7 @@ private Expression interpret_aaApply(UnionExp* pue, InterState* istate, Expressi
         return aa;
     if (aa.op != EXP.assocArrayLiteral)
     {
-        emplaceExp!(IntegerExp)(pue, deleg.loc, 0, Type.tsize_t);
+        emplaceExp!(Integer64Exp)(pue, deleg.loc, 0, Type.tsize_t);
         return pue.exp();
     }
 
@@ -7157,7 +7157,7 @@ private Expression interpret_aaApply(UnionExp* pue, InterState* istate, Expressi
 
     AssocArrayLiteralExp ae = aa.isAssocArrayLiteralExp();
     if (!ae.keys || ae.keys.length == 0)
-        return ctfeEmplaceExp!IntegerExp(deleg.loc, 0, Type.tsize_t);
+        return ctfeEmplaceExp!Integer64Exp(deleg.loc, 0, Type.tsize_t);
     Expression eresult;
 
     for (size_t i = 0; i < ae.keys.length; ++i)
@@ -7169,7 +7169,7 @@ private Expression interpret_aaApply(UnionExp* pue, InterState* istate, Expressi
             Type t = evalue.type;
             auto arr = ctfeEmplaceExp!(ArrayLiteralExp)(aa.loc, t.arrayOf(), ae.values);
             arr.ownedByCtfe = ae.ownedByCtfe;
-            auto idx = ctfeEmplaceExp!(IntegerExp)(aa.loc, i, Type.tsize_t);
+            auto idx = ctfeEmplaceExp!(Integer64Exp)(aa.loc, i, Type.tsize_t);
             evalue = ctfeEmplaceExp!(IndexExp)(aa.loc, arr, idx);
             evalue.type = t;
         }
@@ -7190,7 +7190,7 @@ private Expression interpret_aaApply(UnionExp* pue, InterState* istate, Expressi
     return eresult;
 }
 
-/// Returns: equivalent `StringExp` from `ArrayLiteralExp ale` containing only `IntegerExp` elements
+/// Returns: equivalent `StringExp` from `ArrayLiteralExp ale` containing only `Integer64Exp` elements
 StringExp arrayLiteralToString(ArrayLiteralExp ale)
 {
     const len = ale.length;
@@ -7248,7 +7248,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
     size_t len = cast(size_t)resolveArrayLength(str);
     if (len == 0)
     {
-        emplaceExp!(IntegerExp)(pue, deleg.loc, 0, indexType);
+        emplaceExp!(Integer64Exp)(pue, deleg.loc, 0, indexType);
         return pue.exp();
     }
 
@@ -7365,7 +7365,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
 
         // The index only needs to be set once
         if (numParams == 2)
-            args[0] = ctfeEmplaceExp!IntegerExp(deleg.loc, currentIndex, indexType);
+            args[0] = ctfeEmplaceExp!Integer64Exp(deleg.loc, currentIndex, indexType);
 
         Expression val = null;
 
@@ -7386,7 +7386,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
             default:
                 assert(0);
             }
-            val = ctfeEmplaceExp!IntegerExp(str.loc, codepoint, charType);
+            val = ctfeEmplaceExp!Integer64Exp(str.loc, codepoint, charType);
 
             args[numParams - 1] = val;
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2372,7 +2372,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             auto tsa = t.isTypeSArray();
             if (tsa && hasDollarDimension(tsa))
             {
-                tsa.dim = new IntegerExp(loc, 0, Type.tsize_t);
+                tsa.dim = IntegerExp.create(loc, 0, Type.tsize_t);
             }
 
             if (tsa)
@@ -2529,7 +2529,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     auto dim = srcTsa.dim ? srcTsa.dim.isIntegerExp() : null;
                     if (!dim)
                         break;
-                    dstTsa.dim = new IntegerExp(loc, dim.value, Type.tsize_t);
+                    dstTsa.dim = IntegerExp.create(loc, dim.value, Type.tsize_t);
                 }
                 dstTsa = dstTsa.next.isTypeSArray();
                 srcTsa = srcTsa.next ? srcTsa.next.toBasetype().isTypeSArray() : null;
@@ -2547,7 +2547,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (auto ale = ie.isArrayLiteralExp())
             {
                 dinteger_t len = ale.length;
-                tsa.dim = new IntegerExp(loc, len, Type.tsize_t);
+                tsa.dim = IntegerExp.create(loc, len, Type.tsize_t);
                 if (auto innerTsa = tsa.next.isTypeSArray())
                 {
                     if (len)
@@ -2563,7 +2563,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 Type next = tsa.next.toBasetype();
                 if (next.ty == TY.Tchar || next.ty == TY.Twchar || next.ty == TY.Tdchar)
                 {
-                    tsa.dim = new IntegerExp(loc, se.len, Type.tsize_t);
+                    tsa.dim = IntegerExp.create(loc, se.len, Type.tsize_t);
                     return true;
                 }
                 return false;
@@ -2576,7 +2576,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (!inferExprLength(ie, len))
                 return false;
 
-            tsa.dim = new IntegerExp(loc, len, Type.tsize_t);
+            tsa.dim = IntegerExp.create(loc, len, Type.tsize_t);
 
             // For non-literal forms (e.g. concatenation), propagate any known
             // nested static-array dimensions from the expression element type.
@@ -2614,7 +2614,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (!dsym._init || dsym._init.isVoidInitializer())
             {
                 eSink.error(dsym.loc, "cannot infer static array length from `$`, provide an initializer");
-                tsa.dim = new IntegerExp(dsym.loc, 0, Type.tsize_t);
+                tsa.dim = IntegerExp.create(dsym.loc, 0, Type.tsize_t);
                 dsym._init = new ErrorInitializer();
                 dsym.type = Type.terror;
                 dsym.errors = true;
@@ -2640,7 +2640,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     if (!dimInferred)
                     {
                         eSink.error(dsym.loc, "cannot infer static array length from `$`, provide an initializer");
-                        tsa.dim = new IntegerExp(dsym.loc, 0, Type.tsize_t);
+                        tsa.dim = IntegerExp.create(dsym.loc, 0, Type.tsize_t);
                         dsym._init = new ErrorInitializer();
                         dsym.type = Type.terror;
                         dsym.errors = true;
@@ -8010,7 +8010,7 @@ private extern(C++) class SearchVisitor : Visitor
             /* $ gives the number of type entries in the type tuple
              */
             auto v = new VarDeclaration(loc, Type.tsize_t, Id.dollar, null);
-            Expression e = new IntegerExp(Loc.initial, tt.arguments.length, Type.tsize_t);
+            Expression e = IntegerExp.create(Loc.initial, tt.arguments.length, Type.tsize_t);
             v._init = new ExpInitializer(Loc.initial, e);
             v.storage_class |= STC.temp | STC.static_ | STC.const_;
             v.dsymbolSemantic(sc);
@@ -8025,7 +8025,7 @@ private extern(C++) class SearchVisitor : Visitor
             /* $ gives the number of elements in the tuple
              */
             auto v = new VarDeclaration(loc, Type.tsize_t, Id.dollar, null);
-            Expression e = new IntegerExp(Loc.initial, td.objects.length, Type.tsize_t);
+            Expression e = IntegerExp.create(Loc.initial, td.objects.length, Type.tsize_t);
             v._init = new ExpInitializer(Loc.initial, e);
             v.storage_class |= STC.temp | STC.static_ | STC.const_;
             v.dsymbolSemantic(ass._scope);
@@ -8088,7 +8088,7 @@ private extern(C++) class SearchVisitor : Visitor
                 /* It is for an expression tuple, so the
                  * length will be a const.
                  */
-                Expression e = new IntegerExp(Loc.initial, tupexp.exps.length, Type.tsize_t);
+                Expression e = IntegerExp.create(Loc.initial, tupexp.exps.length, Type.tsize_t);
                 v = new VarDeclaration(loc, Type.tsize_t, Id.dollar, new ExpInitializer(Loc.initial, e));
                 v.storage_class |= STC.temp | STC.static_ | STC.const_;
             }
@@ -8119,7 +8119,7 @@ private extern(C++) class SearchVisitor : Visitor
                     {
                         assert(0);
                     }
-                    Expression edim = new IntegerExp(Loc.initial, dim, Type.tsize_t);
+                    Expression edim = IntegerExp.create(Loc.initial, dim, Type.tsize_t);
                     edim = edim.expressionSemantic(ass._scope);
                     auto tiargs = new Objects(edim);
                     e = new DotTemplateInstanceExp(loc, ce, td.ident, tiargs);
@@ -9609,8 +9609,8 @@ private Expression callScopeDtor(VarDeclaration vd, Scope* sc)
             const sdsz = sd.type.size();
             assert(sdsz != SIZE_INVALID && sdsz != 0);
             const n = sz / sdsz;
-            SliceExp se = new SliceExp(vd.loc, e, new IntegerExp(vd.loc, 0, Type.tsize_t),
-                new IntegerExp(vd.loc, n, Type.tsize_t));
+            SliceExp se = new SliceExp(vd.loc, e, IntegerExp.create(vd.loc, 0, Type.tsize_t),
+                IntegerExp.create(vd.loc, n, Type.tsize_t));
 
             // Prevent redundant bounds check
             se.upperIsInBounds = true;

--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -515,7 +515,7 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
         }
 
         const errors = global.startGagging();
-        Expression e = new IntegerExp(em.loc, 0, t);
+        Expression e = IntegerExp.create(em.loc, 0, t);
         e = e.ctfeInterpret();
         if (global.endGagging(errors) || terror)
         {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -190,7 +190,8 @@ extern (C++) abstract class Expression : ASTNode
     extern (D) final Expression copy()
     {
         Expression e;
-        if (!size)
+        size_t sz = size();
+        if (!sz)
         {
             debug
             {
@@ -200,10 +201,19 @@ extern (C++) abstract class Expression : ASTNode
             assert(0);
         }
 
+        if (op == EXP.int64)
+        {
+            if (sz == __traits(classInstanceSize, Integer64Exp))
+            {
+                auto e64 = cast(Integer64Exp)this;
+                if (e64.value_ >= 0 && e64.value_ < short.max)
+                    return new Integer16Exp(loc, cast(short)e64.value_, type);
+            }
+        }
         // memory never freed, so can use the faster bump-pointer-allocation
-        e = cast(Expression)allocmemoryNoFree(size, expAlign[op]);
+        e = cast(Expression)allocmemoryNoFree(sz, expAlign[op]);
         //printf("Expression::copy(op = %d) e = %p\n", op, e);
-        return cast(Expression)memcpy(cast(void*)e, cast(void*)this, size);
+        return cast(Expression)memcpy(cast(void*)e, cast(void*)this, sz);
     }
 
     Expression syntaxCopy()

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -541,7 +541,7 @@ extern (C++) abstract class IntegerExp : Expression
 
     dinteger_t value() const;
     dinteger_t getInteger();
-    extern (D) void setInteger(dinteger_t value);
+    void setInteger(dinteger_t value);
 
     extern (D) static dinteger_t normalize(TY ty, dinteger_t value)
     {
@@ -667,7 +667,7 @@ extern (C++) class Integer64Exp : IntegerExp
         return value_;
     }
 
-    extern (D) override void setInteger(dinteger_t value)
+    override void setInteger(dinteger_t value)
     {
         this.value_ = normalize(type.toBaseTypeNonSemantic().ty, value);
     }
@@ -700,7 +700,7 @@ extern (C++) class Integer16Exp : IntegerExp
         return value();
     }
 
-    extern (D) override void setInteger(dinteger_t val)
+    override void setInteger(dinteger_t val)
     {
         this.value_ = cast(ushort)normalize(type.toBaseTypeNonSemantic().ty, val);
         // should always be a restricting change keeping or lowering the bit range

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -145,15 +145,7 @@ extern (C++) abstract class Expression : ASTNode
     }
 
     /// Returns: class instance size of this expression (implemented manually because `extern(C++)`)
-    final size_t size() nothrow @nogc pure @safe const
-    {
-        if (op == EXP.int64)
-            return classInstanceSize();
-        return expSize[op];
-    }
-
-    // virtual version of size()
-    size_t classInstanceSize() nothrow @nogc pure @safe const
+    size_t size() nothrow @nogc pure @safe const
     {
         return expSize[op];
     }
@@ -187,7 +179,7 @@ extern (C++) abstract class Expression : ASTNode
     /*********************************
      * Does *not* do a deep copy.
      */
-    extern (D) final Expression copy()
+    Expression copy()
     {
         Expression e;
         size_t sz = size();
@@ -201,17 +193,9 @@ extern (C++) abstract class Expression : ASTNode
             assert(0);
         }
 
-        if (op == EXP.int64)
-        {
-            if (sz == __traits(classInstanceSize, Integer64Exp))
-            {
-                auto e64 = cast(Integer64Exp)this;
-                if (e64.value_ >= 0 && e64.value_ < short.max)
-                    return new Integer16Exp(loc, cast(short)e64.value_, type);
-            }
-        }
+        size_t alignment = expAlign[op];
         // memory never freed, so can use the faster bump-pointer-allocation
-        e = cast(Expression)allocmemoryNoFree(sz, expAlign[op]);
+        e = cast(Expression)allocmemoryNoFree(sz, alignment);
         //printf("Expression::copy(op = %d) e = %p\n", op, e);
         return cast(Expression)memcpy(cast(void*)e, cast(void*)this, sz);
     }
@@ -533,8 +517,9 @@ extern (C++) abstract class IntegerExp : Expression
 
     static IntegerExp create(Loc loc, dinteger_t value, Type type)
     {
-        dinteger_t norm = normalize(type.toBaseTypeNonSemantic().ty, value);
-        if (norm >= 0 && norm <= short.max)
+        import dmd.typesem;
+        dinteger_t val = type.isUnsigned() ? cast(ushort)value : cast(long)cast(short)value;
+        if (val == value)
             return new Integer16Exp(loc, cast(short)value, type);
         return new Integer64Exp(loc, value, type);
     }
@@ -665,9 +650,27 @@ extern (C++) class Integer64Exp : IntegerExp
         value_ = cast(int)value;
     }
 
-    override size_t classInstanceSize() nothrow @nogc pure @safe const
+    override size_t size() nothrow @nogc pure @safe const
     {
         return __traits(classInstanceSize, Integer64Exp);
+    }
+
+    override IntegerExp copy()
+    {
+        import dmd.typesem;
+        dinteger_t val = type.isUnsigned() ? cast(ushort)value_ : cast(long)cast(short)value_;
+        if (val == value_)
+        {
+            auto alignment = classAlignment!Integer16Exp;
+            auto sz = __traits(classInstanceSize, Integer16Exp);
+            auto p = allocmemoryNoFree(sz, alignment);
+            return emplaceClass!Integer16Exp(p, loc, cast(ushort)val, type);
+        }
+        size_t sz = __traits(classInstanceSize, Integer64Exp);
+        size_t alignment = classAlignment!Integer64Exp;
+        // memory never freed, so can use the faster bump-pointer-allocation
+        void* p = allocmemoryNoFree(sz, alignment);
+        return cast(Integer64Exp)memcpy(p, cast(void*)this, sz);
     }
 
     override dinteger_t value() const { return value_; }
@@ -693,10 +696,20 @@ extern (C++) class Integer16Exp : IntegerExp
         value_ = value;
     }
 
-    override size_t classInstanceSize() nothrow @nogc pure @safe const
+    override size_t size() nothrow @nogc pure @safe const
     {
         return __traits(classInstanceSize, Integer16Exp);
     }
+
+    override Integer16Exp copy()
+    {
+        size_t sz = __traits(classInstanceSize, Integer16Exp);
+        size_t alignment = classAlignment!Integer16Exp;
+        // memory never freed, so can use the faster bump-pointer-allocation
+        void* p = allocmemoryNoFree(sz, alignment);
+        return cast(Integer16Exp)memcpy(p, cast(void*)this, sz);
+    }
+
 
     override dinteger_t value() const
     {
@@ -4262,12 +4275,15 @@ immutable ubyte[EXP.max+1] expSize = (){
     return expSize;
 }();
 
+// support for classInstanceAlignment? if not, assume worst case
+static if (__VERSION__ >= 2101)
+    enum classAlignment(T) = __traits(classInstanceAlignment, T);
+else
+    enum classAlignment(T) = 16;
+
 immutable ubyte[EXP.max+1] expAlign = (){
     ubyte[EXP.max+1] expAlign;
     foreach(optype; ExpOpTypePairs)
-        static if (__VERSION__ >= 2101) // support for classInstanceAlignment ?
-            expAlign[optype.op] = __traits(classInstanceAlignment, optype.type);
-        else
-            expAlign[optype.op] = 16; // worst case, GC doesn't guarantee more anyway
+        expAlign[optype.op] = classAlignment!(optype.type);
     return expAlign;
 }();

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -135,7 +135,9 @@ extern (C++) abstract class Expression : ASTNode
     import dmd.common.bitfields;
     mixin(generateBitFields!(BitFields, ubyte));
 
-    extern (D) this(Loc loc, EXP op) scope @safe
+    private ushort astNodeBitFields;
+
+    extern (D) this(Loc loc, EXP op) scope @trusted
     {
         //printf("Expression::Expression(op = %d) this = %p\n", op, this);
         this.loc = loc;
@@ -143,7 +145,18 @@ extern (C++) abstract class Expression : ASTNode
     }
 
     /// Returns: class instance size of this expression (implemented manually because `extern(C++)`)
-    final size_t size() nothrow @nogc pure @safe const { return expSize[op]; }
+    final size_t size() nothrow @nogc pure @safe const
+    {
+        if (op == EXP.int64)
+            return classInstanceSize();
+        return expSize[op];
+    }
+
+    // virtual version of size()
+    size_t classInstanceSize() nothrow @nogc pure @safe const
+    {
+        return expSize[op];
+    }
 
     static void _init()
     {
@@ -491,11 +504,9 @@ bool _isRoughlyScalar(Type _this)
 /***********************************************************
  * A compile-time known integer value
  */
-extern (C++) final class IntegerExp : Expression
+extern (C++) abstract class IntegerExp : Expression
 {
-    dinteger_t value;
-
-    extern (D) this(Loc loc, dinteger_t value, Type type)
+    extern (D) this(Loc loc, Type type)
     {
         super(loc, EXP.int64);
         //printf("IntegerExp(value = %lld, type = '%s')\n", value, type ? type.toChars() : "");
@@ -508,19 +519,19 @@ extern (C++) final class IntegerExp : Expression
         assert(_isRoughlyScalar(type) || type.ty == Terror);
 
         this.type = type;
-        this.value = normalize(type.toBaseTypeNonSemantic().ty, value);
-    }
-
-    extern (D) this(dinteger_t value)
-    {
-        super(Loc.initial, EXP.int64);
-        this.type = Type.tint32;
-        this.value = cast(int)value;
     }
 
     static IntegerExp create(Loc loc, dinteger_t value, Type type)
     {
-        return new IntegerExp(loc, value, type);
+        dinteger_t norm = normalize(type.toBaseTypeNonSemantic().ty, value);
+        if (norm >= 0 && norm <= short.max)
+            return new Integer16Exp(loc, cast(short)value, type);
+        return new Integer64Exp(loc, value, type);
+    }
+
+    static IntegerExp create(dinteger_t value)
+    {
+        return create(Loc.initial, value, Type.tint32);
     }
 
     override void accept(Visitor v)
@@ -528,15 +539,9 @@ extern (C++) final class IntegerExp : Expression
         v.visit(this);
     }
 
-    dinteger_t getInteger()
-    {
-        return value;
-    }
-
-    extern (D) void setInteger(dinteger_t value)
-    {
-        this.value = normalize(type.toBaseTypeNonSemantic().ty, value);
-    }
+    dinteger_t value() const;
+    dinteger_t getInteger();
+    extern (D) void setInteger(dinteger_t value);
 
     extern (D) static dinteger_t normalize(TY ty, dinteger_t value)
     {
@@ -610,7 +615,7 @@ extern (C++) final class IntegerExp : Expression
     {
         __gshared IntegerExp theConstant;
         if (!theConstant)
-            theConstant = new IntegerExp(v);
+            theConstant = IntegerExp.create(v);
         return theConstant;
     }
 
@@ -627,12 +632,82 @@ extern (C++) final class IntegerExp : Expression
         __gshared IntegerExp trueExp, falseExp;
         if (!trueExp)
         {
-            trueExp = new IntegerExp(Loc.initial, 1, Type.tbool);
-            falseExp = new IntegerExp(Loc.initial, 0, Type.tbool);
+            trueExp = IntegerExp.create(Loc.initial, 1, Type.tbool);
+            falseExp = IntegerExp.create(Loc.initial, 0, Type.tbool);
         }
         return b ? trueExp : falseExp;
     }
 }
+
+extern (C++) class Integer64Exp : IntegerExp
+{
+    dinteger_t value_;
+
+    extern (D) this(Loc loc, dinteger_t value, Type type)
+    {
+        super(loc, type);
+        value_ = normalize(type.toBaseTypeNonSemantic().ty, value);
+    }
+
+    extern (D) this(dinteger_t value)
+    {
+        super(Loc.initial, Type.tint32);
+        value_ = cast(int)value;
+    }
+
+    override size_t classInstanceSize() nothrow @nogc pure @safe const
+    {
+        return __traits(classInstanceSize, Integer64Exp);
+    }
+
+    override dinteger_t value() const { return value_; }
+
+    override dinteger_t getInteger()
+    {
+        return value_;
+    }
+
+    extern (D) override void setInteger(dinteger_t value)
+    {
+        this.value_ = normalize(type.toBaseTypeNonSemantic().ty, value);
+    }
+}
+
+extern (C++) class Integer16Exp : IntegerExp
+{
+    alias value_ = astNodeBitFields;
+
+    extern (D) this(Loc loc, ushort value, Type type)
+    {
+        super(loc, type);
+        value_ = value;
+    }
+
+    override size_t classInstanceSize() nothrow @nogc pure @safe const
+    {
+        return __traits(classInstanceSize, Integer16Exp);
+    }
+
+    override dinteger_t value() const
+    {
+        import dmd.typesem;
+        dinteger_t val = (cast()type).isUnsigned() ? value_ : cast(long)cast(short)value_;
+        return val;
+    }
+
+    override dinteger_t getInteger()
+    {
+        return value();
+    }
+
+    extern (D) override void setInteger(dinteger_t val)
+    {
+        this.value_ = cast(ushort)normalize(type.toBaseTypeNonSemantic().ty, val);
+        // should always be a restricting change keeping or lowering the bit range
+        assert(val == value);
+    }
+}
+
 
 /***********************************************************
  * Use this expression for error recovery.

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -154,7 +154,6 @@ real_t toReal(Expression _this)
         // normalize() is necessary until we fix all the paints of 'type'
         const ty = iexp.type.toBasetype().ty;
         const val = iexp.normalize(ty, iexp.value);
-        iexp.value = val;
         return (ty == Tuns64)
             ? real_t(cast(ulong)val)
             : real_t(cast(long)val);
@@ -194,7 +193,7 @@ dinteger_t toInteger(Expression _this)
     if (auto iexp = _this.isIntegerExp())
     {
         // normalize() is necessary until we fix all the paints of 'type'
-        return iexp.value = IntegerExp.normalize(iexp.type.toBasetype().ty, iexp.value);
+        return IntegerExp.normalize(iexp.type.toBasetype().ty, iexp.value);
     }
     else if (auto rexp = _this.isRealExp())
     {
@@ -5475,7 +5474,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         assert(e.type.deco);
-        e.setInteger(e.getInteger());
+        assert(e.value == IntegerExp.normalize(e.type.toBaseTypeNonSemantic().ty, e.value));
         result = e;
     }
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1850,7 +1850,7 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, out Expression pe0)
 
         if (auto ie = e.isIntervalExp())
         {
-            Expression edim = new IntegerExp(ae.loc, i, Type.tsize_t);
+            Expression edim = IntegerExp.create(ae.loc, i, Type.tsize_t);
             edim = edim.expressionSemantic(sc);
             auto tiargs = new Objects(edim);
 
@@ -5308,7 +5308,7 @@ Expression lowerArrayLiteral(ArrayLiteralExp ale, Scope* sc)
     auto tiargs = new Objects(t);
     lowering = new DotTemplateInstanceExp(ale.loc, lowering, hook, tiargs);
 
-    auto arguments = new Expressions(new IntegerExp(dim));
+    auto arguments = new Expressions(IntegerExp.create(dim));
     lowering = new CallExp(ale.loc, lowering, arguments);
     ale.lowering = lowering.expressionSemantic(sc);
 
@@ -7161,7 +7161,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 auto tiargs = new Objects(t);
                 lowering = new DotTemplateInstanceExp(exp.loc, lowering, hook, tiargs);
 
-                auto arguments = new Expressions((*exp.arguments)[0], new IntegerExp(exp.loc, isShared, Type.tbool));
+                auto arguments = new Expressions((*exp.arguments)[0], IntegerExp.create(exp.loc, isShared, Type.tbool));
 
                 lowering = new CallExp(exp.loc, lowering, arguments);
                 exp.lowering = lowering.expressionSemantic(sc);
@@ -7189,7 +7189,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 lowering = new DotTemplateInstanceExp(exp.loc, lowering, hook, tiargs);
 
                 auto arguments = new Expressions(new ArrayLiteralExp(exp.loc, Type.tsize_t.sarrayOf(nargs), exp.arguments),
-                                                 new IntegerExp(exp.loc, tbn.isShared(), Type.tbool));
+                                                 IntegerExp.create(exp.loc, tbn.isShared(), Type.tbool));
 
                 lowering = new CallExp(exp.loc, lowering, arguments);
                 exp.lowering = lowering.expressionSemantic(sc);
@@ -8711,7 +8711,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                         // Add expression `*cast(void**)(cast(void*)this) + offset)` for accessing the interface vptr
                         Expression vptr = new CastExp(loc, new ThisExp(loc), Type.tvoidptr);
-                        vptr = new AddExp(loc, vptr, new IntegerExp(loc, b.offset, Type.tsize_t));
+                        vptr = new AddExp(loc, vptr, IntegerExp.create(loc, b.offset, Type.tsize_t));
                         vptr = new PtrExp(loc, new CastExp(loc, vptr, Type.tvoidptr.pointerTo()));
                         vptrs.push(vptr);
                     }
@@ -13782,7 +13782,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression eValue1;
                 Expression value1 = extractSideEffect(sc, "__appendtmp", eValue1, exp.e1);
 
-                auto arguments = new Expressions(value1, new IntegerExp(exp.loc, 1, Type.tsize_t));
+                auto arguments = new Expressions(value1, IntegerExp.create(exp.loc, 1, Type.tsize_t));
 
                 Expression ce = new CallExp(exp.loc, id, arguments);
 
@@ -13986,13 +13986,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 stride = t2.nextOf().size();
                 if (stride == 0)
                 {
-                    e = new IntegerExp(exp.loc, 0, Type.tptrdiff_t);
+                    e = IntegerExp.create(exp.loc, 0, Type.tptrdiff_t);
                 }
                 else if (stride == cast(long)SIZE_INVALID)
                     e = ErrorExp.get();
                 else
                 {
-                    e = new DivExp(exp.loc, exp, new IntegerExp(Loc.initial, stride, Type.tptrdiff_t));
+                    e = new DivExp(exp.loc, exp, IntegerExp.create(Loc.initial, stride, Type.tptrdiff_t));
                     e.type = Type.tptrdiff_t;
                 }
             }
@@ -14557,7 +14557,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             Expression one;
             if (pe.e1.type.isIntegral()) {
-                one = new IntegerExp(e.loc, 1, pe.e1.type);
+                one = IntegerExp.create(e.loc, 1, pe.e1.type);
             } else {
                 one = new RealExp(e.loc, CTFloat.one, pe.e1.type);
             }
@@ -14752,7 +14752,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (e1x.toBool().hasValue(exp.op == EXP.orOr))
             {
                 if (sc.inCfile)
-                    result = new IntegerExp(exp.op == EXP.orOr);
+                    result = IntegerExp.create(exp.op == EXP.orOr);
                 else
                     result = IntegerExp.createBool(exp.op == EXP.orOr);
                 return;
@@ -15757,7 +15757,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
             }
             case TOK.line:
-                result = new IntegerExp(loc, loc.linnum, Type.tint32).expressionSemantic(sc);
+                result = IntegerExp.create(loc, loc.linnum, Type.tint32).expressionSemantic(sc);
                 break;
             case TOK.moduleString:
             {
@@ -16056,7 +16056,7 @@ private Expression dotIdSemanticPropX(DotIdExp exp, Scope* sc)
         if (exp.ident == Id.length)
         {
             // Don't evaluate te.e0 in runtime
-            return new IntegerExp(exp.loc, te.exps.length, Type.tsize_t);
+            return IntegerExp.create(exp.loc, te.exps.length, Type.tsize_t);
         }
     }
 
@@ -16407,14 +16407,14 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
         const explicitAlignment = exp.e1.isVarExp().var.isVarDeclaration().alignment;
         const naturalAlignment = exp.e1.type.alignsize();
         const actualAlignment = explicitAlignment.isDefault() ? naturalAlignment : explicitAlignment.get();
-        Expression e = new IntegerExp(exp.loc, actualAlignment, Type.tsize_t);
+        Expression e = IntegerExp.create(exp.loc, actualAlignment, Type.tsize_t);
         return e;
     }
     else if ((exp.ident == Id.max || exp.ident == Id.min) && exp.e1.isBitField())
     {
         // For `x.max` and `x.min` get the max/min of the bitfield, not the max/min of its type
         auto bf = exp.e1.isBitField();
-        return new IntegerExp(exp.loc, bf.getMinMax(exp.ident), bf.type);
+        return IntegerExp.create(exp.loc, bf.getMinMax(exp.ident), bf.type);
     }
     else
     {
@@ -18035,7 +18035,7 @@ Expression getThisSkipNestedFuncs(Loc loc, Scope* sc, Dsymbol s, AggregateDeclar
                     e1 = e1.expressionSemantic(sc);
                 e1 = new PtrExp(loc, e1);
                 uint i = f.followInstantiationContext(ad);
-                e1 = new IndexExp(loc, e1, new IntegerExp(i));
+                e1 = new IndexExp(loc, e1, IntegerExp.create(i));
                 s = f.toParentP(ad);
                 continue;
             }
@@ -19467,13 +19467,13 @@ void lowerNonArrayAggregate(StaticForeach sfe, Scope* sc)
         if (sfe.rangefe.op == TOK.foreach_)
         {
             foreach (i; 0 .. length)
-                (*exps)[i] = new IntegerExp(aloc, lwr + i, indexty);
+                (*exps)[i] = IntegerExp.create(aloc, lwr + i, indexty);
         }
         else
         {
             --upr;
             foreach (i; 0 .. length)
-                (*exps)[i] = new IntegerExp(aloc, upr - i, indexty);
+                (*exps)[i] = IntegerExp.create(aloc, upr - i, indexty);
         }
         aggr = new ArrayLiteralExp(aloc, indexty.arrayOf(), exps);
     }
@@ -19565,7 +19565,7 @@ extern(D) void lowerArrayAggregate(StaticForeach sfe, Scope* sc)
         es = new Expressions(length);
         foreach (i; 0 .. length)
         {
-            auto index = new IntegerExp(sfe.loc, i, Type.tsize_t);
+            auto index = IntegerExp.create(sfe.loc, i, Type.tsize_t);
             auto value = new IndexExp(aggr.loc, aggr, index);
             (*es)[i] = value;
         }

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -1371,7 +1371,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         TypeInfo_toObjFile(null, d.loc, tc.next);
         classFieldsToDt(Type.typeinfostaticarray, new Expressions(
             new SymOffExp(d.loc, tc.next.vtinfo, 0),
-            new IntegerExp(d.loc, tc.dim.toInteger(), Type.tsize_t)), *dtb);
+            IntegerExp.create(d.loc, tc.dim.toInteger(), Type.tsize_t)), *dtb);
     }
 
     override void visit(TypeInfoVectorDeclaration d)

--- a/compiler/src/dmd/iasm/package.d
+++ b/compiler/src/dmd/iasm/package.d
@@ -76,7 +76,7 @@ Statement asmSemantic(AsmStatement s, Scope* sc)
             /* Replace the asm statement with an assert(0, msg) that trips at runtime.
              */
             const loc = s.loc;
-            auto e = new IntegerExp(loc, 0, Type.tint32);
+            auto e = IntegerExp.create(loc, 0, Type.tint32);
             auto msg = new StringExp(loc, "Gnu Asm not supported - compile this function with gcc or clang");
             auto ae = new AssertExp(loc, e, msg);
             auto se = new ExpStatement(loc, ae);

--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -660,7 +660,7 @@ void cEnumSemantic(Scope* sc, EnumDeclaration ed)
             /* To merge the type of e with commonType, add 0 of type commonType
                 */
             if (!ed.memtype)
-                e = new AddExp(em.loc, e, new IntegerExp(em.loc, 0, commonType));
+                e = new AddExp(em.loc, e, IntegerExp.create(em.loc, 0, commonType));
 
             e = e.expressionSemantic(sc);
             e = resolveProperties(sc, e);
@@ -684,7 +684,7 @@ void cEnumSemantic(Scope* sc, EnumDeclaration ed)
             nextValue = ie.toInteger();
             if (!ed.memtype)
                 commonType = e.type;
-            em.value = new IntegerExp(em.loc, nextValue, commonType);
+            em.value = IntegerExp.create(em.loc, nextValue, commonType);
         }
         else
         {
@@ -700,7 +700,7 @@ void cEnumSemantic(Scope* sc, EnumDeclaration ed)
                 }
                 nextValue += 1;
             }
-            em.value = new IntegerExp(em.loc, nextValue, commonType);
+            em.value = IntegerExp.create(em.loc, nextValue, commonType);
         }
         em.type = commonType;
         em.semanticRun = PASS.semanticdone;

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -322,7 +322,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             {
                 // Change to array of known length
                 auto tn = tsa.next.toBasetype();
-                tsa = new TypeSArray(tn, new IntegerExp(Loc.initial, i.dim, Type.tsize_t));
+                tsa = new TypeSArray(tn, IntegerExp.create(Loc.initial, i.dim, Type.tsize_t));
                 tx = tsa;      // rewrite caller's type
                 i.type = tsa;  // remember for later passes
             }
@@ -509,7 +509,7 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
             tb.isTypeSArray() && tb.isTypeSArray().isIncomplete())
         {
             StringExp se = i.exp.isStringExp();
-            auto ts = new TypeSArray(tb.nextOf(), new IntegerExp(Loc.initial, se.len + 1, Type.tsize_t));
+            auto ts = new TypeSArray(tb.nextOf(), IntegerExp.create(Loc.initial, se.len + 1, Type.tsize_t));
             t = typeSemantic(ts, Loc.initial, sc);
             i.exp.type = t;
             tx = t;

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -495,7 +495,7 @@ public:
 
                 if (e.offset)
                 {
-                    auto ie = new IntegerExp(e.loc, e.offset, Type.tsize_t);
+                    auto ie = IntegerExp.create(e.loc, e.offset, Type.tsize_t);
                     result = new AddExp(e.loc, result, ie);
                     result.type = e.type;
                 }
@@ -596,7 +596,7 @@ public:
                         }
                         result = new PtrExp(e.loc, result);
                         result.type = Type.tvoidptr.sarrayOf(2);
-                        auto ie = new IndexExp(e.loc, result, new IntegerExp(i));
+                        auto ie = new IndexExp(e.loc, result, IntegerExp.create(i));
                         ie.indexIsInBounds = true; // no runtime bounds checking
                         result = ie;
                         result.type = Type.tvoidptr;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1153,7 +1153,7 @@ extern (C++) final class TypeSArray : TypeArray
     {
         super(Tsarray, t);
         //printf("TypeSArray()\n");
-        this.dim = new IntegerExp(0);
+        this.dim = IntegerExp.create(0);
     }
 
     override const(char)* kind() const

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -905,7 +905,7 @@ Expression opOverloadCmp(CmpExp exp, Scope* sc, Type[2] aliasThisStop)
 
     auto ce = new CallExp(e.loc, cl, arguments);
     ce.fromOpOverload = true;
-    cl = new CmpExp(cmpOp, exp.loc, ce, new IntegerExp(0));
+    cl = new CmpExp(cmpOp, exp.loc, ce, IntegerExp.create(0));
     return cl.expressionSemantic(sc);
 }
 

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -235,7 +235,7 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Expression arr)
             return; // we don't know the length yet
         len = tsa.dim.toInteger();
     }
-    Expression dollar = new IntegerExp(Loc.initial, len, Type.tsize_t);
+    Expression dollar = IntegerExp.create(Loc.initial, len, Type.tsize_t);
     lengthVar._init = new ExpInitializer(Loc.initial, dollar);
     lengthVar.storage_class |= STC.static_ | STC.const_;
 }
@@ -256,7 +256,7 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Type type)
     if (!tsa)
         return; // we don't know the length yet
     const len = tsa.dim.toInteger();
-    Expression dollar = new IntegerExp(Loc.initial, len, Type.tsize_t);
+    Expression dollar = IntegerExp.create(Loc.initial, len, Type.tsize_t);
     lengthVar._init = new ExpInitializer(Loc.initial, dollar);
     lengthVar.storage_class |= STC.static_ | STC.const_;
 }
@@ -567,7 +567,7 @@ Expression optimize(Expression e, int result, bool keepLvalue = false)
             }
             if (eint)
             {
-                ret = new IntegerExp(e.loc, eint.toInteger() + offset, e.type);
+                ret = IntegerExp.create(e.loc, eint.toInteger() + offset, e.type);
                 return;
             }
         }
@@ -601,7 +601,7 @@ Expression optimize(Expression e, int result, bool keepLvalue = false)
                     Expression ex = new AddrExp(ae1.loc, ae1);  // &a[i]
                     ex.type = ae1.type.pointerTo();
 
-                    Expression add = new AddExp(ae.loc, ex, new IntegerExp(ae.e2.loc, offset, ae.e2.type));
+                    Expression add = new AddExp(ae.loc, ex, IntegerExp.create(ae.e2.loc, offset, ae.e2.type));
                     add.type = e.type;
                     ret = optimize(add, result, keepLvalue);
                     return;
@@ -675,7 +675,7 @@ Expression optimize(Expression e, int result, bool keepLvalue = false)
 
                     auto pe = new AddrExp(e.loc, ve);
                     pe.type = e.type;
-                    ret = new AddExp(e.loc, pe, new IntegerExp(e.loc, offset, Type.tsize_t));
+                    ret = new AddExp(e.loc, pe, IntegerExp.create(e.loc, offset, Type.tsize_t));
                     ret.type = e.type;
                     return;
                 }
@@ -1096,7 +1096,7 @@ Expression optimize(Expression e, int result, bool keepLvalue = false)
         {
             // This only applies to floating point, or positive integral powers.
             if (e.e1.type.isFloating() || cast(sinteger_t)e.e2.toInteger() >= 0)
-                e.e2 = new IntegerExp(e.loc, e.e2.toInteger(), Type.tint64);
+                e.e2 = IntegerExp.create(e.loc, e.e2.toInteger(), Type.tint64);
         }
         if (e.e1.isConst() == 1 && e.e2.isConst() == 1)
         {
@@ -1284,7 +1284,7 @@ Expression optimize(Expression e, int result, bool keepLvalue = false)
             {
                 bool n1 = e1Opt.get();
                 bool n2 = e.e2.toBool().get();
-                ret = new IntegerExp(e.loc, oror ? (n1 || n2) : (n1 && n2), e.type);
+                ret = IntegerExp.create(e.loc, oror ? (n1 || n2) : (n1 && n2), e.type);
             }
             else if (e1Opt.hasValue(!oror))
             {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8513,22 +8513,22 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             break;
 
         case TOK.int32Literal:
-            e = new AST.IntegerExp(loc, token.intvalue, AST.Type.tint32);
+            e = AST.IntegerExp.create(loc, token.intvalue, AST.Type.tint32);
             nextToken();
             break;
 
         case TOK.uns32Literal:
-            e = new AST.IntegerExp(loc, token.unsvalue, AST.Type.tuns32);
+            e = AST.IntegerExp.create(loc, token.unsvalue, AST.Type.tuns32);
             nextToken();
             break;
 
         case TOK.int64Literal:
-            e = new AST.IntegerExp(loc, token.intvalue, AST.Type.tint64);
+            e = AST.IntegerExp.create(loc, token.intvalue, AST.Type.tint64);
             nextToken();
             break;
 
         case TOK.uns64Literal:
-            e = new AST.IntegerExp(loc, token.unsvalue, AST.Type.tuns64);
+            e = AST.IntegerExp.create(loc, token.unsvalue, AST.Type.tuns64);
             nextToken();
             break;
 
@@ -8578,27 +8578,27 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             break;
 
         case TOK.true_:
-            e = new AST.IntegerExp(loc, 1, AST.Type.tbool);
+            e = AST.IntegerExp.create(loc, 1, AST.Type.tbool);
             nextToken();
             break;
 
         case TOK.false_:
-            e = new AST.IntegerExp(loc, 0, AST.Type.tbool);
+            e = AST.IntegerExp.create(loc, 0, AST.Type.tbool);
             nextToken();
             break;
 
         case TOK.charLiteral:
-            e = new AST.IntegerExp(loc, token.unsvalue, AST.Type.tchar);
+            e = AST.IntegerExp.create(loc, token.unsvalue, AST.Type.tchar);
             nextToken();
             break;
 
         case TOK.wcharLiteral:
-            e = new AST.IntegerExp(loc, token.unsvalue, AST.Type.twchar);
+            e = AST.IntegerExp.create(loc, token.unsvalue, AST.Type.twchar);
             nextToken();
             break;
 
         case TOK.dcharLiteral:
-            e = new AST.IntegerExp(loc, token.unsvalue, AST.Type.tdchar);
+            e = AST.IntegerExp.create(loc, token.unsvalue, AST.Type.tdchar);
             nextToken();
             break;
 
@@ -9061,14 +9061,14 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         case TOK.plusPlus:
             nextToken();
             e = parseUnaryExp();
-            //e = new AddAssignExp(loc, e, new IntegerExp(loc, 1, Type::tint32));
+            //e = new AddAssignExp(loc, e, IntegerExp.create(loc, 1, Type::tint32));
             e = new AST.PreExp(EXP.prePlusPlus, loc, e);
             break;
 
         case TOK.minusMinus:
             nextToken();
             e = parseUnaryExp();
-            //e = new MinAssignExp(loc, e, new IntegerExp(loc, 1, Type::tint32));
+            //e = new MinAssignExp(loc, e, IntegerExp.create(loc, 1, Type::tint32));
             e = new AST.PreExp(EXP.preMinusMinus, loc, e);
             break;
 

--- a/compiler/src/dmd/root/rmem.d
+++ b/compiler/src/dmd/root/rmem.d
@@ -18,8 +18,6 @@ import core.stdc.string;
 
 import core.memory : GC;
 
-nothrow:
-
 extern (C++) struct Mem
 {
     static char* xstrdup(const(char)* s) nothrow
@@ -198,6 +196,20 @@ extern (D) void* allocmemoryNoFree(size_t m_size, size_t alignment) nothrow
     allocatedNoFree += m_size;
     return _allocmemoryNoFree(m_size, alignment);
 }
+
+T emplaceClass(T, Args...)(void* p, Args args)
+if(is(T == class))
+{
+    static if (__VERSION__ < 2099)
+        const init = typeid(T).initializer;
+    else
+        const init = __traits(initSymbol, T);
+    p[0 .. __traits(classInstanceSize, T)] = init[];
+    auto t = cast(T)p;
+    t.__ctor(args);
+    return t;
+}
+
 
 extern (C) pure @nogc nothrow
 {

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1016,7 +1016,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             exp = Expression.combine(exp, new VarExp(rs.loc, funcdecl.vresult));
 
                             if (rs.caseDim)
-                                exp = Expression.combine(exp, new IntegerExp(rs.caseDim));
+                                exp = Expression.combine(exp, IntegerExp.create(rs.caseDim));
                         }
                         else if (funcdecl.tintro && !tret.equals(funcdecl.tintro.nextOf()))
                         {

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1038,7 +1038,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 {
                     // 'Promote' it to this scope, and replace with a return
                     fs.cases.push(gs);
-                    ss.statement = new ReturnStatement(Loc.initial, new IntegerExp(fs.cases.length + 1));
+                    ss.statement = new ReturnStatement(Loc.initial, IntegerExp.create(fs.cases.length + 1));
                 }
             }
 
@@ -1259,7 +1259,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 if (fs.op == TOK.foreach_reverse_)
                     fs.key._init = new ExpInitializer(loc, tmp_length);
                 else
-                    fs.key._init = new ExpInitializer(loc, new IntegerExp(loc, 0, fs.key.type));
+                    fs.key._init = new ExpInitializer(loc, IntegerExp.create(loc, 0, fs.key.type));
 
                 auto cs = Statements();
                 if (vinit)
@@ -1284,7 +1284,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 if (fs.op == TOK.foreach_)
                 {
                     // key += 1
-                    increment = new AddAssignExp(loc, new VarExp(loc, fs.key), new IntegerExp(loc, 1, fs.key.type));
+                    increment = new AddAssignExp(loc, new VarExp(loc, fs.key), IntegerExp.create(loc, 1, fs.key.type));
                 }
 
                 // T value = tmp[key];
@@ -2164,7 +2164,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
                     Expressions* args = new Expressions(2);
                     (*args)[0] = new StringExp(ss.loc, ss.loc.filename.toDString());
-                    (*args)[1] = new IntegerExp(ss.loc.linnum);
+                    (*args)[1] = IntegerExp.create(ss.loc.linnum);
 
                     sl = new CallExp(ss.loc, sl, args);
                     sl = sl.expressionSemantic(sc);
@@ -2264,7 +2264,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         auto i = 0;
         foreach (c; *csCopy)
         {
-            (*ss.cases)[c.index].exp = new IntegerExp(i++);
+            (*ss.cases)[c.index].exp = IntegerExp.create(i++);
         }
 
         //printf("%s\n", ss._body.toChars());
@@ -2501,7 +2501,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             Statement s = crs.statement;
             if (i != lval) // if not last case
                 s = new ExpStatement(crs.loc, cast(Expression)null);
-            Expression e = new IntegerExp(crs.loc, i, crs.first.type);
+            Expression e = IntegerExp.create(crs.loc, i, crs.first.type);
             Statement cs = new CaseStatement(crs.loc, e, s);
             statements.push(cs);
         }
@@ -2631,7 +2631,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             {
                 assert(rs.caseDim == 0);
                 sc.fes.cases.push(rs);
-                result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.length + 1));
+                result = new ReturnStatement(Loc.initial, IntegerExp.create(sc.fes.cases.length + 1));
                 return;
             }
             if (fd.returnLabel)
@@ -2989,7 +2989,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
                 // Immediately rewrite "this" return statement as:
                 //  return cases.length+1;
-                rs.exp = new IntegerExp(sc.fes.cases.length + 1);
+                rs.exp = IntegerExp.create(sc.fes.cases.length + 1);
                 if (e0)
                 {
                     result = new CompoundStatement(rs.loc, new ExpStatement(rs.loc, e0), rs);
@@ -3069,7 +3069,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                          * and 1 is break.
                          */
                         sc.fes.cases.push(bs);
-                        result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.length + 1));
+                        result = new ReturnStatement(Loc.initial, IntegerExp.create(sc.fes.cases.length + 1));
                         return;
                     }
                     break; // can't break to it
@@ -3157,7 +3157,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                          * and 1 is break.
                          */
                         sc.fes.cases.push(cs);
-                        result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.length + 1));
+                        result = new ReturnStatement(Loc.initial, IntegerExp.create(sc.fes.cases.length + 1));
                         return;
                     }
                     break; // can't continue to it
@@ -4150,7 +4150,7 @@ private extern(D) Statement loopReturn(Expression e, Statements* cases, Loc loc)
     // cases 2...
     foreach (i, c; *cases)
     {
-        s = new CaseStatement(Loc.initial, new IntegerExp(i + 2), c);
+        s = new CaseStatement(Loc.initial, IntegerExp.create(i + 2), c);
         a.push(s);
     }
 
@@ -4639,7 +4639,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
                          p.type.toErrMsg(), cast(ulong)length);
                 return returnEarly();
             }
-            Initializer ie = new ExpInitializer(Loc.initial, new IntegerExp(k));
+            Initializer ie = new ExpInitializer(Loc.initial, IntegerExp.create(k));
             auto var = new VarDeclaration(loc, p.type, p.ident, ie);
             var.storage_class |= STC.foreach_ | STC.manifest;
             if (isStatic)
@@ -4837,7 +4837,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
                 foreach (l; 0 .. dim)
                 {
                     auto cp = (*fs.parameters)[l];
-                    Expression init_ = new IndexExp(loc, access, new IntegerExp(loc, l, Type.tsize_t));
+                    Expression init_ = new IndexExp(loc, access, IntegerExp.create(loc, l, Type.tsize_t));
                     init_ = init_.expressionSemantic(sc);
                     assert(init_.type);
                     declareVariable(p.storageClass, init_.type, cp.ident, cp.unpack, init_, null);

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -1320,9 +1320,9 @@ extern (C++) struct Target
                     return stringExp(driverParams.mscrtlib);
                 return stringExp("");
             case cppStd.stringof:
-                return new IntegerExp(params.cplusplus);
+                return IntegerExp.create(params.cplusplus);
             case CET.stringof:
-                return new IntegerExp(driverParams.ibt);
+                return IntegerExp.create(driverParams.ibt);
 
             default:
                 return null;

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -4938,7 +4938,7 @@ private MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, TemplateIn
                     }
                     else if (TypeAArray taa = tb.isTypeAArray())
                     {
-                        Expression dim = new IntegerExp(instLoc, fargs.length - argi, Type.tsize_t);
+                        Expression dim = IntegerExp.create(instLoc, fargs.length - argi, Type.tsize_t);
 
                         size_t i = templateParameterLookup(taa.index, td.parameters);
                         if (i == IDX_NOTFOUND)

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -313,9 +313,9 @@ private Expression pointerBitmap(TraitsExp e, ErrorSink eSink)
         return ErrorExp.get();
 
     auto exps = new Expressions(data.length + 1);
-    (*exps)[0] = new IntegerExp(e.loc, sz, Type.tsize_t);       // [0] is size in bytes of t
+    (*exps)[0] = IntegerExp.create(e.loc, sz, Type.tsize_t);       // [0] is size in bytes of t
     foreach (size_t i; 1 .. exps.length)
-        (*exps)[i] = new IntegerExp(e.loc, data[cast(size_t) (i - 1)], Type.tsize_t);
+        (*exps)[i] = IntegerExp.create(e.loc, data[cast(size_t) (i - 1)], Type.tsize_t);
 
     auto ale = new ArrayLiteralExp(e.loc, Type.tsize_t.sarrayOf(data.length + 1), exps);
     return ale;
@@ -899,7 +899,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             bitOffset  = 0;
         }
         uint value = e.ident == Id.getBitfieldOffset ? bitOffset : fieldWidth;
-        return new IntegerExp(e.loc, value, Type.tuns32);
+        return IntegerExp.create(e.loc, value, Type.tuns32);
     }
     if (e.ident == Id.getProtection || e.ident == Id.getVisibility)
     {
@@ -1352,7 +1352,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return ErrorExp.get();
         }
 
-        return new IntegerExp(e.loc, e.ident == Id.classInstanceSize ? cd.structsize : cd.alignsize, Type.tsize_t);
+        return IntegerExp.create(e.loc, e.ident == Id.classInstanceSize ? cd.structsize : cd.alignsize, Type.tsize_t);
     }
     if (e.ident == Id.getAliasThis)
     {
@@ -2042,7 +2042,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         }
 
         fd = fd.toAliasFunc(); // Necessary to support multiple overloads.
-        return new IntegerExp(e.loc, fd.vtblIndex, Type.tptrdiff_t);
+        return IntegerExp.create(e.loc, fd.vtblIndex, Type.tptrdiff_t);
     }
     if (e.ident == Id.getPointerBitmap)
     {
@@ -2149,8 +2149,8 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
         auto exps = new Expressions(3);
         (*exps)[0] = new StringExp(e.loc, s.loc.filename.toDString());
-        (*exps)[1] = new IntegerExp(e.loc, s.loc.linnum,Type.tint32);
-        (*exps)[2] = new IntegerExp(e.loc, s.loc.charnum,Type.tint32);
+        (*exps)[1] = IntegerExp.create(e.loc, s.loc.linnum,Type.tint32);
+        (*exps)[2] = IntegerExp.create(e.loc, s.loc.charnum,Type.tint32);
         auto tup = new TupleExp(e.loc, exps);
         return tup.expressionSemantic(sc);
     }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -5071,14 +5071,14 @@ Expression getProperty(Type t, Scope* scope_, Loc loc, Identifier ident, int fla
             const sz = mt.size(loc);
             if (sz == SIZE_INVALID)
                 return ErrorExp.get();
-            return new IntegerExp(loc, sz, Type.tsize_t);
+            return IntegerExp.create(loc, sz, Type.tsize_t);
         }
         else if (ident == Id.__xalignof)
         {
             const explicitAlignment = mt.alignment();
             const naturalAlignment = mt.alignsize();
             const actualAlignment = (explicitAlignment.isDefault() ? naturalAlignment : explicitAlignment.get());
-            return new IntegerExp(loc, actualAlignment, Type.tsize_t);
+            return IntegerExp.create(loc, actualAlignment, Type.tsize_t);
         }
         else if (ident == Id._init)
         {
@@ -5206,12 +5206,12 @@ Expression getProperty(Type t, Scope* scope_, Loc loc, Identifier ident, int fla
     {
         Expression integerValue(dinteger_t i)
         {
-            return new IntegerExp(loc, i, mt);
+            return IntegerExp.create(loc, i, mt);
         }
 
         Expression intValue(dinteger_t i)
         {
-            return new IntegerExp(loc, i, Type.tint32);
+            return IntegerExp.create(loc, i, Type.tint32);
         }
 
         Expression floatValue(real_t r)
@@ -5477,7 +5477,7 @@ Expression getProperty(Type t, Scope* scope_, Loc loc, Identifier ident, int fla
         }
         if (ident == Id.length)
         {
-            e = new IntegerExp(loc, mt.arguments.length, Type.tsize_t);
+            e = IntegerExp.create(loc, mt.arguments.length, Type.tsize_t);
         }
         else if (ident == Id._init)
         {
@@ -6247,7 +6247,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                         else
                             eSink.error(v.loc, "`%s` is not a bitfield, cannot apply `%s`", v.toErrMsg(), ident.toErrMsg());
                     }
-                    return new IntegerExp(e.loc, value, Type.tsize_t);
+                    return IntegerExp.create(e.loc, value, Type.tsize_t);
                 }
             }
             else if (ident == Id._init)
@@ -6496,7 +6496,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
                 auto exps = new Expressions();
                 exps.reserve(length);
                 foreach (i; 0 .. length)
-                    exps.push(new IndexExp(e.loc, ev, new IntegerExp(e.loc, i, Type.tsize_t)));
+                    exps.push(new IndexExp(e.loc, ev, IntegerExp.create(e.loc, i, Type.tsize_t)));
                 e = new TupleExp(e.loc, e0, exps);
             }
         }
@@ -6525,11 +6525,11 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
             if (e.op == EXP.string_)
             {
                 StringExp se = cast(StringExp)e;
-                return new IntegerExp(se.loc, se.len, Type.tsize_t);
+                return IntegerExp.create(se.loc, se.len, Type.tsize_t);
             }
             if (e.op == EXP.null_)
             {
-                return new IntegerExp(e.loc, 0, Type.tsize_t);
+                return IntegerExp.create(e.loc, 0, Type.tsize_t);
             }
             if (checkNonAssignmentArrayOp(e))
             {
@@ -7671,7 +7671,7 @@ Expression defaultInit(Type mt, Loc loc, const bool isCfile = false)
         default:
             break;
         }
-        return new IntegerExp(loc, value, mt);
+        return IntegerExp.create(loc, value, mt);
     }
 
     Expression visitVector(TypeVector mt)
@@ -8498,7 +8498,7 @@ Type referenceTo(Type type)
 Type sarrayOf(Type type, dinteger_t dim)
 {
     assert(type.deco);
-    Type t = new TypeSArray(type, new IntegerExp(Loc.initial, dim, Type.tsize_t));
+    Type t = new TypeSArray(type, IntegerExp.create(Loc.initial, dim, Type.tsize_t));
     // according to TypeSArray.semantic()
     t = t.addMod(type.mod);
     t = t.merge();


### PR DESCRIPTION
.. using the padding space inside Expression

- make IntegerExp abstract, implemented by Integer64Exp and Integer16Exp with appropriate storage space for given value
- use IntegerExp.create instead of new IntegerExp in parsing and semantic
- use emplace!IntegerExp64 in interpreter, it uses a temporary space in a region allocator anyway

The first commit removes some strange modifications of the value that no test triggers. The only remaining `setInteger` calls are `assignInPlace` in CTFE and when restricting the value of a bitfield.

@rikkimax @ibuclaw This might be extended for cent-literals discussed in https://github.com/dlang/dmd/pull/23575