### PR TITLE
Fix issue 19718 - check function safety attributes during template deduction

### DIFF
--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -7183,6 +7183,19 @@ MATCH deduceType(scope RootObject o, scope Scope* sc, scope Type tparam,
                 return;
             }
 
+            // https://github.com/dlang/dmd/issues/19718
+            // The argument's safety must satisfy what the parameter type requires;
+            // an @system (or unmarked) function/delegate cannot match an @safe or
+            // @trusted parameter type. Without this check, template argument
+            // deduction only compares parameter lists and ignores the function's
+            // own attributes, so an unsafe argument can be wrongly deduced to
+            // match an @safe (or stronger) parameter type.
+            if (t.trust <= TRUST.system && tp.trust >= TRUST.trusted)
+            {
+                result = MATCH.nomatch;
+                return;
+            }
+
             foreach (fparam; *tp.parameterList.parameters)
             {
                 // https://issues.dlang.org/show_bug.cgi?id=2579

--- a/compiler/test/fail_compilation/test19718.d
+++ b/compiler/test/fail_compilation/test19718.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test19718.d(29): Error: none of the overloads of template `test19718.execute` are callable using argument types `!()(int function(ref Struct rng) @system)`
+fail_compilation/test19718.d(27): Error: none of the overloads of template `test19718.execute` are callable using argument types `!()(int function(ref Struct rng) @system)`
 fail_compilation/test19718.d(15):        Candidates are: `execute(T)(T function(ref Struct) @safe dg)`
 fail_compilation/test19718.d(21):                        `execute(T)(T delegate(ref Struct) @safe dg)`
 ---
@@ -24,7 +24,4 @@ public T execute (T)(T delegate(ref Struct) @safe dg)
     return dg(rng);
 }
 
-void main (string[] args)
-{
-    execute((ref Struct rng) { return rng.get(); });
-}
+auto x = execute((ref Struct rng) { return rng.get(); });

--- a/compiler/test/fail_compilation/test19718.d
+++ b/compiler/test/fail_compilation/test19718.d
@@ -1,0 +1,30 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test19718.d(29): Error: none of the overloads of template `test19718.execute` are callable using argument types `!()(int function(ref Struct rng) @system)`
+fail_compilation/test19718.d(15):        Candidates are: `execute(T)(T function(ref Struct) @safe dg)`
+fail_compilation/test19718.d(21):                        `execute(T)(T delegate(ref Struct) @safe dg)`
+---
+*/
+
+struct Struct
+{
+    int get() { return 1; }
+}
+
+public T execute (T)(T function(ref Struct) @safe dg)
+{
+    Struct rng;
+    return dg(rng);
+}
+
+public T execute (T)(T delegate(ref Struct) @safe dg)
+{
+    Struct rng;
+    return dg(rng);
+}
+
+void main (string[] args)
+{
+    execute((ref Struct rng) { return rng.get(); });
+}


### PR DESCRIPTION
Fixes #19718