### PR TITLE
Fix(parser): don't leak internal AST dump in noIdentifierForDeclarator error message

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -5133,7 +5133,17 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     /// The parser is expected to sit on the next token after the type.
     private void noIdentifierForDeclarator(AST.Type t, Token tok)
     {
-        error("variable name expected after type `%s`, not `%s`", t.toChars(), tok.toChars);
+        import core.stdc.string : strchr;
+        // The type may embed a broken default argument (e.g. a malformed
+        // function literal produced during error recovery), whose printed
+        // form can contain newlines and leak internal placeholders like
+        // `__error__` into this message. Fall back to a generic string
+        // in that case instead of reproducing the raw internal AST dump.
+        // See https://github.com/dlang/dmd/issues/19824
+        const(char)* ts = t.toChars();
+        if (strchr(ts, '\n'))
+            ts = "<error type>";
+        error("variable name expected after type `%s`, not `%s`", ts, tok.toChars);
 
         // A common mistake is to use a reserved keyword as an identifier, e.g. `in` or `out`
         if (token.isKeyword)

--- a/compiler/test/fail_compilation/e15876_1.d
+++ b/compiler/test/fail_compilation/e15876_1.d
@@ -1,17 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/e15876_1.d(17): Error: valid scope identifiers are `exit`, `failure`, or `success`, not `x`
-fail_compilation/e15876_1.d(18): Error: found `End of File` when expecting `)`
-fail_compilation/e15876_1.d(18): Error: found `End of File` instead of statement
-fail_compilation/e15876_1.d(18): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/e15876_1.d(17):        unmatched `{`
-fail_compilation/e15876_1.d(18): Error: found `End of File` when expecting `]`
-fail_compilation/e15876_1.d(18): Error: variable name expected after type `o[()
-{
-scope(exit) __error__
-}
-]`, not `End of File`
+fail_compilation/e15876_1.d(13): Error: valid scope identifiers are `exit`, `failure`, or `success`, not `x`
+fail_compilation/e15876_1.d(14): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_1.d(14): Error: found `End of File` instead of statement
+fail_compilation/e15876_1.d(14): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/e15876_1.d(13):        unmatched `{`
+fail_compilation/e15876_1.d(14): Error: found `End of File` when expecting `]`
+fail_compilation/e15876_1.d(14): Error: variable name expected after type `<error type>`, not `End of File`
 ---
 */
 o[{scope(x

--- a/compiler/test/fail_compilation/e15876_2.d
+++ b/compiler/test/fail_compilation/e15876_2.d
@@ -1,15 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/e15876_2.d(16): Error: identifier expected following `template`
-fail_compilation/e15876_2.d(16): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/e15876_2.d(15):        unmatched `{`
-fail_compilation/e15876_2.d(16): Error: found `End of File` when expecting `]`
-fail_compilation/e15876_2.d(16): Error: variable name expected after type `o[()
-{
-;
-}
-]`, not `End of File`
+fail_compilation/e15876_2.d(12): Error: identifier expected following `template`
+fail_compilation/e15876_2.d(12): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/e15876_2.d(11):        unmatched `{`
+fail_compilation/e15876_2.d(12): Error: found `End of File` when expecting `]`
+fail_compilation/e15876_2.d(12): Error: variable name expected after type `<error type>`, not `End of File`
 ---
 */
 o[{template

--- a/compiler/test/fail_compilation/e15876_3.d
+++ b/compiler/test/fail_compilation/e15876_3.d
@@ -1,28 +1,20 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/e15876_3.d(28): Error: unexpected `(` in declarator
-fail_compilation/e15876_3.d(28): Error: basic type expected, not `=`
-fail_compilation/e15876_3.d(29): Error: found `End of File` when expecting `(`
-fail_compilation/e15876_3.d(29): Error: found `End of File` instead of statement
-fail_compilation/e15876_3.d(29): Error: expression expected, not `End of File`
-fail_compilation/e15876_3.d(29): Error: found `End of File` when expecting `;` following `for` condition
-fail_compilation/e15876_3.d(29): Error: expression expected, not `End of File`
-fail_compilation/e15876_3.d(29): Error: found `End of File` when expecting `)`
-fail_compilation/e15876_3.d(29): Error: found `End of File` instead of statement
-fail_compilation/e15876_3.d(29): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/e15876_3.d(28):        unmatched `{`
-fail_compilation/e15876_3.d(29): Error: found `End of File` when expecting `)`
-fail_compilation/e15876_3.d(29): Error: variable name expected after type `d(_error_ = ()
-{
-for (__error__
- __error; __error)
-{
-__error__
-}
-}
-)`, not `End of File`
-fail_compilation/e15876_3.d(29): Error: semicolon expected following function declaration, not `End of File`
+fail_compilation/e15876_3.d(20): Error: unexpected `(` in declarator
+fail_compilation/e15876_3.d(20): Error: basic type expected, not `=`
+fail_compilation/e15876_3.d(21): Error: found `End of File` when expecting `(`
+fail_compilation/e15876_3.d(21): Error: found `End of File` instead of statement
+fail_compilation/e15876_3.d(21): Error: expression expected, not `End of File`
+fail_compilation/e15876_3.d(21): Error: found `End of File` when expecting `;` following `for` condition
+fail_compilation/e15876_3.d(21): Error: expression expected, not `End of File`
+fail_compilation/e15876_3.d(21): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_3.d(21): Error: found `End of File` instead of statement
+fail_compilation/e15876_3.d(21): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/e15876_3.d(20):        unmatched `{`
+fail_compilation/e15876_3.d(21): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_3.d(21): Error: variable name expected after type `<error type>`, not `End of File`
+fail_compilation/e15876_3.d(21): Error: semicolon expected following function declaration, not `End of File`
 ---
 */
 d(={for

--- a/compiler/test/fail_compilation/e15876_4.d
+++ b/compiler/test/fail_compilation/e15876_4.d
@@ -1,26 +1,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/e15876_4.d(26): Error: found `)` when expecting `(`
-fail_compilation/e15876_4.d(27): Error: found `End of File` when expecting `(`
-fail_compilation/e15876_4.d(27): Error: found `End of File` instead of statement
-fail_compilation/e15876_4.d(27): Error: expression expected, not `End of File`
-fail_compilation/e15876_4.d(27): Error: found `End of File` when expecting `;` following `for` condition
-fail_compilation/e15876_4.d(27): Error: expression expected, not `End of File`
-fail_compilation/e15876_4.d(27): Error: found `End of File` when expecting `)`
-fail_compilation/e15876_4.d(27): Error: found `End of File` instead of statement
-fail_compilation/e15876_4.d(27): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/e15876_4.d(26):        unmatched `{`
-fail_compilation/e15876_4.d(27): Error: found `End of File` when expecting `)`
-fail_compilation/e15876_4.d(27): Error: variable name expected after type `typeof(()
-{
-for (__error__
- __error; __error)
-{
-__error__
-}
-}
-)`, not `End of File`
+fail_compilation/e15876_4.d(18): Error: found `)` when expecting `(`
+fail_compilation/e15876_4.d(19): Error: found `End of File` when expecting `(`
+fail_compilation/e15876_4.d(19): Error: found `End of File` instead of statement
+fail_compilation/e15876_4.d(19): Error: expression expected, not `End of File`
+fail_compilation/e15876_4.d(19): Error: found `End of File` when expecting `;` following `for` condition
+fail_compilation/e15876_4.d(19): Error: expression expected, not `End of File`
+fail_compilation/e15876_4.d(19): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_4.d(19): Error: found `End of File` instead of statement
+fail_compilation/e15876_4.d(19): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/e15876_4.d(18):        unmatched `{`
+fail_compilation/e15876_4.d(19): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_4.d(19): Error: variable name expected after type `<error type>`, not `End of File`
 ---
 */
 typeof){for

--- a/compiler/test/fail_compilation/e15876_5.d
+++ b/compiler/test/fail_compilation/e15876_5.d
@@ -1,16 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/e15876_5.d(17): Error: basic type expected, not `End of File`
-fail_compilation/e15876_5.d(17): Error: semicolon expected to close `alias` declaration, not `End of File`
-fail_compilation/e15876_5.d(17): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/e15876_5.d(16):        unmatched `{`
-fail_compilation/e15876_5.d(17): Error: found `End of File` when expecting `]`
-fail_compilation/e15876_5.d(17): Error: variable name expected after type `p[()
-{
-alias ;
-}
-]`, not `End of File`
+fail_compilation/e15876_5.d(13): Error: basic type expected, not `End of File`
+fail_compilation/e15876_5.d(13): Error: semicolon expected to close `alias` declaration, not `End of File`
+fail_compilation/e15876_5.d(13): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/e15876_5.d(12):        unmatched `{`
+fail_compilation/e15876_5.d(13): Error: found `End of File` when expecting `]`
+fail_compilation/e15876_5.d(13): Error: variable name expected after type `<error type>`, not `End of File`
 ---
 */
 p[{alias

--- a/compiler/test/fail_compilation/ice11965.d
+++ b/compiler/test/fail_compilation/ice11965.d
@@ -1,15 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11965.d(16): Error: variable name expected after type `b*`, not `End of File`
-fail_compilation/ice11965.d(16): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/ice11965.d(15):        unmatched `{`
-fail_compilation/ice11965.d(16): Error: found `End of File` when expecting `]`
-fail_compilation/ice11965.d(16): Error: variable name expected after type `u[()
-{
-b* A;
-}
-]`, not `End of File`
+fail_compilation/ice11965.d(12): Error: variable name expected after type `b*`, not `End of File`
+fail_compilation/ice11965.d(12): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/ice11965.d(11):        unmatched `{`
+fail_compilation/ice11965.d(12): Error: found `End of File` when expecting `]`
+fail_compilation/ice11965.d(12): Error: variable name expected after type `<error type>`, not `End of File`
 ---
 */
 u[{b*A,

--- a/compiler/test/fail_compilation/ice15855.d
+++ b/compiler/test/fail_compilation/ice15855.d
@@ -2,25 +2,17 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice15855.d(28): Error: found `End of File` when expecting `(`
-fail_compilation/ice15855.d(28): Error: found `End of File` instead of statement
-fail_compilation/ice15855.d(28): Error: expression expected, not `End of File`
-fail_compilation/ice15855.d(28): Error: found `End of File` when expecting `;` following `for` condition
-fail_compilation/ice15855.d(28): Error: expression expected, not `End of File`
-fail_compilation/ice15855.d(28): Error: found `End of File` when expecting `)`
-fail_compilation/ice15855.d(28): Error: found `End of File` instead of statement
-fail_compilation/ice15855.d(28): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/ice15855.d(27):        unmatched `{`
-fail_compilation/ice15855.d(28): Error: found `End of File` when expecting `]`
-fail_compilation/ice15855.d(28): Error: variable name expected after type `a[()
-{
-for (__error__
- __error; __error)
-{
-__error__
-}
-}
-]`, not `End of File`
+fail_compilation/ice15855.d(20): Error: found `End of File` when expecting `(`
+fail_compilation/ice15855.d(20): Error: found `End of File` instead of statement
+fail_compilation/ice15855.d(20): Error: expression expected, not `End of File`
+fail_compilation/ice15855.d(20): Error: found `End of File` when expecting `;` following `for` condition
+fail_compilation/ice15855.d(20): Error: expression expected, not `End of File`
+fail_compilation/ice15855.d(20): Error: found `End of File` when expecting `)`
+fail_compilation/ice15855.d(20): Error: found `End of File` instead of statement
+fail_compilation/ice15855.d(20): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/ice15855.d(19):        unmatched `{`
+fail_compilation/ice15855.d(20): Error: found `End of File` when expecting `]`
+fail_compilation/ice15855.d(20): Error: variable name expected after type `<error type>`, not `End of File`
 ---
 */
 


### PR DESCRIPTION
Fixes #19824

The remaining leak (fail_compilation/e15876_3.d, reported by @thewilsonator) had a different cause than the original __traits(compiles) case, which was already fixed by #20872.

noIdentifierForDeclarator() in parse.d prints the type with toChars(). When the type is a broken function declarator (e.g. malformed default argument recovered from a parse error), toChars() can return a multi-line dump of the partial AST, including internal __error__ placeholders — which then leaks into the error message.

Fix: fall back to a generic `<error type>` placeholder whenever toChars() output spans multiple lines, since a valid type never does.

Updated expected output in the 7 affected fail_compilation tests to match the cleaner message. Full test suite passes.