### PR TITLE
fix #23711 - Internal compiler error array literal should have been lowered ...

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6245,6 +6245,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         auto ale1 = new ArrayLiteralExp(aaExp.loc, keytype.arrayOf(), keys);
         auto ale2 = new ArrayLiteralExp(aaExp.loc, valtype.arrayOf(), values);
+        ale1.onstack = true;
+        ale2.onstack = true;
         lowerArrayLiteral(ale1, sc);
         lowerArrayLiteral(ale2, sc);
         auto arguments = new Expressions(ale1, ale2);

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -189,6 +189,8 @@ public:
             return;
         if (setGC(e, "this associative array literal"))
             return;
+        if (e.lowering)
+            walkPostorder(e.lowering, this);
         f.printGCUsage(e.loc, "associative array literal may cause a GC allocation");
     }
 

--- a/compiler/test/runnable/testaa3.d
+++ b/compiler/test/runnable/testaa3.d
@@ -518,6 +518,14 @@ void test23182()
     assert(calls == 1);
 }
 
+// https://github.com/dlang/dmd/issues/23711
+void test23711()
+{
+    alias AliasSeq(T...) = T;
+    alias Cases = AliasSeq!(["first": [1]]);
+    assert(Cases[0]);
+}
+
 /***************************************************/
 
 // https://github.com/dlang/dmd/issues/22567
@@ -588,4 +596,5 @@ void main()
     test22556();
     test19829();
     test23182();
+    test23711();
 }


### PR DESCRIPTION
… to a _d_arrayliteralTX template.

The dynamic array literal lowering is a side effect of checkGC, so an associative array literal needs to check its lowering there, too, in case it has been moved from compile-time to codegen.

Ensure to pass key and value arrays on the stack to avoid extra warnings about GC usage