### PR TITLE
Fix confusing error and ICE for `new` with -betterC

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7299,7 +7299,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     LskipNewArrayLowering:
         //printf("NewExp: '%s'\n", toChars());
         //printf("NewExp:type '%s'\n", type.toChars());
-        if (!exp.placement)
+        if (!exp.placement && global.params.useGC)
             semanticTypeInfo(sc, exp.type);
 
         if (newprefix)

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -1451,7 +1451,7 @@ elem* toElem(Expression e, ref IRState irs)
             else if (!irs.params.useGC)
             {
                 // new is allowed in CTFE, so this can only be checked at codegen
-                irs.eSink.error(ne.loc, "`new` expression `%s` requires the GC which is not available with -betterC", ne.toErrMsg());
+                irs.eSink.error(ne.loc, "`new` expression `%s` requires the GC which is not available with `-betterC`", ne.toErrMsg());
                 return el_long(TYnptr, 0);
             }
             else
@@ -1534,7 +1534,7 @@ elem* toElem(Expression e, ref IRState irs)
                 e = toElem(ne.lowering, irs);
             else if (!irs.params.useGC)
             {
-                irs.eSink.error(ne.loc, "`new` expression `%s` requires the GC which is not available with -betterC", ne.toErrMsg());
+                irs.eSink.error(ne.loc, "`new` expression `%s` requires the GC which is not available with `-betterC`", ne.toErrMsg());
                 return el_long(TYnptr, 0);
             }
             else
@@ -1562,7 +1562,7 @@ elem* toElem(Expression e, ref IRState irs)
         {
             if (!irs.params.useGC)
             {
-                irs.eSink.error(ne.loc, "`new` expression `%s` requires the GC which is not available with -betterC", ne.toErrMsg());
+                irs.eSink.error(ne.loc, "`new` expression `%s` requires the GC which is not available with `-betterC`", ne.toErrMsg());
                 return el_long(TYnptr, 0);
             }
             assert(ne.lowering, "This case should have been rewritten to `_d_aaNew` in the semantic phase");

--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -1448,6 +1448,12 @@ elem* toElem(Expression e, ref IRState irs)
             else if (auto lowering = ne.lowering)
                 // Call _d_newitemT()
                 ex = toElem(ne.lowering, irs);
+            else if (!irs.params.useGC)
+            {
+                // new is allowed in CTFE, so this can only be checked at codegen
+                irs.eSink.error(ne.loc, "`new` expression `%s` requires the GC which is not available with -betterC", ne.toErrMsg());
+                return el_long(TYnptr, 0);
+            }
             else
                 assert(0, "This case should have been rewritten to `_d_newitemT` in the semantic phase");
 
@@ -1526,6 +1532,11 @@ elem* toElem(Expression e, ref IRState irs)
             else if (auto lowering = ne.lowering)
                 // Call _d_newitemT()
                 e = toElem(ne.lowering, irs);
+            else if (!irs.params.useGC)
+            {
+                irs.eSink.error(ne.loc, "`new` expression `%s` requires the GC which is not available with -betterC", ne.toErrMsg());
+                return el_long(TYnptr, 0);
+            }
             else
                 assert(0, "This case should have been rewritten to `_d_newitemT` in the semantic phase");
 
@@ -1549,6 +1560,11 @@ elem* toElem(Expression e, ref IRState irs)
         }
         else if (auto taa = t.isTypeAArray())
         {
+            if (!irs.params.useGC)
+            {
+                irs.eSink.error(ne.loc, "`new` expression `%s` requires the GC which is not available with -betterC", ne.toErrMsg());
+                return el_long(TYnptr, 0);
+            }
             assert(ne.lowering, "This case should have been rewritten to `_d_aaNew` in the semantic phase");
             return toElem(ne.lowering, irs);
         }

--- a/compiler/test/fail_compilation/betterc_new.d
+++ b/compiler/test/fail_compilation/betterc_new.d
@@ -1,0 +1,19 @@
+/* REQUIRED_ARGS: -betterC
+TEST_OUTPUT:
+---
+fail_compilation/betterc_new.d(105): Error: `new` expression `new S(1)` requires the GC which is not available with -betterC
+fail_compilation/betterc_new.d(106): Error: `new` expression `new int(3)` requires the GC which is not available with -betterC
+fail_compilation/betterc_new.d(107): Error: `new` expression `new int[int]` requires the GC which is not available with -betterC
+---
+*/
+
+#line 100
+
+struct S { int i; }
+
+void test()
+{
+    S* p = new S(1);
+    int* i = new int(3);
+    auto aa = new int[int];
+}

--- a/compiler/test/fail_compilation/betterc_new.d
+++ b/compiler/test/fail_compilation/betterc_new.d
@@ -1,9 +1,9 @@
 /* REQUIRED_ARGS: -betterC
 TEST_OUTPUT:
 ---
-fail_compilation/betterc_new.d(105): Error: `new` expression `new S(1)` requires the GC which is not available with -betterC
-fail_compilation/betterc_new.d(106): Error: `new` expression `new int(3)` requires the GC which is not available with -betterC
-fail_compilation/betterc_new.d(107): Error: `new` expression `new int[int]` requires the GC which is not available with -betterC
+fail_compilation/betterc_new.d(105): Error: `new` expression `new S(1)` requires the GC which is not available with `-betterC`
+fail_compilation/betterc_new.d(106): Error: `new` expression `new int(3)` requires the GC which is not available with `-betterC`
+fail_compilation/betterc_new.d(107): Error: `new` expression `new int[int]` requires the GC which is not available with `-betterC`
 ---
 */
 


### PR DESCRIPTION
While fixing #23678 I found non-placement `new` is also broken with -betterC like - 

- `new S()` errors with a misleading "`TypeInfo` cannot be used with `-betterC`", pointing at the struct declaration
- `new int(3)` and `new int[int]` crash the compiler

both fixed now