### PR TITLE
Fix memory allocation failed regression introduced by #22766

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -2907,7 +2907,8 @@ public:
             for (ClassDeclaration c = cd; c; c = c.baseClass)
                 totalFieldCount += c.fields.length;
 
-            totalFieldCount -= cd.hasMonitor(); // skip __monitor field
+            if (totalFieldCount)
+                totalFieldCount -= cd.hasMonitor(); // skip __monitor field
 
             auto elems = new Expressions(totalFieldCount);
             ptrdiff_t fieldsSoFar = totalFieldCount;

--- a/compiler/test/compilable/reg22766.d
+++ b/compiler/test/compilable/reg22766.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+C22766()
+---
+*/
+module object;
+
+class C22766 { }
+
+pragma(msg, new C22766);


### PR DESCRIPTION
When `Object` doesn't exist, there is no `__monitor` field to skip.

```
core.exception.OutOfMemoryError@src/dmd/root/rmem.d(103): Memory allocation failed
----------------
??:? onOutOfMemoryError [0x5a5c859d445c]
src/dmd/root/rmem.d:103 _ZN3Mem5errorEv [0x5a5c858a316b]
src/dmd/root/rmem.d:117 _ZN3Mem5checkEPv [0x5a5c858a3189]
src/dmd/root/rmem.d:46 _ZN3Mem7xmallocEm [0x5a5c858a2f76]
/home/ibuclaw/src/dlang/dmd/compiler/src/dmd/root/array.d:182 pure nothrow void dmd.root.array.Array!(dmd.expression.Expression).Array.reserve(ulong).enlarge(ulong) [0x5a5c8558fd8a]
/home/ibuclaw/src/dlang/dmd/compiler/src/dmd/root/array.d:239 _ZN5ArrayIP10ExpressionE7reserveEm [0x5a5c8558fd35]
/home/ibuclaw/src/dlang/dmd/compiler/src/dmd/root/array.d:46 _ZN5ArrayIP10ExpressionEC1Em [0x5a5c8558fb33]
src/dmd/dinterpret.d:2873 _ZN11Interpreter5visitEP6NewExp [0x5a5c8566b068]
```