### PR TITLE
[spec/type] List `.` operator under Pointers

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1827,7 +1827,7 @@ $(TABLE
         * Access a $(DDLINK spec/property, Properties, property) of a type or expression.
         * Access a member of a module, package, aggregate type or instance, enum
           or template instance.
-        * Dereference a $(DDSUBLINK spec/struct, struct-pointer, pointer to a struct/union)
+        * Dereference a $(DDSUBLINK spec/struct, struct-pointer, pointer to an aggregate type)
           instance and access a member of it.
         * Call a free function using $(DDSUBLINK spec/function, pseudo-member, UFCS).
     )

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -81,7 +81,6 @@ $(H3 $(LNAME2 storage, Storage))
     assert(q.i == 2); // q points to the same struct instance as p
     ---
     )
-    $(NOTE There is no `->` operator as in C.)
     )
 
     $(P **See also:** $(RELATIVE_LINK2 struct_layout, Struct Layout).)

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -234,11 +234,10 @@ assert(*p == 6);
         or point to a valid instance of type $(I T).)
 
         $(IMPLEMENTATION_DEFINED
-        $(OL
-        $(LI The behavior when a $(I null) pointer is dereferenced. Typically the program
+        The behavior when a $(I null) pointer is dereferenced. Typically the program
         will be aborted - $(DDSUBLINK spec/function, null-dereferences, that is required)
         in `@safe` code.)
-        ))
+        )
 
         $(UNDEFINED_BEHAVIOR dereferencing a pointer that is not $(I null) and does not point
         to a valid instance of type $(I T).)
@@ -257,14 +256,20 @@ assert(*p == 2);
 assert(i == 4);
 ---------
 )
+        $(P The `.` operator will dereference a
+        $(DDSUBLINK spec/struct, struct-pointer, pointer to an aggregate type) instance
+        and access a member of it.)
+
+        $(NOTE There is no `->` operator as in C.)
+
         $(P See also:)
         * $(DDSUBLINK spec/expression, pointer_arithmetic, Pointer Arithmetic)
         * $(DDSUBLINK spec/expression, slice_expressions, Pointer Slicing)
         * $(RELATIVE_LINK2 pointer-conversions, Pointer Conversions)
 
-        $(BEST_PRACTICE Use a $(DDSUBLINK spec/function, ref-params,
+        $(BEST_PRACTICE Consider using a $(DDSUBLINK spec/function, ref-params,
         `ref` function parameter) or a $(DDSUBLINK spec/declaration, ref-variables,
-        `ref` local variable) when the address doesn't escape.)
+        `ref` local variable) instead when the pointer address doesn't escape.)
 
 
 $(H2 $(LEGACY_LNAME2 User Defined Types, user-defined-types, User-Defined Types))


### PR DESCRIPTION
It works on a pointer to an aggregate type, including class/interface, not just struct/union.
Move note about `->` operator.
Tweak best practice `ref` wording.