### PR TITLE
Windows: CI-test *new* UCRT-based MinGW fallback libs

### DIFF
--- a/.azure-pipelines/windows-msbuild.bat
+++ b/.azure-pipelines/windows-msbuild.bat
@@ -69,13 +69,13 @@ if not "%C_RUNTIME%" == "mingw" goto not_mingw
     7z x mingw.zip -o%DMD_DIR%\mingw || exit /B 14
     :mingw_exists
 
-    set DFLAGS=-mscrtlib=msvcrt120
+    set DFLAGS=-mscrtlib=ucrtbase
     if "%MODEL%" == "32" (
         set LIB=%DMD_DIR%\mingw\dmd2\windows\lib32mscoff\mingw
     ) else (
         set LIB=%DMD_DIR%\mingw\dmd2\windows\lib%MODEL%\mingw
     )
-    set REQUIRED_ARGS=-mscrtlib=msvcrt120 "-L/LIBPATH:%LIB%"
+    set REQUIRED_ARGS=-mscrtlib=ucrtbase "-L/LIBPATH:%LIB%"
     rem skip runnable_cxx tests (incompatible MSVC runtime versions - 2017 (cl.exe) vs. 2013)
     rem FIXME: unit_tests excluded too, see above
     set DMD_TESTS=runnable compilable fail_compilation dshell

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -298,6 +298,7 @@ public int runLINK(bool verbose, ErrorSink eSink)
             // legacy `msvcrtNNN` such as `msvcrt120` — do not detect Visual Studio; use
             // lld-link with the MinGW libraries instead.
             const isMingwRuntime = driverParams.mscrtlib == "ucrtbase" ||
+                driverParams.mscrtlib == "vcruntime140" || // legacy name for ucrtbase
                 (driverParams.mscrtlib.length > 6 &&
                  driverParams.mscrtlib[0 .. 6] == "msvcrt" && isdigit(driverParams.mscrtlib[6]));
             if (!isMingwRuntime)
@@ -321,6 +322,10 @@ public int runLINK(bool verbose, ErrorSink eSink)
             // /DEFAULTLIB directive; it also needs the VC runtime library.
             if (driverParams.mscrtlib == "ucrtbase")
                 cmdbuf.writestring(" vcruntime140.lib");
+            // And legacy_stdio_definitions.lib, as the printf/scanf family is defined
+            // inline in the MSVC 2015+ headers.
+            if (driverParams.mscrtlib == "ucrtbase" || driverParams.mscrtlib == "vcruntime140")
+                cmdbuf.writestring(" legacy_stdio_definitions.lib");
 
             if (const(char)* lflags = vsopt.linkOptions(target.isX86_64))
             {

--- a/compiler/test/compilable/objc_class.d
+++ b/compiler/test/compilable/objc_class.d
@@ -1,6 +1,6 @@
 // also check cross compilation, ensure targeting 64-bit
 // REQUIRED_ARGS: -m64 -os=osx
-// doesn't compile with mingw option -mscrtlib=msvcrt120
+// doesn't compile with mingw option -mscrtlib=ucrtbase
 // DISABLED: win32
 
 import core.attribute : selector;

--- a/druntime/src/core/stdcpp/xutility.d
+++ b/druntime/src/core/stdcpp/xutility.d
@@ -149,6 +149,8 @@ version (CppRuntime_Microsoft)
         static if (__CXXLIB__ == "libcmtd" || __CXXLIB__ == "msvcrtd")
             enum _ITERATOR_DEBUG_LEVEL = 2;
         else static if (__CXXLIB__ == "libcmt" || __CXXLIB__ == "msvcrt" ||
+                        // MinGW-based:
+                        __CXXLIB__ == "ucrtbase" || __CXXLIB__ == "vcruntime140" ||
                         __CXXLIB__ == "msvcrt100" || __CXXLIB__ == "msvcrt110" || __CXXLIB__ == "msvcrt120")
             enum _ITERATOR_DEBUG_LEVEL = 0;
         else

--- a/druntime/test/betterc/Makefile
+++ b/druntime/test/betterc/Makefile
@@ -3,11 +3,3 @@ include ../common.mak
 
 $(OBJDIR)/%.done: extra_dflags += -betterC
 $(OBJDIR)/%.done: extra_ldlibs.d =
-
-# for the Windows MinGW CI job:
-ifneq (,$(findstring -mscrtlib=msvcrt120,$(DFLAGS) $(LDFLAGS.d)))
-# DFLAGS=-mscrtlib=msvcrt120 takes precedence over any command line flags, so
-# specify vcruntime140.lib explicitly for using mingw with Universal CRT.
-$(OBJDIR)/test19933$(DOTEXE): extra_ldflags.d = -L/NODEFAULTLIB:msvcrt120.lib
-$(OBJDIR)/test19933$(DOTEXE): extra_ldlibs.d = -Lvcruntime140.lib -Llegacy_stdio_definitions.lib
-endif


### PR DESCRIPTION
Instead of the old MSVC 2013 based `msvcrt120` default. Also fix #23812 while at it, and a few small regressions for `-mscrtlib=vcruntime140`, the old way/name of opting into the newer UCRT-based MinGW version.