### PR TITLE
Fix #23731 - undefined __xopEquals/__xtoHash for instantiated struct

### DIFF
--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -1471,6 +1471,25 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             semanticTypeInfoMembers(sd);
         }
 
+        if (TemplateInstance ti = sd.isInstantiated())
+        {
+            if (!ti.needsCodegen())
+            {
+                if (sd.xeq && sd.xeq != StructDeclaration.xerreq)
+                    toObjFile(sd.xeq, global.params.multiobj);
+                if (sd.xcmp && sd.xcmp != StructDeclaration.xerrcmp)
+                    toObjFile(sd.xcmp, global.params.multiobj);
+                if (FuncDeclaration ftostr = search_toString(sd))
+                    toObjFile(ftostr, global.params.multiobj);
+                if (sd.xhash)
+                    toObjFile(sd.xhash, global.params.multiobj);
+                if (sd.postblit)
+                    toObjFile(sd.postblit, global.params.multiobj);
+                if (sd.dtor)
+                    toObjFile(sd.dtor, global.params.multiobj);
+            }
+        }
+
         /* Put out:
          *  char[] mangledName;
          *  void[] init;

--- a/compiler/test/runnable/imports/test23731a.d
+++ b/compiler/test/runnable/imports/test23731a.d
@@ -1,0 +1,8 @@
+module imports.test23731a;
+
+struct Wrapper(T)
+{
+    T[] values;
+}
+
+enum wrapperIntSize = Wrapper!int.sizeof;

--- a/compiler/test/runnable/test23731.d
+++ b/compiler/test/runnable/test23731.d
@@ -1,0 +1,12 @@
+// https://github.com/dlang/dmd/issues/23731
+
+import imports.test23731a;
+
+void main()
+{
+    auto ti = typeid(Wrapper!int);
+    auto a = Wrapper!int([1, 2]);
+    auto b = Wrapper!int([1, 2]);
+    assert(ti.equals(&a, &b));
+    assert(ti.getHash(&a) == ti.getHash(&b));
+}


### PR DESCRIPTION
Closes #23731

> Claude's description:
>
> Bisected to 786dc71ad7 ("Emit special `__xopEquals`/`__xopCmp`/`__xtoHash` members *once*"), which removed the emission of those members from `TypeInfoStructDeclaration` codegen on the assumption that they are always emitted along with the `StructDeclaration` in some other object file.
>
> That assumption breaks for a struct template instance whose `needsCodegen()` is false but whose `TypeInfo` is still emitted here (`isSpeculativeType` returns false when `ti.minst` is set or `sd.requestTypeInfo` is true):
>
> * `ti.minst is null` — a speculative instance whose `TypeInfo` was requested anyway (e.g. by the inliner, which sets `requestTypeInfo` with a null scope). No module ever runs `TemplateInstance.toObjFile()` for it.
> * `ti.minst` is a non-root module that is not part of the compilation — as in the reported case, where the instance is created while CTFE-evaluating a manifest constant in an imported module that is never itself compiled.
>
> In both cases the emitted `TypeInfo_Struct` ends up referencing `__xopEquals`/`__xtoHash` symbols that no object file defines, giving the reported link errors. This restores the pre-2.113 emission next to the `TypeInfo`; the functions are COMDATs, so a duplicate copy in the module that does emit the instance is harmless.
>
> Note the reduced case in the issue also fails to link with 2.112 and 2.110 on the separate `ModuleInfo for config` error, which is the long-standing "all imported modules that need a `ModuleInfo` must be compiled and linked" requirement and is unrelated to this regression.
