### PR TITLE
remove warningxxxx() from errors.d

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -410,6 +410,8 @@ else
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
+version (LDC) // LDC needs updating to add eSink.warning instead of warning
+{
 static if (__VERSION__ < 2092)
     extern (C++) void warning(Loc loc, const(char)* format, ...)
     {
@@ -426,6 +428,7 @@ else
         global.errorSink.vwarning(loc, format, ap);
         va_end(ap);
     }
+}
 
 /**
  * Print additional details about a warning message.


### PR DESCRIPTION
Start removing all the error message functions that are not derived from ErrorSink. I couldn't go further with this at the moment because https://github.com/dlang/dmd/pull/23654 is not merged yet.