### PR TITLE
Fix #20533 - Use "default initialization" instead of "default construction" in error messages

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -934,7 +934,7 @@ void noDefaultCtorSupplemental(AggregateDeclaration ad)
         auto ts = field.type.baseElemOf().isTypeStruct();
         if (ts && ts.sym.noDefaultCtor)
         {
-            eSink.errorSupplemental(field.loc, "because field `%s` of type `%s` has disabled default construction",
+            eSink.errorSupplemental(field.loc, "because field `%s` of type `%s` has disabled default initialization",
                 field.toChars(), field.type.toErrMsg());
             noDefaultCtorSupplemental(ts.sym);
         }
@@ -3093,7 +3093,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 }
                 else
                 {
-                    eSink.error(dsym.loc, "%s `%s` - default construction is disabled for type `%s`", dsym.kind, dsym.toPrettyChars, dsym.type.toErrMsg());
+                    eSink.error(dsym.loc, "%s `%s` - default initialization is disabled for type `%s`", dsym.kind, dsym.toPrettyChars, dsym.type.toErrMsg());
                     noDefaultCtorSupplemental(tbn.isTypeStruct().sym);
                 }
             }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4220,7 +4220,7 @@ private bool checkDefCtor(Loc loc, Type t)
     if (ad && ad.noDefaultCtor)
     {
         auto eSink = global.errorSink;
-        eSink.error(loc, "default construction is disabled for type `%s`", tb.toErrMsg());
+        eSink.error(loc, "default initialization is disabled for type `%s`", tb.toErrMsg());
         noDefaultCtorSupplemental(ad);
         return true;
     }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -4127,7 +4127,7 @@ Type typeSemantic(Type type, Loc loc, Scope* sc)
                         Type tv = t.baseElemOf();
                         if (tv.ty == Tstruct && tv.isTypeStruct().sym.noDefaultCtor)
                         {
-                            eSink.error(loc, "cannot have `out` parameter of type `%s` because the default construction is disabled", fparam.type.toErrMsg());
+                            eSink.error(loc, "cannot have `out` parameter of type `%s` because the default initialization is disabled", fparam.type.toErrMsg());
                             errors = true;
                         }
                     }

--- a/compiler/test/fail_compilation/diag10099.d
+++ b/compiler/test/fail_compilation/diag10099.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10099.d(16): Error: variable `diag10099.main.s` - default construction is disabled for type `S`
+fail_compilation/diag10099.d(16): Error: variable `diag10099.main.s` - default initialization is disabled for type `S`
 fail_compilation/diag10099.d(11):        because of `@disable this();` here
 ---
 */

--- a/compiler/test/fail_compilation/fail10102.d
+++ b/compiler/test/fail_compilation/fail10102.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10102.d(51): Error: variable `fail10102.main.m` - default construction is disabled for type `NotNull!(int*)`
+fail_compilation/fail10102.d(51): Error: variable `fail10102.main.m` - default initialization is disabled for type `NotNull!(int*)`
 fail_compilation/fail10102.d(26):        because of `@disable this();` here
-fail_compilation/fail10102.d(52): Error: variable `fail10102.main.a` - default construction is disabled for type `NotNull!(int*)[3]`
+fail_compilation/fail10102.d(52): Error: variable `fail10102.main.a` - default initialization is disabled for type `NotNull!(int*)[3]`
 fail_compilation/fail10102.d(26):        because of `@disable this();` here
-fail_compilation/fail10102.d(53): Error: default construction is disabled for type `NotNull!(int*)`
+fail_compilation/fail10102.d(53): Error: default initialization is disabled for type `NotNull!(int*)`
 fail_compilation/fail10102.d(26):        because of `@disable this();` here
 fail_compilation/fail10102.d(54): Error: field `S.m` must be initialized because it has no default constructor
 ---

--- a/compiler/test/fail_compilation/fail10115.d
+++ b/compiler/test/fail_compilation/fail10115.d
@@ -1,15 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10115.d(39): Error: cannot have `out` parameter of type `S` because the default construction is disabled
-fail_compilation/fail10115.d(39): Error: cannot have `out` parameter of type `E` because the default construction is disabled
-fail_compilation/fail10115.d(39): Error: cannot have `out` parameter of type `U` because the default construction is disabled
-fail_compilation/fail10115.d(44): Error: default construction is disabled for type `S`
+fail_compilation/fail10115.d(39): Error: cannot have `out` parameter of type `S` because the default initialization is disabled
+fail_compilation/fail10115.d(39): Error: cannot have `out` parameter of type `E` because the default initialization is disabled
+fail_compilation/fail10115.d(39): Error: cannot have `out` parameter of type `U` because the default initialization is disabled
+fail_compilation/fail10115.d(44): Error: default initialization is disabled for type `S`
 fail_compilation/fail10115.d(20):        because of `@disable this();` here
-fail_compilation/fail10115.d(45): Error: default construction is disabled for type `S`
+fail_compilation/fail10115.d(45): Error: default initialization is disabled for type `S`
 fail_compilation/fail10115.d(20):        because of `@disable this();` here
-fail_compilation/fail10115.d(46): Error: default construction is disabled for type `U`
-fail_compilation/fail10115.d(32):        because field `s` of type `S` has disabled default construction
+fail_compilation/fail10115.d(46): Error: default initialization is disabled for type `U`
+fail_compilation/fail10115.d(32):        because field `s` of type `S` has disabled default initialization
 fail_compilation/fail10115.d(20):        because of `@disable this();` here
 ---
 */

--- a/compiler/test/fail_compilation/fail10630.d
+++ b/compiler/test/fail_compilation/fail10630.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10630.d(12): Error: cannot have `out` parameter of type `S` because the default construction is disabled
+fail_compilation/fail10630.d(12): Error: cannot have `out` parameter of type `S` because the default initialization is disabled
 ---
 */
 

--- a/compiler/test/fail_compilation/fail23210.d
+++ b/compiler/test/fail_compilation/fail23210.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail23210.d(44): Error: variable `fail23210.main.b` - default construction is disabled for type `B`
-fail_compilation/fail23210.d(39):        because field `a` of type `A` has disabled default construction
-fail_compilation/fail23210.d(28):        because field `c` of type `C` has disabled default construction
+fail_compilation/fail23210.d(44): Error: variable `fail23210.main.b` - default initialization is disabled for type `B`
+fail_compilation/fail23210.d(39):        because field `a` of type `A` has disabled default initialization
+fail_compilation/fail23210.d(28):        because field `c` of type `C` has disabled default initialization
 fail_compilation/fail23210.d(17):        because of `@disable this();` here
 ---
 */


### PR DESCRIPTION
Fixes #20533
