### PR TITLE
cleanup #10846 - Eponymous template FQN's re-state the template name

### DIFF
--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -698,22 +698,16 @@ extern (C++) class Dsymbol : ASTNode
             {
                 addQualifiers(p.parent);
 
-                bool isOneMember(T)(T t)
+                if (!keepOneMember)
                 {
-                    import dmd.dsymbolsem;
+                    import dmd.dsymbolsem : oneMembers;
                     Dsymbol sym;
                     if (auto ti = p.parent.isTemplateInstance())
                         if (auto ident = p.getIdent())
                             if (ident is ti.name)
                                 if (oneMembers(ti.members, sym, ident) && sym is p)
-                                    return true;
-                    return false;
+                                    return;
                 }
-
-                if (!keepOneMember)
-                    if (isOneMember(p.parent.isTemplateInstance()) ||
-                        isOneMember(p.parent.isTemplateDeclaration()))
-                        return;
 
                 buf.writeByte('.');
             }


### PR DESCRIPTION
This seems to have gone wrong when rebasing the ancient PR: the TemplateDeclaration instantiation of isOneMember doesn't do anything different than the TemplateInstance one. It seems impossible to trigger emitting that symbol anyway, so we can remove it.

 A tooltip in a language service might still try to display it, though, but the check is very different then:
```D
                    if (auto td = p.parent.isTemplateDeclaration())
                        if (td.onemember is p)
                            return;
```
Should this be added?
