### PR TITLE
fix #17952 - Invalid printf checks for long double on windows

### DIFF
--- a/compiler/src/dmd/chkformat.d
+++ b/compiler/src/dmd/chkformat.d
@@ -156,8 +156,13 @@ bool checkPrintfFormat(Loc loc, scope const char[] format, scope Expression[] ar
             switch (tb.ty)
             {
                 case Tfloat32:
-                case Tfloat64: suggestion = "%g";  break;
-                case Tfloat80: suggestion = "%Lg"; break;
+                case Tfloat64: suggestion = "%g"; break;
+                case Tfloat80:
+                    if (target.realsize != target.c.long_doublesize)
+                        eSink.deprecationSupplemental(arg.loc, "this target has no format specifier for `%s`", tactual.toErrMsg());
+                    else
+                        suggestion = "%Lg";
+                    break;
                 case Tpointer:
                     auto tn = tb.nextOf();
                     if (tn && (tn.ty == Tchar || tn.ty == Tint8 || tn.ty == Tuns8))
@@ -277,7 +282,13 @@ bool checkPrintfFormat(Loc loc, scope const char[] format, scope Expression[] ar
                 break;
 
             case Format.Lg:     // long double
-                if (t.ty != Tfloat80 && t.ty != Timaginary80)
+                if (target.realsize != target.c.long_doublesize)
+                {
+                    assert(target.c.long_doublesize == 8);
+                    if (t.ty != Tfloat64 && t.ty != Timaginary64)
+                        errorMsg(null, e, "c_long_double", t);
+                }
+                else if (t.ty != Tfloat80 && t.ty != Timaginary80)
                     errorMsg(null, e, "real", t);
                 break;
 

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -1480,7 +1480,7 @@ struct TargetC
             else if (os == Target.OS.OSX)
                 longsize = 8;
         }
-        if ((target.isX86_64 || target.isAArch64) && os == Target.OS.Windows)
+        if (os == Target.OS.Windows)
             long_doublesize = 8;
         else
             long_doublesize = target.realsize;

--- a/compiler/test/fail_compilation/chkformat.d
+++ b/compiler/test/fail_compilation/chkformat.d
@@ -23,10 +23,10 @@ fail_compilation/chkformat.d(107):        `"%td"` requires `ptrdiff_t`
 fail_compilation/chkformat.d(107):        `double` may be formatted with `"%g"`
 fail_compilation/chkformat.d(108): Deprecation: argument `8.0L` of type `real` does not match format specification
 fail_compilation/chkformat.d(108):        `"%g"` requires `double`
-fail_compilation/chkformat.d(108):        `real` may be formatted with `"%Lg"`
-fail_compilation/chkformat.d(109): Deprecation: argument `9.0` of type `double` does not match format specification
-fail_compilation/chkformat.d(109):        `"%Lg"` requires `real`
-fail_compilation/chkformat.d(109):        `double` may be formatted with `"%g"`
+fail_compilation/chkformat.d(108):        $?:windows=this target has no format specifier for `real`|`real` may be formatted with `"%Lg"`$
+fail_compilation/chkformat.d(109): Deprecation: argument `$?:windows=9|9.0$` of type `$?:windows=int|double$` does not match format specification
+fail_compilation/chkformat.d(109):        `"%Lg"` requires `$?:windows=c_long_double|real$`
+fail_compilation/chkformat.d(109):        `$?:windows=int|double$` may be formatted with `"%$?:windows=d|g$"`
 fail_compilation/chkformat.d(110): Deprecation: argument `10` of type `int` does not match format specification
 fail_compilation/chkformat.d(110):        `"%p"` requires `void*`
 fail_compilation/chkformat.d(110):        `int` may be formatted with `"%d"`
@@ -138,7 +138,7 @@ void test5() {  printf("%jd\n", 5); }
 void test6() {  printf("%zd\n", 6.0); }
 void test7() {  printf("%td\n", 7.0); }
 void test8() {  printf("%g\n", 8.0L); }
-void test9() {  printf("%Lg\n", 9.0); }
+void test9() {  version(Windows) printf("%Lg\n", 9); else printf("%Lg\n", 9.0); } // no error for Windows for double arg, but produce similar output
 void test10() {  printf("%p\n", 10); }
 void test11() { uint u; printf("%n\n", &u); }
 //void test12() { ushort u; printf("%ln\n", &u); }
@@ -266,7 +266,7 @@ fail_compilation/chkformat.d(501): Deprecation: argument `p` of type `char*` doe
 fail_compilation/chkformat.d(501):        `"%a"` requires `double`
 fail_compilation/chkformat.d(501):        `char*` may be formatted with `"%s"`
 fail_compilation/chkformat.d(502): Deprecation: argument `p` of type `char*` does not match format specification
-fail_compilation/chkformat.d(502):        `"%La"` requires `real`
+fail_compilation/chkformat.d(502):        `"%La"` requires `$?:windows=c_long_double|real$`
 fail_compilation/chkformat.d(502):        `char*` may be formatted with `"%s"`
 fail_compilation/chkformat.d(503): Deprecation: argument `p` of type `char*` does not match format specification
 fail_compilation/chkformat.d(503):        `"%a"` requires `float*`

--- a/compiler/test/runnable/mars1.d
+++ b/compiler/test/runnable/mars1.d
@@ -3,6 +3,7 @@ REQUIRED_ARGS: -mcpu=native
 PERMUTE_ARGS: -O -inline -release
 */
 
+import core.stdc.config;
 import core.stdc.stdio;
 
 template tuple(A...) { alias tuple = A; }
@@ -713,13 +714,13 @@ void test12095(int k)
 
 bool test3918a( float t, real u )
 {
-        printf("%Lf\n", u );
+        printf("%Lf\n", cast(c_long_double)u );
         return t && u;
 }
 
 bool test3918b( real t, float u )
 {
-        printf("%Lf\n", t );
+        printf("%Lf\n", cast(c_long_double)t );
         return t && u;
 }
 

--- a/compiler/test/runnable/stress.d
+++ b/compiler/test/runnable/stress.d
@@ -590,6 +590,7 @@ void DOUBLE()
 
 void REAL()
 {
+    import core.stdc.config;
     const int ITERS = 1000000;
     alias real typ;
     typ[] a;
@@ -602,7 +603,7 @@ void REAL()
     if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
-            printf("a Data Error: %Lg\n",a[idx]);
+            printf("a Data Error: %Lg\n", cast(c_long_double)a[idx]);
             break;
         }
     }
@@ -613,7 +614,7 @@ void REAL()
     if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
-            printf("b Data Error: %Lg\n",b[idx]);
+            printf("b Data Error: %Lg\n", cast(c_long_double)b[idx]);
             break;
         }
     }
@@ -626,7 +627,7 @@ void REAL()
     if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
-            printf("c Data Error: %Lg\n",c[idx]);
+            printf("c Data Error: %Lg\n", cast(c_long_double)c[idx]);
             break;
         }
     }

--- a/compiler/test/runnable/template4.d
+++ b/compiler/test/runnable/template4.d
@@ -589,8 +589,9 @@ template sqrt(real x, real root = x/2, int ntries = 0)
 
 void test20()
 {
+    import core.stdc.config;
     real x = sqrt!(2);
-    printf("%.20Lg\n", x); // 1.4142135623730950487
+    printf("%.20Lg\n", cast(c_long_double)x); // 1.4142135623730950487
 }
 
 /*********************************************************/

--- a/compiler/test/runnable/test34.d
+++ b/compiler/test/runnable/test34.d
@@ -366,12 +366,13 @@ void test17()
 
 void test18()
 {
+    import core.stdc.config;
     real t = 0.;
     for(int i=0; i<10; i++)
     {
         t += 1.;
         real r =  (2*t);
-        printf("%Lg  %Lg  %Lg\n", t, r, 2*t);
+        printf("%Lg  %Lg  %Lg\n", cast(c_long_double)t, cast(c_long_double)r, 2*cast(c_long_double)t);
         assert(2*t == (i+1)*2);
     }
 }

--- a/compiler/test/runnable/test42.d
+++ b/compiler/test/runnable/test42.d
@@ -8,7 +8,7 @@ myBool bool
 i
 s
 C6test42__T4T219TiZ1C
-C6test427test219FZ16__mixin_L3577_C31C
+C6test427test219FZ16__mixin_L3578_C31C
 ---
 */
 
@@ -1665,9 +1665,10 @@ void test100()
 {
     static void check(ulong value)
     {
+        import core.stdc.config;
         real r = value;
         ulong d = cast(ulong)r;
-        printf("ulong: %llu => real: %Lg => ulong: %llu\n", value, r, d);
+        printf("ulong: %llu => real: %Lg => ulong: %llu\n", value, cast(c_long_double)r, d);
         assert(d == value);
     }
 
@@ -3995,6 +3996,7 @@ static immutable real[13] postab =
 
 float parse(ref string p)
 {
+    import core.stdc.config;
     printf("test1\n");
 
     real ldval = 0.0;
@@ -4005,7 +4007,7 @@ float parse(ref string p)
     exp = 2;
 
     ldval = msdec;
-    printf("ldval = %Lg\n", ldval);
+    printf("ldval = %Lg\n", cast(c_long_double)ldval);
     if (ldval)
     {
         uint u = 0;

--- a/compiler/test/runnable/xtest46.d
+++ b/compiler/test/runnable/xtest46.d
@@ -1135,11 +1135,13 @@ class A59 {
 
 void test60()
 {
+    import core.stdc.config : c_long_double;
+
     enum real ONE = 1.0;
     real x;
     for (x=0.0; x<10.0; x+=ONE)
-        printf("%Lg\n", x);
-    printf("%Lg\n", x);
+        printf("%Lg\n", cast(c_long_double)x);
+    printf("%Lg\n", cast(c_long_double)x);
     assert(x == 10);
 }
 

--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -2878,10 +2878,11 @@ extern (C) private
         import core.stdc.stdlib : strtold;
         import core.stdc.stdio : snprintf;
         import core.stdc.errno : errno;
+        import core.stdc.config : c_long_double;
 
         const err = errno;
         real val = strtold(nptr.ptr, null);
-        snprintf(nptr.ptr, nptr.length, "%#Lg", val);
+        snprintf(nptr.ptr, nptr.length, "%#Lg", cast(c_long_double)val);
         errno = err;
     }
 }


### PR DESCRIPTION
The MS runtime doesn't support real if it is larger than double.

Is there a better option for portable code than to always use `cast(c_long_double)` for reals?

FYI: @denizzzka 