### PR TITLE
fix #23673 - `new C()` rejected before ctor overload resolution when a field disables default construction

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6808,7 +6808,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             if (!cd.ctor)
                 cd.ctor = cd.searchCtor();
-            if (!nargs && !cd.defaultCtor && checkDefCtor(exp.loc, cd.type))
+            if (!nargs && !cd.ctor && checkDefCtor(exp.loc, cd.type))
                 return setError();
 
             if (cd.isInterfaceDeclaration())

--- a/compiler/test/compilable/test23673.d
+++ b/compiler/test/compilable/test23673.d
@@ -1,0 +1,28 @@
+// https://github.com/dlang/dmd/issues/23673
+
+struct S
+{
+    int x;
+    @disable this();
+    this(int x) { this.x = x; }
+}
+
+class C
+{
+    S s;
+    this(int x = 0) { s = S(x); }
+}
+
+class CT
+{
+    S s;
+    this()(int x = 0) { s = S(x); }
+}
+
+void test()
+{
+    auto c = new C();
+    auto c2 = new C;
+    auto c3 = new C(1);
+    auto ct = new CT();
+}

--- a/compiler/test/fail_compilation/fail23673.d
+++ b/compiler/test/fail_compilation/fail23673.d
@@ -1,0 +1,27 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23673.d(26): Error: constructor `fail23673.C.this(int x)` is not callable using argument types `()`
+fail_compilation/fail23673.d(26):        too few arguments, expected 1, got 0
+---
+*/
+
+// https://github.com/dlang/dmd/issues/23673
+
+struct S
+{
+    int x;
+    @disable this();
+    this(int x) { this.x = x; }
+}
+
+class C
+{
+    S s;
+    this(int x) { s = S(x); }
+}
+
+void test()
+{
+    auto c = new C();
+}


### PR DESCRIPTION
fixes: #23673
Only do the check when the class has no ctor at all, otherwise overload resolution handles it