### PR TITLE
core.thread: Adds single-threaded Thread stub for development purposes

### DIFF
--- a/druntime/mak/COPY
+++ b/druntime/mak/COPY
@@ -48,6 +48,7 @@ COPY=\
 	$(IMPDIR)\core\internal\spinlock.d \
 	$(IMPDIR)\core\internal\string.d \
 	$(IMPDIR)\core\internal\switch_.d \
+	$(IMPDIR)\core\internal\thread.d \
 	$(IMPDIR)\core\internal\traits.d \
 	$(IMPDIR)\core\internal\utf.d \
 	$(IMPDIR)\core\internal\lifetime.d \
@@ -585,6 +586,7 @@ COPY=\
 	$(IMPDIR)\core\thread\threadbase.d \
 	$(IMPDIR)\core\thread\osthread.d \
 	$(IMPDIR)\core\thread\posix_impl.d \
+	$(IMPDIR)\core\thread\stub_impl.d \
 	$(IMPDIR)\core\thread\windows_impl.d \
 	$(IMPDIR)\core\thread\package.d \
 	\

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -45,6 +45,7 @@ SRCS=\
 	src\core\internal\spinlock.d \
 	src\core\internal\string.d \
 	src\core\internal\switch_.d \
+	src\core\internal\thread.d \
 	src\core\internal\traits.d \
 	src\core\internal\utf.d \
 	src\core\internal\lifetime.d \
@@ -566,6 +567,7 @@ SRCS=\
 	src\core\thread\threadbase.d \
 	src\core\thread\osthread.d \
 	src\core\thread\posix_impl.d \
+	src\core\thread\stub_impl.d \
 	src\core\thread\windows_impl.d \
 	src\core\thread\context.d \
 	src\core\thread\package.d \

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -1803,8 +1803,7 @@ struct Gcx
         usedSmallPages = usedLargePages = 0;
         mappedPages = 0;
         //printf("gcx = %p, self = %x\n", &this, self);
-        version (WASI) {}
-        else version (Posix)
+        version (Posix) static if(!isSingleThreaded)
         {
             import core.sys.posix.pthread : pthread_atfork;
             instance = &this;
@@ -3523,7 +3522,7 @@ Lmark:
         return IsMarked.unknown;
     }
 
-    version (Posix)
+    version (Posix) static if(!isSingleThreaded)
     {
         // A fork might happen while GC code is running in a different thread.
         // Because that would leave the GC in an inconsistent state,

--- a/druntime/src/core/internal/thread.d
+++ b/druntime/src/core/internal/thread.d
@@ -1,0 +1,6 @@
+module core.internal.thread;
+
+import core.thread;
+
+///
+enum bool isSingleThreaded = core.thread.isSingleThreaded;

--- a/druntime/src/core/thread/fiber/base.d
+++ b/druntime/src/core/thread/fiber/base.d
@@ -18,6 +18,7 @@ version(WebAssembly) {} else:
 package:
 
 import core.thread.fiber;
+import core.thread : isSingleThreaded;
 import core.thread.threadbase;
 import core.thread.threadgroup;
 import core.thread.types;
@@ -769,6 +770,7 @@ unittest
 
 
 // Multiple threads running separate fibers
+static if(!isSingleThreaded)
 unittest
 {
     auto group = new ThreadGroup();
@@ -781,6 +783,7 @@ unittest
 
 
 // Multiple threads running shared fibers
+static if(!isSingleThreaded)
 unittest
 {
     shared bool[10] locks;
@@ -987,6 +990,7 @@ unittest
 }
 
 // stress testing GC stack scanning
+static if(!isSingleThreaded)
 unittest
 {
     import core.memory;

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -26,7 +26,10 @@ import core.time;
 ///////////////////////////////////////////////////////////////////////////////
 
 version (FreeStanding)
+{
+    package enum useStub = true;
     public import core.thread.stub_impl;
+}
 else version (Posix)
     public import core.thread.posix_impl;
 else version (Windows)

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -25,7 +25,9 @@ import core.time;
 // Platform Detection and Memory Allocation
 ///////////////////////////////////////////////////////////////////////////////
 
-version (Posix)
+version (FreeStanding)
+    public import core.thread.stub_impl;
+else version (Posix)
     public import core.thread.posix_impl;
 else version (Windows)
     public import core.thread.windows_impl;
@@ -277,9 +279,9 @@ class Thread : ThreadBase
     }
 }
 
-package Thread toThread(return scope ThreadBase t) @trusted nothrow @nogc pure
+package T toThread(T : ThreadBase = Thread)(return scope ThreadBase t) @trusted nothrow @nogc pure
 {
-    return cast(Thread) cast(void*) t;
+    return cast(T) cast(void*) t;
 }
 
 private extern(D) static void thread_yield() @nogc nothrow
@@ -288,7 +290,6 @@ private extern(D) static void thread_yield() @nogc nothrow
 }
 
 ///
-static if (!isSingleThreaded)
 unittest
 {
     class DerivedThread : Thread
@@ -319,6 +320,8 @@ unittest
 }
 
 static if (!isSingleThreaded)
+{
+
 unittest
 {
     int x = 0;
@@ -330,7 +333,6 @@ unittest
     assert( x == 1 );
 }
 
-static if (!isSingleThreaded)
 unittest
 {
     enum MSG = "Test message.";
@@ -351,7 +353,6 @@ unittest
     }
 }
 
-static if (!isSingleThreaded)
 unittest
 {
     // use >pageSize to avoid stack overflow (e.g. in an syscall)
@@ -359,7 +360,6 @@ unittest
     thr.join();
 }
 
-static if (!isSingleThreaded)
 unittest
 {
     import core.memory : GC;
@@ -376,7 +376,6 @@ unittest
     t2.join();
 }
 
-static if (!isSingleThreaded)
 unittest
 {
     import core.sync.semaphore;
@@ -430,7 +429,6 @@ unittest
     }
 }
 
-static if (!isSingleThreaded)
 unittest // Bugzilla 8960
 {
     import core.sync.semaphore;
@@ -444,6 +442,8 @@ unittest // Bugzilla 8960
         auto prio = thr.priority;    // getting priority doesn't cause error
         assert(prio >= PRIORITY_MIN && prio <= PRIORITY_MAX);
     }
+}
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -910,6 +910,7 @@ extern (C) void thread_init() @nogc nothrow
 
     _mainThreadStore[] = cast(void[]) __traits(initSymbol, Thread)[];
     Thread.sm_main = attachThread((cast(Thread)_mainThreadStore.ptr).__ctor());
+    assert(Thread.sm_main !is null);
 }
 
 private alias MainThreadStore = void[__traits(classInstanceSize, Thread)];

--- a/druntime/src/core/thread/posix_impl.d
+++ b/druntime/src/core/thread/posix_impl.d
@@ -169,7 +169,7 @@ class Thread : ThreadBase
 
     static Thread getThis() @safe nothrow @nogc
     {
-        return ThreadBase.getThis().toThread;
+        return ThreadBase.getThis().toThread!Thread;
     }
 
     version (Darwin)

--- a/druntime/src/core/thread/stub_impl.d
+++ b/druntime/src/core/thread/stub_impl.d
@@ -1,12 +1,15 @@
 /// Single-threaded Thread stub
 module core.thread.stub_impl;
 
-import core.thread.osthread: toThread;
+import core.thread.osthread;
 import core.thread.threadbase;
 import core.time: Duration;
 import core.thread.types: ll_ThreadData, ThreadDescr;
 
 package(core) enum isSingleThreaded = true;
+
+static if(__traits(compiles, useStub) && useStub == true)
+{
 
 private alias ThreadID = size_t;
 private immutable assertMsg = "threading not implemented";
@@ -198,4 +201,6 @@ version (CoreDdoc) {} else
 void joinLowLevelThread(ThreadID tid) nothrow @nogc
 {
     assert(false, assertMsg);
+}
+
 }

--- a/druntime/src/core/thread/stub_impl.d
+++ b/druntime/src/core/thread/stub_impl.d
@@ -1,0 +1,201 @@
+/// Single-threaded Thread stub
+module core.thread.stub_impl;
+
+import core.thread.osthread: toThread;
+import core.thread.threadbase;
+import core.time: Duration;
+import core.thread.types: ll_ThreadData, ThreadDescr;
+
+package(core) enum isSingleThreaded = true;
+
+private alias ThreadID = size_t;
+private immutable assertMsg = "threading not implemented";
+
+version (CoreDdoc)
+    import core.thread.osthread: Thread;
+else
+class Thread : ThreadBase
+{
+    private bool started;
+    private void function() fn;
+    private void delegate() dg;
+
+    this(void function() fn, size_t sz = 0) @safe pure nothrow @nogc
+    {
+        this.fn = fn;
+    }
+
+    this(void delegate() dg, size_t sz = 0) @safe pure nothrow @nogc
+    {
+        this.dg = dg;
+    }
+
+    package this( size_t sz = 0 ) @safe pure nothrow @nogc {}
+
+    ~this() nothrow @nogc {}
+
+    static Thread getThis() @safe nothrow @nogc
+    {
+        return ThreadBase.getThis().toThread!Thread;
+    }
+
+    override final void[] savedRegisters() nothrow @nogc
+    {
+        return null;
+    }
+
+    final Thread start()
+    {
+        started = true;
+
+        return this;
+    }
+
+    override final Throwable join( bool rethrow = true )
+    {
+        if(!started)
+            return null;
+
+        if(rethrow)
+            run();
+        else
+        {
+            try
+                run();
+            catch(Exception e)
+                return e;
+        }
+
+        return null;
+    }
+
+    private void run()
+    {
+        if(dg !is null)
+        {
+            dg();
+            dg = null;
+        }
+        else if(fn !is null)
+        {
+            fn();
+            fn = null;
+        }
+    }
+
+    @property static int PRIORITY_MIN() @nogc nothrow pure @trusted
+    {
+        assert(false, assertMsg);
+    }
+
+    @property static const(int) PRIORITY_MAX() @nogc nothrow pure @trusted
+    {
+        assert(false, assertMsg);
+    }
+
+    @property static int PRIORITY_DEFAULT() @nogc nothrow pure @trusted
+    {
+        assert(false, assertMsg);
+    }
+
+    final @property int priority()
+    {
+        assert(false, assertMsg);
+    }
+
+    final @property void priority( int val )
+    {
+        assert(false, assertMsg);
+    }
+
+    override final @property bool isRunning() nothrow @nogc => true;
+
+    static void sleep( Duration val ) @nogc nothrow @trusted
+    {}
+
+    static void yield() @nogc nothrow
+    {
+        assert(false, assertMsg);
+    }
+
+    package static ThreadDescr getCurrentThreadDescr() nothrow @nogc
+    {
+        return ThreadDescr.init;
+    }
+
+    package static void afterDeploy() nothrow @nogc {}
+}
+
+// Returns true on success
+package bool suspendThreadImpl(Thread t) @nogc nothrow
+{
+    assert(false, assertMsg);
+}
+
+// Returns true on success
+package bool resumeThreadImpl(Thread t) @nogc nothrow
+{
+    assert(false, assertMsg);
+}
+
+package void afterStopTheWorld(bool suspendedSelf, size_t cnt) @nogc nothrow
+{
+    assert(false, assertMsg);
+}
+
+package void loadStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
+{}
+
+package void purgeStackAndRegInfo(Thread t, const bool sameThread) nothrow @nogc
+{}
+
+package auto gettid() => ThreadID.init;
+
+version (Posix)
+    import thirdParty = core.thread.posix_impl;
+else version (Windows)
+    import thirdParty = core.thread.windows_impl;
+else
+    static assert(false, "Platform not supported.");
+
+alias getStackBottomImpl = thirdParty.getStackBottomImpl;
+alias swapContextImpl = thirdParty.swapContextImpl;
+
+version (CoreDdoc) {}
+else
+    alias getpid = thirdParty.getpid;
+
+package struct LLThreadProperties
+{
+    void delegate() nothrow dg;
+
+    // Returns: false if error occurred
+    bool initialize(void delegate() nothrow dg, ref LLThreadContext context) nothrow @nogc
+    {
+        this.dg = dg;
+        return true;
+    }
+}
+
+package struct LLThreadContext
+{
+    ThreadID tid;
+    uint stacksize;
+
+    this(uint stacksize, void delegate() nothrow cbDllUnload) nothrow @nogc
+    {
+        this.stacksize = stacksize;
+    }
+}
+
+// Returns: false if error occurred
+package bool launchLLThread(LLThreadProperties* tprop, ref LLThreadContext context, ref ll_ThreadData curr_llt) nothrow @nogc
+{
+    assert(false, assertMsg);
+}
+
+version (CoreDdoc) {} else
+void joinLowLevelThread(ThreadID tid) nothrow @nogc
+{
+    assert(false, assertMsg);
+}

--- a/druntime/src/core/thread/windows_impl.d
+++ b/druntime/src/core/thread/windows_impl.d
@@ -97,7 +97,7 @@ class Thread : ThreadBase
 
     static Thread getThis() @safe nothrow @nogc
     {
-        return ThreadBase.getThis().toThread;
+        return ThreadBase.getThis().toThread!Thread;
     }
 
     version (all)

--- a/druntime/test/gc/collect.d
+++ b/druntime/test/gc/collect.d
@@ -1,12 +1,13 @@
 module core.thread.collect; // get access to package core.thread
 
+import core.thread: isSingleThreaded;
 import core.thread.threadbase;
 import core.memory;
 import core.cpuid;
 
 void main()
 {
-    auto threads = threadsPerCPU();
+    auto threads = isSingleThreaded ? 1 : threadsPerCPU();
     if (threads > 1) // no parallel scanning on single-core CPU
     {
         assert(ll_nThreads == 0);

--- a/druntime/test/gc/sentinel2.d
+++ b/druntime/test/gc/sentinel2.d
@@ -1,10 +1,14 @@
 debug (SENTINEL)
 void main()
 {
+    import core.internal.thread : isSingleThreaded;
     import core.stdc.stdio : printf;
     import core.sys.posix.unistd : _exit;
     import core.thread : Thread, thread_detachThis;
     import core.memory : GC;
+
+    static if(isSingleThreaded)
+        return;
 
     // Create a new thread and immediately detach it from the runtime,
     // so that the pointer p will not be visible to the GC.

--- a/druntime/test/gc/sigmaskgc.d
+++ b/druntime/test/gc/sigmaskgc.d
@@ -25,7 +25,7 @@ void main()
 
         sigprocmask(SIG_BLOCK, &m, null); // block SIGHUP from delivery to main thread
 
-        auto parent_pid = getpid();
+        auto parent_pid = core.thread.getpid();
         auto child_pid = fork();
         assert(child_pid >= 0);
         if (child_pid == 0)

--- a/druntime/test/init_fini/src/thread_join.d
+++ b/druntime/test/init_fini/src/thread_join.d
@@ -1,5 +1,6 @@
 // Bugzilla 11309 - std.concurrency: OwnerTerminated message doesn't work
 // We need to assure that the thread dtors of parent threads run before the thread dtors of the child threads.
+import core.internal.thread : isSingleThreaded;
 import core.thread, core.sync.semaphore;
 
 __gshared Semaphore sem;
@@ -11,6 +12,9 @@ static ~this()
 
 void main()
 {
+    static if(isSingleThreaded)
+        return;
+
     sem = new Semaphore;
     auto thr = new Thread({assert(sem.wait(1.seconds));});
     thr.start();

--- a/druntime/test/shared/src/lib.d
+++ b/druntime/test/shared/src/lib.d
@@ -55,6 +55,7 @@ void testGC()
 }
 
 // test Init
+import core.internal.thread : isSingleThreaded;
 import core.atomic : atomicLoad, atomicOp, atomicStore;
 shared uint shared_static_ctor, shared_static_dtor, static_ctor, static_dtor;
 shared static this() { _assert(atomicOp!"+="(shared_static_ctor, 1) == 1); }
@@ -64,6 +65,9 @@ static ~this() { atomicOp!"+="(static_dtor, 1); }
 
 extern(C) int runTests()
 {
+    static if(isSingleThreaded)
+        return 1;
+
     try
         runTestsImpl();
     catch (Throwable)

--- a/druntime/test/shared/src/link.d
+++ b/druntime/test/shared/src/link.d
@@ -61,7 +61,11 @@ void testInit()
 
 void main()
 {
+    import core.internal.thread : isSingleThreaded;
+
     testEH();
     testGC();
-    testInit();
+
+    static if(!isSingleThreaded)
+        testInit();
 }

--- a/druntime/test/shared/src/load.d
+++ b/druntime/test/shared/src/load.d
@@ -1,4 +1,5 @@
 import core.atomic : atomicLoad;
+import core.internal.thread : isSingleThreaded;
 import core.runtime;
 import core.stdc.string : strrchr;
 import core.thread;
@@ -122,7 +123,9 @@ void runTests(string libName)
 
     testEH();
     testGC();
-    testInit();
+
+    static if(!isSingleThreaded)
+        testInit();
 
     closeLib(handle);
     assert(findModuleInfo("lib") is null);

--- a/druntime/test/thread/src/external_threads.d
+++ b/druntime/test/thread/src/external_threads.d
@@ -1,3 +1,4 @@
+import core.internal.thread : isSingleThreaded;
 import core.memory;
 import core.sys.posix.pthread : pthread_create, pthread_join;
 import core.sys.posix.sys.types : pthread_t;
@@ -32,6 +33,9 @@ void* entry_point2(void*)
 
 void main()
 {
+    if(isSingleThreaded)
+        return;
+
     // allocate some garbage
     auto x = new int[1000];
 

--- a/druntime/test/thread/src/filterthrownglobal.d
+++ b/druntime/test/thread/src/filterthrownglobal.d
@@ -1,10 +1,14 @@
 import core.exception;
 import core.thread;
+import core.internal.thread : isSingleThreaded;
 
 __gshared bool caught;
 
 void main()
 {
+    if(isSingleThreaded)
+        return;
+
     filterThreadThrowableHandler = (ref Throwable t) {
         if (auto t2 = cast(AssertError) t)
         {

--- a/druntime/test/thread/src/filterthrownmethod.d
+++ b/druntime/test/thread/src/filterthrownmethod.d
@@ -1,3 +1,4 @@
+import core.internal.thread : isSingleThreaded;
 import core.exception;
 import core.thread;
 
@@ -5,6 +6,9 @@ __gshared bool caught;
 
 void main()
 {
+    if(isSingleThreaded)
+        return;
+
     Thread t = new MyThread(&entry);
     t.start();
     t.join();

--- a/druntime/test/thread/src/tlsgc_sections.d
+++ b/druntime/test/thread/src/tlsgc_sections.d
@@ -1,3 +1,4 @@
+import core.internal.thread : isSingleThreaded;
 import core.memory;
 import core.sync.condition;
 import core.sync.mutex;
@@ -47,6 +48,9 @@ void test()
 
 void main()
 {
+    if(isSingleThreaded)
+        return;
+
     g_mutex = new Mutex;
     g_cond = new Condition(g_mutex);
 

--- a/druntime/test/thread/src/tlsstack.d
+++ b/druntime/test/thread/src/tlsstack.d
@@ -32,6 +32,9 @@ void main()
     th.start();
     th.join();
 
+    static if(isSingleThreaded)
+        return;
+
     printf("### lowlevel thread\n");
     auto llth = createLowLevelThread(() { showThreadInfo(); });
     joinLowLevelThread(llth);


### PR DESCRIPTION
Threads are an integral part of the D language. However, when implementing support of a new system, it's much more convenient to first get trivial "Hello, world!" and only then implement `Thread` class and sync primitives.

My proposal adds a `Thread` stub that will allow `druntime` compilation without threading support. Also it introduces new `core.internal.thread.isSingleThreaded` flag which allows to disable threads-related testing code and Phobos modules related to the threading.

This stub also makes it easy to add bare-metal systems. Most likely, they will start working just "out of the box" after implementation of startup routine and `getStackBottom()` call. (Of course without threading.)

Please note: there are no protective directive like `version(Windows):` in the beginning of the stub module. This was done specifically so that unsupported Posix- or FakeWindows- system could be used with this stub. ~There's just one problem with this: I don't know how to ensure that the stub code doesn't end up as dead weight in druntime versions where it's not used.~ Solved in b4491f28cdc416ce62e295c6337c34e0a249777e

@QuantumSegfault you may be interested in this. It will be possible to specify one for all `isSingleThreaded` compile-time flag in the Phobos instead of [`version(WASI){} else`](https://github.com/dlang/phobos/blob/587f7f14746f4df1fa54c31deef5b1e7c526608c/std/concurrency.d#L417)
