### PR TITLE
add -vnan to inform user about NaN default initializations

### DIFF
--- a/changelog/dmd.naninit.dd
+++ b/changelog/dmd.naninit.dd
@@ -1,0 +1,15 @@
+Give informational message about use of default NaN initializers
+
+Adding the compiler switch -vnan will cause the compiler to emit
+messages where the compiler default initializes a floating point
+value to NaN.
+
+---
+float f;
+void test() { float g; }
+struct S { float h; }
+cfloat cf;
+---
+
+This is an informational message only, it does not alter the
+generated code.

--- a/compiler/include/dmd/globals.h
+++ b/compiler/include/dmd/globals.h
@@ -143,6 +143,7 @@ struct Verbose
     d_bool verbose;           // verbose compile
     d_bool showColumns;       // print character (column) numbers in diagnostics
     d_bool tls;               // identify thread local variables
+    d_bool nanInit;           // print default initializing a floating point variable to NaN
     d_bool templates;         // collect and list statistics on template instantiations
     // collect and list statistics on template instantiations origins.
     // TODO: make this an enum when we want to list other kinds of instances

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -994,6 +994,12 @@ dmd -cov -unittest myprog.d
                $(LI $(I public):  Export all symbols)
             )",
         ),
+        Option("vnan",
+            "warnings about default initalization of floating point variables to nan",
+            `floating point variables are initialized to nan by default. This switch
+            will cause a warning to be emitted for default nan initialization`,
+            TargetOS.all, false,
+        ),
         Option("vtls",
             "list all variables going into thread local storage"
         ),

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -122,6 +122,7 @@ extern(C++) struct Verbose
     bool verbose;           // verbose compile
     bool showColumns;       // print character (column) numbers in diagnostics
     bool tls;               // identify thread local variables
+    bool nanInit;           // print default initializing a floating point variable to NaN
     bool templates;         // collect and list statistics on template instantiations
     // collect and list statistics on template instantiations origins.
     // TODO: make this an enum when we want to list other kinds of instances

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -130,7 +130,8 @@ void Initializer_toDt(Initializer init, ref DtBuilder dtb, bool isCfile)
             length++;
         }
 
-        Expression edefault = tb.nextOf().defaultInit(Loc.initial, isCfile);
+        assert(ai);
+        Expression edefault = tb.nextOf().defaultInit(ai.loc, isCfile);
 
         const n = tn.numberOfElems(ai.loc);
 
@@ -1024,7 +1025,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
             Expression e = (*elements)[firstFieldIndex + k];
             //printf("elements initializer %s\n", e.toChars());
             if (auto tsa = vd.type.toBasetype().isTypeSArray())
-                toDtElem(tsa, dtbx, e, isCtype);
+                toDtElem(e.loc, tsa, dtbx, e, isCtype);
             else if (bf)
             {
                 auto ie = e.isIntegerExp();
@@ -1070,14 +1071,14 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
                 auto ei = init.isExpInitializer();
                 auto tsa = vd.type.toBasetype().isTypeSArray();
                 if (ei && tsa)
-                    toDtElem(tsa, dtbx, ei.exp, isCtype);
+                    toDtElem(init.loc, tsa, dtbx, ei.exp, isCtype);
                 else
                     Initializer_toDt(init, dtbx, isCtype);
             }
             else if (offset <= vd.offset)
             {
                 //printf("\t\tdefault initializer\n");
-                Type_toDt(vd.type, dtbx);
+                Type_toDt(vd.loc, vd.type, dtbx);
             }
             if (dtbx.isZeroLength())
                 continue;
@@ -1106,16 +1107,16 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
 
 /* ================================================================= */
 
-void Type_toDt(Type t, ref DtBuilder dtb, bool isCtype = false)
+void Type_toDt(Loc loc, Type t, ref DtBuilder dtb, bool isCtype = false)
 {
     switch (t.ty)
     {
         case Tvector:
-            toDtElem(t.isTypeVector().basetype.isTypeSArray(), dtb, null, isCtype);
+            toDtElem(loc, t.isTypeVector().basetype.isTypeSArray(), dtb, null, isCtype);
             break;
 
         case Tsarray:
-            toDtElem(t.isTypeSArray(), dtb, null, isCtype);
+            toDtElem(loc, t.isTypeSArray(), dtb, null, isCtype);
             break;
 
         case Tstruct:
@@ -1123,12 +1124,12 @@ void Type_toDt(Type t, ref DtBuilder dtb, bool isCtype = false)
             break;
 
         default:
-            Expression_toDt(t.defaultInit(Loc.initial, isCtype), dtb);
+            Expression_toDt(t.defaultInit(loc, isCtype), dtb);
             break;
     }
 }
 
-private void toDtElem(TypeSArray tsa, ref DtBuilder dtb, Expression e, bool isCtype)
+private void toDtElem(Loc loc, TypeSArray tsa, ref DtBuilder dtb, Expression e, bool isCtype)
 {
     //printf("TypeSArray.toDtElem() tsa = %s\n", tsa.toChars());
     if (tsa.size(Loc.initial) == 0)
@@ -1151,7 +1152,7 @@ private void toDtElem(TypeSArray tsa, ref DtBuilder dtb, Expression e, bool isCt
             tbn = tnext.toBasetype();
         }
         if (!e)                             // if not already supplied
-            e = tsa.defaultInit(Loc.initial, isCtype);    // use default initializer
+            e = tsa.defaultInit(loc, isCtype);    // use default initializer
 
         if (!e.type.implicitConvTo(tnext))    // https://issues.dlang.org/show_bug.cgi?id=14996
         {

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -645,7 +645,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             }
             else
             {
-                Type_toDt(vd.type, dtb, vd.isCsymbol());
+                Type_toDt(vd.loc, vd.type, dtb, vd.isCsymbol());
             }
             s.Sdt = dtb.finish();
 
@@ -944,7 +944,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             else if (vd._init)
                 initializerToDt(vd, tlvInitDtb, isCfile);
             else
-                Type_toDt(vd.type, tlvInitDtb);
+                Type_toDt(vd.loc, vd.type, tlvInitDtb);
 
             tlvInit.Sdt = tlvInitDtb.finish();
             outdata(tlvInit);

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1413,7 +1413,7 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
 
     Expression visitDefault(DefaultInitializer di)
     {
-        return di.type ? di.type.defaultInit(Loc.initial, isCfile) : null;
+        return di.type ? di.type.defaultInit(init.loc, isCfile) : null;
     }
 
     Expression visitError(ErrorInitializer)
@@ -1559,7 +1559,7 @@ Expression initializerToExpression(Initializer init, Type itype = null, const bo
                 if (!telem) // don't know what type to use
                     return null;
                 if (!defaultInit)
-                    defaultInit = telem.defaultInit(Loc.initial, isCfile);
+                    defaultInit = telem.defaultInit(init.loc, isCfile);
                 element = defaultInit;
             }
         }

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1050,6 +1050,8 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, out Param 
             params.vcg_ast = true;
         else if (arg == "-vasm") // https://dlang.org/dmd.html#switch-vasm
             driverParams.vasm = true;
+        else if (arg == "-vnan")  // https://dlang.org/dmd.html#switch-vnan
+            params.v.nanInit = true;
         else if (arg == "-vtls") // https://dlang.org/dmd.html#switch-vtls
             params.v.tls = true;
         else if (startsWith(p + 1, "vtemplates")) // https://dlang.org/dmd.html#switch-vtemplates

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -168,7 +168,7 @@ Expression expandVar(int result, VarDeclaration v)
                 else
                 {
                     // BUG: what if const is initialized in constructor?
-                    auto e = v.type.defaultInit();
+                    auto e = defaultInit(v.type, v.loc);
                     e.loc = e1.loc;
                     return initializerReturn(e);
                 }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -7652,11 +7652,15 @@ Expression defaultInit(Type mt, Loc loc, const bool isCfile = false)
         case Tfloat32:
         case Tfloat64:
         case Tfloat80:
+            if (!isCfile && global.params.v.nanInit)
+                eSink.message(loc, "default NaN initialization of floating point variable");
             return new RealExp(loc, isCfile ? CTFloat.zero : target.RealProperties.nan, mt);
 
         case Tcomplex32:
         case Tcomplex64:
         case Tcomplex80:
+            if (!isCfile && global.params.v.nanInit)
+                eSink.message(loc, "default NaN initialization of complex floating point variable");
             {
                 // Can't use fvalue + I*fvalue (the im part becomes a quiet NaN).
                 const cvalue = isCfile ? complex_t(CTFloat.zero, CTFloat.zero)

--- a/compiler/test/compilable/naninit.d
+++ b/compiler/test/compilable/naninit.d
@@ -1,0 +1,13 @@
+/* REQUIRED_ARGS: -vnan -d
+TEST_OUTPUT:
+---
+compilable/naninit.d(11): default NaN initialization of floating point variable
+compilable/naninit.d(10): default NaN initialization of floating point variable
+compilable/naninit.d(12): default NaN initialization of floating point variable
+compilable/naninit.d(13): default NaN initialization of complex floating point variable
+---
+*/
+float f;
+void test() { float g; }
+struct S { float h; }
+cfloat cf;


### PR DESCRIPTION
This is in response to the issues many users have of assuming 0.0 default initialization when actually a NaN is used to initialize. It can be difficult to track down the source of the NaN, so this message will identify where it happens.

A switch to actually alter the initialization behavior will split the language into two, and would make it highly impractical to combine different modules with different settings for initialization.