### PR TITLE
Fix issue 21178: spurious "does not override" error when interface has errors

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -5604,6 +5604,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 {
                     if (b.type != Type.terror)
                         eSink.error(cldec.loc, "%s `%s` base type must be `class` or `interface`, not `%s`", cldec.kind, cldec.toPrettyChars, b.type.toErrMsg());
+                    else
+                        cldec.errors = true;
                     cldec.baseclasses.remove(0);
                     goto L7;
                 }

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1354,7 +1354,7 @@ Linterfaces:
         goto L2;
     }
 
-    if (!doesoverride && funcdecl.isOverride() && (funcdecl.type.nextOf() || !may_override))
+    if (!doesoverride && !cd.errors && funcdecl.isOverride() && (funcdecl.type.nextOf() || !may_override))
     {
         BaseClass* bc = null;
         Dsymbol s = null;

--- a/compiler/test/fail_compilation/fail21178.d
+++ b/compiler/test/fail_compilation/fail21178.d
@@ -1,0 +1,19 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21178.d(13): Error: undefined identifier `UnknownType`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=21178
+
+interface IFoo
+{
+    void foo();
+    UnknownType bar();
+}
+
+abstract class Foo : IFoo
+{
+    override void foo() {}
+}


### PR DESCRIPTION
Fixes #21178