### PR TITLE
fix CI failure: recursion check too specific

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7673,6 +7673,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             printf("CallExp::semantic() %s\n", exp.toChars());
         }
 
+        __gshared int nest;
+        if (++nest > global.recursionLimit)
+        {
+            eSink.error(exp.loc, "recursive evaluation of `%s`", exp.toErrMsg());
+            --nest;
+            return setError();
+        }
+        scope(exit) --nest;
+
         scope (exit)
         {
             if (TypeFunction tf = exp.f && exp.f.type ? exp.f.type.isTypeFunction() : null)
@@ -7854,15 +7863,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else
             {
-                __gshared int nest;
-                if (++nest > global.recursionLimit)
-                {
-                    eSink.error(exp.loc, "recursive evaluation of `%s`", exp.toErrMsg());
-                    --nest;
-                    return setError();
-                }
                 Expression ex = unaSemantic(exp, sc);
-                --nest;
                 if (ex)
                 {
                     result = ex;


### PR DESCRIPTION
even though the "recursive evaluation" is reported, recursion still continues on other code paths, e.g. via initializerSemantic in case of fail22039.d. This causes a stack overflow depending on host compiler and settings.