### PR TITLE
druntime: Update to `wasi-sdk` 34

### DIFF
--- a/druntime/src/core/stdc/stdint.d
+++ b/druntime/src/core/stdc/stdint.d
@@ -400,8 +400,8 @@ else version (WASI)
 
     alias int_fast8_t   = byte;   ///
     alias uint_fast8_t  = ubyte;  ///
-    alias int_fast16_t  = short;  ///
-    alias uint_fast16_t = ushort; ///
+    alias int_fast16_t  = int;    ///
+    alias uint_fast16_t = uint;   ///
     alias int_fast32_t  = int;    ///
     alias uint_fast32_t = uint;   ///
 

--- a/druntime/src/core/sync/event.d
+++ b/druntime/src/core/sync/event.d
@@ -280,7 +280,10 @@ nothrow @nogc:
                     timespec t = void;
                     mktspec(t, tmout);
 
-                    result = pthread_cond_timedwait(&m_cond, &m_mutex, &t);
+                    version (WASI)   // wasi-libc traps for single-thread futex
+                        result = -1;
+                    else
+                        result = pthread_cond_timedwait(&m_cond, &m_mutex, &t);
                 }
             }
             if (result == 0 && !m_manualReset)

--- a/druntime/src/core/sys/posix/stdio.d
+++ b/druntime/src/core/sys/posix/stdio.d
@@ -551,13 +551,9 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_WASI)
 {
-    // TODO: once WebAssembly/wasi-libc#851 makes its way to wasi-sdk release
-    version (none)
-    {
-        void   flockfile(FILE*);
-        int    ftrylockfile(FILE*);
-        void   funlockfile(FILE*);
-    }
+    void   flockfile(FILE*);
+    int    ftrylockfile(FILE*);
+    void   funlockfile(FILE*);
     int    getc_unlocked(FILE*);
     int    getchar_unlocked();
     int    putc_unlocked(int, FILE*);

--- a/druntime/src/core/sys/posix/sys/socket.d
+++ b/druntime/src/core/sys/posix/sys/socket.d
@@ -1862,9 +1862,9 @@ else version (CRuntime_WASI)
 
     enum
     {
-        SHUT_RD,
-        SHUT_WR,
-        SHUT_RDWR
+        SHUT_RD = 1,
+        SHUT_WR = 2,
+        SHUT_RDWR = 3
     }
 }
 else


### PR DESCRIPTION
Updates the supported version of `wasi-libc` to the one distributed by `wasi-sdk` 34.

Also updates the version of Wasmtime used by CI to 48.0.1

The diff is smaller than it normally would be, as I incorporated some changes between 33 and 34 when I initially implemented (inadvertently).

Phobos is not yet updated to make use of `flockfile`. This will be done alongside other changes needed for WASIp3 later on (i.e. once it actually matters).

-----

Upstreaming of https://github.com/ldc-developers/ldc/pull/5266