### PR TITLE
Fix bugzilla issue 23984 - DDoc can hyphenate variable names, leading to ambiguity

### DIFF
--- a/compiler/src/dmd/res/default_ddoc_theme.ddoc
+++ b/compiler/src/dmd/res/default_ddoc_theme.ddoc
@@ -424,7 +424,7 @@ DDOC =
         color: rgba(128, 128, 128, 1);
         font-family: Menlo,monospace;
         font-size: 0.85em;
-        word-wrap: break-word;
+        white-space: nowrap;
       }
 
       .ddoc .code i {
@@ -487,6 +487,8 @@ DDOC =
 
       .ddoc .code_sample .code_lines .code {
         color: #000;
+        white-space: normal;
+        word-wrap: break-word;
       }
 
       .ddoc div.dlang {

--- a/compiler/test/compilable/extra-files/ddocYear.html
+++ b/compiler/test/compilable/extra-files/ddocYear.html
@@ -324,7 +324,7 @@
         color: rgba(128, 128, 128, 1);
         font-family: Menlo,monospace;
         font-size: 0.85em;
-        word-wrap: break-word;
+        white-space: nowrap;
       }
 
       .ddoc .code i {
@@ -387,6 +387,8 @@
 
       .ddoc .code_sample .code_lines .code {
         color: #000;
+        white-space: normal;
+        word-wrap: break-word;
       }
 
       .ddoc div.dlang {


### PR DESCRIPTION
Fixes #18174
