### PR TITLE
Don't print @safe deprecation message for const key `in` AA

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15062,6 +15062,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     // Convert key to type of key
                     exp.e1 = exp.e1.implicitCastTo(sc, ta.index);
+                    if (auto ce = exp.e1.isCastExp())
+                        ce.trusted = true;
                 }
 
                 // for backward compatibility, type accepted during semantic, but errors in glue layer

--- a/compiler/test/fail_compilation/cast_qual.d
+++ b/compiler/test/fail_compilation/cast_qual.d
@@ -24,3 +24,10 @@ void test() {
     const Object co;
     auto o = cast() co;
 }
+
+double[int] aa;
+
+double theValueFor(in int key) @safe
+{
+    return *(key in aa); // allow compiler generated cast
+}


### PR DESCRIPTION
Fixes https://github.com/dlang/dmd/issues/23676.