### PR TITLE
Fix unclear "cannot uniquely infer foreach argument types" diagnostic

### DIFF
--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1564,6 +1564,72 @@ private FuncDeclaration findBestOpApplyMatch(Expression ethis, FuncDeclaration f
     return fd_best;
 }
 
+/**
+ * Print supplemental diagnostics explaining why no `opApply` overload
+ * matched the `foreach` statement's parameters, to clarify the generic
+ * "cannot uniquely infer foreach argument types" error (issue 19465).
+ * Only call this when no more-specific error (e.g. ambiguity) was
+ * already printed for the same failure.
+ * Params:
+ *      fstart = first opApply overload (start of overload chain)
+ *      parameters = foreach parameters, as written (types may be missing)
+ *      aggrMod = mutability qualifier of the foreach aggregate
+ */
+void explainForeachArgMismatch(FuncDeclaration fstart, Parameters* parameters, MOD aggrMod)
+{
+    auto eSink = global.errorSink;
+    const nGiven = parameters.length;
+
+    overloadApply(fstart, (Dsymbol s)
+    {
+        auto f = s.isFuncDeclaration();
+        if (!f)
+            return 0;
+        auto tf = f.type.isTypeFunction();
+        if (tf.parameterList.length < 1)
+            return 0;
+        auto de = tf.parameterList[0].type.isTypeDelegate();
+        if (!de)
+            return 0;
+        auto tdg = de.next.isTypeFunction();
+        const nExpected = tdg.parameterList.length;
+
+        if (f.isThis() && !MODimplicitConv(aggrMod, tf.mod))
+        {
+            eSink.errorSupplemental(f.loc, "`%s` is not callable using a `%s` aggregate",
+                tf.toChars(), MODtoChars(aggrMod));
+            return 0;
+        }
+
+        if (nExpected != nGiven)
+        {
+            const(char)* plural = nExpected > 1 ? "s" : "";
+            eSink.errorSupplemental(f.loc, "`%s` expects %llu argument%s, not %llu",
+                tf.toChars(), cast(ulong) nExpected, plural, cast(ulong) nGiven);
+            return 0;
+        }
+
+        bool headerPrinted = false;
+        foreach (u, p; *parameters)
+        {
+            if (!p.type)
+                continue;
+            Parameter param = tdg.parameterList[u];
+            if (!p.type.equals(param.type))
+            {
+                if (!headerPrinted)
+                {
+                    eSink.errorSupplemental(f.loc, "`%s`:", tf.toChars());
+                    headerPrinted = true;
+                }
+                eSink.errorSupplemental(f.loc, "    parameter %llu: `foreach` declares `%s`, expected `%s`",
+                    cast(ulong)(u + 1), p.type.toErrMsg(), param.type.toErrMsg());
+            }
+        }
+        return 0;
+    });
+}
+
 /******************************
  * Determine if foreach parameters match opApply parameters.
  * Infer missing foreach parameter types from type of opApply delegate.

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1564,16 +1564,13 @@ private FuncDeclaration findBestOpApplyMatch(Expression ethis, FuncDeclaration f
     return fd_best;
 }
 
-/**
- * Print supplemental diagnostics explaining why no `opApply` overload
- * matched the `foreach` statement's parameters, to clarify the generic
- * "cannot uniquely infer foreach argument types" error (issue 19465).
- * Only call this when no more-specific error (e.g. ambiguity) was
- * already printed for the same failure.
+/******************************
+ * Print supplemental messages explaining why no opApply overload
+ * matched the foreach parameters.
  * Params:
- *      fstart = first opApply overload (start of overload chain)
- *      parameters = foreach parameters, as written (types may be missing)
- *      aggrMod = mutability qualifier of the foreach aggregate
+ *      fstart = first opApply overload
+ *      parameters = foreach parameters
+ *      aggrMod = mutability of the foreach aggregate
  */
 void explainForeachArgMismatch(FuncDeclaration fstart, Parameters* parameters, MOD aggrMod)
 {

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1614,15 +1614,13 @@ void explainForeachArgMismatch(FuncDeclaration fstart, Parameters* parameters, M
             Parameter param = tdg.parameterList[u];
             if (p.type.equals(param.type))
                 continue;
+            if (!headerPrinted)
             {
-                if (!headerPrinted)
-                {
-                    eSink.errorSupplemental(f.loc, "`%s`:", tf.toChars());
-                    headerPrinted = true;
-                }
-                eSink.errorSupplemental(f.loc, "    parameter %llu: `foreach` declares `%s`, expected `%s`",
-                    cast(ulong)(u + 1), p.type.toErrMsg(), param.type.toErrMsg());
+                eSink.errorSupplemental(f.loc, "`%s`:", tf.toChars());
+                headerPrinted = true;
             }
+            eSink.errorSupplemental(f.loc, "    parameter %llu: `foreach` declares `%s`, expected `%s`",
+                cast(ulong)(u + 1), p.type.toErrMsg(), param.type.toErrMsg());
         }
         return 0;
     });

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1612,7 +1612,8 @@ void explainForeachArgMismatch(FuncDeclaration fstart, Parameters* parameters, M
             if (!p.type)
                 continue;
             Parameter param = tdg.parameterList[u];
-            if (!p.type.equals(param.type))
+            if (p.type.equals(param.type))
+                continue;
             {
                 if (!headerPrinted)
                 {

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -864,6 +864,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         Dsymbol sapplyOld = sapply; // 'sapply' will be NULL if and after 'inferApplyArgTypes' errors
 
         /* Check for inference errors and apply modifier checks inline */
+        const errorsBeforeInfer = global.errors;
         if (!inferApplyArgTypes(fs, sc, sapply))
         {
             bool foundMismatch = false;
@@ -911,7 +912,13 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     cast(ulong) foreachParamCount, plural, cast(ulong) dim);
             }
             else
+            {
+                const bool alreadyExplained = global.errors > errorsBeforeInfer;
                 eSink.error(fs.loc, "cannot uniquely infer `foreach` argument types");
+                if (!alreadyExplained && sapplyOld)
+                    if (auto fd = sapplyOld.isFuncDeclaration())
+                        explainForeachArgMismatch(fd, fs.parameters, fs.aggr.type.mod);
+            }
 
             return setError();
         }

--- a/compiler/test/fail_compilation/test19465.d
+++ b/compiler/test/fail_compilation/test19465.d
@@ -1,0 +1,31 @@
+// https://issues.dlang.org/show_bug.cgi?id=19465
+
+/*
+REQUIRED_ARGS: -verrors=context
+TEST_OUTPUT:
+---
+fail_compilation/test19465.d(30): Error: cannot uniquely infer `foreach` argument types
+    foreach (string x; s) {}
+    ^
+fail_compilation/test19465.d(21):        `int(int delegate(int) dg)`:
+    int opApply(int delegate(int) dg)
+        ^
+fail_compilation/test19465.d(21):            parameter 1: `foreach` declares `string`, expected `int`
+    int opApply(int delegate(int) dg)
+        ^
+---
+*/
+
+struct S
+{
+    int opApply(int delegate(int) dg)
+    {
+        return 0;
+    }
+}
+
+void test()
+{
+    S s;
+    foreach (string x; s) {}
+}

--- a/compiler/test/fail_compilation/test24353.d
+++ b/compiler/test/fail_compilation/test24353.d
@@ -4,21 +4,27 @@
 REQUIRED_ARGS: -verrors=context
 TEST_OUTPUT:
 ---
-fail_compilation/test24353.d(37): Error: mutable method `test24353.S.opApply` is not callable using a `const(S)` foreach aggregate
+fail_compilation/test24353.d(43): Error: mutable method `test24353.S.opApply` is not callable using a `const(S)` foreach aggregate
     foreach (e; s) {} // mod error
                 ^
-fail_compilation/test24353.d(28):        Consider adding a method type qualifier here
+fail_compilation/test24353.d(34):        Consider adding a method type qualifier here
     int opApply(int delegate(int) dg)
         ^
-fail_compilation/test24353.d(40): Error:  shared const method `test24353.S2.opApply` is not callable using a `const(S2)` foreach aggregate
+fail_compilation/test24353.d(46): Error:  shared const method `test24353.S2.opApply` is not callable using a `const(S2)` foreach aggregate
     foreach (i, e; s2) {} // mod error
                    ^
-fail_compilation/test24353.d(47):        Consider adding a method type qualifier here
+fail_compilation/test24353.d(53):        Consider adding a method type qualifier here
     int opApply(int delegate(int, int) dg) const shared;
         ^
-fail_compilation/test24353.d(42): Error: cannot uniquely infer `foreach` argument types
+fail_compilation/test24353.d(48): Error: cannot uniquely infer `foreach` argument types
     foreach (i, e; const S3()) {} // cannot infer
     ^
+fail_compilation/test24353.d(58):        `int(int delegate(int) dg)` is not callable using a `const` aggregate
+    int opApply(int delegate(int) dg);
+        ^
+fail_compilation/test24353.d(59):        `int(int delegate(int, int) dg)` is not callable using a `const` aggregate
+    int opApply(int delegate(int, int) dg);
+        ^
 ---
 */
 


### PR DESCRIPTION
Fixes #19465
