### PR TITLE
Remove front-end dependency from dmd.errors

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -13,7 +13,6 @@ module dmd.errors;
 
 public import core.stdc.stdarg;
 public import dmd.root.string: fTuple;
-public import dmd.hdrgen : toErrMsg;
 import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;

--- a/compiler/src/dmd/iasm/dmdx86.d
+++ b/compiler/src/dmd/iasm/dmdx86.d
@@ -31,6 +31,7 @@ import dmd.expression;
 import dmd.expressionsem;
 import dmd.funcsem : checkNestedReference;
 import dmd.globals;
+import dmd.hdrgen : toErrMsg;
 import dmd.id;
 import dmd.identifier;
 import dmd.init;

--- a/compiler/src/dmd/mangle/cpp.d
+++ b/compiler/src/dmd/mangle/cpp.d
@@ -34,6 +34,7 @@ import dmd.errors;
 import dmd.expression;
 import dmd.func;
 import dmd.globals;
+import dmd.hdrgen : toErrMsg;
 import dmd.id;
 import dmd.identifier;
 import dmd.location;

--- a/compiler/src/dmd/mangle/cppwin.d
+++ b/compiler/src/dmd/mangle/cppwin.d
@@ -30,6 +30,7 @@ import dmd.expression;
 import dmd.func;
 import dmd.funcsem;
 import dmd.globals;
+import dmd.hdrgen : toErrMsg;
 import dmd.id;
 import dmd.identifier;
 import dmd.location;

--- a/compiler/src/dmd/mangle/package.d
+++ b/compiler/src/dmd/mangle/package.d
@@ -153,6 +153,7 @@ import dmd.expression;
 import dmd.func;
 import dmd.funcsem;
 import dmd.globals;
+import dmd.hdrgen : toErrMsg;
 import dmd.id;
 import dmd.identifier;
 import dmd.mtype;

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -32,6 +32,7 @@ import dmd.expressionsem;
 import dmd.func;
 import dmd.funcsem : isRootTraitsCompilesScope;
 import dmd.globals;
+import dmd.hdrgen : toErrMsg;
 import dmd.id;
 import dmd.identifier;
 import dmd.init;


### PR DESCRIPTION
One of #23757 #23758 #23759 introduced forward reference regression when compiling dmd one module at a time.

Remove the problematic import to break the cycle.

```
dmd/errors.d:227:1: error: enum dmd.errors.Classification is forward referenced when looking for 'error'
  227 | enum Classification : Color
      | ^
dmd/dtemplate.d:924:70: error: no property 'error' for type 'Classification'. Did you mean 'Classification.error' ?
  924 |     extern(D) final void printInstantiationTrace(Classification cl = Classification.error,
      |                                                                      ^
dmd/dtemplate.d:1130:27: error: function dmd.dtemplate.TemplateMixin.kind does not override any function
 1130 |     override const(char)* kind() const
      |                           ^
dmd/dtemplate.d:1135:19: error: function dmd.dtemplate.TemplateMixin.accept does not override any function
 1135 |     override void accept(Visitor v)
      |                   ^
```