### PR TITLE
Fix #23802 - don't fuse conversion ops on common subexpressions

### DIFF
--- a/compiler/src/dmd/backend/x86/cg87.d
+++ b/compiler/src/dmd/backend/x86/cg87.d
@@ -1736,6 +1736,8 @@ L5:
         case OPd_f:
         case OPf_d:
         case OPd_ld:
+            if (e.Ecount)
+                goto Ldefault;
             mf1 = (tybasic(e.E1.Ety) == TYfloat || tybasic(e.E1.Ety) == TYifloat)
                     ? MFfloat : MFdouble;
             if (op != -1 && global87.stackused && !noted)

--- a/compiler/test/compilable/issue23802.d
+++ b/compiler/test/compilable/issue23802.d
@@ -1,0 +1,20 @@
+// REQUIRED_ARGS: -O
+
+import core.stdc.math;
+
+int screenNum()
+{
+    return 1;
+}
+
+void XTranslateCoordinates(int*) {}
+
+void processNextEvent()
+{
+    int rx;
+    XTranslateCoordinates(&rx);
+
+    float scale = screenNum();
+    int fx = cast(int) ceill(rx / cast(double) scale);
+    int fw = cast(int) ceil(cast(double) scale);
+}


### PR DESCRIPTION
If a floating point conversion is a common subexpression, avoid encoding precision in the ModR/M byte, but instead do a full load. Otherwise global CSE will have a hard time finding the value in registers.

@WalterBright Please review as this might not be an optimal fix.