### PR TITLE
replace tip() with errorSupplemental()

### DIFF
--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -2424,7 +2424,7 @@ private void printCandidates(Decl)(Loc loc, Decl declaration, bool showDeprecate
         eSink.errorSupplemental(loc, "All possible candidates are marked as `deprecated` or `@disable`");
     // should be only in verbose mode
     if (constraintsTip)
-        tip(constraintsTip);
+        eSink.errorSupplemental(Loc.init, constraintsTip);
 }
 
 /********************************************************

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -3676,7 +3676,7 @@ const(char)* getConstraintEvalError(TemplateDeclaration td, ref const(char)* tip
         buf.writestring(msg);
         buf.writeByte('`');
         buf.writestring(sep);
-        tip = "not satisfied constraints are marked with `>`";
+        tip = "Tip: not satisfied constraints are marked with `>`";
     }
     return buf.extractChars();
 }
@@ -3862,18 +3862,18 @@ bool findBestMatch(TemplateInstance ti, Scope* sc, ArgumentList argumentList)
         {
             // Only one template, so we can give better error message
             const(char)* msg = "does not match template declaration";
-            const(char)* tip;
             OutBuffer buf;
             HdrGenState hgs;
             hgs.skipConstraints = true;
             toCharsMaybeConstraints(tdecl, buf, hgs);
             const tmsg = buf.peekChars();
+            const(char)* tip;
             const cmsg = tdecl.getConstraintEvalError(tip);
             if (cmsg)
             {
                 eSink.error(ti.loc, "%s `%s` %s `%s`\n%s", ti.kind, ti.toPrettyChars, msg, tmsg, cmsg);
                 if (tip)
-                    .tip(tip);
+                    eSink.errorSupplemental(Loc.init, tip);
             }
             else
             {

--- a/compiler/test/fail_compilation/fail15616b.d
+++ b/compiler/test/fail_compilation/fail15616b.d
@@ -22,7 +22,7 @@ fail_compilation/fail15616b.d(26):                        `foo(T)(T a)`
   `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
 `  > is(T == char)
 `  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
-  Tip: not satisfied constraints are marked with `>`
+       Tip: not satisfied constraints are marked with `>`
 ---
 */
 


### PR DESCRIPTION
There are only 2 uses of tip() and do not seem to be necessary. See https://github.com/dlang/dmd/pull/23727