### PR TITLE
Expose individual unittest metadata through ModuleInfo

### DIFF
--- a/changelog/druntime.unittest-metadata.dd
+++ b/changelog/druntime.unittest-metadata.dd
@@ -1,0 +1,14 @@
+Discover individual unittest blocks through ModuleInfo
+
+$(D ModuleInfo.unitTests) exposes a read-only array of pointers to immutable
+$(D UnitTestInfo) records containing a record size, function pointer, and
+compiler-generated name. Entries follow the order used by the existing
+$(D ModuleInfo.unitTest) wrapper. This enables custom runners to discover and
+invoke individual tests without changing the default runner's behavior.
+
+Generated names are not guaranteed unique or stable across builds. Metadata is
+empty for modules without emitted tests and modules built by older compilers;
+such older modules may still provide a $(D unitTest) wrapper.
+
+Records have module lifetime. Future fields can be appended; consumers must
+check the emitted record's $(D size) before reading newer fields.

--- a/compiler/src/dmd/glue/package.d
+++ b/compiler/src/dmd/glue/package.d
@@ -980,6 +980,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     if (ud)
     {
         glue.stests.push(s);
+        glue.testNames.push(ud.ident);
     }
 
     if (global.errors)
@@ -1103,6 +1104,7 @@ struct Glue
     StaticDtorDeclarations ectorgates;
     symbols sdtors;
     symbols stests;
+    Array!Identifier testNames;
 
     symbols ssharedctors; // shared static constructors
     symbols sisharedctors; // standalone shared static constructors
@@ -1343,6 +1345,7 @@ private void genObjFile(Module m, bool multiobj, bool doppelganger)
     glue.esharedctorgates.setDim(0);
     glue.sshareddtors.setDim(0);
     glue.stests.setDim(0);
+    glue.testNames.setDim(0);
 
     if (doppelganger)
     {
@@ -1605,6 +1608,7 @@ private void genModuleInfo(Module m, Symbol* msictor,
         MIimportedModules = 0x400,
         MIlocalClasses    = 0x800,
         MIname            = 0x1000,
+        MIunitTests       = 0x2000,
     }
 
     uint flags = 0;
@@ -1623,7 +1627,7 @@ private void genModuleInfo(Module m, Symbol* msictor,
     if (msictor)
         flags |= MIictor;
     if (mstest)
-        flags |= MIunitTest;
+        flags |= MIunitTest | MIunitTests;
     if (aimports_dim)
         flags |= MIimportedModules;
     if (aclasses.length)
@@ -1684,6 +1688,34 @@ private void genModuleInfo(Module m, Symbol* msictor,
         m.namelen = strlen(name);
         dtb.nbytes(name[0 .. m.namelen + 1]);
         //printf("nameoffset = x%x\n", nameoffset);
+    }
+
+    if (flags & MIunitTests)
+    {
+        // Preserve all existing offsets, including the NUL-terminated name.
+        const pointerSize = target.ptrsize;
+        dtb.nzeros((pointerSize - dtb.length() % pointerSize) % pointerSize);
+        const count = glue.stests.length;
+        const arrayOffset = dtb.length() + 2 * pointerSize;
+        const recordsOffset = arrayOffset + count * pointerSize;
+        // object.UnitTestInfo: size, func, name.length, name.ptr.
+        const recordSize = 4 * pointerSize;
+        auto nameOffset = recordsOffset + count * recordSize;
+        dtb.size(count);
+        dtb.xoff(csym, arrayOffset, TYnptr);
+        foreach (i; 0 .. count)
+            dtb.xoff(csym, recordsOffset + i * recordSize, TYnptr);
+        foreach (i, test; glue.stests[])
+        {
+            const name = glue.testNames[i].toString();
+            dtb.size(recordSize);
+            dtb.xoff(test, 0, TYnptr);
+            dtb.size(name.length);
+            dtb.xoff(csym, nameOffset, TYnptr);
+            nameOffset += name.length;
+        }
+        foreach (name; glue.testNames[])
+            dtb.nbytes(name.toString());
     }
 
     objc.generateModuleInfo(m);

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2326,6 +2326,21 @@ enum
     MIimportedModules = 0x400,
     MIlocalClasses = 0x800,
     MIname       = 0x1000,
+    MIunitTests  = 0x2000,
+}
+
+/*****************************************
+ * Information about an individual compiled unittest block.
+ *
+ * Records are emitted by the compiler and live for the lifetime of their module.
+ * Future fields may be appended; existing fields retain their offsets and types.
+ * Check `size` before accessing a field introduced by a newer runtime.
+ */
+struct UnitTestInfo
+{
+    size_t size;           /// Size of this emitted record in bytes.
+    void function() func;  /// Function executing this unittest block.
+    string name;           /// Compiler-generated name; not guaranteed unique or stable across builds.
 }
 
 /*****************************************
@@ -2353,7 +2368,7 @@ const:
     private void* addrOf(int flag) return nothrow pure @nogc
     in
     {
-        assert(flag >= MItlsctor && flag <= MIname);
+        assert(flag >= MItlsctor && flag <= MIunitTests);
         assert(!(flag & (flag - 1)) && !(flag & ~(flag - 1) << 1));
     }
     do
@@ -2410,7 +2425,12 @@ const:
         if (true || flags & MIname) // always available for now
         {
             if (flag == MIname) return p;
-            p += strlen(cast(immutable char*)p);
+            p += strlen(cast(immutable char*)p) + 1;
+        }
+        if (flags & MIunitTests)
+        {
+            p += (size_t.sizeof - cast(size_t)p % size_t.sizeof) % size_t.sizeof;
+            if (flag == MIunitTests) return p;
         }
         assert(0);
     }
@@ -2480,6 +2500,22 @@ const:
     @property void function() unitTest() nothrow pure @nogc
     {
         return flags & MIunitTest ? *cast(typeof(return)*)addrOf(MIunitTest) : null;
+    }
+
+    /************************
+     * Discover individual unittest blocks in the order used by `unitTest`.
+     * Calling these functions does not perform module initialization or catch
+     * test failures; those remain the responsibility of the caller.
+     *
+     * Returns:
+     *  Read-only pointers to immutable, compiler-emitted records. The slice and
+     *  records remain valid while the module is loaded. Returns an empty slice
+     *  when metadata is unavailable, including modules built by older compilers
+     *  and modules without emitted tests. `unitTest` may still be non-null.
+     */
+    @property const(immutable(UnitTestInfo)*)[] unitTests() return nothrow pure @nogc
+    {
+        return flags & MIunitTests ? *cast(typeof(return)*)addrOf(MIunitTests) : null;
     }
 
     /****************

--- a/druntime/src/rt/minfo.d
+++ b/druntime/src/rt/minfo.d
@@ -35,6 +35,7 @@ enum
     MIimportedModules = 0x400,
     MIlocalClasses = 0x800,
     MIname       = 0x1000,
+    MIunitTests  = 0x2000,
 }
 
 /*****

--- a/druntime/test/unittest/Makefile
+++ b/druntime/test/unittest/Makefile
@@ -1,4 +1,5 @@
-TESTS := good goodn bad badn na
+HANDLER_TESTS := good goodn bad badn na
+TESTS := $(HANDLER_TESTS) metadata metadata_disabled
 
 include ../common.mak
 
@@ -31,7 +32,7 @@ $(ROOT)/na$(DOTEXE): private extra_dflags += -version=NoTests
 # Forces the tests to be matched by this rule instead of being matched
 # by the `$(OBJDIR)/%$(DOTEXE)` (`$(OBJDIR)/%` on posix) rule at the
 # end:
-$(TESTS:%=$(OBJDIR)/%.done): $(OBJDIR)/%.done: $(OBJDIR)/%$(DOTEXE)
+$(HANDLER_TESTS:%=$(OBJDIR)/%.done): $(OBJDIR)/%.done: $(OBJDIR)/%$(DOTEXE)
 	@echo Testing $*
 	$(TIMELIMIT)$< > $@ 2>&1; test $$? -eq $(retcode)
 	test $(hasmain) -eq 0 || grep -q main $@
@@ -41,3 +42,9 @@ $(TESTS:%=$(OBJDIR)/%.done): $(OBJDIR)/%.done: $(OBJDIR)/%$(DOTEXE)
 
 $(OBJDIR)/%$(DOTEXE): customhandler.d
 	$(LINK.d) $< $(extra_sources) $(extra_ldlibs.d) $(LDLIBS.d) $(OUTPUT_OPTION.d)
+
+$(OBJDIR)/metadata$(DOTEXE): metadata.d $(DMD_DEP) $(DRUNTIME_DEP) | $(OBJDIR)
+	$(LINK.d) -unittest $< $(extra_ldlibs.d) $(LDLIBS.d) $(OUTPUT_OPTION.d)
+
+$(OBJDIR)/metadata_disabled$(DOTEXE): metadata.d $(DMD_DEP) $(DRUNTIME_DEP) | $(OBJDIR)
+	$(LINK.d) $< $(extra_ldlibs.d) $(LDLIBS.d) $(OUTPUT_OPTION.d)

--- a/druntime/test/unittest/metadata.d
+++ b/druntime/test/unittest/metadata.d
@@ -39,15 +39,20 @@ void main()
         assert(tests.length == 5);
         alias aggregateTest = __traits(getUnitTests, Aggregate)[0];
         assert(tests[1].func == &aggregateTest);
-        assert(tests[1].name == __traits(identifier, aggregateTest));
         static assert(!__traits(compiles, tests[0] = null));
         static assert(!__traits(compiles, tests[0].name = "changed"));
-        foreach (test; tests)
+        immutable expectedNames = [
+            "__unittest_L6_C1",
+            "__unittest_L9_C5",
+            "__unittest_L11_C1",
+            "__unittest_L14_C5_1",
+            "__unittest_L14_C5_2",
+        ];
+        foreach (i, test; tests)
         {
             assert(test.size == UnitTestInfo.sizeof);
             assert(test.func !is null);
-            assert(test.name.length > "__unittest_".length);
-            assert(test.name[0 .. "__unittest_".length] == "__unittest_");
+            assert(test.name == expectedNames[i]);
             test.func();
         }
         auto individualCalls = calls.dup;

--- a/druntime/test/unittest/metadata.d
+++ b/druntime/test/unittest/metadata.d
@@ -1,0 +1,70 @@
+module metadata;
+
+import core.runtime : Runtime, UnitTestResult;
+
+int[] calls;
+unittest { calls ~= 1; }
+struct Aggregate
+{
+    unittest { calls ~= 2; }
+}
+unittest { calls ~= 3; }
+struct Instance(T)
+{
+    unittest { calls ~= cast(int) T.sizeof; }
+}
+Instance!int intInstance;
+Instance!long longInstance;
+class LocalClass {}
+
+shared static this()
+{
+    // Leave execution to main so it can compare the wrapper with discovery.
+    Runtime.extendedModuleUnitTester = () => UnitTestResult(0, 0, true, false);
+}
+
+void main()
+{
+    ModuleInfo* info;
+    foreach (candidate; ModuleInfo)
+        if (candidate.name == "metadata")
+            info = candidate;
+    assert(info !is null);
+    assert(info.name == "metadata");
+    assert(info.localClasses.length == 1);
+    assert(info.importedModules.length != 0);
+    version (unittest)
+    {
+        auto tests = info.unitTests;
+        assert(tests.length == 5);
+        alias aggregateTest = __traits(getUnitTests, Aggregate)[0];
+        assert(tests[1].func == &aggregateTest);
+        assert(tests[1].name == __traits(identifier, aggregateTest));
+        static assert(!__traits(compiles, tests[0] = null));
+        static assert(!__traits(compiles, tests[0].name = "changed"));
+        foreach (test; tests)
+        {
+            assert(test.size == UnitTestInfo.sizeof);
+            assert(test.func !is null);
+            assert(test.name.length > "__unittest_".length);
+            assert(test.name[0 .. "__unittest_".length] == "__unittest_");
+            test.func();
+        }
+        auto individualCalls = calls.dup;
+        assert(individualCalls.length == 5);
+        assert(individualCalls[0 .. 3] == [1, 2, 3]);
+        calls = null;
+        auto wrapper = info.unitTest;
+        wrapper();
+        assert(calls == individualCalls);
+    }
+    else
+    {
+        assert(info.unitTests.length == 0);
+        assert(info.unitTest is null);
+    }
+
+    // Legacy ModuleInfo records need no trailing metadata to be queried.
+    ModuleInfo legacy;
+    assert(legacy.unitTests.length == 0);
+}

--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -971,7 +971,8 @@ $(H2 $(LNAME2 ModuleInfo, ModuleInfo Instance))
 
         $(UL
         $(LI If the module has a static constructor, static destructor, shared static constructor, or shared static destructor.)
-        $(LI A reference to any unit tests defined by the module.)
+        $(LI A reference to the function running the module's unit tests, and metadata
+            for individual emitted unittest blocks.)
         $(LI An array of references to any imported modules that have one or more of:
             $(OL
             $(LI static constructors)
@@ -993,6 +994,15 @@ $(H2 $(LNAME2 ModuleInfo, ModuleInfo Instance))
         )
 
         $(P `ModuleInfo` is defined in Druntime's $(DRUNTIMESRC object.d), which must match the compiler's output in both the values of flags and layout of fields.)
+
+        $(P The optional individual unittest metadata uses flag $(TT 0x2000).
+        It follows the NUL-terminated module name, padded to pointer alignment,
+        and consists of a slice (length, pointer) of pointers to immutable
+        $(D UnitTestInfo) records. Each record begins with its byte size, a
+        $(D void function()) pointer, and a string (length, pointer) containing
+        the compiler-generated test name. These fields have fixed offsets;
+        future fields may be appended and must be checked against the emitted
+        byte size before access. Existing ModuleInfo fields retain their offsets.)
 
         $(P Modules compiled with $(DDSUBLINK dmd, switch-betterC, $(TT -betterC))
         do not have a `ModuleInfo` instance generated, because such modules must work


### PR DESCRIPTION
Runtime test runners currently receive a single function that executes all unittest blocks in a module. Expose the individual functions and their existing compiler-generated names through `ModuleInfo.unitTests`, providing the metadata needed for future discovery, filtering, and per-test reporting.

The new property returns a read-only slice of pointers to immutable `UnitTestInfo` records (`size`, `func`, `name`). Records can grow by appending fields; consumers must check the emitted size before accessing newer fields. The compiler collects names alongside the existing wrapper's function list, preserving its emitted tests and order.

A flagged, pointer-aligned extension follows the existing NUL-terminated ModuleInfo name. Existing offsets, the `unitTest` wrapper, and default runner behavior are preserved. Older modules expose empty metadata and can still provide their wrapper. Generated names are copied unchanged and are not promised unique or stable.

Includes API and ABI documentation, a changelog, and integration tests for discovery, invocation, exact generated names (including template instance suffixes), aggregate and template tests, wrapper ordering, read-only access, and compilation without unittests.

Validation on Linux x86-64:

- `make -j8` and `make -j8 dmd-unittest` passed.
- `make -j8 druntime-test` passed with tracing enabled for the suite's GDB tests.
- The unittest integration tests passed in debug and release builds.
- Manual compatibility checks passed using installed DMD 2.113.0: newly compiled tests with the older runtime; older compiled tests with the new runtime; and querying an older module's empty metadata while invoking its wrapper.
- A manual `-lib -multiobj` check, linking the whole test archive, verified that each discovered list reproduces its corresponding wrapper across all five tests.
- `git diff --check` passed. Repository-wide druntime style checks fail on pre-existing Makefile tabs and trailing whitespace in the vendored Valgrind header.

Other platforms and 32-bit runtime execution have not been tested locally.
