### PR TITLE
Fix #23833 - use only general-purpose registers when converting FP numbers to unsigned integers

### DIFF
--- a/compiler/src/dmd/backend/x86/cg87.d
+++ b/compiler/src/dmd/backend/x86/cg87.d
@@ -2995,7 +2995,7 @@ private void cdd_u64_I32(ref CGstate cg,ref CodeBuilder cdb, elem* e, ref regm_t
     regm_t retregs = mST0;
     codelem(cg,cdb,e.E1, retregs, false);
     tym_t tym = e.Ety;
-    retregs = pretregs;
+    retregs = pretregs & (ALLREGS | mBP);
     if (!retregs)
         retregs = ALLREGS;
     allocreg(cdb,retregs,tym);
@@ -3079,7 +3079,7 @@ private void cdd_u64_I64(ref CGstate cg,ref CodeBuilder cdb, elem* e, ref regm_t
     regm_t retregs = mST0;
     codelem(cg,cdb,e.E1, retregs, false);
     tym_t tym = e.Ety;
-    retregs = pretregs;
+    retregs = pretregs & (ALLREGS | mBP);
     if (!retregs)
         retregs = ALLREGS;
     const reg = allocreg(cdb,retregs,tym);
@@ -3151,7 +3151,7 @@ void cdd_u32(ref CGstate cg,ref CodeBuilder cdb, elem* e, ref regm_t pretregs)
     regm_t retregs = mST0;
     codelem(cg,cdb,e.E1, retregs, false);
     tym_t tym = e.Ety;
-    retregs = pretregs & ALLREGS;
+    retregs = pretregs & (ALLREGS | mBP);
     if (!retregs)
         retregs = ALLREGS;
     const reg = allocreg(cdb,retregs,tym);

--- a/compiler/test/compilable/ice23833.d
+++ b/compiler/test/compilable/ice23833.d
@@ -1,0 +1,4 @@
+bool isZero(double x)
+{
+    return cast(ulong) x == 0;
+}


### PR DESCRIPTION
Fixes #23833.

Please note DMD's backend has specific assumptions regarding floating point numbers. These quirks have been there since forever, but might still surprise users after this patch (i.e. `cast(long)float.nan` is non-zero but `cast(ulong)float.nan` is zero). Making everything saner would require a much larger patch.