### PR TITLE
Fix #23762 - Struct constructor template not callable when forward referenced

### DIFF
--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -854,6 +854,7 @@ void templateDeclarationSemantic(Scope* sc, TemplateDeclaration tempdecl)
 
     // Compute again
     tempdecl.onemember = null;
+    tempdecl.haveComputedOneMember = false;
     tempdecl.computeOneMember();
     /* BUG: should check:
      *  1. template functions must not introduce virtual functions, as they

--- a/compiler/test/compilable/test23762.d
+++ b/compiler/test/compilable/test23762.d
@@ -1,0 +1,14 @@
+// https://github.com/dlang/dmd/issues/23762
+
+struct S
+{
+    enum e = __traits(compiles, S(0));
+    this(T)(T n) {}
+}
+
+static assert(S.e);
+
+void main()
+{
+    auto x = S(1);
+}

--- a/compiler/test/fail_compilation/fail222.d
+++ b/compiler/test/fail_compilation/fail222.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail222.d(11): Error: template `fail222.getMixin(TArg..., int i = 0)()` template sequence parameter must be the last one
-fail_compilation/fail222.d(18): Error: template instance `getMixin!()` does not match template declaration `getMixin(TArg..., int i = 0)`
+fail_compilation/fail222.d(18): Error: template instance `getMixin!()` does not match template declaration `getMixin(TArg..., int i = 0)()`
 fail_compilation/fail222.d(21): Error: template instance `fail222.Thing!()` error instantiating
 fail_compilation/fail222.d(23): Error: template `fail222.fooBar(A..., B...)()` template sequence parameter must be the last one
 ---


### PR DESCRIPTION
Fixes: #23762 
`templateDeclarationSemantic` resets `onemember` but `computeOneMember()` skips the recompute if it already ran, leaving it null. Reset `haveComputedOneMember` so it recompute