### PR TITLE
ci: Fail fast on pre-commit violations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  call-precommit:
+    uses: ./.github/workflows/pre_commit.yml
+
   main:
+    needs: call-precommit
     strategy:
       fail-fast: false
       matrix:
@@ -183,6 +187,7 @@ jobs:
         run: ci/run.sh codecov
 
   freebsd-vm:
+    needs: call-precommit
     strategy:
       fail-fast: false
       matrix:
@@ -285,6 +290,7 @@ jobs:
         run: echo 'FreeBSD VM check made optional because of random time outs'
 
   arm-qemu:
+    needs: call-precommit
     name: 'Ubuntu 24.04 x64, DMD (AArch64 cross-compile via QEMU)'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -10,6 +10,7 @@ on:
       - master
       - stable
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
### Summary
This PR refactors the CI workflows to improve efficiency and maintainability by extracting the pre-commit checks into a reusable workflow and making the main build matrix dependent on its success.

### Motivation & Benefits
1. **Fail-Fast Mechanism:** Currently, the heavy build matrix (Linux, macOS, Windows, FreeBSD with multiple compilers) starts immediately on every PR. If a PR fails a basic pre-commit check (e.g., changelog formatting), it wastes 20-60 minutes of CI time before failing. With this change, the `main` job is blocked (`needs: call-precommit`) until pre-commit checks pass, catching trivial errors in ~1 minute.
2. **Resource Efficiency:** By preventing the heavy matrix from running on PRs that will inevitably fail basic linting/formatting rules, we save GitHub Actions minutes and reduce the CI queue load for other contributors.
3. **Zero Logic Change:** This is purely an orchestration refactoring. The actual commands, tools, and validation rules remain exactly the same. The risk of regression is minimal.

