### PR TITLE
Don't suggest ~this() in spellchecker error messages

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -5129,6 +5129,9 @@ Expression getProperty(Type t, Scope* scope_, Loc loc, Identifier ident, int fla
             s = s.search_correct(ident);
         if (s && !symbolIsVisible(scope_, s))
             s = null;
+        if (s && s.isDtorDeclaration())
+            // Don't suggest `~this()` as it isn't valid syntax to call it (https://issues.dlang.org/show_bug.cgi?id=23938)
+            s = null;
 
         if (mt == Type.terror)
             return ErrorExp.get();

--- a/compiler/test/fail_compilation/issue20288.d
+++ b/compiler/test/fail_compilation/issue20288.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/issue20288.d(13): Error: no property `dtor` for `new C` of type `issue20288.test.C`
+fail_compilation/issue20288.d(12):        class `C` defined here
+---
+*/
+
+// https://github.com/dlang/dmd/issues/20288
+void test()
+{
+    class C { ~this(){} }
+    (new C).dtor();
+}


### PR DESCRIPTION
Fixes #20288