### PR TITLE
Add supplemental hint when module lacks a module declaration

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -891,7 +891,11 @@ extern (C++) final class Module : Package
                 else if (isRoot() && mprev.isRoot())
                     eSink.error(loc, "%s `%s` from file %s is specified twice on the command line", kind, toPrettyChars, srcname);
                 else
+                {
                     eSink.error(loc, "%s `%s` from file %s must be imported with 'import %s;'", kind, toPrettyChars, srcname, toPrettyChars());
+                    if (mprev.md is null)
+                        eSink.errorSupplemental(loc, "`%s` has no module declaration, so its module name was inferred as `%s` from the filename", srcname, mprev.toChars());
+                }
                 // https://issues.dlang.org/show_bug.cgi?id=14446
                 // Return previously parsed module to avoid AST duplication ICE.
                 return mprev;

--- a/compiler/test/fail_compilation/ice24188.d
+++ b/compiler/test/fail_compilation/ice24188.d
@@ -2,7 +2,8 @@
 REQUIRED_ARGS: fail_compilation/ice24188_a/ice24188_c.d
 TEST_OUTPUT:
 ---
-fail_compilation/ice24188.d(9): Error: module `ice24188_c` from file fail_compilation/ice24188_a/ice24188_c.d must be imported with 'import ice24188_c;'
+fail_compilation/ice24188.d(10): Error: module `ice24188_c` from file fail_compilation/ice24188_a/ice24188_c.d must be imported with 'import ice24188_c;'
+fail_compilation/ice24188.d(10):        `fail_compilation/ice24188_a/ice24188_c.d` has no module declaration, so its module name was inferred as `ice24188_c` from the filename
 ---
 */
 auto b() {


### PR DESCRIPTION
Fixes #17767
