### PR TITLE
importC: fix wrong error location for static/VLA array parameters

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -2963,6 +2963,7 @@ final class CParser(AST) : Parser!AST
                     case TOK.leftBracket:
                     {
                         // post [] syntax, pick up any leading type qualifiers, `static` and `*`
+                        const arrayLoc = token.loc;
                         AST.Type ta;
                         nextToken();
 
@@ -3003,11 +3004,11 @@ final class CParser(AST) : Parser!AST
                         // Issue errors for unsupported types.
                         if (isVLA) // C11 6.7.6.2
                         {
-                            error("variable length arrays are not supported");
+                            error(arrayLoc, "variable length arrays are not supported");
                         }
                         if (isStatic) // C11 6.7.6.3
                         {
-                            error("static array parameters are not supported");
+                            error(arrayLoc, "static array parameters are not supported");
                         }
                         if (declarator != DTR.xparameter)
                         {

--- a/compiler/test/fail_compilation/fail19934.c
+++ b/compiler/test/fail_compilation/fail19934.c
@@ -1,0 +1,20 @@
+// https://issues.dlang.org/show_bug.cgi?id=21964
+/* TEST_OUTPUT:
+REQUIRED_ARGS: -verrors=context
+---
+fail_compilation/fail19934.c(14): Error: static array parameters are not supported
+void f(int a[static 10])
+            ^
+fail_compilation/fail19934.c(18): Error: variable length arrays are not supported
+void g(int n, int a[*])
+                   ^
+---
+*/
+
+void f(int a[static 10])
+{
+}
+
+void g(int n, int a[*])
+{
+}


### PR DESCRIPTION
Fixes #19934

importC: fix wrong error location for static/VLA array parameters

cparse.d's post-[] declarator suffix parsing issued the errors using
the implicit token.loc, which by that point pointed past the
consumed ']' - landing the error on whatever token followed the
declarator instead of on the array suffix itself.

Capture the location of the opening '[' up front and pass it
explicitly to both error() calls.
