### PR TITLE
Fix #23796 - compiler crashes if the type of a sparse array is inferred  

### DIFF
--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1324,7 +1324,26 @@ Initializer inferInitializerType(Initializer init, Scope* sc, Type itype, ErrorS
             ? new AssocArrayLiteralExp(init.loc, keys, values)
             : new ArrayLiteralExp(init.loc, null, values);
         auto ei = new ExpInitializer(init.loc, e);
-        return ei.inferInitializerType(sc, itype, eSink);
+        auto result = ei.inferInitializerType(sc, itype, eSink);
+        // Sparse array literals with an inferred type are completed here, now
+        // that the element type is known. `auto[$]` static arrays are completed
+        // in dsymbolsem.d, after their `$` dimensions have been resolved.
+        if (itype)
+            return result;
+
+        auto ale = e.isArrayLiteralExp();
+        if (!ale || ale.basis || !ale.type)
+            return result;
+
+        foreach (el; *ale.elements)
+        {
+            if (!el)
+            {
+                ale.basis = ale.type.nextOf().defaultInitLiteral(init.loc);
+                break;
+            }
+        }
+        return result;
     }
 
     Initializer visitExp(ExpInitializer init)

--- a/compiler/test/runnable/staticarray.d
+++ b/compiler/test/runnable/staticarray.d
@@ -179,4 +179,37 @@ void main()
 	assert(aa.length == 1);
 	assert(aa[3] == 42);
 	static assert(is(typeof(aa) == int[int]));
+
+	// sparse array initializer with an inferred `auto` type:
+	// the gaps are filled with the default value of the element type
+	auto sparse6 = [1:2, 3];
+	static assert(is(typeof(sparse6) == int[]));
+	assert(sparse6.length == 3);
+	assert(sparse6 == [0, 2, 3]);
+
+	auto sparse7 = [0, 2:2, 3];
+	assert(sparse7 == [0, 0, 2, 3]);
+
+	// the same at compile time
+	enum sparse8 = [1:2, 3];
+	static assert(sparse8 == [0, 2, 3]);
+
+	// nested sparse array with an inferred type
+	auto sparse9 = [[0, 1], 2:[1, 1]];
+	static assert(is(typeof(sparse9) == int[][]));
+	assert(sparse9.length == 3);
+	assert(sparse9[0] == [0, 1]);
+	assert(sparse9[1] is null); // int[].init
+	assert(sparse9[2] == [1, 1]);
+
+	// gaps in both the outer and the inner literal
+	auto sparse10 = [[1:2, 3], 4:[5:6, 7]];
+	assert(sparse10.length == 5);
+	assert(sparse10[0] == [0, 2, 3]);
+	assert(sparse10[1] is null);
+	assert(sparse10[4] == [0, 0, 0, 0, 0, 6, 7]);
+
+	// the same at compile time
+	enum sparse11 = [[1:2, 3], [4, 5]];
+	static assert(sparse11 == [[0, 2, 3], [4, 5]]);
 }


### PR DESCRIPTION
Fix #23796 
                                                                                                                                                                                                                                                                                                                                              
`auto a2 = [1:2, 3];` parses as a sparse array initializer, the value used to fill gaps is stored in `basis`, but it was                                             only filled in for `auto[$]` static arrays in `dsymbolsem.d`, after the `$` dimensions are resolved. For a plain `auto` the literal was left with a null `basis`.                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
Fix it by setting `basis` to the element type's default initializeras as soon as the element type has been inferred.