### PR TITLE
Fix #23692 - [REG 2.106.0] -profile=gc makes the program much slower …

### DIFF
--- a/compiler/test/runnable/profilegc23692.d
+++ b/compiler/test/runnable/profilegc23692.d
@@ -1,0 +1,32 @@
+/*
+REQUIRED_ARGS: -profile=gc
+RUN_OUTPUT:
+---
+bytes allocated, allocations, type, function, file:line
+       32000000	        1000000	void* profilegc23692.main runnable/profilegc23692.d:22
+---
+*/
+
+import core.runtime;
+import core.time;
+
+void main()
+{
+    profilegc_setlogfilename("");
+
+    MonoTime start = MonoTime.currTime;
+
+    void* list;
+    foreach (i; 0 .. 1000000)
+    {
+        auto array = new void*[1];
+        array[0] = list;
+        list = array.ptr;
+
+        // The program should finish in less than a second, but allow
+        // more for different hardware.
+        // Previously it could take more than 600 seconds,
+        // see https://github.com/dlang/dmd/issues/23692.
+        assert(MonoTime.currTime - start < 30.seconds);
+    }
+}

--- a/druntime/src/core/internal/profile_gc.d
+++ b/druntime/src/core/internal/profile_gc.d
@@ -23,16 +23,16 @@ static import core.internal.array.construction;
 static import core.internal.array.capacity;
 static import core.lifetime;
 
-private auto gcStatsPure() nothrow pure
+private auto gcAllocatedInCurrentThreadPure() nothrow pure
 {
     import core.memory : GC;
-    auto impureBypass = cast(GC.Stats function() pure nothrow)&GC.stats;
+    auto impureBypass = cast(ulong function() pure nothrow)&GC.allocatedInCurrentThread;
     return impureBypass();
 }
 
 private ulong accumulatePure(string file, int line, string funcname, string name, ulong currentlyAllocated) nothrow pure
 {
-    const size = gcStatsPure().allocatedInCurrentThread - currentlyAllocated;
+    const size = gcAllocatedInCurrentThreadPure - currentlyAllocated;
 
     if (size == 0)
         return 0;
@@ -74,7 +74,7 @@ auto _d_HookTraceImpl(T, alias Hook, string errorMessage)(Parameters!Hook parame
 {
     version (D_TypeInfo)
     {
-        const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+        const currentlyAllocated = gcAllocatedInCurrentThreadPure;
         scope(exit)
             accumulatePure(file, line, __traits(identifier, Hook), T.stringof, currentlyAllocated);
 
@@ -88,7 +88,7 @@ auto _d_HookTraceImpl(T, alias Hook, string errorMessage)(Parameters!Hook parame
 ref Tarr _d_arrayappendcTX(Tarr : T[], T)(return ref scope Tarr px, size_t n,
     string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
 {
-    const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+    const currentlyAllocated = gcAllocatedInCurrentThreadPure;
     scope(exit)
         accumulatePure(file, line, funcname, Tarr.stringof, currentlyAllocated);
 
@@ -99,7 +99,7 @@ ref Tarr _d_arrayappendcTX(Tarr : T[], T)(return ref scope Tarr px, size_t n,
 ref Tarr _d_arrayappendT(Tarr : T[], T)(return ref scope Tarr x, scope Tarr y,
     string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
 {
-    const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+    const currentlyAllocated = gcAllocatedInCurrentThreadPure;
     scope(exit)
         accumulatePure(file, line, funcname, Tarr.stringof, currentlyAllocated);
 
@@ -110,7 +110,7 @@ ref Tarr _d_arrayappendT(Tarr : T[], T)(return ref scope Tarr x, scope Tarr y,
 Tret _d_arraycatnTX(Tret, Tarr...)(scope auto ref Tarr froms,
     string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
 {
-    const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+    const currentlyAllocated = gcAllocatedInCurrentThreadPure;
     scope(exit)
         accumulatePure(file, line, funcname, Tarr.stringof, currentlyAllocated);
 
@@ -130,7 +130,7 @@ T* _d_newitemT(T)(string file = __FILE__, int line = __LINE__, string funcname =
         cast(void)tnPure(typeid(T));
     }
 
-    const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+    const currentlyAllocated = gcAllocatedInCurrentThreadPure;
     scope(exit)
         accumulatePure(file, line, funcname, T.stringof, currentlyAllocated);
 
@@ -141,7 +141,7 @@ T* _d_newitemT(T)(string file = __FILE__, int line = __LINE__, string funcname =
 T[] _d_newarrayT(T)(size_t length, bool isShared,
     string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
 {
-    const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+    const currentlyAllocated = gcAllocatedInCurrentThreadPure;
     scope(exit)
         accumulatePure(file, line, funcname, T.stringof, currentlyAllocated);
 
@@ -152,7 +152,7 @@ T[] _d_newarrayT(T)(size_t length, bool isShared,
 T[] _d_newarrayU(T)(size_t length, bool isShared,
     string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
 {
-    const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+    const currentlyAllocated = gcAllocatedInCurrentThreadPure;
     scope(exit)
         accumulatePure(file, line, funcname, T.stringof, currentlyAllocated);
 
@@ -163,7 +163,7 @@ T[] _d_newarrayU(T)(size_t length, bool isShared,
 Tarr _d_newarraymTX(Tarr : U[], T, U)(scope size_t[] dims, bool isShared = false,
     string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
 {
-    const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+    const currentlyAllocated = gcAllocatedInCurrentThreadPure;
     scope(exit)
         accumulatePure(file, line, funcname, T.stringof, currentlyAllocated);
 
@@ -174,7 +174,7 @@ Tarr _d_newarraymTX(Tarr : U[], T, U)(scope size_t[] dims, bool isShared = false
 size_t _d_arraysetlengthT(Tarr : T[], T)(return ref scope Tarr arr, size_t newlength,
     string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
 {
-    const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+    const currentlyAllocated = gcAllocatedInCurrentThreadPure;
     scope(exit)
         accumulatePure(file, line, funcname, Tarr.stringof, currentlyAllocated);
 
@@ -185,7 +185,7 @@ size_t _d_arraysetlengthT(Tarr : T[], T)(return ref scope Tarr arr, size_t newle
 void* _d_arrayliteralTX(T)(size_t length,
     string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted pure nothrow
 {
-    const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+    const currentlyAllocated = gcAllocatedInCurrentThreadPure;
     scope(exit)
         accumulatePure(file, line, funcname, (T[]).stringof, currentlyAllocated);
 
@@ -195,7 +195,7 @@ void* _d_arrayliteralTX(T)(size_t length,
 /// Profiling wrapper around $(REF _d_newclassT, core,lifetime).
 T _d_newclassT(T)(string file = __FILE__, int line = __LINE__, string funcname = __FUNCTION__) @trusted
 {
-    const currentlyAllocated = gcStatsPure().allocatedInCurrentThread;
+    const currentlyAllocated = gcAllocatedInCurrentThreadPure;
     scope(exit)
         accumulatePure(file, line, funcname, T.stringof, currentlyAllocated);
 


### PR DESCRIPTION
…again

Function `GC.stats` calculates statistics, which are not needed here. Using `GC.allocatedInCurrentThread` instead is much faster.

See also previous PR https://github.com/dlang/druntime/pull/3164.

The added test measures the time for the test, which can depend on the used hardware.