### PR TITLE
Train PGO per build in the perf check

### DIFF
--- a/.github/PERF.md
+++ b/.github/PERF.md
@@ -1,7 +1,7 @@
 # DMD perf check
 
 Every pull request is measured against its merge-base with master. CI builds dmd at both commits the same way on the runner:
-host compiler ldc-1.42.0, one shared PGO profile, and LTO. So any difference in the numbers comes from the PR itself.
+host compiler ldc-1.42.0, a PGO profile trained on each commit's own testsuite, and LTO. So any difference in the numbers comes from the PR itself.
 
 The bot posts one sticky comment when at least one metric crosses its noise threshold, and updates that same comment on every push.
 If nothing crosses the threshold, it doesn't post at all.

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -77,12 +77,10 @@ jobs:
         run: |
           set -uexo pipefail
           source ~/dlang/*/activate
-          built=generated/$OS_NAME/release/$MODEL
-          profile="$RUNNER_TEMP/pgo/merged.data"
           BASE_SHA="${{ steps.refs.outputs.base }}"
-          mkdir -p "$RUNNER_TEMP/pgo"
 
-          # Check out a ref and build a plain dmd + phobos
+          # Check out a ref and build a plain dmd + phobos, then dmd-pgo trains a profile
+          # on the ref's own testsuite and rebuilds with it.
           setup_ref() {
             local dir="$RUNNER_TEMP/$2/dmd"
             mkdir -p "$RUNNER_TEMP/$2"
@@ -91,23 +89,12 @@ jobs:
             ( cd "$dir" && $DMD -of=generated/build -g compiler/src/build.d )
             ( cd "$dir" && generated/build HOST_DMD=$DMD MODEL=$MODEL -j$N )
             ( cd "$dir/../phobos" && make -j$N MODEL=$MODEL )
+            ( cd "$dir" && generated/build HOST_DMD=$DMD MODEL=$MODEL dmd-pgo -j$N --force )
           }
 
           setup_ref "${{ steps.refs.outputs.head }}" head
           if [ -n "$BASE_SHA" ]; then
             setup_ref "$BASE_SHA" base
-            train=base
-          else
-            train=head
-          fi
-
-          # dmd-pgo trains and rebuilds $train with the merged profile, the other ref just reuses it
-          ( cd "$RUNNER_TEMP/$train/dmd" && generated/build HOST_DMD=$DMD MODEL=$MODEL dmd-pgo -j$N --force )
-          cp "$RUNNER_TEMP/$train/dmd/$built/dmd_profdata/merged.data" "$profile"
-          if [ -n "$BASE_SHA" ]; then
-            ( cd "$RUNNER_TEMP/head/dmd" && generated/build HOST_DMD=$DMD MODEL=$MODEL \
-                ENABLE_RELEASE=1 ENABLE_LTO=1 \
-                DFLAGS="-fprofile-instr-use=$profile -wi" -j$N --force )
           fi
           deactivate
 


### PR DESCRIPTION
The PR run reuses base's PGO profile for head. Some PRs reported big deltas that aren't real, the actual impact is much smaller:

| PR | PR run, hello.d | master run after merge |
|---|---|---|
| #23772 | +7.49% | 0.00% |
| #23699 | +4.69% | +0.46% |
| #23777 | +3.67% | +0.03% |

I also rebuilt #23699's base and head locally: +0.46% with its own profile, +4.9% with base's profile.

With this change both refs run `dmd-pgo`, so head is built the same way as base. The master run already trained per commit, so the history data is unaffected. 
Also this will costs about a minute more per PR.