### PR TITLE
Add DDoc behavior flags for noalloc/nogc/nothrow/pure.

### DIFF
--- a/changelog/dmd.ddoc-behavior-flags.dd
+++ b/changelog/dmd.ddoc-behavior-flags.dd
@@ -2,7 +2,7 @@ Ddoc now emits behavior-flag badges for function guarantees
 
 Documented functions now display badge-like $(I behavior flags) under their
 title, similar to the build-status badges seen in project READMEs. When any are
-present, the badges are introduced by a `Behaviors:` label. Four flags are
+present, the badges are introduced by a `Current Behaviors:` label. Four flags are
 available, each shown only when it applies and each in a distinct color:
 
 $(UL
@@ -31,7 +31,7 @@ void* fastCopy(void* dst, const(void)* src, size_t n) @nogc nothrow pure;
 
 The example above renders a $(I No Allocations) badge (written manually) next to
 the $(I No GC), $(I No Exceptions Thrown) and $(I Is Pure) badges (added
-automatically from the attributes), all shown after a `Behaviors:` label.
+automatically from the attributes), all shown after a `Current Behaviors:` label.
 
 The badges and their grouping container are produced by the new `NOALLOC`,
 `NOGC`, `NOTHROW`, `PURE` and `DDOC_FLAGS` macros, which can be redefined like

--- a/changelog/dmd.ddoc-behavior-flags.dd
+++ b/changelog/dmd.ddoc-behavior-flags.dd
@@ -1,15 +1,16 @@
 Ddoc now emits behavior-flag badges for function guarantees
 
 Documented functions now display badge-like $(I behavior flags) under their
-title, similar to the build-status badges seen in project READMEs. Four flags
-are available, each shown only when it applies and each in a distinct color:
+title, similar to the build-status badges seen in project READMEs. When any are
+present, the badges are introduced by a `Behaviors:` label. Four flags are
+available, each shown only when it applies and each in a distinct color:
 
 $(UL
-$(LI `$(DOLLAR)(NOGC)` $(MDASH) emitted automatically for `@nogc` functions)
-$(LI `$(DOLLAR)(NOTHROW)` $(MDASH) emitted automatically for `nothrow` functions)
-$(LI `$(DOLLAR)(PURE)` $(MDASH) emitted automatically for `pure` functions)
-$(LI `$(DOLLAR)(NOALLOC)` $(MDASH) a manual-only "no-alloc" flag with no
-corresponding language attribute)
+$(LI `$(DOLLAR)(NOGC)` (rendered $(I No GC)) $(MDASH) emitted automatically for `@nogc` functions)
+$(LI `$(DOLLAR)(NOTHROW)` (rendered $(I No Exceptions Thrown)) $(MDASH) emitted automatically for `nothrow` functions)
+$(LI `$(DOLLAR)(PURE)` (rendered $(I Is Pure)) $(MDASH) emitted automatically for `pure` functions)
+$(LI `$(DOLLAR)(NOALLOC)` (rendered $(I No Allocations)) $(MDASH) a manual-only
+flag with no corresponding language attribute)
 )
 
 The `$(DOLLAR)(NOGC)`, `$(DOLLAR)(NOTHROW)` and `$(DOLLAR)(PURE)` flags appear
@@ -28,8 +29,9 @@ $(DOLLAR)(NOALLOC)
 void* fastCopy(void* dst, const(void)* src, size_t n) @nogc nothrow pure;
 -------
 
-The example above renders a `no-alloc` badge (written manually) next to the
-`@nogc`, `nothrow` and `pure` badges (added automatically from the attributes).
+The example above renders a $(I No Allocations) badge (written manually) next to
+the $(I No GC), $(I No Exceptions Thrown) and $(I Is Pure) badges (added
+automatically from the attributes), all shown after a `Behaviors:` label.
 
 The badges and their grouping container are produced by the new `NOALLOC`,
 `NOGC`, `NOTHROW`, `PURE` and `DDOC_FLAGS` macros, which can be redefined like

--- a/changelog/dmd.ddoc-behavior-flags.dd
+++ b/changelog/dmd.ddoc-behavior-flags.dd
@@ -1,0 +1,37 @@
+Ddoc now emits behavior-flag badges for function guarantees
+
+Documented functions now display badge-like $(I behavior flags) under their
+title, similar to the build-status badges seen in project READMEs. Four flags
+are available, each shown only when it applies and each in a distinct color:
+
+$(UL
+$(LI `$(DOLLAR)(NOGC)` $(MDASH) emitted automatically for `@nogc` functions)
+$(LI `$(DOLLAR)(NOTHROW)` $(MDASH) emitted automatically for `nothrow` functions)
+$(LI `$(DOLLAR)(PURE)` $(MDASH) emitted automatically for `pure` functions)
+$(LI `$(DOLLAR)(NOALLOC)` $(MDASH) a manual-only "no-alloc" flag with no
+corresponding language attribute)
+)
+
+The `$(DOLLAR)(NOGC)`, `$(DOLLAR)(NOTHROW)` and `$(DOLLAR)(PURE)` flags appear
+automatically whenever the matching attribute is present on the documented
+declaration. Any flag may also be written manually anywhere in a documentation
+comment; manually-written flags are moved to appear under the declaration's
+title, and duplicate flags $(MDASH) whether written manually or added
+automatically $(MDASH) are collapsed into a single badge.
+
+-------
+/++
+Copy `n` bytes.
+
+$(DOLLAR)(NOALLOC)
++/
+void* fastCopy(void* dst, const(void)* src, size_t n) @nogc nothrow pure;
+-------
+
+The example above renders a `no-alloc` badge (written manually) next to the
+`@nogc`, `nothrow` and `pure` badges (added automatically from the attributes).
+
+The badges and their grouping container are produced by the new `NOALLOC`,
+`NOGC`, `NOTHROW`, `PURE` and `DDOC_FLAGS` macros, which can be redefined like
+any other Ddoc macro. See $(LINK2 $(ROOT_DIR)spec/ddoc.html#behavior_flags,
+Behavior Flags) for details.

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -1557,13 +1557,15 @@ void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
                 {
                     size_t iDescStart = buf.length;
                     dc.writeSections(sc, &dc.a, *buf);
+                    // Emit flags from this declaration's own sections, before
+                    // members are written, so nested member flags aren't consumed.
+                    emitBehaviorFlags(*buf, iDescStart, &dc.a);
                     foreach (sym; dc.a)
                         if (ScopeDsymbol sds = sym.isScopeDsymbol())
                         {
                             emitMemberComments(sds, *buf, sc);
                             break;
                         }
-                    emitBehaviorFlags(*buf, iDescStart, &dc.a);
                 }
                 buf.writestring(ddoc_decl_dd_e);
                 buf.writeByte(')');

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -1344,6 +1344,122 @@ void emitVisibility(ref OutBuffer buf, Visibility vis)
     buf.writeByte(' ');
 }
 
+/****************************************************
+ * Emit the behavior-flag badges (`@nogc`, `nothrow`, `pure`, and the
+ * manual-only `no-alloc`) directly under a declaration's title.
+ *
+ * A flag is emitted automatically when the matching attribute is present on any
+ * of the documented declarations. Flag macros written manually anywhere in the
+ * comment body are moved here too. Duplicates are collapsed into one badge.
+ * Params:
+ *  buf   = buffer holding the description, which the flags are inserted into
+ *  start = the index in `buf` where the description begins
+ *  a     = the declarations sharing this documentation comment
+ */
+void emitBehaviorFlags(ref OutBuffer buf, size_t start, Dsymbols* a)
+{
+    static immutable string[4] names = ["NOALLOC", "NOGC", "NOTHROW", "PURE"];
+    bool[4] present;
+
+    bool matchAt(size_t pos, string name)
+    {
+        if (pos + 3 + name.length > buf.length || buf[pos] != '$' || buf[pos + 1] != '(')
+            return false;
+        foreach (k, ch; name)
+            if (buf[pos + 2 + k] != ch)
+                return false;
+        return buf[pos + 2 + name.length] == ')';
+    }
+
+    // Pull any manually-written flag macros out of the body.
+    for (size_t i = start; i < buf.length;)
+    {
+        bool removed = false;
+        foreach (fi, name; names)
+            if (matchAt(i, name))
+            {
+                present[fi] = true;
+                buf.remove(i, name.length + 3);
+                removed = true;
+                break;
+            }
+        if (!removed)
+            ++i;
+    }
+
+    // Add flags implied by the declarations' attributes (NOALLOC has none).
+    foreach (sym; *a)
+    {
+        if (TypeFunction tf = isTypeFunction(sym))
+        {
+            if (tf.isNogc)
+                present[1] = true;
+            if (tf.isNothrow)
+                present[2] = true;
+            if (tf.purity != PURE.impure)
+                present[3] = true;
+        }
+    }
+
+    bool any = false;
+    foreach (p; present)
+        any |= p;
+    if (!any)
+        return;
+
+    OutBuffer flags;
+    flags.writestring("$(DDOC_FLAGS ");
+    foreach (fi, name; names)
+        if (present[fi])
+        {
+            flags.writestring("$(");
+            flags.writestring(name);
+            flags.writeByte(')');
+        }
+    flags.writeByte(')');
+    buf.insert(start, flags[]);
+}
+
+unittest
+{
+    // No flags: buffer is left untouched.
+    Dsymbols a;
+    OutBuffer buf;
+    buf.writestring("no flags here");
+    emitBehaviorFlags(buf, 0, &a);
+    assert(buf[] == "no flags here");
+}
+
+unittest
+{
+    // Manual flag macros are hoisted to the front and duplicates collapsed.
+    Dsymbols a;
+    OutBuffer buf;
+    buf.writestring("text $(NOGC) more $(PURE) and $(NOGC) end");
+    emitBehaviorFlags(buf, 0, &a);
+    assert(buf[] == "$(DDOC_FLAGS $(NOGC)$(PURE))text  more  and  end");
+}
+
+unittest
+{
+    // Flags are always emitted in canonical order regardless of input order.
+    Dsymbols a;
+    OutBuffer buf;
+    buf.writestring("$(PURE)$(NOTHROW)$(NOALLOC)");
+    emitBehaviorFlags(buf, 0, &a);
+    assert(buf[] == "$(DDOC_FLAGS $(NOALLOC)$(NOTHROW)$(PURE))");
+}
+
+unittest
+{
+    // Text before `start` is not scanned or modified.
+    Dsymbols a;
+    OutBuffer buf;
+    buf.writestring("$(NOGC)|$(PURE)");
+    emitBehaviorFlags(buf, 8, &a);
+    assert(buf[] == "$(NOGC)|$(DDOC_FLAGS $(PURE))");
+}
+
 void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
 {
     extern (C++) final class EmitComment : Visitor
@@ -1439,6 +1555,7 @@ void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
                 // Put the ddoc comment as the document 'description'
                 buf.writestring(ddoc_decl_dd_s);
                 {
+                    size_t iDescStart = buf.length;
                     dc.writeSections(sc, &dc.a, *buf);
                     foreach (sym; dc.a)
                         if (ScopeDsymbol sds = sym.isScopeDsymbol())
@@ -1446,6 +1563,7 @@ void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
                             emitMemberComments(sds, *buf, sc);
                             break;
                         }
+                    emitBehaviorFlags(*buf, iDescStart, &dc.a);
                 }
                 buf.writestring(ddoc_decl_dd_e);
                 buf.writeByte(')');

--- a/compiler/src/dmd/res/default_ddoc_theme.ddoc
+++ b/compiler/src/dmd/res/default_ddoc_theme.ddoc
@@ -65,6 +65,12 @@ YELLOW = <span class="color_yellow">$0</span>
 BLACK = <span class="color_black">$0</span>
 WHITE = <span class="color_white">$0</span>
 
+NOALLOC = <span class="ddoc_flag ddoc_flag_noalloc" title="Does not allocate">no&#8209;alloc</span>
+NOGC = <span class="ddoc_flag ddoc_flag_nogc" title="Does not use the garbage collector">@nogc</span>
+NOTHROW = <span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span>
+PURE = <span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span>
+DDOC_FLAGS = <div class="ddoc_flags">$0</div>$(LF)
+
 D_CODE =
 <section class="code_listing">
   <div class="code_sample">
@@ -163,6 +169,32 @@ DDOC =
       .color_yellow { color: #b58901; }
       .color_black { color: black; }
       .color_white { color: white; }
+
+      .ddoc_flags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin: 6px 0 4px;
+      }
+
+      .ddoc_flag {
+        display: inline-block;
+        margin: 2px 4px 2px 0;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-family: Menlo, monospace;
+        font-size: 11px;
+        font-weight: bold;
+        line-height: 1.6;
+        color: #ffffff;
+        white-space: nowrap;
+        vertical-align: middle;
+      }
+
+      .ddoc_flag_noalloc { background-color: #8e44ad; }
+      .ddoc_flag_nogc    { background-color: #d33682; }
+      .ddoc_flag_nothrow { background-color: #859901; }
+      .ddoc_flag_pure    { background-color: #268bd2; }
 
       .font_big {
         font-size: 1.2em;

--- a/compiler/src/dmd/res/default_ddoc_theme.ddoc
+++ b/compiler/src/dmd/res/default_ddoc_theme.ddoc
@@ -65,11 +65,11 @@ YELLOW = <span class="color_yellow">$0</span>
 BLACK = <span class="color_black">$0</span>
 WHITE = <span class="color_white">$0</span>
 
-NOALLOC = <span class="ddoc_flag ddoc_flag_noalloc" title="Does not allocate">no&#8209;alloc</span>
-NOGC = <span class="ddoc_flag ddoc_flag_nogc" title="Does not use the garbage collector">@nogc</span>
-NOTHROW = <span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span>
-PURE = <span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span>
-DDOC_FLAGS = <div class="ddoc_flags">$0</div>$(LF)
+NOALLOC = <span class="ddoc_flag ddoc_flag_noalloc" title="Does not allocate">No Allocations</span>
+NOGC = <span class="ddoc_flag ddoc_flag_nogc" title="Does not use the garbage collector">No GC</span>
+NOTHROW = <span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span>
+PURE = <span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span>
+DDOC_FLAGS = <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span>$0</div>$(LF)
 
 D_CODE =
 <section class="code_listing">
@@ -174,7 +174,14 @@ DDOC =
         display: flex;
         flex-wrap: wrap;
         gap: 6px;
-        margin: 6px 0 4px;
+        margin: 0px 5px 5px 5px;
+      }
+
+      .ddoc_flags_label {
+        align-self: center;
+        font-weight: bold;
+        font-size: 11px;
+        margin-right: 2px;
       }
 
       .ddoc_flag {

--- a/compiler/src/dmd/res/default_ddoc_theme.ddoc
+++ b/compiler/src/dmd/res/default_ddoc_theme.ddoc
@@ -69,7 +69,7 @@ NOALLOC = <span class="ddoc_flag ddoc_flag_noalloc" title="Does not allocate">No
 NOGC = <span class="ddoc_flag ddoc_flag_nogc" title="Does not use the garbage collector">No GC</span>
 NOTHROW = <span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span>
 PURE = <span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span>
-DDOC_FLAGS = <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span>$0</div>$(LF)
+DDOC_FLAGS = <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span>$0</div>$(LF)
 
 D_CODE =
 <section class="code_listing">

--- a/compiler/test/compilable/extra-files/ddoc10.html
+++ b/compiler/test/compilable/extra-files/ddoc10.html
@@ -582,7 +582,8 @@ void <code class="code">map2</code>()(int <code class="code">rs</code>);
   </section>
 </div>
 <div class="ddoc_decl">
-  
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+
 
 </div>
 
@@ -607,7 +608,8 @@ void <code class="code">map2</code>()(int <code class="code">rs</code>);
   </section>
 </div>
 <div class="ddoc_decl">
-  
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+
 
 </div>
 

--- a/compiler/test/compilable/extra-files/ddoc10.html
+++ b/compiler/test/compilable/extra-files/ddoc10.html
@@ -582,7 +582,7 @@ void <code class="code">map2</code>()(int <code class="code">rs</code>);
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 
 
 </div>
@@ -608,7 +608,7 @@ void <code class="code">map2</code>()(int <code class="code">rs</code>);
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 
 
 </div>

--- a/compiler/test/compilable/extra-files/ddoc10.html
+++ b/compiler/test/compilable/extra-files/ddoc10.html
@@ -582,7 +582,7 @@ void <code class="code">map2</code>()(int <code class="code">rs</code>);
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 
 
 </div>
@@ -608,7 +608,7 @@ void <code class="code">map2</code>()(int <code class="code">rs</code>);
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 
 
 </div>

--- a/compiler/test/compilable/extra-files/ddoc14.html
+++ b/compiler/test/compilable/extra-files/ddoc14.html
@@ -117,7 +117,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     2
@@ -149,7 +150,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     3
@@ -181,7 +183,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     5
@@ -213,7 +216,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     6
@@ -245,7 +249,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     7
@@ -277,7 +282,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     9
@@ -309,7 +315,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     10
@@ -440,7 +447,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     2
@@ -472,7 +480,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     3
@@ -504,7 +513,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     5
@@ -536,7 +546,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     6
@@ -568,7 +579,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     7
@@ -600,7 +612,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     9
@@ -632,7 +645,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     10
@@ -733,7 +747,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     2
@@ -765,7 +780,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     3
@@ -797,7 +813,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     5
@@ -829,7 +846,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     6
@@ -861,7 +879,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     7
@@ -893,7 +912,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     9
@@ -925,7 +945,8 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <section class="section ddoc_sections">
+  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+<section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
     10

--- a/compiler/test/compilable/extra-files/ddoc14.html
+++ b/compiler/test/compilable/extra-files/ddoc14.html
@@ -117,7 +117,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -150,7 +150,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -183,7 +183,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -216,7 +216,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -249,7 +249,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -282,7 +282,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -315,7 +315,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -447,7 +447,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -480,7 +480,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -513,7 +513,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -546,7 +546,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -579,7 +579,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -612,7 +612,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -645,7 +645,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -747,7 +747,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -780,7 +780,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -813,7 +813,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -846,7 +846,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -879,7 +879,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -912,7 +912,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -945,7 +945,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">nothrow</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">

--- a/compiler/test/compilable/extra-files/ddoc14.html
+++ b/compiler/test/compilable/extra-files/ddoc14.html
@@ -117,7 +117,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -150,7 +150,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -183,7 +183,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -216,7 +216,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -249,7 +249,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -282,7 +282,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -315,7 +315,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -447,7 +447,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -480,7 +480,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -513,7 +513,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -546,7 +546,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -579,7 +579,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -612,7 +612,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -645,7 +645,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -747,7 +747,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -780,7 +780,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -813,7 +813,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -846,7 +846,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -879,7 +879,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -912,7 +912,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
@@ -945,7 +945,7 @@
   </section>
 </div>
 <div class="ddoc_decl">
-  <div class="ddoc_flags"><span class="ddoc_flags_label">Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
+  <div class="ddoc_flags"><span class="ddoc_flags_label">Current Behaviors:</span><span class="ddoc_flag ddoc_flag_nothrow" title="Does not throw exceptions">No Exceptions Thrown</span><span class="ddoc_flag ddoc_flag_pure" title="Has no observable side effects">Is Pure</span></div>
 <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">

--- a/compiler/test/compilable/extra-files/ddocYear.html
+++ b/compiler/test/compilable/extra-files/ddocYear.html
@@ -68,7 +68,14 @@
         display: flex;
         flex-wrap: wrap;
         gap: 6px;
-        margin: 6px 0 4px;
+        margin: 0px 5px 5px 5px;
+      }
+
+      .ddoc_flags_label {
+        align-self: center;
+        font-weight: bold;
+        font-size: 11px;
+        margin-right: 2px;
       }
 
       .ddoc_flag {

--- a/compiler/test/compilable/extra-files/ddocYear.html
+++ b/compiler/test/compilable/extra-files/ddocYear.html
@@ -64,6 +64,32 @@
       .color_black { color: black; }
       .color_white { color: white; }
 
+      .ddoc_flags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin: 6px 0 4px;
+      }
+
+      .ddoc_flag {
+        display: inline-block;
+        margin: 2px 4px 2px 0;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-family: Menlo, monospace;
+        font-size: 11px;
+        font-weight: bold;
+        line-height: 1.6;
+        color: #ffffff;
+        white-space: nowrap;
+        vertical-align: middle;
+      }
+
+      .ddoc_flag_noalloc { background-color: #8e44ad; }
+      .ddoc_flag_nogc    { background-color: #d33682; }
+      .ddoc_flag_nothrow { background-color: #859901; }
+      .ddoc_flag_pure    { background-color: #268bd2; }
+
       .font_big {
         font-size: 1.2em;
       }
@@ -543,7 +569,7 @@
   <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
-    __YEAR__
+    2026
   </p>
 </div>
 

--- a/compiler/test/compilable/extra-files/ddocYear.html
+++ b/compiler/test/compilable/extra-files/ddocYear.html
@@ -569,7 +569,7 @@
   <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
-    2026
+    __YEAR__
   </p>
 </div>
 

--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -853,6 +853,46 @@ To prevent unintended emphasis of an identifier, it can be preceded by
 an underscore ($(UNDERSCORE)). The underscore will be stripped from the output.
 )
 
+$(H3 $(LNAME2 behavior_flags, Behavior Flags))
+
+$(P
+Functions can advertise behavioral guarantees with badge-like $(I behavior flags)
+that are displayed under the declaration, similar to the build-status badges
+seen in project READMEs. Four flags are available: `$(DOLLAR)(NOALLOC)` (does not
+allocate), `$(DOLLAR)(NOGC)` (is `@nogc`), `$(DOLLAR)(NOTHROW)` (is `nothrow`)
+and `$(DOLLAR)(PURE)` (is `pure`). Each flag is shown only when it applies, and
+each is rendered in a distinct color.
+)
+
+$(P
+The `$(DOLLAR)(NOGC)`, `$(DOLLAR)(NOTHROW)` and `$(DOLLAR)(PURE)` flags are
+emitted automatically when the corresponding `@nogc`, `nothrow` or `pure`
+attribute is present on the documented declaration. The `$(DOLLAR)(NOALLOC)` flag
+has no corresponding language attribute and is only shown when written manually.
+)
+
+$(P
+Any flag may also be written manually anywhere in a documentation comment.
+Manually-written flags are moved to appear under the declaration's title, and
+duplicate flags $(MDASH) whether written manually or added automatically from an
+attribute $(MDASH) are collapsed into a single badge.
+)
+
+------------------------------------
+/++
+Copy `n` bytes.
+
+$(DOLLAR)(NOALLOC)
++/
+void* fastCopy(void* dst, const(void)* src, size_t n) @nogc nothrow pure;
+------------------------------------
+
+$(P
+The example above renders a `no-alloc` badge (written manually) next to the
+`@nogc`, `nothrow` and `pure` badges (added automatically from the attributes),
+all shown under the function's title.
+)
+
 $(H3 $(LNAME2 character_entities, Character Entities))
 
 $(P
@@ -1083,6 +1123,10 @@ $(P
     $(TROW $(ARGS $(D YELLOW)), $(ARGS argument is set to be yellow))
     $(TROW $(ARGS $(D BLACK)), $(ARGS argument is set to be black))
     $(TROW $(ARGS $(D WHITE)), $(ARGS argument is set to be white))
+    $(TROW $(ARGS $(D NOALLOC)), $(ARGS behavior flag badge: does not allocate))
+    $(TROW $(ARGS $(D NOGC)), $(ARGS behavior flag badge: $(D @nogc)))
+    $(TROW $(ARGS $(D NOTHROW)), $(ARGS behavior flag badge: $(D nothrow)))
+    $(TROW $(ARGS $(D PURE)), $(ARGS behavior flag badge: $(D pure)))
     $(TROW $(ARGS $(D D_CODE)), $(ARGS argument is D code))
     $(TROW $(ARGS $(D D_INLINECODE)), $(ARGS argument is inline D code))
     $(TROW $(ARGS $(D LF)), $(ARGS Insert a line feed (newline)))
@@ -1198,6 +1242,7 @@ $(P
     $(TROW $(ARGS $(D DDOC_KEYWORD)), $(ARGS Highlighting of D keywords.))
     $(TROW $(ARGS $(D DDOC_PARAM)), $(ARGS Highlighting of function parameters.))
     $(TROW $(ARGS $(D DDOC_BACKQUOTED)), $(ARGS Inserts inline code.))
+    $(TROW $(ARGS $(D DDOC_FLAGS)), $(ARGS Container for the behavior flag badges emitted under a declaration.))
     $(TROW $(ARGS $(D DDOC_AUTO_PSYMBOL_SUPPRESS)), $(ARGS Highlighting of auto-detected symbol that starts with underscore))
     $(TROW $(ARGS $(D DDOC_AUTO_PSYMBOL)), $(ARGS Highlighting of auto-detected symbol))
     $(TROW $(ARGS $(D DDOC_AUTO_KEYWORD)), $(ARGS Highlighting of auto-detected keywords))

--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -859,7 +859,7 @@ $(P
 Functions can advertise behavioral guarantees with badge-like $(I behavior flags)
 that are displayed under the declaration, similar to the build-status badges
 seen in project READMEs. When any are present, the badges are introduced by a
-$(D Behaviors:) label. Four flags are available: `$(DOLLAR)(NOALLOC)` (rendered
+$(D Current Behaviors:) label. Four flags are available: `$(DOLLAR)(NOALLOC)` (rendered
 $(I No Allocations)), `$(DOLLAR)(NOGC)` (rendered $(I No GC)),
 `$(DOLLAR)(NOTHROW)` (rendered $(I No Exceptions Thrown)) and `$(DOLLAR)(PURE)`
 (rendered $(I Is Pure)). Each flag is shown only when it applies, and each is
@@ -893,7 +893,7 @@ $(P
 The example above renders a $(I No Allocations) badge (written manually) next to
 the $(I No GC), $(I No Exceptions Thrown) and $(I Is Pure) badges (added
 automatically from the attributes), all shown under the function's title after a
-$(D Behaviors:) label.
+$(D Current Behaviors:) label.
 )
 
 $(H3 $(LNAME2 character_entities, Character Entities))

--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -858,10 +858,12 @@ $(H3 $(LNAME2 behavior_flags, Behavior Flags))
 $(P
 Functions can advertise behavioral guarantees with badge-like $(I behavior flags)
 that are displayed under the declaration, similar to the build-status badges
-seen in project READMEs. Four flags are available: `$(DOLLAR)(NOALLOC)` (does not
-allocate), `$(DOLLAR)(NOGC)` (is `@nogc`), `$(DOLLAR)(NOTHROW)` (is `nothrow`)
-and `$(DOLLAR)(PURE)` (is `pure`). Each flag is shown only when it applies, and
-each is rendered in a distinct color.
+seen in project READMEs. When any are present, the badges are introduced by a
+$(D Behaviors:) label. Four flags are available: `$(DOLLAR)(NOALLOC)` (rendered
+$(I No Allocations)), `$(DOLLAR)(NOGC)` (rendered $(I No GC)),
+`$(DOLLAR)(NOTHROW)` (rendered $(I No Exceptions Thrown)) and `$(DOLLAR)(PURE)`
+(rendered $(I Is Pure)). Each flag is shown only when it applies, and each is
+rendered in a distinct color.
 )
 
 $(P
@@ -888,9 +890,10 @@ void* fastCopy(void* dst, const(void)* src, size_t n) @nogc nothrow pure;
 ------------------------------------
 
 $(P
-The example above renders a `no-alloc` badge (written manually) next to the
-`@nogc`, `nothrow` and `pure` badges (added automatically from the attributes),
-all shown under the function's title.
+The example above renders a $(I No Allocations) badge (written manually) next to
+the $(I No GC), $(I No Exceptions Thrown) and $(I Is Pure) badges (added
+automatically from the attributes), all shown under the function's title after a
+$(D Behaviors:) label.
 )
 
 $(H3 $(LNAME2 character_entities, Character Entities))
@@ -1123,10 +1126,10 @@ $(P
     $(TROW $(ARGS $(D YELLOW)), $(ARGS argument is set to be yellow))
     $(TROW $(ARGS $(D BLACK)), $(ARGS argument is set to be black))
     $(TROW $(ARGS $(D WHITE)), $(ARGS argument is set to be white))
-    $(TROW $(ARGS $(D NOALLOC)), $(ARGS behavior flag badge: does not allocate))
-    $(TROW $(ARGS $(D NOGC)), $(ARGS behavior flag badge: $(D @nogc)))
-    $(TROW $(ARGS $(D NOTHROW)), $(ARGS behavior flag badge: $(D nothrow)))
-    $(TROW $(ARGS $(D PURE)), $(ARGS behavior flag badge: $(D pure)))
+    $(TROW $(ARGS $(D NOALLOC)), $(ARGS behavior flag badge for functions that do not allocate))
+    $(TROW $(ARGS $(D NOGC)), $(ARGS behavior flag badge for $(D @nogc) functions))
+    $(TROW $(ARGS $(D NOTHROW)), $(ARGS behavior flag badge for $(D nothrow) functions))
+    $(TROW $(ARGS $(D PURE)), $(ARGS behavior flag badge for $(D pure) functions))
     $(TROW $(ARGS $(D D_CODE)), $(ARGS argument is D code))
     $(TROW $(ARGS $(D D_INLINECODE)), $(ARGS argument is inline D code))
     $(TROW $(ARGS $(D LF)), $(ARGS Insert a line feed (newline)))


### PR DESCRIPTION
This PR adds behavior flags to DDoc output for the `@nogc`, `nothrow`, and `pure` attributes, as well as adding a new `noalloc` flag for stating that no allocations of any kind are performed.

The flags will be added automatically when the attributes are present or added manually in the documentation comments. Flags are de-duplicated.


LLM Prompts:

- I would like to add four new Macros (or Markup-tags?) to DDoc (See: doc.d ): NOALLOC, NOGC, NOTHROW, PURE. These tags should then generate a "flag" in the documentation output. These behavior flags can look similar to the "build status tags found in GitHub readmes, each should only be displayed when specified, and each should be a different color to aid in quickly determining what behaviors are offered.
- Next let's automatically add these flags when the corresponding attribute is encountered in the code (with the exception of the NOALLOC flag, which has no attribute). We need to continue to allow the programmer to manually add these flags to the doc comments, but they should always be emitted under the "title" of the doc section regardless of where it is used in the documentation comments. Duplicates should be collapsed into a single output.
- Finally we need to add unittests where possible and then run them, then build DMD and run the ddoc generation against the DRuntime so that we see the final behavior flag layout.

Screen capture of the output:
<img width="1928" height="982" alt="image" src="https://github.com/user-attachments/assets/a283b7cc-06c0-4aa8-ac29-12aa9625a0b8" />