### PR TITLE
Fix Issue 21347 - array literal parser doesn't stop on missing comma

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -9024,7 +9024,12 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     values.push(e);
                     if (token.value == TOK.rightBracket)
                         break;
-                    check(TOK.comma);
+                    if (token.value != TOK.comma)
+                    {
+                        check(TOK.comma);
+                        break;
+                    }
+                    nextToken();
                 }
                 check(loc, TOK.rightBracket);
 
@@ -9441,7 +9446,12 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                             arguments.push(index);
                         if (token.value == TOK.rightBracket)
                             break;
-                        check(TOK.comma);
+                        if (token.value != TOK.comma)
+                        {
+                            check(TOK.comma);
+                            break;
+                        }
+                        nextToken();
                     }
                     check(TOK.rightBracket);
                     inBrackets--;

--- a/compiler/test/fail_compilation/fail21347.d
+++ b/compiler/test/fail_compilation/fail21347.d
@@ -1,0 +1,20 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail21347.d(19): Error: expression expected, not `;`
+fail_compilation/fail21347.d(20): Error: found `}` when expecting `,`
+fail_compilation/fail21347.d(19): Error: found `End of File` when expecting `]`
+fail_compilation/fail21347.d(19): Error: found `End of File` when expecting `)`
+fail_compilation/fail21347.d(21): Error: found `End of File` when expecting `;` following expression
+fail_compilation/fail21347.d(19):        expression: `[(__error)]`
+fail_compilation/fail21347.d(21): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/fail21347.d(18):        unmatched `{`
+---
+*/
+
+// https://github.com/dlang/dmd/issues/21347
+// diagnostic: Parser never stops looking for ',' on array literal syntax error
+
+void test21347()
+{
+    ([;
+}

--- a/compiler/test/fail_compilation/fail315.d
+++ b/compiler/test/fail_compilation/fail315.d
@@ -1,14 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail315.d-mixin-17(17): Error: found `;` when expecting `,`
-fail_compilation/fail315.d-mixin-17(17): Error: expression expected, not `}`
-fail_compilation/fail315.d-mixin-17(17): Error: found `End of File` when expecting `,`
-fail_compilation/fail315.d-mixin-17(17): Error: found `End of File` when expecting `]`
-fail_compilation/fail315.d-mixin-17(17): Error: found `End of File` when expecting `;` following `return` statement
-fail_compilation/fail315.d-mixin-17(17): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/fail315.d-mixin-17(17):        unmatched `{`
-fail_compilation/fail315.d(22): Error: template instance `fail315.foo!()` error instantiating
+fail_compilation/fail315.d-mixin-15(15): Error: found `;` when expecting `,`
+fail_compilation/fail315.d-mixin-15(15): Error: found `}` when expecting `]`
+fail_compilation/fail315.d-mixin-15(15): Error: found `End of File` when expecting `;` following `return` statement
+fail_compilation/fail315.d-mixin-15(15): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/fail315.d-mixin-15(15):        unmatched `{`
+fail_compilation/fail315.d(20): Error: template instance `fail315.foo!()` error instantiating
 ---
 */
 


### PR DESCRIPTION
Fixes #21347 
