### PR TITLE
Avoid exposing compiler-generated lambda identifiers in instantiation traces

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -930,6 +930,16 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         // Print full trace for verbose mode, otherwise only short traces
         const(char)* format = "instantiated from here: `%s`";
 
+        // https://issues.dlang.org/show_bug.cgi?id=23847
+        // Avoid exposing compiler-generated lambda template identifiers
+        // (e.g. __lambda_L4_C31!int) in instantiation traces.
+        static bool isLambdaInstance(TemplateInstance ti)
+        {
+            if (auto td = ti.tempdecl ? ti.tempdecl.isTemplateDeclaration() : null)
+                return td.onemember && td.onemember.isFuncLiteralDeclaration() !is null;
+            return false;
+        }
+
         // This returns a function pointer
         scope printFn = () {
             auto eSink = global.errorSink;
@@ -969,7 +979,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         if (n_instantiations <= max_shown)
         {
             for (TemplateInstance cur = this; cur; cur = cur.tinst)
-                printFn(cur.loc, format, cur.toErrMsg());
+                printFn(cur.loc, format, isLambdaInstance(cur) ? "lambda function" : cur.toErrMsg());
         }
         else if (n_instantiations - n_totalrecursions <= max_shown)
         {
@@ -985,9 +995,9 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 else
                 {
                     if (recursionDepth)
-                        printFn(cur.loc, "%d recursive instantiations from here: `%s`", recursionDepth + 2, cur.toChars());
+                        printFn(cur.loc, "%d recursive instantiations from here: `%s`", recursionDepth + 2, isLambdaInstance(cur) ? "lambda function" : cur.toChars());
                     else
-                        printFn(cur.loc, format, cur.toChars());
+                        printFn(cur.loc, format, isLambdaInstance(cur) ? "lambda function" : cur.toChars());
                     recursionDepth = 0;
                 }
             }
@@ -1003,7 +1013,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     printFn(cur.loc, "... (%d instantiations, -v to show) ...", n_instantiations - max_shown);
 
                 if (i < max_shown / 2 || i >= n_instantiations - max_shown + max_shown / 2)
-                    printFn(cur.loc, format, cur.toChars());
+                    printFn(cur.loc, format, isLambdaInstance(cur) ? "lambda function" : cur.toChars());
                 ++i;
             }
         }

--- a/compiler/test/fail_compilation/fail12378.d
+++ b/compiler/test/fail_compilation/fail12378.d
@@ -5,7 +5,7 @@ fail_compilation/fail12378.d(18): Error: undefined identifier `ANYTHING`
 fail_compilation/fail12378.d(18): Error: undefined identifier `GOES`
 fail_compilation/fail12378.d(91):        instantiated from here: `MapResultS!((x0) => ANYTHING - GOES, Result)`
 fail_compilation/fail12378.d(17):        instantiated from here: `mapS!(Result)`
-fail_compilation/fail12378.d(100):        instantiated from here: `__lambda_L16_C19!int`
+fail_compilation/fail12378.d(100):        instantiated from here: `lambda function`
 fail_compilation/fail12378.d(91):        instantiated from here: `MapResultS!((y0) => iota(2).mapS!((x0) => ANYTHING - GOES), Result)`
 fail_compilation/fail12378.d(16):        instantiated from here: `mapS!(Result)`
 ---
@@ -27,7 +27,7 @@ fail_compilation/fail12378.d(40): Error: undefined identifier `ANYTHING`
 fail_compilation/fail12378.d(40): Error: undefined identifier `GOES`
 fail_compilation/fail12378.d(112):        instantiated from here: `MapResultC!((x0) => ANYTHING - GOES, Result)`
 fail_compilation/fail12378.d(39):        instantiated from here: `mapC!(Result)`
-fail_compilation/fail12378.d(123):        instantiated from here: `__lambda_L38_C19!int`
+fail_compilation/fail12378.d(123):        instantiated from here: `lambda function`
 fail_compilation/fail12378.d(112):        instantiated from here: `MapResultC!((y0) => iota(2).mapC!((x0) => ANYTHING - GOES), Result)`
 fail_compilation/fail12378.d(38):        instantiated from here: `mapC!(Result)`
 ---
@@ -49,7 +49,7 @@ fail_compilation/fail12378.d(64): Error: undefined identifier `ANYTHING`
 fail_compilation/fail12378.d(64): Error: undefined identifier `GOES`
 fail_compilation/fail12378.d(135):        instantiated from here: `MapResultI!((x0) => ANYTHING - GOES, Result)`
 fail_compilation/fail12378.d(63):        instantiated from here: `mapI!(Result)`
-fail_compilation/fail12378.d(143):        instantiated from here: `__lambda_L62_C19!int`
+fail_compilation/fail12378.d(143):        instantiated from here: `lambda function`
 fail_compilation/fail12378.d(135):        instantiated from here: `MapResultI!((y0) => iota(2).mapI!((x0) => ANYTHING - GOES), Result)`
 fail_compilation/fail12378.d(62):        instantiated from here: `mapI!(Result)`
 ---

--- a/compiler/test/fail_compilation/ice11822.d
+++ b/compiler/test/fail_compilation/ice11822.d
@@ -6,7 +6,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/ice11822.d(34): Deprecation: function `ice11822.d` is deprecated
 fail_compilation/ice11822.d(26):        `d` is declared here
-fail_compilation/ice11822.d(17):        instantiated from here: `__lambda_L34_C15!int`
+fail_compilation/ice11822.d(17):        instantiated from here: `lambda function`
 fail_compilation/ice11822.d(23):        instantiated from here: `S!(__lambda_L34_C15)`
 fail_compilation/ice11822.d(34):        instantiated from here: `g!((n) => d(i))`
 ---

--- a/compiler/test/fail_compilation/ice11850.d
+++ b/compiler/test/fail_compilation/ice11850.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11850.d(15): Error: incompatible types for `(a) < ([0])`: `uint[]` and `int[]`
-fail_compilation/imports/a11850.d(23):        instantiated from here: `__lambda_L15_C13!(uint[])`
+fail_compilation/imports/a11850.d(23):        instantiated from here: `lambda function`
 fail_compilation/imports/a11850.d(9):        instantiated from here: `FilterResult!(__lambda_L15_C13, uint[][])`
 fail_compilation/ice11850.d(15):        instantiated from here: `filter!(uint[][])`
 ---

--- a/compiler/test/fail_compilation/issue22394.d
+++ b/compiler/test/fail_compilation/issue22394.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/issue22394.d(11): Error: incompatible types for `(a) + (1)`: `string` and `int`
-fail_compilation/issue22394.d(15):        instantiated from here: `__lambda_L11_C1!string`
+fail_compilation/issue22394.d(15):        instantiated from here: `lambda function`
 ---
 */
 


### PR DESCRIPTION
Fixes #23836

Follow-up to #20261 (fixed in #23835)