### PR TITLE
dmd.error: expose ErrorSink to C++ compiler interface

### DIFF
--- a/compiler/include/dmd/errors.h
+++ b/compiler/include/dmd/errors.h
@@ -11,17 +11,8 @@
 #pragma once
 
 #include "root/dsystem.h"
-
-struct Loc;
-
-// Constants used to discriminate kinds of error messages.
-enum class ErrorKind
-{
-    warning = 0,
-    deprecation = 1,
-    error = 2,
-    message = 3,
-};
+#include "errorsink.h"
+#include "globals.h"
 
 #if defined(__GNUC__)
 #define D_ATTRIBUTE_FORMAT(m, n) __attribute__((format(printf, m, n))) __attribute__((nonnull (m)))
@@ -51,3 +42,12 @@ D_ATTRIBUTE_FORMAT(2, 3) void message(Loc loc, const char *format, ...);
 // Called after printing out fatal error messages.
 D_ATTRIBUTE_NORETURN void fatal();
 D_ATTRIBUTE_NORETURN void halt();
+
+class ErrorSinkCompiler : public ErrorSink
+{
+public:
+    uint32_t errorLimit;
+    Diagnostic useWarnings;
+    Diagnostic useDeprecated;
+    d_bool showGaggedErrors;
+};

--- a/compiler/include/dmd/errorsink.h
+++ b/compiler/include/dmd/errorsink.h
@@ -1,0 +1,77 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (C) 1999-2026 by The D Language Foundation, All Rights Reserved
+ * written by Walter Bright
+ * https://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * https://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/src/dmd/errorsink.h
+ */
+
+#pragma once
+
+#include "root/dsystem.h"
+
+struct Loc;
+
+// Constants used to discriminate kinds of error messages.
+enum class ErrorKind
+{
+    warning = 0,
+    deprecation = 1,
+    error = 2,
+    message = 3,
+};
+
+class ErrorSink
+{
+public:
+    virtual void verror(Loc loc, const char *format, va_list ap) = 0;
+    virtual void verrorSupplemental(Loc loc, const char *format, va_list ap) = 0;
+    virtual void vwarning(Loc loc, const char *format, va_list ap) = 0;
+    virtual void vwarningSupplemental(Loc loc, const char *format, va_list ap) = 0;
+    virtual void vmessage(Loc loc, const char *format, va_list ap) = 0;
+    virtual void vdeprecation(Loc loc, const char *format, va_list ap) = 0;
+    virtual void vdeprecationSupplemental(Loc loc, const char *format, va_list ap) = 0;
+
+    virtual void error(Loc loc, const char *format, ...);
+    virtual void errorSupplemental(Loc loc, const char *format, ...);
+    virtual void warning(Loc loc, const char *format, ...);
+    virtual void warningSupplemental(Loc loc, const char *format, ...);
+    virtual void message(Loc loc, const char *format, ...);
+    virtual void deprecation(Loc loc, const char *format, ...);
+    virtual void deprecationSupplemental(Loc loc, const char *format, ...);
+    virtual void plugSink();
+};
+
+class ErrorSinkNull : public ErrorSink
+{
+public:
+    void verror(Loc loc, const char *format, va_list ap) override;
+    void verrorSupplemental(Loc loc, const char *format, va_list ap) override;
+    void vwarning(Loc loc, const char *format, va_list ap) override;
+    void vwarningSupplemental(Loc loc, const char *format, va_list ap) override;
+    void vmessage(Loc loc, const char *format, va_list ap) override;
+    void vdeprecation(Loc loc, const char *format, va_list ap) override;
+    void vdeprecationSupplemental(Loc loc, const char *format, va_list ap) override;
+};
+
+class ErrorSinkLatch : public ErrorSinkNull
+{
+public:
+    bool sawErrors;
+
+    void verror(Loc loc, const char *format, va_list ap) override;
+};
+
+class ErrorSinkStderr : public ErrorSink
+{
+public:
+    void verror(Loc loc, const char *format, va_list ap) override;
+    void verrorSupplemental(Loc loc, const char *format, va_list ap) override;
+    void vwarning(Loc loc, const char *format, va_list ap) override;
+    void vwarningSupplemental(Loc loc, const char *format, va_list ap) override;
+    void vdeprecation(Loc loc, const char *format, va_list ap) override;
+    void vmessage(Loc loc, const char *format, va_list ap) override;
+    void vdeprecationSupplemental(Loc loc, const char *format, va_list ap) override;
+};

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -36,7 +36,7 @@ nothrow:
  * and delegates the actual output to the virtual $(D emit) method, which
  * subclasses such as $(D dmd.sarif.ErrorSinkSarif) override to change format.
  */
-class ErrorSinkCompiler : ErrorSink
+extern (C++) class ErrorSinkCompiler : ErrorSink
 {
     /// Maximum number of errors/deprecations to display before calling $(D fatal).
     /// 0 means unlimited.
@@ -59,7 +59,6 @@ class ErrorSinkCompiler : ErrorSink
     }
 
   nothrow:
-  extern (C++):
 
     // Overrides of the abstract ErrorSink methods convert Loc to SourceLoc
     // and dispatch to the SourceLoc-taking overload that holds the gating body.

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -27,10 +27,9 @@ enum ErrorKind
 /***************************************
  * Where error/warning/deprecation messages go.
  */
-abstract class ErrorSink
+extern (C++) abstract class ErrorSink
 {
   nothrow:
-  extern (C++):
 
     void verror(Loc loc, const(char)* format, va_list ap);
     void verrorSupplemental(Loc loc, const(char)* format, va_list ap);
@@ -177,10 +176,9 @@ else
 /*****************************************
  * Just ignores the messages.
  */
-class ErrorSinkNull : ErrorSink
+extern (C++) class ErrorSinkNull : ErrorSink
 {
   nothrow:
-  extern (C++):
   override:
 
     void verror(Loc loc, const(char)* format, va_list ap) { }
@@ -201,10 +199,9 @@ class ErrorSinkNull : ErrorSink
 /*****************************************
  * Ignores the messages, but sets `sawErrors` for any calls to `error()`
  */
-class ErrorSinkLatch : ErrorSinkNull
+extern (C++) class ErrorSinkLatch : ErrorSinkNull
 {
   nothrow:
-  extern (C++):
   override:
 
     bool sawErrors;
@@ -216,13 +213,12 @@ class ErrorSinkLatch : ErrorSinkNull
  * Simplest implementation, just sends messages to stderr.
  * See also: ErrorSinkCompiler.
  */
-class ErrorSinkStderr : ErrorSink
+extern (C++) class ErrorSinkStderr : ErrorSink
 {
     import core.stdc.stdio;
     import core.stdc.stdarg;
 
   nothrow:
-  extern (C++):
   override:
 
     void verror(Loc loc, const(char)* format, va_list ap)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -16887,7 +16887,7 @@ MATCH matchType(FuncExp funcExp, Type to, Scope* sc, FuncExp* presult, ErrorSink
             (*presult).fd.modifyReturns(sc, tof.next);
         }
     }
-    else if (!cast(ErrorSinkNull)eSink)
+    else
     {
         auto ts = toAutoQualChars(tx, to);
         eSink.error(loc, "cannot implicitly convert expression `%s` of type `%s` to `%s`",


### PR DESCRIPTION
So that gdc/ldc can override the `ErrorSinkCompiler` class to send errors to their backend diagnostics engine.

e.g:
```c++
class ErrorSinkGccCompiler : public ErrorSinkCompiler
{
public:
  static ErrorSinkGccCompiler *create();
  void verror(Loc, const char *, va_list) override final;
  void verrorSupplemental(Loc, const char *, va_list) override final;
  void vwarning(Loc, const char *, va_list) override final;
  void vwarningSupplemental(Loc, const char *, va_list) override final;
  void vdeprecation(Loc, const char *, va_list) override final;
  void vmessage(Loc, const char *, va_list) override final;
  void vdeprecationSupplemental(Loc, const char *, va_list) override final;
};

///

global.errorSink = ErrorSinkGccCompiler::create();
```