### PR TITLE
fix #22054 - crash when running GC collection while attaching to threads during DLL init

### DIFF
--- a/druntime/src/core/sys/windows/threadaux.d
+++ b/druntime/src/core/sys/windows/threadaux.d
@@ -17,6 +17,7 @@ import core.sys.windows.winbase/+ : CloseHandle, GetCurrentThreadId, GetCurrentP
     GetModuleHandleA, GetProcAddress+/;
 import core.sys.windows.windef/+ : BOOL, DWORD, FALSE, HRESULT+/;
 import core.stdc.stdlib;
+import core.memory;
 
 public import core.thread;
 
@@ -371,6 +372,7 @@ void* GetTlsDataAddress( uint id ) nothrow
 // run rt_moduleTlsCtor in the context of the given thread
 void thread_moduleTlsCtor( uint id )
 {
+    GC.disable(); scope(exit) GC.enable();
     thread_aux.impersonate_thread(id, &rt_moduleTlsCtor);
 }
 
@@ -378,5 +380,6 @@ void thread_moduleTlsCtor( uint id )
 // run rt_moduleTlsDtor in the context of the given thread
 void thread_moduleTlsDtor( uint id )
 {
+    GC.disable(); scope(exit) GC.enable();
     thread_aux.impersonate_thread(id, &rt_moduleTlsDtor);
 }

--- a/druntime/src/rt/sections_win64.d
+++ b/druntime/src/rt/sections_win64.d
@@ -294,6 +294,7 @@ extern(C) bool rt_initSharedModule(void* handle)
     sectionGroup.moduleGroup.sortCtors();
     sectionGroup.moduleGroup.runCtors();
 
+    GC.disable(); scope(exit) GC.enable();
     foreach (t; Thread)
     {
         impersonate_thread(t.id, () => sectionGroup.moduleGroup.runTlsCtors());
@@ -311,9 +312,12 @@ extern(C) bool rt_termSharedModule(void* handle)
         return false;
     auto sectionGroup = _sections[i];
 
-    foreach (t; Thread)
     {
-        impersonate_thread(t.id, () => sectionGroup.moduleGroup.runTlsDtors());
+        GC.disable(); scope(exit) GC.enable();
+        foreach (t; Thread)
+        {
+            impersonate_thread(t.id, () => sectionGroup.moduleGroup.runTlsDtors());
+        }
     }
     sectionGroup.moduleGroup.runDtors();
     foreach (rng; sectionGroup._gcRanges)


### PR DESCRIPTION
While loading a DLL, existing threads are initializing their static ctors by "impersonating" the threads, i.e. TLS pointers are patched to represent another thread. This confuses thread suspension if a GC collection is triggered from within static ctors, e.g. beccause `ThreadBase.getThis()` is inconsistent with `GetCurrentThreadID()`. So better disable the GC while "impersonating". This is already done in `thread_attachByAddrB`.