### PR TITLE
Removes runtime swapContext type detection

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -65,17 +65,6 @@ version (GNU)
     import gcc.builtins;
 }
 
-/**
- * Hook for whatever EH implementation is used to save/restore some data
- * per stack.
- *
- * Params:
- *     newContext = The return value of the prior call to this function
- *         where the stack was last swapped out, or null when a fiber stack
- *         is switched in for the first time.
- */
-package extern(C) void* _d_eh_swapContext(void* newContext) nothrow @nogc;
-
 extern(D) void* swapContext(void* newContext) nothrow @nogc => swapContextImpl(newContext);
 
 /**

--- a/druntime/src/core/thread/posix_impl.d
+++ b/druntime/src/core/thread/posix_impl.d
@@ -112,48 +112,10 @@ version (GNU)
     import gcc.builtins;
 }
 
-version (DigitalMars)
+private extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow @nogc;
+package void* swapContextImpl(void* newContext) nothrow @nogc
 {
-    extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow @nogc;
-
-    package void* swapContextImpl(void* newContext) nothrow @nogc
-    {
-        /* Detect at runtime which scheme is being used.
-         * Eventually, determine it statically.
-         */
-        static int which = 0;
-        final switch (which)
-        {
-            case 0:
-            {
-                assert(newContext == null);
-                auto p = _d_eh_swapContext(newContext);
-                auto pdwarf = _d_eh_swapContextDwarf(newContext);
-                if (p)
-                {
-                    which = 1;
-                    return p;
-                }
-                else if (pdwarf)
-                {
-                    which = 2;
-                    return pdwarf;
-                }
-                return null;
-            }
-            case 1:
-                return _d_eh_swapContext(newContext);
-            case 2:
-                return _d_eh_swapContextDwarf(newContext);
-        }
-    }
-}
-else
-{
-    package void* swapContextImpl(void* newContext) nothrow @nogc
-    {
-        return _d_eh_swapContext(newContext);
-    }
+    return _d_eh_swapContextDwarf(newContext);
 }
 
 version (WASI)

--- a/druntime/src/core/thread/windows_impl.d
+++ b/druntime/src/core/thread/windows_impl.d
@@ -47,6 +47,17 @@ version (GNU)
     import gcc.builtins;
 }
 
+/**
+ * Hook for whatever EH implementation is used to save/restore some data
+ * per stack.
+ *
+ * Params:
+ *     newContext = The return value of the prior call to this function
+ *         where the stack was last swapped out, or null when a fiber stack
+ *         is switched in for the first time.
+ */
+private extern(C) void* _d_eh_swapContext(void* newContext) nothrow @nogc;
+
 package void* swapContextImpl()(void* newContext) nothrow @nogc
 {
     return _d_eh_swapContext(newContext);


### PR DESCRIPTION
According to #16143 it seems that selection can be done by this way: any Windows -> `_d_eh_swapContext`, Posix -> `_d_eh_swapContextDwarf`?
