### PR TITLE
Remove dead code in frontend inliner

### DIFF
--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -2119,26 +2119,6 @@ private bool canInline(FuncDeclaration fd, bool hasThis, bool statementsToo, PAS
     else
         fd.inlineStatusExp = ILS.yes;
 
-    if (fd.inlineStatusExp == ILS.uninitialized)
-    {
-        // Need to redo cost computation, as some statements or expressions have been inlined
-        cost = inlineCostFunction(fd, hasThis);
-        static if (CANINLINE_LOG)
-        {
-            printf("recomputed cost = %d for %s\n", cost, fd.toChars());
-        }
-
-        if (tooCostly(cost))
-            goto Lno;
-        if (!statementsToo && cost > COST_MAX)
-            goto Lno;
-
-        if (statementsToo)
-            fd.inlineStatusStmt = ILS.yes;
-        else
-            fd.inlineStatusExp = ILS.yes;
-    }
-
     static if (CANINLINE_LOG)
     {
         printf("\t2: yes %s\n", fd.toChars());

--- a/compiler/src/dmd/inlinecost.d
+++ b/compiler/src/dmd/inlinecost.d
@@ -60,21 +60,6 @@ bool tooCostly(int cost) pure nothrow @safe
 }
 
 /*********************************
- * Determine cost of inlining Expression
- * Params:
- *      e = Expression to determine cost of
- * Returns:
- *      cost of inlining e
- */
-int inlineCostExpression(Expression e)
-{
-    scope InlineCostVisitor icv = new InlineCostVisitor(true, false);
-    icv.expressionInlineCost(e);
-    return icv.cost;
-}
-
-
-/*********************************
  * Determine cost of inlining function
  * Params:
  *      fd = function to determine cost of
@@ -84,7 +69,7 @@ int inlineCostExpression(Expression e)
  */
 int inlineCostFunction(FuncDeclaration fd, bool hasThis)
 {
-    scope InlineCostVisitor icv = new InlineCostVisitor(false, hasThis);
+    scope InlineCostVisitor icv = new InlineCostVisitor(hasThis);
     fd.fbody.accept(icv);
     return icv.cost;
 }
@@ -149,27 +134,20 @@ extern (C++) final class InlineCostVisitor : Visitor
 {
     alias visit = Visitor.visit;
 public:
-    // if the expression being visited is a default argument, which is
-    // specified to be copied at call site and can contain more types of
-    // expression (like alloca) than regular inlining
-    immutable bool callerCopy;
-
     // if the caller can access the callee's this pointer
     immutable bool hasThis;
 
     int nested;
     int cost;           // zero start for subsequent AST
 
-    extern (D) this(bool callerCopy, bool hasThis) scope @safe
+    extern (D) this(bool hasThis) scope @safe
     {
-        this.callerCopy = callerCopy;
         this.hasThis = hasThis;
     }
 
     extern (D) this(InlineCostVisitor icv) scope @safe
     {
         nested = icv.nested;
-        callerCopy = icv.callerCopy;
         hasThis = icv.hasThis;
     }
 
@@ -445,7 +423,7 @@ public:
                 cost = COST_MAX; // finish DeclarationExp.doInlineAs
                 return;
             }
-            if (!callerCopy && vd.isDataseg())
+            if (vd.isDataseg())
             {
                 cost = COST_MAX;
                 return;
@@ -496,7 +474,7 @@ public:
         // can't handle that at present.
         if (e.e1.op == EXP.dotVariable && (cast(DotVarExp)e.e1).e1.op == EXP.super_)
             cost = COST_MAX;
-        else if (e.f && e.f.ident == Id.__alloca && e.f._linkage == LINK.c && !callerCopy)
+        else if (e.f && e.f.ident == Id.__alloca && e.f._linkage == LINK.c)
             cost = COST_MAX; // inlining alloca may cause stack overflows
         else
             cost++;


### PR DESCRIPTION
#22903 removed the use of the inliner for default arguments and #23767 removed the need to rescan an inlining candidate. Removing the vestige here.