### PR TITLE
Fix #23031: Default to AArch64 on AArch64 hosts

### DIFF
--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -333,8 +333,37 @@ void setTargetBuildDefaults(ref Target target) @safe
     target.os = defaultTargetOS();
     target.osMajor = defaultTargetOSMajor();
     target.cpu = CPU.baseline;
-    target.isX86_64 = (size_t.sizeof == 8);
-    target.isX86 = !target.isX86_64;
+    version (AArch64)
+    {
+        target.isAArch64 = true;
+    }
+    else
+    {
+        target.isX86_64 = (size_t.sizeof == 8);
+        target.isX86 = !target.isX86_64;
+    }
+}
+
+unittest
+{
+    Target t;
+    setTargetBuildDefaults(t);
+    version (AArch64)
+    {
+        assert(t.isAArch64);
+        assert(!t.isX86_64);
+    }
+    else version (X86_64)
+    {
+        assert(!t.isAArch64);
+        assert(t.isX86_64);
+    }
+    else version (X86)
+    {
+        assert(!t.isAArch64);
+        assert(!t.isX86_64);
+        assert(t.isX86);
+    }
 }
 
 void setTriple(ref Target target, const ref Triple triple) @safe


### PR DESCRIPTION
Fixes #23031.

`setTargetBuildDefaults()` previously inferred a 64-bit host as x86_64 using `size_t.sizeof == 8`. This incorrectly caused a native AArch64 DMD build to default to an x86_64 target.

Use `version (AArch64)` to initialize the native target correctly while preserving the existing x86/x86_64 behavior and explicit target overrides.

A regression unittest verifies the native target defaults for AArch64, x86_64, and x86.