### PR TITLE
Fix dlang/dmd#17521 - DDoc ignores documentation comment that begins on the same line as the opening curly brace

### DIFF
--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -326,6 +326,7 @@ class Lexer
     final void scan(Token* t)
     {
         const lastLine = linnum;
+        const afterOpenCurly = token.value == TOK.leftCurly;
         Loc startLoc;
         t.blockComment = null;
         t.lineComment = null;
@@ -739,7 +740,7 @@ class Lexer
                     if (doDocComment && t.ptr[2] == '*' && p - 4 != t.ptr)
                     {
                         // if /** but not /**/
-                        getDocComment(t, lastLine == startLoc.linnum, startLoc.linnum - lastDocLine > 1);
+                        getDocComment(t, lastLine == startLoc.linnum && !afterOpenCurly, startLoc.linnum - lastDocLine > 1);
                         lastDocLine = linnum;
                     }
                     continue;
@@ -767,7 +768,7 @@ class Lexer
                             }
                             if (doDocComment && t.ptr[2] == '/')
                             {
-                                getDocComment(t, lastLine == startLoc.linnum, startLoc.linnum - lastDocLine > 1);
+                                getDocComment(t, lastLine == startLoc.linnum && !afterOpenCurly, startLoc.linnum - lastDocLine > 1);
                                 lastDocLine = linnum;
                             }
                             //p = end;
@@ -799,7 +800,7 @@ class Lexer
                     }
                     if (doDocComment && t.ptr[2] == '/')
                     {
-                        getDocComment(t, lastLine == startLoc.linnum, startLoc.linnum - lastDocLine > 1);
+                        getDocComment(t, lastLine == startLoc.linnum && !afterOpenCurly, startLoc.linnum - lastDocLine > 1);
                         lastDocLine = linnum;
                     }
                     p++;
@@ -871,7 +872,7 @@ class Lexer
                         if (doDocComment && t.ptr[2] == '+' && p - 4 != t.ptr)
                         {
                             // if /++ but not /++/
-                            getDocComment(t, lastLine == startLoc.linnum, startLoc.linnum - lastDocLine > 1);
+                            getDocComment(t, lastLine == startLoc.linnum && !afterOpenCurly, startLoc.linnum - lastDocLine > 1);
                             lastDocLine = linnum;
                         }
                         continue;

--- a/compiler/test/compilable/extra-files/test17521.html
+++ b/compiler/test/compilable/extra-files/test17521.html
@@ -1,0 +1,130 @@
+
+<section class="section ddoc_module_members_section">
+  <div class="ddoc_module_members">
+    <ul class="ddoc_members">
+  <li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#C1" id="C1"><code class="code">C1</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="C1"></span>class <code class="code">C1</code>;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  
+<ul class="ddoc_members">
+  <li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#C1.a" id="C1.a"><code class="code">a</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="C1.a"></span>int <code class="code">a</code>;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    abc
+def
+  </p>
+</div>
+
+</section>
+
+</div>
+
+</li>
+</ul>
+
+</div>
+
+</li><li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#C2" id="C2"><code class="code">C2</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="C2"></span>class <code class="code">C2</code>;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  
+<ul class="ddoc_members">
+  <li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#C2.a" id="C2.a"><code class="code">a</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="C2.a"></span>int <code class="code">a</code>;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    abc
+def
+  </p>
+</div>
+
+</section>
+
+</div>
+
+</li>
+</ul>
+
+</div>
+
+</li>
+</ul>
+  </div>
+</section>

--- a/compiler/test/compilable/test17521.d
+++ b/compiler/test/compilable/test17521.d
@@ -1,0 +1,18 @@
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
+// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+// EXTRA_SOURCES: extra-files/ddoc_minimal.ddoc
+
+module test17521;
+
+///
+class C1
+{/// abc
+/// def
+int a; }
+
+///
+class C2
+{/** abc
+def
+*/
+int a; }


### PR DESCRIPTION
Fixes #17521