### PR TITLE
Fix shared foreach ref initialization

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12453,7 +12453,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // We delay checking the value for structs/classes as these might have
             // an opAssign defined.
             if ((t1.ty != Tstruct && t1.ty != Tclass && e2x.checkValue()) ||
-                e2x.checkSharedAccess(sc))
+                // A ref initializer only takes the address of its source.  This is
+                // permitted for shared data, just like passing a shared value to a
+                // ref parameter.
+                e2x.checkSharedAccess(sc, exp.op == EXP.construct &&
+                    exp.e1.isVarExp() && exp.e1.isVarExp().var.storage_class & STC.ref_))
                 return setError();
 
             // taking address of noreturn instance is OK

--- a/compiler/test/compilable/shared.d
+++ b/compiler/test/compilable/shared.d
@@ -55,6 +55,24 @@ void test20908()
     shared U u;
 }
 
+// https://github.com/dlang/dmd/issues/20496
+void test20496()
+{
+    shared(int)[] dynamicArray;
+    foreach (ref element; dynamicArray)
+    {
+        void byRef(ref shared(int)) {}
+        byRef(element);
+    }
+
+    shared int[1] staticArray;
+    foreach (ref element; staticArray)
+    {
+        void byRef(ref shared(int)) {}
+        byRef(element);
+    }
+}
+
 // Simple tests for `DotVarExp`
 // A `DotVarExp` is `a.b`. If `a` is a `shared ref`,
 // it is of type `shared(T)*` (as opposed to `shared(T*)`).

--- a/druntime/src/core/internal/convert.d
+++ b/druntime/src/core/internal/convert.d
@@ -788,14 +788,8 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == delegate) || is(T : V*, V
 private const(ubyte)[] toUbyte_aggregate_ctfe(T)(const return ref scope T val)
 {
     pragma(inline, false);
-
-    // Walking `tupleof` on a shared aggregate is rejected by
-    // `-preview=nosharedaccess`.
-    import core.internal.traits : Unshared;
-    // `ref` avoids copying aggregates with disabled postblits or destructors.
-    ref const(Unshared!T) unsharedVal = *cast(const(Unshared!T)*) &val;
     ubyte[] bytes = ctfe_alloc(T.sizeof);
-    foreach (key, ref cur; unsharedVal.tupleof)
+    foreach (key, ref cur; val.tupleof)
     {
         static if (is(typeof(cur) EType == enum)) // Odd style is to avoid template instantiation in most cases.
             alias CurType = OriginalType!EType;
@@ -803,7 +797,7 @@ private const(ubyte)[] toUbyte_aggregate_ctfe(T)(const return ref scope T val)
             alias CurType = typeof(cur);
         static if (is(CurType == struct) || is(CurType == union) || __traits(isStaticArray, CurType) || !is(typeof(cur is null)))
         {
-            bytes[unsharedVal.tupleof[key].offsetof .. unsharedVal.tupleof[key].offsetof + CurType.sizeof] = toUbyte(cur)[];
+            bytes[val.tupleof[key].offsetof .. val.tupleof[key].offsetof + CurType.sizeof] = toUbyte(cur)[];
         }
         else
         {

--- a/druntime/src/core/internal/hash.d
+++ b/druntime/src/core/internal/hash.d
@@ -201,17 +201,9 @@ if (is(T == S[], S) && (__traits(isScalar, S) || canBitwiseHash!S)) // excludes 
     static if (!canBitwiseHash!ElementType)
     {
         size_t hash = seed;
-        static if (is(ElementType == shared U, U))
+        foreach (ref o; val)
         {
-            // Cast away shared for iteration; caller is responsible for synchronization.
-            auto unshared = (() @trusted => cast(const(U)[]) val)();
-            foreach (ref o; unshared)
-                hash = hashOf(hashOf(o), hash); // double hashing to match TypeInfo.getHash
-        }
-        else
-        {
-            foreach (ref o; val)
-                hash = hashOf(hashOf(o), hash); // double hashing to match TypeInfo.getHash
+            hash = hashOf(hashOf(o), hash); // double hashing to match TypeInfo.getHash
         }
         return hash;
     }
@@ -233,19 +225,10 @@ if (is(T == S[], S) && (__traits(isScalar, S) || canBitwiseHash!S)) // excludes 
 size_t hashOf(T)(T val, size_t seed = 0)
 if (is(T == S[], S) && !(__traits(isScalar, S) || canBitwiseHash!S)) // excludes enum types
 {
-    alias ElementType = typeof(val[0]);
     size_t hash = seed;
-    static if (is(ElementType == shared U, U))
+    foreach (ref o; val)
     {
-        // Cast away shared for iteration; caller is responsible for synchronization.
-        auto unshared = (() @trusted => cast(U[]) val)();
-        foreach (ref o; unshared)
-            hash = hashOf(hashOf(o), hash); // double hashing because TypeInfo.getHash doesn't allow to pass seed value
-    }
-    else
-    {
-        foreach (ref o; val)
-            hash = hashOf(hashOf(o), hash); // double hashing because TypeInfo.getHash doesn't allow to pass seed value
+        hash = hashOf(hashOf(o), hash); // double hashing because TypeInfo.getHash doesn't allow to pass seed value
     }
     return hash;
 }


### PR DESCRIPTION
Follow-up to #23056.

Fixes #20496.

A `ref` initializer takes the address of its source and therefore does not read shared data. Treat it consistently with passing a shared value to a `ref` parameter, allowing `foreach (ref element; sharedArray)` under `-preview=nosharedaccess`.

Removes the now-unneeded shared `foreach(ref ...)` workarounds introduced by #23056.