### PR TITLE
Fix issue 19818: spurious "delegate cannot be members" error for lambdas in UDA args

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -62,6 +62,7 @@ private extern (D) struct FlagBitFields
     bool canFree;            /// is on free list
     bool fullinst;          /// fully instantiate templates
     bool ctfeBlock;         /// inside a `if (__ctfe)` block
+    bool inUda;             /// inside a UserAttributeDeclaration's attribute expressions
 
     /**
     Is any symbol this scope is applied to known to have a compile time only accessible context.
@@ -270,6 +271,7 @@ extern (C++) struct Scope
         s.ignoresymbolvisibility = this.ignoresymbolvisibility;
         s.inCfile = this.inCfile;
         s.ctfeBlock = this.ctfeBlock;
+        s.inUda = this.inUda;
         s.previews = this.previews;
         s.lastdc = null;
         s.knownACompileTimeOnlyContext = this.knownACompileTimeOnlyContext;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4010,7 +4010,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         //printf("UserAttributeDeclaration::semantic() %p\n", this);
         if (uad.decl && !uad._scope)
             uad.Dsymbol.setScope(sc); // for function local symbols
+        const savedInUda = sc.inUda;
+        sc.inUda = true;
         arrayExpressionSemantic(uad.atts.peekSlice(), sc, true);
+        sc.inUda = savedInUda;
         return attribSemantic(uad);
     }
 

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -385,7 +385,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             {
                 if (auto ad = funcdecl.isMember2())
                 {
-                    if (!sc.intypeof)
+                    if (!sc.intypeof && !sc.inUda)
                     {
                         if (fld.tok == TOK.delegate_)
                             eSink.error(funcdecl.loc, "%s `%s` cannot be %s members", funcdecl.kind, funcdecl.toErrMsg, ad.kind());

--- a/compiler/test/compilable/compilable19818.d
+++ b/compiler/test/compilable/compilable19818.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=19818
+
+struct S
+{
+    bool delegate(string) f;
+}
+
+@S(str => true)
+int a;
+
+S s = S(str => true);
+
+struct S2
+{
+    @S(str => false)
+    int a;
+}


### PR DESCRIPTION
Fixes #19818